### PR TITLE
feat(runtime): trace background maintenance step conclusions at debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/loonfs/Cargo.toml
+++ b/crates/loonfs/Cargo.toml
@@ -23,6 +23,7 @@ tracing.workspace = true
 loonfs-test-support = { path = "../loonfs-test-support" }
 serde_json.workspace = true
 tempfile.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -710,9 +710,22 @@ impl FsWriter {
         // Background maintenance runs the same operations an operator runs,
         // through the same handle, rather than a private copy of them.
         let admin = crate::FsAdmin::from_core(self.core.clone());
-        admin
+        let started = tokio::time::Instant::now();
+        let step = admin
             .maintenance_step_namespace(namespace_id, options)
             .await?;
-        admin.drain_reorganization_backlog(namespace_id).await
+        admin.drain_reorganization_backlog(namespace_id).await?;
+        // Quiet conclusions (`NotNeeded`) emit nothing at default levels;
+        // this is the only record that a background step ran at all.
+        tracing::debug!(
+            phase = "auto_maintenance_step",
+            namespace_id = %step.namespace_id,
+            wal_tail_segments_before = step.status_before.wal_tail_segments,
+            wal_flush = ?step.wal_flush,
+            reorganize = ?step.reorganize,
+            elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "background maintenance step concluded"
+        );
+        Ok(())
     }
 }

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -20,7 +20,7 @@ use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 use tokio::time::{timeout, Duration};
 
@@ -859,4 +859,66 @@ fn enabled_writer_drains_reorganization_backlog_without_admin() {
              a leftover run means the drain stopped early"
         );
     });
+}
+
+#[test]
+fn background_step_conclusions_emit_debug_events() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&captured);
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_ansi(false)
+        .with_writer(move || CaptureWriter(Arc::clone(&sink)))
+        .finish();
+    // Thread-local so the capture cannot leak into other tests; the
+    // current-thread runtime keeps spawned background steps on this thread.
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    block_on(async {
+        let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("background maintenance quiesces");
+    });
+
+    let log = String::from_utf8(captured.lock().expect("capture lock").clone())
+        .expect("captured log is utf8");
+    let conclusion = log
+        .lines()
+        .find(|line| line.contains("background maintenance step concluded"))
+        .unwrap_or_else(|| {
+            panic!("background step conclusion missing from captured tracing:\n{log}")
+        });
+    for field in [
+        "wal_flush",
+        "reorganize",
+        "wal_tail_segments_before",
+        "elapsed_ms",
+    ] {
+        assert!(
+            conclusion.contains(field),
+            "missing `{field}` in: {conclusion}"
+        );
+    }
+}
+
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
Background auto-maintenance steps whose outcome is quiet (`NotNeeded`) conclude without any tracing event, so a handle with `FsBackgroundWork::Enabled` gives no way to see whether background stepping is happening at all.

`run_auto_maintenance` now emits one debug event per step conclusion carrying the namespace, the WAL-flush and reorganize outcomes, the tail observed before the step, and elapsed ms. Default levels stay quiet; `RUST_LOG=loonfs=debug` (which the lab harness forwards into run logs) surfaces every background step with timestamps. A handles test captures the subscriber output on an `Enabled` writer crossing the tail threshold and pins the event and its fields.