### PR TITLE
fix(runtime): queue maintenance past the concurrency cap

### DIFF
--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -6,15 +6,24 @@ use crate::checkpoint::record::encode_checkpoint_record;
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
+use crate::namespace::control::{map_control_codec_error, ControlObjectLoadError};
 use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointRecordLifecycle, CheckpointRecordState,
     ControlObjectKind, HeadState, HeadStateEnvelope, NamespaceState,
 };
-use loonfs_api::{ManifestObjectId, NamespaceId};
+use loonfs_api::{GeneratedIdValidationError, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{namespace_config, namespace_prefix, wal_head};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+
+// Decode failure may only ever bias toward retaining bytes, never toward
+// deleting or fabricating them.
+enum HeadObservation {
+    Missing,
+    Valid(HeadState),
+    Unreadable(ControlObjectLoadError),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AbandonedBootstrapReap {
@@ -122,11 +131,22 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
         .get_with_metadata(&head_key)
         .await
         .map_err(|error| CoreError::store(&head_key, &error))?;
-    let decoded_head = head_body.as_ref().and_then(|body| {
-        decode_control_object::<HeadState>(&body.bytes, ControlObjectKind::WalHead)
-            .ok()
-            .map(|envelope| envelope.state)
-    });
+    let observed_head = match &head_body {
+        None => HeadObservation::Missing,
+        Some(body) => {
+            match decode_control_object::<HeadState>(&body.bytes, ControlObjectKind::WalHead) {
+                Ok(envelope) => HeadObservation::Valid(envelope.state),
+                Err(error) => {
+                    HeadObservation::Unreadable(map_control_codec_error(&head_key, error))
+                }
+            }
+        }
+    };
+    let decoded_head = match observed_head {
+        HeadObservation::Missing => None,
+        HeadObservation::Valid(state) => Some(state),
+        HeadObservation::Unreadable(error) => return Err(CoreError::load_head(error)),
+    };
     if let Some(head) = &decoded_head {
         if head.namespace_id != *namespace_id {
             return Ok(AbandonedBootstrapReap::InFlight);
@@ -171,9 +191,10 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
             }
         }
 
-        let mut condemned_head = decoded_head
-            .clone()
-            .unwrap_or_else(|| HeadState::initial(namespace_id.clone()));
+        let mut condemned_head = match decoded_head.clone() {
+            Some(head) => head,
+            None => HeadState::initial(namespace_id.clone()),
+        };
         condemned_head.state = NamespaceState::Condemned;
         let envelope = HeadStateEnvelope::from_state(
             ControlObjectKind::WalHead,
@@ -285,8 +306,10 @@ pub(super) async fn delete_if_aged<S: ObjectStore + ?Sized>(
     Ok(true)
 }
 
-pub(super) fn manifest_object_id_of(key: &str) -> Option<ManifestObjectId> {
+pub(super) fn manifest_object_id_of(
+    key: &str,
+) -> Option<std::result::Result<ManifestObjectId, GeneratedIdValidationError>> {
     let name = key.rsplit('/').next()?;
     let object_id = name.strip_suffix(".manifest.json")?;
-    ManifestObjectId::parse(object_id).ok()
+    Some(ManifestObjectId::parse(object_id))
 }

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -148,9 +148,10 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     let selected = match family {
         CandidateFamily::WalSegments => !mark.wal_segments.contains(key),
         CandidateFamily::MetadataTables => !mark.tables.contains(key),
-        CandidateFamily::Manifests => {
-            manifest_object_id_of(key).is_none_or(|id| !mark.manifests.contains(&id))
-        }
+        CandidateFamily::Manifests => match manifest_object_id_of(key) {
+            Some(Ok(id)) => !mark.manifests.contains(&id),
+            None | Some(Err(_)) => false,
+        },
         CandidateFamily::Checkpoints => !mark.checkpoint_keys.contains(key),
         CandidateFamily::UploadSessions => false,
     };
@@ -178,9 +179,11 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
             }
         }
         CandidateFamily::Manifests => {
-            let live =
-                manifest_object_id_of(key).is_some_and(|id| sweep.live.manifests.contains(&id));
-            if sweep.degraded || live {
+            let live_or_unrecognized = match manifest_object_id_of(key) {
+                Some(Ok(id)) => sweep.live.manifests.contains(&id),
+                None | Some(Err(_)) => true,
+            };
+            if sweep.degraded || live_or_unrecognized {
                 report.retained_candidates += 1;
             } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
                 report.deleted_manifests += 1;

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -848,6 +848,52 @@ async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
     stat_root(&store, &namespace_id).await;
 }
 
+/// Objects whose keys do not name a valid manifest are not proven GC
+/// candidates, so the pass retains their exact bytes.
+#[tokio::test]
+async fn gc_retains_unrecognized_manifest_keys() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+
+    let manifest_prefix = metadata_manifest_prefix(namespace_id.as_str());
+    let foreign_objects = [
+        (
+            format!("{manifest_prefix}notes.txt"),
+            b"foreign key".as_slice(),
+        ),
+        (
+            format!("{manifest_prefix}invalid.manifest.json"),
+            b"invalid manifest id".as_slice(),
+        ),
+    ];
+    for (key, bytes) in &foreign_objects {
+        store
+            .put_if_absent(key, Bytes::copy_from_slice(bytes))
+            .await
+            .expect("write foreign manifest-prefix object");
+    }
+
+    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect("gc pass");
+
+    assert_eq!(report.deleted_manifests, 0);
+    for (key, expected) in foreign_objects {
+        let actual = store
+            .get(&key, None)
+            .await
+            .expect("get foreign manifest-prefix object")
+            .expect("unrecognized object is retained");
+        assert_eq!(actual.as_ref(), expected);
+    }
+}
+
 /// Repeated WAL flushes leave superseded manifests unpinned, so GC
 /// reclaims them once aged. This is what keeps retained metadata
 /// bounded when maintenance runs continuously.

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -388,6 +388,7 @@ mod tests {
     use loonfs_test_support::stores::{
         BlockingStore, KeyPredicate, OperationClass, OperationContext, OperationKind,
     };
+    use std::collections::BTreeMap;
     use std::sync::Arc;
     use tempfile::tempdir;
 
@@ -481,6 +482,100 @@ mod tests {
             .expect("list namespace")
     }
 
+    async fn namespace_objects(
+        store: &LocalFsStore,
+        namespace_id: &NamespaceId,
+    ) -> BTreeMap<String, Vec<u8>> {
+        let mut objects = BTreeMap::new();
+        for key in namespace_keys(store, namespace_id).await {
+            let bytes = store
+                .get(&key, None)
+                .await
+                .expect("get namespace object")
+                .expect("listed namespace object exists");
+            objects.insert(key, bytes.to_vec());
+        }
+        objects
+    }
+
+    fn flip_head_checksum(bytes: &[u8]) -> Vec<u8> {
+        let mut document: serde_json::Value =
+            serde_json::from_slice(bytes).expect("decode head json");
+        let checksum = document["payload_checksum"]
+            .as_str()
+            .expect("head checksum")
+            .to_owned();
+        let replacement = if checksum.as_bytes()[7] == b'0' {
+            "1"
+        } else {
+            "0"
+        };
+        let mut corrupted = checksum;
+        corrupted.replace_range(7..8, replacement);
+        document["payload_checksum"] = serde_json::Value::String(corrupted);
+        serde_json::to_vec(&document).expect("encode corrupt head")
+    }
+
+    fn replace_head_marker(bytes: &[u8], marker: &str, value: serde_json::Value) -> Vec<u8> {
+        let mut document: serde_json::Value =
+            serde_json::from_slice(bytes).expect("decode head json");
+        document[marker] = value;
+        serde_json::to_vec(&document).expect("encode head with foreign marker")
+    }
+
+    async fn assert_repair_retains_unreadable_head(
+        namespace: &str,
+        damage: impl FnOnce(&[u8]) -> Vec<u8>,
+    ) {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse(namespace).expect("namespace id");
+        bootstrap_namespace(&store, &namespace_id, &context(1_000), false)
+            .await
+            .expect("bootstrap");
+        store
+            .delete(&namespace_config(namespace_id.as_str()))
+            .await
+            .expect("simulate crash before the completion marker");
+
+        let head_key = wal_head(namespace_id.as_str());
+        let head = store
+            .get(&head_key, None)
+            .await
+            .expect("get head")
+            .expect("head exists");
+        store
+            .put_overwrite(&head_key, Bytes::from(damage(&head)))
+            .await
+            .expect("damage head");
+        let before = namespace_objects(&store, &namespace_id).await;
+        let aged = context(
+            now_after_newest_object(&store, &namespace_id, GC_MIN_GRACE_WINDOW_MS + 1).await,
+        );
+
+        let error = repair_namespace(&store, &namespace_id, &aged)
+            .await
+            .expect_err("unreadable head is corruption");
+        assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+        let error_key = match &error {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(
+                ControlObjectLoadError::ChecksumMismatch { object_key, .. }
+                | ControlObjectLoadError::Codec { object_key, .. },
+            )) => Some(object_key.as_str()),
+            _ => None,
+        };
+        assert_eq!(
+            error_key,
+            Some(head_key.as_str()),
+            "repair must return typed head corruption"
+        );
+        assert_eq!(
+            namespace_objects(&store, &namespace_id).await,
+            before,
+            "repair must preserve every namespace byte"
+        );
+    }
+
     async fn commit_directory(store: &LocalFsStore, namespace_id: &NamespaceId, name: &str) {
         let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
         engine
@@ -504,6 +599,36 @@ mod tests {
             .pop()
             .expect("one commit result")
             .expect("commit lands");
+    }
+
+    #[tokio::test]
+    async fn repair_reports_corrupt_head_and_preserves_every_namespace_byte() {
+        assert_repair_retains_unreadable_head("checksumcase", flip_head_checksum).await;
+        assert_repair_retains_unreadable_head("truncatedcase", |bytes| {
+            bytes[..bytes.len() / 2].to_vec()
+        })
+        .await;
+        assert_repair_retains_unreadable_head("junkcase", |_| b"not json".to_vec()).await;
+    }
+
+    #[tokio::test]
+    async fn repair_reports_foreign_head_markers_and_preserves_every_namespace_byte() {
+        assert_repair_retains_unreadable_head("kindcase", |bytes| {
+            replace_head_marker(
+                bytes,
+                "kind",
+                serde_json::Value::String("metadata_root".to_owned()),
+            )
+        })
+        .await;
+        assert_repair_retains_unreadable_head("versioncase", |bytes| {
+            replace_head_marker(
+                bytes,
+                "format_version",
+                serde_json::Value::Number(37_u64.into()),
+            )
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/crates/loonfs/src/background.rs
+++ b/crates/loonfs/src/background.rs
@@ -52,10 +52,10 @@ pub(crate) struct BackgroundWork {
 struct BackgroundState {
     closed: bool,
     inflight: BTreeSet<NamespaceId>,
-    /// Namespaces whose over-threshold publish arrived while their step was
-    /// already running. The running step consumes this through
-    /// [`BackgroundWork::finish_or_rerun`] and runs again, so the last write
-    /// before an idle period cannot leave the tail unbounded.
+    /// Distinct dirty namespaces whose step request arrived while their own
+    /// step was running or while the global concurrency cap was full. The
+    /// set coalesces repeated requests and is bounded by the number of
+    /// distinct dirty namespaces.
     pending: BTreeSet<NamespaceId>,
     tasks: Vec<JoinHandle<()>>,
 }
@@ -110,14 +110,15 @@ impl BackgroundWork {
             return false;
         }
         if state.inflight.len() >= self.max_concurrent.get() {
+            state.pending.insert(namespace_id.clone());
             tracing::debug!(
                 namespace_id = %namespace_id,
                 max_concurrent = self.max_concurrent.get(),
-                "maintenance step skipped at the concurrency cap; \
-                 the next over-threshold publish reschedules it"
+                "maintenance step deferred at the concurrency cap"
             );
             return false;
         }
+        state.pending.remove(namespace_id);
         state.inflight.insert(namespace_id.clone())
     }
 
@@ -127,25 +128,39 @@ impl BackgroundWork {
         state.inflight.remove(namespace_id);
     }
 
-    /// Ends one step run for the namespace. When another over-threshold
-    /// publish deferred a request during the run, that request is consumed,
-    /// the singleflight slot stays held, and the caller must run again; only
-    /// a quiet finish releases the slot. Checking and releasing under the
-    /// one state lock closes the window where a request could land between
-    /// a final pending check and the release.
-    pub(crate) fn finish_or_rerun(&self, namespace_id: &NamespaceId) -> bool {
+    /// Ends one step run and returns the namespace the caller must run next.
+    ///
+    /// The finishing namespace's own deferred request wins first and keeps
+    /// its slot. Otherwise the slot transfers to the first pending namespace
+    /// that is not already running. The pending check, release, dequeue, and
+    /// new claim share the one state lock, so no request can be lost between
+    /// freeing the slot and choosing its successor.
+    pub(crate) fn finish_or_rerun(&self, namespace_id: &NamespaceId) -> Option<NamespaceId> {
         let mut state = self.lock_state();
         if !state.closed && state.pending.remove(namespace_id) {
-            return true;
+            return Some(namespace_id.clone());
         }
         state.pending.remove(namespace_id);
         state.inflight.remove(namespace_id);
-        false
+        if state.closed {
+            return None;
+        }
+        let next_namespace_id = state
+            .pending
+            .iter()
+            .find(|candidate| !state.inflight.contains(*candidate))
+            .cloned()?;
+        state.pending.remove(&next_namespace_id);
+        state.inflight.insert(next_namespace_id.clone());
+        Some(next_namespace_id)
     }
 
-    /// Rejects any further background scheduling.
+    /// Rejects further scheduling and discards work still waiting for a
+    /// concurrency slot. Already registered tasks remain visible to drain.
     pub(crate) fn shut_down(&self) {
-        self.lock_state().closed = true;
+        let mut state = self.lock_state();
+        state.closed = true;
+        state.pending.clear();
     }
 
     /// Spawns claimed work on the owning runtime and registers it for
@@ -176,7 +191,8 @@ impl BackgroundWork {
 
     /// Waits for every scheduled task to finish, surfacing panics. Loops
     /// because an in-flight write may schedule more work while an open
-    /// handle waits.
+    /// handle waits, and because a finishing task registers the next queued
+    /// namespace before it exits.
     pub(crate) async fn drain(&self) -> Result<()> {
         let mut panicked = 0usize;
         loop {
@@ -236,12 +252,13 @@ mod tests {
             !background.try_claim(&namespace_id),
             "a request during the active step defers instead of claiming"
         );
-        assert!(
+        assert_eq!(
             background.finish_or_rerun(&namespace_id),
+            Some(namespace_id.clone()),
             "the deferred request keeps the slot held and reruns the step"
         );
         assert!(
-            !background.finish_or_rerun(&namespace_id),
+            background.finish_or_rerun(&namespace_id).is_none(),
             "a quiet finish releases the slot"
         );
         assert!(
@@ -260,7 +277,7 @@ mod tests {
         assert!(!background.try_claim(&namespace_id), "defers while active");
         background.shut_down();
         assert!(
-            !background.finish_or_rerun(&namespace_id),
+            background.finish_or_rerun(&namespace_id).is_none(),
             "a deferred request must not rerun after shutdown closed admission"
         );
     }
@@ -360,7 +377,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn claims_stop_at_the_global_concurrency_cap() {
+    async fn a_freed_slot_claims_the_next_namespace_at_the_global_cap() {
         let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(2));
         let first = NamespaceId::parse("first").expect("valid namespace id");
         let second = NamespaceId::parse("second").expect("valid namespace id");
@@ -373,10 +390,52 @@ mod tests {
             "a third namespace must wait for a slot"
         );
 
-        background.release(&first);
+        assert_eq!(
+            background.finish_or_rerun(&first),
+            Some(third.clone()),
+            "the finishing path transfers its slot to the queued namespace"
+        );
+        background.release(&second);
+        background.release(&third);
+    }
+
+    #[test]
+    fn repeated_requests_for_one_queued_namespace_coalesce_to_one_run() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(1));
+        let active = namespace_id("active");
+        let queued = namespace_id("queued");
+
+        assert!(background.try_claim(&active));
+        for _ in 0..8 {
+            assert!(
+                !background.try_claim(&queued),
+                "the queued namespace cannot claim the occupied slot"
+            );
+        }
+        assert_eq!(
+            background.finish_or_rerun(&active),
+            Some(queued.clone()),
+            "one queued run consumes all coalesced requests"
+        );
         assert!(
-            background.try_claim(&third),
-            "a released slot admits the waiting namespace"
+            background.finish_or_rerun(&queued).is_none(),
+            "coalesced requests must not create a second run"
+        );
+    }
+
+    #[test]
+    fn shutdown_clears_namespaces_waiting_at_the_global_cap() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(1));
+        let active = namespace_id("active");
+        let queued = namespace_id("queued");
+
+        assert!(background.try_claim(&active));
+        assert!(!background.try_claim(&queued));
+        background.shut_down();
+        assert!(background.finish_or_rerun(&active).is_none());
+        assert!(
+            !background.try_claim(&queued),
+            "closed admission must not revive the cleared queue"
         );
     }
 }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -641,34 +641,52 @@ impl FsCore {
             fs: self.clone(),
             namespace_id: namespace_id.clone(),
         };
-        self.inner.background.spawn(async move {
-            loop {
-                if let Err(error) = claim
-                    .fs
-                    .run_auto_maintenance(&claim.namespace_id, options.clone())
-                    .await
-                {
-                    tracing::info!(
-                        phase = "auto_maintenance_step",
-                        result = "error",
-                        error = %error,
-                        "post-publish maintenance step failed"
-                    );
+        self.spawn_claimed_auto_maintenance(claim, options);
+    }
+
+    fn spawn_claimed_auto_maintenance(
+        &self,
+        claim: BackgroundStepClaim,
+        options: MaintenanceStepOptions,
+    ) {
+        // Type erasure lets a finishing task transfer its claim and spawn the
+        // next queued namespace without forming a recursive future type.
+        let future: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
+            Box::pin(async move {
+                let mut claim = claim;
+                loop {
+                    if let Err(error) = claim
+                        .fs
+                        .run_auto_maintenance(&claim.namespace_id, options.clone())
+                        .await
+                    {
+                        tracing::info!(
+                            phase = "auto_maintenance_step",
+                            result = "error",
+                            error = %error,
+                            "post-publish maintenance step failed"
+                        );
+                    }
+                    let Some(next_namespace_id) = claim
+                        .fs
+                        .inner
+                        .background
+                        .finish_or_rerun(&claim.namespace_id)
+                    else {
+                        break;
+                    };
+                    if next_namespace_id == claim.namespace_id {
+                        // Preserve the existing own-namespace rerun in this
+                        // task before handing its slot to global queued work.
+                        continue;
+                    }
+                    claim.namespace_id = next_namespace_id;
+                    let fs = claim.fs.clone();
+                    fs.spawn_claimed_auto_maintenance(claim, options);
+                    return;
                 }
-                // A publish that crossed the threshold while this step ran
-                // deferred its request rather than dropping it; consume it
-                // and run again, so the last write before an idle period
-                // cannot leave the tail unbounded.
-                if !claim
-                    .fs
-                    .inner
-                    .background
-                    .finish_or_rerun(&claim.namespace_id)
-                {
-                    break;
-                }
-            }
-        });
+            });
+        self.inner.background.spawn(future);
     }
 
     async fn run_auto_maintenance(

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -528,8 +528,8 @@ impl FsWriterBuilder {
     /// Caps how many writer-scheduled maintenance steps may run at once
     /// across all namespaces this writer serves. Each namespace already runs
     /// at most one step at a time; this bounds the fan-out when many
-    /// namespaces cross their thresholds together. Skipped steps are
-    /// rescheduled by the next over-threshold publish. Defaults to
+    /// namespaces cross their thresholds together. Requests beyond the cap
+    /// are coalesced by namespace and run as permits become available. Defaults to
     /// [`crate::DEFAULT_MAX_CONCURRENT_MAINTENANCE`]. The limit must be
     /// greater than zero; [`FsBackgroundWork::ManualOnly`] is the only way
     /// to disable scheduling.

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -7,9 +7,9 @@
 //! the handles document.
 
 use loonfs::{
-    CommitId, CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsReader,
-    FsWriter, MaintenanceStepOptions, ManifestId, NamespaceId, PutFileOptions, RuntimeCacheConfig,
-    RuntimeError, SharedObjectStore, StoreConfig,
+    CommitId, CreateCheckpointOptions, CreateNamespaceOptions, ErrorCode, FsAdmin,
+    FsBackgroundWork, FsReader, FsWriter, MaintenanceStepOptions, ManifestId, NamespaceId,
+    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_core::control::load_namespace_metadata_root_control;
@@ -22,6 +22,7 @@ use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::tempdir;
+use tokio::time::{timeout, Duration};
 
 fn store_config(root: &Path) -> StoreConfig {
     StoreConfig::LocalFs {
@@ -63,6 +64,23 @@ async fn fill_wal_tail_past_threshold(writer: &FsWriter, namespace_id: &Namespac
             )
             .await
             .expect("put file");
+    }
+}
+
+async fn fill_wal_tail_through_write_stop(writer: &FsWriter, namespace_id: &NamespaceId) {
+    let writes =
+        u32::try_from(loonfs_core::publish::WalTailPolicy::DEFAULT.reject_writes_at_segments + 1)
+            .expect("WAL write-stop limit plus one should fit in u32");
+    for round in 0..writes {
+        writer
+            .put_file_bytes(
+                namespace_id,
+                &format!("/write-stop/file-{round}.txt"),
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("put file through the write-stop boundary");
     }
 }
 
@@ -136,6 +154,221 @@ fn a_threshold_crossing_during_an_active_step_still_bounds_the_tail() {
             .shutdown_background()
             .await
             .expect("shut down writer background work");
+    });
+}
+
+#[test]
+fn a_step_queued_at_the_global_cap_runs_without_another_publish() {
+    let temp_dir = tempdir().expect("tempdir");
+    let active_namespace = namespace_id("active");
+    let queued_namespace = namespace_id("queued");
+    block_on(async {
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::metadata_root(active_namespace.as_str()),
+            OperationClass::CompareAndSwap,
+        ));
+        let store: SharedObjectStore = blocking.clone();
+        let writer = FsWriter::builder_with_store(store)
+            .writer_id("handle-test-writer")
+            .background_work(FsBackgroundWork::Enabled)
+            .max_concurrent_maintenance(1)
+            .build()
+            .await
+            .expect("build writer");
+        for namespace_id in [&active_namespace, &queued_namespace] {
+            writer
+                .create_namespace(namespace_id, CreateNamespaceOptions::default())
+                .await
+                .expect("create namespace");
+        }
+
+        blocking.block_next();
+        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
+        blocking.wait_until_blocked().await;
+        fill_wal_tail_past_threshold(&writer, &queued_namespace).await;
+
+        blocking.release();
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("queued maintenance quiesces");
+
+        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .namespace_status(&queued_namespace)
+            .await
+            .expect("queued namespace status");
+        assert!(
+            status.wal_tail_segments < wal_tail_segment_threshold(),
+            "the queued step must run without another publish: {status:?}"
+        );
+        writer
+            .shutdown_background()
+            .await
+            .expect("shut down writer background work");
+    });
+}
+
+#[test]
+fn a_write_stopped_namespace_queued_at_the_global_cap_unblocks_itself() {
+    let temp_dir = tempdir().expect("tempdir");
+    let active_namespace = namespace_id("active");
+    let write_stopped_namespace = namespace_id("write-stopped");
+    block_on(async {
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::metadata_root(active_namespace.as_str()),
+            OperationClass::CompareAndSwap,
+        ));
+        let store: SharedObjectStore = blocking.clone();
+        let writer = FsWriter::builder_with_store(store)
+            .writer_id("handle-test-writer")
+            .background_work(FsBackgroundWork::Enabled)
+            .max_concurrent_maintenance(1)
+            .build()
+            .await
+            .expect("build writer");
+        for namespace_id in [&active_namespace, &write_stopped_namespace] {
+            writer
+                .create_namespace(namespace_id, CreateNamespaceOptions::default())
+                .await
+                .expect("create namespace");
+        }
+
+        blocking.block_next();
+        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
+        blocking.wait_until_blocked().await;
+        fill_wal_tail_through_write_stop(&writer, &write_stopped_namespace).await;
+        let error = writer
+            .put_file_bytes(
+                &write_stopped_namespace,
+                "/write-stop/rejected.txt",
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect_err("writes past the hard limit must reject");
+        assert_eq!(error.code(), ErrorCode::MaintenanceRequired);
+
+        blocking.release();
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("queued maintenance quiesces");
+
+        writer
+            .put_file_bytes(
+                &write_stopped_namespace,
+                "/write-stop/rejected.txt",
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("the queued step must unblock writes without another publish");
+        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .namespace_status(&write_stopped_namespace)
+            .await
+            .expect("write-stopped namespace status");
+        assert!(
+            status.wal_tail_segments < wal_tail_segment_threshold(),
+            "the queued step must flush the write-stopped tail before the retry: {status:?}"
+        );
+        writer
+            .shutdown_background()
+            .await
+            .expect("shut down writer background work");
+    });
+}
+
+#[test]
+fn shutdown_clears_a_non_empty_maintenance_queue_without_spawning_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let active_namespace = namespace_id("active");
+    let queued_namespace = namespace_id("queued");
+    block_on(async {
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::metadata_root(active_namespace.as_str()),
+            OperationClass::CompareAndSwap,
+        ));
+        let store: SharedObjectStore = blocking.clone();
+        let writer = FsWriter::builder_with_store(store)
+            .writer_id("handle-test-writer")
+            .background_work(FsBackgroundWork::Enabled)
+            .max_concurrent_maintenance(1)
+            .build()
+            .await
+            .expect("build writer");
+        for namespace_id in [&active_namespace, &queued_namespace] {
+            writer
+                .create_namespace(namespace_id, CreateNamespaceOptions::default())
+                .await
+                .expect("create namespace");
+        }
+
+        blocking.block_next();
+        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
+        blocking.wait_until_blocked().await;
+        fill_wal_tail_past_threshold(&writer, &queued_namespace).await;
+
+        let mut shutdown = Box::pin(writer.shutdown_background());
+        assert!(
+            futures::poll!(shutdown.as_mut()).is_pending(),
+            "shutdown must wait for the parked active step"
+        );
+        blocking.release();
+        timeout(Duration::from_secs(10), shutdown)
+            .await
+            .expect("shutdown must not hang with a non-empty queue")
+            .expect("shut down writer background work");
+
+        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .namespace_status(&queued_namespace)
+            .await
+            .expect("queued namespace status after shutdown");
+        assert_eq!(
+            status.current_manifest_id,
+            Some(ManifestId(0)),
+            "shutdown must clear queued work before the active step releases its permit"
+        );
+
+        writer
+            .put_file_bytes(
+                &queued_namespace,
+                "/after-close.txt",
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("foreground writes remain available after background shutdown");
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("nothing may spawn after background shutdown");
+        let status = admin
+            .namespace_status(&queued_namespace)
+            .await
+            .expect("queued namespace status after post-close write");
+        assert_eq!(
+            status.current_manifest_id,
+            Some(ManifestId(0)),
+            "post-close threshold crossings must not spawn maintenance"
+        );
     });
 }
 


### PR DESCRIPTION
The background scheduler deferred a step request only when the SAME namespace was already running; a different namespace arriving while every permit was held got a debug log and the hope that a later publish would re-request it. That hope fails when it matters: a namespace that crosses the hard WAL write-stop limit while other namespaces hold the permits has its writes rejected, rejected writes never publish, and nothing ever re-requests the step — the namespace is write-blocked until a manual step or restart. A liveness bug, not a tuning issue.

The existing pending set is now a global coalescing dirty queue: cap-full requests enqueue (one entry per namespace), and a finishing step — after honoring its own namespace's rerun — releases its claim and dequeues the next pending namespace under the same lock, registering the successor before the finishing task exits so shutdown's drain still observes it. Shutdown clears the queue under the lock and nothing spawns after close. No configuration was added; the queue is bounded by distinct dirty namespaces.

The fix is proven the honest way: the new hard-limit test was run against the parent commit and fails there (the namespace stays at 129 segments, retries returning maintenance_required), then passes on this commit with no further publish or external nudge. Four more deterministic tests cover queued-at-cap execution, coalescing, and both shutdown paths; the existing own-namespace rerun test passes unmodified. Net +34 production lines.
