### PR TITLE
fix(grep): cover wal revisions below the index watermark in scans

### DIFF
--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -168,6 +168,15 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         &self.content_store_id
     }
 
+    /// Returns the sequence through which this view's manifest tables are materialized.
+    ///
+    /// This is the plan-less scan boundary consumed by `loonfs-grep`: table
+    /// enumeration covers revisions at or below it, and WAL replay covers
+    /// revisions strictly above it.
+    pub fn grep_materialized_through_seq(&self) -> ChangeSeq {
+        self.tables.manifest().payload.head_seq
+    }
+
     /// Opens the memoized visibility session used by one grep page.
     ///
     /// This is part of the read surface consumed by `loonfs-grep`.
@@ -207,7 +216,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .collect())
     }
 
-    /// Loads the validated WAL commit records after an index watermark.
+    /// Loads the validated WAL commit records after a requested sequence.
     ///
     /// This is the narrow WAL-tail read surface consumed by `loonfs-grep`;
     /// the service owns revision selection and all query policy while core
@@ -215,9 +224,9 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
     pub async fn grep_wal_records_after(
         &self,
         store: &S,
-        built_through_seq: ChangeSeq,
+        after_seq: ChangeSeq,
     ) -> Result<Vec<WalCommitPayload>> {
-        if built_through_seq >= self.head.seq {
+        if after_seq >= self.head.seq {
             return Ok(Vec::new());
         }
         let manifest = self.tables.manifest();
@@ -228,7 +237,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 chain_base_seq: manifest.payload.retention_floor_seq,
                 head_seq: self.head.seq,
                 visible_tip: self.head.visible_wal_tip.clone(),
-                stop_after_seq: Some(built_through_seq),
+                stop_after_seq: Some(after_seq),
                 recent_segments: &self.head.recent_segments,
             },
         )
@@ -240,7 +249,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .segments()
             .iter()
             .flat_map(|segment| segment.records())
-            .filter(|record| record.seq > built_through_seq)
+            .filter(|record| record.seq > after_seq)
             .cloned()
             .collect())
     }

--- a/crates/loonfs-grep/src/root/mod.rs
+++ b/crates/loonfs-grep/src/root/mod.rs
@@ -23,6 +23,7 @@ pub use codec::{
     GREP_ROOT_FORMAT_VERSION, GREP_ROOT_KIND,
 };
 pub use error::{GrepManifestIdError, GrepRootCodecError, GrepRootError, GrepRootStateError};
