### PR TITLE
fix(objectstore): make local replacement atomic and honest

### DIFF
--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -272,7 +272,7 @@ async fn checkpoint_publication_preserves_writer_identity() {
 }
 
 #[tokio::test]
-async fn maintenance_does_not_make_orphan_wal_visible() {
+async fn maintenance_and_status_do_not_make_orphan_wal_visible() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -312,6 +312,13 @@ async fn maintenance_does_not_make_orphan_wal_visible() {
         .put_overwrite(&orphan_key, Bytes::from_static(b"not a wal envelope"))
         .await
         .expect("write orphan wal");
+    let status = load_namespace_head_summary(&store, &namespace_id)
+        .await
+        .expect("load namespace status");
+    // Status reports the documented visible-chain length, not race-loser
+    // objects that await garbage collection.
+    assert_eq!(status.wal_tail_segments, 1);
+
     advance_retention_floor(&store, &namespace_id, &context)
         .await
         .expect("advance retention");

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -41,6 +41,7 @@ use crate::namespace::catalog::load_namespace_catalog_entry;
 use crate::namespace::control::{
     read_head_object, read_metadata_root_object, read_wal_floor_object,
 };
+use crate::namespace::status::load_namespace_head_summary;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::path::write::ops::{
     delete_path, move_path, put_file_bytes, restore_file_revision, write_file_bytes,

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -11,12 +11,10 @@ use crate::namespace::catalog::{
 use crate::namespace::control::{
     read_head_and_metadata_root, read_wal_floor_seq_or_zero, ControlObjectLoadError,
 };
+use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
 use loonfs_api::wire::control::NamespaceState;
-use loonfs_api::{wal_segment_id_start_seq, ChangeSeq, ManifestId, NamespaceId};
-use loonfs_objectstore::{
-    keys::{namespace_config, wal_segment_id_from_key, wal_segment_prefix},
-    ObjectStore,
-};
+use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
+use loonfs_objectstore::{keys::namespace_config, ObjectStore};
 use serde::{Deserialize, Serialize};
 
 /// Lightweight namespace head status.
@@ -25,11 +23,7 @@ pub struct NamespaceHeadSummary {
     pub namespace_id: NamespaceId,
     pub head_seq: ChangeSeq,
     pub current_manifest_id: Option<ManifestId>,
-    /// WAL segment objects positioned past the loaded manifest.
-    ///
-    /// Derived from position-ordered object names, not from walking the
-    /// chain: an inspection count for maintenance gating and operators, not
-    /// a validated chain length.
+    /// Number of visible WAL segments after the current manifest.
     pub wal_tail_segments: u64,
     pub retention_floor_seq: ChangeSeq,
 }
@@ -75,12 +69,23 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
             .map_err(|error| {
                 CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
             })?;
-    let manifest_head_seq = manifest.payload.head_seq;
-    let wal_tail_segments = if head.visible_wal_tip.is_some() {
-        count_wal_tail_segments_by_position(store, expected_namespace_id, manifest_head_seq).await?
-    } else {
-        0
-    };
+    let wal_chain = load_validated_wal_chain(
+        store,
+        WalChainLoadRequest {
+            namespace_id: expected_namespace_id,
+            chain_base_seq: manifest.payload.head_seq,
+            head_seq: head.seq,
+            visible_tip: head.visible_wal_tip.clone(),
+            stop_after_seq: None,
+            recent_segments: &head.recent_segments,
+        },
+    )
+    .await
+    .map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
+    })?;
+    let wal_tail_segments = u64::try_from(wal_chain.segments().len())
+        .map_err(|_| CoreError::Internal("WAL tail segment count overflow".to_owned()))?;
     let retention_floor_seq = read_wal_floor_seq_or_zero(store, expected_namespace_id)
         .await
         .map_err(|error| {
@@ -93,32 +98,4 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         wal_tail_segments,
         retention_floor_seq,
     })
-}
-
-/// Counts WAL tail segments from their position-ordered object names.
-///
-/// Status is an inspection surface, so the count comes from one listing
-/// instead of loading and validating segment bodies: segment file names
-/// carry their `start_seq`, and every chain segment past the manifest starts
-/// above it. Objects that lost a head race are counted until reclamation
-/// removes them, which can only over-trigger maintenance, never starve it.
-/// Recovery authority stays with the head and chain.
-async fn count_wal_tail_segments_by_position<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    manifest_head_seq: ChangeSeq,
-) -> Result<u64> {
-    let wal_prefix = wal_segment_prefix(namespace_id.as_str());
-    let keys = store
-        .list_prefix(&wal_prefix)
-        .await
-        .map_err(|error| CoreError::store(&wal_prefix, &error))?;
-    let tail_segments = keys
-        .iter()
-        .filter_map(|key| wal_segment_id_from_key(key))
-        .filter_map(wal_segment_id_start_seq)
-        .filter(|start_seq| *start_seq > manifest_head_seq)
-        .count();
-    u64::try_from(tail_segments)
-        .map_err(|_| CoreError::Internal("WAL tail segment count overflow".to_owned()))
 }

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 /// Identifies the concrete provider backing a [`ConfiguredObjectStore`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfiguredObjectStoreKind {
-    /// Stores objects beneath a local filesystem root.
+    /// Stores objects beneath a Unix-family local filesystem root.
     LocalFs,
     /// Uses AWS S3 through its SigV4 API.
     AwsS3,
