### PR TITLE
fix(core): count the status wal tail from chain pointers

### DIFF
--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -11,7 +11,7 @@ use crate::namespace::catalog::{
 use crate::namespace::control::{
     read_head_and_metadata_root, read_wal_floor_seq_or_zero, ControlObjectLoadError,
 };
-use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
+use crate::wal::{count_visible_wal_tail_segments, WalChainLoadRequest};
 use loonfs_api::wire::control::NamespaceState;
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use loonfs_objectstore::{keys::namespace_config, ObjectStore};
@@ -24,6 +24,12 @@ pub struct NamespaceHeadSummary {
     pub head_seq: ChangeSeq,
     pub current_manifest_id: Option<ManifestId>,
     /// Number of visible WAL segments after the current manifest.
+    ///
+    /// Counted from the head's chain pointers (`recent_segments`, published
+    /// under the same CAS as the tip); segment bodies are fetched and
+    /// validated only for a tail extending past the hinted window. An
+    /// inspection count for maintenance gating and operators — replay
+    /// consumers load the validated chain instead.
     pub wal_tail_segments: u64,
     pub retention_floor_seq: ChangeSeq,
 }
@@ -69,7 +75,7 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
             .map_err(|error| {
                 CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
             })?;
-    let wal_chain = load_validated_wal_chain(
+    let wal_tail_segments = count_visible_wal_tail_segments(
         store,
         WalChainLoadRequest {
             namespace_id: expected_namespace_id,
@@ -84,8 +90,6 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     .map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
-    let wal_tail_segments = u64::try_from(wal_chain.segments().len())
-        .map_err(|_| CoreError::Internal("WAL tail segment count overflow".to_owned()))?;
     let retention_floor_seq = read_wal_floor_seq_or_zero(store, expected_namespace_id)
         .await
         .map_err(|error| {

--- a/crates/loonfs-core/src/wal/mod.rs
+++ b/crates/loonfs-core/src/wal/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use self::frame::{
     DecodedWalRecord, PreparedWalSegment, ReplayedWalTail, ValidatedWalChain, ValidatedWalSegment,
     WalBuildError, WalChainLoadError, WalChainLoadRequest, WalReplayError,
 };
-pub(crate) use self::reader::load_validated_wal_chain;
+pub(crate) use self::reader::{count_visible_wal_tail_segments, load_validated_wal_chain};
 pub(crate) use self::replay::project_validated_wal_tail;
 pub(crate) use self::writer::prepare_wal_segment;
 

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -187,3 +187,122 @@ fn validate_pointer_matches_envelope(
     }
     Ok(())
 }
+
+/// Counts the visible WAL tail segments above `chain_base_seq` without
+/// loading bodies the head already describes.
+///
+/// Every head publish prepends its tip pointer to `recent_segments` under
+/// the same compare-and-swap that installs `visible_wal_tip`, so a hint run
+/// that is contiguous from the tip carries the same authority as the tip
+/// itself: those segments are counted from pointer seq ranges alone. Only
+/// a tail extending past the hinted window (or an unusable hint list) walks
+/// chain links, fetching and pointer-validating one body per unresolved
+/// segment.
+///
+/// Unlike [`load_validated_wal_chain`], hint-covered bodies are neither
+/// fetched nor checksum-verified, and the manifest boundary is accepted at
+/// `base <= chain_base_seq` rather than exact equality: this serves
+/// inspection surfaces (status, maintenance gating) whose callers do not
+/// replay the tail. Replay consumers keep loading the validated chain.
+#[tracing::instrument(
+    level = "info",
+    name = "loonfs.phase",
+    err,
+    skip_all,
+    fields(phase = "count_wal_tail_segments", key_class = "wal_segment")
+)]
+pub(crate) async fn count_visible_wal_tail_segments<S: ObjectStore + ?Sized>(
+    store: &S,
+    request: WalChainLoadRequest<'_>,
+) -> Result<u64, WalChainLoadError> {
+    if request.chain_base_seq > request.head_seq {
+        return Err(WalChainLoadError::InvalidSeqRange {
+            chain_base_seq: request.chain_base_seq,
+            head_seq: request.head_seq,
+        });
+    }
+    if request.chain_base_seq == request.head_seq {
+        return Ok(0);
+    }
+    let tip = request
+        .visible_tip
+        .clone()
+        .ok_or(WalChainLoadError::MissingVisibleTip {
+            namespace_id: request.namespace_id.clone(),
+            seq: request.head_seq,
+        })?;
+    if tip.end_seq != request.head_seq {
+        return Err(WalChainLoadError::TipEndSeqMismatch {
+            expected: request.head_seq,
+            actual: tip.end_seq,
+        });
+    }
+    let stop_after_seq = request.stop_after_seq.unwrap_or(request.chain_base_seq);
+    if tip.end_seq <= stop_after_seq {
+        return Ok(0);
+    }
+
+    let mut count: u64 = 1;
+    // Newest pointer whose tail membership is decided but whose predecessor
+    // is not; the body walk resumes here when pointer math runs out.
+    let mut newest_unresolved = tip.clone();
+    if pointer_reaches_base(&newest_unresolved, stop_after_seq) {
+        return Ok(count);
+    }
+
+    if request.recent_segments.first() == Some(&tip) {
+        for pointer in &request.recent_segments[1..] {
+            if pointer.end_seq.0 + 1 != newest_unresolved.start_seq.0 {
+                // Contiguity break: chain links resume authority below.
+                break;
+            }
+            if pointer.end_seq <= stop_after_seq {
+                // Fully folded: the tail ends right above this pointer.
+                return Ok(count);
+            }
+            count += 1;
+            newest_unresolved = pointer.clone();
+            if pointer_reaches_base(&newest_unresolved, stop_after_seq) {
+                return Ok(count);
+            }
+        }
+    }
+
+    loop {
+        let object_key = newest_unresolved.object_key.clone();
+        let encoded_bytes = store
+            .get(&object_key, None)
+            .await
+            .map_err(|err| WalChainLoadError::ReadWal {
+                object_key: object_key.clone(),
+                message: err.to_string(),
+            })?
+            .ok_or_else(|| WalChainLoadError::MissingWalObject {
+                object_key: object_key.clone(),
+            })?;
+        let envelope = decode_wal_segment_envelope_zstd(&encoded_bytes)
+            .map_err(|err| WalReplayError::Codec(err.to_string()))?;
+        validate_pointer_matches_envelope(&newest_unresolved, &object_key, &envelope)?;
+        let prev = envelope.payload.prev_visible_segment.clone().ok_or(
+            WalReplayError::BrokenChainLink {
+                object_key,
+                required_seq: stop_after_seq,
+            },
+        )?;
+        if prev.end_seq <= stop_after_seq {
+            return Ok(count);
+        }
+        count += 1;
+        newest_unresolved = prev;
+        if pointer_reaches_base(&newest_unresolved, stop_after_seq) {
+            return Ok(count);
+        }
+    }
+}
+
+/// True when the pointer's base (the seq before its first commit) sits at
+/// or below the boundary: every older segment is folded and the tail is
+/// fully counted.
+fn pointer_reaches_base(pointer: &WalSegmentPointer, stop_after_seq: ChangeSeq) -> bool {
+    pointer.start_seq.0.saturating_sub(1) <= stop_after_seq.0
+}

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -645,3 +645,265 @@ fn rewrap_envelope(envelope: &mut WalSegmentEnvelope) {
         WalSegmentEnvelope::from_payload(envelope.writer_version.clone(), envelope.payload.clone())
             .expect("rewrap wal envelope");
 }
+
+fn prepared_create_directory_segment(
+    namespace_id: &NamespaceId,
+    prev_visible_segment: Option<WalSegmentPointer>,
+    commit_id: &str,
+    display_name: &str,
+    apply_after_seq: ChangeSeq,
+    assigned_seq: ChangeSeq,
+) -> PreparedWalSegment {
+    prepare_wal_segment(
+        namespace_id.clone(),
+        WriterEpoch(1),
+        prev_visible_segment,
+        &[materialized_create_directory(
+            namespace_id,
+            commit_id,
+            display_name,
+            apply_after_seq,
+            assigned_seq,
+        )],
+        "test-writer",
+    )
+    .expect("prepare wal segment")
+}
+
+/// Prepares a linked chain of `len` single-commit segments covering seqs
+/// `1..=len`, without writing any of them to a store.
+fn prepared_unstored_chain(namespace_id: &NamespaceId, len: u64) -> Vec<PreparedWalSegment> {
+    let mut chain: Vec<PreparedWalSegment> = Vec::new();
+    for seq in 1..=len {
+        let prev = chain
+            .last()
+            .map(|segment| segment.envelope.pointer(segment.object_key.clone()));
+        chain.push(prepared_create_directory_segment(
+            namespace_id,
+            prev,
+            &format!("c_count_{seq}"),
+            &format!("dir-{seq}"),
+            ChangeSeq(seq - 1),
+            ChangeSeq(seq),
+        ));
+    }
+    chain
+}
+
+fn newest_first_pointers(chain: &[PreparedWalSegment]) -> Vec<WalSegmentPointer> {
+    chain
+        .iter()
+        .rev()
+        .map(|segment| segment.envelope.pointer(segment.object_key.clone()))
+        .collect()
+}
+
+#[tokio::test]
+async fn tail_count_from_contiguous_hints_reads_no_bodies() {
+    // The store stays empty on purpose: any body fetch would fail with
+    // `MissingWalObject`, so a successful count came from pointers alone.
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let chain = prepared_unstored_chain(&namespace_id, 3);
+    let hints = newest_first_pointers(&chain);
+
+    let count = count_visible_wal_tail_segments(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(hints[0].clone()),
+            stop_after_seq: None,
+            recent_segments: &hints,
+        },
+    )
+    .await
+    .expect("count from pointers");
+    assert_eq!(count, 3);
+
+    // A manifest boundary inside the hinted window is honored: only the
+    // segments above it are tail.
+    let count = count_visible_wal_tail_segments(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(2),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(hints[0].clone()),
+            stop_after_seq: None,
+            recent_segments: &hints,
+        },
+    )
+    .await
+    .expect("count above interior boundary");
+    assert_eq!(count, 1);
+
+    // An empty tail costs nothing and consults nothing.
+    let count = count_visible_wal_tail_segments(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(3),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(hints[0].clone()),
+            stop_after_seq: None,
+            recent_segments: &hints,
+        },
+    )
+    .await
+    .expect("count of empty tail");
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn tail_count_walks_only_past_the_hinted_window() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let chain = prepared_unstored_chain(&namespace_id, 3);
+    // Store only the middle segment: the tip is hint-covered and the
+    // oldest is resolved through the middle segment's chain link, so
+    // neither body may be touched.
+    store
+        .put_if_absent(
+            &chain[1].object_key,
+            Bytes::copy_from_slice(&chain[1].encoded_bytes),
+        )
+        .await
+        .expect("write middle wal segment");
+    let pointers = newest_first_pointers(&chain);
+    let short_window = &pointers[..2];
+
+    let count = count_visible_wal_tail_segments(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(pointers[0].clone()),
+            stop_after_seq: None,
+            recent_segments: short_window,
+        },
+    )
+    .await
+    .expect("count past hinted window");
+    assert_eq!(count, 3);
+}
+
+#[tokio::test]
+async fn tail_count_matches_loaded_chain_length() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let chain = prepared_unstored_chain(&namespace_id, 3);
+    for segment in &chain {
+        store
+            .put_if_absent(
+                &segment.object_key,
+                Bytes::copy_from_slice(&segment.encoded_bytes),
+            )
+            .await
+            .expect("write wal segment");
+    }
+    let pointers = newest_first_pointers(&chain);
+
+    for hints in [&pointers[..], &[]] {
+        let request = WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(pointers[0].clone()),
+            stop_after_seq: None,
+            recent_segments: hints,
+        };
+        let count = count_visible_wal_tail_segments(&store, request.clone())
+            .await
+            .expect("count tail");
+        let loaded = load_validated_wal_chain(&store, request)
+            .await
+            .expect("load chain");
+        assert_eq!(count as usize, loaded.segments().len());
+        assert_eq!(count, 3);
+    }
+}
+
+#[tokio::test]
+async fn tail_count_ignores_hints_that_do_not_start_at_the_tip() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let chain = prepared_unstored_chain(&namespace_id, 2);
+    for segment in &chain {
+        store
+            .put_if_absent(
+                &segment.object_key,
+                Bytes::copy_from_slice(&segment.encoded_bytes),
+            )
+            .await
+            .expect("write wal segment");
+    }
+    let pointers = newest_first_pointers(&chain);
+    let mut lying_tip = pointers[0].clone();
+    lying_tip.end_seq = ChangeSeq(999);
+    let garbage = [lying_tip, pointers[1].clone()];
+
+    let count = count_visible_wal_tail_segments(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(2),
+            visible_tip: Some(pointers[0].clone()),
+            stop_after_seq: None,
+            recent_segments: &garbage,
+        },
+    )
+    .await
+    .expect("count despite garbage hints");
+    assert_eq!(count, 2);
+}
+
+#[tokio::test]
+async fn tail_count_reports_broken_chains_truthfully() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    // A segment claiming seqs (1, 2] with no predecessor link cannot reach
+    // a chain base of 0.
+    let orphan = prepared_create_directory_segment(
+        &namespace_id,
+        None,
+        "c_count_orphan",
+        "orphan",
+        ChangeSeq(1),
+        ChangeSeq(2),
+    );
+    store
+        .put_if_absent(
+            &orphan.object_key,
+            Bytes::copy_from_slice(&orphan.encoded_bytes),
+        )
+        .await
+        .expect("write wal segment");
+    let tip = orphan.envelope.pointer(orphan.object_key.clone());
+
+    let error = count_visible_wal_tail_segments(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(2),
+            visible_tip: Some(tip),
+            stop_after_seq: None,
+            recent_segments: &[],
+        },
+    )
+    .await
+    .expect_err("broken chain must not count");
+    assert!(matches!(
+        error,
+        WalChainLoadError::Replay(WalReplayError::BrokenChainLink { .. })
+    ));
+}

