### PR TITLE
test: consolidate shared test support into one crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ dependencies = [
  "loonfs-core",
  "loonfs-grep",
  "loonfs-objectstore",
+ "loonfs-test-support",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -1169,6 +1170,7 @@ dependencies = [
  "loonfs-api",
  "loonfs-model",
  "loonfs-objectstore",
+ "loonfs-test-support",
  "serde",
  "serde_json",
  "sha2",
@@ -1190,6 +1192,7 @@ dependencies = [
  "loonfs-api",
  "loonfs-core",
  "loonfs-objectstore",
+ "loonfs-test-support",
  "regex",
  "regex-syntax",
  "serde",
@@ -1251,6 +1254,7 @@ dependencies = [
  "loonfs-core",
  "loonfs-grep",
  "loonfs-objectstore",
+ "loonfs-test-support",
  "serde",
  "serde_json",
  "tempfile",
@@ -1280,6 +1284,20 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "loonfs-test-support"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "loonfs-api",
+ "loonfs-objectstore",
+ "tempfile",
+ "tokio",
+ "ureq",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "crates/loonfs-api",
+  "crates/loonfs-test-support",
   "crates/loonfs-grep",
   "crates/loonfs-objectstore",
   "crates/loonfs-core",

--- a/crates/loonfs-core/Cargo.toml
+++ b/crates/loonfs-core/Cargo.toml
@@ -28,6 +28,7 @@ default = []
 
 [dev-dependencies]
 loonfs-model = { path = "../loonfs-model" }
+loonfs-test-support = { path = "../loonfs-test-support" }
 tempfile.workspace = true
 tokio.workspace = true
 

--- a/crates/loonfs-core/src/checkpoint/tests.rs
+++ b/crates/loonfs-core/src/checkpoint/tests.rs
@@ -26,6 +26,7 @@ use super::runs::{
 use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
 use crate::namespace::bootstrap::bootstrap_namespace;
+use crate::namespace::catalog::load_namespace_catalog_entry;
 use crate::namespace::control::{
     read_head_object, read_metadata_root_object, read_wal_floor_object,
 };
@@ -34,6 +35,10 @@ use crate::path::write::ops::{
     delete_path, move_path, put_file_bytes, restore_file_revision, write_file_bytes,
 };
 use crate::protocol::list_changes_after;
+use crate::publish::{
+    NamespaceCommitEngine, NamespaceMutationCandidate, PathMutationIntent, PublishTailOptions,
+};
+use crate::storage::content::{prepare_stored_content, store_bytes_as_content};
 use crate::MutationContext;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -46,8 +51,8 @@ use loonfs_api::wire::manifest::{
 };
 use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
 use loonfs_api::{
-    ChangeSeq, CheckpointId, CommitId, DestinationBehavior, EffectiveLimit, InodeId, ManifestId,
-    ManifestObjectId, NameKey, NamespaceId, RevisionNo,
+    AbsolutePath, ChangeSeq, CheckpointId, CommitId, DestinationBehavior, EffectiveLimit, InodeId,
+    ManifestId, ManifestObjectId, NameKey, NamespaceId, RevisionNo,
 };
 use loonfs_objectstore::keys::{
     metadata_manifest_object, metadata_manifest_prefix, metadata_table, wal_head, wal_segment,
@@ -55,6 +60,9 @@ use loonfs_objectstore::keys::{
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use loonfs_test_support::stores::{
+    CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
 };
 use std::collections::BTreeSet;
 use std::num::{NonZeroU32, NonZeroUsize};
@@ -79,6 +87,57 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
         context,
     )
     .await
+}
+
+pub(crate) fn mutation_context(
+    writer_id: &str,
+    writer_session_id: &str,
+    writer_version: &str,
+    now_ms: u64,
+) -> MutationContext {
+    MutationContext {
+        writer_id: writer_id.to_owned(),
+        writer_session_id: writer_session_id.to_owned(),
+        writer_version: writer_version.to_owned(),
+        now_ms,
+    }
+}
+
+pub(crate) async fn write_test_file<S: ObjectStore>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    path: &str,
+    commit_id: &str,
+    context: &MutationContext,
+) {
+    let stored = store_bytes_as_content(store, namespace_id, b"body\n")
+        .await
+        .expect("store content");
+    let content_ref = stored.content_ref.clone();
+    let catalog = load_namespace_catalog_entry(store, namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
+    NamespaceCommitEngine::new(namespace_id.clone())
+        .publish_batch(
+            store,
+            vec![NamespaceMutationCandidate::path_prepared(
+                PathMutationIntent::PutFile {
+                    commit_id: CommitId::parse(commit_id).expect("commit id"),
+                    absolute_path: AbsolutePath::parse(path).expect("path"),
+                    content_ref,
+                    behavior: DestinationBehavior::NoReplace,
+                },
+                vec![prepared],
+            )],
+            context,
+            &PublishTailOptions::default(),
+        )
+        .await
+        .results
+        .pop()
+        .expect("one result")
+        .expect("write file");
 }
 
 #[derive(Debug)]
@@ -473,21 +532,20 @@ async fn create_checkpoint_surfaces_conflicting_invalid_manifest() {
 #[tokio::test]
 async fn retention_advancement_uses_published_manifest_and_updates_floor_only() {
     let temp_dir = tempdir().expect("tempdir");
-    let store =
-        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
         .expect("bootstrap");
 
-    store.reset_metadata_sst_gets();
+    store.reset();
     let unchanged = advance_retention_floor(&store, &namespace_id, &context)
         .await
         .expect("initial manifest already covers floor zero");
     assert_eq!(unchanged.retention_floor_seq, ChangeSeq(0));
     assert_eq!(
-        store.metadata_sst_gets(),
+        store.count(OperationClass::Read),
         0,
         "retention should validate manifest descriptors without loading metadata SST payloads"
     );
@@ -505,13 +563,13 @@ async fn retention_advancement_uses_published_manifest_and_updates_floor_only() 
     create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("create checkpoint");
-    store.reset_metadata_sst_gets();
+    store.reset();
     let advanced = advance_retention_floor(&store, &namespace_id, &context)
         .await
         .expect("advance retention");
     assert_eq!(advanced.retention_floor_seq, ChangeSeq(1));
     assert_eq!(
-        store.metadata_sst_gets(),
+        store.count(OperationClass::Read),
         0,
         "retention should advance from manifest descriptors without materializing rows"
     );
@@ -2323,8 +2381,7 @@ async fn manifest_base_run_tables_have_sorted_segment_coverage() {
 #[tokio::test]
 async fn byte_budgeted_cache_admits_large_table_scans() {
     let temp_dir = tempdir().expect("tempdir");
-    let store =
-        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -2375,7 +2432,7 @@ async fn byte_budgeted_cache_admits_large_table_scans() {
     )
     .await
     .expect("load fresh tables");
-    store.reset_metadata_sst_gets();
+    store.reset();
     let repeated = fresh_tables
         .scan_prefix(ApiMetadataTableFamily::Revisions, "revision-")
         .await
@@ -2384,7 +2441,7 @@ async fn byte_budgeted_cache_admits_large_table_scans() {
 
     assert_eq!(repeated, revisions);
     assert_eq!(
-        store.metadata_sst_gets(),
+        store.count(OperationClass::Read),
         0,
         "a warm wide scan should be served entirely from the cache"
     );
@@ -2394,8 +2451,7 @@ async fn byte_budgeted_cache_admits_large_table_scans() {
 #[tokio::test]
 async fn concurrent_scans_share_one_fetch_per_segment() {
     let temp_dir = tempdir().expect("tempdir");
-    let store =
-        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -2427,12 +2483,12 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
     )
     .await
     .expect("load solo tables");
-    store.reset_metadata_sst_gets();
+    store.reset();
     let solo = solo_tables
         .scan_prefix(ApiMetadataTableFamily::Revisions, "revision-")
         .await
         .expect("solo scan");
-    let solo_fetches = store.metadata_sst_gets();
+    let solo_fetches = store.count(OperationClass::Read);
     assert!(solo.len() >= 8);
     assert!(solo_fetches >= 8, "solo scan should fetch every segment");
 
@@ -2455,12 +2511,12 @@ async fn concurrent_scans_share_one_fetch_per_segment() {
     )
     .await
     .expect("load second tables");
-    store.reset_metadata_sst_gets();
+    store.reset();
     let (first, second) = tokio::join!(
         first_tables.scan_prefix(ApiMetadataTableFamily::Revisions, "revision-"),
         second_tables.scan_prefix(ApiMetadataTableFamily::Revisions, "revision-"),
     );
-    let paired_fetches = store.metadata_sst_gets();
+    let paired_fetches = store.count(OperationClass::Read);
     assert_eq!(first.expect("first scan"), second.expect("second scan"));
     assert_eq!(
         paired_fetches, solo_fetches,
@@ -2597,8 +2653,7 @@ async fn table_range_page_merges_base_and_l0_in_row_key_order() {
 #[tokio::test]
 async fn byte_budgeted_cache_admits_large_range_scans() {
     let temp_dir = tempdir().expect("tempdir");
-    let store =
-        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -2655,7 +2710,7 @@ async fn byte_budgeted_cache_admits_large_range_scans() {
     )
     .await
     .expect("load fresh tables");
-    store.reset_metadata_sst_gets();
+    store.reset();
     let repeated = fresh_tables
         .scan_range_page(
             ApiMetadataTableFamily::DirentryBinds,
@@ -2668,7 +2723,7 @@ async fn byte_budgeted_cache_admits_large_range_scans() {
 
     assert_eq!(repeated, page);
     assert_eq!(
-        store.metadata_sst_gets(),
+        store.count(OperationClass::Read),
         0,
         "a warm range scan should be served entirely from the cache"
     );
@@ -4094,8 +4149,7 @@ async fn create_checkpoint_pins_a_current_basis_without_building_a_new_manifest(
 #[tokio::test]
 async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     let temp_dir = tempdir().expect("tempdir");
-    let store =
-        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -4129,14 +4183,14 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
     let tables = super::load_verified_manifest_tables(&store, &namespace_id, &manifest_object_id)
         .await
         .expect("load tables");
-    store.reset_metadata_sst_gets();
+    store.reset();
     let key = "inode-00000000000000000001";
     assert!(tables
         .get_for_lookup(ApiMetadataTableFamily::Inodes, key, key)
         .await
         .expect("first lookup")
         .is_some());
-    let first_lookup_gets = store.metadata_sst_gets();
+    let first_lookup_gets = store.count(OperationClass::Read);
     assert!(first_lookup_gets > 0, "a cold lookup fetches blocks");
 
     assert!(tables
@@ -4151,7 +4205,7 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
         .expect("second-key lookup")
         .is_some());
     assert_eq!(
-        store.metadata_sst_gets(),
+        store.count(OperationClass::Read),
         first_lookup_gets,
         "later lookups through the same view should reuse decoded blocks"
     );
@@ -4160,8 +4214,7 @@ async fn a_view_reuses_decoded_blocks_without_a_shared_cache() {
 #[tokio::test]
 async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
     let temp_dir = tempdir().expect("tempdir");
-    let store =
-        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -4227,7 +4280,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
     let probe =
         lookup_keys::direntry_bind_probe(binding.parent_inode_id, binding.name_key.as_str());
 
-    store.reset_metadata_sst_gets();
+    store.reset();
     let rows = tables
         .scan_prefix_for_lookup(
             ApiMetadataTableFamily::DirentryBinds,
@@ -4239,7 +4292,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
         .expect("point lookup");
     assert_eq!(rows.len(), 1, "exactly one bind row for the probed name");
     assert_eq!(
-        store.metadata_sst_gets(),
+        store.count(OperationClass::Read),
         1,
         "inline filters reject the other runs without fetches, and the one \
          admitted small segment loads whole with a single ranged GET"
@@ -4263,7 +4316,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
     let stripped_tables = load_verified_manifest_tables(&store, &namespace_id, &stripped_object_id)
         .await
         .expect("load stripped tables");
-    store.reset_metadata_sst_gets();
+    store.reset();
     let stripped_rows = stripped_tables
         .scan_prefix_for_lookup(
             ApiMetadataTableFamily::DirentryBinds,
@@ -4275,7 +4328,7 @@ async fn point_lookups_skip_inline_filtered_runs_without_fetches() {
         .expect("point lookup without inline filters");
     assert_eq!(stripped_rows, rows);
     assert!(
-        store.metadata_sst_gets() > 1,
+        store.count(OperationClass::Read) > 1,
         "without inline copies the ruled-out runs pay filter fetches"
     );
 }
@@ -4420,8 +4473,7 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
 #[tokio::test]
 async fn checkpoint_l0_update_does_not_read_existing_metadata_ssts() {
     let temp_dir = tempdir().expect("tempdir");
-    let store =
-        MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
     bootstrap_namespace(&store, &namespace_id, &context, false)
@@ -4452,14 +4504,14 @@ async fn checkpoint_l0_update_does_not_read_existing_metadata_ssts() {
     )
     .await
     .expect("write second");
-    store.reset_metadata_sst_gets();
+    store.reset();
 
     let checkpoint = create_checkpoint(&store, &namespace_id, &context)
         .await
         .expect("create L0 checkpoint");
 
     assert_eq!(
-        store.metadata_sst_gets(),
+        store.count(OperationClass::Read),
         0,
         "L0 checkpoint update should use the WAL tail and copy existing metadata file refs"
     );
@@ -4615,9 +4667,11 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
-    let store = HeadCasFailureStore::new(
+    let store = FailStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        loonfs_objectstore::keys::metadata_root(namespace_id.as_str()),
+        KeyPredicate::metadata_root(namespace_id.as_str()),
+        OperationClass::CompareAndSwap,
+        InjectedError::PreconditionFailed,
     );
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -4654,7 +4708,7 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
         .await
         .expect("write manifest");
 
-    store.fail_head_cas();
+    store.fail_all();
     let outcome = publish_metadata_root(
         &store,
         &namespace_id,
@@ -5149,12 +5203,7 @@ impl ObjectStore for StaleHeadOnceStore {
 }
 
 fn test_context() -> MutationContext {
-    MutationContext {
-        writer_id: "test-writer".to_owned(),
-        writer_session_id: "wrs_test".to_owned(),
-        writer_version: "test-writer/0.1.0".to_owned(),
-        now_ms: 1_000,
-    }
+    mutation_context("test-writer", "wrs_test", "test-writer/0.1.0", 1_000)
 }
 
 fn manifest_id(seq: ChangeSeq) -> ManifestId {
@@ -5176,80 +5225,6 @@ async fn write_file_and_checkpoint(
         .await
         .expect("create checkpoint")
         .checkpoint_seq
-}
-
-#[derive(Debug)]
-struct HeadCasFailureStore {
-    inner: LocalFsStore,
-    head_key: String,
-    fail_head_cas: Mutex<bool>,
-}
-
-impl HeadCasFailureStore {
-    fn new(inner: LocalFsStore, head_key: String) -> Self {
-        Self {
-            inner,
-            head_key,
-            fail_head_cas: Mutex::new(false),
-        }
-    }
-
-    fn fail_head_cas(&self) {
-        *self
-            .fail_head_cas
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
-    }
-}
-
-#[async_trait]
-impl ObjectStore for HeadCasFailureStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        if key == self.head_key
-            && matches!(&mode, PutMode::CompareAndSwap { .. })
-            && *self
-                .fail_head_cas
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-        {
-            return Err(ObjectStoreError::PreconditionFailed {
-                object_key: key.to_owned(),
-            });
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
 }
 
 #[derive(Debug)]
@@ -5415,85 +5390,6 @@ impl ObjectStore for RootCasTransportAfterCompetingRootStore {
                 ));
             }
         }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct MetadataSstGetCountingStore {
-    inner: LocalFsStore,
-    metadata_sst_gets: Mutex<usize>,
-}
-
-impl MetadataSstGetCountingStore {
-    pub(crate) fn new(inner: LocalFsStore) -> Self {
-        Self {
-            inner,
-            metadata_sst_gets: Mutex::new(0),
-        }
-    }
-
-    pub(crate) fn metadata_sst_gets(&self) -> usize {
-        *self
-            .metadata_sst_gets
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-
-    pub(crate) fn reset_metadata_sst_gets(&self) {
-        *self
-            .metadata_sst_gets
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = 0;
-    }
-
-    fn record_if_metadata_sst(&self, key: &str) {
-        if key.contains("/metadata/tables/") && key.ends_with(".sst.zst") {
-            *self
-                .metadata_sst_gets
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner()) += 1;
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for MetadataSstGetCountingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.record_if_metadata_sst(key);
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.record_if_metadata_sst(key);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
         self.inner.put(key, bytes, mode).await
     }
 

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -569,6 +569,7 @@ mod tests {
     use loonfs_objectstore::keys::wal_segment_prefix;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::ObjectStore;
+    use loonfs_test_support::stores::{CountingStore, OperationClass};
     use std::sync::atomic::{AtomicU64, Ordering};
     use tempfile::tempdir;
 
@@ -904,11 +905,9 @@ mod tests {
     #[tokio::test]
     async fn publish_views_reuse_cached_table_blocks_across_publishes() {
         use crate::cache::MetadataTableCacheConfig;
-        use crate::checkpoint::tests::MetadataSstGetCountingStore;
-
         let temp_dir = tempdir().expect("tempdir");
         let store =
-            MetadataSstGetCountingStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+            CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let writer = context("writer-a", "session-a");
         bootstrap_namespace(&store, &namespace_id, &writer, false)
@@ -940,7 +939,7 @@ mod tests {
         // Without a cache, every publish view re-fetches the table blocks
         // its validation walks need.
         let mut uncached = NamespaceCommitEngine::new(namespace_id.clone());
-        store.reset_metadata_sst_gets();
+        store.reset();
         uncached
             .publish_batch(
                 &store,
@@ -953,10 +952,10 @@ mod tests {
             .remove(0)
             .expect("uncached publish a");
         assert!(
-            store.metadata_sst_gets() > 0,
+            store.count(OperationClass::Read) > 0,
             "publish validation should read table blocks"
         );
-        store.reset_metadata_sst_gets();
+        store.reset();
         uncached
             .publish_batch(
                 &store,
@@ -969,13 +968,13 @@ mod tests {
             .remove(0)
             .expect("uncached publish b");
         assert!(
-            store.metadata_sst_gets() > 0,
+            store.count(OperationClass::Read) > 0,
             "without a cache the next publish re-fetches the same blocks"
         );
 
         let cache = Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default()));
         let mut cached = NamespaceCommitEngine::new(namespace_id.clone()).table_cache(cache);
-        store.reset_metadata_sst_gets();
+        store.reset();
         cached
             .publish_batch(
                 &store,
@@ -988,10 +987,10 @@ mod tests {
             .remove(0)
             .expect("cached publish a");
         assert!(
-            store.metadata_sst_gets() > 0,
+            store.count(OperationClass::Read) > 0,
             "the first cached publish fills the cache"
         );
-        store.reset_metadata_sst_gets();
+        store.reset();
         cached
             .publish_batch(
                 &store,
@@ -1004,7 +1003,7 @@ mod tests {
             .remove(0)
             .expect("cached publish b");
         assert_eq!(
-            store.metadata_sst_gets(),
+            store.count(OperationClass::Read),
             0,
             "a warm cache serves every publish-view table read"
         );

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -268,14 +268,14 @@ async fn read_upload_session_object<S: ObjectStore + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
-    use futures::stream::{self, BoxStream};
     use loonfs_api::wire::control::{ControlObjectKind, HeadStateEnvelope};
     use loonfs_api::NamespaceId;
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
-    use loonfs_objectstore::{ByteRange, ObjectBody, PutMode};
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use loonfs_test_support::stores::{
+        FailStore, InjectedError, KeyPredicate, MetadataMapStore, OperationClass,
+    };
+    use std::sync::atomic::{AtomicBool, Ordering};
     use tempfile::tempdir;
 
     const WRITER_VERSION: &str = "writer/0.1.0";
@@ -329,10 +329,13 @@ mod tests {
         let inner = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         write_initial_head(&inner, &namespace_id).await;
-        let store = ConflictOnceStore {
+        let store = FailStore::new(
             inner,
-            remaining_conflicts: AtomicUsize::new(1),
-        };
+            KeyPredicate::any(),
+            OperationClass::CompareAndSwap,
+            InjectedError::PreconditionFailed,
+        );
+        store.fail_next(1);
 
         let outcome = update_head(&store, &namespace_id, WRITER_VERSION, 3, |loaded| {
             let mut next = loaded.envelope.state.clone();
@@ -346,7 +349,7 @@ mod tests {
         .expect("retry update");
 
         assert_eq!(outcome, "updated");
-        assert_eq!(store.remaining_conflicts.load(Ordering::SeqCst), 0);
+        assert_eq!(store.remaining(), 0);
     }
 
     #[tokio::test]
@@ -355,7 +358,7 @@ mod tests {
         let inner = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         write_initial_head(&inner, &namespace_id).await;
-        let store = MissingEtagStore { inner };
+        let store = MetadataMapStore::without_etag(inner, KeyPredicate::any());
 
         let closure_called = AtomicBool::new(false);
         let error = update_head(&store, &namespace_id, WRITER_VERSION, 3, |_loaded| {
@@ -367,119 +370,5 @@ mod tests {
 
         assert!(matches!(error, ControlUpdateError::MissingEtag { .. }));
         assert!(!closure_called.load(Ordering::SeqCst));
-    }
-
-    #[derive(Debug)]
-    struct ConflictOnceStore {
-        inner: LocalFsStore,
-        remaining_conflicts: AtomicUsize,
-    }
-
-    #[async_trait]
-    impl ObjectStore for ConflictOnceStore {
-        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            self.inner.head(key).await
-        }
-
-        async fn get_with_metadata(
-            &self,
-            key: &str,
-        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
-            self.inner.get_with_metadata(key).await
-        }
-
-        async fn get(
-            &self,
-            key: &str,
-            range: Option<ByteRange>,
-        ) -> Result<Option<Bytes>, ObjectStoreError> {
-            self.inner.get(key, range).await
-        }
-
-        async fn put(
-            &self,
-            key: &str,
-            bytes: Bytes,
-            mode: PutMode,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            self.inner.put(key, bytes, mode).await
-        }
-
-        async fn compare_and_swap(
-            &self,
-            key: &str,
-            expected_etag: &str,
-            bytes: Bytes,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            if self.remaining_conflicts.load(Ordering::SeqCst) > 0 {
-                self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
-                return Err(ObjectStoreError::PreconditionFailed {
-                    object_key: key.to_owned(),
-                });
-            }
-            self.inner.compare_and_swap(key, expected_etag, bytes).await
-        }
-
-        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-            self.inner.delete(key).await
-        }
-
-        fn list_prefix_stream(
-            &self,
-            prefix: &str,
-        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
-        }
-    }
-
-    #[derive(Debug)]
-    struct MissingEtagStore {
-        inner: LocalFsStore,
-    }
-
-    #[async_trait]
-    impl ObjectStore for MissingEtagStore {
-        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            self.inner.head(key).await
-        }
-
-        async fn get_with_metadata(
-            &self,
-            key: &str,
-        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
-            let Some(mut body) = self.inner.get_with_metadata(key).await? else {
-                return Ok(None);
-            };
-            body.metadata.etag = None;
-            Ok(Some(body))
-        }
-
-        async fn get(
-            &self,
-            key: &str,
-            range: Option<ByteRange>,
-        ) -> Result<Option<Bytes>, ObjectStoreError> {
-            self.inner.get(key, range).await
-        }
-
-        async fn put(
-            &self,
-            key: &str,
-            bytes: Bytes,
-            mode: PutMode,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            self.inner.put(key, bytes, mode).await
-        }
-
-        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-            self.inner.delete(key).await
-        }
-
-        fn list_prefix_stream(
-            &self,
-            _prefix: &str,
-        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            Box::pin(stream::empty())
-        }
     }
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -5,7 +5,7 @@ use super::reap::{condemn_checkpoint_if_aged, list_prefix, CheckpointCondemn};
 use super::run::{gc_namespace, gc_namespace_with_reverify_chunk};
 use crate::checkpoint::advance_retention_floor;
 use crate::checkpoint::record::set_checkpoint_record_state;
-use crate::checkpoint::tests::create_checkpoint;
+use crate::checkpoint::tests::{create_checkpoint, mutation_context, write_test_file};
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
@@ -21,22 +21,20 @@ use loonfs_objectstore::keys::{
 use loonfs_objectstore::ObjectStore;
 use std::num::NonZeroUsize;
 
-use crate::commit_engine::{NamespaceCommitEngine, NamespaceMutationCandidate};
 use crate::namespace::bootstrap::bootstrap_namespace;
 use crate::namespace::delete::delete_namespace;
 use crate::namespace::fork::fork_namespace;
 use crate::options::DeleteNamespaceOptions;
 use crate::path::read::{load_metadata_view, ReadLoadContext};
-use crate::publish::PathMutationIntent;
-use crate::storage::content::{prepare_stored_content, store_bytes_as_content};
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use loonfs_test_support::stores::{
+    BlockingStore, KeyPredicate, MetadataMapStore, OperationContext, OperationKind,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::tempdir;
-use tokio::sync::Semaphore;
 
 const GRACE_MS: u64 = 60 * 60 * 1000;
 const REAP_MS: u64 = 7 * 24 * 60 * 60 * 1000;
@@ -49,12 +47,7 @@ fn config() -> GcConfig {
 }
 
 fn context(now_ms: u64) -> MutationContext {
-    MutationContext {
-        writer_id: "gc-test".to_owned(),
-        writer_session_id: "wrs_gc_test".to_owned(),
-        writer_version: "gc-test/0.1.0".to_owned(),
-        now_ms,
-    }
+    mutation_context("gc-test", "wrs_gc_test", "gc-test/0.1.0", now_ms)
 }
 
 /// Derives "now" from durable object ages so the tests never touch a
@@ -80,43 +73,6 @@ async fn now_after_newest_object(
     newest + offset_ms
 }
 
-async fn write_file<S: ObjectStore>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    path: &str,
-    commit_id: &str,
-    context: &MutationContext,
-) {
-    let stored = store_bytes_as_content(store, namespace_id, b"body\n")
-        .await
-        .expect("store content");
-    let content_ref = stored.content_ref.clone();
-    let catalog = crate::namespace::catalog::load_namespace_catalog_entry(store, namespace_id)
-        .await
-        .expect("load namespace catalog");
-    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
-    NamespaceCommitEngine::new(namespace_id.clone())
-        .publish_batch(
-            store,
-            vec![NamespaceMutationCandidate::path_prepared(
-                PathMutationIntent::PutFile {
-                    commit_id: CommitId::parse(commit_id).expect("commit id"),
-                    absolute_path: AbsolutePath::parse(path).expect("path"),
-                    content_ref: content_ref.clone(),
-                    behavior: DestinationBehavior::NoReplace,
-                },
-                vec![prepared],
-            )],
-            context,
-            &crate::protocol::PublishTailOptions::default(),
-        )
-        .await
-        .results
-        .pop()
-        .expect("one result")
-        .expect("write file");
-}
-
 async fn stat_root<S: ObjectStore>(store: &S, namespace_id: &NamespaceId) {
     load_metadata_view(store, namespace_id, ReadLoadContext::latest())
         .await
@@ -124,58 +80,6 @@ async fn stat_root<S: ObjectStore>(store: &S, namespace_id: &NamespaceId) {
         .resolve_path("/")
         .await
         .expect("resolve root");
-}
-
-/// `LocalFsStore` with provider timestamps stripped: rule 1 reads an
-/// object without a timestamp as young, so nothing ever ages out.
-#[derive(Debug)]
-struct TimestamplessStore(LocalFsStore);
-
-fn strip_timestamp(mut metadata: ObjectMetadata) -> ObjectMetadata {
-    metadata.last_modified_ms = None;
-    metadata
-}
-
-#[async_trait::async_trait]
-impl ObjectStore for TimestamplessStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        Ok(self.0.head(key).await?.map(strip_timestamp))
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        Ok(self.0.get_with_metadata(key).await?.map(|mut body| {
-            body.metadata = strip_timestamp(body.metadata);
-            body
-        }))
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.0.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        Ok(strip_timestamp(self.0.put(key, bytes, mode).await?))
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.0.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.0.list_prefix_stream(prefix)
-    }
 }
 
 #[derive(Debug)]
@@ -193,40 +97,9 @@ enum BlockingControlCasTarget {
     UploadCondemned,
 }
 
-#[derive(Debug)]
-struct BlockingControlCasStore {
-    inner: LocalFsStore,
-    target: BlockingControlCasTarget,
-    blocked_once: AtomicBool,
-    entered: Semaphore,
-    release: Semaphore,
-}
-
-impl BlockingControlCasStore {
-    fn new(inner: LocalFsStore, target: BlockingControlCasTarget) -> Self {
-        Self {
-            inner,
-            target,
-            blocked_once: AtomicBool::new(false),
-            entered: Semaphore::new(0),
-            release: Semaphore::new(0),
-        }
-    }
-
-    async fn wait_until_blocked(&self) {
-        self.entered
-            .acquire()
-            .await
-            .expect("blocking store remains open")
-            .forget();
-    }
-
-    fn unblock(&self) {
-        self.release.add_permits(1);
-    }
-
-    fn matches_target(&self, bytes: &[u8]) -> bool {
-        match self.target {
+impl BlockingControlCasTarget {
+    fn matches(self, bytes: &[u8]) -> bool {
+        match self {
             BlockingControlCasTarget::CheckpointActive
             | BlockingControlCasTarget::CheckpointCondemned => {
                 let Ok(envelope) = decode_control_object::<CheckpointRecordState>(
@@ -235,7 +108,7 @@ impl BlockingControlCasStore {
                 ) else {
                     return false;
                 };
-                let target = match self.target {
+                let target = match self {
                     BlockingControlCasTarget::CheckpointActive => CheckpointRecordLifecycle::Active,
                     BlockingControlCasTarget::CheckpointCondemned => {
                         CheckpointRecordLifecycle::Condemned
@@ -252,7 +125,7 @@ impl BlockingControlCasStore {
                 ) else {
                     return false;
                 };
-                match self.target {
+                match self {
                     BlockingControlCasTarget::UploadCompleted => envelope.state.completed.is_some(),
                     BlockingControlCasTarget::UploadCondemned => {
                         envelope.state.state == UploadSessionLifecycle::Condemned
@@ -264,54 +137,23 @@ impl BlockingControlCasStore {
     }
 }
 
-#[async_trait::async_trait]
-impl ObjectStore for BlockingControlCasStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let should_block = matches!(&mode, PutMode::CompareAndSwap { .. })
-            && self.matches_target(&bytes)
-            && !self.blocked_once.swap(true, Ordering::SeqCst);
-        if should_block {
-            self.entered.add_permits(1);
-            self.release
-                .acquire()
-                .await
-                .expect("blocking store remains open")
-                .forget();
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
+fn blocking_control_cas_store(
+    inner: LocalFsStore,
+    target: BlockingControlCasTarget,
+) -> BlockingStore<LocalFsStore> {
+    let store = BlockingStore::matching(inner, move |operation: &OperationContext<'_>| {
+        let bytes = match operation.kind() {
+            OperationKind::CompareAndSwap { bytes, .. }
+            | OperationKind::Put {
+                bytes,
+                mode: PutMode::CompareAndSwap { .. },
+            } => bytes,
+            _ => return false,
+        };
+        target.matches(bytes)
+    });
+    store.block_next();
+    store
 }
 
 #[async_trait::async_trait]
@@ -400,7 +242,7 @@ async fn gc_reaps_below_floor_segments_after_the_grace_window() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("checkpoint");
@@ -506,14 +348,14 @@ async fn active_record_with_a_missing_basis_is_released_not_degrading() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let pinned = create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("first checkpoint");
 
     // Advance the root past the pinned basis so deleting the basis
     // object leaves the namespace itself healthy.
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     let moved_on = crate::checkpoint::create_checkpoint(
         &store,
         &namespace_id,
@@ -588,8 +430,8 @@ async fn deleted_namespace_reclaims_down_to_its_tombstone() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("user pin");
@@ -655,7 +497,7 @@ async fn fork_protected_bases_survive_source_deletion_until_the_target_dies() {
     bootstrap_namespace(&store, &source, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &source, "/docs/shared.txt", "gc-shared", &setup).await;
+    write_test_file(&store, &source, "/docs/shared.txt", "gc-shared", &setup).await;
     fork_namespace(&store, &source, &clone, &setup)
         .await
         .expect("fork");
@@ -722,7 +564,7 @@ async fn upload_sessions_reap_after_the_window_and_survive_inside_it() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let session_key = write_upload_session(&store, &namespace_id).await;
 
     // Past the grace window but inside the reap window: sessions are
@@ -771,7 +613,7 @@ async fn upload_completion_wins_before_condemn_and_the_session_is_retained() {
     let (upload_id, content_ref, content_store_id) =
         stage_upload(&store, &namespace_id, &setup).await;
     let aged = context(now_after_newest_object(&store, &namespace_id, REAP_MS + 1).await);
-    let store = BlockingControlCasStore::new(store, BlockingControlCasTarget::UploadCondemned);
+    let store = blocking_control_cas_store(store, BlockingControlCasTarget::UploadCondemned);
     let gc_config = config();
     let gc = gc_namespace(&store, &namespace_id, &gc_config, &aged);
     let complete = async {
@@ -787,7 +629,7 @@ async fn upload_completion_wins_before_condemn_and_the_session_is_retained() {
             &setup,
         )
         .await;
-        store.unblock();
+        store.release();
         result
     };
     let (report, completion) = tokio::join!(gc, complete);
@@ -813,7 +655,7 @@ async fn upload_condemn_wins_before_completion_and_completion_reports_not_found(
     let (upload_id, content_ref, content_store_id) =
         stage_upload(&store, &namespace_id, &setup).await;
     let aged = context(now_after_newest_object(&store, &namespace_id, REAP_MS + 1).await);
-    let store = BlockingControlCasStore::new(store, BlockingControlCasTarget::UploadCompleted);
+    let store = blocking_control_cas_store(store, BlockingControlCasTarget::UploadCompleted);
     let request = loonfs_api::v0::CompleteUploadRequest {
         content_ref: content_ref.clone(),
     };
@@ -828,7 +670,7 @@ async fn upload_condemn_wins_before_completion_and_completion_reports_not_found(
     let condemn = async {
         store.wait_until_blocked().await;
         let report = gc_namespace(&store, &namespace_id, &config(), &aged).await;
-        store.unblock();
+        store.release();
         report
     };
     let (completion, report) = tokio::join!(completion, condemn);
@@ -850,7 +692,7 @@ async fn gc_retains_everything_inside_the_grace_window() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("checkpoint");
@@ -879,7 +721,7 @@ async fn gc_never_deletes_the_live_replay_chain() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("checkpoint");
@@ -887,7 +729,7 @@ async fn gc_never_deletes_the_live_replay_chain() {
         .await
         .expect("advance floor");
     // A commit past the floor: its segment is the live replay gap.
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
 
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
     let report = gc_namespace(&store, &namespace_id, &config(), &aged)
@@ -916,11 +758,11 @@ async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let first = create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("first checkpoint");
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("second checkpoint");
@@ -1004,7 +846,7 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
         .await
         .expect("bootstrap");
     for round in 0..3 {
-        write_file(
+        write_test_file(
             &store,
             &namespace_id,
             &format!("/docs/file-{round}.txt"),
@@ -1092,11 +934,11 @@ async fn gc_reaps_released_checkpoints_before_their_basis_across_passes() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let pinned = create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("pin checkpoint");
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("advance past the pinned basis");
@@ -1140,7 +982,7 @@ async fn checkpoint_revival_wins_before_condemn_and_keeps_its_basis_pinned() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let checkpoint = create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("checkpoint");
@@ -1154,13 +996,13 @@ async fn checkpoint_revival_wins_before_condemn_and_keeps_its_basis_pinned() {
         .await
         .expect("release checkpoint");
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
-    let store = BlockingControlCasStore::new(store, BlockingControlCasTarget::CheckpointCondemned);
+    let store = blocking_control_cas_store(store, BlockingControlCasTarget::CheckpointCondemned);
     let gc_config = config();
     let gc = gc_namespace(&store, &namespace_id, &gc_config, &aged);
     let revive = async {
         store.wait_until_blocked().await;
         let revived = create_checkpoint(&store, &namespace_id, &setup).await;
-        store.unblock();
+        store.release();
         revived
     };
     let (report, revived) = tokio::join!(gc, revive);
@@ -1172,11 +1014,11 @@ async fn checkpoint_revival_wins_before_condemn_and_keeps_its_basis_pinned() {
 
     // Move the root to another manifest, then run a complete later pass: the
     // revived record is now the only reason its old basis survives.
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("advance metadata root");
-    let aged = context(now_after_newest_object(&store.inner, &namespace_id, GRACE_MS + 1).await);
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
     gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect("full pass after revival");
@@ -1209,13 +1051,13 @@ async fn checkpoint_condemn_wins_before_revival_then_gc_frees_the_name() {
         namespace_id.as_str(),
         checkpoint.checkpoint_id.as_str(),
     );
-    let store = BlockingControlCasStore::new(store, BlockingControlCasTarget::CheckpointActive);
+    let store = blocking_control_cas_store(store, BlockingControlCasTarget::CheckpointActive);
     let revival = create_checkpoint(&store, &namespace_id, &setup);
     let condemn = async {
         store.wait_until_blocked().await;
         let outcome =
             condemn_checkpoint_if_aged(&store, &namespace_id, &key, GRACE_MS, false, &aged).await;
-        store.unblock();
+        store.release();
         outcome
     };
     let (revival, condemn) = tokio::join!(revival, condemn);
@@ -1293,7 +1135,7 @@ async fn gc_reaps_expired_checkpoints_before_their_basis_across_passes() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     // Expiry compares the caller's `now_ms` against the record's stamp;
     // object ages come from provider timestamps. Pin one record already
     // expired at any provider-derived "now" and one that never expires.
@@ -1319,7 +1161,7 @@ async fn gc_reaps_expired_checkpoints_before_their_basis_across_passes() {
     )
     .await
     .expect("lasting checkpoint");
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("advance past the expiring basis");
@@ -1374,7 +1216,7 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let first = crate::checkpoint::create_checkpoint(
         &store,
         &namespace_id,
@@ -1399,7 +1241,7 @@ async fn gc_keeps_a_basis_pinned_by_another_owner_after_one_release() {
     .expect("second owner");
     assert_ne!(first.checkpoint_id, second.checkpoint_id);
     assert_eq!(first.manifest_id, second.manifest_id);
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("advance past the shared basis");
@@ -1453,7 +1295,7 @@ async fn fork_owned_checkpoints_reject_user_release() {
     bootstrap_namespace(&store, &source, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
     fork_namespace(&store, &source, &clone, &setup)
         .await
         .expect("fork");
@@ -1483,11 +1325,11 @@ async fn gc_retains_active_checkpoint_bases() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let first = create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("first checkpoint");
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("second checkpoint");
@@ -1554,14 +1396,14 @@ async fn gc_releases_fork_checkpoints_of_terminally_deleted_targets_across_passe
     bootstrap_namespace(&store, &source, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
     fork_namespace(&store, &source, &clone, &setup)
         .await
         .expect("fork");
     let fork_record = read_fork_record(&store, &source).await;
     // Advance the source root past the fork basis so the basis is
     // reachable only through the fork-owned record.
-    write_file(&store, &source, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &source, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &source, &setup)
         .await
         .expect("advance root past the fork basis");
@@ -1635,7 +1477,7 @@ async fn gc_retains_young_fork_checkpoints_of_terminally_deleted_targets() {
     bootstrap_namespace(&store, &source, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
     fork_namespace(&store, &source, &clone, &setup)
         .await
         .expect("fork");
@@ -1678,7 +1520,7 @@ async fn gc_releases_abandoned_fork_checkpoints_after_the_reap_window() {
     bootstrap_namespace(&store, &source, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
     fork_namespace(&store, &source, &clone, &setup)
         .await
         .expect("fork");
@@ -1728,7 +1570,7 @@ async fn abandoned_fork_retry_revives_and_freshens_the_source_record() {
     bootstrap_namespace(&store, &source, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
     fork_namespace(&store, &source, &clone, &setup)
         .await
         .expect("fork");
@@ -1787,7 +1629,7 @@ async fn gc_retains_unreadable_checkpoint_records_and_degrades() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("checkpoint");
@@ -1826,13 +1668,17 @@ async fn gc_retains_unreadable_checkpoint_records_and_degrades() {
 #[tokio::test]
 async fn gc_retains_everything_without_provider_timestamps() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = TimestamplessStore(LocalFsStore::new(temp_dir.path()).expect("store"));
+    // Rule 1 treats missing provider timestamps as young, so nothing ages out.
+    let store = MetadataMapStore::without_last_modified(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::any(),
+    );
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let setup = context(1_000);
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("checkpoint");
@@ -1842,7 +1688,7 @@ async fn gc_retains_everything_without_provider_timestamps() {
 
     // Far past any window by wall clock, but no object carries a
     // provider timestamp.
-    let aged = context(now_after_newest_object(&store.0, &namespace_id, GRACE_MS + 1).await);
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
     let report = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
         .expect("gc pass");
@@ -1868,11 +1714,11 @@ async fn gc_sweep_reverification_chunks_preserve_outcomes() {
     bootstrap_namespace(&store, &namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let first = create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("first checkpoint");
-    write_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
+    write_test_file(&store, &namespace_id, "/docs/two.txt", "gc-two", &setup).await;
     create_checkpoint(&store, &namespace_id, &setup)
         .await
         .expect("second checkpoint");
@@ -1943,7 +1789,7 @@ async fn gc_degrades_to_retention_when_a_pin_checkpoint_is_unreadable() {
     bootstrap_namespace(&store, &source, &setup, false)
         .await
         .expect("bootstrap");
-    write_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
     fork_namespace(&store, &source, &clone, &setup)
         .await
         .expect("fork");

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -380,144 +380,18 @@ mod tests {
     use crate::namespace::fork::fork_namespace;
     use crate::namespace::repair::repair_namespace;
     use crate::namespace::status::load_namespace_head_summary;
-    use futures::stream::BoxStream;
     use loonfs_api::v0::{CommitOp as ApiCommitOp, CommitRequest as ApiCommitRequest};
     use loonfs_api::wire::control::decode_control_object;
     use loonfs_api::{CommitId, ManifestId, ManifestObjectId, RepairNamespaceOutcome};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
-    use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use loonfs_objectstore::PutMode;
+    use loonfs_test_support::stores::{
+        BlockingStore, KeyPredicate, OperationClass, OperationContext, OperationKind,
+    };
+    use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::Semaphore;
 
     const WRITER_VERSION: &str = "writer/0.1.0";
-
-    #[derive(Debug)]
-    struct BlockingRepairDeleteStore {
-        inner: LocalFsStore,
-        gate_key: String,
-        install_blocked_once: AtomicBool,
-        install_entered: Semaphore,
-        install_release: Semaphore,
-        install_finished: Semaphore,
-        delete_blocked_once: AtomicBool,
-        delete_entered: Semaphore,
-        delete_release: Semaphore,
-    }
-
-    impl BlockingRepairDeleteStore {
-        fn new(inner: LocalFsStore, gate_key: String) -> Self {
-            Self {
-                inner,
-                gate_key,
-                install_blocked_once: AtomicBool::new(false),
-                install_entered: Semaphore::new(0),
-                install_release: Semaphore::new(0),
-                install_finished: Semaphore::new(0),
-                delete_blocked_once: AtomicBool::new(false),
-                delete_entered: Semaphore::new(0),
-                delete_release: Semaphore::new(0),
-            }
-        }
-
-        async fn wait_until_install_blocked(&self) {
-            self.install_entered
-                .acquire()
-                .await
-                .expect("blocking store remains open")
-                .forget();
-        }
-
-        fn unblock_install(&self) {
-            self.install_release.add_permits(1);
-        }
-
-        async fn wait_until_install_finished(&self) {
-            self.install_finished
-                .acquire()
-                .await
-                .expect("blocking store remains open")
-                .forget();
-        }
-
-        async fn wait_until_delete_blocked(&self) {
-            self.delete_entered
-                .acquire()
-                .await
-                .expect("blocking store remains open")
-                .forget();
-        }
-
-        fn unblock_delete(&self) {
-            self.delete_release.add_permits(1);
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl ObjectStore for BlockingRepairDeleteStore {
-        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            self.inner.head(key).await
-        }
-
-        async fn get_with_metadata(
-            &self,
-            key: &str,
-        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
-            self.inner.get_with_metadata(key).await
-        }
-
-        async fn get(
-            &self,
-            key: &str,
-            range: Option<ByteRange>,
-        ) -> Result<Option<Bytes>, ObjectStoreError> {
-            self.inner.get(key, range).await
-        }
-
-        async fn put(
-            &self,
-            key: &str,
-            bytes: Bytes,
-            mode: PutMode,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            let installing_active_head = key == self.gate_key
-                && matches!(&mode, PutMode::CreateIfAbsent)
-                && decode_control_object::<HeadState>(&bytes, ControlObjectKind::WalHead)
-                    .is_ok_and(|envelope| envelope.state.state == NamespaceState::Active)
-                && !self.install_blocked_once.swap(true, Ordering::SeqCst);
-            if installing_active_head {
-                self.install_entered.add_permits(1);
-                self.install_release
-                    .acquire()
-                    .await
-                    .expect("blocking store remains open")
-                    .forget();
-                let result = self.inner.put(key, bytes, mode).await;
-                self.install_finished.add_permits(1);
-                return result;
-            }
-            self.inner.put(key, bytes, mode).await
-        }
-
-        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-            if key != self.gate_key && !self.delete_blocked_once.swap(true, Ordering::SeqCst) {
-                self.delete_entered.add_permits(1);
-                self.delete_release
-                    .acquire()
-                    .await
-                    .expect("blocking store remains open")
-                    .forget();
-            }
-            self.inner.delete(key).await
-        }
-
-        fn list_prefix_stream(
-            &self,
-            prefix: &str,
-        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
-        }
-    }
 
     fn context(now_ms: u64) -> MutationContext {
         MutationContext {
@@ -782,26 +656,51 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-        let store = BlockingRepairDeleteStore::new(store, wal_head(namespace_id.as_str()));
+        let gate_key = wal_head(namespace_id.as_str());
+        let delete_gate = Arc::new(BlockingStore::new(
+            store,
+            KeyPredicate::new({
+                let gate_key = gate_key.clone();
+                move |key| key != gate_key
+            }),
+            OperationClass::Delete,
+        ));
+        delete_gate.block_next();
+        let store = Arc::new(BlockingStore::matching(
+            delete_gate.clone(),
+            move |operation: &OperationContext<'_>| {
+                let OperationKind::Put {
+                    bytes,
+                    mode: PutMode::CreateIfAbsent,
+                } = operation.kind()
+                else {
+                    return false;
+                };
+                operation.key() == gate_key
+                    && decode_control_object::<HeadState>(bytes, ControlObjectKind::WalHead)
+                        .is_ok_and(|envelope| envelope.state.state == NamespaceState::Active)
+            },
+        ));
+        store.block_next();
 
         let create_context = context(1_000);
         let create = bootstrap_namespace(&store, &namespace_id, &create_context, false);
         let repair = async {
-            store.wait_until_install_blocked().await;
+            store.wait_until_blocked().await;
             // The create passed its absent probe and prepared its immutable
             // manifest, but is paused at the first fixed-key conditional
             // install write.
             let repair_context = context(u64::MAX);
             let repair = repair_namespace(&store, &namespace_id, &repair_context);
             let coordinate = async {
-                store.wait_until_delete_blocked().await;
+                delete_gate.wait_until_blocked().await;
                 let head = read_head_object(&store, &namespace_id)
                     .await
                     .expect("condemned gate is durable before subtree deletion");
                 assert_eq!(head.envelope.state.state, NamespaceState::Condemned);
-                store.unblock_install();
-                store.wait_until_install_finished().await;
-                store.unblock_delete();
+                store.release();
+                store.wait_until_completed().await;
+                delete_gate.release();
             };
             let (repair, ()) = tokio::join!(repair, coordinate);
             repair

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -313,16 +313,12 @@ mod tests {
         probe_durable_content_reference, read_durable_content_bytes,
         validate_durable_content_reference, DurableContentValidationError,
     };
-    use async_trait::async_trait;
     use bytes::Bytes;
-    use futures::stream::BoxStream;
     use loonfs_api::{ContentRef, ContentRefKind, ContentStoreId};
     use loonfs_objectstore::keys::content_blob;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
-    use loonfs_objectstore::{
-        ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-    };
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use loonfs_objectstore::ObjectStore;
+    use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -343,16 +339,16 @@ mod tests {
     #[tokio::test]
     async fn validate_whole_file_content_ref_reads_and_hashes_the_bytes() {
         let (_temp_dir, inner, content_store_id) = test_store();
-        let store = GetCountingStore::new(inner);
+        let store = CountingStore::new(inner, KeyPredicate::content_blob());
         let bytes = b"whole file bytes";
         let content_ref = ContentRef::whole_file_v0(bytes);
         put_content_object(&store, &content_store_id, &content_ref, bytes).await;
 
-        store.reset_content_blob_get_count();
+        store.reset();
         validate_durable_content_reference(&store, &content_store_id, &content_ref)
             .await
             .expect("validate content ref");
-        assert_eq!(store.content_blob_get_count(), 1);
+        assert_eq!(store.count(OperationClass::Read), 1);
     }
 
     #[tokio::test]
@@ -417,17 +413,17 @@ mod tests {
     #[tokio::test]
     async fn probe_whole_file_content_ref_proves_durability_without_reading() {
         let (_temp_dir, inner, content_store_id) = test_store();
-        let store = GetCountingStore::new(inner);
+        let store = CountingStore::new(inner, KeyPredicate::content_blob());
         let bytes = b"provider-verified bytes";
         let content_ref = ContentRef::whole_file_v0(bytes);
         put_content_object(&store, &content_store_id, &content_ref, bytes).await;
 
-        store.reset_content_blob_get_count();
+        store.reset();
         probe_durable_content_reference(&store, &content_store_id, &content_ref)
             .await
             .expect("probe content ref");
         assert_eq!(
-            store.content_blob_get_count(),
+            store.count(OperationClass::Read),
             0,
             "the probe proves durability from metadata alone"
         );
@@ -501,76 +497,5 @@ mod tests {
             .put_if_absent(&key, Bytes::copy_from_slice(bytes))
             .await
             .expect("put content");
-    }
-
-    #[derive(Debug)]
-    struct GetCountingStore {
-        inner: LocalFsStore,
-        content_blob_gets: AtomicUsize,
-    }
-
-    impl GetCountingStore {
-        fn new(inner: LocalFsStore) -> Self {
-            Self {
-                inner,
-                content_blob_gets: AtomicUsize::new(0),
-            }
-        }
-
-        fn content_blob_get_count(&self) -> usize {
-            self.content_blob_gets.load(Ordering::Relaxed)
-        }
-
-        fn reset_content_blob_get_count(&self) {
-            self.content_blob_gets.store(0, Ordering::Relaxed);
-        }
-    }
-
-    #[async_trait]
-    impl ObjectStore for GetCountingStore {
-        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            self.inner.head(key).await
-        }
-
-        async fn get(
-            &self,
-            key: &str,
-            range: Option<ByteRange>,
-        ) -> Result<Option<Bytes>, ObjectStoreError> {
-            if key.starts_with("content-stores/") && key.contains("/blobs/") {
-                self.content_blob_gets.fetch_add(1, Ordering::Relaxed);
-            }
-            self.inner.get(key, range).await
-        }
-
-        async fn get_with_metadata(
-            &self,
-            key: &str,
-        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
-            if key.starts_with("content-stores/") && key.contains("/blobs/") {
-                self.content_blob_gets.fetch_add(1, Ordering::Relaxed);
-            }
-            self.inner.get_with_metadata(key).await
-        }
-
-        async fn put(
-            &self,
-            key: &str,
-            bytes: Bytes,
-            mode: PutMode,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            self.inner.put(key, bytes, mode).await
-        }
-
-        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-            self.inner.delete(key).await
-        }
-
-        fn list_prefix_stream(
-            &self,
-            prefix: &str,
-        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
-        }
     }
 }

--- a/crates/loonfs-core/tests/common/mod.rs
+++ b/crates/loonfs-core/tests/common/mod.rs
@@ -1,0 +1,62 @@
+#![allow(dead_code)]
+
+use loonfs_api::NamespaceId;
+use loonfs_core::cache::{
+    MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
+    WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+};
+use loonfs_core::control::load_namespace_read_anchor;
+use loonfs_core::{MutationContext, NamespaceEngine, RuntimeReadContext};
+use loonfs_objectstore::ObjectStore;
+use std::sync::Arc;
+
+pub(crate) fn mutation_context(
+    writer_id: &str,
+    writer_session_id: &str,
+    writer_version: &str,
+    now_ms: u64,
+) -> MutationContext {
+    MutationContext {
+        writer_id: writer_id.to_owned(),
+        writer_session_id: writer_session_id.to_owned(),
+        writer_version: writer_version.to_owned(),
+        now_ms,
+    }
+}
+
+pub(crate) fn namespace_engine<'a, S: ObjectStore + ?Sized>(
+    store: &'a S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> NamespaceEngine<&'a S> {
+    NamespaceEngine::builder(store)
+        .namespace_id(namespace_id.clone())
+        .writer_id(context.writer_id.clone())
+        .writer_session_id(context.writer_session_id.clone())
+        .writer_version(context.writer_version.clone())
+        .build()
+        .expect("build namespace engine")
+}
+
+pub(crate) async fn read_context<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> RuntimeReadContext {
+    let (head, root) = load_namespace_read_anchor(store, namespace_id)
+        .await
+        .expect("load read anchor");
+    RuntimeReadContext {
+        head: head.state,
+        head_etag: head.identity.etag,
+        manifest_id: root.state.manifest_id,
+        manifest_object_id: root.state.manifest_object_id,
+        table_cache: Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default())),
+        tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
+            max_entries: 4,
+            max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+            max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
+        })),
+        catalog: None,
+    }
+}

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -3,31 +3,23 @@
 //! head, nothing correct depends on listing, and maintenance never touches
 //! the head.
 
-use async_trait::async_trait;
+mod common;
+
 use bytes::Bytes;
-use futures::stream::BoxStream;
+use common::{mutation_context, namespace_engine, read_context};
 use loonfs_api::v0::BeginUploadRequest;
 use loonfs_api::AbsolutePath;
-use loonfs_api::{ChangeSeq, EffectiveLimit, NamespaceId};
-use loonfs_core::cache::{
-    MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
-    WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
-};
+use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_core::content::{prepare_existing_content_ref, store_bytes_as_content};
-use loonfs_core::control::load_namespace_read_anchor;
 use loonfs_core::gc::{gc_namespace, GcConfig};
 use loonfs_core::publish::{
     NamespaceCommitEngine, NamespaceMutationCandidate, PathMutationIntent, PublishTailOptions,
 };
-use loonfs_core::{BootstrapOptions, MutationContext, NamespaceEngine, RuntimeReadContext};
+use loonfs_core::{BootstrapOptions, MutationContext};
 use loonfs_objectstore::keys::{wal_head, wal_segment_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use loonfs_objectstore::ObjectStore;
+use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
 use tempfile::tempdir;
 
 async fn put_file<S: ObjectStore + ?Sized>(
@@ -69,121 +61,19 @@ async fn put_file<S: ObjectStore + ?Sized>(
         .expect("put file");
 }
 
-async fn read_context<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-) -> RuntimeReadContext {
-    let (head, root) = load_namespace_read_anchor(store, namespace_id)
-        .await
-        .expect("load read anchor");
-    RuntimeReadContext {
-        head: head.state,
-        head_etag: head.identity.etag,
-        manifest_id: root.state.manifest_id,
-        manifest_object_id: root.state.manifest_object_id,
-        table_cache: Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default())),
-        tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
-            max_entries: 4,
-            max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
-            max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-        })),
-        catalog: None,
-    }
-}
-
-fn page_limit() -> EffectiveLimit {
-    EffectiveLimit::new(std::num::NonZeroU32::new(1024).expect("nonzero limit"))
-}
-
-fn context() -> MutationContext {
-    MutationContext {
-        writer_id: "acceptance".to_owned(),
-        writer_session_id: "wrs_acceptance".to_owned(),
-        writer_version: "acceptance/0.1.0".to_owned(),
-        now_ms: 1_000,
-    }
-}
-
-fn engine<'a, S: ObjectStore + ?Sized>(
-    store: &'a S,
-    namespace_id: &NamespaceId,
-    context: &MutationContext,
-) -> NamespaceEngine<&'a S> {
-    NamespaceEngine::builder(store)
-        .namespace_id(namespace_id.clone())
-        .writer_id(context.writer_id.clone())
-        .writer_session_id(context.writer_session_id.clone())
-        .writer_version(context.writer_version.clone())
-        .build()
-        .expect("build engine")
-}
-
-/// Counts every LIST issued through the store.
-#[derive(Debug)]
-struct ListCountingStore {
-    inner: LocalFsStore,
-    lists: AtomicUsize,
-}
-
-impl ListCountingStore {
-    fn list_count(&self) -> usize {
-        self.lists.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl ObjectStore for ListCountingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.lists.fetch_add(1, Ordering::SeqCst);
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
 /// Nothing correct depends on listing: reads, commits, and the change feed
 /// complete without a single LIST, even with junk parked in the segment
 /// collection (chain traversal never sees it).
 #[tokio::test]
 async fn reads_commits_and_change_feed_never_list() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ListCountingStore {
-        inner: LocalFsStore::new(temp_dir.path()).expect("store"),
-        lists: AtomicUsize::new(0),
-    };
+    let store = CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::any(),
+    );
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-    let context = context();
-    let engine = engine(&store, &namespace_id, &context);
+    let context = mutation_context("acceptance", "wrs_acceptance", "acceptance/0.1.0", 1_000);
+    let engine = namespace_engine(&store, &namespace_id, &context);
     engine
         .bootstrap_namespace(BootstrapOptions::default())
         .await
@@ -199,7 +89,7 @@ async fn reads_commits_and_change_feed_never_list() {
         .await
         .expect("write junk");
 
-    let baseline = store.list_count();
+    let baseline = store.count(OperationClass::List);
     let staged = engine
         .begin_upload(BeginUploadRequest::default())
         .await
@@ -235,7 +125,7 @@ async fn reads_commits_and_change_feed_never_list() {
         .list_path_page_with_runtime_context(
             "/docs",
             loonfs_api::PageRequest {
-                limit: page_limit(),
+                limit: loonfs_test_support::ids::page_limit(1024),
                 cursor: None,
             },
             &ctx,
@@ -248,13 +138,13 @@ async fn reads_commits_and_change_feed_never_list() {
         .expect("read");
     assert_eq!(bytes.bytes, b"hello\n");
     let changes = engine
-        .list_changes_after(ChangeSeq(0), page_limit())
+        .list_changes_after(ChangeSeq(0), loonfs_test_support::ids::page_limit(1024))
         .await
         .expect("change feed");
     assert!(!changes.changes.is_empty());
 
     assert_eq!(
-        store.list_count(),
+        store.count(OperationClass::List),
         baseline,
         "read, commit, upload, and change-feed paths must not LIST"
     );
@@ -268,8 +158,8 @@ async fn maintenance_never_touches_the_wal_head() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-    let context = context();
-    let engine = engine(&store, &namespace_id, &context);
+    let context = mutation_context("acceptance", "wrs_acceptance", "acceptance/0.1.0", 1_000);
+    let engine = namespace_engine(&store, &namespace_id, &context);
     engine
         .bootstrap_namespace(BootstrapOptions::default())
         .await

--- a/crates/loonfs-core/tests/mutation_guards.rs
+++ b/crates/loonfs-core/tests/mutation_guards.rs
@@ -3,8 +3,11 @@
 #![allow(clippy::panic)]
 // These integration tests use panic in unexpected match arms for precise diagnostics.
 
+mod common;
+
 use async_trait::async_trait;
 use bytes::Bytes;
+use common::{namespace_engine, read_context};
 use futures::stream::BoxStream;
 use loonfs_api::{
     sha256_digest,
@@ -26,13 +29,8 @@ use loonfs_api::{
     wire::wal::{decode_wal_segment_envelope_zstd, WalDelta},
     AbsolutePath, AuthoritativePathEntry, ChangeSeq, CommitId, ContentRef, ContentRefKind,
     ContentStoreId, DeleteDirectoryBehavior, DestinationBehavior, DirectoryPageCursor, DisplayName,
-    EffectiveLimit, InodeId, InodeKind, ManifestId, NameKey, NamespaceId, Page, PageRequest,
+    InodeId, InodeKind, ManifestId, NameKey, NamespaceId, Page, PageRequest,
     RepairNamespaceOutcome, RevisionNo, UploadId, WriterEpoch,
-};
-use loonfs_core::cache::{
-    MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
-    WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
 use loonfs_core::commit::{
     build_commit_plan, core_commit_fingerprint_for_v0_request, materialize_commit, CommitOpResult,
@@ -41,14 +39,14 @@ use loonfs_core::commit::{
 use loonfs_core::content::{
     mint_content_token, prepare_existing_content_ref, store_bytes_as_content, verify_content_token,
 };
-use loonfs_core::control::{load_namespace_head_control, load_namespace_read_anchor};
+use loonfs_core::control::load_namespace_head_control;
 use loonfs_core::metadata::MetadataState;
 use loonfs_core::publish::{
     NamespaceCommitEngine, NamespaceMutationCandidate, PathMutationIntent, PublishTailOptions,
 };
 use loonfs_core::{
     repair_namespace, BeginDirectPutUploadTargetResponse, BootstrapOptions, Error as CoreError,
-    ErrorCode, MutationContext, NamespaceEngine, RuntimeReadContext,
+    ErrorCode, MutationContext,
 };
 use loonfs_objectstore::keys::{
     content_blob, content_store_descriptor, metadata_manifest_object, namespace_config,
@@ -58,11 +56,15 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
+use loonfs_test_support::ids::{namespace_id, page_limit};
+use loonfs_test_support::stores::{
+    CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass, OperationContext,
+    OperationKind,
+};
 use std::collections::HashSet;
-use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use tempfile::tempdir;
 
 #[derive(Debug, Clone)]
@@ -72,20 +74,6 @@ struct BindingIdentity {
     child_inode_id: InodeId,
     bind_seq: ChangeSeq,
     bind_delta_index: u32,
-}
-
-fn namespace_engine<'a, S: ObjectStore + ?Sized>(
-    store: &'a S,
-    namespace_id: &NamespaceId,
-    context: &MutationContext,
-) -> NamespaceEngine<&'a S> {
-    NamespaceEngine::builder(store)
-        .namespace_id(namespace_id.clone())
-        .writer_id(context.writer_id.clone())
-        .writer_session_id(context.writer_session_id.clone())
-        .writer_version(context.writer_version.clone())
-        .build()
-        .expect("test context should build namespace engine")
 }
 
 async fn bootstrap_namespace<S: ObjectStore + ?Sized>(
@@ -282,28 +270,6 @@ fn test_display_name(value: impl AsRef<str>) -> DisplayName {
 
 /// Pins the current head and manifest the way the runtime does before a
 /// read.
-async fn read_context<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-) -> RuntimeReadContext {
-    let (head, root) = load_namespace_read_anchor(store, namespace_id)
-        .await
-        .expect("load read anchor");
-    RuntimeReadContext {
-        head: head.state,
-        head_etag: head.identity.etag,
-        manifest_id: root.state.manifest_id,
-        manifest_object_id: root.state.manifest_object_id,
-        table_cache: Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default())),
-        tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
-            max_entries: 4,
-            max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
-            max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-        })),
-        catalog: None,
-    }
-}
-
 /// Publishes one path intent through the commit engine — the single publish
 /// pipeline.
 async fn admitted_candidate<S: ObjectStore + ?Sized>(
@@ -586,10 +552,6 @@ async fn list_path<S: ObjectStore + ?Sized>(
     }
 }
 
-fn page_limit(value: u32) -> EffectiveLimit {
-    EffectiveLimit::new(NonZeroU32::new(value).expect("page limit should be non-zero"))
-}
-
 async fn list_path_page<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -836,7 +798,7 @@ async fn stale_revision_precondition_is_rejected() {
     ]);
     let context = validation_context(&metadata_state, ChangeSeq(3), InodeId(4));
     let request = CommitRequest {
-        namespace_id: namespace_id(),
+        namespace_id: namespace_id("demo"),
         commit_id: CommitId::parse("stale-revision").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_session_id: "wrs_test".to_owned(),
@@ -868,7 +830,7 @@ async fn failed_multi_op_plan_uses_preview_without_mutating_base_metadata() {
     let metadata_state = metadata_state_after(&[]);
     let context = validation_context(&metadata_state, ChangeSeq(0), InodeId(2));
     let request = CommitRequest {
-        namespace_id: namespace_id(),
+        namespace_id: namespace_id("demo"),
         commit_id: CommitId::parse("preview-rollback").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_session_id: "wrs_test".to_owned(),
@@ -928,7 +890,7 @@ async fn create_and_replace_under_ancestor_tombstone_are_rejected() {
 
     let create_error = build_commit_plan(
         &CommitRequest {
-            namespace_id: namespace_id(),
+            namespace_id: namespace_id("demo"),
             commit_id: CommitId::parse("create-under-tombstone").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_session_id: "wrs_test".to_owned(),
@@ -956,7 +918,7 @@ async fn create_and_replace_under_ancestor_tombstone_are_rejected() {
 
     let replace_error = build_commit_plan(
         &CommitRequest {
-            namespace_id: namespace_id(),
+            namespace_id: namespace_id("demo"),
             commit_id: CommitId::parse("replace-under-tombstone").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_session_id: "wrs_test".to_owned(),
@@ -993,7 +955,7 @@ async fn restore_revision_validation_rejects_missing_inode() {
     )]);
     let context = validation_context(&metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
-        namespace_id: namespace_id(),
+        namespace_id: namespace_id("demo"),
         commit_id: CommitId::parse("restore-missing-inode").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_session_id: "wrs_test".to_owned(),
@@ -1028,7 +990,7 @@ async fn restore_revision_validation_rejects_non_file_target() {
     )]);
     let context = validation_context(&metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
-        namespace_id: namespace_id(),
+        namespace_id: namespace_id("demo"),
         commit_id: CommitId::parse("restore-non-file").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_session_id: "wrs_test".to_owned(),
@@ -1071,7 +1033,7 @@ async fn restore_revision_validation_rejects_stale_or_missing_source_revision() 
 
     let stale_base = build_commit_plan(
         &CommitRequest {
-            namespace_id: namespace_id(),
+            namespace_id: namespace_id("demo"),
             commit_id: CommitId::parse("restore-stale-base").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_session_id: "wrs_test".to_owned(),
@@ -1100,7 +1062,7 @@ async fn restore_revision_validation_rejects_stale_or_missing_source_revision() 
 
     let missing_source = build_commit_plan(
         &CommitRequest {
-            namespace_id: namespace_id(),
+            namespace_id: namespace_id("demo"),
             commit_id: CommitId::parse("restore-missing-source").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_session_id: "wrs_test".to_owned(),
@@ -1142,7 +1104,7 @@ async fn restore_revision_can_reference_revision_created_earlier_in_same_request
     let context = validation_context(&metadata_state, ChangeSeq(2), InodeId(4));
 
     let request = CommitRequest {
-        namespace_id: namespace_id(),
+        namespace_id: namespace_id("demo"),
         commit_id: CommitId::parse("restore-same-request-source").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_session_id: "wrs_test".to_owned(),
@@ -1195,7 +1157,7 @@ async fn restore_revision_can_reference_restore_created_earlier_in_same_request(
     let context = validation_context(&metadata_state, ChangeSeq(3), InodeId(4));
 
     let request = CommitRequest {
-        namespace_id: namespace_id(),
+        namespace_id: namespace_id("demo"),
         commit_id: CommitId::parse("restore-after-restore-same-request").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_session_id: "wrs_test".to_owned(),
@@ -1256,7 +1218,7 @@ async fn restore_revision_under_tombstoned_ancestor_is_rejected() {
 
     let error = build_commit_plan(
         &CommitRequest {
-            namespace_id: namespace_id(),
+            namespace_id: namespace_id("demo"),
             commit_id: CommitId::parse("restore-under-tombstone").expect("valid commit id"),
             writer_id: "writer-a".to_owned(),
             writer_session_id: "wrs_test".to_owned(),
@@ -1313,7 +1275,7 @@ async fn restore_revision_overflow_is_rejected() {
         .metadata_state;
     let context = validation_context(&metadata_state, ChangeSeq(1), InodeId(3));
     let request = CommitRequest {
-        namespace_id: namespace_id(),
+        namespace_id: namespace_id("demo"),
         commit_id: CommitId::parse("restore-overflow").expect("valid commit id"),
         writer_id: "writer-a".to_owned(),
         writer_session_id: "wrs_test".to_owned(),
@@ -1344,7 +1306,7 @@ async fn namespace_creation_writes_descriptors_and_rejects_partial_recreation() 
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -1452,7 +1414,7 @@ async fn namespace_creation_writes_descriptors_and_rejects_partial_recreation() 
 #[tokio::test]
 async fn bootstrap_head_lost_ack_stays_partial_until_explicit_repair() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let context = mutation_context();
     let store = InjectCreateFailureStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -1496,7 +1458,7 @@ async fn bootstrap_head_lost_ack_stays_partial_until_explicit_repair() {
 #[tokio::test]
 async fn bootstrap_head_conflict_rechecks_complete_namespace() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let context = mutation_context();
     // The injected conflict simulates a racing create that completed the
     // namespace: its head wins the reservation and its descriptor pair is
@@ -1640,18 +1602,18 @@ async fn begin_upload_does_not_read_manifest_or_wal_replay_objects() {
     .await
     .expect("replace file");
 
-    let guarded_store = ReplayReadGuardStore::new(temp_dir.path(), namespace_id.as_str());
+    let guarded_store = replay_read_guard_store(temp_dir.path(), namespace_id.as_str());
     let begin = begin_upload(&guarded_store, &namespace_id, &context)
         .await
         .expect("begin upload");
     assert_eq!(begin.namespace_id, namespace_id);
-    assert_eq!(guarded_store.guarded_get_count(), 0);
+    assert_eq!(guarded_store.attempts(), 0);
 }
 
 #[tokio::test]
 async fn complete_upload_does_not_get_content_blob_after_staging() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let store = content_blob_counting_store(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
@@ -1665,7 +1627,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
         .await
         .expect("upload content");
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let completed = complete_upload(
         &store,
         &namespace_id,
@@ -1678,9 +1640,9 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     .await
     .expect("complete upload");
     assert_eq!(completed.content_ref, uploaded.content_ref);
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let completed_again = complete_upload(
         &store,
         &namespace_id,
@@ -1693,7 +1655,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     .await
     .expect("complete upload idempotently");
     assert_eq!(completed_again.content_ref, completed.content_ref);
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 
     let mismatch_begin = begin_upload(&store, &namespace_id, &context)
         .await
@@ -1710,7 +1672,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     let wrong_ref = ContentRef::whole_file_v0(b"different");
     assert_ne!(wrong_ref, mismatch_uploaded.content_ref);
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let mismatch = complete_upload(
         &store,
         &namespace_id,
@@ -1723,7 +1685,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     .await
     .expect_err("mismatched content ref");
     assert_eq!(mismatch.code(), ErrorCode::InvalidRequest);
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 }
 
 #[tokio::test]
@@ -1781,7 +1743,7 @@ async fn complete_upload_rejects_direct_put_session_without_bound_target() {
 #[tokio::test]
 async fn path_put_file_without_admission_fails_without_reading_content() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let store = content_blob_counting_store(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
@@ -1792,7 +1754,7 @@ async fn path_put_file_without_admission_fails_without_reading_content() {
         .await
         .expect("stage content");
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let responses = publish_namespace_mutations_batch(
         &store,
         &namespace_id,
@@ -1815,13 +1777,13 @@ async fn path_put_file_without_admission_fails_without_reading_content() {
             .code(),
         ErrorCode::ContentNotPrepared
     );
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 }
 
 #[tokio::test]
 async fn path_batch_rejects_repeated_unadmitted_content_without_reading_it() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let store = content_blob_counting_store(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
@@ -1832,7 +1794,7 @@ async fn path_batch_rejects_repeated_unadmitted_content_without_reading_it() {
         .await
         .expect("stage content");
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let responses = publish_namespace_mutations_batch(
         &store,
         &namespace_id,
@@ -1859,13 +1821,13 @@ async fn path_batch_rejects_repeated_unadmitted_content_without_reading_it() {
             .as_ref()
             .is_err_and(|error| error.code() == ErrorCode::ContentNotPrepared)
     }));
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 }
 
 #[tokio::test]
 async fn valid_content_admission_skips_durable_content_validation() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let store = content_blob_counting_store(temp_dir.path());
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
 
@@ -1896,7 +1858,7 @@ async fn valid_content_admission_skips_durable_content_validation() {
     )
     .expect("verify token");
 
-    store.reset_content_blob_counters();
+    store.reset();
     let responses = publish_namespace_mutations_batch(
         &store,
         &namespace_id,
@@ -1915,15 +1877,15 @@ async fn valid_content_admission_skips_durable_content_validation() {
 
     assert!(responses[0].is_ok());
     // A live admission is the fast path: no content read at all.
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 }
 
 #[tokio::test]
 async fn metadata_queries_do_not_get_content_blobs_but_file_reads_do_once() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let store = content_blob_counting_store(temp_dir.path());
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -1949,16 +1911,16 @@ async fn metadata_queries_do_not_get_content_blobs_but_file_reads_do_once() {
         .expect("put file");
     }
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let stat = resolve_path(&store, &namespace_id, "/docs/file-1.txt")
         .await
         .expect("stat file");
     assert_eq!(stat.inode_kind, InodeKind::File);
     assert_eq!(stat.size_bytes, Some("file-1-bytes".len() as u64));
     assert!(stat.content_ref.is_some());
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let entries = list_path(&store, &namespace_id, "/docs")
         .await
         .expect("list docs");
@@ -1968,14 +1930,14 @@ async fn metadata_queries_do_not_get_content_blobs_but_file_reads_do_once() {
         assert_eq!(entry.size_bytes, Some("file-0-bytes".len() as u64));
         assert!(entry.content_ref.is_some());
     }
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let read = read_file_bytes(&store, &namespace_id, "/docs/file-1.txt")
         .await
         .expect("read file");
     assert_eq!(read.bytes, b"file-1-bytes");
-    assert_eq!(store.content_blob_get_count(), 1);
+    assert_eq!(store.count(OperationClass::Read), 1);
 }
 
 #[tokio::test]
@@ -1983,7 +1945,7 @@ async fn query_driven_reads_use_initial_manifest_with_wal_overlay() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -2014,9 +1976,9 @@ async fn query_driven_reads_use_initial_manifest_with_wal_overlay() {
 #[tokio::test]
 async fn query_driven_stat_and_list_use_metadata_view_with_l0_run_and_wal_overlay() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let store = content_blob_counting_store(temp_dir.path());
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -2114,7 +2076,7 @@ async fn query_driven_stat_and_list_use_metadata_view_with_l0_run_and_wal_overla
         .await
         .expect("file list");
 
-    store.reset_content_blob_get_count();
+    store.reset();
     let actual_stat = resolve_path_latest(&store, &namespace_id, "/docs/moved.txt")
         .await
         .expect("materialized stat");
@@ -2132,7 +2094,7 @@ async fn query_driven_stat_and_list_use_metadata_view_with_l0_run_and_wal_overla
     assert_eq!(actual_casefold_stat, expected_stat);
     assert_eq!(actual_list, expected_list);
     assert_eq!(actual_file_list, expected_file_list);
-    assert_eq!(store.content_blob_get_count(), 0);
+    assert_eq!(store.count(OperationClass::Read), 0);
 
     assert!(resolve_path_latest(&store, &namespace_id, "/docs/a.txt")
         .await
@@ -2145,9 +2107,9 @@ async fn query_driven_stat_and_list_use_metadata_view_with_l0_run_and_wal_overla
 #[tokio::test]
 async fn query_driven_stat_uses_exact_name_key_for_dash_containing_siblings() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = ContentBlobGetCountingStore::new(temp_dir.path());
+    let store = content_blob_counting_store(temp_dir.path());
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -2195,7 +2157,7 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -2261,7 +2223,7 @@ async fn wide_directory_listing_resolves_tail_unbinds_cross_directory_renames_an
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -2388,7 +2350,7 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -3217,7 +3179,7 @@ async fn ack_lost_head_cas_reports_unknown_outcome_and_replays_idempotently() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = mutation_context();
-    let store = AckLostHeadCasStore::new(temp_dir.path(), &namespace_id);
+    let store = ack_lost_head_cas_store(temp_dir.path(), &namespace_id);
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
         .expect("bootstrap");
@@ -4368,7 +4330,7 @@ async fn namespace_descriptor_checksum_is_validated() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -4408,9 +4370,9 @@ async fn namespace_descriptor_checksum_is_validated() {
 #[tokio::test]
 async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = MetadataSstGetCountingStore::new(temp_dir.path());
+    let store = metadata_table_counting_store(temp_dir.path());
     let context = mutation_context();
-    let source_namespace_id = namespace_id();
+    let source_namespace_id = namespace_id("demo");
     let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
 
     bootstrap_namespace(&store, &source_namespace_id, &context, false)
@@ -4446,12 +4408,12 @@ async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
         .await
         .expect("list blobs before fork");
 
-    store.reset_metadata_sst_get_count();
+    store.reset();
     fork_namespace(&store, &source_namespace_id, &clone_namespace_id, &context)
         .await
         .expect("fork namespace");
     assert_eq!(
-        store.metadata_sst_get_count(),
+        store.count(OperationClass::Read),
         0,
         "fork should validate manifest descriptors without loading metadata SST payloads"
     );
@@ -4673,7 +4635,7 @@ async fn fork_namespace_rejects_corrupt_source_manifest_descriptors() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let source_namespace_id = namespace_id();
+    let source_namespace_id = namespace_id("demo");
     let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
 
     bootstrap_namespace(&store, &source_namespace_id, &context, false)
@@ -4744,7 +4706,7 @@ async fn fork_namespace_rejects_corrupt_source_manifest_descriptors() {
 #[tokio::test]
 async fn fork_target_head_reservation_failure_keeps_descriptor_unpublished() {
     let temp_dir = tempdir().expect("tempdir");
-    let source_namespace_id = namespace_id();
+    let source_namespace_id = namespace_id("demo");
     let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let store = InjectCreateFailureStore::new(
@@ -4794,7 +4756,7 @@ async fn fork_target_head_reservation_failure_keeps_descriptor_unpublished() {
 #[tokio::test]
 async fn fork_source_checkpoint_failure_leaves_target_namespace_absent() {
     let temp_dir = tempdir().expect("tempdir");
-    let source_namespace_id = namespace_id();
+    let source_namespace_id = namespace_id("demo");
     let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let store = InjectCreateFailureStore::new(
@@ -4853,7 +4815,7 @@ async fn fork_source_checkpoint_failure_leaves_target_namespace_absent() {
 #[tokio::test]
 async fn fork_target_manifest_failure_leaves_target_namespace_absent() {
     let temp_dir = tempdir().expect("tempdir");
-    let source_namespace_id = namespace_id();
+    let source_namespace_id = namespace_id("demo");
     let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let store = InjectCreateFailureStore::new(
@@ -4912,7 +4874,7 @@ async fn fork_target_manifest_failure_leaves_target_namespace_absent() {
 #[tokio::test]
 async fn fork_failure_after_target_head_before_descriptor_remains_partial() {
     let temp_dir = tempdir().expect("tempdir");
-    let source_namespace_id = namespace_id();
+    let source_namespace_id = namespace_id("demo");
     let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let store = InjectCreateFailureStore::new(
@@ -4961,7 +4923,7 @@ async fn fork_failure_after_target_head_before_descriptor_remains_partial() {
 #[tokio::test]
 async fn fork_target_control_conflict_rechecks_complete_namespace() {
     let temp_dir = tempdir().expect("tempdir");
-    let source_namespace_id = namespace_id();
+    let source_namespace_id = namespace_id("demo");
     let clone_namespace_id = NamespaceId::parse("clone").expect("valid namespace id");
     let context = mutation_context();
     let inner = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -5019,16 +4981,16 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
 
-    let first = store_bytes_as_content(&store, &namespace_id(), b"first")
+    let first = store_bytes_as_content(&store, &namespace_id("demo"), b"first")
         .await
         .expect("stage first");
     commit_operations(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         ApiCommitRequest {
             commit_id: CommitId::parse("restore-create").expect("valid commit id"),
             preconditions: Vec::new(),
@@ -5043,17 +5005,17 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
     )
     .await
     .expect("create file");
-    let inode_id = resolve_path(&store, &namespace_id(), "/restore.txt")
+    let inode_id = resolve_path(&store, &namespace_id("demo"), "/restore.txt")
         .await
         .expect("resolve created file")
         .inode_id;
 
-    let second = store_bytes_as_content(&store, &namespace_id(), b"second")
+    let second = store_bytes_as_content(&store, &namespace_id("demo"), b"second")
         .await
         .expect("stage second");
     commit_operations(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         ApiCommitRequest {
             commit_id: CommitId::parse("restore-replace").expect("valid commit id"),
             preconditions: Vec::new(),
@@ -5079,7 +5041,7 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
 
     let response = commit_operations(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         ApiCommitRequest {
             commit_id: CommitId::parse("restore-missing-content").expect("valid commit id"),
             preconditions: Vec::new(),
@@ -5102,12 +5064,12 @@ async fn metadata_only_commit_does_not_validate_content_store_refs() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/delete-me.txt",
         b"hello",
         &context,
@@ -5115,7 +5077,7 @@ async fn metadata_only_commit_does_not_validate_content_store_refs() {
     )
     .await
     .expect("seed file");
-    let inode_id = resolve_path(&store, &namespace_id(), "/docs/delete-me.txt")
+    let inode_id = resolve_path(&store, &namespace_id("demo"), "/docs/delete-me.txt")
         .await
         .expect("resolve seeded file")
         .inode_id;
@@ -5123,7 +5085,7 @@ async fn metadata_only_commit_does_not_validate_content_store_refs() {
     let guarded_store = ContentStoreAccessLimitStore::new(temp_dir.path(), 1);
     let response = commit_operations(
         &guarded_store,
-        &namespace_id(),
+        &namespace_id("demo"),
         ApiCommitRequest {
             commit_id: CommitId::parse("metadata-only-delete").expect("valid commit id"),
             preconditions: Vec::new(),
@@ -5148,7 +5110,7 @@ async fn explicit_create_file_fails_unprepared_before_parent_validation_without_
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
 
@@ -5156,7 +5118,7 @@ async fn explicit_create_file_fails_unprepared_before_parent_validation_without_
     let missing_content = content_ref("missing-content");
     let error = publish_namespace_mutations_batch(
         &guarded_store,
-        &namespace_id(),
+        &namespace_id("demo"),
         vec![NamespaceMutationCandidate::commit(ApiCommitRequest {
             commit_id: CommitId::parse("create-missing-parent-unprepared-content")
                 .expect("valid commit id"),
@@ -5191,12 +5153,12 @@ async fn explicit_replace_file_fails_unprepared_before_revision_validation_witho
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/replace.txt",
         b"first",
         &context,
@@ -5204,7 +5166,7 @@ async fn explicit_replace_file_fails_unprepared_before_revision_validation_witho
     )
     .await
     .expect("seed replace target");
-    let inode_id = resolve_path(&store, &namespace_id(), "/docs/replace.txt")
+    let inode_id = resolve_path(&store, &namespace_id("demo"), "/docs/replace.txt")
         .await
         .expect("resolve path")
         .inode_id;
@@ -5213,7 +5175,7 @@ async fn explicit_replace_file_fails_unprepared_before_revision_validation_witho
     let missing_content = content_ref("missing-content");
     let error = publish_namespace_mutations_batch(
         &guarded_store,
-        &namespace_id(),
+        &namespace_id("demo"),
         vec![NamespaceMutationCandidate::commit(ApiCommitRequest {
             commit_id: CommitId::parse("replace-stale-missing-content").expect("valid commit id"),
             preconditions: Vec::new(),
@@ -5247,12 +5209,12 @@ async fn restore_revision_missing_source_is_revision_not_found() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/restore.txt",
         b"first",
         &context,
@@ -5260,14 +5222,14 @@ async fn restore_revision_missing_source_is_revision_not_found() {
     )
     .await
     .expect("seed restore target");
-    let inode_id = resolve_path(&store, &namespace_id(), "/docs/restore.txt")
+    let inode_id = resolve_path(&store, &namespace_id("demo"), "/docs/restore.txt")
         .await
         .expect("resolve path")
         .inode_id;
 
     let error = commit_operations(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         ApiCommitRequest {
             commit_id: CommitId::parse("restore-missing-source").expect("valid commit id"),
             preconditions: Vec::new(),
@@ -5290,21 +5252,21 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
 
-    let content = store_bytes_as_content(&store, &namespace_id(), b"idempotent")
+    let content = store_bytes_as_content(&store, &namespace_id("demo"), b"idempotent")
         .await
         .expect("stage content");
     let commit_id = CommitId::parse("idempotent-put-without-token").expect("valid commit id");
     let first = publish_namespace_mutations_batch(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         vec![
             admitted_candidate(
                 &store,
-                &namespace_id(),
+                &namespace_id("demo"),
                 PathMutationIntent::PutFile {
                     commit_id: commit_id.clone(),
                     absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
@@ -5328,7 +5290,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
 
     let retry = publish_namespace_mutations_batch(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         vec![NamespaceMutationCandidate::path(
             PathMutationIntent::PutFile {
                 commit_id,
@@ -5353,12 +5315,12 @@ async fn move_path_into_occupied_target_is_path_conflict() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/a.txt",
         b"alpha",
         &context,
@@ -5368,7 +5330,7 @@ async fn move_path_into_occupied_target_is_path_conflict() {
     .expect("seed docs");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/tmp/a.txt",
         b"tmp-a",
         &context,
@@ -5379,7 +5341,7 @@ async fn move_path_into_occupied_target_is_path_conflict() {
 
     let error = move_path(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/tmp/a.txt",
         "/docs/a.txt",
         &context,
@@ -5395,12 +5357,12 @@ async fn move_path_directory_cycle_is_would_cycle() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/archive/leaf.txt",
         b"leaf",
         &context,
@@ -5411,7 +5373,7 @@ async fn move_path_directory_cycle_is_would_cycle() {
 
     let error = move_path(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs",
         "/docs/archive/docs",
         &context,
@@ -5427,12 +5389,12 @@ async fn write_and_move_under_deleted_ancestor_start_fresh_subtrees() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/old.txt",
         b"old",
         &context,
@@ -5442,7 +5404,7 @@ async fn write_and_move_under_deleted_ancestor_start_fresh_subtrees() {
     .expect("seed docs");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/tmp/source.txt",
         b"source",
         &context,
@@ -5452,7 +5414,7 @@ async fn write_and_move_under_deleted_ancestor_start_fresh_subtrees() {
     .expect("seed source");
     delete_path(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs",
         &context,
         Some("delete-docs"),
@@ -5466,7 +5428,7 @@ async fn write_and_move_under_deleted_ancestor_start_fresh_subtrees() {
     // previous child is not resurrected by the recreation.
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/new.txt",
         b"new",
         &context,
@@ -5474,12 +5436,12 @@ async fn write_and_move_under_deleted_ancestor_start_fresh_subtrees() {
     )
     .await
     .expect("put recreates the subtree");
-    let old_child = resolve_path(&store, &namespace_id(), "/docs/old.txt").await;
+    let old_child = resolve_path(&store, &namespace_id("demo"), "/docs/old.txt").await;
     assert!(old_child.is_err(), "dead subtree child must stay invisible");
 
     move_path(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/tmp/source.txt",
         "/docs/source.txt",
         &context,
@@ -5494,13 +5456,13 @@ async fn create_directory_path_creates_directory_without_auto_parents() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
 
     let created = create_directory_path(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs",
         &context,
         Some("mkdir-docs"),
@@ -5508,14 +5470,14 @@ async fn create_directory_path_creates_directory_without_auto_parents() {
     .await
     .expect("create dir");
     assert_eq!(created.committed_seq, ChangeSeq(1));
-    let docs = resolve_path(&store, &namespace_id(), "/docs")
+    let docs = resolve_path(&store, &namespace_id("demo"), "/docs")
         .await
         .expect("resolve docs");
     assert_eq!(docs.inode_kind, InodeKind::Directory);
 
     let missing_parent = create_directory_path(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/missing/nested",
         &context,
         Some("mkdir-missing-parent"),
@@ -5530,12 +5492,12 @@ async fn path_move_writes_unbind_and_stale_binding_is_fails() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/a.txt",
         b"hello",
         &context,
@@ -5543,15 +5505,16 @@ async fn path_move_writes_unbind_and_stale_binding_is_fails() {
     )
     .await
     .expect("seed file");
-    let file = resolve_path(&store, &namespace_id(), "/docs/a.txt")
+    let file = resolve_path(&store, &namespace_id("demo"), "/docs/a.txt")
         .await
         .expect("resolve file");
     let old_binding =
-        latest_binding_for_child_from_change_feed(&store, &namespace_id(), file.inode_id).await;
+        latest_binding_for_child_from_change_feed(&store, &namespace_id("demo"), file.inode_id)
+            .await;
 
     move_path(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/a.txt",
         "/docs/b.txt",
         &context,
@@ -5559,7 +5522,7 @@ async fn path_move_writes_unbind_and_stale_binding_is_fails() {
     )
     .await
     .expect("move file");
-    let unbind_count = list_changes_after(&store, &namespace_id(), ChangeSeq(0))
+    let unbind_count = list_changes_after(&store, &namespace_id("demo"), ChangeSeq(0))
         .await
         .expect("change feed")
         .changes
@@ -5568,16 +5531,16 @@ async fn path_move_writes_unbind_and_stale_binding_is_fails() {
         .filter(|delta| matches!(delta, CommitDelta::UnbindDirentry { .. }))
         .count();
     assert_eq!(unbind_count, 1);
-    assert!(resolve_path(&store, &namespace_id(), "/docs/a.txt")
+    assert!(resolve_path(&store, &namespace_id("demo"), "/docs/a.txt")
         .await
         .is_err());
-    resolve_path(&store, &namespace_id(), "/docs/b.txt")
+    resolve_path(&store, &namespace_id("demo"), "/docs/b.txt")
         .await
         .expect("new path visible");
 
     let stale_binding = commit_operations(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         ApiCommitRequest {
             commit_id: CommitId::parse("delete-with-stale-binding").expect("valid commit id"),
             preconditions: vec![CommitPrecondition::BindingIs {
@@ -5604,12 +5567,12 @@ async fn put_file_no_replace_rejects_existing_target_without_force() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/hello.txt",
         b"hello",
         &context,
@@ -5620,7 +5583,7 @@ async fn put_file_no_replace_rejects_existing_target_without_force() {
 
     let error = put_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/hello.txt",
         b"new-bytes",
         DestinationBehavior::NoReplace,
@@ -5637,12 +5600,12 @@ async fn delete_path_non_recursive_rejects_non_empty_directory() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/hello.txt",
         b"hello",
         &context,
@@ -5653,7 +5616,7 @@ async fn delete_path_non_recursive_rejects_non_empty_directory() {
 
     let error = delete_path_non_recursive(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs",
         &context,
         Some("delete-docs"),
@@ -5668,12 +5631,12 @@ async fn copy_file_path_creates_new_inode_and_reuses_content_blob() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/source.txt",
         b"hello",
         &context,
@@ -5684,7 +5647,7 @@ async fn copy_file_path_creates_new_inode_and_reuses_content_blob() {
 
     copy_file_path(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/docs/source.txt",
         "/docs/copy.txt",
         &context,
@@ -5693,10 +5656,10 @@ async fn copy_file_path_creates_new_inode_and_reuses_content_blob() {
     .await
     .expect("copy file");
 
-    let source = resolve_path(&store, &namespace_id(), "/docs/source.txt")
+    let source = resolve_path(&store, &namespace_id("demo"), "/docs/source.txt")
         .await
         .expect("source stat");
-    let copy = resolve_path(&store, &namespace_id(), "/docs/copy.txt")
+    let copy = resolve_path(&store, &namespace_id("demo"), "/docs/copy.txt")
         .await
         .expect("copy stat");
     assert_ne!(source.inode_id, copy.inode_id);
@@ -5713,12 +5676,12 @@ async fn resolve_path_uses_nfc_casefold_name_policy() {
     let context = mutation_context();
     let stored_path = "/Cafe\u{0301}.txt";
     let lookup_path = "/CAF\u{00c9}.TXT";
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         stored_path,
         b"hello",
         &context,
@@ -5727,7 +5690,7 @@ async fn resolve_path_uses_nfc_casefold_name_policy() {
     .await
     .expect("seed unicode name");
 
-    let resolved = resolve_path(&store, &namespace_id(), lookup_path)
+    let resolved = resolve_path(&store, &namespace_id("demo"), lookup_path)
         .await
         .expect("resolve path");
     assert_eq!(resolved.absolute_path, stored_path);
@@ -5739,12 +5702,12 @@ async fn no_replace_put_rejects_casefold_and_normalization_equivalent_name() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
     write_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/Cafe\u{0301}.txt",
         b"hello",
         &context,
@@ -5755,7 +5718,7 @@ async fn no_replace_put_rejects_casefold_and_normalization_equivalent_name() {
 
     let error = put_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/CAF\u{00c9}.TXT",
         b"new-bytes",
         DestinationBehavior::NoReplace,
@@ -5988,7 +5951,7 @@ fn validation_context(
     seq: ChangeSeq,
     next_inode_id: InodeId,
 ) -> CommitValidationContext<'_> {
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let head = HeadState {
         namespace_id: namespace_id.clone(),
         seq,
@@ -6012,16 +5975,7 @@ fn validation_context(
 }
 
 fn mutation_context() -> MutationContext {
-    MutationContext {
-        writer_id: "writer-a".to_owned(),
-        writer_session_id: "wrs_test".to_owned(),
-        writer_version: "writer-a/0.1.0".to_owned(),
-        now_ms: 1_000,
-    }
-}
-
-fn namespace_id() -> NamespaceId {
-    NamespaceId::parse("demo").expect("valid namespace id")
+    common::mutation_context("writer-a", "wrs_test", "writer-a/0.1.0", 1_000)
 }
 
 fn content_ref(seed: &str) -> ContentRef {
@@ -6032,228 +5986,33 @@ fn content_ref(seed: &str) -> ContentRef {
     }
 }
 
-#[derive(Debug)]
-struct ReplayReadGuardStore {
-    inner: LocalFsStore,
-    guarded_prefixes: Vec<String>,
-    guarded_gets: AtomicUsize,
+fn replay_read_guard_store(root: impl AsRef<Path>, namespace: &str) -> FailStore<LocalFsStore> {
+    let wal_prefix = format!("namespaces/{namespace}/wal/segments/");
+    let manifest_prefix = format!("namespaces/{namespace}/metadata/manifests/");
+    let store = FailStore::new(
+        LocalFsStore::new(root.as_ref()).expect("store"),
+        KeyPredicate::new(move |key| {
+            key.starts_with(&wal_prefix) || key.starts_with(&manifest_prefix)
+        }),
+        OperationClass::Read,
+        InjectedError::Transport("begin_upload unexpectedly read replay object".to_owned()),
+    );
+    store.fail_all();
+    store
 }
 
-impl ReplayReadGuardStore {
-    fn new(root: impl AsRef<Path>, namespace: &str) -> Self {
-        Self {
-            inner: LocalFsStore::new(root.as_ref()).expect("store"),
-            guarded_prefixes: vec![
-                format!("namespaces/{namespace}/wal/segments/"),
-                format!("namespaces/{namespace}/metadata/manifests/"),
-            ],
-            guarded_gets: AtomicUsize::new(0),
-        }
-    }
-
-    fn guarded_get_count(&self) -> usize {
-        self.guarded_gets.load(Ordering::SeqCst)
-    }
-
-    fn reject_replay_read(&self, key: &str) -> Result<(), ObjectStoreError> {
-        if self
-            .guarded_prefixes
-            .iter()
-            .any(|prefix| key.starts_with(prefix))
-        {
-            self.guarded_gets.fetch_add(1, Ordering::SeqCst);
-            return Err(ObjectStoreError::transport(
-                key,
-                "begin_upload unexpectedly read replay object",
-            ));
-        }
-        Ok(())
-    }
+fn content_blob_counting_store(root: impl AsRef<Path>) -> CountingStore<LocalFsStore> {
+    CountingStore::new(
+        LocalFsStore::new(root.as_ref()).expect("store"),
+        KeyPredicate::content_blob(),
+    )
 }
 
-#[async_trait]
-impl ObjectStore for ReplayReadGuardStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.reject_replay_read(key)?;
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.reject_replay_read(key)?;
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-#[derive(Debug)]
-struct ContentBlobGetCountingStore {
-    inner: LocalFsStore,
-    content_blob_gets: AtomicUsize,
-}
-
-impl ContentBlobGetCountingStore {
-    fn new(root: impl AsRef<Path>) -> Self {
-        Self {
-            inner: LocalFsStore::new(root.as_ref()).expect("store"),
-            content_blob_gets: AtomicUsize::new(0),
-        }
-    }
-
-    fn content_blob_get_count(&self) -> usize {
-        self.content_blob_gets.load(Ordering::SeqCst)
-    }
-
-    fn reset_content_blob_counters(&self) {
-        self.content_blob_gets.store(0, Ordering::SeqCst);
-    }
-
-    fn reset_content_blob_get_count(&self) {
-        self.reset_content_blob_counters();
-    }
-
-    fn record_content_blob_get(&self, key: &str) {
-        if key.starts_with("content-stores/") && key.contains("/blobs/") {
-            self.content_blob_gets.fetch_add(1, Ordering::SeqCst);
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for ContentBlobGetCountingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.record_content_blob_get(key);
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.record_content_blob_get(key);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-#[derive(Debug)]
-struct MetadataSstGetCountingStore {
-    inner: LocalFsStore,
-    metadata_sst_gets: AtomicUsize,
-}
-
-impl MetadataSstGetCountingStore {
-    fn new(root: impl AsRef<Path>) -> Self {
-        Self {
-            inner: LocalFsStore::new(root.as_ref()).expect("store"),
-            metadata_sst_gets: AtomicUsize::new(0),
-        }
-    }
-
-    fn metadata_sst_get_count(&self) -> usize {
-        self.metadata_sst_gets.load(Ordering::SeqCst)
-    }
-
-    fn reset_metadata_sst_get_count(&self) {
-        self.metadata_sst_gets.store(0, Ordering::SeqCst);
-    }
-
-    fn record_metadata_sst_get(&self, key: &str) {
-        if key.contains("/metadata/tables/") && key.ends_with(".sst.zst") {
-            self.metadata_sst_gets.fetch_add(1, Ordering::SeqCst);
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for MetadataSstGetCountingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.record_metadata_sst_get(key);
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.record_metadata_sst_get(key);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
+fn metadata_table_counting_store(root: impl AsRef<Path>) -> CountingStore<LocalFsStore> {
+    CountingStore::new(
+        LocalFsStore::new(root.as_ref()).expect("store"),
+        KeyPredicate::metadata_table(),
+    )
 }
 
 #[derive(Debug)]
@@ -6463,91 +6222,42 @@ impl ObjectStore for StaleHeadGetStore {
     }
 }
 
-#[derive(Debug)]
-struct AckLostHeadCasStore {
-    inner: LocalFsStore,
-    head_key: String,
-    injected_ack_loss: Mutex<bool>,
-}
-
-impl AckLostHeadCasStore {
-    fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
-        Self {
-            inner: LocalFsStore::new(root.as_ref()).expect("store"),
-            head_key: wal_head(namespace_id.as_str()),
-            injected_ack_loss: Mutex::new(false),
-        }
-    }
-
-    fn injected_ack_loss(&self) -> bool {
-        *self
-            .injected_ack_loss
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-}
-
-#[async_trait]
-impl ObjectStore for AckLostHeadCasStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        if key == self.head_key
-            && matches!(mode, PutMode::CompareAndSwap { .. })
-            && head_cas_advances_seq(&self.inner, key, &bytes).await?
-        {
-            let should_inject = {
-                let mut injected = self
-                    .injected_ack_loss
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner());
-                if *injected {
-                    false
-                } else {
-                    *injected = true;
-                    true
-                }
-            };
-            if should_inject {
-                // Apply the CAS, then lose the acknowledgment.
-                self.inner.put(key, bytes, mode).await?;
-                return Err(ObjectStoreError::transport(
-                    key,
-                    "response lost after head compare-and-swap",
-                ));
+fn ack_lost_head_cas_store(
+    root: impl AsRef<Path>,
+    namespace_id: &NamespaceId,
+) -> FailStore<LocalFsStore> {
+    let head_key = wal_head(namespace_id.as_str());
+    let store = FailStore::matching(
+        LocalFsStore::new(root.as_ref()).expect("store"),
+        move |operation: &OperationContext<'_>| {
+            if operation.key() != head_key {
+                return false;
             }
-        }
-        self.inner.put(key, bytes, mode).await
-    }
+            let bytes = match operation.kind() {
+                OperationKind::CompareAndSwap { bytes, .. }
+                | OperationKind::Put {
+                    bytes,
+                    mode: PutMode::CompareAndSwap { .. },
+                } => bytes,
+                _ => return false,
+            };
+            decode_control_object::<HeadState>(bytes, ControlObjectKind::WalHead)
+                .is_ok_and(|envelope| envelope.state.seq > ChangeSeq(0))
+        },
+        InjectedError::Transport("response lost after head compare-and-swap".to_owned()),
+    )
+    .apply_then_fail();
+    store.fail_next(1);
+    store
+}
 
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
+trait AckLossProbe {
+    fn injected_ack_loss(&self) -> bool;
+}
 
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+impl AckLossProbe for FailStore<LocalFsStore> {
+    fn injected_ack_loss(&self) -> bool {
+        self.attempts() > 0 && self.remaining() == 0
     }
 }
 
@@ -6668,19 +6378,19 @@ async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data()
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    bootstrap_namespace(&store, &namespace_id(), &context, false)
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
         .await
         .expect("bootstrap namespace");
 
-    create_directory_path(&store, &namespace_id(), "/live", &context, None)
+    create_directory_path(&store, &namespace_id("demo"), "/live", &context, None)
         .await
         .expect("create live dir");
-    create_directory_path(&store, &namespace_id(), "/dead", &context, None)
+    create_directory_path(&store, &namespace_id("demo"), "/dead", &context, None)
         .await
         .expect("create dead dir");
     put_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/live/kept.txt",
         b"alive",
         DestinationBehavior::NoReplace,
@@ -6691,7 +6401,7 @@ async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data()
     .expect("put live file");
     put_file_bytes(
         &store,
-        &namespace_id(),
+        &namespace_id("demo"),
         "/dead/gone.txt",
         b"doomed",
         DestinationBehavior::NoReplace,
@@ -6700,11 +6410,11 @@ async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data()
     )
     .await
     .expect("put doomed file");
-    delete_path(&store, &namespace_id(), "/dead", &context, None)
+    delete_path(&store, &namespace_id("demo"), "/dead", &context, None)
         .await
         .expect("delete dead subtree");
 
-    let root_entries = list_path(&store, &namespace_id(), "/")
+    let root_entries = list_path(&store, &namespace_id("demo"), "/")
         .await
         .expect("list root");
     let root_names: Vec<&str> = root_entries
@@ -6720,7 +6430,7 @@ async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data()
         "tombstoned directory must not list, got {root_names:?}"
     );
 
-    let live_entries = list_path(&store, &namespace_id(), "/live")
+    let live_entries = list_path(&store, &namespace_id("demo"), "/live")
         .await
         .expect("list live dir");
     assert_eq!(live_entries.len(), 1, "one live child");
@@ -6740,10 +6450,10 @@ async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data()
         "listed entry carries its content ref"
     );
 
-    resolve_path(&store, &namespace_id(), "/dead/gone.txt")
+    resolve_path(&store, &namespace_id("demo"), "/dead/gone.txt")
         .await
         .expect_err("file under tombstoned subtree must not resolve");
-    resolve_path(&store, &namespace_id(), "/dead")
+    resolve_path(&store, &namespace_id("demo"), "/dead")
         .await
         .expect_err("tombstoned directory must not resolve");
 }
@@ -6753,7 +6463,7 @@ async fn move_replace_atomically_replaces_a_file_destination() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -6827,7 +6537,7 @@ async fn move_replace_rejects_directory_destinations_and_self_moves() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -6885,7 +6595,7 @@ async fn copy_replace_appends_a_revision_to_the_destination_inode() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let context = mutation_context();
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await

--- a/crates/loonfs-core/tests/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/visibility_equivalence.rs
@@ -1,18 +1,15 @@
 #![allow(clippy::panic)]
 //! Differential coverage for tombstone visibility versus root reachability.
 
+mod common;
+
+use common::read_context;
 use loonfs_api::v0::{CommitOp, CommitRequest, CommitResponse};
 use loonfs_api::{
     AbsolutePath, ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, DisplayName,
-    EffectiveLimit, InodeId, NamespaceId, PageRequest, RevisionNo,
-};
-use loonfs_core::cache::{
-    MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
-    WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+    InodeId, NamespaceId, PageRequest, RevisionNo,
 };
 use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
-use loonfs_core::control::load_namespace_read_anchor;
 use loonfs_core::metadata::MetadataViewSession;
 use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
 use loonfs_core::{
@@ -22,7 +19,6 @@ use loonfs_core::{
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashSet;
-use std::num::NonZeroU32;
 use std::sync::Arc;
 use tempfile::{tempdir, TempDir};
 
@@ -192,22 +188,7 @@ impl VisibilityHarness {
     }
 
     async fn read_context(&self) -> RuntimeReadContext {
-        let (head, root) = load_namespace_read_anchor(&self.store, self.namespace_id())
-            .await
-            .expect("load read anchor");
-        RuntimeReadContext {
-            head: head.state,
-            head_etag: head.identity.etag,
-            manifest_id: root.state.manifest_id,
-            manifest_object_id: root.state.manifest_object_id,
-            table_cache: Arc::new(MetadataTableCache::new(MetadataTableCacheConfig::default())),
-            tail_cache: Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
-                max_entries: 4,
-                max_rows: DEFAULT_WAL_TAIL_PROJECTION_ROWS,
-                max_decoded_bytes: DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-            })),
-            catalog: None,
-        }
+        read_context(&self.store, self.namespace_id()).await
     }
 
     async fn inode_id(&self, path: &str) -> InodeId {
@@ -328,10 +309,6 @@ async fn derive_root_path<S: ObjectStore + ?Sized>(
     }
     components.reverse();
     Ok(Some(format!("/{}", components.join("/"))))
-}
-
-fn page_limit() -> EffectiveLimit {
-    EffectiveLimit::new(NonZeroU32::new(32).expect("non-zero page limit"))
 }
 
 #[tokio::test]
@@ -1013,7 +990,7 @@ async fn inode_revision_reads_remain_identity_addressed_after_visibility_is_lost
         .list_file_revisions_for_inode_page_with_runtime_context(
             inode_id,
             PageRequest {
-                limit: page_limit(),
+                limit: loonfs_test_support::ids::page_limit(32),
                 cursor: None,
             },
             &context,

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -33,6 +33,7 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 ciborium.workspace = true
+loonfs-test-support = { path = "../loonfs-test-support" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -366,3 +366,6 @@ fn current_time_ms() -> Result<u64, loonfs_core::Error> {
 #[cfg(test)]
 #[path = "main_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+mod test_seeding;

--- a/crates/loonfs-grep/src/main_tests.rs
+++ b/crates/loonfs-grep/src/main_tests.rs
@@ -2,18 +2,14 @@
 //! Standalone poller wakeup coverage with in-process driver observation.
 
 use super::{poll_namespace, PollShutdown};
-use loonfs_api::{
-    AbsolutePath, ChangeSeq, CommitId, DestinationBehavior, GrepRequest, NamespaceId,
-};
+use loonfs_api::{ChangeSeq, GrepRequest, NamespaceId};
 use loonfs_core::cache::{
     MetadataTableCache, MetadataTableCacheConfig, WalTailProjectionCache,
     WalTailProjectionCacheConfig, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
     DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
-use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
 use loonfs_core::control::{load_namespace_head_control, load_namespace_read_anchor};
-use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
-use loonfs_core::{BootstrapOptions, NamespaceEngine, RuntimeReadContext};
+use loonfs_core::{NamespaceEngine, RuntimeReadContext};
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepDriverTask,
@@ -21,6 +17,7 @@ use loonfs_grep::{
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
+use loonfs_test_support::ids::namespace_id;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
@@ -149,10 +146,6 @@ async fn standalone_enable_without_head_change_wakes_empty_backfill() {
     stop_poll_and_driver(poll, shutdown, driver).await;
 }
 
-fn namespace_id(value: &str) -> NamespaceId {
-    NamespaceId::parse(value).expect("namespace id")
-}
-
 fn worker(store: &SharedObjectStore, actor: &str) -> GrepWorker<SharedObjectStore> {
     GrepWorker::new(
         store.clone(),
@@ -166,18 +159,14 @@ async fn bootstrap(
     store: SharedObjectStore,
     namespace_id: &NamespaceId,
 ) -> NamespaceEngine<SharedObjectStore> {
-    let engine = NamespaceEngine::builder(store)
-        .namespace_id(namespace_id.clone())
-        .writer_id(format!("{}-seed", namespace_id.as_str()))
-        .writer_session_id(format!("{}-seed-session", namespace_id.as_str()))
-        .writer_version("standalone-poll-test/0.1")
-        .build()
-        .expect("engine");
-    engine
-        .bootstrap_namespace(BootstrapOptions::default())
-        .await
-        .expect("bootstrap namespace");
-    engine
+    super::test_seeding::bootstrap(
+        store,
+        namespace_id,
+        format!("{}-seed", namespace_id.as_str()),
+        format!("{}-seed-session", namespace_id.as_str()),
+        "standalone-poll-test/0.1",
+    )
+    .await
 }
 
 async fn put_file(
@@ -186,28 +175,15 @@ async fn put_file(
     namespace_id: &NamespaceId,
     commit_id: &str,
 ) {
-    let stored = store_bytes_as_content(&**store, namespace_id, b"standalone wakeup needle\n")
-        .await
-        .expect("store content");
-    let content_ref = stored.content_ref.clone();
-    let catalog = loonfs_core::control::load_namespace_catalog_entry(&**store, namespace_id)
-        .await
-        .expect("load namespace catalog");
-    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
-    let result = engine
-        .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
-            PathMutationIntent::PutFile {
-                commit_id: CommitId::parse(commit_id).expect("commit id"),
-                absolute_path: AbsolutePath::parse("/note.txt").expect("path"),
-                content_ref,
-                behavior: DestinationBehavior::NoReplace,
-            },
-            vec![prepared],
-        )])
-        .await
-        .pop()
-        .expect("one result");
-    result.expect("publish file");
+    super::test_seeding::put_file(
+        store,
+        engine,
+        namespace_id,
+        b"standalone wakeup needle\n",
+        "/note.txt",
+        commit_id,
+    )
+    .await;
 }
 
 fn spawn_driver(

--- a/crates/loonfs-grep/src/test_seeding.rs
+++ b/crates/loonfs-grep/src/test_seeding.rs
@@ -1,0 +1,58 @@
+use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior, NamespaceId};
+use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
+use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
+use loonfs_core::{BootstrapOptions, NamespaceEngine};
+use loonfs_objectstore::ObjectStore;
+
+pub(crate) async fn bootstrap<S: ObjectStore + Clone>(
+    store: S,
+    namespace_id: &NamespaceId,
+    writer_id: String,
+    writer_session_id: String,
+    writer_version: &str,
+) -> NamespaceEngine<S> {
+    let engine = NamespaceEngine::builder(store)
+        .namespace_id(namespace_id.clone())
+        .writer_id(writer_id)
+        .writer_session_id(writer_session_id)
+        .writer_version(writer_version)
+        .build()
+        .expect("engine");
+    engine
+        .bootstrap_namespace(BootstrapOptions::default())
+        .await
+        .expect("bootstrap namespace");
+    engine
+}
+
+pub(crate) async fn put_file<S: ObjectStore + Clone>(
+    store: &S,
+    engine: &NamespaceEngine<S>,
+    namespace_id: &NamespaceId,
+    bytes: &'static [u8],
+    path: &str,
+    commit_id: &str,
+) {
+    let stored = store_bytes_as_content(store, namespace_id, bytes)
+        .await
+        .expect("store content");
+    let content_ref = stored.content_ref.clone();
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
+        .await
+        .expect("load namespace catalog");
+    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
+    engine
+        .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
+            PathMutationIntent::PutFile {
+                commit_id: CommitId::parse(commit_id).expect("commit id"),
+                absolute_path: AbsolutePath::parse(path).expect("path"),
+                content_ref,
+                behavior: DestinationBehavior::NoReplace,
+            },
+            vec![prepared],
+        )])
+        .await
+        .pop()
+        .expect("one result")
+        .expect("publish file");
+}

--- a/crates/loonfs-grep/tests/driver.rs
+++ b/crates/loonfs-grep/tests/driver.rs
@@ -1,13 +1,14 @@
 #![allow(clippy::panic)]
 //! Per-namespace driver isolation, backoff, and explicit-GC boundaries.
 
+#[path = "../src/test_seeding.rs"]
+mod test_seeding;
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior, IndexSegmentId, NamespaceId};
-use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
-use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
-use loonfs_core::{BootstrapOptions, DeleteNamespaceOptions, NamespaceEngine};
+use loonfs_api::{IndexSegmentId, NamespaceId};
+use loonfs_core::{DeleteNamespaceOptions, NamespaceEngine};
 use loonfs_grep::keyspace::{root_key, segment_key};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDriver, GrepDriverParked, GrepDriverState, GrepStepLimiter,
@@ -17,6 +18,7 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
+use loonfs_test_support::ids::nonzero_usize;
 use std::future::Future;
 use std::num::NonZeroUsize;
 use std::path::Path;
@@ -215,10 +217,6 @@ async fn shared_step_limiter_caps_many_namespaces_and_every_driver_converges() {
     }
 }
 
-fn nonzero_usize(value: usize) -> NonZeroUsize {
-    NonZeroUsize::new(value).expect("test value should be nonzero")
-}
-
 #[derive(Debug)]
 struct StepConcurrencyStore {
     inner: LocalFsStore,
@@ -334,18 +332,14 @@ async fn bootstrap<S: ObjectStore + Clone>(
     store: S,
     namespace_id: &NamespaceId,
 ) -> NamespaceEngine<S> {
-    let engine = NamespaceEngine::builder(store)
-        .namespace_id(namespace_id.clone())
-        .writer_id(format!("seed-{namespace_id}"))
-        .writer_session_id(format!("seed-{namespace_id}-session"))
-        .writer_version("driver-test/0.1")
-        .build()
-        .expect("engine");
-    engine
-        .bootstrap_namespace(BootstrapOptions::default())
-        .await
-        .expect("bootstrap namespace");
-    engine
+    test_seeding::bootstrap(
+        store,
+        namespace_id,
+        format!("seed-{namespace_id}"),
+        format!("seed-{namespace_id}-session"),
+        "driver-test/0.1",
+    )
+    .await
 }
 
 async fn put_file<S: ObjectStore + Clone>(
@@ -354,26 +348,13 @@ async fn put_file<S: ObjectStore + Clone>(
     namespace_id: &NamespaceId,
     commit_id: &str,
 ) {
-    let stored = store_bytes_as_content(store, namespace_id, b"driver needle\n")
-        .await
-        .expect("store content");
-    let content_ref = stored.content_ref.clone();
-    let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
-        .await
-        .expect("load namespace catalog");
-    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
-    engine
-        .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
-            PathMutationIntent::PutFile {
-                commit_id: CommitId::parse(commit_id).expect("commit id"),
-                absolute_path: AbsolutePath::parse("/note.txt").expect("path"),
-                content_ref,
-                behavior: DestinationBehavior::NoReplace,
-            },
-            vec![prepared],
-        )])
-        .await
-        .pop()
-        .expect("one result")
-        .expect("publish file");
+    test_seeding::put_file(
+        store,
+        engine,
+        namespace_id,
+        b"driver needle\n",
+        "/note.txt",
+        commit_id,
+    )
+    .await;
 }

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -3,12 +3,13 @@
 #![allow(clippy::panic)]
 
 use loonfs_api::wire::sst_blocks::BlockHandle;
-use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, NamespaceId};
+use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId};
 use loonfs_grep::root::{
     decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root, GrepFoldState,
     GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepManifestId, GrepRootCodecError,
     GrepRootEnvelope, GrepRootPointer, GrepRootState, GrepRootStateError, GrepSegmentRef,
 };
+use loonfs_test_support::ids::namespace_id;
 
 // Frozen v1 format pins. These byte strings are the durable compatibility
 // fixtures: changing field names, ordering, enum tags, or omission rules must
@@ -199,10 +200,6 @@ fn segment_ref(number: u8, run_ordinal: u64, level: u32, segment_index: u32) -> 
         payload_checksum: "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
             .to_owned(),
     }
-}
-
-fn namespace_id(value: &str) -> NamespaceId {
-    NamespaceId::parse(value).expect("valid namespace id")
 }
 
 fn segment_id(number: u8) -> IndexSegmentId {

--- a/crates/loonfs-grep/tests/root_store.rs
+++ b/crates/loonfs-grep/tests/root_store.rs
@@ -12,6 +12,7 @@ use loonfs_grep::root::{
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectStore, PutMode};
+use loonfs_test_support::ids::namespace_id;
 
 #[tokio::test]
 async fn load_rejects_namespace_identity_mismatch() {
@@ -158,8 +159,4 @@ fn root(namespace_id: NamespaceId, built_through_seq: ChangeSeq) -> GrepRootStat
         Vec::new(),
     )
     .expect("valid root")
-}
-
-fn namespace_id(value: &str) -> NamespaceId {
-    NamespaceId::parse(value).expect("valid namespace id")
 }

--- a/crates/loonfs-grep/tests/standalone.rs
+++ b/crates/loonfs-grep/tests/standalone.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::panic)]
 //! Standalone worker one-shot and configuration smoke coverage.
 
-use loonfs_api::{AbsolutePath, CommitId, DestinationBehavior, NamespaceId};
-use loonfs_core::content::{prepare_stored_content, store_bytes_as_content};
-use loonfs_core::publish::{NamespaceMutationCandidate, PathMutationIntent};
+#[path = "../src/test_seeding.rs"]
+mod test_seeding;
+
+use loonfs_api::NamespaceId;
 use loonfs_core::{BootstrapOptions, NamespaceEngine};
 use loonfs_grep::keyspace::{root_key, segments_prefix};
 use loonfs_grep::root::{load_grep_root, GrepLifecycle};
@@ -239,18 +240,14 @@ async fn bootstrap(
     store: &Arc<LocalFsStore>,
     namespace_id: &NamespaceId,
 ) -> NamespaceEngine<Arc<LocalFsStore>> {
-    let engine = NamespaceEngine::builder(store.clone())
-        .namespace_id(namespace_id.clone())
-        .writer_id(format!("standalone-seed-{namespace_id}"))
-        .writer_session_id(format!("standalone-seed-{namespace_id}-session"))
-        .writer_version("standalone-test/0.1")
-        .build()
-        .expect("engine");
-    engine
-        .bootstrap_namespace(BootstrapOptions::default())
-        .await
-        .expect("bootstrap namespace");
-    engine
+    test_seeding::bootstrap(
+        store.clone(),
+        namespace_id,
+        format!("standalone-seed-{namespace_id}"),
+        format!("standalone-seed-{namespace_id}-session"),
+        "standalone-test/0.1",
+    )
+    .await
 }
 
 async fn put_file(
@@ -268,28 +265,15 @@ async fn put_file_at(
     path: &str,
     commit_id: &str,
 ) {
-    let stored = store_bytes_as_content(&**store, namespace_id, b"standalone needle\n")
-        .await
-        .expect("store content");
-    let content_ref = stored.content_ref.clone();
-    let catalog = loonfs_core::control::load_namespace_catalog_entry(&**store, namespace_id)
-        .await
-        .expect("load namespace catalog");
-    let prepared = prepare_stored_content(&catalog, stored).expect("prepare stored content");
-    let result = engine
-        .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
-            PathMutationIntent::PutFile {
-                commit_id: CommitId::parse(commit_id).expect("commit id"),
-                absolute_path: AbsolutePath::parse(path).expect("path"),
-                content_ref,
-                behavior: DestinationBehavior::NoReplace,
-            },
-            vec![prepared],
-        )])
-        .await
-        .pop()
-        .expect("one result");
-    result.expect("publish file");
+    test_seeding::put_file(
+        store,
+        engine,
+        namespace_id,
+        b"standalone needle\n",
+        path,
+        commit_id,
+    )
+    .await;
 }
 
 fn write_config(path: &Path, store_root: &Path, root_fields: &str, grep_fields: &str) {

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -41,6 +41,7 @@ loonfs-client = { path = "../loonfs-client" }
 # Test-only white-box access to the durable head-control plane
 # (`load_namespace_head_control`); production code depends on `loonfs` alone.
 loonfs-core = { path = "../loonfs-core" }
+loonfs-test-support = { path = "../loonfs-test-support" }
 tempfile.workspace = true
 tower = { version = "0.5", features = ["util"] }
 ureq.workspace = true

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -98,77 +98,18 @@ fn error_status_mapping_matches_the_api_spec_table() {
         "api.md documents codes this build does not register: {documented:?}"
     );
 }
+use loonfs_test_support::http::raw_agent;
+use loonfs_test_support::ids::namespace_id;
+use loonfs_test_support::stores::{BlockingStore, KeyPredicate, MetadataMapStore, OperationClass};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
-use tokio::sync::Notify;
 
 #[derive(Debug)]
 struct StaleHeadOnceStore {
     inner: LocalFsStore,
     head_key: String,
     armed: AtomicBool,
-}
-
-#[derive(Debug)]
-struct AgedMetadataStore(LocalFsStore);
-
-fn age_metadata(mut metadata: ObjectMetadata) -> ObjectMetadata {
-    metadata.last_modified_ms = Some(0);
-    metadata
-}
-
-/// Raw-request agent with socket inactivity timeouts. A starved or wedged
-/// server must produce a readable transport error, not an indefinite hang
-/// or a panic inside the HTTP client's response path — the failure mode a
-/// loaded CI runner once hit through the default timeout-less agent.
-fn raw_agent() -> ureq::Agent {
-    ureq::AgentBuilder::new()
-        .timeout_read(std::time::Duration::from_secs(30))
-        .timeout_write(std::time::Duration::from_secs(30))
-        .build()
-}
-
-#[async_trait]
-impl ObjectStore for AgedMetadataStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        Ok(self.0.head(key).await?.map(age_metadata))
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.0.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        Ok(self.0.get_with_metadata(key).await?.map(|mut body| {
-            body.metadata = age_metadata(body.metadata);
-            body
-        }))
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        Ok(age_metadata(self.0.put(key, bytes, mode).await?))
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.0.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.0.list_prefix_stream(prefix)
-    }
 }
 
 impl StaleHeadOnceStore {
@@ -226,15 +167,6 @@ impl ObjectStore for StaleHeadOnceStore {
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         self.inner.list_prefix_stream(prefix)
     }
-}
-
-#[derive(Debug)]
-struct BlockGrepRootOnceStore {
-    inner: LocalFsStore,
-    root_key: String,
-    armed: AtomicBool,
-    entered: Notify,
-    release: Notify,
 }
 
 #[derive(Debug)]
@@ -308,65 +240,6 @@ impl ObjectStore for FaultGrepRootStore {
                 object_key: key.to_owned(),
             });
         }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-impl BlockGrepRootOnceStore {
-    fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
-        Self {
-            inner: LocalFsStore::new(root.as_ref()).expect("construct local store"),
-            root_key: grep_root_key(namespace_id),
-            armed: AtomicBool::new(false),
-            entered: Notify::new(),
-            release: Notify::new(),
-        }
-    }
-
-    fn arm(&self) {
-        self.armed.store(true, Ordering::SeqCst);
-    }
-}
-
-#[async_trait]
-impl ObjectStore for BlockGrepRootOnceStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        if key == self.root_key && self.armed.swap(false, Ordering::SeqCst) {
-            self.entered.notify_one();
-            self.release.notified().await;
-        }
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
         self.inner.put(key, bytes, mode).await
     }
 
@@ -469,7 +342,11 @@ async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
 async fn embedded_shutdown_drains_an_active_grep_step() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("grep-shutdown");
-    let blocking_store = Arc::new(BlockGrepRootOnceStore::new(temp_dir.path(), &namespace_id));
+    let blocking_store = Arc::new(BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("construct local store"),
+        KeyPredicate::exact(grep_root_key(&namespace_id)),
+        OperationClass::GetWithMetadata,
+    ));
     let store = blocking_store.clone() as SharedObjectStore;
     let writer = test_runtime(store.clone(), "grep-shutdown-seed").await;
     writer
@@ -486,7 +363,7 @@ async fn embedded_shutdown_drains_an_active_grep_step() {
     .await
     .expect("enable grep");
 
-    blocking_store.arm();
+    blocking_store.block_next();
     let config = test_config(temp_dir.path(), "grep-shutdown-server");
     let (_router, lifecycle, state) =
         super::app_with_store_and_transfer_issuer(config, store, None)
@@ -497,7 +374,7 @@ async fn embedded_shutdown_drains_an_active_grep_step() {
         .as_ref()
         .expect("embedded drivers")
         .start(&namespace_id);
-    blocking_store.entered.notified().await;
+    blocking_store.wait_until_blocked().await;
 
     let shutdown = tokio::runtime::Handle::current().spawn(lifecycle.shutdown());
     tokio::task::yield_now().await;
@@ -505,7 +382,7 @@ async fn embedded_shutdown_drains_an_active_grep_step() {
         !shutdown.is_finished(),
         "shutdown must wait for the active bounded grep step"
     );
-    blocking_store.release.notify_one();
+    blocking_store.release();
     shutdown
         .await
         .expect("join shutdown")
@@ -975,8 +852,9 @@ async fn http_admin_repair_reports_completed_already_complete_in_flight_and_not_
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_admin_repair_reports_reaped_for_aged_debris() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(AgedMetadataStore(
+    let store = Arc::new(MetadataMapStore::aged(
         LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::any(),
     ));
     let namespace_id = namespace_id("aged");
     let root_key = metadata_root(namespace_id.as_str());
@@ -2152,10 +2030,6 @@ async fn delete_path_recursive(
     )
     .await
     .unwrap_or_else(|error| panic!("delete `{absolute_path}`: {error}"));
-}
-
-fn namespace_id(value: &str) -> NamespaceId {
-    NamespaceId::parse(value).expect("valid namespace id")
 }
 
 fn assert_api_error<T: std::fmt::Debug>(

--- a/crates/loonfs-server/tests/common/mod.rs
+++ b/crates/loonfs-server/tests/common/mod.rs
@@ -1,0 +1,78 @@
+use loonfs_client::{Client, ClientConfig};
+use loonfs_server::{app, GrepConfig, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
+use std::path::PathBuf;
+
+pub(crate) struct TestServer {
+    pub(crate) client: Client,
+    pub(crate) server_url: String,
+    #[allow(dead_code)]
+    pub(crate) store_root: Option<PathBuf>,
+    #[allow(dead_code)]
+    pub(crate) store_key_prefix: Option<String>,
+    pub(crate) server: tokio::task::JoinHandle<()>,
+}
+
+pub(crate) async fn start_server(config: ServerConfig) -> TestServer {
+    let (store_root, store_key_prefix) = match &config.store {
+        StoreConfig::LocalFs { root, key_prefix } => {
+            (Some(PathBuf::from(root)), key_prefix.clone())
+        }
+        _ => (None, None),
+    };
+    let auth_token = config
+        .auth_token
+        .as_ref()
+        .map(|token| token.expose().to_owned());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    // The lifecycle handle is dropped: tests abort the server task instead
+    // of shutting it down gracefully.
+    let (router, _lifecycle) = app(config).await.expect("build app");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve app");
+    });
+    let server_url = format!("http://{addr}");
+
+    TestServer {
+        client: Client::new(ClientConfig {
+            server_url: server_url.clone(),
+            auth_token,
+            request_timeout_ms: None,
+            disable_transient_retry: false,
+        })
+        .expect("valid client config"),
+        server_url,
+        store_root,
+        store_key_prefix,
+        server,
+    }
+}
+
+pub(crate) fn test_config(
+    store: StoreConfig,
+    auth_token: &str,
+    content_token_secret: &str,
+    writer_id: &str,
+) -> ServerConfig {
+    ServerConfig {
+        bind: "127.0.0.1:0".to_owned(),
+        auth_token: Some(auth_token.into()),
+        content_token_secret: content_token_secret.into(),
+        writer_id: writer_id.to_owned(),
+        writer_version: format!("{writer_id}/0.1.0"),
+        runtime_cache: RuntimeCacheConfigOverrides::default(),
+        grep: GrepConfig::default(),
+        background_maintenance: true,
+        min_publish_interval_ms: 0,
+        max_upload_bytes: 256 * 1024 * 1024,
+        max_download_bytes: 256 * 1024 * 1024,
+        max_commit_body_bytes: 8 * 1024 * 1024,
+        max_concurrent_uploads: 8,
+        max_concurrent_downloads: 16,
+        max_concurrent_maintenance: loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+        allow_unauthenticated_remote: false,
+        store,
+    }
+}

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -1,12 +1,15 @@
 // Ignored real-provider tests exercise the full server/client/direct-object-store path.
 
+mod common;
+
+use common::{start_server, test_config};
 use loonfs_api::{
     v0::{CompleteUploadRequest, ObjectTransferAccess, ValidatedContentToken},
     ChangeSeq, CommitId, CommitResponse, ContentRef, DestinationBehavior, FilesystemOperation,
     FilesystemOperationRequest, NamespaceId,
 };
-use loonfs_client::{Client, ClientConfig, ClientError, NamespacePath};
-use loonfs_server::{app, GrepConfig, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
+use loonfs_client::{Client, ClientError, NamespacePath};
+use loonfs_server::{ServerConfig, StoreConfig};
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -18,24 +21,8 @@ const SIGNED_CHECKSUM_HEADER: &str = "x-amz-checksum-sha256";
 #[ignore = "requires real AWS S3 credentials"]
 async fn aws_s3_direct_put_real_provider_round_trip() {
     let config = AwsS3DirectPutConfig::from_env().expect("load AWS S3 direct-put environment");
-    direct_put_round_trip(ServerConfig {
-        bind: "127.0.0.1:0".to_owned(),
-        auth_token: Some(AUTH_TOKEN.into()),
-        content_token_secret: CONTENT_TOKEN_SECRET.into(),
-        writer_id: "direct-put-aws-s3".to_owned(),
-        writer_version: "direct-put-aws-s3/0.1.0".to_owned(),
-        runtime_cache: RuntimeCacheConfigOverrides::default(),
-        grep: GrepConfig::default(),
-        background_maintenance: true,
-        min_publish_interval_ms: 0,
-        max_upload_bytes: 256 * 1024 * 1024,
-        max_download_bytes: 256 * 1024 * 1024,
-        max_commit_body_bytes: 8 * 1024 * 1024,
-        max_concurrent_uploads: 8,
-        max_concurrent_downloads: 16,
-        max_concurrent_maintenance: loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
-        allow_unauthenticated_remote: false,
-        store: StoreConfig::AwsS3 {
+    direct_put_round_trip(test_config(
+        StoreConfig::AwsS3 {
             bucket: config.bucket,
             region: config.region,
             endpoint_url: config.endpoint,
@@ -45,7 +32,10 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
             key_prefix: Some(config.prefix),
             force_path_style: false,
         },
-    })
+        AUTH_TOKEN,
+        CONTENT_TOKEN_SECRET,
+        "direct-put-aws-s3",
+    ))
     .await;
 }
 
@@ -54,24 +44,8 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
 async fn cloudflare_r2_direct_put_real_provider_round_trip() {
     let config =
         CloudflareR2DirectPutConfig::from_env().expect("load Cloudflare R2 direct-put environment");
-    direct_put_round_trip(ServerConfig {
-        bind: "127.0.0.1:0".to_owned(),
-        auth_token: Some(AUTH_TOKEN.into()),
-        content_token_secret: CONTENT_TOKEN_SECRET.into(),
-        writer_id: "direct-put-r2".to_owned(),
-        writer_version: "direct-put-r2/0.1.0".to_owned(),
-        runtime_cache: RuntimeCacheConfigOverrides::default(),
-        grep: GrepConfig::default(),
-        background_maintenance: true,
-        min_publish_interval_ms: 0,
-        max_upload_bytes: 256 * 1024 * 1024,
-        max_download_bytes: 256 * 1024 * 1024,
-        max_commit_body_bytes: 8 * 1024 * 1024,
-        max_concurrent_uploads: 8,
-        max_concurrent_downloads: 16,
-        max_concurrent_maintenance: loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
-        allow_unauthenticated_remote: false,
-        store: StoreConfig::CloudflareR2 {
+    direct_put_round_trip(test_config(
+        StoreConfig::CloudflareR2 {
             bucket: config.bucket,
             account_id: config.account_id,
             endpoint_url: config.endpoint,
@@ -79,7 +53,10 @@ async fn cloudflare_r2_direct_put_real_provider_round_trip() {
             secret_access_key: config.secret_access_key.into(),
             key_prefix: Some(config.prefix),
         },
-    })
+        AUTH_TOKEN,
+        CONTENT_TOKEN_SECRET,
+        "direct-put-r2",
+    ))
     .await;
 }
 
@@ -156,6 +133,8 @@ async fn direct_put_round_trip(config: ServerConfig) {
     })
     .await
     .expect("join blocking task");
+
+    harness.server.abort();
 }
 
 fn assert_wrong_direct_put_bytes_rejected(client: &Client, namespace_id: &NamespaceId) {
@@ -269,44 +248,6 @@ fn expect_client_rejection<T>(result: Result<T, ClientError>, context: &str) {
         Err(error) => {
             unreachable!("{context} failed with unexpected client-side error: {error}")
         }
-    }
-}
-
-struct TestServer {
-    client: Client,
-    server_url: String,
-    server: tokio::task::JoinHandle<()>,
-}
-
-impl Drop for TestServer {
-    fn drop(&mut self) {
-        self.server.abort();
-    }
-}
-
-async fn start_server(config: ServerConfig) -> TestServer {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind listener");
-    let addr = listener.local_addr().expect("listener addr");
-    // The lifecycle handle is dropped: this harness aborts the server task
-    // instead of shutting it down gracefully.
-    let (router, _lifecycle) = app(config).await.expect("build app");
-    let server = tokio::spawn(async move {
-        axum::serve(listener, router).await.expect("serve app");
-    });
-    let server_url = format!("http://{addr}");
-
-    TestServer {
-        client: Client::new(ClientConfig {
-            server_url: server_url.clone(),
-            auth_token: Some(AUTH_TOKEN.to_owned()),
-            request_timeout_ms: None,
-            disable_transient_retry: false,
-        })
-        .expect("valid client config"),
-        server_url,
-        server,
     }
 }
 

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -1,4 +1,7 @@
+mod common;
+
 use bytes::Bytes;
+use common::start_server;
 use loonfs::content_tokens::mint_content_token;
 use loonfs::publish::MAX_COMMIT_CONTENT_TOKENS;
 use loonfs_api::{
@@ -14,38 +17,20 @@ use loonfs_api::{
     LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX,
 };
 use loonfs_client::{
-    Client, ClientConfig, ClientError, CreateDirectoryOptions, DeleteOptions, MutationOptions,
-    NamespacePath, PutFileOptions,
+    Client, ClientError, CreateDirectoryOptions, DeleteOptions, MutationOptions, NamespacePath,
+    PutFileOptions,
 };
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::{ConfiguredObjectStore, ObjectStore};
-use loonfs_server::{app, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
+use loonfs_server::{ServerConfig, StoreConfig};
+use loonfs_test_support::block_on::block_on;
+use loonfs_test_support::http::raw_agent;
+use loonfs_test_support::ids::namespace_id;
 use serde_json::json;
-use std::future::Future;
 use std::io::Read as _;
-use std::path::PathBuf;
 use tempfile::tempdir;
 
 const TEST_CONTENT_TOKEN_SECRET: &str = "test-content-token-secret";
-
-/// Raw-request agent with socket inactivity timeouts. A starved or wedged
-/// server must produce a readable transport error, not an indefinite hang
-/// or a panic inside the HTTP client's response path — the failure mode a
-/// loaded CI runner once hit through the default timeout-less agent.
-fn raw_agent() -> ureq::Agent {
-    ureq::AgentBuilder::new()
-        .timeout_read(std::time::Duration::from_secs(30))
-        .timeout_write(std::time::Duration::from_secs(30))
-        .build()
-}
-
-fn block_on<T>(future: impl Future<Output = T>) -> T {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("test runtime")
-        .block_on(future)
-}
 
 fn replace_file_options() -> PutFileOptions {
     PutFileOptions {
@@ -2472,7 +2457,10 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
     let client = harness.client.clone();
     let cold_client = cold.client.clone();
     let server_url = harness.server_url.clone();
-    let store_root = harness.store_root.clone();
+    let store_root = harness
+        .store_root
+        .clone()
+        .expect("local test server has a store root");
     let store_key_prefix = harness.store_key_prefix.clone();
 
     tokio::task::spawn_blocking(move || {
@@ -2596,68 +2584,16 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
     server_b.server.abort();
 }
 
-struct TestServer {
-    client: Client,
-    server_url: String,
-    store_root: PathBuf,
-    store_key_prefix: Option<String>,
-    server: tokio::task::JoinHandle<()>,
-}
-
-async fn start_server(config: ServerConfig) -> TestServer {
-    let (store_root, store_key_prefix) = match &config.store {
-        StoreConfig::LocalFs { root, key_prefix } => (PathBuf::from(root), key_prefix.clone()),
-        other => unreachable!("test harness requires local fs store, got {other:?}"),
-    };
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind listener");
-    let addr = listener.local_addr().expect("listener addr");
-    // The lifecycle handle is dropped: these tests abort the server task
-    // instead of shutting it down gracefully.
-    let (router, _lifecycle) = app(config).await.expect("build app");
-    let server = tokio::spawn(async move {
-        axum::serve(listener, router).await.expect("serve app");
-    });
-
-    TestServer {
-        client: Client::new(ClientConfig {
-            server_url: format!("http://{}", addr),
-            auth_token: Some("test-token".to_owned()),
-            request_timeout_ms: None,
-            disable_transient_retry: false,
-        })
-        .expect("valid client config"),
-        server_url: format!("http://{}", addr),
-        store_root,
-        store_key_prefix,
-        server,
-    }
-}
-
 fn test_config(store_root: std::path::PathBuf, writer_id: &str, key_prefix: &str) -> ServerConfig {
-    ServerConfig {
-        bind: "127.0.0.1:0".to_owned(),
-        auth_token: Some("test-token".into()),
-        content_token_secret: TEST_CONTENT_TOKEN_SECRET.into(),
-        writer_id: writer_id.to_owned(),
-        writer_version: format!("{writer_id}/0.1.0"),
-        runtime_cache: RuntimeCacheConfigOverrides::default(),
-        grep: loonfs_server::GrepConfig::default(),
-        background_maintenance: true,
-        min_publish_interval_ms: 0,
-        max_upload_bytes: 256 * 1024 * 1024,
-        max_download_bytes: 256 * 1024 * 1024,
-        max_commit_body_bytes: 8 * 1024 * 1024,
-        max_concurrent_uploads: 8,
-        max_concurrent_downloads: 16,
-        max_concurrent_maintenance: loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
-        allow_unauthenticated_remote: false,
-        store: StoreConfig::LocalFs {
+    common::test_config(
+        StoreConfig::LocalFs {
             root: store_root.display().to_string(),
             key_prefix: Some(key_prefix.to_owned()),
         },
-    }
+        "test-token",
+        TEST_CONTENT_TOKEN_SECRET,
+        writer_id,
+    )
 }
 
 fn entry_names(response: &ListPathEntriesResponse) -> Vec<&str> {
@@ -2814,10 +2750,6 @@ fn assert_invalid_namespace_response(result: Result<ureq::Response, ureq::Error>
         }
         other => unreachable!("expected invalid_namespace_id response, got {other:?}"),
     }
-}
-
-fn namespace_id(value: &str) -> NamespaceId {
-    NamespaceId::parse(value).expect("valid namespace id")
 }
 
 fn send_filesystem_operation(

--- a/crates/loonfs-test-support/Cargo.toml
+++ b/crates/loonfs-test-support/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name = "loonfs"
+name = "loonfs-test-support"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-description = "Embedded LoonFS runtime: a durable, agent-native filesystem on object storage."
+publish = false
+description = "Shared test helpers for LoonFS crates."
 repository.workspace = true
 
 [dependencies]
@@ -12,17 +13,10 @@ async-trait.workspace = true
 bytes.workspace = true
 futures.workspace = true
 loonfs-api = { path = "../loonfs-api" }
-loonfs-core = { path = "../loonfs-core" }
-loonfs-grep = { path = "../loonfs-grep" }
 loonfs-objectstore = { path = "../loonfs-objectstore" }
-thiserror.workspace = true
-tokio.workspace = true
-tracing.workspace = true
-
-[dev-dependencies]
-loonfs-test-support = { path = "../loonfs-test-support" }
-serde_json.workspace = true
 tempfile.workspace = true
+tokio = { version = "1", default-features = false, features = ["macros", "rt", "sync", "time"] }
+ureq.workspace = true
 
 [lints]
 workspace = true

--- a/crates/loonfs-test-support/src/block_on.rs
+++ b/crates/loonfs-test-support/src/block_on.rs
@@ -1,0 +1,12 @@
+//! Current-thread runtime setup for synchronous tests.
+
+use std::future::Future;
+
+/// Runs `future` to completion on a fresh current-thread Tokio runtime.
+pub fn block_on<T>(future: impl Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime")
+        .block_on(future)
+}

--- a/crates/loonfs-test-support/src/http.rs
+++ b/crates/loonfs-test-support/src/http.rs
@@ -1,0 +1,12 @@
+//! HTTP-client setup shared by raw server tests.
+
+/// Raw-request agent with socket inactivity timeouts. A starved or wedged
+/// server must produce a readable transport error, not an indefinite hang
+/// or a panic inside the HTTP client's response path — the failure mode a
+/// loaded CI runner once hit through the default timeout-less agent.
+pub fn raw_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_read(std::time::Duration::from_secs(30))
+        .timeout_write(std::time::Duration::from_secs(30))
+        .build()
+}

--- a/crates/loonfs-test-support/src/ids.rs
+++ b/crates/loonfs-test-support/src/ids.rs
@@ -1,0 +1,33 @@
+//! Small validated-value constructors used throughout tests.
+
+use loonfs_api::{EffectiveLimit, NamespaceId};
+use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
+
+/// Parses a namespace id that is expected to be valid test data.
+pub fn namespace_id(value: &str) -> NamespaceId {
+    NamespaceId::parse(value).expect("valid namespace id")
+}
+
+/// Constructs a nonzero `usize` that is expected to be valid test data.
+pub fn nonzero_usize(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value should be nonzero")
+}
+
+/// Constructs a nonzero `u64` that is expected to be valid test data.
+pub fn nonzero_u64(value: u64) -> NonZeroU64 {
+    NonZeroU64::new(value).expect("test value should be nonzero")
+}
+
+/// Constructs a nonzero `u32` that is expected to be valid test data.
+pub fn nonzero_u32(value: u32) -> NonZeroU32 {
+    NonZeroU32::new(value).expect("test value should be nonzero")
+}
+
+/// Constructs an effective page limit from a test-sized integer.
+pub fn page_limit(value: impl TryInto<u32>) -> EffectiveLimit {
+    let value = value
+        .try_into()
+        .ok()
+        .expect("test page limit should fit in u32");
+    EffectiveLimit::new(nonzero_u32(value))
+}

--- a/crates/loonfs-test-support/src/lib.rs
+++ b/crates/loonfs-test-support/src/lib.rs
@@ -1,0 +1,15 @@
+//! Shared test helpers at the object-store boundary.
+//!
+//! This crate contains broadly reusable fault-injection stores, request
+//! instrumentation, runtime helpers, pagination constructors, and HTTP test
+//! setup. It depends only on `loonfs-api` and `loonfs-objectstore` among LoonFS
+//! crates so `loonfs-core` tests can use it without a development-dependency
+//! cycle. Helpers that require `loonfs-core`, `loonfs`, `loonfs-grep`, or
+//! `loonfs-server` types do not belong here; they stay canonicalized inside
+//! the crate that owns those types. Provider-specific conformance helpers also
+//! remain in `loonfs-objectstore`.
+
+pub mod block_on;
+pub mod http;
+pub mod ids;
+pub mod stores;

--- a/crates/loonfs-test-support/src/stores/blocking_store.rs
+++ b/crates/loonfs-test-support/src/stores/blocking_store.rs
@@ -1,0 +1,327 @@
+//! A bounded async gate for selected object-store operations.
+
+use super::{KeyPredicate, OperationClass, OperationContext, OperationKind};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::{self, BoxStream};
+use futures::StreamExt;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::sync::Notify;
+use tokio::time::{timeout, Duration};
+
+type Predicate = dyn for<'a> Fn(&OperationContext<'a>) -> bool + Send + Sync;
+
+#[derive(Debug)]
+struct Gate {
+    armed: AtomicBool,
+    block_next: AtomicUsize,
+    blocked: AtomicBool,
+    released: AtomicBool,
+    completed: AtomicBool,
+    blocked_notify: Notify,
+    release_notify: Notify,
+    completed_notify: Notify,
+}
+
+impl Default for Gate {
+    fn default() -> Self {
+        Self {
+            armed: AtomicBool::new(false),
+            block_next: AtomicUsize::new(0),
+            blocked: AtomicBool::new(false),
+            released: AtomicBool::new(false),
+            completed: AtomicBool::new(false),
+            blocked_notify: Notify::new(),
+            release_notify: Notify::new(),
+            completed_notify: Notify::new(),
+        }
+    }
+}
+
+/// Parks selected operations until a test releases them.
+pub struct BlockingStore<S> {
+    inner: S,
+    predicate: Arc<Predicate>,
+    gate: Arc<Gate>,
+}
+
+impl<S> BlockingStore<S> {
+    /// Selects operations by key predicate and operation class.
+    pub fn new(inner: S, keys: KeyPredicate, operation: OperationClass) -> Self {
+        Self::matching(inner, move |context| {
+            keys.matches(context.key()) && operation.matches(context.kind())
+        })
+    }
+
+    /// Selects operations with an arbitrary operation predicate.
+    pub fn matching(
+        inner: S,
+        predicate: impl for<'a> Fn(&OperationContext<'a>) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            inner,
+            predicate: Arc::new(predicate),
+            gate: Arc::new(Gate::default()),
+        }
+    }
+
+    /// Arms a level-triggered gate. Every matching operation parks until release.
+    pub fn arm(&self) {
+        self.prepare();
+        self.gate.armed.store(true, Ordering::SeqCst);
+    }
+
+    /// Arms a one-shot gate for the next matching operation.
+    pub fn block_next(&self) {
+        self.prepare();
+        self.gate.block_next.store(1, Ordering::SeqCst);
+    }
+
+    /// Waits until a selected operation has parked.
+    pub async fn wait_until_blocked(&self) {
+        timeout(Duration::from_secs(10), async {
+            while !self.gate.blocked.load(Ordering::SeqCst) {
+                let notified = self.gate.blocked_notify.notified();
+                if self.gate.blocked.load(Ordering::SeqCst) {
+                    break;
+                }
+                // Bounded wait: `notified` registers on first poll, so a notify
+                // between the flag check and the await would otherwise be lost.
+                let _ = timeout(Duration::from_millis(50), notified).await;
+            }
+        })
+        .await
+        .expect("a selected store operation must reach the block");
+    }
+
+    /// Releases all parked operations and disarms a level-triggered gate.
+    pub fn release(&self) {
+        self.gate.armed.store(false, Ordering::SeqCst);
+        self.gate.released.store(true, Ordering::SeqCst);
+        self.gate.release_notify.notify_waiters();
+    }
+
+    /// Waits until the most recently blocked operation finishes forwarding.
+    pub async fn wait_until_completed(&self) {
+        timeout(Duration::from_secs(10), async {
+            while !self.gate.completed.load(Ordering::SeqCst) {
+                let notified = self.gate.completed_notify.notified();
+                if self.gate.completed.load(Ordering::SeqCst) {
+                    break;
+                }
+                // Bounded wait: `notified` registers on first poll, so a notify
+                // between the flag check and the await would otherwise be lost.
+                let _ = timeout(Duration::from_millis(50), notified).await;
+            }
+        })
+        .await
+        .expect("a released store operation must finish");
+    }
+
+    /// Returns a reference to the wrapped store.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    fn prepare(&self) {
+        self.gate.released.store(false, Ordering::SeqCst);
+        self.gate.blocked.store(false, Ordering::SeqCst);
+        self.gate.completed.store(false, Ordering::SeqCst);
+    }
+
+    fn matches(&self, context: &OperationContext<'_>) -> bool {
+        (self.predicate)(context)
+    }
+
+    async fn block_if_selected(&self, context: &OperationContext<'_>) -> bool {
+        if !self.matches(context) {
+            return false;
+        }
+        let level_triggered = self.gate.armed.load(Ordering::SeqCst);
+        let one_shot = !level_triggered
+            && self
+                .gate
+                .block_next
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok();
+        if !level_triggered && !one_shot {
+            return false;
+        }
+
+        self.gate.blocked.store(true, Ordering::SeqCst);
+        self.gate.blocked_notify.notify_waiters();
+        timeout(Duration::from_secs(10), async {
+            while !self.gate.released.load(Ordering::SeqCst) {
+                let notified = self.gate.release_notify.notified();
+                if self.gate.released.load(Ordering::SeqCst) {
+                    break;
+                }
+                // Bounded wait: `notified` registers on first poll, so a notify
+                // between the flag check and the await would otherwise be lost.
+                let _ = timeout(Duration::from_millis(50), notified).await;
+            }
+        })
+        .await
+        .expect("a blocked store operation must be released");
+        self.gate.blocked.store(false, Ordering::SeqCst);
+        true
+    }
+
+    fn mark_completed(&self, was_blocked: bool) {
+        if was_blocked {
+            self.gate.completed.store(true, Ordering::SeqCst);
+            self.gate.completed_notify.notify_waiters();
+        }
+    }
+}
+
+impl<S: fmt::Debug> fmt::Debug for BlockingStore<S> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BlockingStore")
+            .field("inner", &self.inner)
+            .field("gate", &self.gate)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<S: ObjectStore> ObjectStore for BlockingStore<S> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        let blocked = self
+            .block_if_selected(&OperationContext::new(key, OperationKind::Head))
+            .await;
+        let result = self.inner.head(key).await;
+        self.mark_completed(blocked);
+        result
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let blocked = self
+            .block_if_selected(&OperationContext::new(key, OperationKind::GetWithMetadata))
+            .await;
+        let result = self.inner.get_with_metadata(key).await;
+        self.mark_completed(blocked);
+        result
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let blocked = self
+            .block_if_selected(&OperationContext::new(
+                key,
+                OperationKind::Get {
+                    range: range.as_ref(),
+                },
+            ))
+            .await;
+        let result = self.inner.get(key, range).await;
+        self.mark_completed(blocked);
+        result
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let blocked = self
+            .block_if_selected(&OperationContext::new(
+                key,
+                OperationKind::Put {
+                    bytes: &bytes,
+                    mode: &mode,
+                },
+            ))
+            .await;
+        let result = self.inner.put(key, bytes, mode).await;
+        self.mark_completed(blocked);
+        result
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let blocked = self
+            .block_if_selected(&OperationContext::new(
+                key,
+                OperationKind::CompareAndSwap {
+                    expected_etag,
+                    bytes: &bytes,
+                },
+            ))
+            .await;
+        let result = self.inner.compare_and_swap(key, expected_etag, bytes).await;
+        self.mark_completed(blocked);
+        result
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        let blocked = self
+            .block_if_selected(&OperationContext::new(key, OperationKind::Delete))
+            .await;
+        let result = self.inner.delete(key).await;
+        self.mark_completed(blocked);
+        result
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        let selected = self.matches(&OperationContext::new(prefix, OperationKind::List));
+        let gate = Arc::clone(&self.gate);
+        let inner = self.inner.list_prefix_stream(prefix);
+        if !selected {
+            return inner;
+        }
+        Box::pin(
+            stream::once(async move {
+                let level_triggered = gate.armed.load(Ordering::SeqCst);
+                let one_shot = !level_triggered
+                    && gate
+                        .block_next
+                        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                            remaining.checked_sub(1)
+                        })
+                        .is_ok();
+                if level_triggered || one_shot {
+                    gate.blocked.store(true, Ordering::SeqCst);
+                    gate.blocked_notify.notify_waiters();
+                    timeout(Duration::from_secs(10), async {
+                        while !gate.released.load(Ordering::SeqCst) {
+                            let notified = gate.release_notify.notified();
+                            if gate.released.load(Ordering::SeqCst) {
+                                break;
+                            }
+                            // Bounded wait: `notified` registers on first poll, so a notify
+                            // between the flag check and the await would otherwise be lost.
+                            let _ = timeout(Duration::from_millis(50), notified).await;
+                        }
+                    })
+                    .await
+                    .expect("a blocked store operation must be released");
+                    gate.blocked.store(false, Ordering::SeqCst);
+                    gate.completed.store(true, Ordering::SeqCst);
+                    gate.completed_notify.notify_waiters();
+                }
+                inner
+            })
+            .flatten(),
+        )
+    }
+}

--- a/crates/loonfs-test-support/src/stores/counting_store.rs
+++ b/crates/loonfs-test-support/src/stores/counting_store.rs
@@ -1,0 +1,272 @@
+//! Per-operation request and byte counters for selected keys.
+
+use super::{KeyPredicate, OperationClass};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+/// Snapshot of request counts and transferred bytes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StoreCounts {
+    /// Metadata-only read calls.
+    pub heads: usize,
+    /// Byte `get` calls.
+    pub gets: usize,
+    /// Full-object `get_with_metadata` calls.
+    pub gets_with_metadata: usize,
+    /// All put calls, including CAS-mode puts.
+    pub puts: usize,
+    /// Overwrite puts.
+    pub overwrite_puts: usize,
+    /// Create-if-absent puts.
+    pub create_if_absent_puts: usize,
+    /// Compare-and-swap calls and CAS-mode puts.
+    pub compare_and_swaps: usize,
+    /// Delete calls.
+    pub deletes: usize,
+    /// Prefix-list calls.
+    pub lists: usize,
+    /// Bytes returned by successful byte reads.
+    pub read_bytes: u64,
+    /// Bytes supplied to put calls.
+    pub written_bytes: u64,
+}
+
+impl StoreCounts {
+    /// Returns the request count for `operation`.
+    pub fn operations(self, operation: OperationClass) -> usize {
+        match operation {
+            OperationClass::Any => {
+                self.heads
+                    + self.gets
+                    + self.gets_with_metadata
+                    + self.puts
+                    + self.deletes
+                    + self.lists
+            }
+            OperationClass::Head => self.heads,
+            OperationClass::Get => self.gets,
+            OperationClass::GetWithMetadata => self.gets_with_metadata,
+            OperationClass::Read => self.gets + self.gets_with_metadata,
+            OperationClass::Put => self.puts,
+            OperationClass::PutOverwrite => self.overwrite_puts,
+            OperationClass::PutCreateIfAbsent => self.create_if_absent_puts,
+            OperationClass::CompareAndSwap => self.compare_and_swaps,
+            OperationClass::Delete => self.deletes,
+            OperationClass::List => self.lists,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Counters {
+    heads: AtomicUsize,
+    gets: AtomicUsize,
+    gets_with_metadata: AtomicUsize,
+    puts: AtomicUsize,
+    overwrite_puts: AtomicUsize,
+    create_if_absent_puts: AtomicUsize,
+    compare_and_swaps: AtomicUsize,
+    deletes: AtomicUsize,
+    lists: AtomicUsize,
+    read_bytes: AtomicU64,
+    written_bytes: AtomicU64,
+}
+
+/// Counts operations on selected object keys.
+#[derive(Debug)]
+pub struct CountingStore<S> {
+    inner: S,
+    keys: KeyPredicate,
+    counters: Counters,
+}
+
+impl<S> CountingStore<S> {
+    /// Counts every operation whose key matches `keys`.
+    pub fn new(inner: S, keys: KeyPredicate) -> Self {
+        Self {
+            inner,
+            keys,
+            counters: Counters::default(),
+        }
+    }
+
+    /// Counts operations on content blobs.
+    pub fn content_blobs(inner: S) -> Self {
+        Self::new(inner, KeyPredicate::content_blob())
+    }
+
+    /// Counts operations on metadata tables.
+    pub fn metadata_tables(inner: S) -> Self {
+        Self::new(inner, KeyPredicate::metadata_table())
+    }
+
+    /// Returns the current counters.
+    pub fn snapshot(&self) -> StoreCounts {
+        StoreCounts {
+            heads: self.counters.heads.load(Ordering::SeqCst),
+            gets: self.counters.gets.load(Ordering::SeqCst),
+            gets_with_metadata: self.counters.gets_with_metadata.load(Ordering::SeqCst),
+            puts: self.counters.puts.load(Ordering::SeqCst),
+            overwrite_puts: self.counters.overwrite_puts.load(Ordering::SeqCst),
+            create_if_absent_puts: self.counters.create_if_absent_puts.load(Ordering::SeqCst),
+            compare_and_swaps: self.counters.compare_and_swaps.load(Ordering::SeqCst),
+            deletes: self.counters.deletes.load(Ordering::SeqCst),
+            lists: self.counters.lists.load(Ordering::SeqCst),
+            read_bytes: self.counters.read_bytes.load(Ordering::SeqCst),
+            written_bytes: self.counters.written_bytes.load(Ordering::SeqCst),
+        }
+    }
+
+    /// Returns the current request count for `operation`.
+    pub fn count(&self, operation: OperationClass) -> usize {
+        self.snapshot().operations(operation)
+    }
+
+    /// Resets every counter.
+    pub fn reset(&self) {
+        self.counters.heads.store(0, Ordering::SeqCst);
+        self.counters.gets.store(0, Ordering::SeqCst);
+        self.counters.gets_with_metadata.store(0, Ordering::SeqCst);
+        self.counters.puts.store(0, Ordering::SeqCst);
+        self.counters.overwrite_puts.store(0, Ordering::SeqCst);
+        self.counters
+            .create_if_absent_puts
+            .store(0, Ordering::SeqCst);
+        self.counters.compare_and_swaps.store(0, Ordering::SeqCst);
+        self.counters.deletes.store(0, Ordering::SeqCst);
+        self.counters.lists.store(0, Ordering::SeqCst);
+        self.counters.read_bytes.store(0, Ordering::SeqCst);
+        self.counters.written_bytes.store(0, Ordering::SeqCst);
+    }
+
+    /// Returns a reference to the wrapped store.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    fn matches(&self, key: &str) -> bool {
+        self.keys.matches(key)
+    }
+
+    fn record_read_bytes(&self, bytes: usize) {
+        self.counters
+            .read_bytes
+            .fetch_add(u64::try_from(bytes).unwrap_or(u64::MAX), Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl<S: ObjectStore> ObjectStore for CountingStore<S> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        if self.matches(key) {
+            self.counters.heads.fetch_add(1, Ordering::SeqCst);
+        }
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let matches = self.matches(key);
+        if matches {
+            self.counters
+                .gets_with_metadata
+                .fetch_add(1, Ordering::SeqCst);
+        }
+        let result = self.inner.get_with_metadata(key).await;
+        if matches {
+            if let Ok(Some(body)) = &result {
+                self.record_read_bytes(body.bytes.len());
+            }
+        }
+        result
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let matches = self.matches(key);
+        if matches {
+            self.counters.gets.fetch_add(1, Ordering::SeqCst);
+        }
+        let result = self.inner.get(key, range).await;
+        if matches {
+            if let Ok(Some(bytes)) = &result {
+                self.record_read_bytes(bytes.len());
+            }
+        }
+        result
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if self.matches(key) {
+            self.counters.puts.fetch_add(1, Ordering::SeqCst);
+            self.counters.written_bytes.fetch_add(
+                u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
+            match mode {
+                PutMode::Overwrite => {
+                    self.counters.overwrite_puts.fetch_add(1, Ordering::SeqCst);
+                }
+                PutMode::CreateIfAbsent => {
+                    self.counters
+                        .create_if_absent_puts
+                        .fetch_add(1, Ordering::SeqCst);
+                }
+                PutMode::CompareAndSwap { .. } => {
+                    self.counters
+                        .compare_and_swaps
+                        .fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if self.matches(key) {
+            self.counters.puts.fetch_add(1, Ordering::SeqCst);
+            self.counters
+                .compare_and_swaps
+                .fetch_add(1, Ordering::SeqCst);
+            self.counters.written_bytes.fetch_add(
+                u64::try_from(bytes.len()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
+        }
+        self.inner.compare_and_swap(key, expected_etag, bytes).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        if self.matches(key) {
+            self.counters.deletes.fetch_add(1, Ordering::SeqCst);
+        }
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        if self.matches(prefix) {
+            self.counters.lists.fetch_add(1, Ordering::SeqCst);
+        }
+        self.inner.list_prefix_stream(prefix)
+    }
+}

--- a/crates/loonfs-test-support/src/stores/fail_store.rs
+++ b/crates/loonfs-test-support/src/stores/fail_store.rs
@@ -1,0 +1,293 @@
+//! Configurable failures for selected object-store operations.
+
+use super::{KeyPredicate, OperationClass, OperationContext, OperationKind};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::{self, BoxStream};
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+type Predicate = dyn for<'a> Fn(&OperationContext<'a>) -> bool + Send + Sync;
+
+/// Error returned by a [`FailStore`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InjectedError {
+    /// A provider precondition failure.
+    PreconditionFailed,
+    /// A test-only protocol conflict.
+    Conflict,
+    /// A transport failure carrying the supplied message.
+    Transport(String),
+}
+
+impl InjectedError {
+    fn for_key(&self, key: &str) -> ObjectStoreError {
+        match self {
+            Self::PreconditionFailed => ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            },
+            Self::Conflict => ObjectStoreError::Conflict {
+                object_key: key.to_owned(),
+            },
+            Self::Transport(message) => ObjectStoreError::transport(key, message),
+        }
+    }
+}
+
+/// Whether a selected write is applied before its injected failure is returned.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FailureMode {
+    /// Return the failure without forwarding the operation.
+    #[default]
+    BeforeApply,
+    /// Forward successfully, then return the configured failure.
+    ApplyThenFail,
+}
+
+/// Injects a configured error into selected operations.
+pub struct FailStore<S> {
+    inner: S,
+    predicate: Arc<Predicate>,
+    error: InjectedError,
+    mode: FailureMode,
+    remaining: AtomicUsize,
+    fail_all: AtomicBool,
+    attempts: AtomicUsize,
+}
+
+impl<S> FailStore<S> {
+    /// Selects operations by key predicate and operation class.
+    pub fn new(
+        inner: S,
+        keys: KeyPredicate,
+        operation: OperationClass,
+        error: InjectedError,
+    ) -> Self {
+        Self::matching(
+            inner,
+            move |context| keys.matches(context.key()) && operation.matches(context.kind()),
+            error,
+        )
+    }
+
+    /// Selects operations with an arbitrary operation predicate.
+    pub fn matching(
+        inner: S,
+        predicate: impl for<'a> Fn(&OperationContext<'a>) -> bool + Send + Sync + 'static,
+        error: InjectedError,
+    ) -> Self {
+        Self {
+            inner,
+            predicate: Arc::new(predicate),
+            error,
+            mode: FailureMode::BeforeApply,
+            remaining: AtomicUsize::new(0),
+            fail_all: AtomicBool::new(false),
+            attempts: AtomicUsize::new(0),
+        }
+    }
+
+    /// Returns failures after selected operations have been applied.
+    pub fn apply_then_fail(mut self) -> Self {
+        self.mode = FailureMode::ApplyThenFail;
+        self
+    }
+
+    /// Fails the next `count` matching operations and resets the attempt count.
+    pub fn fail_next(&self, count: usize) {
+        self.attempts.store(0, Ordering::SeqCst);
+        self.fail_all.store(false, Ordering::SeqCst);
+        self.remaining.store(count, Ordering::SeqCst);
+    }
+
+    /// Fails every matching operation until [`Self::clear`] is called.
+    pub fn fail_all(&self) {
+        self.attempts.store(0, Ordering::SeqCst);
+        self.remaining.store(0, Ordering::SeqCst);
+        self.fail_all.store(true, Ordering::SeqCst);
+    }
+
+    /// Stops injecting failures.
+    pub fn clear(&self) {
+        self.fail_all.store(false, Ordering::SeqCst);
+        self.remaining.store(0, Ordering::SeqCst);
+    }
+
+    /// Returns the number of matching attempts since the most recent arming.
+    pub fn attempts(&self) -> usize {
+        self.attempts.load(Ordering::SeqCst)
+    }
+
+    /// Returns the number of failures still armed.
+    pub fn remaining(&self) -> usize {
+        self.remaining.load(Ordering::SeqCst)
+    }
+
+    /// Returns a reference to the wrapped store.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    fn should_fail(&self, context: &OperationContext<'_>) -> bool {
+        if !(self.predicate)(context) {
+            return false;
+        }
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        self.fail_all.load(Ordering::SeqCst)
+            || self
+                .remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+    }
+}
+
+impl<S: fmt::Debug> fmt::Debug for FailStore<S> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FailStore")
+            .field("inner", &self.inner)
+            .field("error", &self.error)
+            .field("mode", &self.mode)
+            .field("remaining", &self.remaining)
+            .field("fail_all", &self.fail_all)
+            .field("attempts", &self.attempts)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<S: ObjectStore> ObjectStore for FailStore<S> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        let fail = self.should_fail(&OperationContext::new(key, OperationKind::Head));
+        if fail && self.mode == FailureMode::BeforeApply {
+            return Err(self.error.for_key(key));
+        }
+        let result = self.inner.head(key).await;
+        if fail {
+            result?;
+            Err(self.error.for_key(key))
+        } else {
+            result
+        }
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let fail = self.should_fail(&OperationContext::new(key, OperationKind::GetWithMetadata));
+        if fail && self.mode == FailureMode::BeforeApply {
+            return Err(self.error.for_key(key));
+        }
+        let result = self.inner.get_with_metadata(key).await;
+        if fail {
+            result?;
+            Err(self.error.for_key(key))
+        } else {
+            result
+        }
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let fail = self.should_fail(&OperationContext::new(
+            key,
+            OperationKind::Get {
+                range: range.as_ref(),
+            },
+        ));
+        if fail && self.mode == FailureMode::BeforeApply {
+            return Err(self.error.for_key(key));
+        }
+        let result = self.inner.get(key, range).await;
+        if fail {
+            result?;
+            Err(self.error.for_key(key))
+        } else {
+            result
+        }
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let fail = self.should_fail(&OperationContext::new(
+            key,
+            OperationKind::Put {
+                bytes: &bytes,
+                mode: &mode,
+            },
+        ));
+        if fail && self.mode == FailureMode::BeforeApply {
+            return Err(self.error.for_key(key));
+        }
+        let result = self.inner.put(key, bytes, mode).await;
+        if fail {
+            result?;
+            Err(self.error.for_key(key))
+        } else {
+            result
+        }
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let fail = self.should_fail(&OperationContext::new(
+            key,
+            OperationKind::CompareAndSwap {
+                expected_etag,
+                bytes: &bytes,
+            },
+        ));
+        if fail && self.mode == FailureMode::BeforeApply {
+            return Err(self.error.for_key(key));
+        }
+        let result = self.inner.compare_and_swap(key, expected_etag, bytes).await;
+        if fail {
+            result?;
+            Err(self.error.for_key(key))
+        } else {
+            result
+        }
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        let fail = self.should_fail(&OperationContext::new(key, OperationKind::Delete));
+        if fail && self.mode == FailureMode::BeforeApply {
+            return Err(self.error.for_key(key));
+        }
+        let result = self.inner.delete(key).await;
+        if fail {
+            result?;
+            Err(self.error.for_key(key))
+        } else {
+            result
+        }
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        if self.should_fail(&OperationContext::new(prefix, OperationKind::List)) {
+            return Box::pin(stream::once({
+                let error = self.error.for_key(prefix);
+                async move { Err(error) }
+            }));
+        }
+        self.inner.list_prefix_stream(prefix)
+    }
+}

--- a/crates/loonfs-test-support/src/stores/key_predicate.rs
+++ b/crates/loonfs-test-support/src/stores/key_predicate.rs
@@ -1,0 +1,75 @@
+//! Reusable key predicates for object-store wrappers.
+
+use loonfs_objectstore::keys::{metadata_root, wal_head};
+use loonfs_objectstore::layout::{parse_object_key, DurableObjectFamily};
+use std::fmt;
+use std::sync::Arc;
+
+type Predicate = dyn Fn(&str) -> bool + Send + Sync;
+
+/// A cloneable predicate selecting object keys for a test wrapper.
+#[derive(Clone)]
+pub struct KeyPredicate {
+    predicate: Arc<Predicate>,
+}
+
+impl KeyPredicate {
+    /// Selects keys accepted by `predicate`.
+    pub fn new(predicate: impl Fn(&str) -> bool + Send + Sync + 'static) -> Self {
+        Self {
+            predicate: Arc::new(predicate),
+        }
+    }
+
+    /// Selects every key.
+    pub fn any() -> Self {
+        Self::new(|_| true)
+    }
+
+    /// Selects exactly `key`.
+    pub fn exact(key: impl Into<String>) -> Self {
+        let key = key.into();
+        Self::new(move |candidate| candidate == key)
+    }
+
+    /// Selects keys beginning with `prefix`.
+    pub fn prefix(prefix: impl Into<String>) -> Self {
+        let prefix = prefix.into();
+        Self::new(move |key| key.starts_with(&prefix))
+    }
+
+    /// Selects keys in one durable object family.
+    pub fn family(family: DurableObjectFamily) -> Self {
+        Self::new(move |key| parse_object_key(key).is_some_and(|parsed| parsed.family() == family))
+    }
+
+    /// Selects content-blob keys.
+    pub fn content_blob() -> Self {
+        Self::family(DurableObjectFamily::ContentBlob)
+    }
+
+    /// Selects metadata-table keys.
+    pub fn metadata_table() -> Self {
+        Self::family(DurableObjectFamily::MetadataTable)
+    }
+
+    /// Selects the WAL head for `namespace`.
+    pub fn wal_head(namespace: &str) -> Self {
+        Self::exact(wal_head(namespace))
+    }
+
+    /// Selects the metadata root for `namespace`.
+    pub fn metadata_root(namespace: &str) -> Self {
+        Self::exact(metadata_root(namespace))
+    }
+
+    pub(crate) fn matches(&self, key: &str) -> bool {
+        (self.predicate)(key)
+    }
+}
+
+impl fmt::Debug for KeyPredicate {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("KeyPredicate(..)")
+    }
+}

--- a/crates/loonfs-test-support/src/stores/metadata_map_store.rs
+++ b/crates/loonfs-test-support/src/stores/metadata_map_store.rs
@@ -1,0 +1,142 @@
+//! Metadata transforms for selected object-store operations.
+
+use super::KeyPredicate;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::fmt;
+use std::sync::Arc;
+
+type Transform = dyn Fn(ObjectMetadata) -> ObjectMetadata + Send + Sync;
+
+/// Maps returned metadata for selected keys.
+pub struct MetadataMapStore<S> {
+    inner: S,
+    keys: KeyPredicate,
+    transform: Arc<Transform>,
+}
+
+impl<S> MetadataMapStore<S> {
+    /// Applies `transform` to returned metadata for matching keys.
+    pub fn new(
+        inner: S,
+        keys: KeyPredicate,
+        transform: impl Fn(ObjectMetadata) -> ObjectMetadata + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            inner,
+            keys,
+            transform: Arc::new(transform),
+        }
+    }
+
+    /// Reports matching objects as last modified at unix epoch zero.
+    pub fn aged(inner: S, keys: KeyPredicate) -> Self {
+        Self::new(inner, keys, |mut metadata| {
+            metadata.last_modified_ms = Some(0);
+            metadata
+        })
+    }
+
+    /// Removes last-modified timestamps from matching metadata.
+    pub fn without_last_modified(inner: S, keys: KeyPredicate) -> Self {
+        Self::new(inner, keys, |mut metadata| {
+            metadata.last_modified_ms = None;
+            metadata
+        })
+    }
+
+    /// Removes etags from matching metadata.
+    pub fn without_etag(inner: S, keys: KeyPredicate) -> Self {
+        Self::new(inner, keys, |mut metadata| {
+            metadata.etag = None;
+            metadata
+        })
+    }
+
+    /// Returns a reference to the wrapped store.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    fn map(&self, key: &str, metadata: ObjectMetadata) -> ObjectMetadata {
+        if self.keys.matches(key) {
+            (self.transform)(metadata)
+        } else {
+            metadata
+        }
+    }
+}
+
+impl<S: fmt::Debug> fmt::Debug for MetadataMapStore<S> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MetadataMapStore")
+            .field("inner", &self.inner)
+            .field("keys", &self.keys)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<S: ObjectStore> ObjectStore for MetadataMapStore<S> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        Ok(self
+            .inner
+            .head(key)
+            .await?
+            .map(|metadata| self.map(key, metadata)))
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        Ok(self.inner.get_with_metadata(key).await?.map(|mut body| {
+            body.metadata = self.map(key, body.metadata);
+            body
+        }))
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let metadata = self.inner.put(key, bytes, mode).await?;
+        Ok(self.map(key, metadata))
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let metadata = self
+            .inner
+            .compare_and_swap(key, expected_etag, bytes)
+            .await?;
+        Ok(self.map(key, metadata))
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}

--- a/crates/loonfs-test-support/src/stores/mod.rs
+++ b/crates/loonfs-test-support/src/stores/mod.rs
@@ -1,0 +1,17 @@
+//! Composable object-store wrappers for test fault injection and observation.
+
+mod blocking_store;
+mod counting_store;
+mod fail_store;
+mod key_predicate;
+mod metadata_map_store;
+mod operation;
+mod recording_store;
+
+pub use blocking_store::BlockingStore;
+pub use counting_store::{CountingStore, StoreCounts};
+pub use fail_store::{FailStore, FailureMode, InjectedError};
+pub use key_predicate::KeyPredicate;
+pub use metadata_map_store::MetadataMapStore;
+pub use operation::{OperationClass, OperationContext, OperationKind};
+pub use recording_store::{RecordedGet, RecordedOperation, RecordingStore};

--- a/crates/loonfs-test-support/src/stores/operation.rs
+++ b/crates/loonfs-test-support/src/stores/operation.rs
@@ -1,0 +1,126 @@
+//! Object-store operation descriptions used by wrapper predicates.
+
+use bytes::Bytes;
+use loonfs_objectstore::{ByteRange, PutMode};
+
+/// A broad operation class selected by a test wrapper.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationClass {
+    /// Every operation.
+    Any,
+    /// Metadata-only reads.
+    Head,
+    /// Byte reads through `get`.
+    Get,
+    /// Full reads through `get_with_metadata`.
+    GetWithMetadata,
+    /// Either byte-read form.
+    Read,
+    /// Any `put` mode.
+    Put,
+    /// Overwriting puts.
+    PutOverwrite,
+    /// Create-if-absent puts.
+    PutCreateIfAbsent,
+    /// Compare-and-swap calls and CAS-mode puts.
+    CompareAndSwap,
+    /// Deletes.
+    Delete,
+    /// Prefix-list calls.
+    List,
+}
+
+impl OperationClass {
+    pub(crate) fn matches(self, kind: &OperationKind<'_>) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Head => matches!(kind, OperationKind::Head),
+            Self::Get => matches!(kind, OperationKind::Get { .. }),
+            Self::GetWithMetadata => matches!(kind, OperationKind::GetWithMetadata),
+            Self::Read => matches!(
+                kind,
+                OperationKind::Get { .. } | OperationKind::GetWithMetadata
+            ),
+            Self::Put => matches!(kind, OperationKind::Put { .. }),
+            Self::PutOverwrite => matches!(
+                kind,
+                OperationKind::Put {
+                    mode: PutMode::Overwrite,
+                    ..
+                }
+            ),
+            Self::PutCreateIfAbsent => matches!(
+                kind,
+                OperationKind::Put {
+                    mode: PutMode::CreateIfAbsent,
+                    ..
+                }
+            ),
+            Self::CompareAndSwap => matches!(
+                kind,
+                OperationKind::CompareAndSwap { .. }
+                    | OperationKind::Put {
+                        mode: PutMode::CompareAndSwap { .. },
+                        ..
+                    }
+            ),
+            Self::Delete => matches!(kind, OperationKind::Delete),
+            Self::List => matches!(kind, OperationKind::List),
+        }
+    }
+}
+
+/// Details of one intercepted object-store operation.
+#[derive(Debug)]
+pub struct OperationContext<'a> {
+    key: &'a str,
+    kind: OperationKind<'a>,
+}
+
+impl<'a> OperationContext<'a> {
+    pub(crate) fn new(key: &'a str, kind: OperationKind<'a>) -> Self {
+        Self { key, kind }
+    }
+
+    /// Returns the addressed object key or list prefix.
+    pub fn key(&self) -> &str {
+        self.key
+    }
+
+    /// Returns the exact operation details.
+    pub fn kind(&self) -> &OperationKind<'a> {
+        &self.kind
+    }
+}
+
+/// Borrowed details of one exact object-store operation.
+#[derive(Debug)]
+pub enum OperationKind<'a> {
+    /// A `head` call.
+    Head,
+    /// A `get` call.
+    Get {
+        /// Requested byte range.
+        range: Option<&'a ByteRange>,
+    },
+    /// A `get_with_metadata` call.
+    GetWithMetadata,
+    /// A `put` call.
+    Put {
+        /// Bytes supplied by the caller.
+        bytes: &'a Bytes,
+        /// Write mode supplied by the caller.
+        mode: &'a PutMode,
+    },
+    /// A `compare_and_swap` call.
+    CompareAndSwap {
+        /// Expected current etag.
+        expected_etag: &'a str,
+        /// Bytes supplied by the caller.
+        bytes: &'a Bytes,
+    },
+    /// A `delete` call.
+    Delete,
+    /// A `list_prefix_stream` call.
+    List,
+}

--- a/crates/loonfs-test-support/src/stores/recording_store.rs
+++ b/crates/loonfs-test-support/src/stores/recording_store.rs
@@ -1,0 +1,203 @@
+//! Exact operation logs for selected object keys.
+
+use super::KeyPredicate;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs_objectstore::{
+    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+};
+use std::sync::Mutex;
+
+/// An owned get record containing its key and optional `(start, end)` byte range.
+pub type RecordedGet = (String, Option<(u64, u64)>);
+
+/// One owned operation-log entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordedOperation {
+    /// A metadata-only read.
+    Head { key: String },
+    /// A byte read.
+    Get {
+        key: String,
+        range: Option<ByteRange>,
+    },
+    /// A full-object read.
+    GetWithMetadata { key: String },
+    /// A put.
+    Put {
+        key: String,
+        mode: PutMode,
+        bytes: usize,
+    },
+    /// A compare-and-swap call.
+    CompareAndSwap { key: String, bytes: usize },
+    /// A delete.
+    Delete { key: String },
+    /// A prefix-list call.
+    List { prefix: String },
+}
+
+impl RecordedOperation {
+    /// Returns the addressed key or list prefix.
+    pub fn key(&self) -> &str {
+        match self {
+            Self::Head { key }
+            | Self::Get { key, .. }
+            | Self::GetWithMetadata { key }
+            | Self::Put { key, .. }
+            | Self::CompareAndSwap { key, .. }
+            | Self::Delete { key } => key,
+            Self::List { prefix } => prefix,
+        }
+    }
+}
+
+/// Records selected object-store operations in call order.
+#[derive(Debug)]
+pub struct RecordingStore<S> {
+    inner: S,
+    keys: KeyPredicate,
+    operations: Mutex<Vec<RecordedOperation>>,
+}
+
+impl<S> RecordingStore<S> {
+    /// Records every operation whose key matches `keys`.
+    pub fn new(inner: S, keys: KeyPredicate) -> Self {
+        Self {
+            inner,
+            keys,
+            operations: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Returns a snapshot without clearing the log.
+    pub fn snapshot(&self) -> Vec<RecordedOperation> {
+        self.operations
+            .lock()
+            .expect("operation log lock poisoned")
+            .clone()
+    }
+
+    /// Takes and clears the operation log.
+    pub fn take(&self) -> Vec<RecordedOperation> {
+        std::mem::take(&mut *self.operations.lock().expect("operation log lock poisoned"))
+    }
+
+    /// Takes all operations and returns only byte-read records.
+    ///
+    /// `get_with_metadata` records carry no range.
+    pub fn take_gets(&self) -> Vec<RecordedGet> {
+        self.take()
+            .into_iter()
+            .filter_map(|operation| match operation {
+                RecordedOperation::Get { key, range } => Some((
+                    key,
+                    range.map(|range| (range.start_inclusive, range.end_exclusive)),
+                )),
+                RecordedOperation::GetWithMetadata { key } => Some((key, None)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Takes all operations and returns only keys read through either get form.
+    pub fn take_get_keys(&self) -> Vec<String> {
+        self.take_gets().into_iter().map(|(key, _)| key).collect()
+    }
+
+    /// Clears the operation log.
+    pub fn reset(&self) {
+        self.operations
+            .lock()
+            .expect("operation log lock poisoned")
+            .clear();
+    }
+
+    /// Returns a reference to the wrapped store.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    fn record(&self, operation: RecordedOperation) {
+        if self.keys.matches(operation.key()) {
+            self.operations
+                .lock()
+                .expect("operation log lock poisoned")
+                .push(operation);
+        }
+    }
+}
+
+#[async_trait]
+impl<S: ObjectStore> ObjectStore for RecordingStore<S> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.record(RecordedOperation::Head {
+            key: key.to_owned(),
+        });
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.record(RecordedOperation::GetWithMetadata {
+            key: key.to_owned(),
+        });
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.record(RecordedOperation::Get {
+            key: key.to_owned(),
+            range: range.clone(),
+        });
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.record(RecordedOperation::Put {
+            key: key.to_owned(),
+            mode: mode.clone(),
+            bytes: bytes.len(),
+        });
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.record(RecordedOperation::CompareAndSwap {
+            key: key.to_owned(),
+            bytes: bytes.len(),
+        });
+        self.inner.compare_and_swap(key, expected_etag, bytes).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.record(RecordedOperation::Delete {
+            key: key.to_owned(),
+        });
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.record(RecordedOperation::List {
+            prefix: prefix.to_owned(),
+        });
+        self.inner.list_prefix_stream(prefix)
+    }
+}

--- a/crates/loonfs/src/background.rs
+++ b/crates/loonfs/src/background.rs
@@ -207,15 +207,12 @@ mod tests {
     // The drain test injects a task panic to assert it is surfaced.
 
     use super::*;
+    use loonfs_test_support::ids::{namespace_id, nonzero_usize};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
-    fn namespace_id() -> NamespaceId {
-        NamespaceId::parse("demo").expect("valid namespace id")
-    }
-
     fn concurrency_cap(value: usize) -> NonZeroUsize {
-        NonZeroUsize::new(value).expect("test cap should be nonzero")
+        nonzero_usize(value)
     }
 
     /// Sets its flag when dropped, mimicking the claim guard the auto-tick
@@ -232,7 +229,7 @@ mod tests {
     #[test]
     fn a_request_during_an_active_tick_defers_and_reruns_exactly_once() {
         let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
-        let namespace_id = namespace_id();
+        let namespace_id = namespace_id("demo");
 
         assert!(background.try_claim(&namespace_id), "first claim spawns");
         assert!(
@@ -257,7 +254,7 @@ mod tests {
     #[test]
     fn shutdown_wins_over_a_deferred_rerun() {
         let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
-        let namespace_id = namespace_id();
+        let namespace_id = namespace_id("demo");
 
         assert!(background.try_claim(&namespace_id));
         assert!(!background.try_claim(&namespace_id), "defers while active");
@@ -271,7 +268,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_after_shut_down_refuses_and_drops_the_future() {
         let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
-        let namespace_id = namespace_id();
+        let namespace_id = namespace_id("demo");
 
         // The racy interleaving a shutdown must win: the claim lands first...
         assert!(background.try_claim(&namespace_id));
@@ -336,7 +333,7 @@ mod tests {
     #[tokio::test]
     async fn claims_are_singleflight_and_refused_after_shut_down() {
         let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(8));
-        let namespace_id = namespace_id();
+        let namespace_id = namespace_id("demo");
         assert!(background.try_claim(&namespace_id));
         assert!(
             !background.try_claim(&namespace_id),
@@ -359,7 +356,7 @@ mod tests {
     async fn manual_only_policy_never_claims() {
         let background =
             BackgroundWork::new(FsBackgroundWork::ManualOnly, None, concurrency_cap(8));
-        assert!(!background.try_claim(&namespace_id()));
+        assert!(!background.try_claim(&namespace_id("demo")));
     }
 
     #[tokio::test]

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1096,128 +1096,22 @@ mod tests {
     use loonfs_objectstore::{
         ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
     };
+    use loonfs_test_support::stores::{
+        BlockingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+    };
     use std::path::Path;
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Condvar;
     use tempfile::tempdir;
 
-    #[derive(Debug)]
-    struct BlockingHeadCasStore {
-        inner: LocalFsStore,
-        head_key: String,
-        gate: Arc<HeadCasGate>,
-    }
-
-    #[derive(Debug)]
-    struct HeadCasGate {
-        state: Mutex<HeadCasGateState>,
-        cvar: Condvar,
-    }
-
-    #[derive(Debug)]
-    struct HeadCasGateState {
-        blocks_remaining: usize,
-        entered: usize,
-        released: bool,
-    }
-
-    impl BlockingHeadCasStore {
-        fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
-            Self {
-                inner: LocalFsStore::new(root.as_ref()).expect("store"),
-                head_key: wal_head(namespace_id.as_str()),
-                gate: Arc::new(HeadCasGate {
-                    state: Mutex::new(HeadCasGateState {
-                        blocks_remaining: 0,
-                        entered: 0,
-                        released: false,
-                    }),
-                    cvar: Condvar::new(),
-                }),
-            }
-        }
-
-        fn arm_next_head_cas(&self) {
-            let mut state = self.gate.state.lock().expect("head gate mutex poisoned");
-            state.blocks_remaining = 1;
-            state.released = false;
-        }
-
-        async fn wait_for_blocked_head_cas(&self) {
-            let gate = self.gate.clone();
-            tokio::task::spawn_blocking(move || {
-                let mut state = gate.state.lock().expect("head gate mutex poisoned");
-                while state.entered < 1 {
-                    state = gate.cvar.wait(state).expect("head gate mutex poisoned");
-                }
-            })
-            .await
-            .expect("wait for blocked head CAS");
-        }
-
-        fn release_head_cas(&self) {
-            let mut state = self.gate.state.lock().expect("head gate mutex poisoned");
-            state.released = true;
-            self.gate.cvar.notify_all();
-        }
-    }
-
-    #[async_trait]
-    impl ObjectStore for BlockingHeadCasStore {
-        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            self.inner.head(key).await
-        }
-
-        async fn get(
-            &self,
-            key: &str,
-            range: Option<ByteRange>,
-        ) -> Result<Option<Bytes>, ObjectStoreError> {
-            self.inner.get(key, range).await
-        }
-
-        async fn get_with_metadata(
-            &self,
-            key: &str,
-        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
-            self.inner.get_with_metadata(key).await
-        }
-
-        async fn put(
-            &self,
-            key: &str,
-            bytes: Bytes,
-            mode: PutMode,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            if key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. }) {
-                let gate = self.gate.clone();
-                tokio::task::spawn_blocking(move || {
-                    let mut state = gate.state.lock().expect("head gate mutex poisoned");
-                    if state.blocks_remaining > 0 {
-                        state.blocks_remaining -= 1;
-                        state.entered += 1;
-                        gate.cvar.notify_all();
-                        while !state.released {
-                            state = gate.cvar.wait(state).expect("head gate mutex poisoned");
-                        }
-                    }
-                })
-                .await
-                .expect("head CAS gate wait task panicked");
-            }
-            self.inner.put(key, bytes, mode).await
-        }
-
-        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-            self.inner.delete(key).await
-        }
-
-        fn list_prefix_stream(
-            &self,
-            prefix: &str,
-        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
-        }
+    fn blocking_head_cas_store(
+        root: impl AsRef<Path>,
+        namespace_id: &NamespaceId,
+    ) -> BlockingStore<LocalFsStore> {
+        BlockingStore::new(
+            LocalFsStore::new(root.as_ref()).expect("store"),
+            KeyPredicate::wal_head(namespace_id.as_str()),
+            OperationClass::CompareAndSwap,
+        )
     }
 
     #[derive(Debug)]
@@ -1263,7 +1157,7 @@ mod tests {
             state.released = false;
         }
 
-        async fn wait_for_blocked_head_cas(&self) {
+        async fn wait_until_blocked(&self) {
             let gate = self.gate.clone();
             tokio::task::spawn_blocking(move || {
                 let mut state = gate.lock_state();
@@ -1357,79 +1251,17 @@ mod tests {
         }
     }
 
-    /// Applies head CAS writes but reports a transport failure for the next
-    /// one: the commit lands durably while the acknowledgement is lost.
-    #[derive(Debug)]
-    struct LostHeadCasAckStore {
-        inner: LocalFsStore,
-        head_key: String,
-        lose_next_head_cas_ack: AtomicBool,
-    }
-
-    impl LostHeadCasAckStore {
-        fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
-            Self {
-                inner: LocalFsStore::new(root.as_ref()).expect("store"),
-                head_key: wal_head(namespace_id.as_str()),
-                lose_next_head_cas_ack: AtomicBool::new(false),
-            }
-        }
-
-        fn lose_next_head_cas_ack(&self) {
-            self.lose_next_head_cas_ack.store(true, Ordering::SeqCst);
-        }
-    }
-
-    #[async_trait]
-    impl ObjectStore for LostHeadCasAckStore {
-        async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-            self.inner.head(key).await
-        }
-
-        async fn get(
-            &self,
-            key: &str,
-            range: Option<ByteRange>,
-        ) -> Result<Option<Bytes>, ObjectStoreError> {
-            self.inner.get(key, range).await
-        }
-
-        async fn get_with_metadata(
-            &self,
-            key: &str,
-        ) -> Result<Option<ObjectBody>, ObjectStoreError> {
-            self.inner.get_with_metadata(key).await
-        }
-
-        async fn put(
-            &self,
-            key: &str,
-            bytes: Bytes,
-            mode: PutMode,
-        ) -> Result<ObjectMetadata, ObjectStoreError> {
-            let lose_ack = key == self.head_key
-                && matches!(mode, PutMode::CompareAndSwap { .. })
-                && self.lose_next_head_cas_ack.swap(false, Ordering::SeqCst);
-            let metadata = self.inner.put(key, bytes, mode).await?;
-            if lose_ack {
-                return Err(ObjectStoreError::transport(
-                    key,
-                    "injected lost head CAS acknowledgement",
-                ));
-            }
-            Ok(metadata)
-        }
-
-        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-            self.inner.delete(key).await
-        }
-
-        fn list_prefix_stream(
-            &self,
-            prefix: &str,
-        ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
-        }
+    fn lost_head_cas_ack_store(
+        root: impl AsRef<Path>,
+        namespace_id: &NamespaceId,
+    ) -> FailStore<LocalFsStore> {
+        FailStore::new(
+            LocalFsStore::new(root.as_ref()).expect("store"),
+            KeyPredicate::wal_head(namespace_id.as_str()),
+            OperationClass::CompareAndSwap,
+            InjectedError::Transport("injected lost head CAS acknowledgement".to_owned()),
+        )
+        .apply_then_fail()
     }
 
     fn test_fs(store: SharedStore) -> FsCore {
@@ -1684,19 +1516,19 @@ mod tests {
     async fn publisher_admits_pending_batch_while_active_publish_blocks() {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let fs = test_fs(shared.clone());
         create_namespace(&fs, &namespace_id).await;
         let publisher = standalone_publisher(&namespace_id, &fs);
 
-        store.arm_next_head_cas();
+        store.block_next();
         let active = admit_commit(
             &publisher,
             &namespace_id,
             create_directory_request("active", "active"),
         );
-        store.wait_for_blocked_head_cas().await;
+        store.wait_until_blocked().await;
 
         let pending = admit_commit(
             &publisher,
@@ -1720,7 +1552,7 @@ mod tests {
             );
         }
 
-        store.release_head_cas();
+        store.release();
         let active_response = recv_commit(active, "active").await;
         let pending_response = recv_commit(pending, "pending").await;
         assert_eq!(active_response.committed_seq, ChangeSeq(1));
@@ -1738,19 +1570,19 @@ mod tests {
     async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let fs = test_fs(shared.clone());
         create_namespace(&fs, &namespace_id).await;
         let publisher = standalone_publisher(&namespace_id, &fs);
 
-        store.arm_next_head_cas();
+        store.block_next();
         let active = admit_commit(
             &publisher,
             &namespace_id,
             create_directory_request("active", "active"),
         );
-        store.wait_for_blocked_head_cas().await;
+        store.wait_until_blocked().await;
 
         let duplicate = admit_commit(
             &publisher,
@@ -1767,7 +1599,7 @@ mod tests {
             Err(CoreError::CommitIdReuseConflict(commit_id)) if commit_id == "active"
         ));
 
-        store.release_head_cas();
+        store.release();
         let active_response = recv_commit(active, "active").await;
         let duplicate_response = recv_commit(duplicate, "duplicate").await;
         assert_eq!(active_response.committed_seq, ChangeSeq(1));
@@ -1779,19 +1611,19 @@ mod tests {
     async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let fs = test_fs(shared.clone());
         create_namespace(&fs, &namespace_id).await;
         let publisher = standalone_publisher(&namespace_id, &fs);
 
-        store.arm_next_head_cas();
+        store.block_next();
         let active = admit_commit(
             &publisher,
             &namespace_id,
             create_directory_request("active", "active"),
         );
-        store.wait_for_blocked_head_cas().await;
+        store.wait_until_blocked().await;
 
         let mut pending = Vec::with_capacity(MAX_BATCH_CANDIDATES);
         for index in 0..MAX_BATCH_CANDIDATES {
@@ -1824,7 +1656,7 @@ mod tests {
         );
         assert!(matches!(overflow, Err(CoreError::CommitQueueFull)));
 
-        store.release_head_cas();
+        store.release();
         assert_eq!(
             recv_commit(active, "active").await.committed_seq,
             ChangeSeq(1)
@@ -1848,13 +1680,13 @@ mod tests {
     async fn publisher_takes_a_cold_full_batch_immediately() {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let fs = test_fs(shared.clone());
         create_namespace(&fs, &namespace_id).await;
         let publisher = standalone_publisher(&namespace_id, &fs);
 
-        store.arm_next_head_cas();
+        store.block_next();
         let mut receivers = Vec::with_capacity(MAX_BATCH_CANDIDATES);
         for index in 0..MAX_BATCH_CANDIDATES {
             receivers.push(admit_commit(
@@ -1873,7 +1705,7 @@ mod tests {
             assert!(state.publishing);
             assert!(state.batch.is_none());
         }
-        store.release_head_cas();
+        store.release();
         for (index, receiver) in receivers.into_iter().enumerate() {
             assert_eq!(
                 recv_commit(receiver, "full").await.committed_seq,
@@ -1951,7 +1783,7 @@ mod tests {
     async fn publisher_resolves_unknown_head_outcome_by_replaying_receipt() {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let store = Arc::new(LostHeadCasAckStore::new(temp_dir.path(), &namespace_id));
+        let store = Arc::new(lost_head_cas_ack_store(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let fs = test_fs(shared);
         create_namespace(&fs, &namespace_id).await;
@@ -1960,7 +1792,7 @@ mod tests {
         // The commit lands but the CAS acknowledgement is lost. The publisher
         // retries with the same commit id and replays the durable receipt
         // instead of reporting `commit_outcome_unknown` to the waiter.
-        store.lose_next_head_cas_ack();
+        store.fail_next(1);
         let response = recv_commit(
             admit_commit(
                 &publisher,
@@ -1990,7 +1822,7 @@ mod tests {
             &namespace_id,
             create_directory_request("doomed", "doomed"),
         );
-        store.wait_for_blocked_head_cas().await;
+        store.wait_until_blocked().await;
 
         // Queued behind the in-flight batch: only the abort guard's respawn
         // can ever publish this one.
@@ -2030,20 +1862,20 @@ mod tests {
     async fn delete_barrier_publishes_admitted_work_and_rejects_later_work() {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let fs = test_fs(shared.clone());
         create_namespace(&fs, &namespace_id).await;
         let publisher = standalone_publisher(&namespace_id, &fs);
 
         // A publishes and blocks at its head CAS; B queues behind it.
-        store.arm_next_head_cas();
+        store.block_next();
         let before_a = admit_commit(
             &publisher,
             &namespace_id,
             create_directory_request("before-a", "before-a"),
         );
-        store.wait_for_blocked_head_cas().await;
+        store.wait_until_blocked().await;
         let before_b = admit_commit(
             &publisher,
             &namespace_id,
@@ -2080,7 +1912,7 @@ mod tests {
             create_directory_request("after", "after"),
         );
 
-        store.release_head_cas();
+        store.release();
 
         // Admitted-before work publishes; the delete lands after it.
         assert_eq!(
@@ -2269,14 +2101,14 @@ mod tests {
     async fn registry_close_admission_refuses_new_work_while_admitted_work_drains() {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let writer = test_writer(shared.clone()).await;
         create_namespace(writer.core(), &namespace_id).await;
         let registry = writer.publisher();
 
         // An admitted publication blocks at its head CAS...
-        store.arm_next_head_cas();
+        store.block_next();
         let active = {
             let registry = registry.clone();
             let namespace_id = namespace_id.clone();
@@ -2286,7 +2118,7 @@ mod tests {
                     .await
             })
         };
-        store.wait_for_blocked_head_cas().await;
+        store.wait_until_blocked().await;
 
         // ...then admission closes. New work is refused at the front door.
         registry.close_admission();
@@ -2315,7 +2147,7 @@ mod tests {
         assert!(matches!(direct, Err(CoreError::ShuttingDown)));
 
         // The admitted publication still settles, and drain joins its task.
-        store.release_head_cas();
+        store.release();
         let response = active
             .await
             .expect("submit task")
@@ -2346,7 +2178,7 @@ mod tests {
                     .await
             })
         };
-        store.wait_for_blocked_head_cas().await;
+        store.wait_until_blocked().await;
 
         // Queued behind the blocked batch: only the abort guard's respawn
         // publishes this one, and the drain must join that respawn.
@@ -2479,7 +2311,7 @@ mod tests {
     async fn delete_queued_mid_publish_waits_behind_the_sealed_batch() {
         let temp_dir = tempdir().expect("tempdir");
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let store = Arc::new(BlockingHeadCasStore::new(temp_dir.path(), &namespace_id));
+        let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
         let shared = store.clone() as SharedStore;
         let writer = test_writer(shared.clone()).await;
         create_namespace(writer.core(), &namespace_id).await;
@@ -2490,7 +2322,7 @@ mod tests {
         // before the delete runs, and the blocked CAS outlasts the pacing
         // interval — the interleaving where a racing second task could run
         // the delete first.
-        store.arm_next_head_cas();
+        store.block_next();
         let before = {
             let registry = registry.clone();
             let namespace_id = namespace_id.clone();
@@ -2500,7 +2332,7 @@ mod tests {
                     .await
             })
         };
-        store.wait_for_blocked_head_cas().await;
+        store.wait_until_blocked().await;
         let publisher = registry
             .shared
             .lock_state()
@@ -2584,7 +2416,7 @@ mod tests {
 
         // Released: the parked commit publishes, then the sealed batch, and
         // only then the delete.
-        store.release_head_cas();
+        store.release();
         assert_eq!(
             unfinished_tasks_while_blocked, 1,
             "a delete must not spawn a racing second publish task"

--- a/crates/loonfs/tests/capability_conformance.rs
+++ b/crates/loonfs/tests/capability_conformance.rs
@@ -6,20 +6,12 @@
 
 use loonfs::{CapabilityDocument, FsReader, SharedObjectStore};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_test_support::block_on::block_on;
 use std::collections::BTreeSet;
-use std::future::Future;
 use std::sync::Arc;
 use tempfile::tempdir;
 
 const API_SPEC_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../docs/specs/api.md");
-
-fn block_on<T>(future: impl Future<Output = T>) -> T {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("test runtime")
-        .block_on(future)
-}
 
 fn embedded_capabilities() -> CapabilityDocument {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -9,8 +9,6 @@
 //! lookups was the scale term, and dependent per-section GETs were the
 //! wave count.
 
-use async_trait::async_trait;
-use bytes::Bytes;
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
 };
@@ -18,96 +16,19 @@ use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_api::AbsolutePath;
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
+use loonfs_test_support::stores::{KeyPredicate, RecordedGet, RecordingStore};
 use std::collections::BTreeSet;
-use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tempfile::tempdir;
-
-type RecordedGet = (String, Option<(u64, u64)>);
-
-#[derive(Debug, Default)]
-struct RequestLog {
-    gets: Mutex<Vec<RecordedGet>>,
-}
-
-impl RequestLog {
-    fn record(&self, key: &str, range: Option<&ByteRange>) {
-        self.gets.lock().expect("request log lock poisoned").push((
-            key.to_owned(),
-            range.map(|range| (range.start_inclusive, range.end_exclusive)),
-        ));
-    }
-
-    fn take(&self) -> Vec<RecordedGet> {
-        std::mem::take(&mut *self.gets.lock().expect("request log lock poisoned"))
-    }
-}
-
-#[derive(Debug)]
-struct RecordingStore {
-    inner: LocalFsStore,
-    log: Arc<RequestLog>,
-}
-
-impl RecordingStore {
-    fn new(root: &Path, log: Arc<RequestLog>) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            log,
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for RecordingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.log.record(key, range.as_ref());
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.log.record(key, None);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> futures::stream::BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
 
 #[tokio::test]
 async fn cold_stat_pays_no_per_run_filter_fetches() {
     let temp_dir = tempdir().expect("tempdir");
-    let log = Arc::new(RequestLog::default());
-    let store: loonfs::SharedObjectStore =
-        Arc::new(RecordingStore::new(temp_dir.path(), Arc::clone(&log)));
+    let log = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let store: loonfs::SharedObjectStore = log.clone();
     let namespace_id = NamespaceId::parse("coldstat").expect("valid namespace id");
 
     let writer = FsWriter::builder_with_store(store.clone())
@@ -244,7 +165,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .build()
         .await
         .expect("build reader");
-    let _ = log.take();
+    let _ = log.take_gets();
     let entry = reader
         .stat_path(&namespace_id, "/tree/dir-000000/file-000000042.txt")
         .await
@@ -252,7 +173,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
     assert_eq!(entry.display_name.as_str(), "file-000000042.txt");
     assert!(entry.revision_no.is_some(), "file stat carries a revision");
 
-    let gets = log.take();
+    let gets = log.take_gets();
     let table_gets: Vec<&RecordedGet> = gets
         .iter()
         .filter(|(key, _)| table_keys.contains(key))

--- a/crates/loonfs/tests/content_request_accounting.rs
+++ b/crates/loonfs/tests/content_request_accounting.rs
@@ -1,8 +1,6 @@
 //! Content-object request accounting across staging and publication.
 
-use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::content_tokens::ContentTokenError;
 use loonfs::publish::{
     parse_mutation_path, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
@@ -17,32 +15,19 @@ use loonfs_api::wire::control::{
     encode_control_object, ControlObjectKind, NamespaceConfigEnvelope, NamespaceConfigState,
 };
 use loonfs_api::{ContentStoreId, NamePolicy};
-use loonfs_objectstore::keys::{namespace_config, wal_head};
+use loonfs_objectstore::keys::namespace_config;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+use loonfs_test_support::stores::{
+    BlockingStore, CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
 };
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tempfile::{tempdir, TempDir};
-use tokio::sync::Notify;
-use tokio::time::{timeout, Duration};
 
 #[derive(Debug, Clone, Copy)]
 enum KeyClass {
     Content = 0,
     Other = 1,
-}
-
-impl KeyClass {
-    fn of(key: &str) -> Self {
-        if key.starts_with("content-stores/") {
-            Self::Content
-        } else {
-            Self::Other
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -64,310 +49,64 @@ impl RequestCounts {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone)]
 struct RequestLog {
-    counts: Mutex<RequestCounts>,
+    store: SharedObjectStore,
+    content: Arc<CountingStore<SharedObjectStore>>,
+    other: Arc<CountingStore<SharedObjectStore>>,
 }
 
 impl RequestLog {
-    fn record_head(&self, key: &str) {
-        self.counts
-            .lock()
-            .expect("request log lock poisoned")
-            .by_class[KeyClass::of(key) as usize]
-            .head += 1;
-    }
-
-    fn record_get(&self, key: &str, bytes_read: usize) {
-        let class = KeyClass::of(key);
-        let mut counts = self.counts.lock().expect("request log lock poisoned");
-        counts.by_class[class as usize].get += 1;
-        if matches!(class, KeyClass::Content) {
-            counts.content_get_bytes += bytes_read;
-        }
-    }
-
-    fn record_put(&self, key: &str) {
-        self.counts
-            .lock()
-            .expect("request log lock poisoned")
-            .by_class[KeyClass::of(key) as usize]
-            .put += 1;
-    }
-
-    fn snapshot(&self) -> RequestCounts {
-        *self.counts.lock().expect("request log lock poisoned")
-    }
-
-    fn reset(&self) {
-        *self.counts.lock().expect("request log lock poisoned") = RequestCounts::default();
-    }
-}
-
-#[derive(Debug)]
-struct RecordingStore {
-    inner: LocalFsStore,
-    log: RequestLog,
-}
-
-impl RecordingStore {
     fn new(root: &Path) -> Self {
+        let inner: SharedObjectStore =
+            Arc::new(LocalFsStore::new(root).expect("create local-fs store"));
+        let other = Arc::new(CountingStore::new(
+            inner,
+            KeyPredicate::new(|key| !key.starts_with("content-stores/")),
+        ));
+        let content = Arc::new(CountingStore::new(
+            other.clone() as SharedObjectStore,
+            KeyPredicate::prefix("content-stores/"),
+        ));
         Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            log: RequestLog::default(),
+            store: content.clone(),
+            content,
+            other,
         }
+    }
+
+    fn store(&self) -> SharedObjectStore {
+        self.store.clone()
     }
 
     fn snapshot(&self) -> RequestCounts {
-        self.log.snapshot()
+        let content = self.content.snapshot();
+        let other = self.other.snapshot();
+        let mut counts = RequestCounts::default();
+        counts.by_class[KeyClass::Content as usize] = OperationCounts {
+            head: content.heads,
+            get: content.gets + content.gets_with_metadata,
+            put: content.puts,
+        };
+        counts.by_class[KeyClass::Other as usize] = OperationCounts {
+            head: other.heads,
+            get: other.gets + other.gets_with_metadata,
+            put: other.puts,
+        };
+        counts.content_get_bytes =
+            usize::try_from(content.read_bytes).expect("test byte count should fit usize");
+        counts
     }
 
     fn reset(&self) {
-        self.log.reset();
-    }
-}
-
-#[async_trait]
-impl ObjectStore for RecordingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.log.record_head(key);
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        let result = self.inner.get(key, range).await;
-        let bytes_read = result
-            .as_ref()
-            .ok()
-            .and_then(|bytes| bytes.as_ref())
-            .map_or(0, Bytes::len);
-        self.log.record_get(key, bytes_read);
-        result
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        let result = self.inner.get_with_metadata(key).await;
-        let bytes_read = result
-            .as_ref()
-            .ok()
-            .and_then(|body| body.as_ref())
-            .map_or(0, |body| body.bytes.len());
-        self.log.record_get(key, bytes_read);
-        result
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.log.record_put(key);
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-#[derive(Debug)]
-struct BlockingHeadCasStore {
-    inner: Arc<RecordingStore>,
-    head_key: String,
-    block_next: AtomicBool,
-    blocked: AtomicBool,
-    released: AtomicBool,
-    blocked_notify: Notify,
-    release_notify: Notify,
-}
-
-impl BlockingHeadCasStore {
-    fn new(inner: Arc<RecordingStore>, namespace_id: &NamespaceId) -> Self {
-        Self {
-            inner,
-            head_key: wal_head(namespace_id.as_str()),
-            block_next: AtomicBool::new(false),
-            blocked: AtomicBool::new(false),
-            released: AtomicBool::new(false),
-            blocked_notify: Notify::new(),
-            release_notify: Notify::new(),
-        }
-    }
-
-    fn arm_next_head_cas(&self) {
-        self.released.store(false, Ordering::SeqCst);
-        self.blocked.store(false, Ordering::SeqCst);
-        self.block_next.store(true, Ordering::SeqCst);
-    }
-
-    async fn wait_for_blocked_head_cas(&self) {
-        timeout(Duration::from_secs(10), async {
-            while !self.blocked.load(Ordering::SeqCst) {
-                let notified = self.blocked_notify.notified();
-                if self.blocked.load(Ordering::SeqCst) {
-                    break;
-                }
-                // Bounded wait: `notified` registers on first poll, so a notify
-                // between the flag check and the await would otherwise be lost.
-                let _ = timeout(Duration::from_millis(50), notified).await;
-            }
-        })
-        .await
-        .expect("a head CAS must reach the block");
-    }
-
-    fn release_head_cas(&self) {
-        self.released.store(true, Ordering::SeqCst);
-        self.release_notify.notify_waiters();
-    }
-}
-
-#[async_trait]
-impl ObjectStore for BlockingHeadCasStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let should_block = key == self.head_key
-            && matches!(mode, PutMode::CompareAndSwap { .. })
-            && self.block_next.swap(false, Ordering::SeqCst);
-        if should_block {
-            self.blocked.store(true, Ordering::SeqCst);
-            self.blocked_notify.notify_waiters();
-            while !self.released.load(Ordering::SeqCst) {
-                let notified = self.release_notify.notified();
-                if self.released.load(Ordering::SeqCst) {
-                    break;
-                }
-                // Bounded wait, matching publication.rs: a release landing between
-                // the flag check and the await must not strand this writer.
-                let _ = timeout(Duration::from_millis(50), notified).await;
-            }
-            self.blocked.store(false, Ordering::SeqCst);
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-#[derive(Debug)]
-struct HeadCasConflictStore {
-    inner: Arc<RecordingStore>,
-    head_key: String,
-    fail_next: AtomicBool,
-    attempts: AtomicUsize,
-}
-
-impl HeadCasConflictStore {
-    fn new(inner: Arc<RecordingStore>, namespace_id: &NamespaceId) -> Self {
-        Self {
-            inner,
-            head_key: wal_head(namespace_id.as_str()),
-            fail_next: AtomicBool::new(false),
-            attempts: AtomicUsize::new(0),
-        }
-    }
-
-    fn fail_next_head_cas(&self) {
-        self.attempts.store(0, Ordering::SeqCst);
-        self.fail_next.store(true, Ordering::SeqCst);
-    }
-
-    fn head_cas_attempts(&self) -> usize {
-        self.attempts.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl ObjectStore for HeadCasConflictStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        if key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. }) {
-            self.attempts.fetch_add(1, Ordering::SeqCst);
-            if self.fail_next.swap(false, Ordering::SeqCst) {
-                return Err(ObjectStoreError::PreconditionFailed {
-                    object_key: key.to_owned(),
-                });
-            }
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.content.reset();
+        self.other.reset();
     }
 }
 
 struct TestHarness {
     _temp_dir: TempDir,
-    recording: Arc<RecordingStore>,
+    recording: RequestLog,
     store: SharedObjectStore,
     namespace_id: NamespaceId,
     writer: FsWriter,
@@ -376,8 +115,8 @@ struct TestHarness {
 impl TestHarness {
     async fn new(namespace: &str) -> Self {
         let temp_dir = tempdir().expect("tempdir");
-        let recording = Arc::new(RecordingStore::new(temp_dir.path()));
-        let store: SharedObjectStore = recording.clone();
+        let recording = RequestLog::new(temp_dir.path());
+        let store = recording.store();
         let namespace_id = NamespaceId::parse(namespace).expect("valid namespace id");
         let writer =
             build_initialized_writer(store.clone(), &namespace_id, "accounting-writer").await;
@@ -571,8 +310,8 @@ async fn put_file_prepared_performs_no_content_io() {
 #[tokio::test]
 async fn prepared_content_for_another_store_is_rejected_without_content_io() {
     let temp_dir = tempdir().expect("tempdir");
-    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
-    let store: SharedObjectStore = recording.clone();
+    let recording = RequestLog::new(temp_dir.path());
+    let store = recording.store();
     let source = NamespaceId::parse("source-store").expect("source namespace id");
     let target = NamespaceId::parse("target-store").expect("target namespace id");
     let writer = build_initialized_writer(store.clone(), &source, "cross-store-writer").await;
@@ -614,8 +353,8 @@ async fn prepared_content_for_another_store_is_rejected_without_content_io() {
 #[tokio::test]
 async fn independent_namespaces_sharing_a_store_share_prepared_content() {
     let temp_dir = tempdir().expect("tempdir");
-    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
-    let store: SharedObjectStore = recording.clone();
+    let recording = RequestLog::new(temp_dir.path());
+    let store = recording.store();
     let source = NamespaceId::parse("shared-source").expect("source namespace id");
     let target = NamespaceId::parse("shared-target").expect("target namespace id");
     let writer = build_initialized_writer(store.clone(), &source, "shared-store-writer").await;
@@ -653,8 +392,8 @@ async fn independent_namespaces_sharing_a_store_share_prepared_content() {
 #[tokio::test]
 async fn fork_and_source_share_prepared_content_in_both_directions() {
     let temp_dir = tempdir().expect("tempdir");
-    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
-    let store: SharedObjectStore = recording.clone();
+    let recording = RequestLog::new(temp_dir.path());
+    let store = recording.store();
     let source = NamespaceId::parse("fork-source").expect("source namespace id");
     let fork = NamespaceId::parse("fork-target").expect("fork namespace id");
     let writer = build_initialized_writer(store, &source, "fork-sharing-writer").await;
@@ -1221,10 +960,11 @@ async fn new_rejected_preparation_fails_before_path_planning_without_content_ope
 async fn in_flight_duplicate_performs_no_additional_content_operations() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("in-flight-duplicate").expect("valid namespace id");
-    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
-    let blocking = Arc::new(BlockingHeadCasStore::new(
-        Arc::clone(&recording),
-        &namespace_id,
+    let recording = RequestLog::new(temp_dir.path());
+    let blocking = Arc::new(BlockingStore::new(
+        recording.store(),
+        KeyPredicate::wal_head(namespace_id.as_str()),
+        OperationClass::CompareAndSwap,
     ));
     let store: SharedObjectStore = blocking.clone();
     let writer = build_initialized_writer(store.clone(), &namespace_id, "duplicate-writer").await;
@@ -1239,7 +979,7 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
     let prepared = prepare_content(&store, &namespace_id, &content_ref).await;
     recording.reset();
 
-    blocking.arm_next_head_cas();
+    blocking.block_next();
     let primary = {
         let registry = writer.publisher();
         let namespace_id = namespace_id.clone();
@@ -1251,7 +991,7 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
                 .await
         })
     };
-    blocking.wait_for_blocked_head_cas().await;
+    blocking.wait_until_blocked().await;
     let primary_counts = recording.snapshot();
     assert_content_counts(primary_counts, 0, 0, 0, 0);
 
@@ -1265,7 +1005,7 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
         futures::poll!(duplicate.as_mut()).is_pending(),
         "the duplicate must join the in-flight primary"
     );
-    blocking.release_head_cas();
+    blocking.release();
 
     let duplicate_receipt = duplicate.await.expect("duplicate receipt");
     let primary_receipt = primary
@@ -1288,10 +1028,12 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
 async fn stale_head_retry_preserves_content_admission() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("stale-head-retry").expect("valid namespace id");
-    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
-    let conflicting = Arc::new(HeadCasConflictStore::new(
-        Arc::clone(&recording),
-        &namespace_id,
+    let recording = RequestLog::new(temp_dir.path());
+    let conflicting = Arc::new(FailStore::new(
+        recording.store(),
+        KeyPredicate::wal_head(namespace_id.as_str()),
+        OperationClass::CompareAndSwap,
+        InjectedError::PreconditionFailed,
     ));
     let store: SharedObjectStore = conflicting.clone();
     let writer = build_initialized_writer(store.clone(), &namespace_id, "retry-writer").await;
@@ -1305,7 +1047,7 @@ async fn stale_head_retry_preserves_content_admission() {
     // before the reset so this phase isolates publication retries.
     let prepared = prepare_content(&store, &namespace_id, &content_ref).await;
     recording.reset();
-    conflicting.fail_next_head_cas();
+    conflicting.fail_next(1);
 
     writer
         .publisher()
@@ -1313,7 +1055,7 @@ async fn stale_head_retry_preserves_content_admission() {
         .await
         .expect("publish after stale-head retry");
 
-    assert_eq!(conflicting.head_cas_attempts(), 2);
+    assert_eq!(conflicting.attempts(), 2);
     assert_content_counts(recording.snapshot(), 0, 0, 0, 0);
 }
 
@@ -1323,10 +1065,11 @@ async fn stale_head_retry_preserves_content_admission() {
 async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_content_io() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("mixed-preparation").expect("valid namespace id");
-    let recording = Arc::new(RecordingStore::new(temp_dir.path()));
-    let blocking = Arc::new(BlockingHeadCasStore::new(
-        Arc::clone(&recording),
-        &namespace_id,
+    let recording = RequestLog::new(temp_dir.path());
+    let blocking = Arc::new(BlockingStore::new(
+        recording.store(),
+        KeyPredicate::wal_head(namespace_id.as_str()),
+        OperationClass::CompareAndSwap,
     ));
     let store: SharedObjectStore = blocking.clone();
     let writer = build_initialized_writer(store.clone(), &namespace_id, "mixed-writer").await;
@@ -1340,7 +1083,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
     let prepared = prepare_content(&store, &namespace_id, &content_ref).await;
     recording.reset();
 
-    blocking.arm_next_head_cas();
+    blocking.block_next();
     let blocker = {
         let registry = writer.publisher();
         let namespace_id = namespace_id.clone();
@@ -1357,7 +1100,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
                 .await
         })
     };
-    blocking.wait_for_blocked_head_cas().await;
+    blocking.wait_until_blocked().await;
 
     let registry = writer.publisher();
     let mut admitted = Box::pin(registry.submit_path_intent_with_prepared_content(
@@ -1378,7 +1121,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
         "unprepared put must join the pending batch"
     );
 
-    blocking.release_head_cas();
+    blocking.release();
     blocker
         .await
         .expect("blocker task")

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -17,8 +17,9 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
+use loonfs_test_support::ids::nonzero_usize;
 use std::collections::BTreeSet;
-use std::num::{NonZeroU64, NonZeroUsize};
+use std::num::NonZeroU64;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -34,10 +35,6 @@ fn request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
-}
-
-fn nonzero_usize(value: usize) -> NonZeroUsize {
-    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 /// Content blob object keys currently in the store, for pinpointing the

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -21,8 +21,8 @@ use loonfs_grep::root::load_grep_root;
 use loonfs_grep::GramIndexBuildPolicy;
 use loonfs_grep::{GrepBuildOutcome, GrepFoldOutcome, GrepIndexSnapshot, GrepService, GrepWorker};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_test_support::ids::nonzero_usize;
 use std::collections::BTreeSet;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -36,10 +36,6 @@ fn request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
-}
-
-fn nonzero_usize(value: usize) -> NonZeroUsize {
-    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 async fn read_context(store: &SharedObjectStore, namespace_id: &NamespaceId) -> RuntimeReadContext {

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -6,9 +6,6 @@
 //! handle from one runtime fixture, matching the runtime-ownership contract
 //! the handles document.
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::{
     CommitId, CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsReader,
     FsWriter, MaintenanceTickOptions, ManifestId, NamespaceId, PutFileOptions, RuntimeCacheConfig,
@@ -16,36 +13,21 @@ use loonfs::{
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_core::control::load_namespace_metadata_root_control;
-use loonfs_objectstore::keys::{metadata_manifest_object, metadata_root};
+use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
-use std::future::Future;
+use loonfs_objectstore::ObjectStore;
+use loonfs_test_support::block_on::block_on;
+use loonfs_test_support::ids::namespace_id;
+use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
-use tokio::sync::Notify;
-use tokio::time::{timeout, Duration};
 
 fn store_config(root: &Path) -> StoreConfig {
     StoreConfig::LocalFs {
         root: root.to_string_lossy().into_owned(),
         key_prefix: None,
     }
-}
-
-fn namespace_id() -> NamespaceId {
-    NamespaceId::parse("demo").expect("valid namespace id")
-}
-
-fn block_on<T>(future: impl Future<Output = T>) -> T {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("test runtime")
-        .block_on(future)
 }
 
 fn wal_tail_segment_threshold() -> u64 {
@@ -84,113 +66,6 @@ async fn fill_wal_tail_past_threshold(writer: &FsWriter, namespace_id: &Namespac
     }
 }
 
-/// Holds a maintenance tick mid-run by blocking the namespace's metadata
-/// root compare-and-swap; publishes keep flowing (they CAS the WAL head, a
-/// different key). Bounded-wait pattern as in publication.rs.
-#[derive(Debug)]
-struct BlockingRootCasStore {
-    inner: LocalFsStore,
-    root_key: String,
-    block_next: AtomicBool,
-    blocked: AtomicBool,
-    released: AtomicBool,
-    blocked_notify: Notify,
-    release_notify: Notify,
-}
-
-impl BlockingRootCasStore {
-    fn new(root: &Path, namespace_id: &NamespaceId) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            root_key: metadata_root(namespace_id.as_str()),
-            block_next: AtomicBool::new(false),
-            blocked: AtomicBool::new(false),
-            released: AtomicBool::new(false),
-            blocked_notify: Notify::new(),
-            release_notify: Notify::new(),
-        }
-    }
-
-    fn arm_next_root_cas(&self) {
-        self.released.store(false, Ordering::SeqCst);
-        self.blocked.store(false, Ordering::SeqCst);
-        self.block_next.store(true, Ordering::SeqCst);
-    }
-
-    async fn wait_for_blocked_root_cas(&self) {
-        timeout(Duration::from_secs(10), async {
-            while !self.blocked.load(Ordering::SeqCst) {
-                let notified = self.blocked_notify.notified();
-                if self.blocked.load(Ordering::SeqCst) {
-                    break;
-                }
-                let _ = timeout(Duration::from_millis(50), notified).await;
-            }
-        })
-        .await
-        .expect("a metadata root CAS must reach the block");
-    }
-
-    fn release_root_cas(&self) {
-        self.released.store(true, Ordering::SeqCst);
-        self.release_notify.notify_waiters();
-    }
-}
-
-#[async_trait]
-impl ObjectStore for BlockingRootCasStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let should_block = key == self.root_key
-            && matches!(mode, PutMode::CompareAndSwap { .. })
-            && self.block_next.swap(false, Ordering::SeqCst);
-        if should_block {
-            self.blocked.store(true, Ordering::SeqCst);
-            self.blocked_notify.notify_waiters();
-            while !self.released.load(Ordering::SeqCst) {
-                let notified = self.release_notify.notified();
-                if self.released.load(Ordering::SeqCst) {
-                    break;
-                }
-                let _ = timeout(Duration::from_millis(50), notified).await;
-            }
-            self.blocked.store(false, Ordering::SeqCst);
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
 #[test]
 fn a_threshold_crossing_during_an_active_tick_still_bounds_the_tail() {
     // The interleaving behind the CI failures on the extraction stack: the
@@ -199,9 +74,13 @@ fn a_threshold_crossing_during_an_active_tick_still_bounds_the_tail() {
     // them leaves the tail unbounded when those were the last writes before
     // an idle period.
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     block_on(async {
-        let blocking = Arc::new(BlockingRootCasStore::new(temp_dir.path(), &namespace_id));
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::metadata_root(namespace_id.as_str()),
+            OperationClass::CompareAndSwap,
+        ));
         let store: SharedObjectStore = blocking.clone();
         let writer = FsWriter::builder_with_store(store)
             .writer_id("handle-test-writer")
@@ -216,9 +95,9 @@ fn a_threshold_crossing_during_an_active_tick_still_bounds_the_tail() {
 
         // The threshold-crossing publish spawns the tick; the armed store
         // holds that tick at its metadata root CAS.
-        blocking.arm_next_root_cas();
+        blocking.block_next();
         fill_wal_tail_past_threshold(&writer, &namespace_id).await;
-        blocking.wait_for_blocked_root_cas().await;
+        blocking.wait_until_blocked().await;
 
         // A full second threshold's worth of publishes lands while the tick
         // is held; every crossing defers to the running tick.
@@ -234,7 +113,7 @@ fn a_threshold_crossing_during_an_active_tick_still_bounds_the_tail() {
                 .expect("put file during held tick");
         }
 
-        blocking.release_root_cas();
+        blocking.release();
         writer
             .wait_for_background_work()
             .await
@@ -263,7 +142,7 @@ fn a_threshold_crossing_during_an_active_tick_still_bounds_the_tail() {
 #[test]
 fn writer_reader_and_admin_share_a_namespace_through_store_config() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     block_on(async {
         let writer = writer(temp_dir.path(), FsBackgroundWork::ManualOnly).await;
         writer
@@ -408,7 +287,7 @@ fn put_file_bytes_and_prepare_then_put_commit_equivalent_state() {
 #[test]
 fn manual_only_writer_never_schedules_maintenance() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     block_on(async {
         let writer = writer(temp_dir.path(), FsBackgroundWork::ManualOnly).await;
         writer
@@ -468,7 +347,7 @@ fn manual_only_writer_never_schedules_maintenance() {
 #[test]
 fn enabled_writer_schedules_maintenance_on_its_owning_runtime() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     block_on(async {
         let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
         writer
@@ -510,7 +389,7 @@ fn enabled_writer_schedules_maintenance_with_caches_disabled() {
     // Cache configuration is performance-only: with the caches off, the
     // Enabled policy still schedules the same post-publish maintenance.
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     block_on(async {
         let writer = FsWriter::builder(store_config(temp_dir.path()))
             .writer_id("handle-test-writer")
@@ -552,7 +431,7 @@ fn enabled_writer_schedules_maintenance_with_caches_disabled() {
 #[test]
 fn shut_down_writer_rejects_new_background_work_but_keeps_writing() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     block_on(async {
         let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
         writer
@@ -648,7 +527,7 @@ fn writer_builder_rejects_zero_maintenance_concurrency() {
 #[test]
 fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     block_on(async {
         let writer = writer(temp_dir.path(), FsBackgroundWork::ManualOnly).await;
         writer
@@ -698,7 +577,7 @@ fn admin_checkpoint_and_retention_are_explicit_one_shot_calls() {
 #[test]
 fn enabled_writer_drains_reorganization_backlog_without_admin() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     block_on(async {
         let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
         writer

--- a/crates/loonfs/tests/immutable_view_inputs.rs
+++ b/crates/loonfs/tests/immutable_view_inputs.rs
@@ -3,87 +3,14 @@
 //! once per operation. These tests pin that a warm handle stops re-fetching
 //! them entirely.
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
     PutFileOptions, SharedObjectStore,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
-use std::path::Path;
-use std::sync::{Arc, Mutex};
+use loonfs_test_support::stores::{KeyPredicate, RecordingStore};
+use std::sync::Arc;
 use tempfile::tempdir;
-
-#[derive(Debug)]
-struct GetRecordingStore {
-    inner: LocalFsStore,
-    gets: Mutex<Vec<String>>,
-}
-
-impl GetRecordingStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            gets: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn take_gets(&self) -> Vec<String> {
-        std::mem::take(&mut *self.gets.lock().expect("get log lock poisoned"))
-    }
-
-    fn record(&self, key: &str) {
-        self.gets
-            .lock()
-            .expect("get log lock poisoned")
-            .push(key.to_owned());
-    }
-}
-
-#[async_trait]
-impl ObjectStore for GetRecordingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.record(key);
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.record(key);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
 
 fn immutable_input_gets(gets: &[String]) -> Vec<String> {
     gets.iter()
@@ -138,7 +65,10 @@ async fn build_namespace(store: &SharedObjectStore, namespace_id: &NamespaceId) 
 #[tokio::test]
 async fn warm_reader_stops_fetching_immutable_view_inputs() {
     let temp_dir = tempdir().expect("tempdir");
-    let recording = Arc::new(GetRecordingStore::new(temp_dir.path()));
+    let recording = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
     let store: SharedObjectStore = recording.clone();
     let namespace_id = NamespaceId::parse("pins").expect("valid namespace id");
     build_namespace(&store, &namespace_id).await;
@@ -151,7 +81,7 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
         .stat_path(&namespace_id, "/docs/file-0.txt")
         .await
         .expect("first stat");
-    let warmup = immutable_input_gets(&recording.take_gets());
+    let warmup = immutable_input_gets(&recording.take_get_keys());
     assert!(
         !warmup.is_empty(),
         "the first read on a handle loads the immutable inputs"
@@ -161,7 +91,7 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
         .stat_path(&namespace_id, "/docs/file-1.txt")
         .await
         .expect("second stat");
-    let repeats = immutable_input_gets(&recording.take_gets());
+    let repeats = immutable_input_gets(&recording.take_get_keys());
     assert_eq!(
         repeats,
         Vec::<String>::new(),
@@ -173,7 +103,10 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
 #[tokio::test]
 async fn warm_writer_stops_fetching_immutable_view_inputs() {
     let temp_dir = tempdir().expect("tempdir");
-    let recording = Arc::new(GetRecordingStore::new(temp_dir.path()));
+    let recording = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
     let store: SharedObjectStore = recording.clone();
     let namespace_id = NamespaceId::parse("pins").expect("valid namespace id");
     build_namespace(&store, &namespace_id).await;
@@ -193,7 +126,7 @@ async fn warm_writer_stops_fetching_immutable_view_inputs() {
         )
         .await
         .expect("first write");
-    let warmup = immutable_input_gets(&recording.take_gets());
+    let warmup = immutable_input_gets(&recording.take_get_keys());
     assert!(
         !warmup.is_empty(),
         "the first write on a handle loads the immutable inputs"
@@ -208,7 +141,7 @@ async fn warm_writer_stops_fetching_immutable_view_inputs() {
         )
         .await
         .expect("second write");
-    let repeats = immutable_input_gets(&recording.take_gets());
+    let repeats = immutable_input_gets(&recording.take_get_keys());
     assert_eq!(
         repeats,
         Vec::<String>::new(),

--- a/crates/loonfs/tests/invalidation.rs
+++ b/crates/loonfs/tests/invalidation.rs
@@ -2,89 +2,14 @@
 //! instead of dropping them, and no cache lifecycle event — invalidation,
 //! LRU eviction, or running with caches disabled — erases writer fencing.
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::{
     CreateNamespaceOptions, FsWriter, NamespaceId, PutFileOptions, RuntimeCacheConfig,
     RuntimeError, SharedObjectStore,
 };
-use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
-use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass, RecordingStore};
+use std::sync::Arc;
 use tempfile::tempdir;
-
-#[derive(Debug)]
-struct GetRecordingStore {
-    inner: LocalFsStore,
-    gets: Mutex<Vec<String>>,
-}
-
-impl GetRecordingStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            gets: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn take_gets(&self) -> Vec<String> {
-        std::mem::take(&mut *self.gets.lock().expect("get log lock poisoned"))
-    }
-
-    fn record(&self, key: &str) {
-        self.gets
-            .lock()
-            .expect("get log lock poisoned")
-            .push(key.to_owned());
-    }
-}
-
-#[async_trait]
-impl ObjectStore for GetRecordingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.record(key);
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.record(key);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
 
 async fn writer(store: &SharedObjectStore, writer_id: &str) -> FsWriter {
     writer_with_cache(store, writer_id, RuntimeCacheConfig::default()).await
@@ -113,71 +38,6 @@ fn expect_writer_fenced<T: std::fmt::Debug>(result: loonfs::Result<T>, when: &st
         ),
         "{when}: unexpected error: {error:?}"
     );
-}
-
-/// Counts head compare-and-swap writes for one namespace's head key, so a
-/// test can prove a fenced session stops touching durable state.
-#[derive(Debug)]
-struct HeadCasCountingStore {
-    inner: LocalFsStore,
-    head_key: String,
-    head_cas_writes: AtomicUsize,
-}
-
-impl HeadCasCountingStore {
-    fn new(root: &Path, namespace_id: &NamespaceId) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            head_key: wal_head(namespace_id.as_str()),
-            head_cas_writes: AtomicUsize::new(0),
-        }
-    }
-
-    fn head_cas_writes(&self) -> usize {
-        self.head_cas_writes.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl ObjectStore for HeadCasCountingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        if key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. }) {
-            self.head_cas_writes.fetch_add(1, Ordering::SeqCst);
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
 }
 
 /// A fenced writer session must stay fenced: before this fix, the runtime
@@ -250,7 +110,10 @@ async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
     let temp_dir = tempdir().expect("tempdir");
     let ns_fence = NamespaceId::parse("fence").expect("valid namespace id");
     let ns_other = NamespaceId::parse("other").expect("valid namespace id");
-    let counting = Arc::new(HeadCasCountingStore::new(temp_dir.path(), &ns_fence));
+    let counting = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::wal_head(ns_fence.as_str()),
+    ));
     let store: SharedObjectStore = counting.clone();
 
     let single_entry_cache = RuntimeCacheConfig {
@@ -291,7 +154,7 @@ async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
         .await
         .expect("writer a publishes to the other namespace");
 
-    let head_cas_after_fencing = counting.head_cas_writes();
+    let head_cas_after_fencing = counting.count(OperationClass::CompareAndSwap);
     expect_writer_fenced(
         writer_a
             .put_file_bytes(&ns_fence, "/a3.txt", b"a", PutFileOptions::default())
@@ -299,7 +162,7 @@ async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
         "fenced session stays fenced after eviction",
     );
     assert_eq!(
-        counting.head_cas_writes(),
+        counting.count(OperationClass::CompareAndSwap),
         head_cas_after_fencing,
         "a fenced session must not touch the fenced namespace's head"
     );
@@ -318,7 +181,10 @@ async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
 async fn fenced_writer_stays_fenced_with_runtime_caches_disabled() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("nocache").expect("valid namespace id");
-    let counting = Arc::new(HeadCasCountingStore::new(temp_dir.path(), &namespace_id));
+    let counting = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::wal_head(namespace_id.as_str()),
+    ));
     let store: SharedObjectStore = counting.clone();
 
     let writer_a = writer_with_cache(&store, "writer-a", RuntimeCacheConfig::disabled()).await;
@@ -344,7 +210,7 @@ async fn fenced_writer_stays_fenced_with_runtime_caches_disabled() {
         "superseded writer surfaces fencing",
     );
 
-    let head_cas_after_fencing = counting.head_cas_writes();
+    let head_cas_after_fencing = counting.count(OperationClass::CompareAndSwap);
     expect_writer_fenced(
         writer_a
             .put_file_bytes(&namespace_id, "/a3.txt", b"a", PutFileOptions::default())
@@ -352,7 +218,7 @@ async fn fenced_writer_stays_fenced_with_runtime_caches_disabled() {
         "fenced session stays fenced across throwaway engines",
     );
     assert_eq!(
-        counting.head_cas_writes(),
+        counting.count(OperationClass::CompareAndSwap),
         head_cas_after_fencing,
         "a fenced session must not touch the namespace's head"
     );
@@ -369,7 +235,10 @@ async fn fenced_writer_stays_fenced_with_runtime_caches_disabled() {
 #[tokio::test]
 async fn read_after_write_is_served_from_seeded_caches() {
     let temp_dir = tempdir().expect("tempdir");
-    let recording = Arc::new(GetRecordingStore::new(temp_dir.path()));
+    let recording = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
     let store: SharedObjectStore = recording.clone();
     let namespace_id = NamespaceId::parse("seeded").expect("valid namespace id");
 
@@ -395,7 +264,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
         .await
         .expect("warmup stat");
 
-    recording.take_gets();
+    recording.take_get_keys();
     writer
         .put_file_bytes(
             &namespace_id,
@@ -407,7 +276,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
         .expect("steady-state put");
     // The publish itself must read the live head and root for freshness;
     // nothing else.
-    let write_gets = recording.take_gets();
+    let write_gets = recording.take_get_keys();
     assert!(
         write_gets
             .iter()
@@ -419,7 +288,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
         .stat_path(&namespace_id, "/docs/fresh.txt")
         .await
         .expect("read after write");
-    let read_gets = recording.take_gets();
+    let read_gets = recording.take_get_keys();
     assert_eq!(
         read_gets,
         Vec::<String>::new(),

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -3,129 +3,21 @@
 //! one, or all of them — abandons only result delivery, never the
 //! publication itself.
 
-use async_trait::async_trait;
-use bytes::Bytes;
 use futures::future::BoxFuture;
-use futures::stream::BoxStream;
 use loonfs::publish::{parse_mutation_path, PathMutationIntent};
 use loonfs::{
     BeginUploadRequest, CommitId, CommitResponse, CoreError, CreateNamespaceOptions,
     DestinationBehavior, FsWriter, NamespaceId, PutFileOptions, SharedObjectStore,
 };
-use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
+use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
-use tokio::sync::Notify;
 use tokio::time::{timeout, Duration};
 
-/// Blocks head compare-and-swap writes while armed, so a test can park a
-/// publication mid-flight, cancel its callers, and then let it finish.
-#[derive(Debug)]
-struct BlockingHeadCasStore {
-    inner: LocalFsStore,
-    head_key: String,
-    armed: AtomicBool,
-    blocked: AtomicBool,
-    blocked_notify: Notify,
-    release: Notify,
-}
-
-impl BlockingHeadCasStore {
-    fn new(root: &Path, namespace_id: &NamespaceId) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            head_key: wal_head(namespace_id.as_str()),
-            armed: AtomicBool::new(false),
-            blocked: AtomicBool::new(false),
-            blocked_notify: Notify::new(),
-            release: Notify::new(),
-        }
-    }
-
-    fn arm(&self) {
-        self.armed.store(true, Ordering::SeqCst);
-    }
-
-    async fn wait_for_blocked_head_cas(&self) {
-        timeout(Duration::from_secs(10), async {
-            while !self.blocked.load(Ordering::SeqCst) {
-                let notified = self.blocked_notify.notified();
-                if self.blocked.load(Ordering::SeqCst) {
-                    break;
-                }
-                let _ = timeout(Duration::from_millis(50), notified).await;
-            }
-        })
-        .await
-        .expect("a head CAS must reach the block");
-    }
-
-    fn release(&self) {
-        self.armed.store(false, Ordering::SeqCst);
-        self.release.notify_waiters();
-    }
-}
-
-#[async_trait]
-impl ObjectStore for BlockingHeadCasStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let is_head_cas = key == self.head_key && matches!(mode, PutMode::CompareAndSwap { .. });
-        if is_head_cas && self.armed.load(Ordering::SeqCst) {
-            self.blocked.store(true, Ordering::SeqCst);
-            self.blocked_notify.notify_waiters();
-            while self.armed.load(Ordering::SeqCst) {
-                let released = self.release.notified();
-                if !self.armed.load(Ordering::SeqCst) {
-                    break;
-                }
-                let _ = timeout(Duration::from_millis(50), released).await;
-            }
-            self.blocked.store(false, Ordering::SeqCst);
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
 struct ParkedPuts {
-    store: Arc<BlockingHeadCasStore>,
+    store: Arc<BlockingStore<LocalFsStore>>,
     writer: Arc<FsWriter>,
     namespace_id: NamespaceId,
     first: tokio::task::JoinHandle<loonfs::Result<CommitResponse>>,
@@ -149,7 +41,11 @@ struct ParkedPuts {
 /// that never existed cannot land.
 async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
     let namespace_id = NamespaceId::parse("parked").expect("valid namespace id");
-    let store_impl = Arc::new(BlockingHeadCasStore::new(temp_dir, &namespace_id));
+    let store_impl = Arc::new(BlockingStore::new(
+        LocalFsStore::new(temp_dir).expect("create local-fs store"),
+        KeyPredicate::wal_head(namespace_id.as_str()),
+        OperationClass::CompareAndSwap,
+    ));
     let store: SharedObjectStore = store_impl.clone();
     let writer = Arc::new(
         FsWriter::builder_with_store(store.clone())
@@ -200,7 +96,7 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
                 .await
         })
     };
-    store_impl.wait_for_blocked_head_cas().await;
+    store_impl.wait_until_blocked().await;
 
     // The publish task is parked inside the blocked CAS with its batch
     // already taken, so this submission deterministically opens the next

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -7,9 +7,6 @@
 //! Run with:
 //!   cargo test -p loonfs --test request_accounting -- --ignored --nocapture
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenanceTickOptions, NamespaceId,
     PageRequest, PaginationPolicy, PutFileOptions, SharedObjectStore,
@@ -19,93 +16,14 @@ use loonfs_api::AbsolutePath;
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
+use loonfs_test_support::stores::{KeyPredicate, RecordedGet, RecordingStore};
 use std::collections::BTreeMap;
-use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tempfile::tempdir;
 
 const FILES: usize = 10_000;
 const BATCH: usize = 100;
 const TICK_EVERY_BATCHES: usize = 33;
-
-type RecordedGet = (String, Option<(u64, u64)>);
-
-#[derive(Debug, Default)]
-struct RequestLog {
-    gets: Mutex<Vec<RecordedGet>>,
-}
-
-impl RequestLog {
-    fn record(&self, key: &str, range: Option<&ByteRange>) {
-        self.gets.lock().expect("request log lock poisoned").push((
-            key.to_owned(),
-            range.map(|range| (range.start_inclusive, range.end_exclusive)),
-        ));
-    }
-
-    fn take(&self) -> Vec<RecordedGet> {
-        std::mem::take(&mut *self.gets.lock().expect("request log lock poisoned"))
-    }
-}
-
-#[derive(Debug)]
-struct RecordingStore {
-    inner: LocalFsStore,
-    log: Arc<RequestLog>,
-}
-
-impl RecordingStore {
-    fn new(root: &Path, log: Arc<RequestLog>) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            log,
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for RecordingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.log.record(key, range.as_ref());
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.log.record(key, None);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
 
 /// (family, level, index_offset, filter_offset) per table object key.
 type TableMap = BTreeMap<String, (String, u32, u64, u64)>;
@@ -185,8 +103,11 @@ fn report(phase: &str, gets: &[RecordedGet], tables: &TableMap) {
 #[ignore = "diagnostic: prints warm-phase request accounting"]
 async fn warm_phase_request_accounting() {
     let temp_dir = tempdir().expect("tempdir");
-    let log = Arc::new(RequestLog::default());
-    let store: SharedObjectStore = Arc::new(RecordingStore::new(temp_dir.path(), Arc::clone(&log)));
+    let log = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let store: SharedObjectStore = log.clone();
     let namespace_id = NamespaceId::parse("acct").expect("valid namespace id");
 
     // Build phase: bench-like shape — one wide hot directory, maintenance
@@ -274,7 +195,7 @@ async fn warm_phase_request_accounting() {
             .map(|(_, level, _, _)| *level)
             .collect::<std::collections::BTreeSet<_>>()
     );
-    let _ = log.take();
+    let _ = log.take_gets();
 
     // Warm phases, each on the same fresh handle like the bench: a full
     // paged list, then stat, read, write.
@@ -304,19 +225,19 @@ async fn warm_phase_request_accounting() {
         }
     }
     assert_eq!(listed, FILES);
-    report("warm full list", &log.take(), &tables);
+    report("warm full list", &log.take_gets(), &tables);
 
     reader
         .stat_path(&namespace_id, "/hot/file-04999.txt")
         .await
         .expect("stat");
-    report("warm stat", &log.take(), &tables);
+    report("warm stat", &log.take_gets(), &tables);
 
     reader
         .read_file_bytes(&namespace_id, "/hot/file-05000.txt")
         .await
         .expect("read");
-    report("warm read", &log.take(), &tables);
+    report("warm read", &log.take_gets(), &tables);
 
     let writer = FsWriter::builder_with_store(store.clone())
         .writer_id("acct-writer-2")
@@ -336,7 +257,7 @@ async fn warm_phase_request_accounting() {
         )
         .await
         .expect("warm write");
-    report("warm write", &log.take(), &tables);
+    report("warm write", &log.take_gets(), &tables);
 
     // A second write on the same handle separates per-handle warmup cost
     // from per-write cost.
@@ -352,5 +273,9 @@ async fn warm_phase_request_accounting() {
         )
         .await
         .expect("second warm write");
-    report("warm write (same handle, second)", &log.take(), &tables);
+    report(
+        "warm write (same handle, second)",
+        &log.take_gets(),
+        &tables,
+    );
 }

--- a/crates/loonfs/tests/runtime.rs
+++ b/crates/loonfs/tests/runtime.rs
@@ -3,9 +3,7 @@
 #![allow(clippy::panic)]
 // Runtime integration tests use panic in helper assertions for precise diagnostics.
 
-use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::publish::{parse_mutation_path, PathMutationIntent};
 use loonfs::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadRequest,
@@ -15,20 +13,20 @@ use loonfs::{
     CreateNamespaceOptions, DeleteOptions, DestinationBehavior, DirectoryPageCursor, ErrorCode,
     FsAdmin, FsReader, FsWriter, FsWriterBuilder, InodeId, InodeKind, ListChangesOptions,
     MaintenanceTickOptions, MaintenanceTickOutcome, MaintenanceTickResult, ManifestId, MoveOptions,
-    NamespaceId, NamespaceStatusResponse, PageRequest, PaginationPolicy, PutFileOptions,
-    RuntimeCacheConfig, RuntimeError, SharedObjectStore, TraceStoreKind, UploadContentResponse,
-    UploadId,
+    NamespaceId, NamespaceStatusResponse, PageRequest, PutFileOptions, RuntimeCacheConfig,
+    RuntimeError, SharedObjectStore, TraceStoreKind, UploadContentResponse, UploadId,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::{metadata_manifest_object, namespace_config, wal_head};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::metrics::{ObjectStoreOperation, VecObjectStoreMetricsRecorder};
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+use loonfs_objectstore::ObjectStore;
+use loonfs_test_support::block_on::block_on;
+use loonfs_test_support::ids::{namespace_id, page_limit};
+use loonfs_test_support::stores::{
+    CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
 };
-use std::future::Future;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -216,18 +214,6 @@ impl TestRuntime {
     }
 }
 
-fn namespace_id() -> NamespaceId {
-    NamespaceId::parse("demo").expect("valid namespace id")
-}
-
-fn block_on<T>(future: impl Future<Output = T>) -> T {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("test runtime")
-        .block_on(future)
-}
-
 async fn wal_segment_count(store: &SharedObjectStore, namespace_id: &NamespaceId) -> usize {
     use futures::StreamExt;
     store
@@ -239,13 +225,6 @@ async fn wal_segment_count(store: &SharedObjectStore, namespace_id: &NamespaceId
         .collect::<Vec<_>>()
         .await
         .len()
-}
-
-fn page_limit(limit: u32) -> loonfs::EffectiveLimit {
-    PaginationPolicy::from_values(limit, limit)
-        .expect("valid pagination policy")
-        .resolve_limit(Some(limit))
-        .expect("valid page limit")
 }
 
 fn decode_directory_page_cursor(value: &str) -> DirectoryPageCursor {
@@ -632,7 +611,7 @@ fn builder_metrics_recorder_instruments_object_store() {
             .metrics_recorder(recorder.clone())
     });
 
-    fs.create_namespace_blocking(&namespace_id(), CreateNamespaceOptions::default())
+    fs.create_namespace_blocking(&namespace_id("demo"), CreateNamespaceOptions::default())
         .expect("create namespace");
 
     let samples = recorder.samples();
@@ -649,7 +628,7 @@ fn builder_metrics_recorder_instruments_object_store() {
 fn filesystem_operations_match_core_semantics() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "filesystem-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -719,7 +698,7 @@ fn filesystem_operations_match_core_semantics() {
 async fn async_runtime_methods_are_the_engine_boundary() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = open_runtime_async(store(temp_dir.path()), "async-runtime-test").await;
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     FsWriter::create_namespace(&fs.writer, &namespace_id, CreateNamespaceOptions::default())
         .await
@@ -745,12 +724,12 @@ async fn async_runtime_methods_are_the_engine_boundary() {
 #[test]
 fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let fs = open_runtime(object_store, "tail-projection-cache-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -801,12 +780,12 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
 #[test]
 fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let setup = open_runtime(object_store.clone(), "publish-tail");
     let measured = open_runtime(object_store, "publish-tail");
 
@@ -851,12 +830,12 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
 #[test]
 fn runtime_publish_allows_multi_segment_wal_tail() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let setup = open_runtime(object_store.clone(), "publish-tail");
     let measured = open_runtime(object_store, "publish-tail");
 
@@ -882,12 +861,12 @@ fn runtime_publish_allows_multi_segment_wal_tail() {
 #[test]
 fn runtime_cache_observes_head_advanced_by_another_runtime() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let reader = open_runtime(object_store.clone(), "tail-cache-reader");
     let writer = open_runtime(object_store, "tail-cache-writer");
 
@@ -922,12 +901,12 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
 #[test]
 fn runtime_cache_can_be_disabled() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let fs = open_runtime_with(object_store, "tail-cache-disabled-test", |builder| {
         builder.runtime_cache(RuntimeCacheConfig::disabled())
     });
@@ -999,12 +978,12 @@ fn runtime_wal_tail_projection_cache_evicts_by_namespace_count() {
 #[test]
 fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let fs = open_runtime_with(object_store, "tail-oversized-test", |builder| {
         builder.runtime_cache(RuntimeCacheConfig {
             max_cached_wal_tail_projection_rows: 0,
@@ -1038,7 +1017,7 @@ fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
 #[test]
 fn runtime_read_allows_multi_segment_wal_tail() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let fs = open_runtime(store(temp_dir.path()), "tail-read-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -1055,12 +1034,12 @@ fn runtime_read_allows_multi_segment_wal_tail() {
 #[test]
 fn stale_head_write_error_recovers_and_reseeds_caches() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let fs = open_runtime(object_store, "tail-cache-stale-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -1098,7 +1077,7 @@ fn stale_head_write_error_recovers_and_reseeds_caches() {
 fn delete_options_select_recursive_behavior() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "delete-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -1141,7 +1120,7 @@ fn delete_options_select_recursive_behavior() {
 fn undelete_recovers_a_deleted_file_and_generations_stay_scoped() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "undelete-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     fs.put_file_bytes_blocking(
@@ -1268,7 +1247,7 @@ fn undelete_recovers_a_deleted_file_and_generations_stay_scoped() {
 fn undelete_recovers_a_deleted_subtree_and_rejects_covered_children() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "undelete-subtree-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     fs.put_file_bytes_blocking(
@@ -1335,7 +1314,7 @@ fn undelete_recovers_a_deleted_subtree_and_rejects_covered_children() {
 fn undelete_of_an_ancestor_keeps_independently_deleted_children_hidden() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "undelete-nested-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     fs.put_file_bytes_blocking(
@@ -1404,7 +1383,7 @@ fn undelete_of_an_ancestor_keeps_independently_deleted_children_hidden() {
 fn undelete_survives_checkpoints_and_reopen_in_both_orders() {
     let temp_dir = tempdir().expect("tempdir");
     let object_store = store(temp_dir.path());
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     // Order one: delete + undelete in the WAL tail, then checkpoint,
     // then reopen cold from object storage.
@@ -1535,7 +1514,7 @@ fn undelete_survives_checkpoints_and_reopen_in_both_orders() {
 fn change_feed_carries_the_exact_revoked_generation() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "undelete-feed-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     fs.put_file_bytes_blocking(
@@ -1603,7 +1582,7 @@ fn change_feed_carries_the_exact_revoked_generation() {
 fn undelete_rejects_deletions_from_the_same_commit() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "undelete-same-commit-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     fs.put_file_bytes_blocking(
@@ -1661,7 +1640,7 @@ fn undelete_rejects_deletions_from_the_same_commit() {
 fn delete_with_expected_inode_refuses_a_raced_rebinding() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "delete-expectation-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     fs.put_file_bytes_blocking(
@@ -1717,7 +1696,7 @@ fn delete_with_expected_inode_refuses_a_raced_rebinding() {
 fn directory_pages_use_canonical_name_key_order() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-order-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     for path in [
@@ -1773,7 +1752,7 @@ fn directory_pages_use_canonical_name_key_order() {
 fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "file-revision-page-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
 
@@ -1855,7 +1834,7 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
 fn directory_cursor_after_later_writes_is_rejected() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-snapshot-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
@@ -1906,7 +1885,7 @@ fn directory_cursor_after_later_writes_is_rejected() {
 fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-floor-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
@@ -1957,7 +1936,7 @@ fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
 fn directory_cursor_rejects_path_inode_mismatch() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-mismatch-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
     for path in ["/docs/a.txt", "/docs/b.txt"] {
@@ -1998,7 +1977,7 @@ fn directory_cursor_rejects_path_inode_mismatch() {
 fn forked_namespace_shares_content_then_diverges() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "fork-test");
-    let source = namespace_id();
+    let source = namespace_id("demo");
     let clone = NamespaceId::parse("clone").expect("valid namespace id");
 
     fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
@@ -2050,7 +2029,7 @@ fn forked_namespace_shares_content_then_diverges() {
 fn upload_flow_is_available_from_runtime() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "upload-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2081,7 +2060,7 @@ fn upload_flow_is_available_from_runtime() {
 fn direct_put_upload_flow_validates_durable_object_on_complete() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "direct-put-upload-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let bytes = b"direct uploaded";
     let content_ref = ContentRef::whole_file_v0(bytes);
 
@@ -2125,8 +2104,11 @@ fn direct_put_upload_flow_validates_durable_object_on_complete() {
 #[test]
 fn direct_put_completion_proves_upload_without_reading_content() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::content_blob(),
+    ));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = open_runtime(object_store, "direct-put-probe-test");
     let bytes = b"direct uploaded, provider verified";
@@ -2142,7 +2124,7 @@ fn direct_put_completion_proves_upload_without_reading_content() {
     block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
         .expect("write direct object");
 
-    raw_store.reset_content_blob_counters();
+    raw_store.reset();
     let completed = fs
         .complete_upload_blocking(
             &namespace_id,
@@ -2154,7 +2136,7 @@ fn direct_put_completion_proves_upload_without_reading_content() {
         .expect("complete direct put");
     assert_eq!(completed.content_ref, content_ref);
     assert_eq!(
-        raw_store.content_blob_get_count(),
+        raw_store.count(OperationClass::Read),
         0,
         "completion proves the upload from object metadata alone"
     );
@@ -2164,7 +2146,7 @@ fn direct_put_completion_proves_upload_without_reading_content() {
 fn direct_put_completion_rejects_a_mis_declared_size() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "direct-put-size-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let bytes = b"direct put bytes with a lying size";
     // The digest names the object; the declared size rides the reference
     // unchecked by the provider, so completion's size check must catch it.
@@ -2196,7 +2178,7 @@ fn direct_put_completion_rejects_a_mis_declared_size() {
 #[test]
 fn stat_and_list_use_initial_manifest_without_checkpoint() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let fs = runtime(temp_dir.path(), "read-fallback-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -2216,8 +2198,11 @@ fn stat_and_list_use_initial_manifest_without_checkpoint() {
 #[test]
 fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::content_blob(),
+    ));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = open_runtime(object_store, "read-materialized-test");
 
@@ -2233,7 +2218,7 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
     fs.create_checkpoint_blocking(&namespace_id)
         .expect("checkpoint");
 
-    raw_store.reset_content_blob_counters();
+    raw_store.reset();
     fs.stat_path_blocking(&namespace_id, "/docs/file.txt")
         .expect("stat materialized file");
     fs.list_path_blocking(&namespace_id, "/docs")
@@ -2241,14 +2226,14 @@ fn stat_and_list_use_materialized_tables_after_checkpoint_without_content_reads(
 
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.latest_metadata_view_reads, 2);
-    assert_eq!(raw_store.content_blob_get_count(), 0);
+    assert_eq!(raw_store.count(OperationClass::Read), 0);
 }
 
 /// Concurrent stat and list race through the shared async metadata-view cache.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn concurrent_materialized_stat_and_list_share_async_store() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let fs = open_runtime_async(store(temp_dir.path()), "concurrent-materialized-read-test").await;
 
     fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
@@ -2285,7 +2270,7 @@ async fn concurrent_materialized_stat_and_list_share_async_store() {
 #[test]
 fn repeated_materialized_stat_uses_metadata_table_cache() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let fs = runtime(temp_dir.path(), "metadata-table-cache-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -2315,15 +2300,18 @@ fn repeated_materialized_stat_uses_metadata_table_cache() {
 #[test]
 fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(ContentBlobGetCountingStore::new(temp_dir.path()));
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::content_blob(),
+    ));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = open_runtime(object_store, "put-file-content-validation-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
 
-    raw_store.reset_content_blob_counters();
+    raw_store.reset();
     fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/direct.txt",
@@ -2335,11 +2323,11 @@ fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
     // The put writes the blob exactly once and never reads it back: the
     // write's own ack is the durability proof the head CAS waits on, so
     // validation issues no probe for content the put itself is writing.
-    assert_eq!(raw_store.content_blob_put_count(), 1);
-    assert_eq!(raw_store.content_blob_get_count(), 0);
+    assert_eq!(raw_store.count(OperationClass::Put), 1);
+    assert_eq!(raw_store.count(OperationClass::Read), 0);
 
     // A replace put rides the same overlapped path: new blob, no probe.
-    raw_store.reset_content_blob_counters();
+    raw_store.reset();
     fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/direct.txt",
@@ -2351,22 +2339,22 @@ fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
     )
     .expect("replace file bytes");
 
-    assert_eq!(raw_store.content_blob_put_count(), 1);
-    assert_eq!(raw_store.content_blob_get_count(), 0);
+    assert_eq!(raw_store.count(OperationClass::Put), 1);
+    assert_eq!(raw_store.count(OperationClass::Read), 0);
 }
 
 #[test]
 fn put_file_bytes_retries_a_transient_content_write_failure() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(FailContentBlobPutsStore::new(temp_dir.path()));
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(fail_content_blob_puts_store(temp_dir.path()));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = open_runtime(object_store, "content-write-failure-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
 
-    raw_store.fail_next_content_blob_puts(1);
+    raw_store.fail_next(1);
     fs.put_file_bytes_blocking(
         &namespace_id,
         "/docs/report.txt",
@@ -2386,7 +2374,7 @@ fn put_file_bytes_retries_a_transient_content_write_failure() {
 #[test]
 fn path_mutations_return_the_commit_id_they_committed_under() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let object_store = store(temp_dir.path());
     block_on(async {
         let fs = open_runtime_async(object_store, "commit-id-echo-test").await;
@@ -2447,7 +2435,7 @@ fn path_mutations_return_the_commit_id_they_committed_under() {
 #[test]
 fn concurrent_puts_coalesce_into_one_wal_segment() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let object_store = store(temp_dir.path());
     block_on(async {
         let fs = open_runtime_async(object_store.clone(), "publication-batch-test").await;
@@ -2570,7 +2558,7 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
 #[test]
 fn zero_interval_publishes_sequential_submissions_immediately() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let object_store = store(temp_dir.path());
     block_on(async {
         let fs = open_runtime_with_async(object_store.clone(), "zero-interval-test", |builder| {
@@ -2604,8 +2592,8 @@ fn zero_interval_publishes_sequential_submissions_immediately() {
 #[test]
 fn concurrent_puts_both_commit_after_one_transient_content_failure() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(FailContentBlobPutsStore::new(temp_dir.path()));
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(fail_content_blob_puts_store(temp_dir.path()));
     let object_store: SharedObjectStore = raw_store.clone();
     block_on(async {
         let fs = open_runtime_async(object_store, "window-abort-test").await;
@@ -2615,7 +2603,7 @@ fn concurrent_puts_both_commit_after_one_transient_content_failure() {
 
         // One content write fails once before either submission enters the
         // commit window. Its immutable retry is independent of its peer.
-        raw_store.fail_next_content_blob_puts(1);
+        raw_store.fail_next(1);
         let (a, b) = tokio::join!(
             fs.put_file_bytes(
                 &namespace_id,
@@ -2649,12 +2637,12 @@ fn concurrent_puts_both_commit_after_one_transient_content_failure() {
 #[test]
 fn begin_upload_validates_controls_without_replay_reads() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let fs = open_runtime(object_store, "begin-upload-cache-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -2692,12 +2680,12 @@ fn begin_upload_validates_controls_without_replay_reads() {
 #[test]
 fn runtime_control_cache_reuses_head_for_materialization_validation() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let fs = open_runtime(object_store, "control-cache-head-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -2720,13 +2708,13 @@ fn runtime_control_cache_reuses_head_for_materialization_validation() {
 #[test]
 fn control_cache_eviction_reloads_head_for_materialization_validation() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
     let other_namespace = NamespaceId::parse("other").expect("valid namespace id");
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let fs = open_runtime_with(object_store, "control-cache-eviction-test", |builder| {
         builder.runtime_cache(RuntimeCacheConfig {
             max_cached_namespaces: 1,
@@ -2760,12 +2748,12 @@ fn control_cache_eviction_reloads_head_for_materialization_validation() {
 #[test]
 fn runtime_control_cache_reloads_head_after_external_change() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let reader = open_runtime(object_store.clone(), "control-cache-reader");
     let writer = open_runtime(object_store, "control-cache-writer");
 
@@ -2807,7 +2795,7 @@ fn begin_upload_rejects_missing_and_partial_namespace() {
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = open_runtime(object_store, "begin-upload-missing-partial-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     assert_core_error_kind(
         fs.begin_upload_blocking(&namespace_id),
@@ -2831,7 +2819,7 @@ fn begin_upload_rejects_malformed_descriptors() {
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = open_runtime(object_store, "begin-upload-malformed-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2894,7 +2882,7 @@ fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
 fn explicit_commit_appears_in_change_feed() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "commit-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2927,7 +2915,7 @@ fn explicit_commit_appears_in_change_feed() {
 fn namespace_status_reports_wal_tail_segments() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "status-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2961,7 +2949,7 @@ fn namespace_status_reports_wal_tail_segments() {
 fn root_stat_and_list_work_immediately_after_namespace_create() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "initial-manifest-read-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -2984,7 +2972,7 @@ fn root_stat_and_list_work_immediately_after_namespace_create() {
 fn namespace_status_and_tick_reject_missing_namespace() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "missing-status-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     assert_core_error_kind(
         fs.namespace_status_blocking(&namespace_id),
@@ -3002,7 +2990,7 @@ fn namespace_status_and_tick_reject_partial_namespace() {
     let raw_store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local-fs store"));
     let object_store: SharedObjectStore = raw_store.clone();
     let fs = open_runtime(object_store, "partial-status-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -3023,7 +3011,7 @@ fn namespace_status_and_tick_reject_partial_namespace() {
 fn maintenance_tick_below_threshold_is_not_needed() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-not-needed-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -3053,7 +3041,7 @@ fn maintenance_tick_below_threshold_is_not_needed() {
 fn maintenance_tick_at_segment_threshold_flushes_the_wal() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-publish-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -3107,7 +3095,7 @@ fn maintenance_tick_at_segment_threshold_flushes_the_wal() {
 fn maintenance_tick_after_existing_manifest_writes_l0_manifest() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-l0-run-publish-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -3187,7 +3175,7 @@ fn maintenance_tick_after_existing_manifest_writes_l0_manifest() {
 fn maintenance_tick_counts_segments_not_commits() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-segment-count-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -3270,7 +3258,7 @@ fn maintenance_tick_counts_segments_not_commits() {
 fn maintenance_tick_rejects_zero_threshold() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-config-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -3295,7 +3283,7 @@ fn maintenance_tick_rejects_thresholds_above_the_write_rejection_cap() {
     // while every publish is rejected with `maintenance_required`.
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "tick-config-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -3320,12 +3308,12 @@ fn maintenance_tick_rejects_thresholds_above_the_write_rejection_cap() {
 #[test]
 fn maintenance_tick_treats_metadata_root_cas_loss_as_benign_race() {
     let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id();
-    let raw_store = Arc::new(HeadCasFailureStore::new(
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(
         temp_dir.path(),
         namespace_id.as_str(),
     ));
-    let object_store: SharedObjectStore = raw_store.clone();
+    let object_store = raw_store.store();
     let fs = open_runtime(object_store, "tick-race-test");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -3366,7 +3354,7 @@ fn maintenance_tick_treats_metadata_root_cas_loss_as_benign_race() {
 fn checkpoint_and_retention_hooks_are_available() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "maintenance-test");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -3392,7 +3380,7 @@ fn separate_runtime_instances_share_object_store_state() {
     let temp_dir = tempdir().expect("tempdir");
     let writer = runtime(temp_dir.path(), "writer");
     let reader = runtime(temp_dir.path(), "reader");
-    let namespace_id = namespace_id();
+    let namespace_id = namespace_id("demo");
 
     writer
         .create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -3413,294 +3401,97 @@ fn separate_runtime_instances_share_object_store_state() {
 }
 
 #[derive(Debug)]
-struct HeadCasFailureStore {
-    inner: LocalFsStore,
-    head_key: String,
-    root_key: String,
-    wal_prefix: String,
-    manifest_prefix: String,
-    fail_head_cas: AtomicBool,
-    fail_root_cas: AtomicBool,
-    wal_get_count: AtomicUsize,
-    manifest_get_count: AtomicUsize,
-    head_get_count: AtomicUsize,
+struct RuntimeStoreProbe {
+    store: SharedObjectStore,
+    fail_head_cas: Arc<FailStore<SharedObjectStore>>,
+    fail_root_cas: Arc<FailStore<SharedObjectStore>>,
+    wal_gets: Arc<CountingStore<SharedObjectStore>>,
+    manifest_gets: Arc<CountingStore<SharedObjectStore>>,
+    head_gets: Arc<CountingStore<SharedObjectStore>>,
 }
 
-impl HeadCasFailureStore {
+impl RuntimeStoreProbe {
     fn new(root: &Path, namespace: &str) -> Self {
+        let inner: SharedObjectStore =
+            Arc::new(LocalFsStore::new(root).expect("create local-fs store"));
+        let wal_gets = Arc::new(CountingStore::new(
+            inner,
+            KeyPredicate::prefix(format!("namespaces/{namespace}/wal/segments/")),
+        ));
+        let manifest_gets = Arc::new(CountingStore::new(
+            wal_gets.clone() as SharedObjectStore,
+            KeyPredicate::prefix(format!("namespaces/{namespace}/metadata/manifests/")),
+        ));
+        let head_gets = Arc::new(CountingStore::new(
+            manifest_gets.clone() as SharedObjectStore,
+            KeyPredicate::wal_head(namespace),
+        ));
+        let fail_head_cas = Arc::new(FailStore::new(
+            head_gets.clone() as SharedObjectStore,
+            KeyPredicate::wal_head(namespace),
+            OperationClass::CompareAndSwap,
+            InjectedError::PreconditionFailed,
+        ));
+        let fail_root_cas = Arc::new(FailStore::new(
+            fail_head_cas.clone() as SharedObjectStore,
+            KeyPredicate::metadata_root(namespace),
+            OperationClass::CompareAndSwap,
+            InjectedError::PreconditionFailed,
+        ));
         Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            head_key: wal_head(namespace),
-            root_key: loonfs_objectstore::keys::metadata_root(namespace),
-            wal_prefix: format!("namespaces/{namespace}/wal/segments/"),
-            manifest_prefix: format!("namespaces/{namespace}/metadata/manifests/"),
-            fail_head_cas: AtomicBool::new(false),
-            fail_root_cas: AtomicBool::new(false),
-            wal_get_count: AtomicUsize::new(0),
-            manifest_get_count: AtomicUsize::new(0),
-            head_get_count: AtomicUsize::new(0),
+            store: fail_root_cas.clone(),
+            fail_head_cas,
+            fail_root_cas,
+            wal_gets,
+            manifest_gets,
+            head_gets,
         }
     }
 
+    fn store(&self) -> SharedObjectStore {
+        self.store.clone()
+    }
+
     fn fail_head_cas(&self) {
-        self.fail_head_cas.store(true, Ordering::SeqCst);
+        self.fail_head_cas.fail_all();
     }
 
     fn allow_head_cas(&self) {
-        self.fail_head_cas.store(false, Ordering::SeqCst);
+        self.fail_head_cas.clear();
     }
 
     fn fail_root_cas(&self) {
-        self.fail_root_cas.store(true, Ordering::SeqCst);
+        self.fail_root_cas.fail_all();
     }
 
     fn reset_wal_get_count(&self) {
-        self.wal_get_count.store(0, Ordering::SeqCst);
+        self.wal_gets.reset();
     }
 
     fn reset_control_get_counts(&self) {
-        self.manifest_get_count.store(0, Ordering::SeqCst);
-        self.head_get_count.store(0, Ordering::SeqCst);
+        self.manifest_gets.reset();
+        self.head_gets.reset();
         self.reset_wal_get_count();
     }
 
     fn wal_get_count(&self) -> usize {
-        self.wal_get_count.load(Ordering::SeqCst)
+        self.wal_gets.count(OperationClass::Read)
     }
 
     fn manifest_get_count(&self) -> usize {
-        self.manifest_get_count.load(Ordering::SeqCst)
+        self.manifest_gets.count(OperationClass::Read)
     }
 
     fn head_get_count(&self) -> usize {
-        self.head_get_count.load(Ordering::SeqCst)
+        self.head_gets.count(OperationClass::Read)
     }
 }
 
-#[async_trait]
-impl ObjectStore for HeadCasFailureStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        if key.starts_with(&self.wal_prefix) {
-            self.wal_get_count.fetch_add(1, Ordering::SeqCst);
-        }
-        if key.starts_with(&self.manifest_prefix) {
-            self.manifest_get_count.fetch_add(1, Ordering::SeqCst);
-        }
-        if key == self.head_key {
-            self.head_get_count.fetch_add(1, Ordering::SeqCst);
-        }
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        if key.starts_with(&self.wal_prefix) {
-            self.wal_get_count.fetch_add(1, Ordering::SeqCst);
-        }
-        if key.starts_with(&self.manifest_prefix) {
-            self.manifest_get_count.fetch_add(1, Ordering::SeqCst);
-        }
-        if key == self.head_key {
-            self.head_get_count.fetch_add(1, Ordering::SeqCst);
-        }
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        if key == self.head_key
-            && matches!(&mode, PutMode::CompareAndSwap { .. })
-            && self.fail_head_cas.load(Ordering::SeqCst)
-        {
-            return Err(ObjectStoreError::PreconditionFailed {
-                object_key: key.to_owned(),
-            });
-        }
-        if key == self.root_key
-            && matches!(&mode, PutMode::CompareAndSwap { .. })
-            && self.fail_root_cas.load(Ordering::SeqCst)
-        {
-            return Err(ObjectStoreError::PreconditionFailed {
-                object_key: key.to_owned(),
-            });
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-#[derive(Debug)]
-struct ContentBlobGetCountingStore {
-    inner: LocalFsStore,
-    content_blob_gets: AtomicUsize,
-    content_blob_puts: AtomicUsize,
-}
-
-impl ContentBlobGetCountingStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            content_blob_gets: AtomicUsize::new(0),
-            content_blob_puts: AtomicUsize::new(0),
-        }
-    }
-
-    fn reset_content_blob_counters(&self) {
-        self.content_blob_gets.store(0, Ordering::SeqCst);
-        self.content_blob_puts.store(0, Ordering::SeqCst);
-    }
-
-    fn content_blob_get_count(&self) -> usize {
-        self.content_blob_gets.load(Ordering::SeqCst)
-    }
-
-    fn content_blob_put_count(&self) -> usize {
-        self.content_blob_puts.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl ObjectStore for ContentBlobGetCountingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        if key.starts_with("content-stores/") && key.contains("/blobs/") {
-            self.content_blob_gets.fetch_add(1, Ordering::SeqCst);
-        }
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        if key.starts_with("content-stores/") && key.contains("/blobs/") {
-            self.content_blob_gets.fetch_add(1, Ordering::SeqCst);
-        }
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        if key.starts_with("content-stores/") && key.contains("/blobs/") {
-            self.content_blob_puts.fetch_add(1, Ordering::SeqCst);
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-#[derive(Debug)]
-struct FailContentBlobPutsStore {
-    inner: LocalFsStore,
-    fail_remaining: AtomicUsize,
-}
-
-impl FailContentBlobPutsStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            fail_remaining: AtomicUsize::new(0),
-        }
-    }
-
-    /// Arms the store to fail the next `count` content-blob puts, then
-    /// recover.
-    fn fail_next_content_blob_puts(&self, count: usize) {
-        self.fail_remaining.store(count, Ordering::SeqCst);
-    }
-
-    fn should_fail_content_blob_put(&self) -> bool {
-        self.fail_remaining
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
-                remaining.checked_sub(1)
-            })
-            .is_ok()
-    }
-}
-
-#[async_trait]
-impl ObjectStore for FailContentBlobPutsStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        if key.starts_with("content-stores/")
-            && key.contains("/blobs/")
-            && self.should_fail_content_blob_put()
-        {
-            return Err(ObjectStoreError::transport(
-                key,
-                "injected content write failure",
-            ));
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
+fn fail_content_blob_puts_store(root: &Path) -> FailStore<LocalFsStore> {
+    FailStore::new(
+        LocalFsStore::new(root).expect("create local-fs store"),
+        KeyPredicate::content_blob(),
+        OperationClass::Put,
+        InjectedError::Transport("injected content write failure".to_owned()),
+    )
 }


### PR DESCRIPTION
Fifty-three hand-rolled `ObjectStore` wrappers existed across the test binaries and inline suites — three blocking-CAS variants re-implementing the same lost-wakeup-safe parking, verbatim-duplicated recording stores, near-identical counting and fail-once injectors, four `block_on` copies, two `raw_agent` copies, and a five-times-copied engine-seeding body. The new `loonfs-test-support` crate (publish = false, dev-dependency only) replaces them with five parameterized stores (Blocking, Fail, Counting, Recording, MetadataMap — each configured by a key predicate and operation class), plus `block_on`, `raw_agent`, and the tiny id/limit constructors. Existing test code shrinks by 2,315 lines (net −788 including the new crate); no assertion changed anywhere, and no production code changed 
