### PR TITLE
fix(core): retain revision history and make retention advance opt-in

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -520,7 +520,8 @@ pub enum MaintenanceStepKind {
 }
 
 /// Options for one explicit maintenance step. Absent fields use the
-/// server's defaults; garbage collection runs only when `gc` is present.
+/// server's defaults; retention advance runs only when `retention` is true
+/// and garbage collection only when `gc` is present.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct MaintenanceStepRequest {
@@ -529,13 +530,18 @@ pub struct MaintenanceStepRequest {
     /// rejected as `invalid_request`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_wal_tail_segments: Option<u64>,
+    /// Advance the retention floor to the flushed manifest head. Nothing
+    /// surrenders replay history unless this is true or `only` selects
+    /// `retention`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention: Option<bool>,
     /// Run the mark-and-sweep garbage collector after the step's
     /// flush work. Nothing sweeps unless this is present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gc: Option<GcRequest>,
     /// Restrict the step to one sub-step. Absent runs the whole step: WAL
-    /// flush, then reorganization, then retention, then garbage collection
-    /// if `gc` opted in.
+    /// flush, then reorganization, then retention if `retention` opted in,
+    /// then garbage collection if `gc` opted in.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub only: Option<MaintenanceStepKind>,
 }

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -533,7 +533,8 @@ pub(crate) enum AdminCommand {
     CheckpointRelease(AdminCheckpointReleaseArgs),
     /// Flush the WAL tail into a durable segment.
     Flush(AdminNamespaceArgs),
-    /// Advance the retention floor to reclaim old history.
+    /// Advance the retention floor, surrendering replay history below the
+    /// flushed manifest head. File revision history is never affected.
     RetentionAdvance(AdminNamespaceArgs),
     /// Run one core maintenance step (WAL flush and metadata folds).
     Step(AdminStepArgs),
@@ -582,6 +583,10 @@ pub(crate) struct AdminStepArgs {
     /// segments (server default when omitted).
     #[arg(long)]
     pub max_wal_tail_segments: Option<u64>,
+    /// Advance the retention floor after the step's flush work. Replay
+    /// history below the flushed manifest head is surrendered.
+    #[arg(long)]
+    pub retention: bool,
     /// Run a garbage-collection pass after the step's flush work.
     #[arg(long)]
     pub gc: bool,

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -58,6 +58,7 @@ async fn run_admin_step(
     let context = resolve_command_context(kind, &args.target).await?;
     let request = MaintenanceStepRequest {
         max_wal_tail_segments: args.max_wal_tail_segments,
+        retention: args.retention.then_some(true),
         gc: args.gc.then(GcRequest::default),
         only: None,
     };
@@ -97,6 +98,7 @@ async fn run_admin_gc(
                 &context.namespace,
                 MaintenanceStepRequest {
                     max_wal_tail_segments: None,
+                    retention: None,
                     gc: Some(request.clone()),
                     only: Some(MaintenanceStepKind::Gc),
                 },
@@ -203,6 +205,7 @@ async fn run_admin_flush(
                 // The WAL flush an operator asks for explicitly runs whatever
                 // the tail length, so the threshold drops to one segment.
                 max_wal_tail_segments: Some(1),
+                retention: None,
                 gc: None,
                 only: Some(MaintenanceStepKind::WalFlush),
             },
@@ -230,6 +233,7 @@ async fn run_admin_retention_advance(
             &context.namespace,
             MaintenanceStepRequest {
                 max_wal_tail_segments: None,
+                retention: None,
                 gc: None,
                 only: Some(MaintenanceStepKind::Retention),
             },

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1431,7 +1431,8 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_eq!(step_data["namespace_id"], "demo");
         assert_eq!(step_data["wal_flush"]["kind"], "not_needed");
         assert_eq!(step_data["reorganize"]["kind"], "not_needed");
-        // Retention runs inside every unrestricted step now.
+        // An unrestricted step never advances the floor on its own; it
+        // reports the floor the earlier retention-advance established.
         assert_eq!(step_data["retention_floor_seq"], 2);
         assert_eq!(step_data["status_before"]["namespace_id"], "demo");
         assert!(step_data.get("gc").is_none());

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -5,12 +5,12 @@
 //! follows the WAL delta, never the namespace. Folding those L0 runs into
 //! the base happens here instead, one **family group** at a time: the
 //! group's rows are merged from an oldest-first, budgeted subset of complete
-//! runs, rows below the retention floor are dropped, new base segments are
-//! written, and a manifest publishes that swaps just those references.
-//! Families whose retention rules read each other compact together — bind,
-//! child bind, and unbind rows form one group; revisions and their descending
-//! index another — so index parity and the drop invariants hold within every
-//! unit.
+//! runs, rows no retained sequence can observe are dropped, new base
+//! segments are written, and a manifest publishes that swaps just those
+//! references. Families whose rows must stay mutually consistent compact
+//! together — bind, child bind, and unbind rows form one group because their
+//! drop rules read each other; revisions travel with their descending index
+//! so index parity holds within every unit.
 //!
 //! There is no progress record: each unit ends in a durable manifest, so a
 //! crashed or interrupted reorganization resumes by reading the live
@@ -51,10 +51,10 @@ use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Families whose rows merge in one reorganization unit. Groupings follow
-/// the retention rules in `drop_rows_below_retention_floor`: families that
-/// read each other's rows to decide what to drop must compact together, and
-/// a secondary index always travels with its canonical family.
+/// Families whose rows merge in one reorganization unit. Families that read
+/// each other's rows to decide what to drop (see
+/// `drop_rows_below_retention_floor`) must compact together, and a secondary
+/// index always travels with its canonical family.
 const REORGANIZE_FAMILY_GROUPS: [&[MetadataTableFamily]; 5] = [
     &[
         MetadataTableFamily::DirentryBinds,
@@ -539,60 +539,15 @@ async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
 }
 
 /// Drops rows that no retained sequence can observe (format spec,
-/// "Compaction"). Conservative subset: superseded revisions, superseded or
-/// unbound bindings, and spent unbind markers at or below the retention
-/// floor. Tombstone and inode rows are always retained until
-/// reachability-based dropping is designed.
+/// "Compaction"). Conservative subset: superseded or unbound bindings and
+/// spent unbind markers at or below the retention floor. Revision rows are
+/// never dropped — file history is durable data retained independently of
+/// the replay floor — and tombstone and inode rows are always retained
+/// until reachability-based dropping is designed.
 pub(super) fn drop_rows_below_retention_floor(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,
 ) -> Result<()> {
-    // The latest revision at or below the floor is what the floor itself
-    // observes; every older one is superseded at every retained sequence.
-    let mut latest_revision_at_floor = BTreeMap::new();
-    for row in rows_by_family
-        .get(&MetadataTableFamily::Revisions)
-        .into_iter()
-        .flatten()
-    {
-        if let MetadataRow::Revision {
-            inode_id,
-            revision_no,
-            committed_seq,
-            ..
-        } = row
-        {
-            if *committed_seq <= retention_floor_seq {
-                let latest = latest_revision_at_floor
-                    .entry(*inode_id)
-                    .or_insert(*revision_no);
-                if *revision_no > *latest {
-                    *latest = *revision_no;
-                }
-            }
-        }
-    }
-    let retain_revision = |row: &MetadataRow| match row {
-        MetadataRow::Revision {
-            inode_id,
-            revision_no,
-            committed_seq,
-            ..
-        } => {
-            *committed_seq > retention_floor_seq
-                || latest_revision_at_floor.get(inode_id) == Some(revision_no)
-        }
-        _ => true,
-    };
-    for family in [
-        MetadataTableFamily::Revisions,
-        MetadataTableFamily::RevisionsByInodeDesc,
-    ] {
-        if let Some(rows) = rows_by_family.get_mut(&family) {
-            rows.retain(retain_revision);
-        }
-    }
-
     // At the floor only the latest non-unbound bind per (parent, name) slot
     // is visible; an unbind marker at or below the floor has finished its
     // work once every bind it covered is gone.

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -358,7 +358,7 @@ fn drop_pass_refuses_superseded_bind_without_unbind() {
 }
 
 #[tokio::test]
-async fn restore_below_the_floor_fails_with_revision_not_found() {
+async fn restore_below_the_floor_succeeds_after_reorganization() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -407,8 +407,9 @@ async fn restore_below_the_floor_fails_with_revision_not_found() {
             .await
             .expect("create checkpoint");
     }
-    // The superseded revision is reclaimed when reorganization folds the
-    // runs against the advanced floor, not at checkpoint time.
+    // Revision history is retained independently of the replay floor:
+    // folding the runs against the advanced floor must leave every
+    // revision readable.
     drain_reorganization(
         &store,
         &namespace_id,
@@ -417,7 +418,7 @@ async fn restore_below_the_floor_fails_with_revision_not_found() {
     )
     .await;
 
-    let error = restore_file_revision(
+    let restored = restore_file_revision(
         &store,
         &namespace_id,
         "/docs/a.txt",
@@ -426,12 +427,12 @@ async fn restore_below_the_floor_fails_with_revision_not_found() {
         None,
     )
     .await
-    .expect_err("restoring a reclaimed revision must fail cleanly");
-    assert_eq!(error.code(), crate::error::ErrorCode::RevisionNotFound);
+    .expect("restoring a revision below the floor succeeds");
+    assert!(restored.committed_seq > ChangeSeq(0));
 }
 
 #[tokio::test]
-async fn base_rebuild_drops_revisions_superseded_below_floor() {
+async fn base_rebuild_retains_revisions_superseded_below_floor() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -483,8 +484,9 @@ async fn base_rebuild_drops_revisions_superseded_below_floor() {
             .expect("create checkpoint");
         last_manifest_id = Some(checkpoint.manifest_id);
     }
-    // Checkpoints only append; dropping happens when reorganization folds
-    // the runs against the advanced floor.
+    // Checkpoints only append, and the base rebuild folds the runs against
+    // the advanced floor — but revision rows are never dropped: file
+    // history is durable data, not replay state.
     let _ = last_manifest_id.expect("manifest id");
     let reorganized_manifest_id = drain_reorganization(
         &store,
@@ -507,7 +509,7 @@ async fn base_rebuild_drops_revisions_superseded_below_floor() {
     );
     let digest_one = loonfs_api::sha256_digest(b"one\n");
     let digest_two = loonfs_api::sha256_digest(b"two\n");
-    assert!(!revisions.iter().any(|row| matches!(
+    assert!(revisions.iter().any(|row| matches!(
         row,
         MetadataRow::Revision { content_ref, .. } if content_ref.digest == digest_one
     )));
@@ -515,6 +517,11 @@ async fn base_rebuild_drops_revisions_superseded_below_floor() {
         row,
         MetadataRow::Revision { content_ref, .. } if content_ref.digest == digest_two
     )));
+    let index_rows = manifest_rows_for_family(
+        &materialized.metadata_state,
+        ApiMetadataTableFamily::RevisionsByInodeDesc,
+    );
+    assert_eq!(index_rows.len(), revisions.len());
 }
 
 #[tokio::test]

--- a/crates/loonfs-server/tests/http_admin.rs
+++ b/crates/loonfs-server/tests/http_admin.rs
@@ -323,6 +323,7 @@ async fn http_admin_maintenance_step_reports_outcomes_not_errors() {
             &namespace,
             &loonfs_api::MaintenanceStepRequest {
                 max_wal_tail_segments: Some(1),
+                retention: None,
                 gc: Some(loonfs_api::GcRequest::default()),
                 only: None,
             },

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -35,10 +35,11 @@ impl FsAdmin {
     ///
     /// A full step does four things in order: flush the visible WAL tail
     /// once it reaches `options.max_wal_tail_segments`, merge one bounded
-    /// metadata reorganization unit, advance the retention floor behind a
-    /// verified checkpoint, and — only when `options.gc` opted in — run one
-    /// bounded garbage-collection pass. `options.only` restricts the step to
-    /// a single sub-step.
+    /// metadata reorganization unit, and — each strictly opt-in — advance
+    /// the retention floor (`options.retention`) and run one bounded
+    /// garbage-collection pass (`options.gc`). Nothing surrenders replay
+    /// history or sweeps objects unless the caller asked for it.
+    /// `options.only` restricts the step to a single sub-step.
     ///
     /// Every part reports separately. Losing the head race or being
     /// superseded by another publisher is an outcome, not an error.
@@ -131,9 +132,14 @@ impl FsAdmin {
         };
 
         // Retention advance is idempotent: with nothing new to cover it
-        // reports the floor already in place. Running it here is what keeps
-        // an unattended deployment from growing history forever.
-        let retention_floor_seq = if runs(MaintenanceStepKind::Retention) {
+        // reports the floor already in place. It never runs implicitly —
+        // an unattended deployment retains its full replay history until an
+        // operator opts in here or restricts a step to this sub-step.
+        let retention_runs = match options.only {
+            Some(only) => only == MaintenanceStepKind::Retention,
+            None => options.retention,
+        };
+        let retention_floor_seq = if retention_runs {
             self.advance_retention_floor(namespace_id)
                 .await?
                 .retention_floor_seq

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -19,6 +19,10 @@ pub struct MaintenanceStepOptions {
     /// Flush the visible WAL tail into metadata tables when it reaches this many
     /// segments.
     pub max_wal_tail_segments: u64,
+    /// Advance the retention floor to the flushed manifest head as part of
+    /// the step. Nothing surrenders replay history unless this is set or
+    /// the step is restricted to `only: Retention`.
+    pub retention: bool,
     /// Run the mark-and-sweep garbage collector after the step's flush work.
     /// Nothing sweeps unless this is set; an absent `max_objects` inside the
     /// config resolves to the per-step default.
@@ -31,6 +35,7 @@ impl Default for MaintenanceStepOptions {
     fn default() -> Self {
         Self {
             max_wal_tail_segments: WalTailPolicy::DEFAULT.checkpoint_at_segments,
+            retention: false,
             gc: None,
             only: None,
         }
@@ -45,6 +50,7 @@ impl MaintenanceStepOptions {
             max_wal_tail_segments: request
                 .max_wal_tail_segments
                 .unwrap_or(defaults.max_wal_tail_segments),
+            retention: request.retention.unwrap_or(defaults.retention),
             gc: request.gc.map(|request| {
                 let mut config = gc_config_from_request(request);
                 if config.max_objects.is_none() {
@@ -203,6 +209,7 @@ mod tests {
 
         let step = MaintenanceStepOptions::from_request(MaintenanceStepRequest {
             max_wal_tail_segments: None,
+            retention: None,
             gc: Some(GcRequest::default()),
             only: None,
         });
@@ -213,9 +220,25 @@ mod tests {
     }
 
     #[test]
+    fn retention_stays_off_unless_the_request_opts_in() {
+        let defaults = MaintenanceStepOptions::default();
+        assert!(!defaults.retention);
+
+        let absent = MaintenanceStepOptions::from_request(MaintenanceStepRequest::default());
+        assert!(!absent.retention);
+
+        let opted_in = MaintenanceStepOptions::from_request(MaintenanceStepRequest {
+            retention: Some(true),
+            ..MaintenanceStepRequest::default()
+        });
+        assert!(opted_in.retention);
+    }
+
+    #[test]
     fn step_gc_preserves_explicit_budget_and_cursor() {
         let step = MaintenanceStepOptions::from_request(MaintenanceStepRequest {
             max_wal_tail_segments: None,
+            retention: None,
             gc: Some(GcRequest {
                 max_objects: Some(7),
                 cursor: Some("opaque".to_owned()),

--- a/crates/loonfs/tests/maintenance.rs
+++ b/crates/loonfs/tests/maintenance.rs
@@ -8,8 +8,8 @@ mod common;
 use common::*;
 use loonfs::{
     ChangeSeq, CommitId, CommitOp, CommitRequest, CreateNamespaceOptions, ErrorCode, InodeId,
-    MaintenanceStepOptions, ManifestId, PutFileOptions, RuntimeError, SharedObjectStore,
-    WalFlushStepOutcome,
+    MaintenanceStepKind, MaintenanceStepOptions, ManifestId, PutFileOptions, RuntimeError,
+    SharedObjectStore, WalFlushStepOutcome,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::{metadata_manifest_object, namespace_config, wal_segment_prefix};
@@ -153,6 +153,7 @@ fn maintenance_step_below_threshold_is_not_needed() {
             &namespace_id,
             MaintenanceStepOptions {
                 max_wal_tail_segments: 2,
+                retention: false,
                 gc: None,
                 only: None,
             },
@@ -184,6 +185,7 @@ fn maintenance_step_at_segment_threshold_flushes_the_wal() {
             &namespace_id,
             MaintenanceStepOptions {
                 max_wal_tail_segments: 1,
+                retention: false,
                 gc: None,
                 only: None,
             },
@@ -219,6 +221,88 @@ fn maintenance_step_at_segment_threshold_flushes_the_wal() {
 }
 
 #[test]
+fn maintenance_step_advances_the_floor_only_when_retention_opts_in() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "step-retention-opt-in-test");
+    let namespace_id = namespace_id("demo");
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+
+    // A full step flushes, but never surrenders replay history on its own.
+    let step = fs
+        .maintenance_step_namespace_blocking(
+            &namespace_id,
+            MaintenanceStepOptions {
+                max_wal_tail_segments: 1,
+                retention: false,
+                gc: None,
+                only: None,
+            },
+        )
+        .expect("step without retention");
+    assert_eq!(
+        step.wal_flush,
+        WalFlushStepOutcome::Flushed {
+            manifest_head_seq: ChangeSeq(1)
+        }
+    );
+    assert_eq!(step.retention_floor_seq, ChangeSeq(0));
+
+    // Opting in advances the floor to the flushed manifest head.
+    let step = fs
+        .maintenance_step_namespace_blocking(
+            &namespace_id,
+            MaintenanceStepOptions {
+                max_wal_tail_segments: 1,
+                retention: true,
+                gc: None,
+                only: None,
+            },
+        )
+        .expect("step with retention");
+    assert_eq!(step.retention_floor_seq, ChangeSeq(1));
+
+    // Restricting a step to the retention sub-step is itself the opt-in.
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/second.txt",
+        b"second",
+        PutFileOptions::default(),
+    )
+    .expect("put second file");
+    fs.maintenance_step_namespace_blocking(
+        &namespace_id,
+        MaintenanceStepOptions {
+            max_wal_tail_segments: 1,
+            retention: false,
+            gc: None,
+            only: None,
+        },
+    )
+    .expect("flush second segment");
+    let step = fs
+        .maintenance_step_namespace_blocking(
+            &namespace_id,
+            MaintenanceStepOptions {
+                max_wal_tail_segments: 1,
+                retention: false,
+                gc: None,
+                only: Some(MaintenanceStepKind::Retention),
+            },
+        )
+        .expect("retention-only step");
+    assert_eq!(step.retention_floor_seq, ChangeSeq(2));
+}
+
+#[test]
 fn maintenance_step_after_existing_manifest_writes_l0_manifest() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "step-l0-run-publish-test");
@@ -237,6 +321,7 @@ fn maintenance_step_after_existing_manifest_writes_l0_manifest() {
         &namespace_id,
         MaintenanceStepOptions {
             max_wal_tail_segments: 1,
+            retention: false,
             gc: None,
             only: None,
         },
@@ -255,6 +340,7 @@ fn maintenance_step_after_existing_manifest_writes_l0_manifest() {
             &namespace_id,
             MaintenanceStepOptions {
                 max_wal_tail_segments: 1,
+                retention: false,
                 gc: None,
                 only: None,
             },
@@ -344,6 +430,7 @@ fn maintenance_step_counts_segments_not_commits() {
             &namespace_id,
             MaintenanceStepOptions {
                 max_wal_tail_segments: 2,
+                retention: false,
                 gc: None,
                 only: None,
             },
@@ -370,6 +457,7 @@ fn maintenance_step_counts_segments_not_commits() {
             &namespace_id,
             MaintenanceStepOptions {
                 max_wal_tail_segments: 2,
+                retention: false,
                 gc: None,
                 only: None,
             },
@@ -398,6 +486,7 @@ fn maintenance_step_rejects_zero_threshold() {
             &namespace_id,
             MaintenanceStepOptions {
                 max_wal_tail_segments: 0,
+                retention: false,
                 gc: None,
                 only: None,
             },
@@ -424,6 +513,7 @@ fn maintenance_step_rejects_thresholds_above_the_write_rejection_cap() {
             &namespace_id,
             MaintenanceStepOptions {
                 max_wal_tail_segments: 129,
+                retention: false,
                 gc: None,
                 only: None,
             },
@@ -465,6 +555,7 @@ fn maintenance_step_treats_metadata_root_cas_loss_as_benign_race() {
             &namespace_id,
             MaintenanceStepOptions {
                 max_wal_tail_segments: 1,
+                retention: false,
                 gc: None,
                 only: None,
             },

--- a/crates/loonfs/tests/undelete.rs
+++ b/crates/loonfs/tests/undelete.rs
@@ -364,6 +364,7 @@ fn undelete_survives_checkpoints_and_reopen_in_both_orders() {
                 &namespace_id,
                 MaintenanceStepOptions {
                     max_wal_tail_segments: 1,
+                    retention: false,
                     gc: None,
                     only: None,
                 },
@@ -402,6 +403,7 @@ fn undelete_survives_checkpoints_and_reopen_in_both_orders() {
                 &namespace_id,
                 MaintenanceStepOptions {
                     max_wal_tail_segments: 1,
+                    retention: false,
                     gc: None,
                     only: None,
                 },
@@ -426,6 +428,7 @@ fn undelete_survives_checkpoints_and_reopen_in_both_orders() {
                 &namespace_id,
                 MaintenanceStepOptions {
                     max_wal_tail_segments: 1,
+                    retention: false,
                     gc: None,
                     only: None,
                 },

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -437,9 +437,10 @@ A representative v0 binding is shown below.
 One maintenance step does four things in order: folds the visible WAL tail
 into metadata tables and advances the metadata root once the tail reaches
 `max_wal_tail_segments`, merges one bounded metadata reorganization unit,
-advances the retention floor behind a verified checkpoint, and — only when
-the body carries `gc` — runs one bounded garbage-collection pass. None of it
-creates a checkpoint record.
+and — each strictly opt-in — advances the retention floor (only when the
+body carries `retention: true`) and runs one bounded garbage-collection
+pass (only when the body carries `gc`). None of it creates a checkpoint
+record.
 
 Each part reports separately in the response: `wal_flush`, `reorganize`,
 `retention_floor_seq`, and `gc`. Races and supersessions are outcomes, not
@@ -448,7 +449,9 @@ to see whether the floor moved.
 
 The body is optional. `max_wal_tail_segments` overrides the flush threshold,
 and a value above the write-rejection threshold is rejected as
-`invalid_request`. `gc` opts into sweeping and overrides
+`invalid_request`. `retention: true` opts into advancing the retention
+floor to the flushed manifest head; nothing surrenders replay history
+unless it is present. `gc` opts into sweeping and overrides
 `grace_window_ms`/`reap_window_ms`, bounds one invocation with `max_objects`,
 and resumes with `cursor`; a grace window below the derived safety floor or a
 zero budget is rejected as `invalid_request`. Step-driven GC defaults
@@ -456,8 +459,13 @@ zero budget is rejected as `invalid_request`. Step-driven GC defaults
 than looping internally. Nothing sweeps unless `gc` is present.
 
 `only` restricts the step to one sub-step — `wal_flush`, `reorganize`,
-`retention`, or `gc` — for operators who want exactly one of them. An
-unrestricted step runs all four.
+`retention`, or `gc` — for operators who want exactly one of them; naming
+`retention` or `gc` this way is itself the opt-in. An unrestricted step
+runs the two opted-in sub-steps after flush and reorganization.
+
+The retention floor bounds incremental replay only. File revision history
+is never pruned: a revisions listing is always complete, however far the
+floor has advanced.
 
 Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to
@@ -754,7 +762,9 @@ Revision listing endpoints return newest revisions first and use the same
 `limit` / `cursor` pattern as directory listing. Path-based
 revision listing resolves the current path to its current inode, while inode
 revision listing is stable across later renames. Responses include
-`next_cursor` only when another page is available.
+`next_cursor` only when another page is available. Revision history is never
+pruned — paging to the end always reaches revision 1, regardless of how far
+the retention floor has advanced.
 
 ```json
 {

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1481,14 +1481,14 @@ the rewrite selected.
 Compaction rewrites metadata runs (and, in the future, content layouts) into
 more efficient physical shapes.
 
-A base rebuild drops rows that no retained sequence can observe: revisions
-superseded at or below the retention floor, bindings superseded or unbound at
-or below the floor, spent unbind markers, and commit receipts below the
-floor. The floor is the single retention policy: history below it — including
-file revision history — is reclaimed, except where an active checkpoint record
-still pins an older manifest that can serve it. Tombstone rows — set and
-revoke events alike — and inode rows are always retained for now;
-reachability-based dropping for them is future work.
+A base rebuild drops rows that no retained sequence can observe: bindings
+superseded or unbound at or below the retention floor, spent unbind markers,
+and commit receipts below the floor. The floor governs replay state only.
+Revision rows are never dropped: file revision history is durable data,
+retained in full regardless of the floor, and a revisions listing is always
+complete. Tombstone rows — set and revoke events alike — and inode rows are
+always retained for now; reachability-based dropping for them is future
+work.
 
 Invariants:
 
@@ -1509,10 +1509,15 @@ checkpoints — and roots its basis for as long as the record exists.
 ### 6.3 Retention management
 
 Retention management decides how far back incremental replay is still
-promised.
+promised. It bounds only replay state — change-feed resumption, superseded
+binding rows, and commit receipts — never file revision history, which is
+retained in full.
 
 A retention floor may advance only when the system has enough verified
-material to support readers from the new floor forward.
+material to support readers from the new floor forward, and it never
+advances implicitly: the default posture retains everything, and the floor
+moves only when an operator opts in (an explicit retention advance, or a
+maintenance step that requested it).
 
 ### 6.4 Garbage collection
 

--- a/docs/specs/glossary.md
+++ b/docs/specs/glossary.md
@@ -19,7 +19,7 @@
 | **Content ref** | The metadata pointer for a file revision. In v0 it has `kind: "whole_file_v0"`, a `sha256:<hex>` digest, and `size_bytes`. |
 | **NamePolicy** | The versioned rule that decides how sibling names are compared for collisions. |
 | **Tombstone** | A metadata record that hides a deleted inode or subtree without erasing history. |
-| **Retention floor** | The oldest sequence number from which the system still promises incremental replay. Older clients must re-bootstrap. |
+| **Retention floor** | The oldest sequence number from which the system still promises incremental replay. Older clients must re-bootstrap. It bounds replay only: file revision history is retained in full regardless of the floor, and the floor never advances unless an operator opts in. |
 | **Change feed** | The ordered stream of committed metadata changes after a chosen `seq`. |
 | **Cursor** | A bookmark such as `after_seq` used to resume incremental reads. |
 | **Mount** | Reserved for the future: presenting another namespace, or a subtree of one, inside a visible tree. Not a v0 inode kind. |

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4694,7 +4694,7 @@
       },
       "MaintenanceStepRequest": {
         "type": "object",
-        "description": "Options for one explicit maintenance step. Absent fields use the\nserver's defaults; garbage collection runs only when `gc` is present.",
+        "description": "Options for one explicit maintenance step. Absent fields use the\nserver's defaults; retention advance runs only when `retention` is true\nand garbage collection only when `gc` is present.",
         "properties": {
           "gc": {
             "oneOf": [
@@ -4723,9 +4723,16 @@
               },
               {
                 "$ref": "#/components/schemas/MaintenanceStepKind",
-                "description": "Restrict the step to one sub-step. Absent runs the whole step: WAL\nflush, then reorganization, then retention, then garbage collection\nif `gc` opted in."
+                "description": "Restrict the step to one sub-step. Absent runs the whole step: WAL\nflush, then reorganization, then retention if `retention` opted in,\nthen garbage collection if `gc` opted in."
               }
             ]
+          },
+          "retention": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Advance the retention floor to the flushed manifest head. Nothing\nsurrenders replay history unless this is true or `only` selects\n`retention`."
           }
         }
       },


### PR DESCRIPTION
The blackbox audit found that an actively edited file silently loses its old revisions around the 250th save: compaction dropped revision rows below the retention floor, and the floor jumped to the manifest head on every background maintenance step. A checkpoint did not protect the history, no error or warning was ever shown, and the revisions listing reported the truncated history as complete. This also contradicted the documented contract in background.rs, which says writer-scheduled maintenance never enables retention advancement.

Per the retention decision: file revision history is durable data, not replay state. Compaction no longer touches the two revision families at all, so every revision stays readable forever (this also removes a latent bug where keep-latest-at-floor was computed over only the runs selected for that compaction pass). The replay floor still bounds the change feed, superseded bindings, and commit receipts, but it now advances only when explicitly requested, mirroring how gc already opts in: a new `retention` flag on the maintenance step (options, wire request, and `loon admin step --retention`), with `only: retention` (what `loon admin retention-advance` sends) unchanged. Background maintenance uses the defaults, so nothing forgets anything unless an operator asks.