--- a/crates/loonfs/tests/maintenance.rs
+++ b/crates/loonfs/tests/maintenance.rs
@@ -12,7 +12,7 @@ use loonfs::{
     SharedObjectStore,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
-use loonfs_objectstore::keys::{metadata_manifest_object, namespace_config};
+use loonfs_objectstore::keys::{metadata_manifest_object, namespace_config, wal_segment_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::block_on::block_on;
@@ -59,6 +59,38 @@ fn namespace_status_reports_wal_tail_segments() {
     assert_eq!(status.wal_tail_segments, 1);
     assert_eq!(status.retention_floor_seq, ChangeSeq(0));
     assert_eq!(store.count(OperationClass::List), 0);
+}
+
+#[test]
+fn namespace_status_counts_wal_tail_without_reading_segments() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    // Count only WAL segment reads: the head's chain pointers must be
+    // enough to size a hint-covered tail.
+    let store = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+    ));
+    let fs = open_runtime(store.clone(), "status-count-test");
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for revision in 0..3 {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            &format!("/docs/hello-{revision}.txt"),
+            format!("rev {revision}").as_bytes(),
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+    }
+
+    store.reset();
+    let status = fs
+        .namespace_status_blocking(&namespace_id)
+        .expect("status with populated tail");
+    assert_eq!(status.wal_tail_segments, 3);
+    assert_eq!(store.count(OperationClass::Read), 0);
 }
 
 #[test]


### PR DESCRIPTION
A recent change (#376) made `load_namespace_head_summary` load and validate every visible WAL segment body just to size the tail, so the status probe went from one LIST to O(tail) serialized GETs — 40 GETs / 3.3s at a 33-segment tail in the s3-100k bench, paid twice per maintenance tick (gating + fold) and once per bootstrap, and scaling to ~8s at the 128-segment backpressure cap.

Every head publish prepends its tip pointer to `recent_segments` under the same CAS that installs the tip, so a hint run contiguous from the tip carries the same authority as the tip itself. Status now counts the tail from those pointer seq ranges and walks chain links only for a tail extending past the hinted window (one body fetch at tail=33, zero at tail<=32). Hint-covered bodies stay unverified — status is an inspection surface; replay consumers keep loading the full validated chain.