@@ -70,7 +70,8 @@ enum ConfiguredObjectStoreInner {
 impl ConfiguredObjectStore {
     /// Opens a local-filesystem provider with optional logical key scoping.
     ///
-    /// Construction fails when the root cannot be created or `key_prefix` is invalid.
+    /// Construction fails outside Unix-family platforms, when the root cannot
+    /// be created, or when `key_prefix` is invalid.
     pub fn local_fs(root: impl Into<PathBuf>, key_prefix: Option<&str>) -> Result<Self> {
         Ok(Self {
             kind: ConfiguredObjectStoreKind::LocalFs,

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -1,9 +1,11 @@
 //! [`LocalFsStore`]: the local-filesystem [`ObjectStore`] provider.
 //!
-//! This is the dev and test provider. Its correctness contract is identical
-//! to the cloud providers'; its performance shapes are deliberately relaxed
-//! (content-hash etags, whole-file reads, whole-tree listings) and are not
-//! optimization targets.
+//! This is the dev and test provider. On Unix-family platforms, sibling
+//! staging files and atomic rename-replace give it the same replacement
+//! visibility contract as the cloud providers. Construction fails on other
+//! platforms rather than exposing a weaker contract. Its performance shapes
+//! are deliberately relaxed (content-hash etags, whole-file reads,
+//! whole-tree listings) and are not optimization targets.
 
 use crate::keyspace::validate_segments;
 use crate::object_store::Result;
@@ -23,7 +25,11 @@ use tokio::sync::Mutex;
 /// holding process dies. Never listed as an object (see `is_scratch_name`).
 const STORE_LOCK_FILE_NAME: &str = ".loonfs-store.lock";
 
-/// Implements the object-store contract on a local directory for development and tests.
+/// Implements the object-store contract on a Unix-family local directory.
+///
+/// Replacements are atomic: a concurrent reader observes either the complete
+/// prior object or the complete replacement, never a missing or partial
+/// object.
 #[derive(Debug)]
 pub struct LocalFsStore {
     root: PathBuf,
@@ -33,8 +39,11 @@ pub struct LocalFsStore {
 impl LocalFsStore {
     /// Opens a local store, creating its root directory when necessary.
     ///
-    /// Construction fails when the root cannot be created.
+    /// Construction fails outside Unix-family platforms, where the provider
+    /// does not claim atomic rename-replace support, or when the root cannot
+    /// be created.
     pub fn new(root: impl Into<PathBuf>) -> Result<Self> {
+        require_atomic_rename_replace()?;
         let root = root.into();
         std::fs::create_dir_all(&root).map_err(|err| {
             ObjectStoreError::Configuration(format!(
@@ -184,25 +193,9 @@ impl LocalFsStore {
                 .map_err(|err| io_error(key, err))?;
             file.sync_all().await.map_err(|err| io_error(key, err))?;
 
-            match fs::rename(&temp_path, path).await {
-                Ok(()) => Ok(()),
-                Err(rename_error)
-                    if fs::try_exists(path).await.unwrap_or(false)
-                        && matches!(
-                            rename_error.kind(),
-                            std::io::ErrorKind::AlreadyExists
-                                | std::io::ErrorKind::PermissionDenied
-                        ) =>
-                {
-                    fs::remove_file(path)
-                        .await
-                        .map_err(|err| io_error(key, err))?;
-                    fs::rename(&temp_path, path)
-                        .await
-                        .map_err(|err| io_error(key, err))
-                }
-                Err(rename_error) => Err(io_error(key, rename_error)),
-            }
+            fs::rename(&temp_path, path)
+                .await
+                .map_err(|err| io_error(key, err))
         }
         .await;
 
@@ -363,6 +356,20 @@ impl ObjectStore for LocalFsStore {
             ),
         )
     }
+}
+
+#[cfg(unix)]
+fn require_atomic_rename_replace() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn require_atomic_rename_replace() -> Result<()> {
+    Err(ObjectStoreError::Configuration(
+        "local filesystem provider requires atomic rename-replace and is supported only on \
+         Unix-family platforms"
+            .to_owned(),
+    ))
 }
 
 async fn list_prefix_for_root(root: PathBuf, prefix: String) -> Result<Vec<String>> {
@@ -590,7 +597,26 @@ mod tests {
     use bytes::Bytes;
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::sync::Barrier;
+
+    #[test]
+    fn construction_requires_atomic_rename_replace_support() {
+        let temp_dir = TestDir::new("construction-gate");
+        let result = LocalFsStore::new(temp_dir.path());
+
+        #[cfg(unix)]
+        assert!(result.is_ok());
+
+        #[cfg(not(unix))]
+        assert!(matches!(
+            result,
+            Err(ObjectStoreError::Configuration(message))
+                if message.contains("requires atomic rename-replace")
+                    && message.contains("Unix-family")
+        ));
+    }
 
     #[tokio::test]
     async fn overwrite_refreshes_head_and_visible_bytes() {
@@ -627,6 +653,66 @@ mod tests {
         assert_eq!(head.etag, second.etag);
         assert_eq!(head.size_bytes, second.size_bytes);
         assert_ne!(first, second);
+    }
+
+    /// Readers race each overwrite rename to exercise replacement visibility across runtime workers.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_readers_observe_complete_replacement_generations() {
+        const PAYLOAD_BYTES: usize = 16 * 1024;
+        const READER_COUNT: usize = 4;
+        const REPLACEMENT_COUNT: u8 = 32;
+
+        let temp_dir = TestDir::new("atomic-replacement");
+        let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local fs store"));
+        let key = wal_head("ns-atomic-replacement");
+        store
+            .put(
+                &key,
+                Bytes::from(vec![0; PAYLOAD_BYTES]),
+                PutMode::Overwrite,
+            )
+            .await
+            .expect("seed replacement object");
+
+        let round_barrier = Arc::new(Barrier::new(READER_COUNT + 1));
+        let mut readers = Vec::new();
+        for _ in 0..READER_COUNT {
+            let reader = Arc::clone(&store);
+            let reader_key = key.clone();
+            let reader_barrier = Arc::clone(&round_barrier);
+            readers.push(tokio::spawn(async move {
+                for _ in 0..REPLACEMENT_COUNT {
+                    reader_barrier.wait().await;
+                    let bytes = reader
+                        .get(&reader_key, None)
+                        .await
+                        .expect("read during replacement")
+                        .expect("replacement key remains present");
+                    assert_eq!(bytes.len(), PAYLOAD_BYTES);
+                    let generation = bytes[0];
+                    assert!(generation <= REPLACEMENT_COUNT);
+                    assert!(bytes.iter().all(|byte| *byte == generation));
+                    reader_barrier.wait().await;
+                }
+            }));
+        }
+
+        for generation in 1..=REPLACEMENT_COUNT {
+            round_barrier.wait().await;
+            store
+                .put(
+                    &key,
+                    Bytes::from(vec![generation; PAYLOAD_BYTES]),
+                    PutMode::Overwrite,
+                )
+                .await
+                .expect("replace object");
+            round_barrier.wait().await;
+        }
+
+        for reader in readers {
+            reader.await.expect("reader task");
+        }
     }
 
     #[tokio::test]

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
 pub enum StoreConfig {
-    /// Stores objects beneath a directory using filesystem-backed compare-and-swap.
+    /// Stores objects beneath a Unix-family directory using atomic filesystem replacement.
     LocalFs {
         /// Directory created or opened as the physical store root.
         root: String,

--- a/crates/loonfs/tests/maintenance.rs
+++ b/crates/loonfs/tests/maintenance.rs
@@ -17,13 +17,18 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
+use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
 use std::sync::Arc;
 use tempfile::tempdir;
 
 #[test]
 fn namespace_status_reports_wal_tail_segments() {
     let temp_dir = tempdir().expect("tempdir");
-    let fs = runtime(temp_dir.path(), "status-test");
+    let store = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::any(),
+    ));
+    let fs = open_runtime(store.clone(), "status-test");
     let namespace_id = namespace_id("demo");
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
@@ -45,6 +50,7 @@ fn namespace_status_reports_wal_tail_segments() {
     )
     .expect("put file");
 
+    store.reset();
     let status = fs
         .namespace_status_blocking(&namespace_id)
         .expect("status after commit");
@@ -52,6 +58,7 @@ fn namespace_status_reports_wal_tail_segments() {
     assert_eq!(status.current_manifest_id, Some(ManifestId(0)));
     assert_eq!(status.wal_tail_segments, 1);
     assert_eq!(status.retention_floor_seq, ChangeSeq(0));
+    assert_eq!(store.count(OperationClass::List), 0);
 }
 
 #[test]

--- a/docs/specs/object-storage-providers.md
+++ b/docs/specs/object-storage-providers.md
@@ -21,13 +21,17 @@ This document is a non-normative reference: provider limits and performance data
 | **Request scale, partitions, throughput** | At least 3,500 write-class requests/s and 5,500 GET/HEAD requests/s per partitioned prefix; unlimited prefixes; scaling is gradual and may return 503 Slow Down. AWS also cites up to 100 Gb/s from a single EC2 instance and aggregate multi-Tb/s workloads.[^9] | Initial bucket scale is about 1,000 writes/s and 5,000 reads/s, then auto-scales. Ramp no faster than roughly doubling every 20 minutes. Sequential names can hotspot; random prefixes improve initial fanout. Internet egress default quota is commonly 200 Gbps per region, subject to account history and quotas.[^19][^20] | Public r2.dev buckets are test-only and may throttle at hundreds of req/s; production should use custom domains or direct APIs. Cloudflare REST management API is not for high-throughput object I/O; use S3-compatible or Workers APIs.[^32] | Standard GPv2/blob accounts: default max request rate 40,000 req/s in many listed regions, 20,000 elsewhere; ingress commonly 60/25 Gbps and egress 200/50 Gbps by region, increaseable by request. Partition hot spots can cause 503/500; use distribution and backoff.[^44][^45] | Vendor-specific. Run compatibility and load tests before relying on any numbers. |
 | **Published GET/HEAD latency** | AWS publishes rough general S3 small-object / first-byte latencies of about 100-200 ms.[^10] | No provider-published average GET/HEAD latency found. Need to benchmark. | No provider-published average GET/HEAD latency found. Need to benchmark. | No provider-published average GET/HEAD latency found. Need to benchmark. | Need to benchmark to verify. |
 
-## 3. LoonFS Design Implications
+## 3. Local Filesystem Provider
+
+The local provider is a development and test provider supported on Unix-family platforms. It stages each replacement in the destination directory, makes the staged bytes durable, and atomically renames the staged file over the destination. A concurrent reader therefore observes either the complete prior object or the complete replacement, never a missing or partial object. Construction fails on other platforms rather than claiming a weaker replacement contract.
+
+## 4. LoonFS Design Implications
 
 1. **WAL/head flush cadence:** one update per second is the same-key CAS ceiling for GCS and R2. For more throughput, write immutable segment objects and update multiple sharded heads or a batched manifest.
 2. **Immutable content path:** content-addressed or monotonic keys can scale through multipart upload and distributed prefixes. 
 3. **Checksums:** LoonFS should own end-to-end integrity. Provider checksums help validate transport/storage, but ETag/checksum semantics diverge sharply across providers and multipart modes.
 
-## 4. Sources
+## 5. Sources
 
 [^1]: Google Cloud Storage, "Quotas & limits": [https://cloud.google.com/storage/quotas](https://cloud.google.com/storage/quotas)
 


### PR DESCRIPTION
The local filesystem provider documented cloud-parity replacement semantics while carrying a delete-then-rename fallback: when rename over an existing file failed with AlreadyExists or PermissionDenied, it removed the destination and renamed again, opening a window where a concurrent reader or a crash observes the key missing. Worse than the visibility blink: a Unix permission failure (sticky directory, mode change) could take the delete branch, remove the destination, and then fail the second rename - destroying the object it was replacing.

The fallback is gone. Replacement is now stage, fsync, one atomic rename - the contract Unix rename gives; genuine failures surface as the store errors they are. The fallback existed for platforms where std rename cannot replace, so the contract narrows honestly instead: LocalFsStore construction fails on non-Unix platforms with a message naming the requirement, structured as one small gate that is trivially deletable if native Windows support is ever built. Docs state the contract. 
