### PR TITLE
feat(core): bound metadata reorganization per step

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -6,11 +6,11 @@ use crate::envelope::EnvelopeCodecError;
 use crate::v0::UploadMode;
 use crate::WriterEpoch;
 use crate::{
-    ChangeSeq, CheckpointId, CommitId, ContentRef, ContentStoreId, InodeId, ManifestId,
-    ManifestObjectId, NamePolicy, NamespaceId, UploadId, WalSegmentId, ROOT_INODE_ID,
+    ChangeSeq, CheckpointId, CommitId, ContentRef, ContentRefKind, ContentStoreId, InodeId,
+    ManifestId, ManifestObjectId, NamePolicy, NamespaceId, UploadId, WalSegmentId, ROOT_INODE_ID,
 };
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Selects one independently versioned mutable control-object family.
 ///
@@ -87,6 +87,7 @@ impl ControlObjectKind {
 ///
 /// See [namespaces and identity](../../../docs/specs/format.md#21-namespaces-and-identity).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NamespaceConfigState {
     /// Namespace whose durable tree owns this configuration object.
     pub namespace_id: NamespaceId,
@@ -108,6 +109,7 @@ pub struct NamespaceConfigState {
 /// and actual deletion additionally requires delete-time re-verification
 /// (format spec, "Garbage collection").
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalFloorState {
     /// Namespace whose retained history this floor bounds.
     pub namespace_id: NamespaceId,
@@ -127,6 +129,7 @@ pub struct WalFloorState {
 /// manifest (pure compaction), and a lower-seq replacement no-ops. This
 /// object never defines live visibility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MetadataRootState {
     /// Namespace whose materialized file set this root selects.
     pub namespace_id: NamespaceId,
@@ -146,6 +149,7 @@ pub struct MetadataRootState {
 ///
 /// See [immutable content rules](../../../docs/specs/format.md#16-immutable-content-rules).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ContentStoreDescriptorState {
     /// Content-store identity that must agree with the descriptor's durable key.
     pub content_store_id: ContentStoreId,
@@ -184,7 +188,7 @@ impl std::fmt::Display for CheckpointRecordLifecycle {
 /// Durable owner of a checkpoint record: the party whose lifecycle decides
 /// when the pin is released.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CheckpointOwner {
     /// An operator-created pin, released explicitly by checkpoint id or by
     /// its declared expiry. The name is a label, not a key: several records
@@ -211,6 +215,7 @@ pub enum CheckpointOwner {
 /// against the floor, and a failed verification flips the record to
 /// `released`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CheckpointRecordState {
     /// Deterministic record identity derived from basis and owner identity.
     pub checkpoint_id: CheckpointId,
@@ -262,6 +267,7 @@ pub struct WalSegmentPointer {
 /// commit validity, takeover permission, or expiry, and no wall-clock
 /// comparison may gate a publish.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WriterBlock {
     /// Stable writer label supplied by the embedding process for diagnostics.
     pub writer_id: String,
@@ -321,7 +327,7 @@ impl NamespaceState {
 /// Carries the authoritative visibility, allocation, and fencing state of a namespace.
 ///
 /// See [head update authority](../../../docs/specs/format.md#14-head-update-authority).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct HeadState {
     /// Namespace whose live history this head governs.
     pub namespace_id: NamespaceId,
@@ -351,6 +357,66 @@ pub struct HeadState {
     pub state: NamespaceState,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictHeadState {
+    namespace_id: NamespaceId,
+    seq: ChangeSeq,
+    head_commit_id: CommitId,
+    writer_epoch: WriterEpoch,
+    #[serde(default)]
+    writer: Option<WriterBlock>,
+    next_inode_id: InodeId,
+    #[serde(default)]
+    visible_wal_tip: Option<StrictWalSegmentPointer>,
+    #[serde(default)]
+    recent_segments: Vec<StrictWalSegmentPointer>,
+    #[serde(default)]
+    state: NamespaceState,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictWalSegmentPointer {
+    object_key: String,
+    segment_id: WalSegmentId,
+    start_seq: ChangeSeq,
+    end_seq: ChangeSeq,
+    payload_checksum: String,
+}
+
+impl From<StrictWalSegmentPointer> for WalSegmentPointer {
+    fn from(pointer: StrictWalSegmentPointer) -> Self {
+        Self {
+            object_key: pointer.object_key,
+            segment_id: pointer.segment_id,
+            start_seq: pointer.start_seq,
+            end_seq: pointer.end_seq,
+            payload_checksum: pointer.payload_checksum,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for HeadState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let state = StrictHeadState::deserialize(deserializer)?;
+        Ok(Self {
+            namespace_id: state.namespace_id,
+            seq: state.seq,
+            head_commit_id: state.head_commit_id,
+            writer_epoch: state.writer_epoch,
+            writer: state.writer,
+            next_inode_id: state.next_inode_id,
+            visible_wal_tip: state.visible_wal_tip.map(Into::into),
+            recent_segments: state.recent_segments.into_iter().map(Into::into).collect(),
+            state: state.state,
+        })
+    }
+}
+
 const GENESIS_COMMIT_ID: &str = "c_00000000000000000000000000000000";
 
 impl HeadState {
@@ -373,6 +439,7 @@ impl HeadState {
 
 /// Records the immutable content selected when an upload session completed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CompletedUpload {
     /// Verified content reference returned by every idempotent completion retry.
     pub content_ref: ContentRef,
@@ -396,7 +463,7 @@ pub enum UploadSessionLifecycle {
 /// Tracks one durable content-upload workflow independently of commit publication.
 ///
 /// See [upload before publish](../../../docs/specs/format.md#242-upload-before-publish).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UploadSessionState {
     /// Namespace authorized to consume the staged content.
     pub namespace_id: NamespaceId,
@@ -419,6 +486,77 @@ pub struct UploadSessionState {
     pub created_at_ms: u64,
     /// Guarded lifecycle that prevents upload operations racing with cleanup.
     pub state: UploadSessionLifecycle,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictUploadSessionState {
+    namespace_id: NamespaceId,
+    upload_id: UploadId,
+    #[serde(default)]
+    mode: UploadMode,
+    #[serde(default)]
+    direct_put_content_ref: Option<StrictContentRef>,
+    #[serde(default)]
+    staged_content_ref: Option<StrictContentRef>,
+    #[serde(default)]
+    completed: Option<StrictCompletedUpload>,
+    created_at_ms: u64,
+    state: UploadSessionLifecycle,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictCompletedUpload {
+    content_ref: StrictContentRef,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictContentRef {
+    kind: MutableContentRefKind,
+    digest: String,
+    size_bytes: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MutableContentRefKind {
+    WholeFileV0,
+}
+
+impl From<StrictContentRef> for ContentRef {
+    fn from(content_ref: StrictContentRef) -> Self {
+        let kind = match content_ref.kind {
+            MutableContentRefKind::WholeFileV0 => ContentRefKind::WholeFileV0,
+        };
+        Self {
+            kind,
+            digest: content_ref.digest,
+            size_bytes: content_ref.size_bytes,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UploadSessionState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let state = StrictUploadSessionState::deserialize(deserializer)?;
+        Ok(Self {
+            namespace_id: state.namespace_id,
+            upload_id: state.upload_id,
+            mode: state.mode,
+            direct_put_content_ref: state.direct_put_content_ref.map(Into::into),
+            staged_content_ref: state.staged_content_ref.map(Into::into),
+            completed: state.completed.map(|completed| CompletedUpload {
+                content_ref: completed.content_ref.into(),
+            }),
+            created_at_ms: state.created_at_ms,
+            state: state.state,
+        })
+    }
 }
 
 /// In-memory view of a control object envelope.
@@ -520,7 +658,7 @@ pub fn decode_control_object<T>(
 where
     T: DeserializeOwned,
 {
-    let decoded = crate::envelope::decode_json_envelope(
+    let decoded = crate::envelope::decode_strict_json_envelope(
         bytes,
         expected_kind.format_version(),
         // The kind registry reports unknown kinds distinctly from
@@ -549,7 +687,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::digest::sha256_digest;
 
     #[test]
     fn control_object_kind_strings_round_trip_and_match_serde() {
@@ -594,37 +731,5 @@ mod tests {
         )
         .expect_err("kind mismatch");
         assert!(matches!(mismatch, EnvelopeCodecError::KindMismatch { .. }));
-    }
-
-    #[test]
-    fn control_object_decode_tolerates_unknown_payload_fields() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let envelope = HeadStateEnvelope::from_state(
-            ControlObjectKind::WalHead,
-            "test-writer",
-            HeadState::initial(namespace_id),
-        )
-        .expect("envelope");
-        let encoded = encode_control_object(&envelope).expect("encode");
-
-        // Simulate a newer writer adding a payload field: splice it into the
-        // raw payload fragment and re-checksum, the way a v-next writer would.
-        let text = String::from_utf8(encoded).expect("utf8");
-        let future_payload = serde_json::to_string(&envelope.state)
-            .expect("payload json")
-            .replacen('{', "{\"field_from_the_future\":true,", 1);
-        let future_checksum = sha256_digest(future_payload.as_bytes());
-        let future_text = text
-            .replace(
-                &serde_json::to_string(&envelope.state).expect("payload json"),
-                &future_payload,
-            )
-            .replace(&envelope.payload_checksum, &future_checksum);
-
-        let decoded: HeadStateEnvelope =
-            decode_control_object(future_text.as_bytes(), ControlObjectKind::WalHead)
-                .expect("additive payload fields must remain readable");
-        assert_eq!(decoded.state, envelope.state);
-        assert_eq!(decoded.payload_checksum, future_checksum);
     }
 }

--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -176,6 +176,28 @@ struct JsonEnvelopeDocument {
     payload: Box<RawValue>,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictJsonEnvelopeDocument {
+    kind: String,
+    format_version: u32,
+    writer_version: String,
+    payload_checksum: String,
+    payload: Box<RawValue>,
+}
+
+impl From<StrictJsonEnvelopeDocument> for JsonEnvelopeDocument {
+    fn from(document: StrictJsonEnvelopeDocument) -> Self {
+        Self {
+            kind: document.kind,
+            format_version: document.format_version,
+            writer_version: document.writer_version,
+            payload_checksum: document.payload_checksum,
+            payload: document.payload,
+        }
+    }
+}
+
 /// The `sha256:<hex>` checksum a JSON payload will carry, computed over its
 /// canonical serialization.
 pub(crate) fn json_payload_checksum<T: Serialize>(
@@ -232,13 +254,41 @@ pub(crate) fn decode_json_envelope<T: DeserializeOwned>(
     supported_version: u32,
     classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
 ) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+    decode_json_envelope_probe(bytes, supported_version, classify_kind)?;
+    let document: JsonEnvelopeDocument = serde_json::from_slice(bytes)
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+    decode_json_envelope_payload(document)
+}
+
+/// Immutable envelope families tolerate unknown fields, while mutable control-object envelopes
+/// reject them. A tolerant read followed by rewrite would erase fields the current binary does
+/// not understand.
+pub(crate) fn decode_strict_json_envelope<T: DeserializeOwned>(
+    bytes: &[u8],
+    supported_version: u32,
+    classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
+) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
+    decode_json_envelope_probe(bytes, supported_version, classify_kind)?;
+    let document: StrictJsonEnvelopeDocument = serde_json::from_slice(bytes)
+        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+    decode_json_envelope_payload(document.into())
+}
+
+fn decode_json_envelope_probe(
+    bytes: &[u8],
+    supported_version: u32,
+    classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
+) -> Result<(), EnvelopeCodecError> {
     let probe: EnvelopeProbe = serde_json::from_slice(bytes)
         .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
     classify_kind(&probe.kind)?;
     verify_version(&probe.kind, probe.format_version, supported_version)?;
+    Ok(())
+}
 
-    let document: JsonEnvelopeDocument = serde_json::from_slice(bytes)
-        .map_err(|err| EnvelopeCodecError::EnvelopeDecode(err.to_string()))?;
+fn decode_json_envelope_payload<T: DeserializeOwned>(
+    document: JsonEnvelopeDocument,
+) -> Result<DecodedJsonEnvelope<T>, EnvelopeCodecError> {
     verify_payload_checksum(
         &document.payload_checksum,
         document.payload.get().as_bytes(),

--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
 
-/// Normalized absolute path plus its parsed components.
+/// Canonical absolute path plus its parsed components.
 ///
 /// Richer than the string-id newtypes (it carries segments), so it exposes
 /// only `Display`/`AsRef<str>` on top of its structural accessors instead of
@@ -100,10 +100,11 @@ pub enum PathError {
 }
 
 impl AbsolutePath {
-    /// Parses and normalizes an absolute path while preserving each component's display spelling.
+    /// Parses a canonical absolute path while preserving each component's display spelling.
     ///
-    /// Empty and relative paths, explicit `.` or `..` components, and components
-    /// outside the [`DisplayName`] grammar are rejected.
+    /// Empty and relative paths, repeated or trailing separators, explicit `.`
+    /// or `..` components, and components outside the [`DisplayName`] grammar
+    /// are rejected.
     pub fn parse(value: impl AsRef<str>) -> Result<Self, PathError> {
         let value = value.as_ref();
         if value.is_empty() {
@@ -114,11 +115,14 @@ impl AbsolutePath {
                 path: value.to_owned(),
             });
         }
+        if value == "/" {
+            return Ok(Self::root());
+        }
 
         let mut components = Vec::new();
-        for component in value.split('/') {
+        for component in value[1..].split('/') {
             if component.is_empty() {
-                continue;
+                return Err(PathError::EmptyDisplayName);
             }
             if component == "." {
                 return Err(PathError::DotComponent {
@@ -148,7 +152,7 @@ impl AbsolutePath {
         }
     }
 
-    /// Returns the normalized absolute spelling, with `/` as the sole root representation.
+    /// Returns the canonical absolute spelling, with `/` as the sole root representation.
     pub fn as_str(&self) -> &str {
         &self.normalized
     }
@@ -375,12 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn absolute_path_rejects_relative_empty_dot_and_dotdot() {
-        assert_eq!(AbsolutePath::parse(""), Err(PathError::EmptyPath));
-        assert!(matches!(
-            AbsolutePath::parse("docs"),
-            Err(PathError::RelativePath { .. })
-        ));
+    fn absolute_path_rejects_dot_and_dotdot_components() {
         assert!(matches!(
             AbsolutePath::parse("/docs/./a.txt"),
             Err(PathError::DotComponent { .. })
@@ -392,17 +391,18 @@ mod tests {
     }
 
     #[test]
-    fn absolute_path_normalizes_repeated_and_trailing_separators() {
-        let path = AbsolutePath::parse("//docs///A.txt/").expect("path should parse");
-
-        assert_eq!(path.as_str(), "/docs/A.txt");
+    fn absolute_path_rejects_noncanonical_spellings() {
+        assert_eq!(AbsolutePath::parse("//a"), Err(PathError::EmptyDisplayName));
         assert_eq!(
-            path.components()
-                .iter()
-                .map(|component| component.as_str())
-                .collect::<Vec<_>>(),
-            vec!["docs", "A.txt"]
+            AbsolutePath::parse("/a//b"),
+            Err(PathError::EmptyDisplayName)
         );
+        assert_eq!(AbsolutePath::parse("/a/"), Err(PathError::EmptyDisplayName));
+        assert!(matches!(
+            AbsolutePath::parse("a"),
+            Err(PathError::RelativePath { .. })
+        ));
+        assert_eq!(AbsolutePath::parse(""), Err(PathError::EmptyPath));
     }
 
     #[test]

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -14,10 +14,9 @@
 //! - If a fixture stops decoding, the current reader can no longer read bytes
 //!   another implementation of the same format version wrote — a
 //!   compatibility break once that format is deployed.
-//! - Additive payload fields must keep decoding (`*_tolerates_additive_*`):
-//!   that is the format's only same-version evolution mechanism, made
-//!   possible by checksumming the stored payload bytes rather than a
-//!   re-encoding.
+//! - Additive payload fields in immutable families must keep decoding
+//!   (`*_tolerates_additive_*`). Mutable control objects reject unknown
+//!   fields so an older reader cannot erase them during a guarded rewrite.
 
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointOwner, CheckpointRecordLifecycle,
@@ -354,6 +353,42 @@ where
     assert_eq!(decoded, envelope);
 }
 
+fn control_document_with_payload_edit(
+    fixture: &str,
+    edit: impl FnOnce(&mut serde_json::Value),
+) -> Vec<u8> {
+    let mut document: serde_json::Value =
+        serde_json::from_slice(&read_golden(fixture)).expect("decode control fixture");
+    edit(&mut document["payload"]);
+    let payload = serde_json::to_string(&document["payload"]).expect("encode edited payload");
+    document["payload_checksum"] = serde_json::Value::from(sha256_digest(payload.as_bytes()));
+    format!(
+        "{{\"kind\":{},\"format_version\":{},\"writer_version\":{},\"payload_checksum\":{},\"payload\":{}}}",
+        document["kind"],
+        document["format_version"],
+        document["writer_version"],
+        document["payload_checksum"],
+        payload,
+    )
+    .into_bytes()
+}
+
+fn assert_control_payload_edit_is_corrupt<T>(
+    fixture: &str,
+    kind: ControlObjectKind,
+    edit: impl FnOnce(&mut serde_json::Value),
+) where
+    T: DeserializeOwned + Debug,
+{
+    let edited = control_document_with_payload_edit(fixture, edit);
+    let error = decode_control_object::<T>(&edited, kind)
+        .expect_err("unknown mutable payload field must be rejected");
+    assert!(
+        matches!(error, EnvelopeCodecError::PayloadDecode(_)),
+        "unexpected error for {kind:?}: {error}"
+    );
+}
+
 #[test]
 fn head_state_reading_is_fail_closed_on_unknown_lifecycle_states() {
     // An active head encodes without the field at all: the golden fixture
@@ -566,6 +601,113 @@ fn control_objects_match_golden_bytes() {
             created_at_ms: 1_000,
             state: UploadSessionLifecycle::Condemned,
         },
+    );
+}
+
+#[test]
+fn every_mutable_control_payload_rejects_unknown_fields_as_corruption() {
+    let add_unknown = |payload: &mut serde_json::Value| {
+        payload["field_from_the_future"] = serde_json::Value::from(true);
+    };
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<WalFloorState>(
+        "control_wal_floor.v1.json",
+        ControlObjectKind::WalFloor,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<MetadataRootState>(
+        "control_metadata_root.v1.json",
+        ControlObjectKind::MetadataRoot,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<CheckpointRecordState>(
+        "control_checkpoint_record.v1.json",
+        ControlObjectKind::CheckpointRecord,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+        "control_upload_session.v1.json",
+        ControlObjectKind::UploadSession,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<NamespaceConfigState>(
+        "control_namespace_config.v1.json",
+        ControlObjectKind::NamespaceConfig,
+        add_unknown,
+    );
+    assert_control_payload_edit_is_corrupt::<ContentStoreDescriptorState>(
+        "control_content_store_descriptor.v1.json",
+        ControlObjectKind::ContentStoreDescriptor,
+        add_unknown,
+    );
+}
+
+#[test]
+fn mutable_control_nested_structs_reject_unknown_fields_as_corruption() {
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        |payload| payload["writer"]["field_from_the_future"] = serde_json::Value::from(true),
+    );
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        |payload| {
+            payload["visible_wal_tip"]["field_from_the_future"] = serde_json::Value::from(true);
+        },
+    );
+    assert_control_payload_edit_is_corrupt::<CheckpointRecordState>(
+        "control_checkpoint_record.v1.json",
+        ControlObjectKind::CheckpointRecord,
+        |payload| payload["owner"]["field_from_the_future"] = serde_json::Value::from(true),
+    );
+    assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+        "control_upload_session.v1.json",
+        ControlObjectKind::UploadSession,
+        |payload| payload["completed"]["field_from_the_future"] = serde_json::Value::from(true),
+    );
+    assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+        "control_upload_session.v1.json",
+        ControlObjectKind::UploadSession,
+        |payload| {
+            payload["staged_content_ref"]["field_from_the_future"] = serde_json::Value::from(true);
+        },
+    );
+}
+
+#[test]
+fn mutable_control_enums_fail_closed_on_unknown_variants() {
+    assert_control_payload_edit_is_corrupt::<HeadState>(
+        "control_wal_head.v1.json",
+        ControlObjectKind::WalHead,
+        |payload| payload["state"] = serde_json::Value::from("future_state"),
+    );
+    assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+        "control_upload_session.v1.json",
+        ControlObjectKind::UploadSession,
+        |payload| {
+            payload["staged_content_ref"]["kind"] = serde_json::Value::from("future_content_kind");
+        },
+    );
+}
+
+#[test]
+fn mutable_control_envelope_rejects_unknown_fields_as_corruption() {
+    let mut document: serde_json::Value =
+        serde_json::from_slice(&read_golden("control_wal_head.v1.json"))
+            .expect("decode control fixture");
+    document["field_from_the_future"] = serde_json::Value::from(true);
+    let edited = serde_json::to_vec(&document).expect("encode edited envelope");
+
+    let error = decode_control_object::<HeadState>(&edited, ControlObjectKind::WalHead)
+        .expect_err("unknown mutable envelope field must be rejected");
+    assert!(
+        matches!(error, EnvelopeCodecError::EnvelopeDecode(_)),
+        "unexpected error: {error}"
     );
 }
 

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -91,19 +91,27 @@ pub(crate) fn namespace_path(
 ) -> Result<NamespacePath, CliError> {
     Ok(NamespacePath::new(
         namespace_id.clone(),
-        normalize_absolute_path(path, allow_root)?,
+        normalize_user_path(path, allow_root)?,
     ))
 }
 
-/// Parses a CLI path argument through the API's absolute-path grammar, so
-/// the CLI rejects exactly what the server would. `allow_root` is the only
-/// CLI-local policy on top.
-pub(crate) fn normalize_absolute_path(
-    path: &str,
-    allow_root: bool,
-) -> Result<AbsolutePath, CliError> {
-    let path =
-        AbsolutePath::parse(path).map_err(|error| CliError::invalid_input(error.to_string()))?;
+/// Normalizes human-entered CLI path arguments before the strict API parser.
+pub(crate) fn normalize_user_path(path: &str, allow_root: bool) -> Result<AbsolutePath, CliError> {
+    if path.is_empty() || !path.starts_with('/') {
+        return AbsolutePath::parse(path)
+            .map_err(|error| CliError::invalid_input(error.to_string()));
+    }
+    let components = path
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .collect::<Vec<_>>();
+    let normalized = if components.is_empty() {
+        "/".to_owned()
+    } else {
+        format!("/{}", components.join("/"))
+    };
+    let path = AbsolutePath::parse(normalized)
+        .map_err(|error| CliError::invalid_input(error.to_string()))?;
     if !allow_root && path.is_root() {
         return Err(CliError::invalid_input(
             "root path is not allowed for this command",
@@ -155,5 +163,28 @@ pub(crate) fn fail(
         profile,
         mode,
         error: Box::new(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_user_path;
+
+    #[test]
+    fn user_paths_are_normalized_only_at_the_cli_boundary() {
+        assert_eq!(
+            normalize_user_path("//docs///A.txt/", false)
+                .expect("human path")
+                .as_str(),
+            "/docs/A.txt"
+        );
+        assert_eq!(
+            normalize_user_path("///", true)
+                .expect("human root")
+                .as_str(),
+            "/"
+        );
+        assert!(normalize_user_path("docs/A.txt", false).is_err());
+        assert!(normalize_user_path("", false).is_err());
     }
 }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -2,8 +2,8 @@
 //! and grep.
 
 use super::context::{
-    default_remote_put_path, destination_path_for_get, fail, namespace_path,
-    normalize_absolute_path, render_target, resolve_command_context,
+    default_remote_put_path, destination_path_for_get, fail, namespace_path, normalize_user_path,
+    render_target, resolve_command_context,
 };
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
@@ -117,7 +117,7 @@ pub(crate) async fn run_filesystem_grep(
     let path_prefix = args
         .path_prefix
         .as_deref()
-        .map(|path| normalize_absolute_path(path, true))
+        .map(|path| normalize_user_path(path, true))
         .transpose()
         .map_err(|error| context.fail(kind, error))?;
     let mut request = loonfs_api::GrepRequest {
@@ -336,7 +336,7 @@ pub(crate) async fn run_filesystem_put(
     }
 
     let remote_path = match args.remote_path {
-        Some(path) => normalize_absolute_path(&path, false),
+        Some(path) => normalize_user_path(&path, false),
         None => default_remote_put_path(&local_path),
     }
     .map_err(|error| context.fail(kind, error))?;

--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -228,6 +228,28 @@ pub(super) async fn load_segment_index<S: ObjectStore + ?Sized>(
     memo: &SessionBlockMemo,
     descriptor: &MetadataFileRef,
 ) -> Result<Arc<Vec<SegmentIndexEntry>>, ManifestLoadError> {
+    load_segment_index_inner(store, table_cache, memo, descriptor, true).await
+}
+
+/// Loads only the index section even for a small segment. Reorganization
+/// uses this to account data-block decoded bytes before any row payload is
+/// decoded; the normal lookup path keeps its whole-small-segment shortcut.
+pub(super) async fn load_segment_index_for_reorganization<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
+    descriptor: &MetadataFileRef,
+) -> Result<Arc<Vec<SegmentIndexEntry>>, ManifestLoadError> {
+    load_segment_index_inner(store, table_cache, memo, descriptor, false).await
+}
+
+async fn load_segment_index_inner<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    memo: &SessionBlockMemo,
+    descriptor: &MetadataFileRef,
+    load_small_segment_whole: bool,
+) -> Result<Arc<Vec<SegmentIndexEntry>>, ManifestLoadError> {
     let handle = descriptor.index_block;
     let cache_key =
         segment_block_cache_key(descriptor, MetadataTableBlockKind::Index, handle.offset);
@@ -235,14 +257,30 @@ pub(super) async fn load_segment_index<S: ObjectStore + ?Sized>(
         return Ok(entries);
     }
     let fetch = || async {
-        load_and_publish_segment_sections(
-            store,
-            table_cache,
-            memo,
-            descriptor,
-            MetadataTableBlockKind::Index,
-        )
-        .await
+        if load_small_segment_whole {
+            load_and_publish_segment_sections(
+                store,
+                table_cache,
+                memo,
+                descriptor,
+                MetadataTableBlockKind::Index,
+            )
+            .await
+        } else {
+            let stored = load_section_bytes(
+                store,
+                &descriptor.object_key,
+                handle.offset,
+                u64::from(handle.stored_len),
+            )
+            .await?;
+            let entries = decode_index_block(&stored, &handle)
+                .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
+            Ok(DecodedMetadataTableBlock::Index {
+                decoded_byte_len: handle.decoded_len as usize,
+                entries: Arc::new(entries),
+            })
+        }
     };
     let block = match table_cache {
         Some(cache) => cache.get_or_load(&cache_key, fetch).await?,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -4,13 +4,13 @@
 //! Checkpoint publication only ever appends an L0 delta run, so its cost
 //! follows the WAL delta, never the namespace. Folding those L0 runs into
 //! the base happens here instead, one **family group** at a time: the
-//! group's rows are merged from every run it appears in, rows below the
-//! retention floor are dropped, new base segments are written, and a
-//! manifest publishes that swaps just that group's references. Families
-//! whose retention rules read each other compact together — bind, child
-//! bind, and unbind rows form one group; revisions and their descending
-//! index another — so index parity and the drop invariants hold within
-//! every unit.
+//! group's rows are merged from an oldest-first, budgeted subset of complete
+//! runs, rows below the retention floor are dropped, new base segments are
+//! written, and a manifest publishes that swaps just those references.
+//! Families whose retention rules read each other compact together — bind,
+//! child bind, and unbind rows form one group; revisions and their descending
+//! index another — so index parity and the drop invariants hold within every
+//! unit.
 //!
 //! There is no progress record: each unit ends in a durable manifest, so a
 //! crashed or interrupted reorganization resumes by reading the live
@@ -20,6 +20,7 @@
 //! the unit's segments are left unreferenced for garbage collection and the
 //! next step retries against the fresh manifest.
 
+use super::block_fetch::load_segment_index_for_reorganization;
 use super::build::{
     build_manifest_tables_from_rows, debug_assert_manifest_table_segments_do_not_overlap,
     MetadataTableSegmentation,
@@ -32,9 +33,10 @@ use super::load::{
 };
 use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
 use super::runs::{
-    flatten_manifest_tables, l0_run_count, MetadataLsmPolicy, CHECKPOINT_BASE_RUN_LEVEL,
-    CHECKPOINT_L0_RUN_LEVEL,
+    flatten_manifest_tables, l0_run_count, MetadataLsmPolicy, MetadataRunManifest,
+    CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
 };
+use super::scan::VerifiedMetadataTables;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::limits::CONTENTION_RETRY_LIMIT;
@@ -74,12 +76,21 @@ pub enum MetadataReorganizeOutcome {
     /// The manifest's L0 run count is below the policy trigger; nothing to
     /// fold yet.
     NotNeeded { l0_runs: usize },
-    /// One family group folded into new base segments and the manifest
-    /// advanced.
+    /// One bounded complete-run subset for a family group folded into new
+    /// base segments and the manifest advanced.
     UnitPublished {
         families: Vec<MetadataTableFamily>,
         folded_l0_rows: u64,
+        input_runs: usize,
+        decoded_input_rows: u64,
+        decoded_input_bytes: u64,
         manifest_id: ManifestId,
+    },
+    /// The trigger fired, but no oldest-first subset that would make
+    /// progress fit the hard per-step input budgets.
+    BudgetExhausted {
+        families: Vec<MetadataTableFamily>,
+        l0_runs: usize,
     },
     /// A concurrent publication moved the root while this unit ran; its
     /// output is unreferenced (garbage collection reclaims it) and the next
@@ -138,7 +149,9 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let previous = tables.manifest();
 
     let l0_runs = l0_run_count(&previous.payload);
-    if l0_runs < policy.max_l0_runs.get() {
+    if l0_runs < policy.max_l0_runs.get()
+        && !manifest_has_partial_reorganization(tables.scan_runs.as_ref())
+    {
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
@@ -151,31 +164,45 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
         });
     };
-    let folded_l0_rows = group_l0_rows(&previous.payload, group);
+    let Some(input) = select_reorganization_input(&tables, group, policy)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+        })?
+    else {
+        return Ok(MetadataReorganizeReport {
+            namespace_id: namespace_id.clone(),
+            outcome: MetadataReorganizeOutcome::BudgetExhausted {
+                families: group.to_vec(),
+                l0_runs,
+            },
+        });
+    };
 
-    // Merge the group's rows from every run it appears in. The scan reads
-    // exactly the manifest's tables — never the WAL tail — so the unit's
-    // output represents the same head the manifest already describes.
+    // Merge only the selected complete runs. The scan reads exactly the
+    // manifest's tables — never the WAL tail — and the unselected
+    // descriptors remain in the replacement manifest unchanged.
     let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
     for family in group {
-        let rows = tables.scan_prefix(*family, "").await.map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-        })?;
+        let rows = tables
+            .scan_prefix_in_runs(&input.runs, *family, "")
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+            })?;
         rows_by_family.insert(*family, rows);
     }
     // The paired groups exist to preserve index parity; verify it on the
-    // merged rows before writing anything.
+    // selected complete runs before writing anything.
     if group.contains(&MetadataTableFamily::DirentryBinds) {
         validate_direntry_child_bind_index(
             root.manifest_object_id.as_ref(),
             rows_by_family
                 .get(&MetadataTableFamily::DirentryBinds)
-                .cloned()
-                .unwrap_or_default(),
+                .map_or(&[], Vec::as_slice),
             rows_by_family
                 .get(&MetadataTableFamily::DirentryChildBinds)
-                .cloned()
-                .unwrap_or_default(),
+                .map_or(&[], Vec::as_slice),
         )
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
@@ -186,12 +213,10 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             root.manifest_object_id.as_ref(),
             rows_by_family
                 .get(&MetadataTableFamily::Revisions)
-                .cloned()
-                .unwrap_or_default(),
+                .map_or(&[], Vec::as_slice),
             rows_by_family
                 .get(&MetadataTableFamily::RevisionsByInodeDesc)
-                .cloned()
-                .unwrap_or_default(),
+                .map_or(&[], Vec::as_slice),
         )
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
@@ -219,7 +244,12 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         .payload
         .metadata_files
         .iter()
-        .filter(|descriptor| !group.contains(&descriptor.family))
+        .filter(|descriptor| {
+            !group.contains(&descriptor.family)
+                || !input
+                    .run_ids
+                    .contains(&(descriptor.run_seq, descriptor.level))
+        })
         .cloned()
         .collect();
     metadata_files.extend(flatten_manifest_tables(run_tables));
@@ -264,7 +294,10 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::UnitPublished {
                 families: group.to_vec(),
-                folded_l0_rows,
+                folded_l0_rows: input.folded_l0_rows,
+                input_runs: input.runs.len(),
+                decoded_input_rows: input.decoded_rows,
+                decoded_input_bytes: input.decoded_bytes,
                 manifest_id: manifest.payload.manifest_id,
             },
         }),
@@ -275,6 +308,136 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             })
         }
     }
+}
+
+struct ReorganizationInput {
+    runs: Vec<MetadataRunManifest>,
+    run_ids: BTreeSet<(ChangeSeq, u32)>,
+    folded_l0_rows: u64,
+    decoded_rows: u64,
+    decoded_bytes: u64,
+}
+
+/// Selects the existing compacted accumulator followed by L0 runs
+/// oldest-first. Index sections are read before row payloads so the
+/// decoded-byte budget is known exactly from each data block's durable
+/// `decoded_len`; a run that would cross a budget is not decoded or
+/// partially included.
+async fn select_reorganization_input<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    group: &[MetadataTableFamily],
+    policy: MetadataLsmPolicy,
+) -> std::result::Result<Option<ReorganizationInput>, ManifestLoadError> {
+    let mut candidates = tables
+        .scan_runs
+        .iter()
+        .filter(|run| run_has_group_rows(run, group))
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        let left_is_l0 = left.level == CHECKPOINT_L0_RUN_LEVEL;
+        let right_is_l0 = right.level == CHECKPOINT_L0_RUN_LEVEL;
+        left_is_l0
+            .cmp(&right_is_l0)
+            .then(left.run_seq.cmp(&right.run_seq))
+            .then(right.level.cmp(&left.level))
+    });
+    let candidate_count = candidates.len();
+    let row_budget =
+        u64::try_from(policy.max_decoded_input_rows_per_step.get()).unwrap_or(u64::MAX);
+    let byte_budget =
+        u64::try_from(policy.max_decoded_input_bytes_per_step.get()).unwrap_or(u64::MAX);
+
+    let mut runs = Vec::new();
+    let mut decoded_rows = 0u64;
+    let mut decoded_bytes = 0u64;
+    let mut folded_l0_rows = 0u64;
+    for run in candidates
+        .into_iter()
+        .take(policy.max_input_runs_per_step.get())
+    {
+        let run_rows = group_run_descriptors(run, group)
+            .map(|descriptor| descriptor.row_count)
+            .sum::<u64>();
+        if decoded_rows.saturating_add(run_rows) > row_budget {
+            break;
+        }
+        let run_bytes = decoded_group_run_bytes(tables, run, group).await?;
+        if decoded_bytes.saturating_add(run_bytes) > byte_budget {
+            break;
+        }
+        if run.level == CHECKPOINT_L0_RUN_LEVEL {
+            folded_l0_rows = folded_l0_rows.saturating_add(run_rows);
+        }
+        decoded_rows = decoded_rows.saturating_add(run_rows);
+        decoded_bytes = decoded_bytes.saturating_add(run_bytes);
+        runs.push(run.clone());
+    }
+
+    let selected_l0 = runs.iter().any(|run| run.level == CHECKPOINT_L0_RUN_LEVEL);
+    let makes_progress = selected_l0 && (runs.len() > 1 || candidate_count == 1);
+    if !makes_progress {
+        return Ok(None);
+    }
+    let run_ids = runs.iter().map(|run| (run.run_seq, run.level)).collect();
+    Ok(Some(ReorganizationInput {
+        runs,
+        run_ids,
+        folded_l0_rows,
+        decoded_rows,
+        decoded_bytes,
+    }))
+}
+
+/// A bounded fold stamps its output at the manifest head. If older or
+/// same-seq L0 runs remain, that ordering is the durable resume marker. A
+/// fresh L0 appended after a completed fold is strictly newer than every
+/// base-tier run and therefore does not bypass the normal trigger.
+fn manifest_has_partial_reorganization(runs: &[MetadataRunManifest]) -> bool {
+    let Some(oldest_l0_seq) = runs
+        .iter()
+        .filter(|run| run.level == CHECKPOINT_L0_RUN_LEVEL)
+        .map(|run| run.run_seq)
+        .min()
+    else {
+        return false;
+    };
+    runs.iter()
+        .any(|run| run.level != CHECKPOINT_L0_RUN_LEVEL && run.run_seq >= oldest_l0_seq)
+}
+
+fn run_has_group_rows(run: &MetadataRunManifest, group: &[MetadataTableFamily]) -> bool {
+    group_run_descriptors(run, group).next().is_some()
+}
+
+fn group_run_descriptors<'a>(
+    run: &'a MetadataRunManifest,
+    group: &'a [MetadataTableFamily],
+) -> impl Iterator<Item = &'a MetadataFileRef> {
+    run.tables
+        .iter()
+        .filter(|table| group.contains(&table.family))
+        .flat_map(|table| &table.segments)
+}
+
+async fn decoded_group_run_bytes<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    run: &MetadataRunManifest,
+    group: &[MetadataTableFamily],
+) -> std::result::Result<u64, ManifestLoadError> {
+    let mut decoded_bytes = 0u64;
+    for descriptor in group_run_descriptors(run, group) {
+        let index = load_segment_index_for_reorganization(
+            tables.store,
+            tables.table_cache,
+            &tables.block_memo,
+            descriptor,
+        )
+        .await?;
+        for entry in index.iter() {
+            decoded_bytes = decoded_bytes.saturating_add(u64::from(entry.block.decoded_len));
+        }
+    }
+    Ok(decoded_bytes)
 }
 
 /// The family group with the most L0 rows to fold; ties resolve in group

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -12,6 +12,9 @@ pub(super) const DEFAULT_MAX_CHECKPOINT_L0_RUNS: usize = 8;
 /// base segments are sized large to amortize their index and filter
 /// sections across many lookups (design doc, "Sizing").
 pub(super) const DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT: usize = 65_536;
+pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_RUNS: usize = 8;
+pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_ROWS: usize = 131_072;
+pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_BYTES: usize = 64 * 1024 * 1024;
 
 pub(super) const MAX_MAINTENANCE_TABLE_IO: usize = 8;
 pub(super) const CHECKPOINT_L0_RUN_LEVEL: u32 = 0;
@@ -44,6 +47,12 @@ pub(super) struct MetadataRunManifest {
 pub(crate) struct MetadataLsmPolicy {
     pub max_l0_runs: NonZeroUsize,
     pub max_rows_per_segment: NonZeroUsize,
+    /// Complete logical runs one reorganization step may inspect and merge.
+    pub max_input_runs_per_step: NonZeroUsize,
+    /// Row payloads one reorganization step may decode across its selected runs.
+    pub max_decoded_input_rows_per_step: NonZeroUsize,
+    /// Decoded SST data-block bytes one reorganization step may materialize.
+    pub max_decoded_input_bytes_per_step: NonZeroUsize,
 }
 
 impl Default for MetadataLsmPolicy {
@@ -53,6 +62,16 @@ impl Default for MetadataLsmPolicy {
                 .expect("default L0 run limit should be nonzero"),
             max_rows_per_segment: NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT)
                 .expect("default segment row budget should be nonzero"),
+            max_input_runs_per_step: NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_RUNS)
+                .expect("default reorganization run budget should be nonzero"),
+            max_decoded_input_rows_per_step: NonZeroUsize::new(
+                DEFAULT_MAX_REORGANIZATION_INPUT_ROWS,
+            )
+            .expect("default reorganization row budget should be nonzero"),
+            max_decoded_input_bytes_per_step: NonZeroUsize::new(
+                DEFAULT_MAX_REORGANIZATION_INPUT_BYTES,
+            )
+            .expect("default reorganization byte budget should be nonzero"),
         }
     }
 }

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -72,6 +72,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             .map(|(_, row)| row))
     }
 
+    #[cfg(test)]
     pub(crate) async fn scan_prefix(
         &self,
         family: MetadataTableFamily,
@@ -79,6 +80,20 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
     ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
         Ok(strip_row_keys(
             self.scan_prefix_rows(family, prefix, None, Readahead::Enabled)
+                .await?,
+        ))
+    }
+
+    /// Scans only `runs`, for a reorganization unit that is replacing that
+    /// complete run subset while leaving every other descriptor untouched.
+    pub(super) async fn scan_prefix_in_runs(
+        &self,
+        runs: &[MetadataRunManifest],
+        family: MetadataTableFamily,
+        prefix: &str,
+    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
+        Ok(strip_row_keys(
+            self.scan_prefix_rows_in_runs(runs, family, prefix, None, Readahead::Disabled)
                 .await?,
         ))
     }
@@ -128,6 +143,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             return Ok(Vec::new());
         }
         self.scan_range_page_rows(
+            self.scan_runs.as_ref(),
             family,
             lower_bound,
             upper_bound,
@@ -153,6 +169,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         }
         Ok(strip_row_keys(
             self.scan_range_page_rows(
+                self.scan_runs.as_ref(),
                 family,
                 lower_bound,
                 upper_bound,
@@ -173,8 +190,27 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: Option<&str>,
         readahead: Readahead,
     ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
+        self.scan_prefix_rows_in_runs(
+            self.scan_runs.as_ref(),
+            family,
+            prefix,
+            filter_probe,
+            readahead,
+        )
+        .await
+    }
+
+    async fn scan_prefix_rows_in_runs(
+        &self,
+        runs: &[MetadataRunManifest],
+        family: MetadataTableFamily,
+        prefix: &str,
+        filter_probe: Option<&str>,
+        readahead: Readahead,
+    ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
         let upper_bound = string_prefix_upper_bound(prefix);
         self.scan_range_page_rows(
+            runs,
             family,
             prefix,
             upper_bound.as_deref(),
@@ -218,6 +254,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
     #[allow(clippy::too_many_arguments)]
     async fn scan_range_page_rows(
         &self,
+        runs: &[MetadataRunManifest],
         family: MetadataTableFamily,
         lower_bound: &str,
         upper_bound: Option<&str>,
@@ -226,7 +263,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         readahead: Readahead,
     ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
         let mut candidates = Vec::new();
-        for run in self.scan_runs.iter() {
+        for run in runs {
             let table = manifest_table_for_family(&self.manifest_object_key, &run.tables, family)?;
             candidates.extend(table.segments.iter().filter(|descriptor| {
                 descriptor_may_intersect_range(descriptor, lower_bound, upper_bound)

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -600,7 +600,7 @@ async fn base_rebuild_drops_bindings_unbound_below_floor() {
 }
 
 #[tokio::test]
-async fn base_rebuild_rejects_divergent_revision_index() {
+async fn bounded_subset_rebuild_rejects_divergent_revision_index() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -634,21 +634,24 @@ async fn base_rebuild_rejects_divergent_revision_index() {
     // L0 appends never re-read the base run; the reorganization merge that
     // folds every run back together is the production point that must
     // reject it.
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/another.txt",
-        b"body\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write");
-    create_checkpoint(&store, &namespace_id, &context)
+    for index in 0..3 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/another-{index}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
         .await
-        .expect("l0 checkpoint");
+        .expect("write");
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("l0 checkpoint");
+    }
     let fold_policy = MetadataLsmPolicy {
         max_l0_runs: NonZeroUsize::MIN,
+        max_input_runs_per_step: NonZeroUsize::new(2).expect("test run budget should be nonzero"),
         ..MetadataLsmPolicy::default()
     };
     let mut rebuild_error = None;

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -208,13 +208,13 @@ where
 
     validate_direntry_child_bind_index(
         manifest_object_key,
-        direntry_bind_rows,
-        direntry_child_bind_rows,
+        &direntry_bind_rows,
+        &direntry_child_bind_rows,
     )?;
     validate_revision_by_inode_desc_index(
         manifest_object_key,
-        revision_rows,
-        revision_by_inode_desc_rows,
+        &revision_rows,
+        &revision_by_inode_desc_rows,
     )
 }
 

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -208,6 +208,9 @@ async fn drain_reorganization<S: ObjectStore + ?Sized>(
             super::MetadataReorganizeOutcome::UnitPublished { .. }
             | super::MetadataReorganizeOutcome::Superseded => continue,
             super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                panic!("test reorganization budget should admit a progress-making subset")
+            }
         }
     }
     read_metadata_root_object(store, namespace_id)

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -42,6 +42,57 @@ fn assert_manifest_rows_have_unique_keys(metadata_state: &MetadataState) {
     }
 }
 
+type TableRunShape = (ApiMetadataTableFamily, u64, usize);
+type ManifestRunShape = (ChangeSeq, u32, Vec<TableRunShape>);
+
+fn manifest_run_shape(manifest: &NamespaceManifestEnvelope) -> Vec<ManifestRunShape> {
+    runs_from_metadata_files(&manifest.payload)
+        .into_iter()
+        .map(|run| {
+            let tables = run
+                .tables
+                .into_iter()
+                .map(|table| {
+                    let row_count = table
+                        .segments
+                        .iter()
+                        .map(|descriptor| descriptor.row_count)
+                        .sum();
+                    (table.family, row_count, table.segments.len())
+                })
+                .collect();
+            (run.run_seq, run.level, tables)
+        })
+        .collect()
+}
+
+async fn drain_reorganization_with_count<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+) -> (ManifestId, usize) {
+    let mut published = 0usize;
+    for _ in 0..128 {
+        let report = super::reorganize_metadata_step(store, namespace_id, context, policy)
+            .await
+            .expect("reorganization step");
+        match report.outcome {
+            super::MetadataReorganizeOutcome::UnitPublished { .. } => published += 1,
+            super::MetadataReorganizeOutcome::Superseded => {
+                panic!("single-writer test must not be superseded")
+            }
+            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                panic!("test budget must admit a progress-making subset")
+            }
+            super::MetadataReorganizeOutcome::NotNeeded { .. } => {
+                return (current_manifest_id(store, namespace_id).await, published);
+            }
+        }
+    }
+    panic!("reorganization did not converge")
+}
+
 /// Deterministic timer advancing a fixed step per reading, so publication
 /// budgets are consumed by observations instead of wall time.
 #[derive(Debug)]
@@ -486,6 +537,9 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
                 panic!("no concurrent publisher exists in this test")
             }
             super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                panic!("test reorganization budget should admit a progress-making subset")
+            }
         }
     }
     assert!(units >= 2, "several family groups should fold, got {units}");
@@ -509,6 +563,213 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
 }
 
 #[tokio::test]
+async fn reorganization_step_honors_run_row_and_decoded_byte_budgets() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 1..=5 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{index}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write file");
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+    }
+
+    let root_before = current_manifest_id(&store, &namespace_id).await;
+    let tiny_byte_policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_input_runs_per_step: NonZeroUsize::new(2).expect("test run budget should be nonzero"),
+        max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
+        ..MetadataLsmPolicy::default()
+    };
+    store.reset();
+    let blocked =
+        super::reorganize_metadata_step(&store, &namespace_id, &context, tiny_byte_policy)
+            .await
+            .expect("budgeted step");
+    let super::MetadataReorganizeOutcome::BudgetExhausted { families, .. } = blocked.outcome else {
+        panic!("one byte must not admit an SST run");
+    };
+    assert_eq!(
+        current_manifest_id(&store, &namespace_id).await,
+        root_before,
+        "a budget-blocked step must not publish"
+    );
+    assert_eq!(store.count(OperationClass::Put), 0);
+    assert!(
+        store.count(OperationClass::Read) <= families.len(),
+        "byte preflight should read only the oldest candidate's index sections"
+    );
+
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_input_runs_per_step: NonZeroUsize::new(2).expect("test run budget should be nonzero"),
+        max_decoded_input_rows_per_step: NonZeroUsize::new(6)
+            .expect("test row budget should be nonzero"),
+        ..MetadataLsmPolicy::default()
+    };
+    store.reset();
+    let published = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+        .await
+        .expect("bounded step");
+    let super::MetadataReorganizeOutcome::UnitPublished {
+        families,
+        input_runs,
+        decoded_input_rows,
+        decoded_input_bytes,
+        ..
+    } = published.outcome
+    else {
+        panic!("two oldest runs should fit the test budgets");
+    };
+    assert_eq!(input_runs, 2);
+    assert!(input_runs <= policy.max_input_runs_per_step.get());
+    assert!(decoded_input_rows <= policy.max_decoded_input_rows_per_step.get() as u64);
+    assert!(decoded_input_bytes <= policy.max_decoded_input_bytes_per_step.get() as u64);
+    assert!(
+        store.count(OperationClass::Read) <= input_runs * families.len() * 2,
+        "the step should read index and data sections only for selected-run family segments"
+    );
+}
+
+#[tokio::test]
+async fn bounded_reorganization_converges_to_unbounded_shape_and_preserves_intermediate_reads() {
+    let bounded_dir = tempdir().expect("bounded tempdir");
+    let unbounded_dir = tempdir().expect("unbounded tempdir");
+    let bounded_store = LocalFsStore::new(bounded_dir.path()).expect("bounded store");
+    let unbounded_store = LocalFsStore::new(unbounded_dir.path()).expect("unbounded store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    for store in [&bounded_store, &unbounded_store] {
+        bootstrap_namespace(store, &namespace_id, &context, false)
+            .await
+            .expect("bootstrap");
+        for index in 1..=6 {
+            let commit_id =
+                CommitId::parse(format!("bounded-convergence-{index}")).expect("commit id");
+            write_file_bytes(
+                store,
+                &namespace_id,
+                &format!("/docs/file-{index}.txt"),
+                format!("file {index}\n").as_bytes(),
+                &context,
+                Some(&commit_id),
+            )
+            .await
+            .expect("write file");
+            create_checkpoint(store, &namespace_id, &context)
+                .await
+                .expect("create checkpoint");
+        }
+    }
+
+    let visible_before = load_current_projection(&bounded_store, &namespace_id)
+        .await
+        .expect("visible state before bounded reorganization");
+    let unlimited = NonZeroUsize::new(usize::MAX).expect("usize max should be nonzero");
+    let bounded_policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::new(4).expect("test trigger should be nonzero"),
+        max_input_runs_per_step: NonZeroUsize::new(2).expect("test run budget should be nonzero"),
+        max_decoded_input_rows_per_step: unlimited,
+        max_decoded_input_bytes_per_step: unlimited,
+        ..MetadataLsmPolicy::default()
+    };
+    let first =
+        super::reorganize_metadata_step(&bounded_store, &namespace_id, &context, bounded_policy)
+            .await
+            .expect("first bounded step");
+    assert!(matches!(
+        first.outcome,
+        super::MetadataReorganizeOutcome::UnitPublished { input_runs: 2, .. }
+    ));
+    let visible_between = load_current_projection(&bounded_store, &namespace_id)
+        .await
+        .expect("visible state between bounded steps");
+    assert!(metadata_states_equivalent(
+        &visible_before.metadata_state,
+        &visible_between.metadata_state
+    ));
+
+    let (bounded_manifest_id, bounded_steps_after_first) =
+        drain_reorganization_with_count(&bounded_store, &namespace_id, &context, bounded_policy)
+            .await;
+    let unbounded_policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::new(4).expect("test trigger should be nonzero"),
+        max_input_runs_per_step: unlimited,
+        max_decoded_input_rows_per_step: unlimited,
+        max_decoded_input_bytes_per_step: unlimited,
+        ..MetadataLsmPolicy::default()
+    };
+    let (unbounded_manifest_id, unbounded_steps) = drain_reorganization_with_count(
+        &unbounded_store,
+        &namespace_id,
+        &context,
+        unbounded_policy,
+    )
+    .await;
+    assert!(bounded_steps_after_first + 1 > unbounded_steps);
+
+    let bounded = load_manifest_materialization_for_inspection(
+        &bounded_store,
+        &namespace_id,
+        bounded_manifest_id,
+    )
+    .await
+    .expect("load bounded result");
+    let unbounded = load_manifest_materialization_for_inspection(
+        &unbounded_store,
+        &namespace_id,
+        unbounded_manifest_id,
+    )
+    .await
+    .expect("load unbounded result");
+    assert!(metadata_states_equivalent(
+        &bounded.metadata_state,
+        &unbounded.metadata_state
+    ));
+    assert_eq!(
+        manifest_run_shape(&bounded.manifest),
+        manifest_run_shape(&unbounded.manifest)
+    );
+    assert!(l0_runs(&bounded.manifest).is_empty());
+
+    let later_commit = CommitId::parse("bounded-convergence-later").expect("commit id");
+    write_file_bytes(
+        &bounded_store,
+        &namespace_id,
+        "/docs/later.txt",
+        b"later\n",
+        &context,
+        Some(&later_commit),
+    )
+    .await
+    .expect("write later file");
+    create_checkpoint(&bounded_store, &namespace_id, &context)
+        .await
+        .expect("checkpoint later file");
+    let below_trigger =
+        super::reorganize_metadata_step(&bounded_store, &namespace_id, &context, bounded_policy)
+            .await
+            .expect("below-trigger step");
+    assert!(matches!(
+        below_trigger.outcome,
+        super::MetadataReorganizeOutcome::NotNeeded { l0_runs: 1 }
+    ));
+}
+
+#[tokio::test]
 async fn whole_run_compaction_rewrites_base_segments() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -518,6 +779,7 @@ async fn whole_run_compaction_rewrites_base_segments() {
         max_l0_runs: NonZeroUsize::MIN,
         max_rows_per_segment: NonZeroUsize::new(2)
             .expect("test segment row budget should be nonzero"),
+        ..MetadataLsmPolicy::default()
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -619,6 +881,7 @@ async fn whole_run_compaction_resegments_row_key_range_families_with_l0_runs() {
         max_l0_runs: NonZeroUsize::MIN,
         max_rows_per_segment: NonZeroUsize::new(2)
             .expect("test segment row budget should be nonzero"),
+        ..MetadataLsmPolicy::default()
     };
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -745,6 +1008,9 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
                 panic!("no concurrent publisher exists in this test")
             }
             super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                panic!("test reorganization budget should admit a progress-making subset")
+            }
         }
     }
     assert!(folded_groups.len() >= 2);

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -146,13 +146,15 @@ pub(super) fn validate_manifest_row_seq_range<'a>(
 
 pub(super) fn validate_direntry_child_bind_index(
     object_key: &str,
-    mut direntry_bind_rows: Vec<MetadataRow>,
-    mut direntry_child_bind_rows: Vec<MetadataRow>,
+    direntry_bind_rows: &[MetadataRow],
+    direntry_child_bind_rows: &[MetadataRow],
 ) -> Result<(), ManifestLoadError> {
+    let mut direntry_bind_rows = direntry_bind_rows.iter().collect::<Vec<_>>();
+    let mut direntry_child_bind_rows = direntry_child_bind_rows.iter().collect::<Vec<_>>();
     direntry_bind_rows
-        .sort_by_key(|row| row.row_key_for_family(MetadataTableFamily::DirentryChildBinds));
+        .sort_by_cached_key(|row| row.row_key_for_family(MetadataTableFamily::DirentryChildBinds));
     direntry_child_bind_rows
-        .sort_by_key(|row| row.row_key_for_family(MetadataTableFamily::DirentryChildBinds));
+        .sort_by_cached_key(|row| row.row_key_for_family(MetadataTableFamily::DirentryChildBinds));
 
     if direntry_bind_rows != direntry_child_bind_rows {
         return Err(ManifestLoadError::SegmentDescriptorMismatch {
@@ -167,22 +169,24 @@ pub(super) fn validate_direntry_child_bind_index(
 
 pub(super) fn validate_revision_by_inode_desc_index(
     object_key: &str,
-    mut revision_rows: Vec<MetadataRow>,
-    mut revision_by_inode_desc_rows: Vec<MetadataRow>,
+    revision_rows: &[MetadataRow],
+    revision_by_inode_desc_rows: &[MetadataRow],
 ) -> Result<(), ManifestLoadError> {
     validate_revision_rows_have_unique_keys(
         object_key,
         MetadataTableFamily::Revisions,
-        &revision_rows,
+        revision_rows,
     )?;
     validate_revision_rows_have_unique_keys(
         object_key,
         MetadataTableFamily::RevisionsByInodeDesc,
-        &revision_by_inode_desc_rows,
+        revision_by_inode_desc_rows,
     )?;
 
-    revision_rows.sort_by_key(revision_logical_key);
-    revision_by_inode_desc_rows.sort_by_key(revision_logical_key);
+    let mut revision_rows = revision_rows.iter().collect::<Vec<_>>();
+    let mut revision_by_inode_desc_rows = revision_by_inode_desc_rows.iter().collect::<Vec<_>>();
+    revision_rows.sort_by_cached_key(|row| revision_logical_key(row));
+    revision_by_inode_desc_rows.sort_by_cached_key(|row| revision_logical_key(row));
 
     if revision_rows != revision_by_inode_desc_rows {
         return Err(ManifestLoadError::RevisionIndexMismatch {

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -6,15 +6,24 @@ use crate::checkpoint::record::encode_checkpoint_record;
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
+use crate::namespace::control::{map_control_codec_error, ControlObjectLoadError};
 use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointRecordLifecycle, CheckpointRecordState,
     ControlObjectKind, HeadState, HeadStateEnvelope, NamespaceState,
 };
-use loonfs_api::{ManifestObjectId, NamespaceId};
+use loonfs_api::{GeneratedIdValidationError, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{namespace_config, namespace_prefix, wal_head};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+
+// Decode failure may only ever bias toward retaining bytes, never toward
+// deleting or fabricating them.
+enum HeadObservation {
+    Missing,
+    Valid(HeadState),
+    Unreadable(ControlObjectLoadError),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AbandonedBootstrapReap {
@@ -122,11 +131,22 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
         .get_with_metadata(&head_key)
         .await
         .map_err(|error| CoreError::store(&head_key, &error))?;
-    let decoded_head = head_body.as_ref().and_then(|body| {
-        decode_control_object::<HeadState>(&body.bytes, ControlObjectKind::WalHead)
-            .ok()
-            .map(|envelope| envelope.state)
-    });
+    let observed_head = match &head_body {
+        None => HeadObservation::Missing,
+        Some(body) => {
+            match decode_control_object::<HeadState>(&body.bytes, ControlObjectKind::WalHead) {
+                Ok(envelope) => HeadObservation::Valid(envelope.state),
+                Err(error) => {
+                    HeadObservation::Unreadable(map_control_codec_error(&head_key, error))
+                }
+            }
+        }
+    };
+    let decoded_head = match observed_head {
+        HeadObservation::Missing => None,
+        HeadObservation::Valid(state) => Some(state),
+        HeadObservation::Unreadable(error) => return Err(CoreError::load_head(error)),
+    };
     if let Some(head) = &decoded_head {
         if head.namespace_id != *namespace_id {
             return Ok(AbandonedBootstrapReap::InFlight);
@@ -171,9 +191,10 @@ pub(crate) async fn reap_abandoned_bootstrap<S: ObjectStore + ?Sized>(
             }
         }
 
-        let mut condemned_head = decoded_head
-            .clone()
-            .unwrap_or_else(|| HeadState::initial(namespace_id.clone()));
+        let mut condemned_head = match decoded_head.clone() {
+            Some(head) => head,
+            None => HeadState::initial(namespace_id.clone()),
+        };
         condemned_head.state = NamespaceState::Condemned;
         let envelope = HeadStateEnvelope::from_state(
             ControlObjectKind::WalHead,
@@ -285,8 +306,10 @@ pub(super) async fn delete_if_aged<S: ObjectStore + ?Sized>(
     Ok(true)
 }
 
-pub(super) fn manifest_object_id_of(key: &str) -> Option<ManifestObjectId> {
+pub(super) fn manifest_object_id_of(
+    key: &str,
+) -> Option<std::result::Result<ManifestObjectId, GeneratedIdValidationError>> {
     let name = key.rsplit('/').next()?;
     let object_id = name.strip_suffix(".manifest.json")?;
-    ManifestObjectId::parse(object_id).ok()
+    Some(ManifestObjectId::parse(object_id))
 }

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -148,9 +148,10 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     let selected = match family {
         CandidateFamily::WalSegments => !mark.wal_segments.contains(key),
         CandidateFamily::MetadataTables => !mark.tables.contains(key),
-        CandidateFamily::Manifests => {
-            manifest_object_id_of(key).is_none_or(|id| !mark.manifests.contains(&id))
-        }
+        CandidateFamily::Manifests => match manifest_object_id_of(key) {
+            Some(Ok(id)) => !mark.manifests.contains(&id),
+            None | Some(Err(_)) => false,
+        },
         CandidateFamily::Checkpoints => !mark.checkpoint_keys.contains(key),
         CandidateFamily::UploadSessions => false,
     };
@@ -178,9 +179,11 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
             }
         }
         CandidateFamily::Manifests => {
-            let live =
-                manifest_object_id_of(key).is_some_and(|id| sweep.live.manifests.contains(&id));
-            if sweep.degraded || live {
+            let live_or_unrecognized = match manifest_object_id_of(key) {
+                Some(Ok(id)) => sweep.live.manifests.contains(&id),
+                None | Some(Err(_)) => true,
+            };
+            if sweep.degraded || live_or_unrecognized {
                 report.retained_candidates += 1;
             } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
                 report.deleted_manifests += 1;

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -848,6 +848,52 @@ async fn gc_reaps_dead_checkpoints_before_their_basis_across_passes() {
     stat_root(&store, &namespace_id).await;
 }
 
+/// Objects whose keys do not name a valid manifest are not proven GC
+/// candidates, so the pass retains their exact bytes.
+#[tokio::test]
+async fn gc_retains_unrecognized_manifest_keys() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+
+    let manifest_prefix = metadata_manifest_prefix(namespace_id.as_str());
+    let foreign_objects = [
+        (
+            format!("{manifest_prefix}notes.txt"),
+            b"foreign key".as_slice(),
+        ),
+        (
+            format!("{manifest_prefix}invalid.manifest.json"),
+            b"invalid manifest id".as_slice(),
+        ),
+    ];
+    for (key, bytes) in &foreign_objects {
+        store
+            .put_if_absent(key, Bytes::copy_from_slice(bytes))
+            .await
+            .expect("write foreign manifest-prefix object");
+    }
+
+    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect("gc pass");
+
+    assert_eq!(report.deleted_manifests, 0);
+    for (key, expected) in foreign_objects {
+        let actual = store
+            .get(&key, None)
+            .await
+            .expect("get foreign manifest-prefix object")
+            .expect("unrecognized object is retained");
+        assert_eq!(actual.as_ref(), expected);
+    }
+}
+
 /// Repeated WAL flushes leave superseded manifests unpinned, so GC
 /// reclaims them once aged. This is what keeps retained metadata
 /// bounded when maintenance runs continuously.

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -388,6 +388,7 @@ mod tests {
     use loonfs_test_support::stores::{
         BlockingStore, KeyPredicate, OperationClass, OperationContext, OperationKind,
     };
+    use std::collections::BTreeMap;
     use std::sync::Arc;
     use tempfile::tempdir;
 
@@ -481,6 +482,100 @@ mod tests {
             .expect("list namespace")
     }
 
+    async fn namespace_objects(
+        store: &LocalFsStore,
+        namespace_id: &NamespaceId,
+    ) -> BTreeMap<String, Vec<u8>> {
+        let mut objects = BTreeMap::new();
+        for key in namespace_keys(store, namespace_id).await {
+            let bytes = store
+                .get(&key, None)
+                .await
+                .expect("get namespace object")
+                .expect("listed namespace object exists");
+            objects.insert(key, bytes.to_vec());
+        }
+        objects
+    }
+
+    fn flip_head_checksum(bytes: &[u8]) -> Vec<u8> {
+        let mut document: serde_json::Value =
+            serde_json::from_slice(bytes).expect("decode head json");
+        let checksum = document["payload_checksum"]
+            .as_str()
+            .expect("head checksum")
+            .to_owned();
+        let replacement = if checksum.as_bytes()[7] == b'0' {
+            "1"
+        } else {
+            "0"
+        };
+        let mut corrupted = checksum;
+        corrupted.replace_range(7..8, replacement);
+        document["payload_checksum"] = serde_json::Value::String(corrupted);
+        serde_json::to_vec(&document).expect("encode corrupt head")
+    }
+
+    fn replace_head_marker(bytes: &[u8], marker: &str, value: serde_json::Value) -> Vec<u8> {
+        let mut document: serde_json::Value =
+            serde_json::from_slice(bytes).expect("decode head json");
+        document[marker] = value;
+        serde_json::to_vec(&document).expect("encode head with foreign marker")
+    }
+
+    async fn assert_repair_retains_unreadable_head(
+        namespace: &str,
+        damage: impl FnOnce(&[u8]) -> Vec<u8>,
+    ) {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse(namespace).expect("namespace id");
+        bootstrap_namespace(&store, &namespace_id, &context(1_000), false)
+            .await
+            .expect("bootstrap");
+        store
+            .delete(&namespace_config(namespace_id.as_str()))
+            .await
+            .expect("simulate crash before the completion marker");
+
+        let head_key = wal_head(namespace_id.as_str());
+        let head = store
+            .get(&head_key, None)
+            .await
+            .expect("get head")
+            .expect("head exists");
+        store
+            .put_overwrite(&head_key, Bytes::from(damage(&head)))
+            .await
+            .expect("damage head");
+        let before = namespace_objects(&store, &namespace_id).await;
+        let aged = context(
+            now_after_newest_object(&store, &namespace_id, GC_MIN_GRACE_WINDOW_MS + 1).await,
+        );
+
+        let error = repair_namespace(&store, &namespace_id, &aged)
+            .await
+            .expect_err("unreadable head is corruption");
+        assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+        let error_key = match &error {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(
+                ControlObjectLoadError::ChecksumMismatch { object_key, .. }
+                | ControlObjectLoadError::Codec { object_key, .. },
+            )) => Some(object_key.as_str()),
+            _ => None,
+        };
+        assert_eq!(
+            error_key,
+            Some(head_key.as_str()),
+            "repair must return typed head corruption"
+        );
+        assert_eq!(
+            namespace_objects(&store, &namespace_id).await,
+            before,
+            "repair must preserve every namespace byte"
+        );
+    }
+
     async fn commit_directory(store: &LocalFsStore, namespace_id: &NamespaceId, name: &str) {
         let mut engine = NamespaceCommitEngine::new(namespace_id.clone());
         engine
@@ -504,6 +599,36 @@ mod tests {
             .pop()
             .expect("one commit result")
             .expect("commit lands");
+    }
+
+    #[tokio::test]
+    async fn repair_reports_corrupt_head_and_preserves_every_namespace_byte() {
+        assert_repair_retains_unreadable_head("checksumcase", flip_head_checksum).await;
+        assert_repair_retains_unreadable_head("truncatedcase", |bytes| {
+            bytes[..bytes.len() / 2].to_vec()
+        })
+        .await;
+        assert_repair_retains_unreadable_head("junkcase", |_| b"not json".to_vec()).await;
+    }
+
+    #[tokio::test]
+    async fn repair_reports_foreign_head_markers_and_preserves_every_namespace_byte() {
+        assert_repair_retains_unreadable_head("kindcase", |bytes| {
+            replace_head_marker(
+                bytes,
+                "kind",
+                serde_json::Value::String("metadata_root".to_owned()),
+            )
+        })
+        .await;
+        assert_repair_retains_unreadable_head("versioncase", |bytes| {
+            replace_head_marker(
+                bytes,
+                "format_version",
+                serde_json::Value::Number(37_u64.into()),
+            )
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -388,13 +388,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn path_intent_fingerprint_normalizes_paths() {
+    async fn path_intent_fingerprint_is_stable_for_canonical_paths() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let left = path_intent_fingerprint(
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs-a").expect("valid commit id"),
-                absolute_path: AbsolutePath::parse("/docs//a/").expect("path"),
+                absolute_path: AbsolutePath::parse("/docs/a").expect("path"),
                 parents: false,
             },
         )

--- a/crates/loonfs-core/tests/batch_publish.rs
+++ b/crates/loonfs-core/tests/batch_publish.rs
@@ -1294,7 +1294,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
 
     let intent = PathMutationIntent::PutFile {
         commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
-        absolute_path: AbsolutePath::parse("/same//path.txt").expect("path"),
+        absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
         content_ref: content.content_ref.clone(),
         behavior: DestinationBehavior::NoReplace,
     };

--- a/crates/loonfs-core/tests/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/visibility_equivalence.rs
@@ -896,6 +896,9 @@ async fn drain_reorganization(
             MetadataReorganizeOutcome::Superseded => {
                 panic!("single-writer test must not supersede reorganization")
             }
+            MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                panic!("default budget must admit the visibility scenario")
+            }
         }
     }
     panic!("reorganization did not drain within the family-group bound");

--- a/crates/loonfs-grep/src/root/codec.rs
+++ b/crates/loonfs-grep/src/root/codec.rs
@@ -121,6 +121,28 @@ struct EnvelopeDocument {
     payload: Box<RawValue>,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictEnvelopeDocument {
+    kind: String,
+    format_version: String,
+    writer_version: String,
+    payload_checksum: String,
+    payload: Box<RawValue>,
+}
+
+impl From<StrictEnvelopeDocument> for EnvelopeDocument {
+    fn from(document: StrictEnvelopeDocument) -> Self {
+        Self {
+            kind: document.kind,
+            format_version: document.format_version,
+            writer_version: document.writer_version,
+            payload_checksum: document.payload_checksum,
+            payload: document.payload,
+        }
+    }
+}
+
 /// Encodes a root pointer after rechecking its version and checksum.
 pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepRootCodecError> {
     encode_envelope(
@@ -135,7 +157,7 @@ pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepRoot
 
 /// Decodes only the current root-pointer format and verifies exact payload bytes.
 pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepRootCodecError> {
-    let document = decode_document(bytes, GREP_ROOT_KIND, GREP_ROOT_FORMAT_VERSION)?;
+    let document = decode_strict_document(bytes, GREP_ROOT_KIND, GREP_ROOT_FORMAT_VERSION)?;
     let pointer: GrepRootPointer = decode_payload(&document)?;
     Ok(GrepRootEnvelope {
         format_version: document.format_version,
@@ -231,6 +253,35 @@ fn decode_document(
     expected_kind: &str,
     supported_version: &str,
 ) -> Result<EnvelopeDocument, GrepRootCodecError> {
+    decode_probe(bytes, expected_kind, supported_version)?;
+    let document: EnvelopeDocument =
+        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
+            message: error.to_string(),
+        })?;
+    verify_document_checksum(&document)?;
+    Ok(document)
+}
+
+fn decode_strict_document(
+    bytes: &[u8],
+    expected_kind: &str,
+    supported_version: &str,
+) -> Result<EnvelopeDocument, GrepRootCodecError> {
+    decode_probe(bytes, expected_kind, supported_version)?;
+    let document: StrictEnvelopeDocument =
+        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
+            message: error.to_string(),
+        })?;
+    let document = EnvelopeDocument::from(document);
+    verify_document_checksum(&document)?;
+    Ok(document)
+}
+
+fn decode_probe(
+    bytes: &[u8],
+    expected_kind: &str,
+    supported_version: &str,
+) -> Result<(), GrepRootCodecError> {
     let probe: EnvelopeProbe =
         serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
             message: error.to_string(),
@@ -242,19 +293,18 @@ fn decode_document(
         });
     }
     verify_version(&probe.format_version, supported_version)?;
+    Ok(())
+}
 
-    let document: EnvelopeDocument =
-        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
-            message: error.to_string(),
-        })?;
+fn verify_document_checksum(document: &EnvelopeDocument) -> Result<(), GrepRootCodecError> {
     let actual = sha256_digest(document.payload.get().as_bytes());
     if actual != document.payload_checksum {
         return Err(GrepRootCodecError::ChecksumMismatch {
-            expected: document.payload_checksum,
+            expected: document.payload_checksum.clone(),
             actual,
         });
     }
-    Ok(document)
+    Ok(())
 }
 
 fn decode_payload<T: DeserializeOwned>(

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -123,6 +123,7 @@ impl<'de> Deserialize<'de> for GrepManifestId {
 
 /// Small mutable control payload installed at `extensions/grep/root.json`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GrepRootPointer {
     namespace_id: NamespaceId,
     manifest_id: GrepManifestId,

--- a/crates/loonfs-grep/tests/root_format.rs
+++ b/crates/loonfs-grep/tests/root_format.rs
@@ -6,8 +6,8 @@ use loonfs_api::wire::sst_blocks::BlockHandle;
 use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId};
 use loonfs_grep::root::{
     decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root, GrepFoldState,
-    GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepManifestId, GrepRootCodecError,
-    GrepRootEnvelope, GrepRootPointer, GrepRootState, GrepRootStateError, GrepSegmentRef,
+    GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepRootCodecError, GrepRootEnvelope,
+    GrepRootPointer, GrepRootState, GrepRootStateError, GrepSegmentRef,
 };
 use loonfs_test_support::ids::namespace_id;
 
@@ -57,23 +57,42 @@ fn encoded_manifests_and_pointers_match_frozen_v1_bytes() {
 }
 
 #[test]
-fn decoders_read_frozen_v1_bytes_with_additive_fields() {
+fn immutable_manifest_decoder_reads_frozen_v1_bytes_with_additive_fields() {
     let decoded =
         decode_grep_manifest(ADDITIVE_V1.as_bytes()).expect("decode additive manifest fixture");
 
     assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11), 0));
-    let pointer =
-        decode_grep_root(ADDITIVE_POINTER_V1.as_bytes()).expect("decode additive pointer fixture");
-    assert_eq!(
-        pointer.pointer(),
-        &GrepRootPointer::new(
-            namespace_id("docs"),
-            GrepManifestId::parse(
-                "9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad"
-            )
-            .expect("valid manifest id")
-        )
+}
+
+#[test]
+fn mutable_pointer_payload_rejects_unknown_fields_as_corruption() {
+    let mut document: serde_json::Value =
+        serde_json::from_str(STEADY_POINTER_V1).expect("decode pointer fixture");
+    document["payload"]["field_from_the_future"] = serde_json::Value::from(true);
+    let payload = serde_json::to_string(&document["payload"]).expect("encode edited payload");
+    document["payload_checksum"] =
+        serde_json::Value::from(loonfs_api::sha256_digest(payload.as_bytes()));
+    let edited = format!(
+        "{{\"kind\":{},\"format_version\":{},\"writer_version\":{},\"payload_checksum\":{},\"payload\":{}}}",
+        document["kind"],
+        document["format_version"],
+        document["writer_version"],
+        document["payload_checksum"],
+        payload,
     );
+
+    assert!(matches!(
+        decode_grep_root(edited.as_bytes()),
+        Err(GrepRootCodecError::PayloadDecode { .. })
+    ));
+}
+
+#[test]
+fn mutable_pointer_envelope_rejects_unknown_fields_as_corruption() {
+    assert!(matches!(
+        decode_grep_root(ADDITIVE_POINTER_V1.as_bytes()),
+        Err(GrepRootCodecError::EnvelopeDecode { .. })
+    ));
 }
 
 #[test]

--- a/crates/loonfs/src/background.rs
+++ b/crates/loonfs/src/background.rs
@@ -52,10 +52,10 @@ pub(crate) struct BackgroundWork {
 struct BackgroundState {
     closed: bool,
     inflight: BTreeSet<NamespaceId>,
-    /// Namespaces whose over-threshold publish arrived while their step was
-    /// already running. The running step consumes this through
-    /// [`BackgroundWork::finish_or_rerun`] and runs again, so the last write
-    /// before an idle period cannot leave the tail unbounded.
+    /// Distinct dirty namespaces whose step request arrived while their own
+    /// step was running or while the global concurrency cap was full. The
+    /// set coalesces repeated requests and is bounded by the number of
+    /// distinct dirty namespaces.
     pending: BTreeSet<NamespaceId>,
     tasks: Vec<JoinHandle<()>>,
 }
@@ -110,14 +110,15 @@ impl BackgroundWork {
             return false;
         }
         if state.inflight.len() >= self.max_concurrent.get() {
+            state.pending.insert(namespace_id.clone());
             tracing::debug!(
                 namespace_id = %namespace_id,
                 max_concurrent = self.max_concurrent.get(),
-                "maintenance step skipped at the concurrency cap; \
-                 the next over-threshold publish reschedules it"
+                "maintenance step deferred at the concurrency cap"
             );
             return false;
         }
+        state.pending.remove(namespace_id);
         state.inflight.insert(namespace_id.clone())
     }
 
@@ -127,25 +128,39 @@ impl BackgroundWork {
         state.inflight.remove(namespace_id);
     }
 
-    /// Ends one step run for the namespace. When another over-threshold
-    /// publish deferred a request during the run, that request is consumed,
-    /// the singleflight slot stays held, and the caller must run again; only
-    /// a quiet finish releases the slot. Checking and releasing under the
-    /// one state lock closes the window where a request could land between
-    /// a final pending check and the release.
-    pub(crate) fn finish_or_rerun(&self, namespace_id: &NamespaceId) -> bool {
+    /// Ends one step run and returns the namespace the caller must run next.
+    ///
+    /// The finishing namespace's own deferred request wins first and keeps
+    /// its slot. Otherwise the slot transfers to the first pending namespace
+    /// that is not already running. The pending check, release, dequeue, and
+    /// new claim share the one state lock, so no request can be lost between
+    /// freeing the slot and choosing its successor.
+    pub(crate) fn finish_or_rerun(&self, namespace_id: &NamespaceId) -> Option<NamespaceId> {
         let mut state = self.lock_state();
         if !state.closed && state.pending.remove(namespace_id) {
-            return true;
+            return Some(namespace_id.clone());
         }
         state.pending.remove(namespace_id);
         state.inflight.remove(namespace_id);
-        false
+        if state.closed {
+            return None;
+        }
+        let next_namespace_id = state
+            .pending
+            .iter()
+            .find(|candidate| !state.inflight.contains(*candidate))
+            .cloned()?;
+        state.pending.remove(&next_namespace_id);
+        state.inflight.insert(next_namespace_id.clone());
+        Some(next_namespace_id)
     }
 
-    /// Rejects any further background scheduling.
+    /// Rejects further scheduling and discards work still waiting for a
+    /// concurrency slot. Already registered tasks remain visible to drain.
     pub(crate) fn shut_down(&self) {
-        self.lock_state().closed = true;
+        let mut state = self.lock_state();
+        state.closed = true;
+        state.pending.clear();
     }
 
     /// Spawns claimed work on the owning runtime and registers it for
@@ -176,7 +191,8 @@ impl BackgroundWork {
 
     /// Waits for every scheduled task to finish, surfacing panics. Loops
     /// because an in-flight write may schedule more work while an open
-    /// handle waits.
+    /// handle waits, and because a finishing task registers the next queued
+    /// namespace before it exits.
     pub(crate) async fn drain(&self) -> Result<()> {
         let mut panicked = 0usize;
         loop {
@@ -236,12 +252,13 @@ mod tests {
             !background.try_claim(&namespace_id),
             "a request during the active step defers instead of claiming"
         );
-        assert!(
+        assert_eq!(
             background.finish_or_rerun(&namespace_id),
+            Some(namespace_id.clone()),
             "the deferred request keeps the slot held and reruns the step"
         );
         assert!(
-            !background.finish_or_rerun(&namespace_id),
+            background.finish_or_rerun(&namespace_id).is_none(),
             "a quiet finish releases the slot"
         );
         assert!(
@@ -260,7 +277,7 @@ mod tests {
         assert!(!background.try_claim(&namespace_id), "defers while active");
         background.shut_down();
         assert!(
-            !background.finish_or_rerun(&namespace_id),
+            background.finish_or_rerun(&namespace_id).is_none(),
             "a deferred request must not rerun after shutdown closed admission"
         );
     }
@@ -360,7 +377,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn claims_stop_at_the_global_concurrency_cap() {
+    async fn a_freed_slot_claims_the_next_namespace_at_the_global_cap() {
         let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(2));
         let first = NamespaceId::parse("first").expect("valid namespace id");
         let second = NamespaceId::parse("second").expect("valid namespace id");
@@ -373,10 +390,52 @@ mod tests {
             "a third namespace must wait for a slot"
         );
 
-        background.release(&first);
+        assert_eq!(
+            background.finish_or_rerun(&first),
+            Some(third.clone()),
+            "the finishing path transfers its slot to the queued namespace"
+        );
+        background.release(&second);
+        background.release(&third);
+    }
+
+    #[test]
+    fn repeated_requests_for_one_queued_namespace_coalesce_to_one_run() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(1));
+        let active = namespace_id("active");
+        let queued = namespace_id("queued");
+
+        assert!(background.try_claim(&active));
+        for _ in 0..8 {
+            assert!(
+                !background.try_claim(&queued),
+                "the queued namespace cannot claim the occupied slot"
+            );
+        }
+        assert_eq!(
+            background.finish_or_rerun(&active),
+            Some(queued.clone()),
+            "one queued run consumes all coalesced requests"
+        );
         assert!(
-            background.try_claim(&third),
-            "a released slot admits the waiting namespace"
+            background.finish_or_rerun(&queued).is_none(),
+            "coalesced requests must not create a second run"
+        );
+    }
+
+    #[test]
+    fn shutdown_clears_namespaces_waiting_at_the_global_cap() {
+        let background = BackgroundWork::new(FsBackgroundWork::Enabled, None, concurrency_cap(1));
+        let active = namespace_id("active");
+        let queued = namespace_id("queued");
+
+        assert!(background.try_claim(&active));
+        assert!(!background.try_claim(&queued));
+        background.shut_down();
+        assert!(background.finish_or_rerun(&active).is_none());
+        assert!(
+            !background.try_claim(&queued),
+            "closed admission must not revive the cleared queue"
         );
     }
 }

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -127,13 +127,25 @@ impl FsCore {
             loonfs_core::MetadataReorganizeOutcome::UnitPublished {
                 families,
                 folded_l0_rows,
+                input_runs,
+                decoded_input_rows,
+                decoded_input_bytes,
                 ..
             } => {
                 self.invalidate_namespace_cache(namespace_id);
                 tracing::info!(
                     families = ?families,
                     folded_l0_rows,
+                    input_runs,
+                    decoded_input_rows,
+                    decoded_input_bytes,
                     "metadata reorganization unit published"
+                );
+            }
+            loonfs_core::MetadataReorganizeOutcome::BudgetExhausted { families, .. } => {
+                tracing::warn!(
+                    families = ?families,
+                    "metadata reorganization input does not fit the per-step budget"
                 );
             }
             loonfs_core::MetadataReorganizeOutcome::Superseded => {
@@ -160,6 +172,7 @@ impl FsCore {
             match self.run_step_reorganization(namespace_id).await? {
                 loonfs_core::MetadataReorganizeOutcome::UnitPublished { .. } => {}
                 loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. }
+                | loonfs_core::MetadataReorganizeOutcome::BudgetExhausted { .. }
                 | loonfs_core::MetadataReorganizeOutcome::Superseded => break,
             }
         }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -641,34 +641,52 @@ impl FsCore {
             fs: self.clone(),
             namespace_id: namespace_id.clone(),
         };
-        self.inner.background.spawn(async move {
-            loop {
-                if let Err(error) = claim
-                    .fs
-                    .run_auto_maintenance(&claim.namespace_id, options.clone())
-                    .await
-                {
-                    tracing::info!(
-                        phase = "auto_maintenance_step",
-                        result = "error",
-                        error = %error,
-                        "post-publish maintenance step failed"
-                    );
+        self.spawn_claimed_auto_maintenance(claim, options);
+    }
+
+    fn spawn_claimed_auto_maintenance(
+        &self,
+        claim: BackgroundStepClaim,
+        options: MaintenanceStepOptions,
+    ) {
+        // Type erasure lets a finishing task transfer its claim and spawn the
+        // next queued namespace without forming a recursive future type.
+        let future: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
+            Box::pin(async move {
+                let mut claim = claim;
+                loop {
+                    if let Err(error) = claim
+                        .fs
+                        .run_auto_maintenance(&claim.namespace_id, options.clone())
+                        .await
+                    {
+                        tracing::info!(
+                            phase = "auto_maintenance_step",
+                            result = "error",
+                            error = %error,
+                            "post-publish maintenance step failed"
+                        );
+                    }
+                    let Some(next_namespace_id) = claim
+                        .fs
+                        .inner
+                        .background
+                        .finish_or_rerun(&claim.namespace_id)
+                    else {
+                        break;
+                    };
+                    if next_namespace_id == claim.namespace_id {
+                        // Preserve the existing own-namespace rerun in this
+                        // task before handing its slot to global queued work.
+                        continue;
+                    }
+                    claim.namespace_id = next_namespace_id;
+                    let fs = claim.fs.clone();
+                    fs.spawn_claimed_auto_maintenance(claim, options);
+                    return;
                 }
-                // A publish that crossed the threshold while this step ran
-                // deferred its request rather than dropping it; consume it
-                // and run again, so the last write before an idle period
-                // cannot leave the tail unbounded.
-                if !claim
-                    .fs
-                    .inner
-                    .background
-                    .finish_or_rerun(&claim.namespace_id)
-                {
-                    break;
-                }
-            }
-        });
+            });
+        self.inner.background.spawn(future);
     }
 
     async fn run_auto_maintenance(

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -528,8 +528,8 @@ impl FsWriterBuilder {
     /// Caps how many writer-scheduled maintenance steps may run at once
     /// across all namespaces this writer serves. Each namespace already runs
     /// at most one step at a time; this bounds the fan-out when many
-    /// namespaces cross their thresholds together. Skipped steps are
-    /// rescheduled by the next over-threshold publish. Defaults to
+    /// namespaces cross their thresholds together. Requests beyond the cap
+    /// are coalesced by namespace and run as permits become available. Defaults to
     /// [`crate::DEFAULT_MAX_CONCURRENT_MAINTENANCE`]. The limit must be
     /// greater than zero; [`FsBackgroundWork::ManualOnly`] is the only way
     /// to disable scheduling.

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -7,9 +7,9 @@
 //! the handles document.
 
 use loonfs::{
-    CommitId, CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsReader,
-    FsWriter, MaintenanceStepOptions, ManifestId, NamespaceId, PutFileOptions, RuntimeCacheConfig,
-    RuntimeError, SharedObjectStore, StoreConfig,
+    CommitId, CreateCheckpointOptions, CreateNamespaceOptions, ErrorCode, FsAdmin,
+    FsBackgroundWork, FsReader, FsWriter, MaintenanceStepOptions, ManifestId, NamespaceId,
+    PutFileOptions, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_core::control::load_namespace_metadata_root_control;
@@ -22,6 +22,7 @@ use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::tempdir;
+use tokio::time::{timeout, Duration};
 
 fn store_config(root: &Path) -> StoreConfig {
     StoreConfig::LocalFs {
@@ -63,6 +64,23 @@ async fn fill_wal_tail_past_threshold(writer: &FsWriter, namespace_id: &Namespac
             )
             .await
             .expect("put file");
+    }
+}
+
+async fn fill_wal_tail_through_write_stop(writer: &FsWriter, namespace_id: &NamespaceId) {
+    let writes =
+        u32::try_from(loonfs_core::publish::WalTailPolicy::DEFAULT.reject_writes_at_segments + 1)
+            .expect("WAL write-stop limit plus one should fit in u32");
+    for round in 0..writes {
+        writer
+            .put_file_bytes(
+                namespace_id,
+                &format!("/write-stop/file-{round}.txt"),
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("put file through the write-stop boundary");
     }
 }
 
@@ -136,6 +154,221 @@ fn a_threshold_crossing_during_an_active_step_still_bounds_the_tail() {
             .shutdown_background()
             .await
             .expect("shut down writer background work");
+    });
+}
+
+#[test]
+fn a_step_queued_at_the_global_cap_runs_without_another_publish() {
+    let temp_dir = tempdir().expect("tempdir");
+    let active_namespace = namespace_id("active");
+    let queued_namespace = namespace_id("queued");
+    block_on(async {
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::metadata_root(active_namespace.as_str()),
+            OperationClass::CompareAndSwap,
+        ));
+        let store: SharedObjectStore = blocking.clone();
+        let writer = FsWriter::builder_with_store(store)
+            .writer_id("handle-test-writer")
+            .background_work(FsBackgroundWork::Enabled)
+            .max_concurrent_maintenance(1)
+            .build()
+            .await
+            .expect("build writer");
+        for namespace_id in [&active_namespace, &queued_namespace] {
+            writer
+                .create_namespace(namespace_id, CreateNamespaceOptions::default())
+                .await
+                .expect("create namespace");
+        }
+
+        blocking.block_next();
+        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
+        blocking.wait_until_blocked().await;
+        fill_wal_tail_past_threshold(&writer, &queued_namespace).await;
+
+        blocking.release();
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("queued maintenance quiesces");
+
+        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .namespace_status(&queued_namespace)
+            .await
+            .expect("queued namespace status");
+        assert!(
+            status.wal_tail_segments < wal_tail_segment_threshold(),
+            "the queued step must run without another publish: {status:?}"
+        );
+        writer
+            .shutdown_background()
+            .await
+            .expect("shut down writer background work");
+    });
+}
+
+#[test]
+fn a_write_stopped_namespace_queued_at_the_global_cap_unblocks_itself() {
+    let temp_dir = tempdir().expect("tempdir");
+    let active_namespace = namespace_id("active");
+    let write_stopped_namespace = namespace_id("write-stopped");
+    block_on(async {
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::metadata_root(active_namespace.as_str()),
+            OperationClass::CompareAndSwap,
+        ));
+        let store: SharedObjectStore = blocking.clone();
+        let writer = FsWriter::builder_with_store(store)
+            .writer_id("handle-test-writer")
+            .background_work(FsBackgroundWork::Enabled)
+            .max_concurrent_maintenance(1)
+            .build()
+            .await
+            .expect("build writer");
+        for namespace_id in [&active_namespace, &write_stopped_namespace] {
+            writer
+                .create_namespace(namespace_id, CreateNamespaceOptions::default())
+                .await
+                .expect("create namespace");
+        }
+
+        blocking.block_next();
+        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
+        blocking.wait_until_blocked().await;
+        fill_wal_tail_through_write_stop(&writer, &write_stopped_namespace).await;
+        let error = writer
+            .put_file_bytes(
+                &write_stopped_namespace,
+                "/write-stop/rejected.txt",
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect_err("writes past the hard limit must reject");
+        assert_eq!(error.code(), ErrorCode::MaintenanceRequired);
+
+        blocking.release();
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("queued maintenance quiesces");
+
+        writer
+            .put_file_bytes(
+                &write_stopped_namespace,
+                "/write-stop/rejected.txt",
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("the queued step must unblock writes without another publish");
+        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .namespace_status(&write_stopped_namespace)
+            .await
+            .expect("write-stopped namespace status");
+        assert!(
+            status.wal_tail_segments < wal_tail_segment_threshold(),
+            "the queued step must flush the write-stopped tail before the retry: {status:?}"
+        );
+        writer
+            .shutdown_background()
+            .await
+            .expect("shut down writer background work");
+    });
+}
+
+#[test]
+fn shutdown_clears_a_non_empty_maintenance_queue_without_spawning_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let active_namespace = namespace_id("active");
+    let queued_namespace = namespace_id("queued");
+    block_on(async {
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            KeyPredicate::metadata_root(active_namespace.as_str()),
+            OperationClass::CompareAndSwap,
+        ));
+        let store: SharedObjectStore = blocking.clone();
+        let writer = FsWriter::builder_with_store(store)
+            .writer_id("handle-test-writer")
+            .background_work(FsBackgroundWork::Enabled)
+            .max_concurrent_maintenance(1)
+            .build()
+            .await
+            .expect("build writer");
+        for namespace_id in [&active_namespace, &queued_namespace] {
+            writer
+                .create_namespace(namespace_id, CreateNamespaceOptions::default())
+                .await
+                .expect("create namespace");
+        }
+
+        blocking.block_next();
+        fill_wal_tail_past_threshold(&writer, &active_namespace).await;
+        blocking.wait_until_blocked().await;
+        fill_wal_tail_past_threshold(&writer, &queued_namespace).await;
+
+        let mut shutdown = Box::pin(writer.shutdown_background());
+        assert!(
+            futures::poll!(shutdown.as_mut()).is_pending(),
+            "shutdown must wait for the parked active step"
+        );
+        blocking.release();
+        timeout(Duration::from_secs(10), shutdown)
+            .await
+            .expect("shutdown must not hang with a non-empty queue")
+            .expect("shut down writer background work");
+
+        let admin = FsAdmin::builder_with_store(blocking.clone() as SharedObjectStore)
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .namespace_status(&queued_namespace)
+            .await
+            .expect("queued namespace status after shutdown");
+        assert_eq!(
+            status.current_manifest_id,
+            Some(ManifestId(0)),
+            "shutdown must clear queued work before the active step releases its permit"
+        );
+
+        writer
+            .put_file_bytes(
+                &queued_namespace,
+                "/after-close.txt",
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("foreground writes remain available after background shutdown");
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("nothing may spawn after background shutdown");
+        let status = admin
+            .namespace_status(&queued_namespace)
+            .await
+            .expect("queued namespace status after post-close write");
+        assert_eq!(
+            status.current_manifest_id,
+            Some(ManifestId(0)),
+            "post-close threshold crossings must not spawn maintenance"
+        );
     });
 }
 

--- a/docs/design/metadata-block-storage.md
+++ b/docs/design/metadata-block-storage.md
@@ -81,19 +81,20 @@ delta run and publishes a manifest referencing every prior run
 unchanged. Its cost is proportional to what changed since the last
 checkpoint, never to namespace size.
 
-**Reorganization folds.** As delta runs accumulate, maintenance merges
-them into the base run — one family group per step, each fold ending in
-its own manifest publish. Rows that no retained history can observe are
-dropped during the merge; runs no longer referenced by any retained
-manifest become garbage.
+**Reorganization folds.** As delta runs accumulate, maintenance merges an
+oldest-first subset of complete runs for one family group, each fold ending
+in its own manifest publish. The subset is capped by logical-run count,
+decoded row count, and decoded SST data-block bytes. Rows that no retained
+history can observe are dropped during the merge; runs no longer referenced
+by any retained manifest become garbage.
 
 ```
 checkpoints append:          reorganization folds, one group per step:
 
-  delta run 3 (newest)         bindings:  base + deltas -> new base
-  delta run 2                  revisions: base + deltas -> new base
-  delta run 1                  inodes:    base + deltas -> new base
-  base run    (oldest)         ...until no delta rows remain
+  delta run 3 (newest)         bindings:  oldest bounded subset -> base
+  delta run 2                  revisions: oldest bounded subset -> base
+  delta run 1                  inodes:    oldest bounded subset -> base
+  base run    (oldest)         ...repeated until no delta rows remain
 ```
 
 Because every fold publishes a manifest, the manifest doubles as the
@@ -103,10 +104,18 @@ separate progress record to maintain, repair, or mistrust. Readers
 never observe an intermediate state — every step lands through the
 normal manifest publication path.
 
-The two secondary-index families fold together with their canonical
-family ({bindings, child bindings} and {revisions, revisions-by-inode})
-so row-count parity between table and index is validated on every
-rewrite.
+A bounded output carries the manifest head sequence. While an older or
+same-sequence delta run remains, that base/delta ordering tells the next step
+that a triggered reorganization is still in progress even if the remaining
+delta count fell below the normal trigger. Once the batch is drained, later
+delta runs are strictly newer than the base and the ordinary trigger applies
+again.
+
+The two secondary-index families fold together with their canonical family
+({bindings, child bindings} and {revisions, revisions-by-inode}). Every
+selected input is a complete logical run, so row-level parity is validated
+over exactly the subset being replaced without materializing or cloning the
+unselected family.
 
 ## Constants and tunables
 
@@ -121,3 +130,7 @@ Two kinds of numbers appear above, with different contracts:
   compression and base segments target 65,536 rows; readers take
   whatever the descriptor and index describe, so both can be retuned
   without a format change.
+- **Reorganization budgets are writer-side defaults.** One step inspects at
+  most 8 complete runs and decodes at most 131,072 row payloads or 64 MiB of
+  SST data blocks. A manifest publish is the only progress record, so later
+  steps continue with the runs the prior publish left referenced.

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1136,9 +1136,9 @@ consistent cut at the index watermark — files whose newest revision
 postdates it are omitted entirely rather than mixed in. The `path_prefix`
 value is a complete absolute path, not a partial textual segment prefix. Its
 scope resolves to an inode under the namespace's name policy and filters by
-ancestry, so it follows the same validation and normalization as every other
-path read. A missing data half answers `not_supported` with the `feature`
-field naming `grep.index`.
+ancestry, so it requires the same canonical spelling and validation as every
+other path read. A missing data half answers `not_supported` with the
+`feature` field naming `grep.index`.
 
 ## 7. Conformance requirements
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -16,7 +16,8 @@ a deployment exposes.
 Encoding conventions used by every durable and wire shape in this specification:
 field names and enum values are `snake_case`; fields holding typed identifiers
 are suffixed `_id`; tagged unions carry their discriminator in a `kind` field;
-decoders tolerate unknown fields (readers ignore what they do not understand).
+HTTP wire shapes and immutable, never-rewritten families tolerate unknown
+fields, while mutable control-object envelopes and payloads reject them.
 
 ## 1. Object store contract
 
@@ -247,6 +248,14 @@ Small mutable objects such as the namespace head must use compare-and-swap
 semantics. These objects must remain small enough that guarded rewrite is
 practical.
 
+Mutable control-object decoders reject unknown fields in both the envelope and
+the complete nested payload. Otherwise, an older binary could tolerate a
+newer field, erase it during read-modify-write, and still report a successful
+guarded update. Namespace configuration and content-store descriptors use the
+same strict control-object decoder; immutable WAL segments, metadata segments,
+namespace manifests, grep segments, and grep manifests remain tolerant of
+additive fields.
+
 Readers of small mutable control objects must use a full-object read that
 returns bytes and the object identity metadata for those same bytes. This does
 not by itself guarantee freshness; it guarantees self-consistency. A reader
@@ -444,6 +453,11 @@ character rules with a 768-byte cap: case folding expands at most threefold
 in bytes, so every key derivable from a valid display name is admissible.
 Requests carrying a name or key outside this grammar fail validation; nothing
 is truncated or normalized on the caller's behalf.
+
+An absolute path has one canonical spelling: exactly one leading `/`, no empty
+components or repeated separators, and no trailing `/` except for the root
+path `/`. Wire decoders reject every noncanonical spelling rather than
+normalizing it.
 
 #### 2.3.1 NamePolicy
 
@@ -972,8 +986,8 @@ retry of the same
 logical commit must fingerprint identically no matter who retries it or when.
 
 Path-level mutations fingerprint the same way with domain
-`loonfs.path.intent.semantic.v0` over the normalized path intent (intent kind,
-normalized absolute paths, and the intent's semantic parameters).
+`loonfs.path.intent.semantic.v0` over the canonical path intent (intent kind,
+canonical absolute paths, and the intent's semantic parameters).
 
 The idempotency horizon is the retention floor. Commit receipts below the
 floor are dropped when metadata runs are rebuilt, so a commit retried from
@@ -1321,7 +1335,9 @@ grep state: `namespace_id`, `lifecycle`, nested `index` bookkeeping, and the
 `segments` descriptors. Both decoders verify the checksum over the exact
 stored payload fragment before decoding, reject unknown versions and kind
 mismatches without fallback, and validate namespace, manifest-id, lifecycle,
-fold, run-allocation, and segment invariants at every boundary.
+fold, run-allocation, and segment invariants at every boundary. The mutable
+root-pointer decoder rejects unknown envelope and payload fields; the
+immutable manifest decoder tolerates additive fields.
 
 A gram-index segment uses the section 4.2.1 block grammar unchanged —
 prefix-compressed data blocks, one bloom filter block, one index block,

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1473,8 +1473,8 @@ inode revision scans. Readers treat a missing, extra, duplicate, or changed
 revision index row as namespace corruption. Segment reads enforce per-segment
 checksums and key ranges; manifest-table loads enforce per-run row-count
 equality between canonical and index families; full row-level index equality
-is enforced at every base rebuild, the production point that materializes all
-rows.
+is enforced by every reorganization rewrite over the complete input runs that
+the rewrite selected.
 
 ### 6.2 Compaction
 


### PR DESCRIPTION
One metadata reorganization step scanned a whole table family across all runs into vectors and cloned paired families for validation — segment size was bounded, but a step's total input, memory, and work grew with namespace age, so a years-old namespace could turn routine maintenance into a memory spike behind a name that promised otherwise.

We need to move to streaming, resumable k-way merge (estimated +700 lines). This takes the deliberately cheaper shape instead, because the LSM already tolerates partial compaction: a step now selects a bounded subset of runs (the compacted accumulator first, then complete L0 runs oldest-first) under a per-step budget of input runs, decoded rows, and decoded bytes, merges only those, and publishes the manifest exactly as today — the manifest is the resume point, so there is no cursor and no new durable state. Repeated steps strictly reduce run count until thresholds hold. Paired-index parity is validated across the selected runs with borrowed rows; the full-family clones are gone. Defaults: 8 runs, 131,072 rows, 64 MiB per step; the existing L0 trigger and segment sizing are unchanged.

Proven by tests: a bounded step reads at most the budgeted runs/rows/bytes; bounded two-run steps converge to the byte-equal metadata state and terminal run shape one unbounded step produces; visibility oracles pass at intermediate steps; the parity-rejection suite still catches an injected violation within a subset merge. One additive outcome, `BudgetExhausted`, reports honestly when no progress-making subset fits a hand-lowered hard budget rather than silently exceeding it. Net +274 production lines against the audit's +700 estimate; no durable-format changes, versions stay 1, goldens byte-identical.
