### PR TITLE
fix(core): bound namespace status to the visible wal chain

### DIFF
--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -272,7 +272,7 @@ async fn checkpoint_publication_preserves_writer_identity() {
 }
 
 #[tokio::test]
-async fn maintenance_does_not_make_orphan_wal_visible() {
+async fn maintenance_and_status_do_not_make_orphan_wal_visible() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -312,6 +312,13 @@ async fn maintenance_does_not_make_orphan_wal_visible() {
         .put_overwrite(&orphan_key, Bytes::from_static(b"not a wal envelope"))
         .await
         .expect("write orphan wal");
+    let status = load_namespace_head_summary(&store, &namespace_id)
+        .await
+        .expect("load namespace status");
+    // Status reports the documented visible-chain length, not race-loser
+    // objects that await garbage collection.
+    assert_eq!(status.wal_tail_segments, 1);
+
     advance_retention_floor(&store, &namespace_id, &context)
         .await
         .expect("advance retention");

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -41,6 +41,7 @@ use crate::namespace::catalog::load_namespace_catalog_entry;
 use crate::namespace::control::{
     read_head_object, read_metadata_root_object, read_wal_floor_object,
 };
+use crate::namespace::status::load_namespace_head_summary;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::ops::{
     delete_path, move_path, put_file_bytes, restore_file_revision, write_file_bytes,

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -11,12 +11,10 @@ use crate::namespace::catalog::{
 use crate::namespace::control::{
     read_head_and_metadata_root, read_wal_floor_seq_or_zero, ControlObjectLoadError,
 };
+use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
 use loonfs_api::wire::control::NamespaceState;
-use loonfs_api::{wal_segment_id_start_seq, ChangeSeq, ManifestId, NamespaceId};
-use loonfs_objectstore::{
-    keys::{namespace_config, wal_segment_id_from_key, wal_segment_prefix},
-    ObjectStore,
-};
+use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
+use loonfs_objectstore::{keys::namespace_config, ObjectStore};
 use serde::{Deserialize, Serialize};
 
 /// Lightweight namespace head status.
@@ -25,11 +23,7 @@ pub struct NamespaceHeadSummary {
     pub namespace_id: NamespaceId,
     pub head_seq: ChangeSeq,
     pub current_manifest_id: Option<ManifestId>,
-    /// WAL segment objects positioned past the loaded manifest.
-    ///
-    /// Derived from position-ordered object names, not from walking the
-    /// chain: an inspection count for maintenance gating and operators, not
-    /// a validated chain length.
+    /// Number of visible WAL segments after the current manifest.
     pub wal_tail_segments: u64,
     pub retention_floor_seq: ChangeSeq,
 }
@@ -75,12 +69,23 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
             .map_err(|error| {
                 CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
             })?;
-    let manifest_head_seq = manifest.payload.head_seq;
-    let wal_tail_segments = if head.visible_wal_tip.is_some() {
-        count_wal_tail_segments_by_position(store, expected_namespace_id, manifest_head_seq).await?
-    } else {
-        0
-    };
+    let wal_chain = load_validated_wal_chain(
+        store,
+        WalChainLoadRequest {
+            namespace_id: expected_namespace_id,
+            chain_base_seq: manifest.payload.head_seq,
+            head_seq: head.seq,
+            visible_tip: head.visible_wal_tip.clone(),
+            stop_after_seq: None,
+            recent_segments: &head.recent_segments,
+        },
+    )
+    .await
+    .map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
+    })?;
+    let wal_tail_segments = u64::try_from(wal_chain.segments().len())
+        .map_err(|_| CoreError::Internal("WAL tail segment count overflow".to_owned()))?;
     let retention_floor_seq = read_wal_floor_seq_or_zero(store, expected_namespace_id)
         .await
         .map_err(|error| {
@@ -93,32 +98,4 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         wal_tail_segments,
         retention_floor_seq,
     })
-}
-
-/// Counts WAL tail segments from their position-ordered object names.
-///
-/// Status is an inspection surface, so the count comes from one listing
-/// instead of loading and validating segment bodies: segment file names
-/// carry their `start_seq`, and every chain segment past the manifest starts
-/// above it. Objects that lost a head race are counted until reclamation
-/// removes them, which can only over-trigger maintenance, never starve it.
-/// Recovery authority stays with the head and chain.
-async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    manifest_head_seq: ChangeSeq,
-) -> Result<u64> {
-    let wal_prefix = wal_segment_prefix(namespace_id.as_str());
-    let keys = store
-        .list_prefix(&wal_prefix)
-        .await
-        .map_err(|error| CoreError::store(&wal_prefix, &error))?;
-    let tail_segments = keys
-        .iter()
-        .filter_map(|key| wal_segment_id_from_key(key))
-        .filter_map(wal_segment_id_start_seq)
-        .filter(|start_seq| *start_seq > manifest_head_seq)
-        .count();
-    u64::try_from(tail_segments)
-        .map_err(|_| CoreError::Internal("WAL tail segment count overflow".to_owned()))
 }

--- a/crates/loonfs/tests/maintenance.rs
+++ b/crates/loonfs/tests/maintenance.rs
@@ -17,13 +17,18 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
+use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
 use std::sync::Arc;
 use tempfile::tempdir;
 
 #[test]
 fn namespace_status_reports_wal_tail_segments() {
     let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "status-test");
+    let store = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let fs = open_runtime(store.clone(), "status-test");
     let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -45,6 +50,7 @@ fn namespace_status_reports_wal_tail_segments() {
     )
     .expect("put file");
 
+    store.reset();
     let status = fs
         .namespace_status_blocking(&namespace_id)
         .expect("status after commit");
@@ -52,6 +58,7 @@ fn namespace_status_reports_wal_tail_segments() {
     assert_eq!(status.current_manifest_id, Some(ManifestId(0)));
     assert_eq!(status.wal_tail_segments, 1);
     assert_eq!(status.retention_floor_seq, ChangeSeq(0));
+    assert_eq!(store.count(OperationClass::List), 0);
 }
 
 #[test]


### PR DESCRIPTION
Namespace status answered "how many WAL segments sit after the manifest" by listing the namespace whole WAL prefix — cost proportional to years of accumulated history, and the count included orphaned race-loser segments that only GC removes, so the number did not even match its own field documentation. Status now counts the validated visible chain from the manifest sequence to the head, which is authoritative and bounded by the write-tail policy. One extra bounded get replaces the unbounded list; a counting-store test pins the status path at zero list operations, and an injected-orphan test proves losers no longer inflate the count. The wire shape is unchanged and the reported number now matches its documented meaning exactly. 
