### PR TITLE
feat(api): type wire paths and the nameless root

### DIFF
--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -1,6 +1,7 @@
 //! The absolute-path grammar: parsing, components, and display names.
 
 use crate::ids::string_id;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
 
@@ -203,9 +204,57 @@ impl AsRef<str> for AbsolutePath {
     }
 }
 
+impl std::ops::Deref for AbsolutePath {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl PartialEq<&str> for AbsolutePath {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
 impl fmt::Display for AbsolutePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.normalized)
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for AbsolutePath {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::Object::builder()
+            .schema_type(utoipa::openapi::schema::Type::String)
+            .description(Some(
+                "Validated complete absolute namespace path, serialized as a plain string.",
+            ))
+            .into()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for AbsolutePath {}
+
+impl Serialize for AbsolutePath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.normalized)
+    }
+}
+
+impl<'de> Deserialize<'de> for AbsolutePath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -354,6 +403,22 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["docs", "A.txt"]
         );
+    }
+
+    #[test]
+    fn absolute_path_serde_is_a_validated_plain_string() {
+        let path = AbsolutePath::parse("/Docs/ReadMe.TXT").expect("path should parse");
+
+        assert_eq!(
+            serde_json::to_string(&path).expect("serialize path"),
+            r#""/Docs/ReadMe.TXT""#
+        );
+        assert_eq!(
+            serde_json::from_str::<AbsolutePath>(r#""/Docs/ReadMe.TXT""#)
+                .expect("deserialize path"),
+            path
+        );
+        assert!(serde_json::from_str::<AbsolutePath>(r#""relative/path""#).is_err());
     }
 
     #[test]

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -6,8 +6,8 @@
 
 use super::ValidatedContentToken;
 use crate::{
-    ChangeSeq, CheckpointId, CommitId, ContentRef, InodeId, ManifestId, NamespaceId, RevisionNo,
-    WriterEpoch,
+    AbsolutePath, ChangeSeq, CheckpointId, CommitId, ContentRef, InodeId, ManifestId, NamespaceId,
+    RevisionNo, WriterEpoch,
 };
 use serde::{Deserialize, Serialize};
 
@@ -200,7 +200,7 @@ pub enum FilesystemOperation {
     #[cfg_attr(feature = "openapi", schema(title = "FsOpCreateDirectory"))]
     CreateDirectory {
         /// Absolute destination path, rejected when invalid or already bound.
-        path: String,
+        path: AbsolutePath,
         /// Also create missing ancestor directories (the same auto-create
         /// `put_file` performs). The final component must still be new.
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -210,7 +210,7 @@ pub enum FilesystemOperation {
     #[cfg_attr(feature = "openapi", schema(title = "FsOpPutFile"))]
     PutFile {
         /// Absolute destination path; missing ancestors are created automatically.
-        path: String,
+        path: AbsolutePath,
         /// Immutable bytes that must be covered by a valid preparation proof.
         content_ref: ContentRef,
         /// Whether an existing file may receive a new revision instead of causing a conflict.
@@ -221,7 +221,7 @@ pub enum FilesystemOperation {
     #[cfg_attr(feature = "openapi", schema(title = "FsOpDeletePath"))]
     DeletePath {
         /// Absolute path that must resolve to a visible inode.
-        path: String,
+        path: AbsolutePath,
         /// Whether a non-empty directory may be tombstoned recursively.
         #[serde(default)]
         behavior: DeleteDirectoryBehavior,
@@ -235,9 +235,9 @@ pub enum FilesystemOperation {
     #[cfg_attr(feature = "openapi", schema(title = "FsOpMovePath"))]
     MovePath {
         /// Absolute source path that must resolve to a visible inode.
-        from_path: String,
+        from_path: AbsolutePath,
         /// Absolute destination whose parent must be visible and writable.
-        to_path: String,
+        to_path: AbsolutePath,
         /// Whether an existing destination file may be replaced.
         #[serde(default)]
         behavior: DestinationBehavior,
@@ -246,9 +246,9 @@ pub enum FilesystemOperation {
     #[cfg_attr(feature = "openapi", schema(title = "FsOpCopyPath"))]
     CopyPath {
         /// Absolute source path that must resolve to a visible file.
-        from_path: String,
+        from_path: AbsolutePath,
         /// Absolute destination whose parent must be visible and writable.
-        to_path: String,
+        to_path: AbsolutePath,
         /// Whether an existing destination file may receive a copied revision.
         #[serde(default)]
         behavior: DestinationBehavior,
@@ -265,13 +265,13 @@ pub enum FilesystemOperation {
         /// Observed deletion sequence, which prevents cancelling a newer tombstone generation.
         deleted_at_seq: ChangeSeq,
         /// Absolute destination path whose parent must be visible and whose name must be absent.
-        path: String,
+        path: AbsolutePath,
     },
     /// Restore an older revision as the current revision for a path.
     #[cfg_attr(feature = "openapi", schema(title = "FsOpRestoreRevision"))]
     RestoreRevision {
         /// Absolute path that must resolve to a visible file.
-        path: String,
+        path: AbsolutePath,
         /// Existing historical revision whose content will be copied into a new current revision.
         source_revision_no: RevisionNo,
     },
@@ -532,6 +532,10 @@ pub struct MaintenanceTickResponse {
 mod tests {
     use super::*;
 
+    fn path(value: &str) -> AbsolutePath {
+        AbsolutePath::parse(value).expect("valid test path")
+    }
+
     #[test]
     fn behavior_enums_use_snake_case_wire_values() {
         assert_eq!(
@@ -565,7 +569,7 @@ mod tests {
     #[test]
     fn filesystem_delete_and_move_operations_use_behavior_field() {
         let create_directory = FilesystemOperation::CreateDirectory {
-            path: "/docs".to_owned(),
+            path: path("/docs"),
             parents: false,
         };
         assert_eq!(
@@ -577,7 +581,7 @@ mod tests {
         );
 
         let create_directory_with_parents = FilesystemOperation::CreateDirectory {
-            path: "/docs/notes".to_owned(),
+            path: path("/docs/notes"),
             parents: true,
         };
         assert_eq!(
@@ -591,7 +595,7 @@ mod tests {
         );
 
         let delete = FilesystemOperation::DeletePath {
-            path: "/docs".to_owned(),
+            path: path("/docs"),
             behavior: DeleteDirectoryBehavior::Recursive,
             expected_inode_id: None,
         };
@@ -605,8 +609,8 @@ mod tests {
         );
 
         let move_path = FilesystemOperation::MovePath {
-            from_path: "/docs/a.txt".to_owned(),
-            to_path: "/docs/b.txt".to_owned(),
+            from_path: path("/docs/a.txt"),
+            to_path: path("/docs/b.txt"),
             behavior: DestinationBehavior::Replace,
         };
         assert_eq!(
@@ -620,8 +624,8 @@ mod tests {
         );
 
         let copy_path = FilesystemOperation::CopyPath {
-            from_path: "/docs/a.txt".to_owned(),
-            to_path: "/docs/b.txt".to_owned(),
+            from_path: path("/docs/a.txt"),
+            to_path: path("/docs/b.txt"),
             behavior: DestinationBehavior::Replace,
         };
         assert_eq!(
@@ -663,7 +667,7 @@ mod tests {
         assert_eq!(
             delete,
             FilesystemOperation::DeletePath {
-                path: "/docs".to_owned(),
+                path: path("/docs"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
                 expected_inode_id: None,
             }
@@ -678,8 +682,8 @@ mod tests {
         assert_eq!(
             move_path,
             FilesystemOperation::MovePath {
-                from_path: "/docs/a.txt".to_owned(),
-                to_path: "/docs/b.txt".to_owned(),
+                from_path: path("/docs/a.txt"),
+                to_path: path("/docs/b.txt"),
                 behavior: DestinationBehavior::NoReplace,
             }
         );
@@ -693,10 +697,97 @@ mod tests {
         assert_eq!(
             copy_path,
             FilesystemOperation::CopyPath {
-                from_path: "/docs/a.txt".to_owned(),
-                to_path: "/docs/b.txt".to_owned(),
+                from_path: path("/docs/a.txt"),
+                to_path: path("/docs/b.txt"),
                 behavior: DestinationBehavior::NoReplace,
             }
         );
+    }
+
+    #[test]
+    fn filesystem_operation_paths_keep_the_plain_string_wire_shape() {
+        let content_ref = ContentRef::whole_file_v0(b"hello");
+        let cases = [
+            (
+                FilesystemOperation::PutFile {
+                    path: path("/docs/a.txt"),
+                    content_ref: content_ref.clone(),
+                    behavior: DestinationBehavior::NoReplace,
+                },
+                serde_json::json!({
+                    "kind": "put_file",
+                    "path": "/docs/a.txt",
+                    "content_ref": content_ref,
+                    "behavior": "no_replace"
+                }),
+            ),
+            (
+                FilesystemOperation::Undelete {
+                    inode_id: InodeId(7),
+                    deleted_at_seq: ChangeSeq(8),
+                    path: path("/docs/restored"),
+                },
+                serde_json::json!({
+                    "kind": "undelete",
+                    "inode_id": 7,
+                    "deleted_at_seq": 8,
+                    "path": "/docs/restored"
+                }),
+            ),
+            (
+                FilesystemOperation::RestoreRevision {
+                    path: path("/docs/a.txt"),
+                    source_revision_no: RevisionNo(2),
+                },
+                serde_json::json!({
+                    "kind": "restore_revision",
+                    "path": "/docs/a.txt",
+                    "source_revision_no": 2
+                }),
+            ),
+        ];
+
+        for (operation, string_shaped_json) in cases {
+            assert_eq!(
+                serde_json::to_value(operation).expect("serialize filesystem operation"),
+                string_shaped_json
+            );
+        }
+    }
+
+    #[test]
+    fn filesystem_operation_paths_validate_during_deserialization() {
+        for encoded in [
+            serde_json::json!({"kind": "create_directory", "path": "relative", "parents": false}),
+            serde_json::json!({
+                "kind": "put_file",
+                "path": "relative",
+                "content_ref": ContentRef::whole_file_v0(b"hello")
+            }),
+            serde_json::json!({"kind": "delete_path", "path": "relative"}),
+            serde_json::json!({
+                "kind": "move_path",
+                "from_path": "relative",
+                "to_path": "/target"
+            }),
+            serde_json::json!({
+                "kind": "copy_path",
+                "from_path": "/source",
+                "to_path": "relative"
+            }),
+            serde_json::json!({
+                "kind": "undelete",
+                "inode_id": 7,
+                "deleted_at_seq": 8,
+                "path": "relative"
+            }),
+            serde_json::json!({
+                "kind": "restore_revision",
+                "path": "relative",
+                "source_revision_no": 2
+            }),
+        ] {
+            assert!(serde_json::from_value::<FilesystemOperation>(encoded).is_err());
+        }
     }
 }

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -2,7 +2,9 @@
 //! entry, the directory-listing envelope, and the file-bytes read result.
 //! The mutating operation shapes live in [`super::operations`].
 
-use crate::{ChangeSeq, ContentRef, InodeId, InodeKind, NamespaceId, RevisionNo};
+use crate::{
+    AbsolutePath, ChangeSeq, ContentRef, DisplayName, InodeId, InodeKind, NamespaceId, RevisionNo,
+};
 use serde::{Deserialize, Serialize};
 
 /// Authoritative metadata for one visible path.
@@ -15,7 +17,7 @@ pub struct AuthoritativePathEntry {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
     /// Absolute path as rendered from stored display names.
-    pub absolute_path: String,
+    pub absolute_path: AbsolutePath,
     /// Stable inode identity for this item.
     pub inode_id: InodeId,
     /// Whether the item is a file or directory.
@@ -24,12 +26,9 @@ pub struct AuthoritativePathEntry {
     pub head_seq: ChangeSeq,
     /// Parent directory inode, or `None` for the root.
     pub parent_inode_id: Option<InodeId>,
-    /// Stored display name for this path component. The root directory has
-    /// no name and serializes as the empty string, which the validating
-    /// [`DisplayName`](crate::DisplayName) newtype cannot represent — this
-    /// field stays a raw `String` until the wire decides how to spell
-    /// "nameless".
-    pub display_name: String,
+    /// Stored display name for this path component, absent for the nameless root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<DisplayName>,
     /// Current file revision number, for files.
     pub revision_no: Option<RevisionNo>,
     /// Current file size in bytes, for files.
@@ -54,7 +53,7 @@ pub struct ListPathEntriesResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
     /// Absolute path of the listed directory.
-    pub absolute_path: String,
+    pub absolute_path: AbsolutePath,
     /// Namespace head sequence this listing was read from.
     pub head_seq: ChangeSeq,
     /// Directory entries for this page.
@@ -75,4 +74,87 @@ pub struct AuthoritativeFileBytes {
     pub entry: AuthoritativePathEntry,
     /// Validated file bytes.
     pub bytes: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(
+        path: &str,
+        parent_inode_id: Option<InodeId>,
+        display_name: Option<&str>,
+    ) -> AuthoritativePathEntry {
+        AuthoritativePathEntry {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            absolute_path: AbsolutePath::parse(path).expect("absolute path"),
+            inode_id: InodeId(if parent_inode_id.is_some() { 2 } else { 1 }),
+            inode_kind: InodeKind::Directory,
+            head_seq: ChangeSeq(3),
+            parent_inode_id,
+            display_name: display_name.map(|name| DisplayName::parse(name).expect("display name")),
+            revision_no: None,
+            size_bytes: None,
+            content_ref: None,
+            committed_at_ms: None,
+        }
+    }
+
+    #[test]
+    fn authoritative_entry_paths_keep_the_plain_string_wire_shape() {
+        let named = entry("/docs", Some(InodeId(1)), Some("docs"));
+        assert_eq!(
+            serde_json::to_value(&named).expect("serialize named entry"),
+            serde_json::json!({
+                "namespace_id": "demo",
+                "absolute_path": "/docs",
+                "inode_id": 2,
+                "inode_kind": "dir",
+                "head_seq": 3,
+                "parent_inode_id": 1,
+                "display_name": "docs",
+                "revision_no": null,
+                "size_bytes": null,
+                "content_ref": null
+            })
+        );
+
+        let response = ListPathEntriesResponse {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            absolute_path: AbsolutePath::parse("/").expect("absolute path"),
+            head_seq: ChangeSeq(3),
+            entries: vec![named],
+            next_cursor: None,
+        };
+        assert_eq!(
+            serde_json::to_value(response).expect("serialize listing"),
+            serde_json::json!({
+                "namespace_id": "demo",
+                "absolute_path": "/",
+                "head_seq": 3,
+                "entries": [{
+                    "namespace_id": "demo",
+                    "absolute_path": "/docs",
+                    "inode_id": 2,
+                    "inode_kind": "dir",
+                    "head_seq": 3,
+                    "parent_inode_id": 1,
+                    "display_name": "docs",
+                    "revision_no": null,
+                    "size_bytes": null,
+                    "content_ref": null
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn nameless_root_omits_display_name_while_named_entries_carry_it() {
+        let root_json = serde_json::to_value(entry("/", None, None)).expect("serialize root");
+        assert!(root_json.get("display_name").is_none());
+
+        let named_json = serde_json::to_value(entry("/docs", Some(InodeId(1)), Some("docs")))
+            .expect("serialize named entry");
+        assert_eq!(named_json["display_name"], "docs");
+    }
 }

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -1,7 +1,7 @@
 //! Content search (grep) request and response shapes: the `query/v0`
 //! plane's first operation (API spec, "Content search").
 
-use crate::{ChangeSeq, InodeId, NamespaceId, RevisionNo};
+use crate::{AbsolutePath, ChangeSeq, InodeId, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 use xxhash_rust::xxh64::xxh64;
 
@@ -17,9 +17,10 @@ pub struct GrepRequest {
     /// consulted through its case-folded grams.
     #[serde(default)]
     pub case_insensitive: bool,
-    /// Restrict matches to files under this absolute path prefix.
+    /// Restrict matches to files under this complete absolute path, resolved
+    /// to a directory inode before candidates are filtered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path_prefix: Option<String>,
+    pub path_prefix: Option<AbsolutePath>,
     /// Resume cursor from a previous page. The cursor resumes strictly
     /// after the last candidate the issuing page finished scanning and is
     /// bound to that page's request; each page is evaluated against the
@@ -46,7 +47,14 @@ impl GrepRequest {
     /// opaque and short-lived, so this may change between builds.
     pub fn fingerprint(&self) -> u64 {
         let mut seed = xxh64(self.pattern.as_bytes(), 0);
-        seed = xxh64(self.path_prefix.as_deref().unwrap_or("").as_bytes(), seed);
+        seed = xxh64(
+            self.path_prefix
+                .as_ref()
+                .map(AbsolutePath::as_str)
+                .unwrap_or("")
+                .as_bytes(),
+            seed,
+        );
         let flags = [
             u8::from(self.case_insensitive),
             u8::from(self.allow_stale),
@@ -61,7 +69,7 @@ impl GrepRequest {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GrepMatch {
     /// The file's absolute path, derived at the snapshot.
-    pub absolute_path: String,
+    pub absolute_path: AbsolutePath,
     /// Durable identity of the matched file.
     pub inode_id: InodeId,
     /// The matched revision (the newest visible one at the snapshot).
@@ -141,4 +149,64 @@ pub struct GrepGcResponse {
     pub retained_candidates: u64,
     /// Whether unreadable namespace or grep state forced conservative retention.
     pub namespace_degraded: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grep_paths_keep_the_plain_string_wire_shape() {
+        let request = GrepRequest {
+            pattern: "needle".to_owned(),
+            case_insensitive: false,
+            path_prefix: Some(AbsolutePath::parse("/docs").expect("path prefix")),
+            cursor: None,
+            limit: None,
+            allow_stale: false,
+            allow_scan: false,
+        };
+        assert_eq!(
+            serde_json::to_value(request).expect("serialize grep request"),
+            serde_json::json!({
+                "pattern": "needle",
+                "case_insensitive": false,
+                "path_prefix": "/docs",
+                "allow_stale": false,
+                "allow_scan": false
+            })
+        );
+
+        let found = GrepMatch {
+            absolute_path: AbsolutePath::parse("/docs/a.txt").expect("match path"),
+            inode_id: InodeId(2),
+            revision_no: RevisionNo(3),
+            line_number: 4,
+            byte_offset: 5,
+            line: "needle".to_owned(),
+            line_truncated: false,
+        };
+        assert_eq!(
+            serde_json::to_value(found).expect("serialize grep match"),
+            serde_json::json!({
+                "absolute_path": "/docs/a.txt",
+                "inode_id": 2,
+                "revision_no": 3,
+                "line_number": 4,
+                "byte_offset": 5,
+                "line": "needle",
+                "line_truncated": false
+            })
+        );
+    }
+
+    #[test]
+    fn grep_path_prefix_validates_during_deserialization() {
+        let encoded = serde_json::json!({
+            "pattern": "needle",
+            "path_prefix": "relative/path"
+        });
+
+        assert!(serde_json::from_value::<GrepRequest>(encoded).is_err());
+    }
 }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -91,7 +91,7 @@ pub(crate) async fn run_filesystem_stat(
     args: FilesystemPathArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let allow_root = false;
+    let allow_root = true;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
     let entry = context
@@ -114,10 +114,16 @@ pub(crate) async fn run_filesystem_grep(
     args: FilesystemGrepArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
+    let path_prefix = args
+        .path_prefix
+        .as_deref()
+        .map(|path| normalize_absolute_path(path, true))
+        .transpose()
+        .map_err(|error| context.fail(kind, error))?;
     let mut request = loonfs_api::GrepRequest {
         pattern: args.pattern.clone(),
         case_insensitive: args.ignore_case,
-        path_prefix: args.path_prefix.clone(),
+        path_prefix,
         cursor: None,
         limit: args.limit,
         allow_stale: args.allow_stale,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -338,12 +338,15 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             lines.join("\n")
         }
         CommandData::PathEntry(entry) => {
-            let mut lines = vec![
-                format!("path: {}", entry.absolute_path),
+            let mut lines = vec![format!("path: {}", entry.absolute_path)];
+            if let Some(display_name) = &entry.display_name {
+                lines.push(format!("name: {display_name}"));
+            }
+            lines.extend([
                 format!("inode: {}", entry.inode_id),
                 format!("kind: {}", entry.inode_kind),
                 format!("seq: {}", entry.head_seq.0),
-            ];
+            ]);
             if let Some(size) = entry.size_bytes {
                 lines.push(format!("size: {size}"));
             }
@@ -435,13 +438,65 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{human_success, json_error};
+    use super::{human_success, json_error, json_success};
     use crate::args::CommandKind;
     use crate::commands::{CommandData, CommandFailure, CommandOutput};
     use crate::config::{ProfileConfig, StoreConfig};
     use crate::error::CliError;
     use crate::profiles::ProfileSummary;
     use insta::{assert_json_snapshot, assert_snapshot};
+    use loonfs_api::{
+        AbsolutePath, AuthoritativePathEntry, ChangeSeq, DisplayName, InodeId, InodeKind,
+        NamespaceId,
+    };
+
+    fn path_entry(path: &str, display_name: Option<&str>) -> AuthoritativePathEntry {
+        AuthoritativePathEntry {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            absolute_path: AbsolutePath::parse(path).expect("absolute path"),
+            inode_id: InodeId(if display_name.is_some() { 2 } else { 1 }),
+            inode_kind: InodeKind::Directory,
+            head_seq: ChangeSeq(3),
+            parent_inode_id: display_name.map(|_| InodeId(1)),
+            display_name: display_name.map(|name| DisplayName::parse(name).expect("display name")),
+            revision_no: None,
+            size_bytes: None,
+            content_ref: None,
+            committed_at_ms: None,
+        }
+    }
+
+    fn stat_output(entry: AuthoritativePathEntry) -> CommandOutput {
+        CommandOutput {
+            kind: CommandKind::FilesystemStat,
+            profile: Some("default".to_owned()),
+            mode: Some("embedded".to_owned()),
+            data: CommandData::PathEntry(entry),
+        }
+    }
+
+    #[test]
+    fn human_stat_omits_the_absent_root_name() {
+        let root = stat_output(path_entry("/", None));
+        assert_eq!(human_success(&root), "path: /\ninode: 1\nkind: dir\nseq: 3");
+
+        let named = stat_output(path_entry("/docs", Some("docs")));
+        assert_eq!(
+            human_success(&named),
+            "path: /docs\nname: docs\ninode: 2\nkind: dir\nseq: 3"
+        );
+    }
+
+    #[test]
+    fn json_stat_preserves_the_absent_root_name() {
+        let root = stat_output(path_entry("/", None));
+        let json: serde_json::Value =
+            serde_json::from_str(&json_success(&root).expect("JSON stat should render"))
+                .expect("rendered stat is JSON");
+
+        assert!(json["data"].get("display_name").is_none());
+    }
+
     #[test]
     fn human_profile_list_renders_default_marker() {
         let output = CommandOutput {

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -687,7 +687,7 @@ impl Client {
                 commit_id,
                 content_tokens: staged.validated_content_token.into_iter().collect(),
                 operation: FilesystemOperation::PutFile {
-                    path: spec.absolute_path().as_str().to_owned(),
+                    path: spec.absolute_path().clone(),
                     content_ref: staged.content_ref,
                     behavior: options.behavior,
                 },
@@ -708,7 +708,7 @@ impl Client {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::CreateDirectory {
-                    path: spec.absolute_path().as_str().to_owned(),
+                    path: spec.absolute_path().clone(),
                     parents: options.parents,
                 },
             },
@@ -728,7 +728,7 @@ impl Client {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::DeletePath {
-                    path: spec.absolute_path().as_str().to_owned(),
+                    path: spec.absolute_path().clone(),
                     behavior: options.behavior,
                     expected_inode_id: options.expected_inode_id,
                 },
@@ -758,8 +758,8 @@ impl Client {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::MovePath {
-                    from_path: from.absolute_path().as_str().to_owned(),
-                    to_path: to.absolute_path().as_str().to_owned(),
+                    from_path: from.absolute_path().clone(),
+                    to_path: to.absolute_path().clone(),
                     behavior,
                 },
             },
@@ -788,8 +788,8 @@ impl Client {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::CopyPath {
-                    from_path: from.absolute_path().as_str().to_owned(),
-                    to_path: to.absolute_path().as_str().to_owned(),
+                    from_path: from.absolute_path().clone(),
+                    to_path: to.absolute_path().clone(),
                     behavior,
                 },
             },
@@ -816,7 +816,7 @@ impl Client {
                 operation: FilesystemOperation::Undelete {
                     inode_id,
                     deleted_at_seq,
-                    path: spec.absolute_path().as_str().to_owned(),
+                    path: spec.absolute_path().clone(),
                 },
             },
         )?;
@@ -836,7 +836,7 @@ impl Client {
                 commit_id,
                 content_tokens: Vec::new(),
                 operation: FilesystemOperation::RestoreRevision {
-                    path: spec.absolute_path().as_str().to_owned(),
+                    path: spec.absolute_path().clone(),
                     source_revision_no,
                 },
             },

--- a/crates/loonfs-core/src/path/helpers.rs
+++ b/crates/loonfs-core/src/path/helpers.rs
@@ -26,8 +26,16 @@ pub(crate) fn parse_absolute_path_for_core(absolute_path: &str) -> Result<Absolu
 /// only the root guard ([`ensure_mutation_path`]) and never re-parses.
 pub fn parse_mutation_path(absolute_path: &str) -> Result<AbsolutePath> {
     let path = parse_absolute_path_for_core(absolute_path)?;
-    ensure_mutation_path(&path)?;
+    validate_mutation_path(&path)?;
     Ok(path)
+}
+
+/// Checks that an already-validated path is a legal mutation target.
+///
+/// The absolute-path grammar is carried by the type; this guard rejects the
+/// root, which is readable but cannot be mutated.
+pub fn validate_mutation_path(path: &AbsolutePath) -> Result<()> {
+    ensure_mutation_path(path)
 }
 
 /// The root-mutation guard on an already-parsed path. Intents can be built

--- a/crates/loonfs-core/src/path/mod.rs
+++ b/crates/loonfs-core/src/path/mod.rs
@@ -4,4 +4,4 @@ pub(crate) mod helpers;
 pub(crate) mod read;
 pub(crate) mod write;
 
-pub use helpers::{parse_mutation_path, validate_path_for_mutation};
+pub use helpers::{parse_mutation_path, validate_mutation_path, validate_path_for_mutation};

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -24,8 +24,8 @@ use loonfs_api::wire::wal::WalCommitPayload;
 use loonfs_api::ManifestObjectId;
 use loonfs_api::{
     AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentStoreId,
-    DirectoryPageCursor, FileRevision, FileRevisionsPageCursor, InodeId, InodeKind, ManifestId,
-    NamePolicy, NamespaceId, Page, PageRequest, RevisionNo,
+    DirectoryPageCursor, DisplayName, FileRevision, FileRevisionsPageCursor, InodeId, InodeKind,
+    ManifestId, NamePolicy, NamespaceId, Page, PageRequest, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -377,7 +377,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let entry = self.resolve_path(absolute_path).await?;
         if entry.inode_kind != InodeKind::File {
             return Err(CoreError::ExpectedFile {
-                path: entry.absolute_path,
+                path: entry.absolute_path.to_string(),
                 kind: entry.inode_kind,
             });
         }
@@ -401,7 +401,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let entry = self.resolve_path(absolute_path).await?;
         if entry.inode_kind != InodeKind::File {
             return Err(CoreError::ExpectedFile {
-                path: entry.absolute_path,
+                path: entry.absolute_path.to_string(),
                 kind: entry.inode_kind,
             });
         }
@@ -486,7 +486,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let mut entry = self.resolve_path(absolute_path).await?;
         if entry.inode_kind != InodeKind::File {
             return Err(CoreError::ExpectedFile {
-                path: entry.absolute_path,
+                path: entry.absolute_path.to_string(),
                 kind: entry.inode_kind,
             });
         }
@@ -695,14 +695,31 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let size_bytes = content_ref
             .as_ref()
             .map(|content_ref| content_ref.size_bytes);
+        let absolute_path = AbsolutePath::parse(&resolved.absolute_path).map_err(|error| {
+            CoreError::NamespaceCorrupt(format!(
+                "resolved visible path `{}` is not a valid absolute path: {error}",
+                resolved.absolute_path
+            ))
+        })?;
+        let display_name = resolved
+            .parent_inode_id
+            .map(|_| {
+                DisplayName::parse(&resolved.display_name).map_err(|error| {
+                    CoreError::NamespaceCorrupt(format!(
+                        "stored display name for inode `{}` is invalid: {error}",
+                        resolved.inode_id
+                    ))
+                })
+            })
+            .transpose()?;
         Ok(AuthoritativePathEntry {
             namespace_id: self.namespace_id.clone(),
-            absolute_path: resolved.absolute_path.clone(),
+            absolute_path,
             inode_id: resolved.inode_id,
             inode_kind: resolved.inode_kind,
             head_seq: self.head.seq,
             parent_inode_id: resolved.parent_inode_id,
-            display_name: resolved.display_name.clone(),
+            display_name,
             revision_no: revision.as_ref().map(|revision| revision.revision_no),
             size_bytes,
             content_ref,

--- a/crates/loonfs-core/tests/path_intents.rs
+++ b/crates/loonfs-core/tests/path_intents.rs
@@ -26,6 +26,14 @@ use loonfs_test_support::ids::{namespace_id, page_limit};
 use loonfs_test_support::stores::OperationClass;
 use tempfile::tempdir;
 
+fn named_entry(entry: &AuthoritativePathEntry) -> &str {
+    entry
+        .display_name
+        .as_ref()
+        .expect("non-root entry should carry a display name")
+        .as_str()
+}
+
 async fn delete_path<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -534,7 +542,7 @@ async fn query_driven_stat_uses_exact_name_key_for_dash_containing_siblings() {
         .expect("materialized stat");
 
     assert_eq!(actual, expected);
-    assert_eq!(actual.absolute_path, "/docs/report");
+    assert_eq!(actual.absolute_path.as_str(), "/docs/report");
     assert_eq!(actual.size_bytes, Some(5));
 }
 
@@ -636,11 +644,7 @@ async fn wide_directory_listing_resolves_tail_unbinds_cross_directory_renames_an
         let page = list_path_page(&store, &namespace_id, "/wide", 16, cursor.clone())
             .await
             .expect("list page");
-        listed.extend(
-            page.items
-                .iter()
-                .map(|entry| entry.display_name.as_str().to_owned()),
-        );
+        listed.extend(page.items.iter().map(|entry| named_entry(entry).to_owned()));
         cursor = page.next_cursor;
         if cursor.is_none() {
             break;
@@ -788,22 +792,14 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
         .await
         .expect("first page");
     assert_eq!(
-        first
-            .items
-            .iter()
-            .map(|entry| entry.display_name.as_str())
-            .collect::<Vec<_>>(),
+        first.items.iter().map(named_entry).collect::<Vec<_>>(),
         vec!["a-dir", "b-renamed.txt"]
     );
     let second = list_path_page(&store, &namespace_id, "/docs", 2, first.next_cursor.clone())
         .await
         .expect("second page");
     assert_eq!(
-        second
-            .items
-            .iter()
-            .map(|entry| entry.display_name.as_str())
-            .collect::<Vec<_>>(),
+        second.items.iter().map(named_entry).collect::<Vec<_>>(),
         vec!["c-file.txt", "d-tail.txt"]
     );
     let third = list_path_page(
@@ -817,11 +813,7 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
     .expect("third page");
     assert!(third.next_cursor.is_none());
     assert_eq!(
-        third
-            .items
-            .iter()
-            .map(|entry| entry.display_name.as_str())
-            .collect::<Vec<_>>(),
+        third.items.iter().map(named_entry).collect::<Vec<_>>(),
         vec!["e-tail-dir"]
     );
 
@@ -832,10 +824,7 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
         .chain(third.items)
         .collect::<Vec<_>>();
     assert_eq!(
-        entries
-            .iter()
-            .map(|entry| entry.display_name.as_str())
-            .collect::<Vec<_>>(),
+        entries.iter().map(named_entry).collect::<Vec<_>>(),
         vec![
             "a-dir",
             "b-renamed.txt",
@@ -844,15 +833,14 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
             "e-tail-dir"
         ]
     );
-    assert!(entries.iter().all(|entry| !matches!(
-        entry.display_name.as_str(),
-        "stale.txt" | "dead" | "tail-dead"
-    )));
+    assert!(entries
+        .iter()
+        .all(|entry| !matches!(named_entry(entry), "stale.txt" | "dead" | "tail-dead")));
 
     for directory_name in ["a-dir", "e-tail-dir"] {
         let entry = entries
             .iter()
-            .find(|entry| entry.display_name.as_str() == directory_name)
+            .find(|entry| named_entry(entry) == directory_name)
             .expect("directory entry");
         assert_eq!(entry.inode_kind, InodeKind::Directory);
         assert_eq!(entry.revision_no, None);
@@ -867,7 +855,7 @@ async fn query_driven_directory_page_merges_manifest_and_tail_visible_children()
     ] {
         let entry = entries
             .iter()
-            .find(|entry| entry.display_name.as_str() == file_name)
+            .find(|entry| named_entry(entry) == file_name)
             .expect("file entry");
         assert_eq!(entry.inode_kind, InodeKind::File);
         assert_eq!(entry.revision_no, Some(RevisionNo(1)));
@@ -1577,8 +1565,8 @@ async fn resolve_path_uses_nfc_casefold_name_policy() {
     let resolved = resolve_path(&store, &namespace_id("demo"), lookup_path)
         .await
         .expect("resolve path");
-    assert_eq!(resolved.absolute_path, stored_path);
-    assert_eq!(resolved.display_name.as_str(), "Cafe\u{0301}.txt");
+    assert_eq!(resolved.absolute_path.as_str(), stored_path);
+    assert_eq!(named_entry(&resolved), "Cafe\u{0301}.txt");
 }
 
 #[tokio::test]
@@ -1681,7 +1669,7 @@ async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data()
         .expect("list live dir");
     assert_eq!(live_entries.len(), 1, "one live child");
     let kept = &live_entries[0];
-    assert_eq!(kept.absolute_path, "/live/kept.txt");
+    assert_eq!(kept.absolute_path.as_str(), "/live/kept.txt");
     assert_eq!(
         kept.size_bytes,
         Some(b"alive".len() as u64),

--- a/crates/loonfs-grep/src/main_tests.rs
+++ b/crates/loonfs-grep/src/main_tests.rs
@@ -285,7 +285,7 @@ async fn assert_searchable(store: &SharedObjectStore, namespace_id: &NamespaceId
         .await
         .expect("query caught-up index");
     assert_eq!(response.matches.len(), 1);
-    assert_eq!(response.matches[0].absolute_path, "/note.txt");
+    assert_eq!(response.matches[0].absolute_path.as_str(), "/note.txt");
 }
 
 async fn stop_poll_and_driver(

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -585,9 +585,10 @@ async fn derive_visible_path<S: ObjectStore + ?Sized>(
         .resolve_visible_path(&parsed, LeafRevisionPrefetch::Skip)
         .await
     {
-        Ok(resolved) if resolved.inode_id == inode_id => {
-            Ok(Some(VisiblePathChain { path, ancestors }))
-        }
+        Ok(resolved) if resolved.inode_id == inode_id => Ok(Some(VisiblePathChain {
+            path: parsed,
+            ancestors,
+        })),
         Ok(_) => Ok(None),
         Err(error) if error.code() == ErrorCode::PathNotFound => Ok(None),
         Err(error) => Err(error.into()),
@@ -616,7 +617,7 @@ fn fold_rejected_frontier(
 /// A derived visible path plus the inode chain that produced it, root
 /// included.
 struct VisiblePathChain {
-    path: String,
+    path: AbsolutePath,
     ancestors: Vec<InodeId>,
 }
 
@@ -626,7 +627,7 @@ struct VisiblePathChain {
 struct GrepContentCandidate {
     inode_id: InodeId,
     revision: RevisionRecord,
-    path: String,
+    path: AbsolutePath,
     /// The declared content size exceeds the index eligibility cap, so no
     /// read is scheduled: the file could never pass the post-read text
     /// check, and the walk skips it as fully scanned.
@@ -720,11 +721,8 @@ impl GrepService {
         // has no matches.
         let scope_root = match &request.path_prefix {
             Some(prefix) => {
-                let parsed = AbsolutePath::parse(prefix).map_err(|error| {
-                    CoreError::InvalidPath(error.invalid_path_input().to_owned())
-                })?;
                 match session
-                    .resolve_visible_path(&parsed, LeafRevisionPrefetch::Skip)
+                    .resolve_visible_path(prefix, LeafRevisionPrefetch::Skip)
                     .await
                 {
                     Ok(resolved) => Some(resolved.inode_id),

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -12,7 +12,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use loonfs::publish::{
-    parse_mutation_path, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
+    validate_mutation_path, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
     PathMutationIntent, PreparedContent,
 };
 use loonfs::{
@@ -26,7 +26,7 @@ use loonfs_api::{
         ChangesResponse, CommitRequest as ApiCommitRequest, CommitResponse as ApiCommitResponse,
         CommitSubmissionRequest, ValidatedContentToken,
     },
-    ContentRef, DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation,
+    AbsolutePath, ContentRef, DirectoryPageCursor, FileRevisionsPageCursor, FilesystemOperation,
     FilesystemOperationRequest, InodeId, LimitError, ListFileRevisionsResponse, PageCursorError,
     PageRequest, PaginationPolicy, RestoreFileRevisionRequest, RevisionNo,
 };
@@ -491,18 +491,19 @@ pub(super) async fn filesystem_operation(
         ),
         _ => None,
     };
-    // Wire paths are raw strings; the intent carries validated paths, so
-    // this is the convert-once point for the whole remote mutation path.
-    let parse_path = |path: &str| {
-        parse_mutation_path(path).map_err(|error| {
+    // Absolute-path grammar was validated while decoding the wire body. The
+    // root remains a valid read path but is not a legal mutation target.
+    let validate_path = |path: AbsolutePath| {
+        validate_mutation_path(&path).map_err(|error| {
             ApiResponseError::core_for_namespace(&namespace_id, error)
                 .with_commit_id(&commit_id_for_errors)
-        })
+        })?;
+        Ok(path)
     };
     let intent = match operation {
         FilesystemOperation::CreateDirectory { path, parents } => PathMutationIntent::CreateDir {
             commit_id,
-            absolute_path: parse_path(&path)?,
+            absolute_path: validate_path(path)?,
             parents,
         },
         FilesystemOperation::PutFile {
@@ -511,7 +512,7 @@ pub(super) async fn filesystem_operation(
             behavior,
         } => PathMutationIntent::PutFile {
             commit_id,
-            absolute_path: parse_path(&path)?,
+            absolute_path: validate_path(path)?,
             content_ref,
             behavior,
         },
@@ -521,7 +522,7 @@ pub(super) async fn filesystem_operation(
             expected_inode_id,
         } => PathMutationIntent::DeletePath {
             commit_id,
-            absolute_path: parse_path(&path)?,
+            absolute_path: validate_path(path)?,
             behavior,
             expected_inode_id,
         },
@@ -531,8 +532,8 @@ pub(super) async fn filesystem_operation(
             behavior,
         } => PathMutationIntent::MovePath {
             commit_id,
-            from_path: parse_path(&from_path)?,
-            to_path: parse_path(&to_path)?,
+            from_path: validate_path(from_path)?,
+            to_path: validate_path(to_path)?,
             behavior,
         },
         FilesystemOperation::CopyPath {
@@ -541,8 +542,8 @@ pub(super) async fn filesystem_operation(
             behavior,
         } => PathMutationIntent::CopyFilePath {
             commit_id,
-            from_path: parse_path(&from_path)?,
-            to_path: parse_path(&to_path)?,
+            from_path: validate_path(from_path)?,
+            to_path: validate_path(to_path)?,
             behavior,
         },
         FilesystemOperation::RestoreRevision {
@@ -550,7 +551,7 @@ pub(super) async fn filesystem_operation(
             source_revision_no,
         } => PathMutationIntent::RestoreRevision {
             commit_id,
-            absolute_path: parse_path(&path)?,
+            absolute_path: validate_path(path)?,
             source_revision_no,
         },
         FilesystemOperation::Undelete {
@@ -561,7 +562,7 @@ pub(super) async fn filesystem_operation(
             commit_id,
             inode_id,
             deleted_at_seq,
-            absolute_path: parse_path(&path)?,
+            absolute_path: validate_path(path)?,
         },
     };
     let response_result = if let Some(payload_class) = put_payload_class {

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1192,6 +1192,46 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
             .send_string("{not json")
             .expect_err("unauthorized malformed body should answer 401");
         expect_enveloped(error, 401, "unauthorized");
+
+        // Filesystem-operation paths now validate while the authorized JSON
+        // body is decoded. The served code stays the same invalid_request
+        // classification the former handler-boundary validation used.
+        let operation_url = format!("http://{addr}/v0/namespaces/demo/filesystem/operations");
+        let invalid_operation = r#"{
+            "commit_id":"invalid-path",
+            "operation":{"kind":"create_directory","path":"relative"}
+        }"#;
+        let error = raw_agent()
+            .post(&operation_url)
+            .set("authorization", "Bearer test-token")
+            .set("content-type", "application/json")
+            .send_string(invalid_operation)
+            .expect_err("invalid operation path should answer 400");
+        expect_enveloped(error, 400, "invalid_request");
+        let error = raw_agent()
+            .post(&operation_url)
+            .set("content-type", "application/json")
+            .send_string(invalid_operation)
+            .expect_err("authorization should precede operation path decoding");
+        expect_enveloped(error, 401, "unauthorized");
+
+        // Grep scope paths make the same boundary move and retain the same
+        // invalid_request code.
+        let grep_url = format!("http://{addr}/v0/namespaces/demo/query/grep");
+        let invalid_grep = r#"{"pattern":"needle","path_prefix":"relative"}"#;
+        let error = raw_agent()
+            .post(&grep_url)
+            .set("authorization", "Bearer test-token")
+            .set("content-type", "application/json")
+            .send_string(invalid_grep)
+            .expect_err("invalid grep path should answer 400");
+        expect_enveloped(error, 400, "invalid_request");
+        let error = raw_agent()
+            .post(&grep_url)
+            .set("content-type", "application/json")
+            .send_string(invalid_grep)
+            .expect_err("authorization should precede grep path decoding");
+        expect_enveloped(error, 401, "unauthorized");
     })
     .await
     .expect("join blocking task");

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -120,7 +120,7 @@ async fn direct_put_round_trip(config: ServerConfig) {
                     token: validated_content_token,
                 }],
                 operation: FilesystemOperation::PutFile {
-                    path: target.absolute_path().as_str().to_owned(),
+                    path: target.absolute_path().clone(),
                     content_ref,
                     behavior: DestinationBehavior::NoReplace,
                 },

--- a/crates/loonfs-server/tests/http_auth.rs
+++ b/crates/loonfs-server/tests/http_auth.rs
@@ -10,8 +10,8 @@ use loonfs_api::{
     v0::{
         CommitOp, CommitRequest as ApiCommitRequest, CommitSubmissionRequest, ValidatedContentToken,
     },
-    ApiError, ChangeSeq, CommitId, CommitResponse, ContentRef, DestinationBehavior, ErrorCode,
-    FilesystemOperation, FilesystemOperationRequest, InodeId, NamespaceId,
+    AbsolutePath, ApiError, ChangeSeq, CommitId, CommitResponse, ContentRef, DestinationBehavior,
+    ErrorCode, FilesystemOperation, FilesystemOperationRequest, InodeId, NamespaceId,
 };
 use loonfs_client::NamespacePath;
 use loonfs_test_support::http::raw_agent;
@@ -126,7 +126,7 @@ async fn path_put_with_bad_content_token_fails_content_not_prepared() {
                 token: "not.a.valid.token".to_owned(),
             }],
             operation: FilesystemOperation::PutFile {
-                path: "/bad-token.txt".to_owned(),
+                path: AbsolutePath::parse("/bad-token.txt").expect("path"),
                 content_ref: completed.content_ref,
                 behavior: DestinationBehavior::NoReplace,
             },
@@ -164,7 +164,7 @@ async fn path_put_without_content_token_fails_content_not_prepared() {
             commit_id: CommitId::parse("missing-token-put").expect("valid commit id"),
             content_tokens: Vec::new(),
             operation: FilesystemOperation::PutFile {
-                path: "/missing-token.txt".to_owned(),
+                path: AbsolutePath::parse("/missing-token.txt").expect("path"),
                 content_ref: completed.content_ref,
                 behavior: DestinationBehavior::NoReplace,
             },
@@ -209,7 +209,7 @@ async fn path_put_with_valid_content_token_succeeds() {
                     .expect("completed upload carries token"),
             }],
             operation: FilesystemOperation::PutFile {
-                path: "/valid-token.txt".to_owned(),
+                path: AbsolutePath::parse("/valid-token.txt").expect("path"),
                 content_ref: completed.content_ref,
                 behavior: DestinationBehavior::NoReplace,
             },
@@ -259,7 +259,7 @@ async fn landed_path_put_replays_after_content_token_is_absent_expired_or_garbag
                     .expect("completed upload carries token"),
             }],
             operation: FilesystemOperation::PutFile {
-                path: "/token-replay.txt".to_owned(),
+                path: AbsolutePath::parse("/token-replay.txt").expect("path"),
                 content_ref: completed.content_ref,
                 behavior: DestinationBehavior::NoReplace,
             },
@@ -321,7 +321,7 @@ async fn path_put_with_only_an_irrelevant_token_reports_the_missing_put_proof() 
                     .expect("completed upload carries token"),
             }],
             operation: FilesystemOperation::PutFile {
-                path: "/irrelevant-token.txt".to_owned(),
+                path: AbsolutePath::parse("/irrelevant-token.txt").expect("path"),
                 content_ref: target.content_ref,
                 behavior: DestinationBehavior::NoReplace,
             },

--- a/crates/loonfs-server/tests/http_pagination.rs
+++ b/crates/loonfs-server/tests/http_pagination.rs
@@ -20,7 +20,13 @@ fn entry_names(response: &ListPathEntriesResponse) -> Vec<&str> {
     response
         .entries
         .iter()
-        .map(|entry| entry.display_name.as_str())
+        .map(|entry| {
+            entry
+                .display_name
+                .as_ref()
+                .expect("listed entry should carry a display name")
+                .as_str()
+        })
         .collect()
 }
 

--- a/crates/loonfs-server/tests/http_paths.rs
+++ b/crates/loonfs-server/tests/http_paths.rs
@@ -9,8 +9,56 @@ use loonfs_api::{
     CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeId,
 };
 use loonfs_client::{ClientError, DeleteOptions, MutationOptions, NamespacePath, PutFileOptions};
+use loonfs_test_support::http::raw_agent;
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_stat_omits_the_root_name_and_carries_named_child_names() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-root-name",
+        "http-root-name",
+    ))
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        harness
+            .client
+            .create_namespace(&namespace_id("demo"))
+            .expect("create namespace");
+        harness
+            .client
+            .create_directory(
+                &NamespacePath::parse("demo", "/docs").expect("directory path"),
+                &loonfs_client::CreateDirectoryOptions::default(),
+            )
+            .expect("create directory");
+
+        let stat_json = |encoded_path: &str| {
+            let response = raw_agent()
+                .get(&format!(
+                    "{}/v0/namespaces/demo/filesystem/stat?path={encoded_path}",
+                    harness.server_url
+                ))
+                .set("authorization", "Bearer test-token")
+                .call()
+                .expect("stat request");
+            serde_json::from_reader::<_, serde_json::Value>(response.into_reader())
+                .expect("stat JSON")
+        };
+
+        let root = stat_json("%2F");
+        assert!(root.get("display_name").is_none());
+        let child = stat_json("%2Fdocs");
+        assert_eq!(child["display_name"], "docs");
+    })
+    .await
+    .expect("join blocking task");
+
+    harness.server.abort();
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_put_no_replace_and_copy_preserve_cli_semantics() {

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -125,7 +125,7 @@ impl FsCore {
         let next_cursor = page.next_cursor;
         let response = ListPathEntriesResponse {
             namespace_id: namespace_id.clone(),
-            absolute_path: listed_path.as_str().to_owned(),
+            absolute_path: listed_path,
             head_seq,
             entries: page.items,
             next_cursor: None,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -78,7 +78,7 @@ pub mod publish {
     pub use loonfs_core::limits::{
         MAX_COMMIT_CONTENT_TOKENS, MAX_COMMIT_EXTERNAL_CONTENT_REFS, MAX_COMMIT_OPERATIONS,
     };
-    pub use loonfs_core::path::parse_mutation_path;
+    pub use loonfs_core::path::{parse_mutation_path, validate_mutation_path};
     pub use loonfs_core::publish::{
         ContentPreparation, ContentPreparationError, NamespaceMutation, NamespaceMutationCandidate,
         PathMutationIntent, PreparedContent,

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -170,7 +170,14 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .stat_path(&namespace_id, "/tree/dir-000000/file-000000042.txt")
         .await
         .expect("cold stat");
-    assert_eq!(entry.display_name.as_str(), "file-000000042.txt");
+    assert_eq!(
+        entry
+            .display_name
+            .as_ref()
+            .expect("file entry should carry a display name")
+            .as_str(),
+        "file-000000042.txt"
+    );
     assert!(entry.revision_no.is_some(), "file stat carries a revision");
 
     let gets = log.take_gets();

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -619,7 +619,7 @@ async fn collect_grep_paths(
             response
                 .matches
                 .into_iter()
-                .map(|found| found.absolute_path),
+                .map(|found| found.absolute_path.to_string()),
         );
         let Some(cursor) = response.next_cursor else {
             return paths;
@@ -692,7 +692,7 @@ async fn grep_answers_identically_across_tiered_folds() {
         let mut matched: Vec<String> = response
             .matches
             .iter()
-            .map(|found| found.absolute_path.clone())
+            .map(|found| found.absolute_path.to_string())
             .collect();
         matched.sort();
         assert_eq!(

--- a/crates/loonfs/tests/pagination.rs
+++ b/crates/loonfs/tests/pagination.rs
@@ -17,7 +17,13 @@ use tempfile::tempdir;
 fn display_names(entries: &[AuthoritativePathEntry]) -> Vec<&str> {
     entries
         .iter()
-        .map(|entry| entry.display_name.as_str())
+        .map(|entry| {
+            entry
+                .display_name
+                .as_ref()
+                .expect("listed entry should carry a display name")
+                .as_str()
+        })
         .collect()
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -637,6 +637,11 @@ created the current revision, in Unix milliseconds. It is observational —
 sequences are the order, and no validity rule reads it. Directory entries
 carry no modification time in v0.
 
+The namespace root is nameless: its entry has `parent_inode_id: null` and
+omits `display_name` entirely. Every non-root entry carries a validated
+`display_name`; the empty string is not a spelling for the root or for any
+named path component.
+
 ### 6.5 `GET /filesystem/list`
 
 The envelope names the listed path and the head the listing was read from, so
@@ -1106,9 +1111,10 @@ rejected with `index_lagging` unless `allow_stale` accepts indexed-only
 results (reported via `tail_scanned: false`); stale results are a
 consistent cut at the index watermark — files whose newest revision
 postdates it are omitted entirely rather than mixed in. The `path_prefix`
-scope resolves to an inode under the namespace's name policy and filters
-by ancestry, so it follows the same normalization as every other path
-read. A missing data half answers `not_supported` with the `feature`
+value is a complete absolute path, not a partial textual segment prefix. Its
+scope resolves to an inode under the namespace's name policy and filters by
+ancestry, so it follows the same validation and normalization as every other
+path read. A missing data half answers `not_supported` with the `feature`
 field naming `index.grams`.
 
 ## 7. Conformance requirements

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2716,6 +2716,10 @@
   },
   "components": {
     "schemas": {
+      "AbsolutePath": {
+        "type": "string",
+        "description": "Validated complete absolute namespace path, serialized as a plain string."
+      },
       "AdvanceRetentionResponse": {
         "type": "object",
         "description": "Result of advancing the retention floor.",
@@ -2785,12 +2789,11 @@
           "absolute_path",
           "inode_id",
           "inode_kind",
-          "head_seq",
-          "display_name"
+          "head_seq"
         ],
         "properties": {
           "absolute_path": {
-            "type": "string",
+            "$ref": "#/components/schemas/AbsolutePath",
             "description": "Absolute path as rendered from stored display names."
           },
           "committed_at_ms": {
@@ -2814,8 +2817,15 @@
             ]
           },
           "display_name": {
-            "type": "string",
-            "description": "Stored display name for this path component. The root directory has\nno name and serializes as the empty string, which the validating\n[`DisplayName`](crate::DisplayName) newtype cannot represent — this\nfield stays a raw `String` until the wire decides how to spell\n\"nameless\"."
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DisplayName",
+                "description": "Stored display name for this path component, absent for the nameless root."
+              }
+            ]
           },
           "head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
@@ -4232,7 +4242,7 @@
                 "description": "Also create missing ancestor directories (the same auto-create\n`put_file` performs). The final component must still be new."
               },
               "path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute destination path, rejected when invalid or already bound."
               }
             }
@@ -4262,7 +4272,7 @@
                 ]
               },
               "path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute destination path; missing ancestors are created automatically."
               }
             }
@@ -4298,7 +4308,7 @@
                 ]
               },
               "path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute path that must resolve to a visible inode."
               }
             }
@@ -4318,7 +4328,7 @@
                 "description": "Whether an existing destination file may be replaced."
               },
               "from_path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute source path that must resolve to a visible inode."
               },
               "kind": {
@@ -4328,7 +4338,7 @@
                 ]
               },
               "to_path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute destination whose parent must be visible and writable."
               }
             }
@@ -4348,7 +4358,7 @@
                 "description": "Whether an existing destination file may receive a copied revision."
               },
               "from_path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute source path that must resolve to a visible file."
               },
               "kind": {
@@ -4358,7 +4368,7 @@
                 ]
               },
               "to_path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute destination whose parent must be visible and writable."
               }
             }
@@ -4389,7 +4399,7 @@
                 ]
               },
               "path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute destination path whose parent must be visible and whose name must be absent."
               }
             }
@@ -4411,7 +4421,7 @@
                 ]
               },
               "path": {
-                "type": "string",
+                "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute path that must resolve to a visible file."
               },
               "source_revision_no": {
@@ -4661,7 +4671,7 @@
         ],
         "properties": {
           "absolute_path": {
-            "type": "string",
+            "$ref": "#/components/schemas/AbsolutePath",
             "description": "The file's absolute path, derived at the snapshot."
           },
           "byte_offset": {
@@ -4730,11 +4740,15 @@
             "minimum": 0
           },
           "path_prefix": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Restrict matches to files under this absolute path prefix."
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AbsolutePath",
+                "description": "Restrict matches to files under this complete absolute path, resolved\nto a directory inode before candidates are filtered."
+              }
+            ]
           },
           "pattern": {
             "type": "string",
@@ -4848,7 +4862,7 @@
         ],
         "properties": {
           "absolute_path": {
-            "type": "string",
+            "$ref": "#/components/schemas/AbsolutePath",
             "description": "Absolute path of the listed directory."
           },
           "entries": {


### PR DESCRIPTION
wire path fields carry the validated `AbsolutePath` type, and the nameless root's `display_name` is `Option<DisplayName>` serialized absent (the empty-string spelling is gone)

Thirteen fields are typed (the filesystem-operation paths, the read-entry and listing paths, and grep's `path_prefix` and match paths); serialization is identical for every valid value, and malformed paths now reject at deserialization inside the enveloped extractor while keeping the same `invalid_request` code they produced before. Every candidate ended up typed 