### PR TITLE
fix(gc): retain namespaces whose head fails decoding

### DIFF
--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -6,15 +6,24 @@ use crate::checkpoint::record::encode_checkpoint_record;
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
+use crate::namespace::control::{map_control_codec_error, ControlObjectLoadError};
 use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointRecordLifecycle, CheckpointRecordState,
     ControlObjectKind, HeadState, HeadStateEnvelope, NamespaceState,
 };
-use loonfs_api::{ManifestObjectId, NamespaceId};
+use loonfs_api::{GeneratedIdValidationError, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{namespace_config, namespace_prefix, wal_head};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+
+// Decode failure may only ever bias toward retaining bytes, never toward
+// deleting or fabricating them.
+enum HeadObservation {
+    Missing,
+    Valid(HeadState),
+    Unreadable(ControlObjectLoadError),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AbandonedBootstrapReap {
@@ -122,11 +131,22 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
         .get_with_metadata(&head_key)
         .await
         .map_err(|error| CoreError::store(&head_key, &error))?;
-    let decoded_head = head_body.as_ref().and_then(|body| {
-        decode_control_object::<HeadState>(&body.bytes, ControlObjectKind::WalHead)
-            .ok()
-            .map(|envelope| envelope.state)
-    });
+    let observed_head = match &head_body {
+        None => HeadObservation::Missing,
+        Some(body) => {
+            match decode_control_object::<HeadState>(&body.bytes, ControlObjectKind::WalHead) {
+                Ok(envelope) => HeadObservation::Valid(envelope.state),
+                Err(error) => {
+                    HeadObservation::Unreadable(map_control_codec_error(&head_key, error))
+                }
+            }
+        }
+    };
+    let decoded_head = match observed_head {
+        HeadObservation::Missing => None,
+        HeadObservation::Valid(state) => Some(state),
+        HeadObservation::Unreadable(error) => return Err(CoreError::load_head(error)),
+    };
     if let Some(head) = &decoded_head {
         if head.namespace_id != *namespace_id {
             return Ok(AbandonedBootstrapReap::InFlight);
@@ -171,9 +191,10 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
             }
         }
 
-        let mut condemned_head = decoded_head
-            .clone()
-            .unwrap_or_else(|| HeadState::initial(namespace_id.clone()));
+        let mut condemned_head = match decoded_head.clone() {
+            Some(head) => head,
+            None => HeadState::initial(namespace_id.clone()),
+        };
         condemned_head.state = NamespaceState::Condemned;
         let envelope = HeadStateEnvelope::from_state(
             ControlObjectKind::WalHead,
@@ -285,8 +306,10 @@ pub(super) async fn delete_if_aged<S: ObjectStore + ?Sized>(
     Ok(true)
 }
 
-pub(super) fn manifest_object_id_of(key: &str) -> Option<ManifestObjectId> {
+pub(super) fn manifest_object_id_of(
+    key: &str,
+) -> Option<std::result::Result<ManifestObjectId, GeneratedIdValidationError>> {
     let name = key.rsplit('/').next()?;
     let object_id = name.strip_suffix(".manifest.json")?;
-    ManifestObjectId::parse(object_id).ok()
+    Some(ManifestObjectId::parse(object_id))
 }

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -148,9 +148,10 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     let selected = match family {
         CandidateFamily::WalSegments => !mark.wal_segments.contains(key),
         CandidateFamily::MetadataTables => !mark.tables.contains(key),
-        CandidateFamily::Manifests => {
-            manifest_object_id_of(key).is_none_or(|id| !mark.manifests.contains(&id))
-        }
+        CandidateFamily::Manifests => match manifest_object_id_of(key) {
+            Some(Ok(id)) => !mark.manifests.contains(&id),
+            None | Some(Err(_)) => false,
+        },
         CandidateFamily::Checkpoints => !mark.checkpoint_keys.contains(key),
         CandidateFamily::UploadSessions => false,
     };
@@ -178,9 +179,11 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
             }
         }
         CandidateFamily::Manifests => {
-            let live =
-                manifest_object_id_of(key).is_some_and(|id| sweep.live.manifests.contains(&id));
-            if sweep.degraded || live {
+            let live_or_unrecognized = match manifest_object_id_of(key) {
+                Some(Ok(id)) => sweep.live.manifests.contains(&id),
+                None | Some(Err(_)) => true,
+            };
+            if sweep.degraded || live_or_unrecognized {
                 report.retained_candidates += 1;
             } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
                 report.deleted_manifests += 1;

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -848,6 +848,52 @@ async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
     stat_root(&store, &namespace_id).await;
 }
 
+/// Objects whose keys do not name a valid manifest are not proven GC
+/// candidates, so the pass retains their exact bytes.
+#[tokio::test]
+async fn gc_retains_unrecognized_manifest_keys() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+
+    let manifest_prefix = metadata_manifest_prefix(namespace_id.as_str());
+    let foreign_objects = [
+        (
+            format!("{manifest_prefix}notes.txt"),
+            b"foreign key".as_slice(),
+        ),
+        (
+            format!("{manifest_prefix}invalid.manifest.json"),
+            b"invalid manifest id".as_slice(),
+        ),
+    ];
+    for (key, bytes) in &foreign_objects {
+        store
+            .put_if_absent(key, Bytes::copy_from_slice(bytes))
+            .await
+            .expect("write foreign manifest-prefix object");
+    }
+
+    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect("gc pass");
+
+    assert_eq!(report.deleted_manifests, 0);
+    for (key, expected) in foreign_objects {
+        let actual = store
+            .get(&key, None)
+            .await
+            .expect("get foreign manifest-prefix object")
+            .expect("unrecognized object is retained");
+        assert_eq!(actual.as_ref(), expected);
+    }
+}
+
 /// Repeated WAL flushes leave superseded manifests unpinned, so GC
 /// reclaims them once aged. This is what keeps retained metadata
 /// bounded when maintenance runs continuously.

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -388,6 +388,7 @@ mod tests {
     use loonfs_test_support::stores::{
         BlockingStore, KeyPredicate, OperationClass, OperationContext, OperationKind,
     };
+    use std::collections::BTreeMap;
     use std::sync::Arc;
     use tempfile::tempdir;
 
@@ -481,6 +482,100 @@ mod tests {
             .expect("list namespace")
     }
 
+    async fn namespace_objects(
+        store: &LocalFsStore,
+        namespace_id: &NamespaceId,
+    ) -> BTreeMap<String, Vec<u8>> {
+        let mut objects = BTreeMap::new();
+        for key in namespace_keys(store, namespace_id).await {
+            let bytes = store
+                .get(&key, None)
+                .await
+                .expect("get namespace object")
+                .expect("listed namespace object exists");
+            objects.insert(key, bytes.to_vec());
+        }
+        objects
+    }
+
+    fn flip_head_checksum(bytes: &[u8]) -> Vec<u8> {
+        let mut document: serde_json::Value =
+            serde_json::from_slice(bytes).expect("decode head json");
+        let checksum = document["payload_checksum"]
+            .as_str()
+            .expect("head checksum")
+            .to_owned();
+        let replacement = if checksum.as_bytes()[7] == b'0' {
+            "1"
+        } else {
+            "0"
+        };
+        let mut corrupted = checksum;
+        corrupted.replace_range(7..8, replacement);
+        document["payload_checksum"] = serde_json::Value::String(corrupted);
+        serde_json::to_vec(&document).expect("encode corrupt head")
+    }
+
+    fn replace_head_marker(bytes: &[u8], marker: &str, value: serde_json::Value) -> Vec<u8> {
+        let mut document: serde_json::Value =
+            serde_json::from_slice(bytes).expect("decode head json");
+        document[marker] = value;
+        serde_json::to_vec(&document).expect("encode head with foreign marker")
+    }
+
+    async fn assert_repair_retains_unreadable_head(
+        namespace: &str,
+        damage: impl FnOnce(&[u8]) -> Vec<u8>,
+    ) {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse(namespace).expect("namespace id");
+        bootstrap_namespace(&store, &namespace_id, &context(1_000), false)
+            .await
+            .expect("bootstrap");
+        store
+            .delete(&namespace_config(namespace_id.as_str()))
+            .await
+            .expect("simulate crash before the completion marker");
+
+        let head_key = wal_head(namespace_id.as_str());
+        let head = store
+            .get(&head_key, None)
+            .await
+            .expect("get head")
+            .expect("head exists");
+        store
+            .put_overwrite(&head_key, Bytes::from(damage(&head)))
+            .await
+            .expect("damage head");
+        let before = namespace_objects(&store, &namespace_id).await;
+        let aged = context(
+            now_after_newest_object(&store, &namespace_id, GC_MIN_GRACE_WINDOW_MS + 1).await,
+        );
+
+        let error = repair_namespace(&store, &namespace_id, &aged)
+            .await
+            .expect_err("unreadable head is corruption");
+        assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+        let error_key = match &error {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(
+                ControlObjectLoadError::ChecksumMismatch { object_key, .. }
+                | ControlObjectLoadError::Codec { object_key, .. },
+            )) => Some(object_key.as_str()),
+            _ => None,
+        };
+        assert_eq!(
+            error_key,
+            Some(head_key.as_str()),
+            "repair must return typed head corruption"
+        );
+        assert_eq!(
+            namespace_objects(&store, &namespace_id).await,
+            before,
+            "repair must preserve every namespace byte"
+        );
+    }
+
     async fn commit_directory(store: &LocalFsStore, namespace_id: &NamespaceId, name: &str) {
         let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
         engine
@@ -504,6 +599,36 @@ mod tests {
             .pop()
             .expect("one commit result")
             .expect("commit lands");
+    }
+
+    #[tokio::test]
+    async fn repair_reports_corrupt_head_and_preserves_every_namespace_byte() {
+        assert_repair_retains_unreadable_head("checksumcase", flip_head_checksum).await;
+        assert_repair_retains_unreadable_head("truncatedcase", |bytes| {
+            bytes[..bytes.len() / 2].to_vec()
+        })
+        .await;
+        assert_repair_retains_unreadable_head("junkcase", |_| b"not json".to_vec()).await;
+    }
+
+    #[tokio::test]
+    async fn repair_reports_foreign_head_markers_and_preserves_every_namespace_byte() {
+        assert_repair_retains_unreadable_head("kindcase", |bytes| {
+            replace_head_marker(
+                bytes,
+                "kind",
+                serde_json::Value::String("metadata_root".to_owned()),
+            )
+        })
+        .await;
+        assert_repair_retains_unreadable_head("versioncase", |bytes| {
+            replace_head_marker(
+                bytes,
+                "format_version",
+                serde_json::Value::Number(37_u64.into()),
+            )
+        })
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
The abandoned-bootstrap reaper collapsed any head-decode failure into "no head" — `decode(..).ok()` followed by `unwrap_or_else(HeadState::initial)` — so a damaged checksum, truncated read, or foreign bytes at the head key sent an explicit repair command down the condemn-and-delete path against a namespace that might be fully recoverable. Repair code must demand more proof before destroying than serving code does; this was demanding less. The same file already handled checkpoint records correctly (decode failure retains), which made the head path's collapse an outlier rather than a design.

The head observation is now an explicit tri-state: Missing may fabricate the condemned gate and reap aged debris, Valid proceeds only under the existing abandoned-bootstrap conditions, and Unreadable stops explicit repair with the existing `namespace_corrupt` error carrying the head's object key — no bytes change. A whole-file audit of decode collapses under the rule "decode failure may only bias toward retaining bytes, never deleting or fabricating them" found one more: an unparseable manifest object key could previously become a deletion candidate and now retains. Tests cover corrupt bytes (flipped checksum, truncation, junk), foreign kind and version markers, and the unchanged missing/valid-incomplete reap behavior — each corruption case asserts the complete namespace key-to-bytes map is byte-identical before and after repair. Net +26 production lines.