+pub(crate) use state::ChangeFeedResume;
 pub use state::{
     GrepFoldState, GrepIndexState, GrepLifecycle, GrepManifestId, GrepRootPointer, GrepRootState,
     GrepSegmentRef, GREP_INDEX_FORMAT_VERSION,

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -198,6 +198,50 @@ pub struct GrepIndexState {
     pub next_run_ordinal: u64,
 }
 
+/// Change-feed resume point derived from the grep watermark pair.
+///
+/// A commit-boundary cursor (`next_delta_index == 0`) resumes strictly after
+/// `built_through_seq`. An in-commit cursor reloads that commit and skips the
+/// already represented delta prefix, keeping feed selection and delta
+/// selection complementary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ChangeFeedResume {
+    built_through_seq: ChangeSeq,
+    next_delta_index: u32,
+}
+
+impl ChangeFeedResume {
+    pub(crate) fn new(built_through_seq: ChangeSeq, next_delta_index: u32) -> Self {
+        Self {
+            built_through_seq,
+            next_delta_index,
+        }
+    }
+
+    pub(crate) fn after_seq(self) -> ChangeSeq {
+        if self.next_delta_index == 0 {
+            self.built_through_seq
+        } else {
+            ChangeSeq(self.built_through_seq.0.saturating_sub(1))
+        }
+    }
+
+    pub(crate) fn start_delta_index(
+        self,
+        record_seq: ChangeSeq,
+    ) -> std::result::Result<usize, std::num::TryFromIntError> {
+        if record_seq == self.built_through_seq {
+            usize::try_from(self.next_delta_index)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub(crate) fn next_delta_index(self) -> u32 {
+        self.next_delta_index
+    }
+}
+
 impl GrepIndexState {
     /// Creates index bookkeeping in the current grep-owned format.
     pub fn new(

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -9,7 +9,9 @@ use crate::index_read::{
 };
 use crate::keyspace::{manifest_key, segment_key};
 use crate::query::{plan_pattern, GramPlanOutcome, GramQueryPlan};
-use crate::root::{load_grep_manifest, load_grep_root_pointer, GrepLifecycle, GrepRootState};
+use crate::root::{
+    load_grep_manifest, load_grep_root_pointer, ChangeFeedResume, GrepLifecycle, GrepRootState,
+};
 use crate::{GrepError, Result};
 use futures::future::{join_all, try_join_all};
 use loonfs_api::wire::hex::hex_decode_bytes;
@@ -461,24 +463,18 @@ async fn segment_postings_for_gram<S: ObjectStore + ?Sized>(
 async fn tail_revisions<S: ObjectStore + ?Sized>(
     store: &S,
     view: &LoadedMetadataView<'_, S>,
-    built_through_seq: ChangeSeq,
-    next_delta_index: u32,
+    resume: ChangeFeedResume,
 ) -> Result<BTreeSet<InodeId>> {
     let mut tail = BTreeMap::new();
-    let after_seq = if next_delta_index == 0 {
-        built_through_seq
-    } else {
-        ChangeSeq(built_through_seq.0.saturating_sub(1))
-    };
-    for record in view.grep_wal_records_after(store, after_seq).await? {
-        let start_delta_index = if record.seq == built_through_seq {
-            usize::try_from(next_delta_index).map_err(|_| {
-                CoreError::Internal("grep delta cursor does not fit in memory".to_owned())
-            })?
-        } else {
-            0
-        };
+    for record in view
+        .grep_wal_records_after(store, resume.after_seq())
+        .await?
+    {
+        let start_delta_index = resume.start_delta_index(record.seq).map_err(|_| {
+            CoreError::Internal("grep delta cursor does not fit in memory".to_owned())
+        })?;
         if start_delta_index > record.deltas.len() {
+            let next_delta_index = resume.next_delta_index();
             return Err(GrepError::CorruptIndex {
                 message: format!(
                     "grep delta cursor `{next_delta_index}` exceeds commit `{}` length `{}`",
@@ -743,12 +739,13 @@ impl GrepService {
         };
 
         let mut candidates = GrepCandidates::default();
-        match plan_pattern(&request.pattern, request.case_insensitive)
+        let tail_resume = match plan_pattern(&request.pattern, request.case_insensitive)
             .map_err(CoreError::InvalidQuery)?
         {
             GramPlanOutcome::Indexable(plan) => {
                 candidates.indexed =
                     indexed_candidates(store, &self.block_cache, &snapshot.segments, &plan).await?;
+                ChangeFeedResume::new(snapshot.built_through_seq, snapshot.next_delta_index)
             }
             GramPlanOutcome::Unindexable => {
                 if !request.allow_scan {
@@ -760,16 +757,11 @@ impl GrepService {
                     .into());
                 }
                 candidates.unfiltered = scan_candidate_inodes(view).await?;
+                ChangeFeedResume::new(view.grep_materialized_through_seq(), 0)
             }
-        }
+        };
 
-        let tail = tail_revisions(
-            store,
-            view,
-            snapshot.built_through_seq,
-            snapshot.next_delta_index,
-        )
-        .await?;
+        let tail = tail_revisions(store, view, tail_resume).await?;
         let mut tail_scanned = true;
         if tail.len() > MAX_GREP_TAIL_FILES {
             if request.allow_stale {

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -9,8 +9,8 @@ use crate::keyspace::{
     manifest_key, namespace_prefix, parse_key, root_key, segment_key, GrepKeyKind,
 };
 use crate::root::{
-    advance_grep_root, load_grep_root, seed_grep_root, GrepFoldState, GrepIndexState,
-    GrepLifecycle, GrepRootError, GrepRootState, GrepSegmentRef, LoadedGrepRoot,
+    advance_grep_root, load_grep_root, seed_grep_root, ChangeFeedResume, GrepFoldState,
+    GrepIndexState, GrepLifecycle, GrepRootError, GrepRootState, GrepSegmentRef, LoadedGrepRoot,
 };
 use crate::service::is_indexable_text_content;
 use crate::{GrepError, Result};
@@ -686,12 +686,8 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
     next_delta_index: u32,
     policy: GramIndexBuildPolicy,
 ) -> Result<IncrementalCollection> {
-    let after_seq = if next_delta_index == 0 {
-        built_through_seq
-    } else {
-        ChangeSeq(built_through_seq.0.saturating_sub(1))
-    };
-    let feed = load_grep_change_feed(store, namespace_id, after_seq).await?;
+    let resume = ChangeFeedResume::new(built_through_seq, next_delta_index);
+    let feed = load_grep_change_feed(store, namespace_id, resume.after_seq()).await?;
     let GrepChangeFeed::Records { records, .. } = feed else {
         return Ok(IncrementalCollection::RebootstrapRequired);
     };
@@ -711,13 +707,9 @@ async fn collect_incremental_unit<S: ObjectStore + ?Sized>(
     let mut planned_content_bytes = 0u64;
     let mut examined_files = 0usize;
     'records: for record in records {
-        let start_delta_index = if record.seq == built_through_seq {
-            usize::try_from(next_delta_index).map_err(|_| {
-                CoreError::Internal("grep delta cursor does not fit in memory".to_owned())
-            })?
-        } else {
-            0
-        };
+        let start_delta_index = resume.start_delta_index(record.seq).map_err(|_| {
+            CoreError::Internal("grep delta cursor does not fit in memory".to_owned())
+        })?;
         if start_delta_index > record.deltas.len() {
             return Ok(IncrementalCollection::RebootstrapRequired);
         }

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -5,7 +5,7 @@
 
 use loonfs::{
     CommitId, CoreError, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions,
-    DestinationBehavior, FsWriter, GrepRequest, GrepResponse, MoveOptions, NamespaceId,
+    DestinationBehavior, FsAdmin, FsWriter, GrepRequest, GrepResponse, MoveOptions, NamespaceId,
     PutFileOptions, SharedObjectStore,
 };
 use loonfs_api::AbsolutePath;
@@ -24,7 +24,7 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::ids::nonzero_usize;
 use std::collections::BTreeSet;
 use std::sync::Arc;
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 
 fn request(pattern: &str) -> GrepRequest {
     GrepRequest {
@@ -194,6 +194,46 @@ async fn drive_worker_to_current(
     panic!("grep worker backlog must drain");
 }
 
+struct PlanlessBoundaryFixture {
+    _temp_dir: TempDir,
+    store: SharedObjectStore,
+    namespace_id: NamespaceId,
+    writer: FsWriter,
+    admin: FsAdmin,
+}
+
+async fn planless_boundary_fixture(namespace: &str) -> PlanlessBoundaryFixture {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse(namespace).expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("planless-boundary-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("build writer");
+    let admin = FsAdmin::builder_with_store(store.clone())
+        .actor_id("planless-boundary-admin")
+        .build()
+        .await
+        .expect("build admin");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let worker = worker(&store);
+    worker.enable(&namespace_id).await.expect("enable grep");
+    drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
+    PlanlessBoundaryFixture {
+        _temp_dir: temp_dir,
+        store,
+        namespace_id,
+        writer,
+        admin,
+    }
+}
+
 async fn gram_segment_levels(
     store: &SharedObjectStore,
     namespace_id: &NamespaceId,
@@ -207,6 +247,137 @@ async fn gram_segment_levels(
         .iter()
         .map(|segment| segment.level)
         .collect()
+}
+
+#[tokio::test]
+async fn planless_scan_returns_exact_materialized_and_wal_boundary_revisions_once_each() {
+    let fixture = planless_boundary_fixture("grep-planless-boundary").await;
+    fixture
+        .writer
+        .put_file_bytes(
+            &fixture.namespace_id,
+            "/materialized.txt",
+            b"x materialized\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write materialized file");
+    let (materialized_head, _) = load_namespace_read_anchor(&*fixture.store, &fixture.namespace_id)
+        .await
+        .expect("load materialized head");
+    fixture
+        .admin
+        .flush_wal(&fixture.namespace_id)
+        .await
+        .expect("flush materialized commit");
+    let (_, materialized_root) = load_namespace_read_anchor(&*fixture.store, &fixture.namespace_id)
+        .await
+        .expect("load materialized root");
+    assert_eq!(
+        materialized_root.state.manifest_head_seq,
+        materialized_head.state.seq
+    );
+
+    fixture
+        .writer
+        .put_file_bytes(
+            &fixture.namespace_id,
+            "/wal-only.txt",
+            b"x wal\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write WAL-only file");
+    let (head, root) = load_namespace_read_anchor(&*fixture.store, &fixture.namespace_id)
+        .await
+        .expect("load boundary");
+    assert_eq!(root.state.manifest_head_seq, materialized_head.state.seq);
+    assert_eq!(
+        head.state.seq.0,
+        root.state.manifest_head_seq.0 + 1,
+        "the WAL-only file must be committed immediately after the materialized boundary"
+    );
+
+    let harness = ServiceHarness::new(fixture.store.clone(), fixture.namespace_id.clone());
+    let mut scan = request("x");
+    scan.allow_scan = true;
+    let response = harness
+        .success("exact materialization boundary", &scan)
+        .await;
+    let paths = response
+        .matches
+        .iter()
+        .map(|found| found.absolute_path.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(paths.len(), 2);
+    assert_eq!(
+        paths
+            .iter()
+            .filter(|path| **path == "/materialized.txt")
+            .count(),
+        1
+    );
+    assert_eq!(
+        paths
+            .iter()
+            .filter(|path| **path == "/wal-only.txt")
+            .count(),
+        1
+    );
+
+    fixture
+        .writer
+        .shutdown_background()
+        .await
+        .expect("writer shutdown");
+}
+
+#[tokio::test]
+async fn planless_scan_deduplicates_an_inode_revised_across_materialization() {
+    let fixture = planless_boundary_fixture("grep-planless-dedup").await;
+    fixture
+        .writer
+        .put_file_bytes(
+            &fixture.namespace_id,
+            "/overlap.txt",
+            b"x materialized revision\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write materialized revision");
+    fixture
+        .admin
+        .flush_wal(&fixture.namespace_id)
+        .await
+        .expect("flush materialized revision");
+    fixture
+        .writer
+        .put_file_bytes(
+            &fixture.namespace_id,
+            "/overlap.txt",
+            b"x WAL revision\n",
+            PutFileOptions {
+                behavior: DestinationBehavior::Replace,
+                commit_id: None,
+            },
+        )
+        .await
+        .expect("write WAL revision");
+
+    let harness = ServiceHarness::new(fixture.store.clone(), fixture.namespace_id.clone());
+    let mut scan = request("x");
+    scan.allow_scan = true;
+    let response = harness.success("overlapping inode sources", &scan).await;
+    assert_eq!(response.matches.len(), 1);
+    assert_eq!(response.matches[0].absolute_path, "/overlap.txt");
+    assert_eq!(response.matches[0].revision_no.0, 2);
+    assert_eq!(response.matches[0].line, "x WAL revision");
+
+    fixture
+        .writer
+        .shutdown_background()
+        .await
+        .expect("writer shutdown");
 }
 
 #[tokio::test]
@@ -352,11 +523,33 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
         )
         .await;
     scan_off.allow_scan = true;
-    let scanned = harness
-        .success("allow_scan on and short pattern", &scan_off)
-        .await;
-    assert_eq!(scanned.matches.len(), 1);
-    assert_eq!(scanned.matches[0].absolute_path, "/tail/tail-hit.txt");
+    let mut scanned_paths = BTreeSet::new();
+    let mut scan_pages = 0usize;
+    loop {
+        let scanned = harness
+            .success("allow_scan on and short pattern", &scan_off)
+            .await;
+        scan_pages += 1;
+        assert!(scanned.tail_scanned);
+        scanned_paths.extend(
+            scanned
+                .matches
+                .iter()
+                .map(|found| found.absolute_path.as_str().to_owned()),
+        );
+        let Some(cursor) = scanned.next_cursor else {
+            break;
+        };
+        scan_off.cursor = Some(cursor);
+    }
+    assert!(scan_pages > 1);
+    assert_eq!(
+        scanned_paths,
+        BTreeSet::from(["/docs/short.txt", "/tail/tail-hit.txt"])
+            .into_iter()
+            .map(str::to_owned)
+            .collect()
+    );
 
     let mut case_folded = request("mixed case token");
     case_folded.case_insensitive = true;
@@ -370,7 +563,7 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
     assert_eq!(visible.matches.len(), 1);
     assert_eq!(visible.matches[0].absolute_path, "/archive/moved.txt");
 
-    let mut binary = request("bi");
+    let mut binary = request("ry");
     binary.allow_scan = true;
     let binary = harness.success("binary eligibility", &binary).await;
     assert!(binary.matches.is_empty());

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -601,6 +601,73 @@ async fn write_pointer(
         .expect("write pointer");
 }
 
+#[tokio::test]
+async fn planless_scan_covers_wal_revisions_at_or_below_index_watermark() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("scan-gap").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("scan-gap-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    let worker = worker(&store);
+    worker.enable(&namespace_id).await.expect("enable");
+    drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
+
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/only-in-wal.txt",
+            b"x\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write WAL-only file");
+    drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
+
+    let (head, metadata_root) = load_namespace_read_anchor(&*store, &namespace_id)
+        .await
+        .expect("read anchor");
+    assert!(
+        metadata_root.state.manifest_head_seq < head.state.seq,
+        "the WAL-only revision must sit past metadata materialization"
+    );
+    let grep_root = loonfs_grep::root::load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load grep root")
+        .expect("grep root exists");
+    assert_eq!(
+        grep_root.state().index().built_through_seq,
+        head.state.seq,
+        "the independent worker can advance past metadata materialization"
+    );
+
+    let mut scan = request("x");
+    scan.allow_scan = true;
+    let response = new_query(&store, &namespace_id, &scan)
+        .await
+        .expect("plan-less scan");
+    assert_eq!(
+        response.matches.len(),
+        1,
+        "scan must cover the WAL-only revision"
+    );
+    assert_eq!(
+        response.matches[0].absolute_path.as_str(),
+        "/only-in-wal.txt"
+    );
+
+    writer.shutdown_background().await.expect("shutdown");
+}
+
 fn assert_not_enabled_error(case: &str, result: loonfs::Result<GrepResponse>) {
     match result {
         Err(loonfs::Error::Grep(error @ loonfs::GrepError::NotEnabled)) => {


### PR DESCRIPTION
Bug fix: a plan-less grep scan enumerated candidates from the manifest revision tables (covering up to the materialization boundary) and from a WAL walk starting after the grep index watermark. The independent worker routinely indexes past materialization, so revisions living only in the WAL between the manifest boundary and the watermark were invisible to scans — the reproduction shows a freshly-written file that a sub-trigram scan simply cannot find. Plan-ful queries were never affected; the index itself covers those revisions via the change feed.

The fix makes the scan's tail boundary a view property rather than an index property: plan-less scans now walk the WAL from the view's materialization boundary (new `grep_materialized_through_seq()` accessor on the sanctioned grep read location), making the two sources exactly complementary. The change-feed resume arithmetic that worker and service each spelled locally — the duplication that let the two boundaries drift apart in the first place — is hoisted into one `ChangeFeedResume` type used at all three call sites, so this class of divergence is now unrepresentable.

One subtlety: an in-flight scan cursor issued under the old boundary could skip newly-visible candidates after the fix. Cursors do not encode the boundary, so the request fingerprint gains a cursor-semantics salt — stale cursors fail validation loudly instead of silently missing results; no cursor field or wire shape changed. New tests pin the reproduction, exact-boundary coverage (a revision at the boundary and one just past it, each returned once), cross-materialization dedup, cursor invalidation, and multi-page budgeted resume.
