### PR TITLE
fix(api): strict mutable control decoding and canonical paths

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -6,11 +6,11 @@ use crate::envelope::EnvelopeCodecError;
 use crate::v0::UploadMode;
 use crate::WriterEpoch;
 use crate::{
-    ChangeSeq, CheckpointId, CommitId, ContentRef, ContentStoreId, InodeId, ManifestId,
-    ManifestObjectId, NamePolicy, NamespaceId, UploadId, WalSegmentId, ROOT_INODE_ID,
+    ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind, ContentStoreId, InodeId,
+    ManifestId, ManifestObjectId, NamePolicy, NamespaceId, UploadId, WalSegmentId, ROOT_INODE_ID,
 };
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Selects one independently versioned mutable control-object family.
 ///
@@ -87,6 +87,7 @@ impl ControlObjectKind {
 ///
 /// See [namespaces and identity](../../../docs/specs/format.md#21-namespaces-and-identity).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NamespaceConfigState {
     /// Namespace whose durable tree owns this configuration object.
     pub namespace_id: NamespaceId,
@@ -108,6 +109,7 @@ pub struct NamespaceConfigState {
 /// and actual deletion additionally requires delete-time re-verification
 /// (format spec, "Garbage collection").
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalFloorState {
     /// Namespace whose retained history this floor bounds.
     pub namespace_id: NamespaceId,
@@ -127,6 +129,7 @@ pub struct WalFloorState {
 /// manifest (pure compaction), and a lower-seq replacement no-ops. This
 /// object never defines live visibility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MetadataRootState {
     /// Namespace whose materialized file set this root selects.
     pub namespace_id: NamespaceId,
@@ -146,6 +149,7 @@ pub struct MetadataRootState {
 ///
 /// See [immutable content rules](../../../docs/specs/format.md#16-immutable-content-rules).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ContentStoreDescriptorState {
     /// Content-store identity that must agree with the descriptor's durable key.
     pub content_store_id: ContentStoreId,
@@ -184,7 +188,7 @@ impl std::fmt::Display for CheckpointRecordLifecycle {
 /// Durable owner of a checkpoint record: the party whose lifecycle decides
 /// when the pin is released.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CheckpointOwner {
     /// An operator-created pin, released explicitly by checkpoint id or by
     /// its declared expiry. The name is a label, not a key: several records
@@ -211,6 +215,7 @@ pub enum CheckpointOwner {
 /// against the floor, and a failed verification flips the record to
 /// `released`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CheckpointRecordState {
     /// Deterministic record identity derived from basis and owner identity.
     pub checkpoint_id: CheckpointId,
@@ -262,6 +267,7 @@ pub struct WalSegmentPointer {
 /// commit validity, takeover permission, or expiry, and no wall-clock
 /// comparison may gate a publish.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WriterBlock {
     /// Stable writer label supplied by the embedding process for diagnostics.
     pub writer_id: String,
@@ -321,7 +327,7 @@ impl NamespaceState {
 /// Carries the authoritative visibility, allocation, and fencing state of a namespace.
 ///
 /// See [head update authority](../../../docs/specs/format.md#14-head-update-authority).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct HeadState {
     /// Namespace whose live history this head governs.
     pub namespace_id: NamespaceId,
@@ -351,6 +357,66 @@ pub struct HeadState {
     pub state: NamespaceState,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictHeadState {
+    namespace_id: NamespaceId,
+    seq: ChangeSeq,
+    head_commit_id: CommitId,
+    writer_epoch: WriterEpoch,
+    #[serde(default)]
+    writer: Option<WriterBlock>,
+    next_inode_id: InodeId,
+    #[serde(default)]
+    visible_wal_tip: Option<StrictWalSegmentPointer>,
+    #[serde(default)]
+    recent_segments: Vec<StrictWalSegmentPointer>,
+    #[serde(default)]
+    state: NamespaceState,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictWalSegmentPointer {
+    object_key: String,
+    segment_id: WalSegmentId,
+    start_seq: ChangeSeq,
+    end_seq: ChangeSeq,
+    payload_checksum: String,
+}
+
+impl From<StrictWalSegmentPointer> for WalSegmentPointer {
+    fn from(pointer: StrictWalSegmentPointer) -> Self {
+        Self {
+            object_key: pointer.object_key,
+            segment_id: pointer.segment_id,
+            start_seq: pointer.start_seq,
+            end_seq: pointer.end_seq,
+            payload_checksum: pointer.payload_checksum,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for HeadState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let state = StrictHeadState::deserialize(deserializer)?;
+        Ok(Self {
+            namespace_id: state.namespace_id,
+            seq: state.seq,
+            head_commit_id: state.head_commit_id,
+            writer_epoch: state.writer_epoch,
+            writer: state.writer,
+            next_inode_id: state.next_inode_id,
+            visible_wal_tip: state.visible_wal_tip.map(Into::into),
+            recent_segments: state.recent_segments.into_iter().map(Into::into).collect(),
+            state: state.state,
+        })
+    }
+}
+
 const GENESIS_COMMIT_ID: &str = "c_00000000000000000000000000000000";
 
 impl HeadState {
@@ -373,6 +439,7 @@ impl HeadState {
 
 /// Records the immutable content selected when an upload session completed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CompletedUpload {
     /// Verified content reference returned by every idempotent completion retry.
     pub content_ref: ContentRef,
@@ -396,7 +463,7 @@ pub enum UploadSessionLifecycle {
 /// Tracks one durable content-upload workflow independently of commit publication.
 ///
 /// See [upload before publish](../../../docs/specs/format.md#242-upload-before-publish).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UploadSessionState {
     /// Namespace authorized to consume the staged content.
     pub namespace_id: NamespaceId,
@@ -419,6 +486,77 @@ pub struct UploadSessionState {
     pub created_at_ms: u64,
     /// Guarded lifecycle that prevents upload operations racing with cleanup.
     pub state: UploadSessionLifecycle,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictUploadSessionState {
+    namespace_id: NamespaceId,
+    upload_id: UploadId,
+    #[serde(default)]
+    mode: UploadMode,
+    #[serde(default)]
+    direct_put_content_ref: Option<StrictContentRef>,
+    #[serde(default)]
+    staged_content_ref: Option<StrictContentRef>,
+    #[serde(default)]
+    completed: Option<StrictCompletedUpload>,
+    created_at_ms: u64,
+    state: UploadSessionLifecycle,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictCompletedUpload {
+    content_ref: StrictContentRef,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictContentRef {
+    kind: MutableContentRefKind,
+    digest: String,
+    size_bytes: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MutableContentRefKind {
+    WholeFileV0,
+}
+
+impl From<StrictContentRef> for ContentRef {
+    fn from(content_ref: StrictContentRef) -> Self {
+        let kind = match content_ref.kind {
+            MutableContentRefKind::WholeFileV0 => ContentRefKind::WholeFileV0,
+        };
+        Self {
+            kind,
+            digest: content_ref.digest,
+            size_bytes: content_ref.size_bytes,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UploadSessionState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let state = StrictUploadSessionState::deserialize(deserializer)?;
+        Ok(Self {
+            namespace_id: state.namespace_id,
+            upload_id: state.upload_id,
+            mode: state.mode,
+            direct_put_content_ref: state.direct_put_content_ref.map(Into::into),
+            staged_content_ref: state.staged_content_ref.map(Into::into),
+            completed: state.completed.map(|completed| CompletedUpload {
+                content_ref: completed.content_ref.into(),
+            }),
+            created_at_ms: state.created_at_ms,
+            state: state.state,
+        })
+    }
 }
 
 /// In-memory view of a control object envelope.
@@ -520,7 +658,7 @@ pub fn decode_control_object<T>(
 where
     T: DeserializeOwned,
 {
-    let decoded = crate::envelope::decode_json_envelope(
+    let decoded = crate::envelope::decode_strict_json_envelope(
         bytes,
         expected_kind.format_version(),
         // The kind registry reports unknown kinds distinctly from
@@ -549,7 +687,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::digest::sha256_digest;
 
     #[test]
     fn control_object_kind_strings_round_trip_and_match_serde() {
@@ -594,37 +731,5 @@ mod tests {
         )
         .expect_err("kind mismatch");
         assert!(matches!(mismatch, EnvelopeCodecError::KindMismatch { .. }));
-    }
-
-    #[test]
-    fn control_object_decode_tolerates_unknown_payload_fields() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let envelope = HeadStateEnvelope::from_state(
-            ControlObjectKind::WalHead,
-            "test-writer",
-            HeadState::initial(namespace_id),
-        )
-        .expect("envelope");
-        let encoded = encode_control_object(&envelope).expect("encode");
-
-        // Simulate a newer writer adding a payload field: splice it into the
-        // raw payload fragment and re-checksum, the way a v-next writer would.
-        let text = String::from_utf8(encoded).expect("utf8");
-        let future_payload = serde_json::to_string(&envelope.state)
-            .expect("payload json")
-            .replacen('{', "{\"field_from_the_future\":true,", 1);
-        let future_checksum = sha256_digest(future_payload.as_bytes());
-        let future_text = text
-            .replace(
-                &serde_json::to_string(&envelope.state).expect("payload json"),
-                &future_payload,
-            )
-            .replace(&envelope.payload_checksum, &future_checksum);
-
-        let decoded: HeadStateEnvelope =
-            decode_control_object(future_text.as_bytes(), ControlObjectKind::WalHead)
-                .expect("additive payload fields must remain readable");
-        assert_eq!(decoded.state, envelope.state);
-        assert_eq!(decoded.payload_checksum, future_checksum);
     }
 }

--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -176,6 +176,28 @@ struct JsonEnvelopeDocument {
     payload: Box<RawValue>,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictJsonEnvelopeDocument {
+    kind: String,
+    format_version: u32,
+    writer_version: String,
+    payload_checksum: String,
+    payload: Box<RawValue>,
+}
+
+impl From<StrictJsonEnvelopeDocument> for JsonEnvelopeDocument {
+    fn from(document: StrictJsonEnvelopeDocument) -> Self {
+        Self {
+            kind: document.kind,
+            format_version: document.format_version,
+            writer_version: document.writer_version,
+            payload_checksum: document.payload_checksum,
+            payload: document.payload,
+        }
+    }
+}
+
 /// The `sha256:<hex>` checksum a JSON payload will carry, computed over its
 /// canonical serialization.
 pub(crate) fn json_payload_checksum<T: Serialize>(
@@ -232,13 +254,41 @@ pub(crate) fn decode_json_envelope<T: DeserializeOwned>(
     supported_version: u32,
     classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
 ) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+    decode_json_envelope_probe(bytes, supported_version, classify_kind)?;
+    let document: JsonEnvelopeDocument = serde_json::from_slice(bytes)
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+    decode_json_envelope_payload(document)
+}
+
+/// Immutable envelope families tolerate unknown fields, while mutable control-object envelopes
+/// reject them. A tolerant read followed by rewrite would erase fields the current binary does
+/// not understand.
+pub(crate) fn decode_strict_json_envelope<T: DeserializeOwned>(
+    bytes: &[u8],
+    supported_version: u32,
+    classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
+) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+    decode_json_envelope_probe(bytes, supported_version, classify_kind)?;
+    let document: StrictJsonEnvelopeDocument = serde_json::from_slice(bytes)
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+    decode_json_envelope_payload(document.into())
+}
+
+fn decode_json_envelope_probe(
+    bytes: &[u8],
+    supported_version: u32,
+    classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
+) -> Result<(), EnvelopeCodecError> {
     let probe: EnvelopeProbe = serde_json::from_slice(bytes)
         .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
     classify_kind(&probe.kind)?;
     verify_version(&probe.kind, probe.format_version, supported_version)?;
+    Ok(())
+}
 
-    let document: JsonEnvelopeDocument = serde_json::from_slice(bytes)
-        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+fn decode_json_envelope_payload<T: DeserializeOwned>(
+    document: JsonEnvelopeDocument,
+) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
     verify_payload_checksum(
         &document.payload_checksum,
         document.payload.get().as_bytes(),

--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
 
-/// Normalized absolute path plus its parsed components.
+/// Canonical absolute path plus its parsed components.
 ///
 /// Richer than the string-id newtypes (it carries segments), so it exposes
 /// only `Display`/`AsRef<str>` on top of its structural accessors instead of
@@ -100,10 +100,11 @@ pub enum PathError {
 }
 
 impl AbsolutePath {
-    /// Parses and normalizes an absolute path while preserving each component's display spelling.
+    /// Parses a canonical absolute path while preserving each component's display spelling.
     ///
-    /// Empty and relative paths, explicit `.` or `..` components, and components
-    /// outside the [`DisplayName`] grammar are rejected.
+    /// Empty and relative paths, repeated or trailing separators, explicit `.`
+    /// or `..` components, and components outside the [`DisplayName`] grammar
+    /// are rejected.
     pub fn parse(value: impl AsRef<str>) -> Result<Self, PathError> {
         let value = value.as_ref();
         if value.is_empty() {
@@ -114,11 +115,14 @@ impl AbsolutePath {
                 path: value.to_owned(),
             });
         }
+        if value == "/" {
+            return Ok(Self::root());
+        }
 
         let mut components = Vec::new();
-        for component in value.split('/') {
+        for component in value[1..].split('/') {
             if component.is_empty() {
-                continue;
+                return Err(PathError::EmptyDisplayName);
             }
             if component == "." {
                 return Err(PathError::DotComponent {
@@ -148,7 +152,7 @@ impl AbsolutePath {
         }
     }
 
-    /// Returns the normalized absolute spelling, with `/` as the sole root representation.
+    /// Returns the canonical absolute spelling, with `/` as the sole root representation.
     pub fn as_str(&self) -> &str {
         &self.normalized
     }
@@ -375,12 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn absolute_path_rejects_relative_empty_dot_and_dotdot() {
-        assert_eq!(AbsolutePath::parse(""), Err(PathError::EmptyPath));
-        assert!(matches!(
-            AbsolutePath::parse("docs"),
-            Err(PathError::RelativePath { .. })
-        ));
+    fn absolute_path_rejects_dot_and_dotdot_components() {
         assert!(matches!(
             AbsolutePath::parse("/docs/./a.txt"),
             Err(PathError::DotComponent { .. })
@@ -392,17 +391,18 @@ mod tests {
     }
 
     #[test]
-    fn absolute_path_normalizes_repeated_and_trailing_separators() {
-        let path = AbsolutePath::parse("//docs///A.txt/").expect("path should parse");
-
-        assert_eq!(path.as_str(), "/docs/A.txt");
+    fn absolute_path_rejects_noncanonical_spellings() {
+        assert_eq!(AbsolutePath::parse("//a"), Err(PathError::EmptyDisplayName));
         assert_eq!(
-            path.components()
-                .iter()
-                .map(|component| component.as_str())
-                .collect::<Vec<_>>(),
-            vec!["docs", "A.txt"]
+            AbsolutePath::parse("/a//b"),
+            Err(PathError::EmptyDisplayName)
         );
+        assert_eq!(AbsolutePath::parse("/a/"), Err(PathError::EmptyDisplayName));
+        assert!(matches!(
+            AbsolutePath::parse("a"),
+            Err(PathError::RelativePath { .. })
+        ));
+        assert_eq!(AbsolutePath::parse(""), Err(PathError::EmptyPath));
     }
 
     #[test]

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -14,10 +14,9 @@
 //! - If a fixture stops decoding, the current reader can no longer read bytes
 //!   another implementation of the same format version wrote — a
 //!   compatibility break once that format is deployed.
-//! - Additive payload fields must keep decoding (`*_tolerates_additive_*`):
-//!   that is the format's only same-version evolution mechanism, made
-//!   possible by checksumming the stored payload bytes rather than a
-//!   re-encoding.
+//! - Additive payload fields in immutable families must keep decoding
+//!   (`*_tolerates_additive_*`). Mutable control objects reject unknown
+//!   fields so an older reader cannot erase them during a guarded rewrite.
 
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointOwner, CheckpointRecordLifecycle,
@@ -354,6 +353,42 @@ where
     assert_eq!(decoded, envelope);
 }
 
+fn control_document_with_payload_edit(
+    fixture: &str,
+    edit: impl FnOnce(&mut serde_json::Value),
+) -> Vec<u8> {
+    let mut document: serde_json::Value =
+        serde_json::from_slice(&read_golden(fixture)).expect("decode control fixture");
+    edit(&mut document["payload"]);
+    let payload = serde_json::to_string(&document["payload"]).expect("encode edited payload");
+    document["payload_checksum"] = serde_json::Value::from(sha256_digest(payload.as_bytes()));
+    format!(
+        "{{\"kind\":{},\"format_version\":{},\"writer_version\":{},\"payload_checksum\":{},\"payload\":{}}}",
+        document["kind"],
+        document["format_version"],
+        document["writer_version"],
+        document["payload_checksum"],
+        payload,
+    )
+    .into_bytes()
+}
+
+fn assert_control_payload_edit_is_corrupt<T>(
+    fixture: &str,
+    kind: ControlObjectKind,
+    edit: impl FnOnce(&mut serde_json::Value),
+) where
+    T: DeserializeOwned + Debug,
+{
+    let edited = control_document_with_payload_edit(fixture, edit);
+    let error = decode_control_object::<T>(&edited, kind)
+        .expect_err("unknown mutable payload field must be rejected");
+    assert!(
+        matches!(error, EnvelopeCodecError::PayloadDecode(_)),
+        "unexpected error for {kind:?}: {error}"
+    );
+}
+
 #[test]
 fn head_state_reading_is_fail_closed_on_unknown_lifecycle_states() {
     // An active head encodes without the field at all: the golden fixture
@@ -566,6 +601,113 @@ fn control_objects_match_golden_bytes() {
             created_at_ms: 1_000,
             state: UploadSessionLifecycle::Condemned,
         },
+    );
+}
+
+#[test]
+fn every_mutable_control_payload_rejects_unknown_fields_as_corruption() {
+    let add_unknown = |payload: &mut serde_json::Value| {
+        payload["field_from_the_future"] = serde_json::Value::from(true);
+    };
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<WalFloorState>(
+        "control_wal_floor.v1.json",
+        ControlObjectKind::WalFloor,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<MetadataRootState>(
+        "control_metadata_root.v1.json",
+        ControlObjectKind::MetadataRoot,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<CheckpointRecordState>(
+        "control_checkpoint_record.v1.json",
+        ControlObjectKind::CheckpointRecord,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+        "control_upload_session.v1.json",
+        ControlObjectKind::UploadSession,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<NamespaceConfigState>(
+        "control_namespace_config.v1.json",
+        ControlObjectKind::NamespaceConfig,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<ContentStoreDescriptorState>(
+        "control_content_store_descriptor.v1.json",
+        ControlObjectKind::ContentStoreDescriptor,
+        add_unknown,
+    );
+}
+
+#[test]
+fn mutable_control_nested_structs_reject_unknown_fields_as_corruption() {
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        |payload| payload["writer"]["field_from_the_future"] = serde_json::Value::from(true),
+    );
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        |payload| {
+            payload["visible_wal_tip"]["field_from_the_future"] = serde_json::Value::from(true);
+        },
+    );
+    assert_control_payload_edit_is_corrupt::<CheckpointRecordState>(
+        "control_checkpoint_record.v1.json",
+        ControlObjectKind::CheckpointRecord,
+        |payload| payload["owner"]["field_from_the_future"] = serde_json::Value::from(true),
+    );
+    assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+        "control_upload_session.v1.json",
+        ControlObjectKind::UploadSession,
+        |payload| payload["completed"]["field_from_the_future"] = serde_json::Value::from(true),
+    );
+    assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+        "control_upload_session.v1.json",
+        ControlObjectKind::UploadSession,
+        |payload| {
+            payload["staged_content_ref"]["field_from_the_future"] = serde_json::Value::from(true);
+        },
+    );
+}
+
+#[test]
+fn mutable_control_enums_fail_closed_on_unknown_variants() {
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        |payload| payload["state"] = serde_json::Value::from("future_state"),
+    );
+    assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+        "control_upload_session.v1.json",
+        ControlObjectKind::UploadSession,
+        |payload| {
+            payload["staged_content_ref"]["kind"] = serde_json::Value::from("future_content_kind");
+        },
+    );
+}
+
+#[test]
+fn mutable_control_envelope_rejects_unknown_fields_as_corruption() {
+    let mut document: serde_json::Value =
+        serde_json::from_slice(&read_golden("control_wal_head.v1.json"))
+            .expect("decode control fixture");
+    document["field_from_the_future"] = serde_json::Value::from(true);
+    let edited = serde_json::to_vec(&document).expect("encode edited envelope");
+
+    let error = decode_control_object::<HeadState>(&edited, ControlObjectKind::WalHead)
+        .expect_err("unknown mutable envelope field must be rejected");
+    assert!(
+        matches!(error, EnvelopeCodecError::EnvelopeDecode(_)),
+        "unexpected error: {error}"
     );
 }
 

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -91,19 +91,27 @@ pub(crate) fn namespace_path(
 ) -> Result<NamespacePath, CliError> {
     Ok(NamespacePath::new(
         namespace_id.clone(),
-        normalize_absolute_path(path, allow_root)?,
+        normalize_user_path(path, allow_root)?,
     ))
 }
 
-/// Parses a CLI path argument through the API's absolute-path grammar, so
-/// the CLI rejects exactly what the server would. `allow_root` is the only
-/// CLI-local policy on top.
-pub(crate) fn normalize_absolute_path(
-    path: &str,
-    allow_root: bool,
-) -> Result<AbsolutePath, CliError> {
-    let path =
-        AbsolutePath::parse(path).map_err(|error| CliError::invalid_input(error.to_string()))?;
+/// Normalizes human-entered CLI path arguments before the strict API parser.
+pub(crate) fn normalize_user_path(path: &str, allow_root: bool) -> Result<AbsolutePath, CliError> {
+    if path.is_empty() || !path.starts_with('/') {
+        return AbsolutePath::parse(path)
+            .map_err(|error| CliError::invalid_input(error.to_string()));
+    }
+    let components = path
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .collect::<Vec<_>>();
+    let normalized = if components.is_empty() {
+        "/".to_owned()
+    } else {
+        format!("/{}", components.join("/"))
+    };
+    let path = AbsolutePath::parse(normalized)
+        .map_err(|error| CliError::invalid_input(error.to_string()))?;
     if !allow_root && path.is_root() {
         return Err(CliError::invalid_input(
             "root path is not allowed for this command",
@@ -155,5 +163,28 @@ pub(crate) fn fail(
         profile,
         mode,
         error: Box::new(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_user_path;
+
+    #[test]
+    fn user_paths_are_normalized_only_at_the_cli_boundary() {
+        assert_eq!(
+            normalize_user_path("//docs///A.txt/", false)
+                .expect("human path")
+                .as_str(),
+            "/docs/A.txt"
+        );
+        assert_eq!(
+            normalize_user_path("///", true)
+                .expect("human root")
+                .as_str(),
+            "/"
+        );
+        assert!(normalize_user_path("docs/A.txt", false).is_err());
+        assert!(normalize_user_path("", false).is_err());
     }
 }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -2,8 +2,8 @@
 //! and grep.
 
 use super::context::{
-    default_remote_put_path, destination_path_for_get, fail, namespace_path,
-    normalize_absolute_path, render_target, resolve_command_context,
+    default_remote_put_path, destination_path_for_get, fail, namespace_path, normalize_user_path,
+    render_target, resolve_command_context,
 };
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
@@ -117,7 +117,7 @@ pub(crate) async fn run_filesystem_grep(
     let path_prefix = args
         .path_prefix
         .as_deref()
-        .map(|path| normalize_absolute_path(path, true))
+        .map(|path| normalize_user_path(path, true))
         .transpose()
         .map_err(|error| context.fail(kind, error))?;
     let mut request = loonfs_api::GrepRequest {
@@ -336,7 +336,7 @@ pub(crate) async fn run_filesystem_put(
     }
 
     let remote_path = match args.remote_path {
-        Some(path) => normalize_absolute_path(&path, false),
+        Some(path) => normalize_user_path(&path, false),
         None => default_remote_put_path(&local_path),
     }
     .map_err(|error| context.fail(kind, error))?;

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -388,13 +388,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn path_intent_fingerprint_normalizes_paths() {
+    async fn path_intent_fingerprint_is_stable_for_canonical_paths() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let left = path_intent_fingerprint(
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs-a").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs//a/").expect("path"),
+                absolute_path: AbsolutePath::parse("/docs/a").expect("path"),
                 parents: false,
             },
         )

--- a/crates/loonfs-core/tests/batch_publish.rs
+++ b/crates/loonfs-core/tests/batch_publish.rs
@@ -1294,7 +1294,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
 
     let intent = PathMutationIntent::PutFile {
         commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
-        absolute_path: AbsolutePath::parse("/same//path.txt").expect("path"),
+        absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
         content_ref: content.content_ref.clone(),
         behavior: DestinationBehavior::NoReplace,
     };

--- a/crates/loonfs-grep/src/root/codec.rs
+++ b/crates/loonfs-grep/src/root/codec.rs
@@ -121,6 +121,28 @@ struct EnvelopeDocument {
     payload: Box<RawValue>,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictEnvelopeDocument {
+    kind: String,
+    format_version: String,
+    writer_version: String,
+    payload_checksum: String,
+    payload: Box<RawValue>,
+}
+
+impl From<StrictEnvelopeDocument> for EnvelopeDocument {
+    fn from(document: StrictEnvelopeDocument) -> Self {
+        Self {
+            kind: document.kind,
+            format_version: document.format_version,
+            writer_version: document.writer_version,
+            payload_checksum: document.payload_checksum,
+            payload: document.payload,
+        }
+    }
+}
+
 /// Encodes a root pointer after rechecking its version and checksum.
 pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepRootCodecError> {
     encode_envelope(
@@ -135,7 +157,7 @@ pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepRoot
 
 /// Decodes only the current root-pointer format and verifies exact payload bytes.
 pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepRootCodecError> {
-    let document = decode_document(bytes, GREP_ROOT_KIND, GREP_ROOT_FORMAT_VERSION)?;
+    let document = decode_strict_document(bytes, GREP_ROOT_KIND, GREP_ROOT_FORMAT_VERSION)?;
     let pointer: GrepRootPointer = decode_payload(&document)?;
     Ok(GrepRootEnvelope {
         format_version: document.format_version,
@@ -231,6 +253,35 @@ fn decode_document(
     expected_kind: &str,
     supported_version: &str,
 ) -> Result<EnvelopeDocument, GrepRootCodecError> {
+    decode_probe(bytes, expected_kind, supported_version)?;
+    let document: EnvelopeDocument =
+        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
+            message: error.to_string(),
+        })?;
+    verify_document_checksum(&document)?;
+    Ok(document)
+}
+
+fn decode_strict_document(
+    bytes: &[u8],
+    expected_kind: &str,
+    supported_version: &str,
+) -> Result<EnvelopeDocument, GrepRootCodecError> {
+    decode_probe(bytes, expected_kind, supported_version)?;
+    let document: StrictEnvelopeDocument =
+        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
+            message: error.to_string(),
+        })?;
+    let document = EnvelopeDocument::from(document);
+    verify_document_checksum(&document)?;
+    Ok(document)
+}
+
+fn decode_probe(
+    bytes: &[u8],
+    expected_kind: &str,
+    supported_version: &str,
+) -> Result<(), GrepRootCodecError> {
     let probe: EnvelopeProbe =
         serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
             message: error.to_string(),
@@ -242,19 +293,18 @@ fn decode_document(
         });
     }
     verify_version(&probe.format_version, supported_version)?;
+    Ok(())
+}
 
-    let document: EnvelopeDocument =
-        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
-            message: error.to_string(),
-        })?;
+fn verify_document_checksum(document: &EnvelopeDocument) -> Result<(), GrepRootCodecError> {
     let actual = sha256_digest(document.payload.get().as_bytes());
     if actual != document.payload_checksum {
         return Err(GrepRootCodecError::ChecksumMismatch {
-            expected: document.payload_checksum,
+            expected: document.payload_checksum.clone(),
             actual,
         });
     }
-    Ok(document)
+    Ok(())
 }
 
 fn decode_payload<T: DeserializeOwned>(

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -123,6 +123,7 @@ impl<'de> Deserialize<'de> for GrepManifestId {
 
 /// Small mutable control payload installed at `extensions/grep/root.json`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GrepRootPointer {
     namespace_id: NamespaceId,
     manifest_id: GrepManifestId,

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -6,8 +6,8 @@ use loonfs_api::wire::sst_blocks::BlockHandle;
 use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId};
 use loonfs_grep::root::{
     decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root, GrepFoldState,
-    GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepManifestId, GrepRootCodecError,
-    GrepRootEnvelope, GrepRootPointer, GrepRootState, GrepRootStateError, GrepSegmentRef,
+    GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepRootCodecError, GrepRootEnvelope,
+    GrepRootPointer, GrepRootState, GrepRootStateError, GrepSegmentRef,
 };
 use loonfs_test_support::ids::namespace_id;
 
@@ -57,23 +57,42 @@ fn encoded_manifests_and_pointers_match_frozen_v1_bytes() {
 }
 
 #[test]
-fn decoders_read_frozen_v1_bytes_with_additive_fields() {
+fn immutable_manifest_decoder_reads_frozen_v1_bytes_with_additive_fields() {
     let decoded =
         decode_grep_manifest(ADDITIVE_V1.as_bytes()).expect("decode additive manifest fixture");
 
     assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11), 0));
-    let pointer =
-        decode_grep_root(ADDITIVE_POINTER_V1.as_bytes()).expect("decode additive pointer fixture");
-    assert_eq!(
-        pointer.pointer(),
-        &GrepRootPointer::new(
-            namespace_id("docs"),
-            GrepManifestId::parse(
-                "9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad"
-            )
-            .expect("valid manifest id")
-        )
+}
+
+#[test]
+fn mutable_pointer_payload_rejects_unknown_fields_as_corruption() {
+    let mut document: serde_json::Value =
+        serde_json::from_str(STEADY_POINTER_V1).expect("decode pointer fixture");
+    document["payload"]["field_from_the_future"] = serde_json::Value::from(true);
+    let payload = serde_json::to_string(&document["payload"]).expect("encode edited payload");
+    document["payload_checksum"] =
+        serde_json::Value::from(loonfs_api::sha256_digest(payload.as_bytes()));
+    let edited = format!(
+        "{{\"kind\":{},\"format_version\":{},\"writer_version\":{},\"payload_checksum\":{},\"payload\":{}}}",
+        document["kind"],
+        document["format_version"],
+        document["writer_version"],
+        document["payload_checksum"],
+        payload,
     );
+
+    assert!(matches!(
+        decode_grep_root(edited.as_bytes()),
+        Err(GrepRootCodecError::PayloadDecode { .. })
+    ));
+}
+
+#[test]
+fn mutable_pointer_envelope_rejects_unknown_fields_as_corruption() {
+    assert!(matches!(
+        decode_grep_root(ADDITIVE_POINTER_V1.as_bytes()),
+        Err(GrepRootCodecError::EnvelopeDecode { .. })
+    ));
 }
 
 #[test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1136,9 +1136,9 @@ consistent cut at the index watermark — files whose newest revision
 postdates it are omitted entirely rather than mixed in. The `path_prefix`
 value is a complete absolute path, not a partial textual segment prefix. Its
 scope resolves to an inode under the namespace's name policy and filters by
-ancestry, so it follows the same validation and normalization as every other
-path read. A missing data half answers `not_supported` with the `feature`
-field naming `grep.index`.
+ancestry, so it requires the same canonical spelling and validation as every
+other path read. A missing data half answers `not_supported` with the
+`feature` field naming `grep.index`.
 
 ## 7. Conformance requirements
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -16,7 +16,8 @@ a deployment exposes.
 Encoding conventions used by every durable and wire shape in this specification:
 field names and enum values are `snake_case`; fields holding typed identifiers
 are suffixed `_id`; tagged unions carry their discriminator in a `kind` field;
-decoders tolerate unknown fields (readers ignore what they do not understand).
+HTTP wire shapes and immutable, never-rewritten families tolerate unknown
+fields, while mutable control-object envelopes and payloads reject them.
 
 ## 1. Object store contract
 
@@ -247,6 +248,14 @@ Small mutable objects such as the namespace head must use compare-and-swap
 semantics. These objects must remain small enough that guarded rewrite is
 practical.
 
+Mutable control-object decoders reject unknown fields in both the envelope and
+the complete nested payload. Otherwise, an older binary could tolerate a
+newer field, erase it during read-modify-write, and still report a successful
+guarded update. Namespace configuration and content-store descriptors use the
+same strict control-object decoder; immutable WAL segments, metadata segments,
+namespace manifests, grep segments, and grep manifests remain tolerant of
+additive fields.
+
 Readers of small mutable control objects must use a full-object read that
 returns bytes and the object identity metadata for those same bytes. This does
 not by itself guarantee freshness; it guarantees self-consistency. A reader
@@ -444,6 +453,11 @@ character rules with a 768-byte cap: case folding expands at most threefold
 in bytes, so every key derivable from a valid display name is admissible.
 Requests carrying a name or key outside this grammar fail validation; nothing
 is truncated or normalized on the caller's behalf.
+
+An absolute path has one canonical spelling: exactly one leading `/`, no empty
+components or repeated separators, and no trailing `/` except for the root
+path `/`. Wire decoders reject every noncanonical spelling rather than
+normalizing it.
 
 #### 2.3.1 NamePolicy
 
@@ -972,8 +986,8 @@ retry of the same
 logical commit must fingerprint identically no matter who retries it or when.
 
 Path-level mutations fingerprint the same way with domain
-`loonfs.path.intent.semantic.v0` over the normalized path intent (intent kind,
-normalized absolute paths, and the intent's semantic parameters).
+`loonfs.path.intent.semantic.v0` over the canonical path intent (intent kind,
+canonical absolute paths, and the intent's semantic parameters).
 
 The idempotency horizon is the retention floor. Commit receipts below the
 floor are dropped when metadata runs are rebuilt, so a commit retried from
@@ -1321,7 +1335,9 @@ grep state: `namespace_id`, `lifecycle`, nested `index` bookkeeping, and the
 `segments` descriptors. Both decoders verify the checksum over the exact
 stored payload fragment before decoding, reject unknown versions and kind
 mismatches without fallback, and validate namespace, manifest-id, lifecycle,
-fold, run-allocation, and segment invariants at every boundary.
+fold, run-allocation, and segment invariants at every boundary. The mutable
+root-pointer decoder rejects unknown envelope and payload fields; the
+immutable manifest decoder tolerates additive fields.
 
 A gram-index segment uses the section 4.2.1 block grammar unchanged —
 prefix-compressed data blocks, one bloom filter block, one index block,


### PR DESCRIPTION
Durable decoding was tolerant everywhere, which is only sound for objects that are never rewritten: for read-modify-write control objects, tolerant-read-then-rewrite silently erases any field the writing binary does not know - and fencing takeover by an older binary is exactly how two versions touch one namespace. Decoding now splits by object kind. Every mutable control payload rejects unknown fields (head, metadata root, WAL floor, checkpoint record, upload session, namespace config, content-store descriptor, and greps root pointer - where the audit said "grep root state", inspection showed the state lives in immutable content-addressed manifests and only the pointer is mutable, so strictness went exactly where rewrite-erasure can occur). Immutable families keep tolerant additive decoding, pinned by tests on both sides of the split. Fixture bytes are untouched; strictness changes what decodes, not what encodes.

Second half: AbsolutePath::parse no longer normalizes. Since typed wire paths landed, its skip-empty-components behavior had become the server silently rewriting request paths ("//docs///A.txt/" served as "/docs/A.txt") - multiple spellings for one resource, poisoning logs and idempotency. Parse is now canonical-only (the old blessing test became a rejection matrix), and the one place humans type paths - the CLI - normalizes input through an explicitly named helper before building requests. Wire, client library, and embedded callers are strict.
