### PR TITLE
feat(core): bound and resume garbage collection

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -412,7 +412,7 @@ pub struct FlushWalResponse {
 
 /// Optional overrides for one garbage-collection pass. Absent fields use
 /// the server's conservative defaults.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GcRequest {
     /// Objects younger than this are never deleted, reachable or not. The
@@ -424,6 +424,14 @@ pub struct GcRequest {
     /// reaped or released. Must be at least the grace window.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reap_window_ms: Option<u64>,
+    /// Maximum candidates examined by this invocation. Omit to retain the
+    /// run-to-completion behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_objects: Option<u64>,
+    /// Opaque resume token returned as `next_cursor` by an earlier pass
+    /// against the same namespace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
 /// Result of one mark-and-sweep garbage-collection pass.
@@ -458,6 +466,11 @@ pub struct GcResponse {
     /// True when the namespace lacks a complete head-and-descriptor pair, so
     /// the pass deliberately performed no listing or deletion.
     pub incomplete_namespace_ignored: bool,
+    /// Opaque resume token when more candidates remain. Resuming rebuilds
+    /// every safety proof; the token carries enumeration position only and
+    /// is valid only against the same namespace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 /// Result of advancing the retention floor.
@@ -472,7 +485,7 @@ pub struct AdvanceRetentionResponse {
 
 /// Options for one explicit maintenance step. Absent fields use the
 /// server's defaults; garbage collection runs only when `gc` is present.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct MaintenanceStepRequest {
     /// Flush the visible WAL tail into metadata tables when it reaches this

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -599,6 +599,10 @@ pub(crate) struct AdminGcArgs {
     /// (server default when omitted).
     #[arg(long)]
     pub reap_window_ms: Option<u64>,
+    /// Examine at most this many candidates and return after one bounded
+    /// pass. Omit to loop bounded passes through completion.
+    #[arg(long)]
+    pub max_objects: Option<u64>,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -79,16 +79,32 @@ async fn run_admin_gc(
     args: AdminGcArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
-    let request = GcRequest {
+    let single_pass = args.max_objects.is_some();
+    let mut request = GcRequest {
         grace_window_ms: args.grace_window_ms,
         reap_window_ms: args.reap_window_ms,
+        max_objects: Some(args.max_objects.unwrap_or(loonfs::DEFAULT_GC_MAX_OBJECTS)),
+        cursor: None,
     };
-    let response = context
-        .target
-        .backend()
-        .gc_namespace(&context.namespace, request)
-        .await
-        .map_err(|error| context.fail(kind, error))?;
+    let mut response = None;
+    loop {
+        let pass = context
+            .target
+            .backend()
+            .gc_namespace(&context.namespace, request.clone())
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        let next_cursor = pass.next_cursor.clone();
+        match &mut response {
+            Some(total) => accumulate_gc_response(total, pass),
+            None => response = Some(pass),
+        }
+        if single_pass || next_cursor.is_none() {
+            break;
+        }
+        request.cursor = next_cursor;
+    }
+    let response = response.expect("GC loop should run at least once");
 
     Ok(CommandOutput {
         kind,
@@ -96,6 +112,20 @@ async fn run_admin_gc(
         mode: Some(context.mode),
         data: CommandData::GarbageCollected(response),
     })
+}
+
+fn accumulate_gc_response(total: &mut loonfs_api::GcResponse, pass: loonfs_api::GcResponse) {
+    total.deleted_wal_segments += pass.deleted_wal_segments;
+    total.deleted_metadata_tables += pass.deleted_metadata_tables;
+    total.deleted_manifests += pass.deleted_manifests;
+    total.deleted_checkpoint_records += pass.deleted_checkpoint_records;
+    total.released_fork_checkpoints += pass.released_fork_checkpoints;
+    total.deleted_upload_sessions += pass.deleted_upload_sessions;
+    total.released_missing_basis_checkpoints += pass.released_missing_basis_checkpoints;
+    total.retained_candidates += pass.retained_candidates;
+    total.degraded_retention |= pass.degraded_retention;
+    total.incomplete_namespace_ignored |= pass.incomplete_namespace_ignored;
+    total.next_cursor = pass.next_cursor;
 }
 
 async fn run_admin_checkpoint(

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -28,6 +28,9 @@ fn gc_summary(report: &GcResponse) -> String {
     if report.degraded_retention {
         summary.push_str("; retention degraded: ambiguous roots suppressed deletion");
     }
+    if let Some(cursor) = &report.next_cursor {
+        summary.push_str(&format!("; next_cursor: {cursor}"));
+    }
     summary
 }
 

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1439,6 +1439,23 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_eq!(gc_data["deleted_manifests"], 0);
         assert_eq!(gc_data["degraded_retention"], false);
         assert_eq!(gc_data["incomplete_namespace_ignored"], false);
+        assert!(gc_data.get("next_cursor").is_none());
+
+        // Supplying a candidate budget requests exactly one pass and exposes
+        // the opaque cursor instead of the CLI's default completion loop.
+        let bounded_gc = harness.run(&[
+            "--json",
+            "admin",
+            "gc",
+            "--max-objects",
+            "1",
+            "--profile",
+            profile,
+        ]);
+        assert_success(&bounded_gc);
+        assert!(json_data(&bounded_gc)["next_cursor"]
+            .as_str()
+            .is_some_and(|cursor| !cursor.is_empty()));
 
         let repair = harness.run(&["--json", "admin", "repair", "--profile", profile]);
         assert_success(&repair);

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -567,6 +567,8 @@ impl Client {
     }
 
     /// Runs one mark-and-sweep garbage-collection pass (admin plane).
+    /// `GcRequest::max_objects` bounds one invocation; pass a returned
+    /// `GcResponse::next_cursor` back as `GcRequest::cursor` to resume.
     /// Nothing sweeps without this explicit call or a maintenance-step
     /// opt-in.
     pub fn gc_namespace(

--- a/crates/loonfs-core/src/gc/config.rs
+++ b/crates/loonfs-core/src/gc/config.rs
@@ -8,10 +8,22 @@ use serde::{Deserialize, Serialize};
 /// Both are wall-clock cleanup policy, never validity inputs. The defaults
 /// are conservative: every object gets one hour of unconditional protection,
 /// while old upload sessions and abandoned fork records wait seven days.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GcConfig {
     pub grace_window_ms: u64,
     pub reap_window_ms: u64,
+    /// Maximum sweep candidates examined by this invocation. `None` keeps
+    /// the run-to-completion behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_objects: Option<u64>,
+    /// Opaque enumeration cursor returned by an earlier invocation.
+    ///
+    /// The cursor is valid only for the same namespace. Resuming always
+    /// rebuilds the live roots and safety floors; a stale cursor can only
+    /// re-examine work or defer keys that moved before it until the next
+    /// full pass, never authorize deletion of a newly live object.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
 impl Default for GcConfig {
@@ -19,6 +31,8 @@ impl Default for GcConfig {
         Self {
             grace_window_ms: 60 * 60 * 1000,
             reap_window_ms: 7 * 24 * 60 * 60 * 1000,
+            max_objects: None,
+            cursor: None,
         }
     }
 }
@@ -40,11 +54,16 @@ impl GcConfig {
                 "reap_window_ms must be at least the grace window".to_owned(),
             ));
         }
+        if self.max_objects == Some(0) {
+            return Err(CoreError::InvalidGcConfig(
+                "max_objects must be greater than zero".to_owned(),
+            ));
+        }
         Ok(())
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GcReport {
     pub deleted_wal_segments: u64,
     pub deleted_metadata_tables: u64,
@@ -72,4 +91,11 @@ pub struct GcReport {
     /// The namespace lacked a complete head-and-descriptor pair, so GC
     /// deliberately skipped it without listing or deleting any objects.
     pub incomplete_namespace_ignored: bool,
+    /// Opaque resume token when more sweep candidates remain.
+    ///
+    /// Callers must return it only to the same namespace. It resumes
+    /// enumeration, not safety state: every invocation rebuilds roots and
+    /// floors before deciding a deletion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -1,0 +1,157 @@
+//! Opaque, namespace-bound cursors for bounded GC enumeration.
+
+use crate::error::{CoreError, Result};
+use base64::Engine as _;
+use loonfs_api::NamespaceId;
+use loonfs_objectstore::keys::{
+    checkpoint_prefix, metadata_manifest_prefix, metadata_table_prefix, upload_session_prefix,
+    wal_segment_prefix,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum CandidateFamily {
+    WalSegments,
+    MetadataTables,
+    Manifests,
+    Checkpoints,
+    UploadSessions,
+}
+
+impl CandidateFamily {
+    pub(super) const ALL: [Self; 5] = [
+        Self::WalSegments,
+        Self::MetadataTables,
+        Self::Manifests,
+        Self::Checkpoints,
+        Self::UploadSessions,
+    ];
+
+    pub(super) fn index(self) -> usize {
+        match self {
+            Self::WalSegments => 0,
+            Self::MetadataTables => 1,
+            Self::Manifests => 2,
+            Self::Checkpoints => 3,
+            Self::UploadSessions => 4,
+        }
+    }
+
+    pub(super) fn prefix(self, namespace_id: &NamespaceId) -> String {
+        match self {
+            Self::WalSegments => wal_segment_prefix(namespace_id.as_str()),
+            Self::MetadataTables => metadata_table_prefix(namespace_id.as_str()),
+            Self::Manifests => metadata_manifest_prefix(namespace_id.as_str()),
+            Self::Checkpoints => checkpoint_prefix(namespace_id.as_str()),
+            Self::UploadSessions => upload_session_prefix(namespace_id.as_str()),
+        }
+    }
+}
+
+/// Cursor payloads are short-lived API tokens, not durable objects. Serde's
+/// default unknown-field handling makes decoding tolerant of additive fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct GcCursor {
+    namespace_id: NamespaceId,
+    pub(super) family: CandidateFamily,
+    #[serde(default)]
+    pub(super) last_key: Option<String>,
+}
+
+impl GcCursor {
+    pub(super) fn initial(namespace_id: &NamespaceId) -> Self {
+        Self {
+            namespace_id: namespace_id.clone(),
+            family: CandidateFamily::WalSegments,
+            last_key: None,
+        }
+    }
+
+    pub(super) fn after(namespace_id: &NamespaceId, family: CandidateFamily, key: String) -> Self {
+        Self {
+            namespace_id: namespace_id.clone(),
+            family,
+            last_key: Some(key),
+        }
+    }
+
+    pub(super) fn decode(token: &str, namespace_id: &NamespaceId) -> Result<Self> {
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(token)
+            .map_err(|_| invalid_cursor())?;
+        let cursor: Self = serde_json::from_slice(&bytes).map_err(|_| invalid_cursor())?;
+        if cursor.namespace_id != *namespace_id {
+            return Err(CoreError::InvalidGcConfig(
+                "cursor belongs to a different namespace".to_owned(),
+            ));
+        }
+        if cursor
+            .last_key
+            .as_ref()
+            .is_some_and(|key| !key.starts_with(&cursor.family.prefix(namespace_id)))
+        {
+            return Err(invalid_cursor());
+        }
+        Ok(cursor)
+    }
+
+    pub(super) fn encode(&self) -> Result<String> {
+        let bytes = serde_json::to_vec(self)
+            .map_err(|error| CoreError::Internal(format!("failed to encode GC cursor: {error}")))?;
+        Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+    }
+}
+
+fn invalid_cursor() -> CoreError {
+    CoreError::InvalidGcConfig("cursor is malformed".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_decode_tolerates_additive_fields() {
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let payload = serde_json::json!({
+            "namespace_id": "demo",
+            "family": "metadata_tables",
+            "last_key": "namespaces/demo/metadata/tables/table.sst.zst",
+            "future_field": {"ignored": true}
+        });
+        let token = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&payload).expect("encode payload"));
+
+        let cursor = GcCursor::decode(&token, &namespace_id).expect("decode cursor");
+        assert_eq!(cursor.family, CandidateFamily::MetadataTables);
+        assert_eq!(
+            cursor.last_key.as_deref(),
+            Some("namespaces/demo/metadata/tables/table.sst.zst")
+        );
+    }
+
+    #[test]
+    fn cursor_is_bound_to_its_namespace_and_family_prefix() {
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let other_namespace_id = NamespaceId::parse("other").expect("namespace id");
+        let cursor = GcCursor::after(
+            &namespace_id,
+            CandidateFamily::WalSegments,
+            "namespaces/demo/wal/segments/segment.wal.zst".to_owned(),
+        );
+        let token = cursor.encode().expect("encode cursor");
+
+        assert!(GcCursor::decode(&token, &namespace_id).is_ok());
+        assert!(GcCursor::decode(&token, &other_namespace_id).is_err());
+
+        let malformed = serde_json::json!({
+            "namespace_id": "demo",
+            "family": "wal_segments",
+            "last_key": "namespaces/demo/checkpoints/checkpoint.json"
+        });
+        let malformed = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&malformed).expect("encode malformed payload"));
+        assert!(GcCursor::decode(&malformed, &namespace_id).is_err());
+    }
+}

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -1,11 +1,11 @@
 //! Release rules for fork-owned and missing-basis checkpoint records.
 
 use super::config::GcConfig;
-use super::reap::list_prefix;
 use crate::checkpoint::record::{encode_checkpoint_record, set_checkpoint_record_state};
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
 use crate::namespace::control::{read_head_object, ControlObjectLoadError};
+use futures::StreamExt;
 use loonfs_api::wire::control::{
     decode_control_object, CheckpointOwner, CheckpointRecordLifecycle, CheckpointRecordState,
     ControlObjectKind, NamespaceState,
@@ -174,8 +174,9 @@ pub(super) async fn fork_target_proven_gone<S: ObjectStore + ?Sized>(
         Ok(loaded) => Ok(loaded.envelope.state.state == NamespaceState::Deleted),
         Err(ControlObjectLoadError::MissingObject { .. }) => {
             let target_prefix = namespace_prefix(target_namespace_id);
-            let tree = list_prefix(store, &target_prefix).await?;
-            if !tree.is_empty() {
+            let mut tree = store.list_prefix_stream(&target_prefix);
+            if let Some(item) = tree.next().await {
+                item.map_err(|error| CoreError::store(&target_prefix, &error))?;
                 // Either a bootstrap is in progress or rule 10 has not
                 // reaped the partial tree yet; ambiguity retains.
                 return Ok(false);

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -3,7 +3,6 @@
 
 use super::config::GcConfig;
 use super::fork_checkpoints::fork_target_proven_gone;
-use super::reap::list_prefix;
 use crate::checkpoint::load_namespace_manifest_envelope_if_present;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
@@ -11,6 +10,7 @@ use crate::namespace::control::{
     read_head_object, read_metadata_root_object, read_wal_floor_object, ControlObjectLoadError,
 };
 use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
+use futures::StreamExt;
 use loonfs_api::wire::control::{
     decode_control_object, CheckpointOwner, CheckpointRecordLifecycle, CheckpointRecordState,
     ControlObjectKind, NamespaceState,
@@ -19,6 +19,7 @@ use loonfs_api::{ChangeSeq, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{checkpoint_prefix, metadata_manifest_object};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 /// Everything reachable from the fresh root set (rule 4).
 pub(super) struct LiveSet {
@@ -29,7 +30,7 @@ pub(super) struct LiveSet {
     /// Still-active records whose basis manifest is verifiably absent —
     /// the crash window between record write and verification. The pass
     /// releases them; they never degrade sweeping.
-    pub(super) missing_basis_records: Vec<String>,
+    pub(super) missing_basis_records: BTreeSet<String>,
     /// Record resolution failed somewhere: manifest/table deletion must not
     /// proceed on this pass.
     pub(super) degraded: bool,
@@ -41,14 +42,14 @@ pub(super) struct LiveSet {
 /// live set no staler than `reverify_chunk` candidates. Rule 5 degradation
 /// is sticky for the pass once any collection observes it.
 pub(super) struct SweepVerifier {
-    pub(super) live: LiveSet,
+    pub(super) live: Arc<LiveSet>,
     pub(super) degraded: bool,
     pub(super) reverify_chunk: usize,
     pub(super) decided_since_collect: usize,
 }
 
 impl SweepVerifier {
-    pub(super) fn seeded(live: LiveSet, reverify_chunk: usize) -> Self {
+    pub(super) fn seeded(live: Arc<LiveSet>, reverify_chunk: usize) -> Self {
         Self {
             degraded: live.degraded,
             live,
@@ -65,7 +66,7 @@ impl SweepVerifier {
         context: &MutationContext,
     ) -> Result<()> {
         if self.decided_since_collect >= self.reverify_chunk {
-            self.live = collect_live_set(store, namespace_id, config, context).await?;
+            self.live = Arc::new(collect_live_set(store, namespace_id, config, context).await?);
             self.degraded |= self.live.degraded;
             self.decided_since_collect = 0;
         }
@@ -103,7 +104,7 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
         tables: BTreeSet::new(),
         wal_segments: BTreeSet::new(),
         checkpoint_keys: BTreeSet::new(),
-        missing_basis_records: Vec::new(),
+        missing_basis_records: BTreeSet::new(),
         degraded: false,
         namespace_deleted,
     };
@@ -126,7 +127,10 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     // revival to protect. The basis becomes collectable after condemnation,
     // while records-last ordering keeps a newly condemned record's basis
     // alive through the pass that performed the CAS.
-    for key in list_prefix(store, &checkpoint_prefix(namespace_id.as_str())).await? {
+    let checkpoints_prefix = checkpoint_prefix(namespace_id.as_str());
+    let mut checkpoint_keys = store.list_prefix_stream(&checkpoints_prefix);
+    while let Some(item) = checkpoint_keys.next().await {
+        let key = item.map_err(|error| CoreError::store(&checkpoints_prefix, &error))?;
         let Some(body) = store
             .get_with_metadata(&key)
             .await

--- a/crates/loonfs-core/src/gc/mod.rs
+++ b/crates/loonfs-core/src/gc/mod.rs
@@ -9,6 +9,7 @@
 //! in doubt, this module retains.
 
 mod config;
+mod cursor;
 mod fork_checkpoints;
 mod live_set;
 mod reap;

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -7,6 +7,7 @@ use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
 use bytes::Bytes;
+use futures::StreamExt;
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointRecordLifecycle, CheckpointRecordState,
     ControlObjectKind, HeadState, HeadStateEnvelope, NamespaceState,
@@ -104,10 +105,11 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<AbandonedBootstrapReap> {
     let namespace_prefix = namespace_prefix(namespace_id);
-    let keys = list_prefix(store, &namespace_prefix).await?;
-    if keys.is_empty() {
+    let mut initial_keys = store.list_prefix_stream(&namespace_prefix);
+    let Some(first_key) = initial_keys.next().await else {
         return Ok(AbandonedBootstrapReap::Reaped);
-    }
+    };
+    let first_key = first_key.map_err(|error| CoreError::store(&namespace_prefix, &error))?;
 
     let descriptor_key = namespace_config(namespace_id.as_str());
     let head_key = wal_head(namespace_id.as_str());
@@ -146,18 +148,14 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
         // The newest object bounds the tree's age; a missing timestamp reads
         // as "young" and blocks the reap. An already-condemned gate bypasses
         // age on retry because no installer may legally leave that state.
-        for key in keys.iter().filter(|key| *key != &head_key) {
-            let Some(metadata) = store
-                .head(key)
-                .await
-                .map_err(|error| CoreError::store(key, &error))?
-            else {
-                continue;
-            };
-            let Some(last_modified_ms) = metadata.last_modified_ms else {
-                return Ok(AbandonedBootstrapReap::InFlight);
-            };
-            if context.now_ms.saturating_sub(last_modified_ms) < GC_MIN_GRACE_WINDOW_MS {
+        if first_key != head_key
+            && !old_enough_for_bootstrap_reap(store, &first_key, context).await?
+        {
+            return Ok(AbandonedBootstrapReap::InFlight);
+        }
+        while let Some(item) = initial_keys.next().await {
+            let key = item.map_err(|error| CoreError::store(&namespace_prefix, &error))?;
+            if key != head_key && !old_enough_for_bootstrap_reap(store, &key, context).await? {
                 return Ok(AbandonedBootstrapReap::InFlight);
             }
         }
@@ -220,18 +218,40 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
     // Re-list after winning the gate so pre-head debris, including an
     // immutable manifest written by the losing installer before its admission
     // attempt, is included. A loser performs no later fixed-key writes.
-    let keys = list_prefix(store, &namespace_prefix).await?;
-    for key in keys.iter().filter(|key| *key != &head_key) {
+    let mut keys = store.list_prefix_stream(&namespace_prefix);
+    while let Some(item) = keys.next().await {
+        let key = item.map_err(|error| CoreError::store(&namespace_prefix, &error))?;
+        if key == head_key {
+            continue;
+        }
         store
-            .delete(key)
+            .delete(&key)
             .await
-            .map_err(|error| CoreError::store(key, &error))?;
+            .map_err(|error| CoreError::store(&key, &error))?;
     }
     store
         .delete(&head_key)
         .await
         .map_err(|error| CoreError::store(&head_key, &error))?;
     Ok(AbandonedBootstrapReap::Reaped)
+}
+
+async fn old_enough_for_bootstrap_reap<S: ObjectStore + ?Sized>(
+    store: &S,
+    key: &str,
+    context: &MutationContext,
+) -> Result<bool> {
+    let Some(metadata) = store
+        .head(key)
+        .await
+        .map_err(|error| CoreError::store(key, &error))?
+    else {
+        return Ok(true);
+    };
+    let Some(last_modified_ms) = metadata.last_modified_ms else {
+        return Ok(false);
+    };
+    Ok(context.now_ms.saturating_sub(last_modified_ms) >= GC_MIN_GRACE_WINDOW_MS)
 }
 
 pub(super) async fn delete_if_aged<S: ObjectStore + ?Sized>(
@@ -263,16 +283,6 @@ pub(super) async fn delete_if_aged<S: ObjectStore + ?Sized>(
         .await
         .map_err(|error| CoreError::store(key, &error))?;
     Ok(true)
-}
-
-pub(super) async fn list_prefix<S: ObjectStore + ?Sized>(
-    store: &S,
-    prefix: &str,
-) -> Result<Vec<String>> {
-    store
-        .list_prefix(prefix)
-        .await
-        .map_err(|error| CoreError::store(prefix, &error))
 }
 
 pub(super) fn manifest_object_id_of(key: &str) -> Option<ManifestObjectId> {

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -1,14 +1,14 @@
 //! The GC entry point: orchestrates root collection, verification,
-//! and the sweep.
+//! and the bounded, resumable sweep.
 
 use super::config::{GcConfig, GcReport};
+use super::cursor::{CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
     maybe_release_fork_checkpoint, release_missing_basis_checkpoint, ForkCheckpointSweep,
 };
-use super::live_set::{collect_live_set, SweepVerifier};
+use super::live_set::{collect_live_set, LiveSet, SweepVerifier};
 use super::reap::{
-    condemn_checkpoint_if_aged, delete_if_aged, list_prefix, manifest_object_id_of,
-    CheckpointCondemn,
+    condemn_checkpoint_if_aged, delete_if_aged, manifest_object_id_of, CheckpointCondemn,
 };
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
@@ -17,12 +17,11 @@ use crate::namespace::catalog::{
     NamespaceInitializationState,
 };
 use crate::protocol::{condemn_upload_session_if_aged, UploadSessionSweep};
+use futures::StreamExt;
 use loonfs_api::{NamespaceId, UploadId};
-use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_manifest_prefix, metadata_table_prefix, upload_session_prefix,
-    wal_segment_prefix,
-};
 use loonfs_objectstore::ObjectStore;
+use std::sync::Arc;
+
 pub async fn gc_namespace<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -35,9 +34,7 @@ pub async fn gc_namespace<S: ObjectStore + ?Sized>(
 
 /// How many sweep candidates may be decided against one live set before the
 /// set is re-collected (rule 3: candidate selection may be stale, deletion
-/// may not). On a large sweep, deciding every candidate against a single
-/// snapshot would leave the last deletions working from an arbitrarily old
-/// view; re-collecting every chunk bounds that staleness.
+/// may not).
 const SWEEP_REVERIFY_CHUNK: usize = 1024;
 
 pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
@@ -58,189 +55,222 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
         });
     }
 
-    // Mark: select sweep candidates against one live-set snapshot. The
-    // selection may be stale (rule 3); the delete-time checks below decide.
-    let mark = collect_live_set(store, namespace_id, config, context).await?;
+    let resume = match config.cursor.as_deref() {
+        Some(token) => GcCursor::decode(token, namespace_id)?,
+        None => GcCursor::initial(namespace_id),
+    };
+
+    // Every invocation rebuilds all roots before interpreting the cursor.
+    // The cursor can skip enumeration only; it never carries safety state.
+    let mark = Arc::new(collect_live_set(store, namespace_id, config, context).await?);
+    let mut sweep = SweepVerifier::seeded(Arc::clone(&mark), reverify_chunk);
     let mut report = GcReport::default();
+    let mut examined = 0_u64;
+    let mut position = resume.clone();
 
-    let candidate_segments = list_prefix(store, &wal_segment_prefix(namespace_id.as_str())).await?;
-    let candidate_tables =
-        list_prefix(store, &metadata_table_prefix(namespace_id.as_str())).await?;
-    let candidate_manifests =
-        list_prefix(store, &metadata_manifest_prefix(namespace_id.as_str())).await?;
-    let candidate_checkpoints =
-        list_prefix(store, &checkpoint_prefix(namespace_id.as_str())).await?;
-    let candidate_upload_sessions =
-        list_prefix(store, &upload_session_prefix(namespace_id.as_str())).await?;
-
-    let segment_candidates: Vec<String> = candidate_segments
-        .into_iter()
-        .filter(|key| !mark.wal_segments.contains(key))
-        .collect();
-    let table_candidates: Vec<String> = candidate_tables
-        .into_iter()
-        .filter(|key| !mark.tables.contains(key))
-        .collect();
-    let manifest_candidates: Vec<String> = candidate_manifests
-        .into_iter()
-        .filter(|key| manifest_object_id_of(key).is_none_or(|id| !mark.manifests.contains(&id)))
-        .collect();
-    let checkpoint_candidates: Vec<String> = candidate_checkpoints
-        .into_iter()
-        .filter(|key| !mark.checkpoint_keys.contains(key))
-        .collect();
-
-    // Sweep: every deletion is decided against a fresh live set (rule 3:
-    // candidate selection may be stale, deletion may not). Zero decisions
-    // separate the mark from the first sweep step, so the mark set seeds
-    // the verifier directly; it is re-collected every `reverify_chunk`
-    // candidates so a large sweep never runs far ahead of its snapshot.
-    let mut sweep = SweepVerifier::seeded(mark, reverify_chunk);
-
-    // Delete data before records. Every readable checkpoint record roots
-    // its basis in the live set, so the pass that deletes a record can
-    // never also delete the data that record was protecting. A crash
-    // mid-sweep leaves orphaned data for the next pass — never a record
-    // whose data vanished underneath it.
-    // WAL segments, metadata tables, and namespace manifests are immutable:
-    // one key can only ever be recreated with identical bytes under their
-    // create-if-absent protocols. Deleting an unreferenced, grace-aged key is
-    // therefore safe without condemnation; a zombie retry can only restore
-    // the same unreferenced bytes for a later pass.
-    for key in segment_candidates {
-        sweep
-            .refresh_if_due(store, namespace_id, config, context)
-            .await?;
-        if sweep.live.wal_segments.contains(&key) {
-            report.retained_candidates += 1;
-            continue;
-        }
-        if delete_if_aged(store, &key, config.grace_window_ms, context, &mut report).await? {
-            report.deleted_wal_segments += 1;
-        }
-    }
-    for key in table_candidates {
-        sweep
-            .refresh_if_due(store, namespace_id, config, context)
-            .await?;
-        // Rule 5: ambiguous roots suppress manifest and table deletion for
-        // the whole pass; degradation seen by any re-collection is sticky.
-        if sweep.degraded {
-            report.retained_candidates += 1;
-            continue;
-        }
-        if sweep.live.tables.contains(&key) {
-            report.retained_candidates += 1;
-            continue;
-        }
-        if delete_if_aged(store, &key, config.grace_window_ms, context, &mut report).await? {
-            report.deleted_metadata_tables += 1;
-        }
-    }
-    for key in manifest_candidates {
-        sweep
-            .refresh_if_due(store, namespace_id, config, context)
-            .await?;
-        if sweep.degraded {
-            report.retained_candidates += 1;
-            continue;
-        }
-        if manifest_object_id_of(&key).is_some_and(|id| sweep.live.manifests.contains(&id)) {
-            report.retained_candidates += 1;
-            continue;
-        }
-        if delete_if_aged(store, &key, config.grace_window_ms, context, &mut report).await? {
-            report.deleted_manifests += 1;
-        }
-    }
-    for key in checkpoint_candidates {
-        sweep
-            .refresh_if_due(store, namespace_id, config, context)
-            .await?;
-        if sweep.live.checkpoint_keys.contains(&key) {
-            report.retained_candidates += 1;
-            continue;
-        }
-        // Active fork-owned records are released by compare-and-swap. Every
-        // collectable mutable record is then condemned under the exact etag
-        // inspected with its age before physical deletion.
-        match maybe_release_fork_checkpoint(store, &key, config, context).await? {
-            ForkCheckpointSweep::Released => {
-                report.released_fork_checkpoints += 1;
+    // Data precedes mutable records. A crash or bounded return can therefore
+    // leave data protected for an extra pass, never a readable record whose
+    // basis was removed underneath it.
+    for &family in &CandidateFamily::ALL[resume.family.index()..] {
+        let prefix = family.prefix(namespace_id);
+        let mut stream = store.list_prefix_stream(&prefix);
+        while let Some(item) = stream.next().await {
+            let key = item.map_err(|error| CoreError::store(&prefix, &error))?;
+            if family == resume.family
+                && resume
+                    .last_key
+                    .as_ref()
+                    .is_some_and(|last_key| key <= *last_key)
+            {
                 continue;
             }
-            ForkCheckpointSweep::Retained => {
-                report.retained_candidates += 1;
-                continue;
+            if config
+                .max_objects
+                .is_some_and(|max_objects| examined >= max_objects)
+            {
+                // This one-key lookahead proves work remains. It performs no
+                // candidate reads or mutations; the key is reconsidered from
+                // the exclusive last-examined position on resume.
+                report.next_cursor = Some(position.encode()?);
+                report.degraded_retention = sweep.degraded;
+                return Ok(report);
             }
-            ForkCheckpointSweep::NotAnActiveFork => {}
-        }
-        match condemn_checkpoint_if_aged(
-            store,
-            namespace_id,
-            &key,
-            config.grace_window_ms,
-            sweep.live.namespace_deleted,
-            context,
-        )
-        .await?
-        {
-            CheckpointCondemn::Delete => {
-                store
-                    .delete(&key)
-                    .await
-                    .map_err(|error| CoreError::store(&key, &error))?;
-                report.deleted_checkpoint_records += 1;
-            }
-            CheckpointCondemn::Retain => report.retained_candidates += 1,
+
+            process_candidate(
+                store,
+                namespace_id,
+                config,
+                context,
+                family,
+                &key,
+                &mark,
+                &mut sweep,
+                &mut report,
+            )
+            .await?;
+            examined = examined.saturating_add(1);
+            position = GcCursor::after(namespace_id, family, key);
         }
     }
-    // Zombie release: an active record whose basis manifest is verifiably
-    // gone can never serve a read — the crash window between the record
-    // write and its verification skipped the release the creator would
-    // have performed. The release is the same compare-and-swap create runs
-    // on verification failure, decided against fresh reads and gated by
-    // the grace window so an in-flight create is never raced.
-    for key in sweep.live.missing_basis_records.clone() {
-        if release_missing_basis_checkpoint(store, namespace_id, &key, config, context).await? {
+
+    report.degraded_retention = sweep.degraded;
+    Ok(report)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn process_candidate<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    config: &GcConfig,
+    context: &MutationContext,
+    family: CandidateFamily,
+    key: &str,
+    mark: &LiveSet,
+    sweep: &mut SweepVerifier,
+    report: &mut GcReport,
+) -> Result<()> {
+    if family == CandidateFamily::UploadSessions {
+        return process_upload_session(store, namespace_id, config, context, key, report).await;
+    }
+
+    if family == CandidateFamily::Checkpoints && mark.missing_basis_records.contains(key) {
+        if release_missing_basis_checkpoint(store, namespace_id, key, config, context).await? {
             report.released_missing_basis_checkpoints += 1;
         } else {
             report.retained_candidates += 1;
         }
+        return Ok(());
     }
 
-    // Upload sessions root nothing and nothing durable references them. An
-    // aged active session is first condemned by one exact-etag CAS; completed
-    // and condemned sessions are already absorbing. A completion that loses
-    // to condemnation observes `upload_not_found`, while a condemn CAS that
-    // loses is retained for a later pass. Writer clocks are never consulted.
-    for key in candidate_upload_sessions {
-        let Some(upload_id) = upload_id_of(&key) else {
-            report.retained_candidates += 1;
-            continue;
-        };
-        match condemn_upload_session_if_aged(
-            store,
-            namespace_id,
-            &upload_id,
-            config.reap_window_ms,
-            context,
-        )
-        .await?
-        {
-            UploadSessionSweep::Delete => {
-                store
-                    .delete(&key)
-                    .await
-                    .map_err(|error| CoreError::store(&key, &error))?;
-                report.deleted_upload_sessions += 1;
-            }
-            UploadSessionSweep::Retain => report.retained_candidates += 1,
+    // Preserve the existing mark selection exactly: objects reachable from
+    // the invocation's root snapshot are skipped, while every selected
+    // candidate is re-verified immediately before its decision.
+    let selected = match family {
+        CandidateFamily::WalSegments => !mark.wal_segments.contains(key),
+        CandidateFamily::MetadataTables => !mark.tables.contains(key),
+        CandidateFamily::Manifests => {
+            manifest_object_id_of(key).is_none_or(|id| !mark.manifests.contains(&id))
         }
+        CandidateFamily::Checkpoints => !mark.checkpoint_keys.contains(key),
+        CandidateFamily::UploadSessions => false,
+    };
+    if !selected {
+        return Ok(());
     }
-    report.degraded_retention = sweep.degraded;
 
-    Ok(report)
+    sweep
+        .refresh_if_due(store, namespace_id, config, context)
+        .await?;
+    match family {
+        CandidateFamily::WalSegments => {
+            if sweep.live.wal_segments.contains(key) {
+                report.retained_candidates += 1;
+            } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
+                report.deleted_wal_segments += 1;
+            }
+        }
+        CandidateFamily::MetadataTables => {
+            // Rule 5 is sticky across every re-collection in this pass.
+            if sweep.degraded || sweep.live.tables.contains(key) {
+                report.retained_candidates += 1;
+            } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
+                report.deleted_metadata_tables += 1;
+            }
+        }
+        CandidateFamily::Manifests => {
+            let live =
+                manifest_object_id_of(key).is_some_and(|id| sweep.live.manifests.contains(&id));
+            if sweep.degraded || live {
+                report.retained_candidates += 1;
+            } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
+                report.deleted_manifests += 1;
+            }
+        }
+        CandidateFamily::Checkpoints => {
+            process_checkpoint(store, namespace_id, config, context, key, sweep, report).await?;
+        }
+        CandidateFamily::UploadSessions => {}
+    }
+    Ok(())
+}
+
+async fn process_checkpoint<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    config: &GcConfig,
+    context: &MutationContext,
+    key: &str,
+    sweep: &SweepVerifier,
+    report: &mut GcReport,
+) -> Result<()> {
+    if sweep.live.checkpoint_keys.contains(key) {
+        report.retained_candidates += 1;
+        return Ok(());
+    }
+    match maybe_release_fork_checkpoint(store, key, config, context).await? {
+        ForkCheckpointSweep::Released => {
+            report.released_fork_checkpoints += 1;
+            return Ok(());
+        }
+        ForkCheckpointSweep::Retained => {
+            report.retained_candidates += 1;
+            return Ok(());
+        }
+        ForkCheckpointSweep::NotAnActiveFork => {}
+    }
+    match condemn_checkpoint_if_aged(
+        store,
+        namespace_id,
+        key,
+        config.grace_window_ms,
+        sweep.live.namespace_deleted,
+        context,
+    )
+    .await?
+    {
+        CheckpointCondemn::Delete => {
+            store
+                .delete(key)
+                .await
+                .map_err(|error| CoreError::store(key, &error))?;
+            report.deleted_checkpoint_records += 1;
+        }
+        CheckpointCondemn::Retain => report.retained_candidates += 1,
+    }
+    Ok(())
+}
+
+async fn process_upload_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    config: &GcConfig,
+    context: &MutationContext,
+    key: &str,
+    report: &mut GcReport,
+) -> Result<()> {
+    let Some(upload_id) = upload_id_of(key) else {
+        report.retained_candidates += 1;
+        return Ok(());
+    };
+    match condemn_upload_session_if_aged(
+        store,
+        namespace_id,
+        &upload_id,
+        config.reap_window_ms,
+        context,
+    )
+    .await?
+    {
+        UploadSessionSweep::Delete => {
+            store
+                .delete(key)
+                .await
+                .map_err(|error| CoreError::store(key, &error))?;
+            report.deleted_upload_sessions += 1;
+        }
+        UploadSessionSweep::Retain => report.retained_candidates += 1,
+    }
+    Ok(())
 }
 
 fn upload_id_of(key: &str) -> Option<UploadId> {

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1,7 +1,8 @@
 //! Behavior tests for namespace GC.
 
-use super::config::GcConfig;
-use super::reap::{condemn_checkpoint_if_aged, list_prefix, CheckpointCondemn};
+use super::config::{GcConfig, GcReport};
+use super::live_set::collect_live_set;
+use super::reap::{condemn_checkpoint_if_aged, CheckpointCondemn};
 use super::run::{gc_namespace, gc_namespace_with_reverify_chunk};
 use crate::checkpoint::advance_retention_floor;
 use crate::checkpoint::record::set_checkpoint_record_state;
@@ -15,10 +16,11 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::{ContentRef, ContentStoreId, NamespaceId, UploadId};
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_manifest_object, metadata_manifest_prefix, metadata_table_prefix,
-    namespace_config, wal_head, wal_segment_prefix,
+    checkpoint_prefix, metadata_manifest_object, metadata_manifest_prefix, metadata_table,
+    metadata_table_prefix, namespace_config, wal_head, wal_segment, wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
+use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 
 use crate::namespace::bootstrap::bootstrap_namespace;
@@ -31,7 +33,7 @@ use futures::stream::BoxStream;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
 use loonfs_test_support::stores::{
-    BlockingStore, KeyPredicate, MetadataMapStore, OperationContext, OperationKind,
+    BlockingStore, CountingStore, KeyPredicate, MetadataMapStore, OperationContext, OperationKind,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::tempdir;
@@ -43,6 +45,8 @@ fn config() -> GcConfig {
     GcConfig {
         grace_window_ms: GRACE_MS,
         reap_window_ms: REAP_MS,
+        max_objects: None,
+        cursor: None,
     }
 }
 
@@ -208,6 +212,7 @@ async fn gc_rejects_grace_windows_below_the_derived_minimum() {
     let too_small = GcConfig {
         grace_window_ms: GC_MIN_GRACE_WINDOW_MS - 1,
         reap_window_ms: REAP_MS,
+        ..GcConfig::default()
     };
     let error = gc_namespace(&store, &namespace_id, &too_small, &context(1_000))
         .await
@@ -226,10 +231,20 @@ async fn gc_rejects_grace_windows_below_the_derived_minimum() {
     let inverted = GcConfig {
         grace_window_ms: GRACE_MS,
         reap_window_ms: GRACE_MS - 1,
+        ..GcConfig::default()
     };
     let error = gc_namespace(&store, &namespace_id, &inverted, &context(1_000))
         .await
         .expect_err("reap below grace must be rejected");
+    assert!(matches!(error, CoreError::InvalidGcConfig(_)));
+
+    let zero_budget = GcConfig {
+        max_objects: Some(0),
+        ..config()
+    };
+    let error = gc_namespace(&store, &namespace_id, &zero_budget, &context(1_000))
+        .await
+        .expect_err("zero budget must be rejected");
     assert!(matches!(error, CoreError::InvalidGcConfig(_)));
 }
 
@@ -879,7 +894,8 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
     // are all still referenced (a flush only appends L0 runs).
     assert_eq!(report.deleted_manifests, 3);
     assert!(!report.degraded_retention);
-    let manifests_left = list_prefix(&store, &metadata_manifest_prefix(namespace_id.as_str()))
+    let manifests_left = store
+        .list_prefix(&metadata_manifest_prefix(namespace_id.as_str()))
         .await
         .expect("list manifests");
     assert_eq!(manifests_left.len(), 1, "only the live root manifest stays");
@@ -1815,4 +1831,318 @@ async fn gc_degrades_to_retention_when_a_pin_checkpoint_is_unreadable() {
     assert!(report.degraded_retention);
     assert_eq!(report.deleted_manifests, 0);
     assert_eq!(report.deleted_metadata_tables, 0);
+}
+
+async fn add_bounded_gc_fixture(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    setup: &MutationContext,
+) {
+    bootstrap_namespace(store, namespace_id, setup, false)
+        .await
+        .expect("bootstrap");
+    let mut checkpoints = Vec::new();
+    for index in 0..6 {
+        write_test_file(
+            store,
+            namespace_id,
+            &format!("/docs/{index}.txt"),
+            &format!("bounded-gc-{index}"),
+            setup,
+        )
+        .await;
+        checkpoints.push(
+            create_checkpoint(store, namespace_id, setup)
+                .await
+                .expect("checkpoint"),
+        );
+    }
+    for checkpoint in &checkpoints[..checkpoints.len() - 1] {
+        set_checkpoint_record_state(
+            store,
+            namespace_id,
+            &checkpoint.checkpoint_id,
+            CheckpointRecordLifecycle::Released,
+            &setup.writer_version,
+        )
+        .await
+        .expect("release checkpoint");
+    }
+    advance_retention_floor(store, namespace_id, setup)
+        .await
+        .expect("advance floor");
+
+    for index in 0..6 {
+        for key in [
+            wal_segment(
+                namespace_id.as_str(),
+                &format!("00000000000000000000-orphan-{index:02}"),
+            ),
+            metadata_table(namespace_id.as_str(), &format!("000-orphan-{index:02}")),
+            format!(
+                "{}000-orphan-{index:02}.manifest.json",
+                metadata_manifest_prefix(namespace_id.as_str())
+            ),
+        ] {
+            store
+                .put_if_absent(&key, Bytes::from_static(b"orphan"))
+                .await
+                .expect("write orphan");
+        }
+    }
+    write_upload_session(store, namespace_id).await;
+}
+
+fn copy_tree(source: &std::path::Path, target: &std::path::Path) {
+    std::fs::create_dir_all(target).expect("create copied store directory");
+    for entry in std::fs::read_dir(source).expect("read source store") {
+        let entry = entry.expect("read source entry");
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        if entry.file_type().expect("read source file type").is_dir() {
+            copy_tree(&source_path, &target_path);
+        } else {
+            std::fs::copy(&source_path, &target_path).expect("copy store object");
+        }
+    }
+}
+
+async fn namespace_keys(store: &LocalFsStore, namespace_id: &NamespaceId) -> BTreeSet<String> {
+    store
+        .list_prefix(&loonfs_objectstore::keys::namespace_prefix(namespace_id))
+        .await
+        .expect("list namespace")
+        .into_iter()
+        .collect()
+}
+
+fn accumulate_report(total: &mut GcReport, pass: &GcReport) {
+    total.deleted_wal_segments += pass.deleted_wal_segments;
+    total.deleted_metadata_tables += pass.deleted_metadata_tables;
+    total.deleted_manifests += pass.deleted_manifests;
+    total.deleted_checkpoint_records += pass.deleted_checkpoint_records;
+    total.released_fork_checkpoints += pass.released_fork_checkpoints;
+    total.deleted_upload_sessions += pass.deleted_upload_sessions;
+    total.released_missing_basis_checkpoints += pass.released_missing_basis_checkpoints;
+    total.retained_candidates += pass.retained_candidates;
+    total.degraded_retention |= pass.degraded_retention;
+    total.incomplete_namespace_ignored |= pass.incomplete_namespace_ignored;
+}
+
+#[tokio::test]
+async fn bounded_passes_delete_exactly_the_unbounded_pass_set() {
+    let temp_dir = tempdir().expect("tempdir");
+    let unbounded_root = temp_dir.path().join("unbounded");
+    let bounded_root = temp_dir.path().join("bounded");
+    let unbounded_store = LocalFsStore::new(&unbounded_root).expect("unbounded store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    add_bounded_gc_fixture(&unbounded_store, &namespace_id, &setup).await;
+    copy_tree(&unbounded_root, &bounded_root);
+    let bounded_store = LocalFsStore::new(&bounded_root).expect("bounded store");
+
+    let unbounded_now = now_after_newest_object(&unbounded_store, &namespace_id, REAP_MS + 1).await;
+    let unbounded_report = gc_namespace(
+        &unbounded_store,
+        &namespace_id,
+        &config(),
+        &context(unbounded_now),
+    )
+    .await
+    .expect("unbounded pass");
+
+    let bounded_now = now_after_newest_object(&bounded_store, &namespace_id, REAP_MS + 1).await;
+    let mut bounded_config = config();
+    bounded_config.max_objects = Some(3);
+    let mut bounded_report = GcReport::default();
+    let mut passes = 0;
+    loop {
+        let pass = gc_namespace(
+            &bounded_store,
+            &namespace_id,
+            &bounded_config,
+            &context(bounded_now),
+        )
+        .await
+        .expect("bounded pass");
+        passes += 1;
+        accumulate_report(&mut bounded_report, &pass);
+        let Some(cursor) = pass.next_cursor else {
+            break;
+        };
+        bounded_config.cursor = Some(cursor);
+    }
+
+    assert!(passes > 5, "fixture should require substantial resumption");
+    assert_eq!(
+        namespace_keys(&bounded_store, &namespace_id).await,
+        namespace_keys(&unbounded_store, &namespace_id).await
+    );
+    assert_eq!(
+        (
+            bounded_report.deleted_wal_segments,
+            bounded_report.deleted_metadata_tables,
+            bounded_report.deleted_manifests,
+            bounded_report.deleted_checkpoint_records,
+            bounded_report.deleted_upload_sessions,
+        ),
+        (
+            unbounded_report.deleted_wal_segments,
+            unbounded_report.deleted_metadata_tables,
+            unbounded_report.deleted_manifests,
+            unbounded_report.deleted_checkpoint_records,
+            unbounded_report.deleted_upload_sessions,
+        )
+    );
+}
+
+#[tokio::test]
+async fn budget_caps_candidate_operations_and_cursor_resumes_mid_family() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let orphan_keys: Vec<String> = (0..5)
+        .map(|index| {
+            wal_segment(
+                namespace_id.as_str(),
+                &format!("00000000000000000000-orphan-{index:02}"),
+            )
+        })
+        .collect();
+    for key in &orphan_keys {
+        inner
+            .put_if_absent(key, Bytes::from_static(b"orphan"))
+            .await
+            .expect("write orphan");
+    }
+    let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
+    let wal_prefix = wal_segment_prefix(namespace_id.as_str());
+    let store = CountingStore::new(inner, KeyPredicate::prefix(wal_prefix));
+    let mut bounded = config();
+    bounded.max_objects = Some(2);
+
+    let first = gc_namespace(&store, &namespace_id, &bounded, &aged)
+        .await
+        .expect("first bounded pass");
+    assert_eq!(first.deleted_wal_segments, 2);
+    assert!(first.next_cursor.is_some());
+    assert_eq!(store.snapshot().heads, 2);
+    assert_eq!(store.snapshot().deletes, 2);
+    for key in &orphan_keys[..2] {
+        assert!(store.head(key).await.expect("head orphan").is_none());
+    }
+    assert!(store
+        .head(&orphan_keys[2])
+        .await
+        .expect("head next orphan")
+        .is_some());
+
+    bounded.cursor = first.next_cursor;
+    store.reset();
+    let second = gc_namespace(&store, &namespace_id, &bounded, &aged)
+        .await
+        .expect("second bounded pass");
+    assert_eq!(second.deleted_wal_segments, 2);
+    assert!(second.next_cursor.is_some());
+    assert_eq!(store.snapshot().heads, 2);
+    assert_eq!(store.snapshot().deletes, 2);
+    for key in &orphan_keys[..4] {
+        assert!(store.head(key).await.expect("head orphan").is_none());
+    }
+
+    bounded.cursor = second.next_cursor;
+    loop {
+        store.reset();
+        let pass = gc_namespace(&store, &namespace_id, &bounded, &aged)
+            .await
+            .expect("remaining bounded pass");
+        assert!(store.snapshot().heads <= 2);
+        assert!(store.snapshot().deletes <= 2);
+        let Some(cursor) = pass.next_cursor else {
+            break;
+        };
+        bounded.cursor = Some(cursor);
+    }
+    for key in &orphan_keys {
+        assert!(store.head(key).await.expect("head orphan").is_none());
+    }
+}
+
+#[tokio::test]
+async fn stale_cursor_rebuilds_roots_before_resuming() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..2 {
+        let key = wal_segment(
+            namespace_id.as_str(),
+            &format!("00000000000000000000-orphan-{index:02}"),
+        );
+        store
+            .put_if_absent(&key, Bytes::from_static(b"orphan"))
+            .await
+            .expect("write orphan");
+    }
+    let first_now = now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await;
+    let mut bounded = config();
+    bounded.max_objects = Some(1);
+    let first = gc_namespace(&store, &namespace_id, &bounded, &context(first_now))
+        .await
+        .expect("first bounded pass");
+    let cursor = first.next_cursor.expect("work remains");
+
+    write_test_file(
+        &store,
+        &namespace_id,
+        "/docs/new.txt",
+        "stale-cursor-new-wal",
+        &setup,
+    )
+    .await;
+    create_checkpoint(&store, &namespace_id, &setup)
+        .await
+        .expect("new checkpoint");
+    let resume_now = now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await;
+    let resume_context = context(resume_now);
+    let live = collect_live_set(&store, &namespace_id, &config(), &resume_context)
+        .await
+        .expect("collect advanced live set");
+
+    let mut resume = config();
+    resume.cursor = Some(cursor);
+    gc_namespace(&store, &namespace_id, &resume, &resume_context)
+        .await
+        .expect("resume stale cursor");
+
+    for key in live
+        .wal_segments
+        .iter()
+        .chain(live.tables.iter())
+        .chain(live.checkpoint_keys.iter())
+    {
+        assert!(
+            store.head(key).await.expect("head live object").is_some(),
+            "live object `{key}` must survive stale-cursor resumption"
+        );
+    }
+    for manifest_object_id in live.manifests {
+        let key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
+        assert!(
+            store
+                .head(&key)
+                .await
+                .expect("head live manifest")
+                .is_some(),
+            "live manifest `{key}` must survive stale-cursor resumption"
+        );
+    }
+    stat_root(&store, &namespace_id).await;
 }

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -69,6 +69,9 @@ pub const METADATA_PUBLICATION_BUDGET_MS: u64 = 15 * 60 * 1000;
 /// plus scheduling slop around the budget checks.
 pub const GC_SAFETY_MARGIN_MS: u64 = 3 * 60 * 1000;
 
+/// Default candidate budget for one step-driven garbage-collection pass.
+pub const DEFAULT_GC_MAX_OBJECTS: u64 = 1024;
+
 const fn max_u64(left: u64, right: u64) -> u64 {
     if left > right {
         left

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -424,9 +424,9 @@ pub(super) async fn advance_retention_floor(
         path = "/v0/admin/namespaces/{namespace}/gc",
         tag = "admin",
         summary = "Collect garbage",
-        description = "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). Incomplete namespaces are ignored without listing or deletion. Nothing sweeps without this explicit call or a maintenance-step opt-in.",
+        description = "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). max_objects bounds candidate decisions and cursor resumes enumeration; every resumed invocation rebuilds safety roots. Incomplete namespaces are ignored without listing or deletion. Nothing sweeps without this explicit call or a maintenance-step opt-in.",
         params(("namespace" = String, Path, description = "Namespace id")),
-        request_body(content = GcRequest, description = "Optional window overrides"),
+        request_body(content = GcRequest, description = "Optional window, budget, and resume overrides"),
         responses(
             (status = 200, description = "Garbage collection pass completed", body = GcResponse),
             (status = 400, description = "Invalid namespace id or windows", body = ApiError),
@@ -457,7 +457,7 @@ pub(super) async fn gc_namespace(
         path = "/v0/admin/namespaces/{namespace}/maintenance/step",
         tag = "admin",
         summary = "Run maintenance step",
-        description = "Runs one bounded maintenance step: flushes the WAL tail once it reaches the threshold, and optionally runs a garbage-collection pass afterwards. Losing the root race is an outcome, not an error.",
+        description = "Runs one bounded maintenance step: flushes the WAL tail once it reaches the threshold, and optionally runs a garbage-collection pass afterwards. Step-driven GC defaults to 1024 candidates and returns its cursor for a later step rather than looping internally. Losing the root race is an outcome, not an error.",
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body(content = MaintenanceStepRequest, description = "Optional threshold and GC overrides"),
         responses(

--- a/crates/loonfs-server/tests/http_admin.rs
+++ b/crates/loonfs-server/tests/http_admin.rs
@@ -233,14 +233,33 @@ async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
             .expect("write file");
         post_checkpoint(&server_url, namespace.as_str()).expect("checkpoint");
 
+        // A bounded pass returns an opaque cursor, and the route accepts it
+        // on the next invocation without carrying any safety state.
+        let bounded: loonfs_api::GcResponse = post_admin_json_body(
+            &format!("{server_url}/v0/admin/namespaces/{namespace}/gc"),
+            "test-token",
+            serde_json::json!({ "max_objects": 1 }),
+        )
+        .expect("bounded gc pass");
+        let cursor = bounded.next_cursor.expect("more candidate families remain");
+        let resumed: loonfs_api::GcResponse = post_admin_json_body(
+            &format!("{server_url}/v0/admin/namespaces/{namespace}/gc"),
+            "test-token",
+            serde_json::json!({ "max_objects": 1, "cursor": cursor }),
+        )
+        .expect("resumed gc pass");
+        assert!(resumed.next_cursor.is_some());
+
         // A freshly written namespace sits entirely inside the grace
-        // window: the pass runs, deletes nothing, and reads keep working.
+        // window: the unbounded pass completes, deletes nothing, and reads
+        // keep working.
         let report = post_gc(&server_url, namespace.as_str()).expect("gc pass");
         assert_eq!(report.deleted_wal_segments, 0);
         assert_eq!(report.deleted_metadata_tables, 0);
         assert_eq!(report.deleted_manifests, 0);
         assert_eq!(report.deleted_checkpoint_records, 0);
         assert!(!report.degraded_retention);
+        assert!(report.next_cursor.is_none());
 
         let bytes = client.get_file_bytes(&target).expect("read file");
         assert_eq!(bytes, b"hello gc\n");

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -35,6 +35,12 @@ impl FsCore {
     ) -> Result<MaintenanceStepResult> {
         let span = tracing::Span::current();
         self.record_trace_context(&span);
+        let mut options = options;
+        if let Some(gc) = &mut options.gc {
+            if gc.max_objects.is_none() {
+                gc.max_objects = Some(loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS);
+            }
+        }
         if options.max_wal_tail_segments == 0 {
             return Err(RuntimeError::Config(
                 "max_wal_tail_segments must be greater than zero".to_owned(),
@@ -241,8 +247,9 @@ impl FsCore {
 
     /// Runs the v1 mark-and-sweep garbage collector for one namespace.
     ///
-    /// Never runs implicitly: callers opt in here or through
-    /// [`MaintenanceStepOptions::gc`].
+    /// Bounded calls return an enumeration cursor; every resume rebuilds the
+    /// current live roots. Never runs implicitly: callers opt in here or
+    /// through [`MaintenanceStepOptions::gc`].
     pub(crate) async fn gc_namespace(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -645,7 +645,7 @@ impl FsCore {
             loop {
                 if let Err(error) = claim
                     .fs
-                    .run_auto_maintenance(&claim.namespace_id, options)
+                    .run_auto_maintenance(&claim.namespace_id, options.clone())
                     .await
                 {
                     tracing::info!(

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -149,8 +149,10 @@ impl FsAdmin {
 
     /// Runs the v1 mark-and-sweep garbage collector for one namespace.
     ///
-    /// Never runs implicitly: callers opt in here or through
-    /// [`MaintenanceStepOptions::gc`].
+    /// `GcConfig::max_objects` bounds one invocation; return
+    /// `GcReport::next_cursor` as `GcConfig::cursor` to resume. Every resume
+    /// rebuilds the live roots. Never runs implicitly: callers opt in here or
+    /// through [`MaintenanceStepOptions::gc`].
     pub async fn gc_namespace(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -61,6 +61,7 @@ pub use loonfs_api::{
     PROFILE_QUERY_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::MetadataTableCacheConfig;
+pub use loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS;
 pub use loonfs_core::{
     BootstrapNamespaceError, DeleteNamespaceOptions, Error as CoreError, ErrorCode, ErrorKind,
     GcConfig, GcReport, WriterFence,

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -14,13 +14,14 @@ use loonfs_api::v0::{
 use loonfs_core::publish::WalTailPolicy;
 
 /// Options for one maintenance step.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MaintenanceStepOptions {
     /// Flush the visible WAL tail into metadata tables when it reaches this many
     /// segments.
     pub max_wal_tail_segments: u64,
-    /// Run the mark-and-sweep garbage collector after the step's
-    /// flush work. Nothing sweeps unless this is set.
+    /// Run the mark-and-sweep garbage collector after the step's flush work.
+    /// Nothing sweeps unless this is set; an absent `max_objects` inside the
+    /// config resolves to the per-step default.
     pub gc: Option<GcConfig>,
 }
 
@@ -41,7 +42,13 @@ impl MaintenanceStepOptions {
             max_wal_tail_segments: request
                 .max_wal_tail_segments
                 .unwrap_or(defaults.max_wal_tail_segments),
-            gc: request.gc.map(gc_config_from_request),
+            gc: request.gc.map(|request| {
+                let mut config = gc_config_from_request(request);
+                if config.max_objects.is_none() {
+                    config.max_objects = Some(loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS);
+                }
+                config
+            }),
         }
     }
 }
@@ -52,6 +59,8 @@ pub fn gc_config_from_request(request: GcRequest) -> GcConfig {
     GcConfig {
         grace_window_ms: request.grace_window_ms.unwrap_or(defaults.grace_window_ms),
         reap_window_ms: request.reap_window_ms.unwrap_or(defaults.reap_window_ms),
+        max_objects: request.max_objects,
+        cursor: request.cursor,
     }
 }
 
@@ -69,6 +78,7 @@ pub fn gc_response_from_report(namespace_id: NamespaceId, report: GcReport) -> G
         retained_candidates: report.retained_candidates,
         degraded_retention: report.degraded_retention,
         incomplete_namespace_ignored: report.incomplete_namespace_ignored,
+        next_cursor: report.next_cursor,
     }
 }
 
@@ -258,4 +268,40 @@ pub struct UndeleteOptions {
 pub struct ListChangesOptions {
     /// Page limit; `None` resolves the default pagination policy.
     pub limit: Option<EffectiveLimit>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_gc_stays_unbounded_while_step_gc_gets_the_default_budget() {
+        let explicit = gc_config_from_request(GcRequest::default());
+        assert_eq!(explicit.max_objects, None);
+        assert_eq!(explicit.cursor, None);
+
+        let step = MaintenanceStepOptions::from_request(MaintenanceStepRequest {
+            max_wal_tail_segments: None,
+            gc: Some(GcRequest::default()),
+        });
+        assert_eq!(
+            step.gc.expect("GC opted in").max_objects,
+            Some(loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS)
+        );
+    }
+
+    #[test]
+    fn step_gc_preserves_explicit_budget_and_cursor() {
+        let step = MaintenanceStepOptions::from_request(MaintenanceStepRequest {
+            max_wal_tail_segments: None,
+            gc: Some(GcRequest {
+                max_objects: Some(7),
+                cursor: Some("opaque".to_owned()),
+                ..GcRequest::default()
+            }),
+        });
+        let gc = step.gc.expect("GC opted in");
+        assert_eq!(gc.max_objects, Some(7));
+        assert_eq!(gc.cursor.as_deref(), Some("opaque"));
+    }
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -429,8 +429,8 @@ A representative v0 binding is shown below.
 | Release a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoints/{checkpoint_id}/release` (idempotent; fork-owned records are rejected) |
 | Flush the WAL tail | `POST /v0/admin/namespaces/{ns}/wal/flush` (folds the visible WAL tail into metadata tables and advances the metadata root; creates no checkpoint record) |
 | Advance the retention floor | `POST /v0/admin/namespaces/{ns}/retention/advance` |
-| Run a maintenance step | `POST /v0/admin/namespaces/{ns}/maintenance/step` (optional body overrides `max_wal_tail_segments` and opts into `gc`; an override above the write-rejection threshold is rejected as `invalid_request`; flush races surface as outcomes, not errors) |
-| Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`; a grace window below the derived safety floor is rejected as `invalid_request`; nothing sweeps without an explicit call) |
+| Run a maintenance step | `POST /v0/admin/namespaces/{ns}/maintenance/step` (optional body overrides `max_wal_tail_segments` and opts into `gc`; step-driven GC defaults `max_objects` to 1024 and returns any `next_cursor` for a later step rather than looping internally; an override above the write-rejection threshold is rejected as `invalid_request`; flush races surface as outcomes, not errors) |
+| Collect garbage | `POST /v0/admin/namespaces/{ns}/gc` (optional body overrides `grace_window_ms`/`reap_window_ms`, bounds one invocation with `max_objects`, and resumes with `cursor`; a grace window below the derived safety floor or a zero budget is rejected as `invalid_request`; absent `max_objects` preserves run-to-completion behavior; nothing sweeps without an explicit call) |
 | Repair an incomplete namespace | `POST /v0/admin/namespaces/{ns}/repair` (no body or options; reports `already_complete`, `completed`, `reaped`, or `in_flight`; an absent namespace reports `namespace_not_found`) |
 | Content search | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires a materialized steady-state grep root) |
 | Enable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/enable` (CAS-publishes the independent grep root into checkpointed backfill; embedded mode starts that namespace's event-driven driver; idempotent) |
@@ -440,6 +440,16 @@ A representative v0 binding is shown below.
 Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to
 `core/v0`.
+
+GC responses carry `next_cursor` only when more candidate enumeration remains.
+The token is opaque, tolerant of additive fields when decoded, and valid only
+against the namespace that issued it. It encodes the last examined key and
+object family, not a live set or retention proof: every resumed invocation
+reloads the current roots, WAL floor, and checkpoint protections before any
+deletion. If the namespace advances or keys disappear between calls, a stale
+cursor may re-examine work or defer a newly inserted key that sorts before its
+position until the next full pass; it can never make a newly live object
+deletable.
 
 Namespace repair is deterministic and takes no request body. Its response is
 `{"namespace_id":"...","outcome":"..."}`: `already_complete` is a no-op,

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -242,7 +242,7 @@
           "admin"
         ],
         "summary": "Collect garbage",
-        "description": "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). Incomplete namespaces are ignored without listing or deletion. Nothing sweeps without this explicit call or a maintenance-step opt-in.",
+        "description": "Runs one mark-and-sweep garbage-collection pass under the format's safety rules (grace window, delete-time re-verification, retention wins). max_objects bounds candidate decisions and cursor resumes enumeration; every resumed invocation rebuilds safety roots. Incomplete namespaces are ignored without listing or deletion. Nothing sweeps without this explicit call or a maintenance-step opt-in.",
         "operationId": "gc_namespace",
         "parameters": [
           {
@@ -256,7 +256,7 @@
           }
         ],
         "requestBody": {
-          "description": "Optional window overrides",
+          "description": "Optional window, budget, and resume overrides",
           "content": {
             "application/json": {
               "schema": {
@@ -575,7 +575,7 @@
           "admin"
         ],
         "summary": "Run maintenance step",
-        "description": "Runs one bounded maintenance step: flushes the WAL tail once it reaches the threshold, and optionally runs a garbage-collection pass afterwards. Losing the root race is an outcome, not an error.",
+        "description": "Runs one bounded maintenance step: flushes the WAL tail once it reaches the threshold, and optionally runs a garbage-collection pass afterwards. Step-driven GC defaults to 1024 candidates and returns its cursor for a later step rather than looping internally. Losing the root race is an outcome, not an error.",
         "operationId": "maintenance_step",
         "parameters": [
           {
@@ -4517,6 +4517,13 @@
         "type": "object",
         "description": "Optional overrides for one garbage-collection pass. Absent fields use\nthe server's conservative defaults.",
         "properties": {
+          "cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque resume token returned as `next_cursor` by an earlier pass\nagainst the same namespace."
+          },
           "grace_window_ms": {
             "type": [
               "integer",
@@ -4524,6 +4531,15 @@
             ],
             "format": "int64",
             "description": "Objects younger than this are never deleted, reachable or not. The\nwindow has a derived safety floor (publication budgets plus provider\ndeadlines); a smaller value is rejected as `invalid_request`.",
+            "minimum": 0
+          },
+          "max_objects": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Maximum candidates examined by this invocation. Omit to retain the\nrun-to-completion behavior.",
             "minimum": 0
           },
           "reap_window_ms": {
@@ -4593,6 +4609,13 @@
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Namespace the pass ran against."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque resume token when more candidates remain. Resuming rebuilds\nevery safety proof; the token carries enumeration position only and\nis valid only against the same namespace."
           },
           "released_fork_checkpoints": {
             "type": "integer",


### PR DESCRIPTION
Core GC loaded complete listings for every object family before deleting anything and processed all candidates in one invocation - work and memory proportional to namespace age. GC is now bounded and resumable with no new durable state: the request takes an optional max_objects budget, the report returns an opaque namespace-bound cursor, and the caller loops. Every invocation rebuilds its safety basis from current roots, floors, and checkpoint protections, so a stale cursor can only re-examine or defer work, never authorize deleting newly live data - a test advances the namespace between passes and proves the fresh live set survives. Candidate enumeration streams instead of collecting; the one deliberate exception is checkpoint-root discovery, which must stream the complete root index to prove absence but no longer holds it in memory. An equivalence test pins that bounded passes looped to completion delete exactly what one unbounded pass deletes, and the budget test pins exact per-pass operation counts. The CLI keeps its run-to-completion feel by looping 1024-candidate passes and gains --max-objects for a single bounded pass; tick-driven GC does one budgeted pass per tick. Additive wire fields only; goldens byte-identical.
