### PR TITLE
fix(core): directory and revision cursors tolerate forward head drift

### DIFF
--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -185,18 +185,21 @@ pub struct Page<T, C> {
     pub next_cursor: Option<C>,
 }
 
-/// Cursor for one directory listing snapshot.
+/// Cursor for one directory listing position.
 ///
-/// Directory pagination advances in canonical `name_key` order.
+/// Directory pagination advances in canonical `name_key` order. The cursor
+/// is an ordering resume, not a snapshot pin: any head at or past `head_seq`
+/// serves the next page, resuming strictly after `last_name_key` — the same
+/// forward-only drift grep cursors tolerate.
 ///
-/// The cursor intentionally contains only the snapshot (`head_seq`), listed
-/// directory identity (`directory_inode_id`), and resume position (`last_name_key`).
-/// HTTP clients must pass the URL namespace and `path` on every page.
-/// Runtime/server code resolves that path at `head_seq` and rejects the cursor
-/// unless it names `directory_inode_id`.
+/// The cursor intentionally contains only the minting head (`head_seq`),
+/// listed directory identity (`directory_inode_id`), and resume position
+/// (`last_name_key`). HTTP clients must pass the URL namespace and `path` on
+/// every page. Runtime/server code resolves that path at the current head
+/// and rejects the cursor unless it names `directory_inode_id`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirectoryPageCursor {
-    /// Snapshot sequence captured by the first page.
+    /// Head sequence the issuing page was evaluated at.
     pub head_seq: ChangeSeq,
     /// Directory inode resolved at `head_seq`.
     // The wire field is frozen as `dir_inode_id` in page cursor version 1.
@@ -210,14 +213,15 @@ impl PageCursor for DirectoryPageCursor {
     const KIND: &'static str = "directory";
 }
 
-/// Cursor for one file revision listing snapshot.
+/// Cursor for one file revision listing position.
 ///
 /// Revision pagination advances in newest-first revision order for one file
-/// inode. The cursor includes the snapshot head plus the last returned row's
-/// complete ordering identity so ties stay unambiguous.
+/// inode. Like directory and grep cursors, it is an ordering resume that
+/// tolerates forward head drift; it includes the minting head plus the last
+/// returned row's complete ordering identity so ties stay unambiguous.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FileRevisionsPageCursor {
-    /// Snapshot sequence captured by the first page.
+    /// Head sequence the issuing page was evaluated at.
     pub head_seq: ChangeSeq,
     /// File inode whose revisions are being listed.
     pub inode_id: InodeId,

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -23,7 +23,7 @@ use loonfs_api::{
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId, CommitId,
     ContentRef, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
-    DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior, ErrorCode,
+    DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior,
     FilesystemOperation, FilesystemOperationRequest, ForkNamespaceRequest, GrepRequest,
     GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
     MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse,
@@ -248,54 +248,37 @@ impl Client {
 
     /// Lists a directory by aggregating every page into one response.
     ///
-    /// A commit landing mid-listing retires the cursor with
-    /// `rebootstrap_required` (API spec: restart the listing from a fresh
-    /// first page). This helper performs that restart itself, discarding
-    /// the partial aggregation, up to three times before surfacing the
-    /// error. Use [`Self::list_path_entries_page`] for page-level control and
-    /// cursor errors surfaced as-is.
+    /// Listing cursors tolerate commits landing mid-listing — each page
+    /// resumes in name-key order against the head the server has loaded —
+    /// so aggregation never restarts. The envelope's `head_seq` reports the
+    /// newest head that served a page. Use
+    /// [`Self::list_path_entries_page`] for page-level control.
     pub async fn list_path_entries_all(
         &self,
         spec: &NamespacePath,
     ) -> Result<ListPathEntriesResponse> {
-        // Bounded so a write-hot namespace cannot pin this loop forever.
-        const MAX_LISTING_RESTARTS: u32 = 3;
-        let mut restarts = 0;
-        'restart: loop {
-            let mut entries = Vec::new();
-            let mut envelope = None;
-            let mut cursor = None;
-            loop {
-                let page = match self
-                    .list_path_entries_page(spec, None, cursor.as_deref())
-                    .await
-                {
-                    Ok(page) => page,
-                    Err(error)
-                        if cursor.is_some()
-                            && restarts < MAX_LISTING_RESTARTS
-                            && error.code() == Some(ErrorCode::RebootstrapRequired) =>
-                    {
-                        restarts += 1;
-                        continue 'restart;
-                    }
-                    Err(error) => return Err(error),
-                };
-                let envelope_ref = envelope.get_or_insert_with(|| ListPathEntriesResponse {
-                    namespace_id: page.namespace_id.clone(),
-                    absolute_path: page.absolute_path.clone(),
-                    head_seq: page.head_seq,
-                    entries: Vec::new(),
-                    next_cursor: None,
-                });
-                entries.extend(page.entries);
-                cursor = page.next_cursor;
-                if cursor.is_none() {
-                    // Pages arrive in canonical name-key order; concatenation
-                    // preserves it, so aggregation must not re-sort.
-                    envelope_ref.entries = entries;
-                    return Ok(envelope.expect("first page initializes response envelope"));
-                }
+        let mut entries = Vec::new();
+        let mut envelope = None;
+        let mut cursor = None;
+        loop {
+            let page = self
+                .list_path_entries_page(spec, None, cursor.as_deref())
+                .await?;
+            let envelope_ref = envelope.get_or_insert_with(|| ListPathEntriesResponse {
+                namespace_id: page.namespace_id.clone(),
+                absolute_path: page.absolute_path.clone(),
+                head_seq: page.head_seq,
+                entries: Vec::new(),
+                next_cursor: None,
+            });
+            envelope_ref.head_seq = envelope_ref.head_seq.max(page.head_seq);
+            entries.extend(page.entries);
+            cursor = page.next_cursor;
+            if cursor.is_none() {
+                // Pages arrive in canonical name-key order; concatenation
+                // preserves it, so aggregation must not re-sort.
+                envelope_ref.entries = entries;
+                return Ok(envelope.expect("first page initializes response envelope"));
             }
         }
     }
@@ -953,7 +936,7 @@ fn append_query_param(url: &mut String, has_query: &mut bool, name: &str, value:
 mod tests {
     use super::*;
     use crate::transport::{transient_failure, MAX_TRANSIENT_ATTEMPTS};
-    use loonfs_api::ErrorKind;
+    use loonfs_api::{ErrorCode, ErrorKind};
     use std::fs;
     use tempfile::tempdir;
 

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -198,16 +198,9 @@ pub enum MetadataViewError {
         reason: String,
     },
     #[error(
-        "the cursor's snapshot (seq `{requested_seq}`) is no longer available (current head `{head_seq}`); restart the listing"
+        "the cursor was minted at seq `{requested_seq}`, ahead of the loaded head `{head_seq}`; restart the listing"
     )]
     SnapshotUnavailable {
-        requested_seq: ChangeSeq,
-        head_seq: ChangeSeq,
-    },
-    #[error(
-        "metadata view only supports the loaded head `{head_seq}`, not historical snapshot `{requested_seq}`"
-    )]
-    UnsupportedHistoricalRead {
         requested_seq: ChangeSeq,
         head_seq: ChangeSeq,
     },
@@ -515,11 +508,10 @@ fn classify_metadata_view_error(error: &MetadataViewError) -> ErrorCode {
     match error {
         MetadataViewError::MissingManifest { .. } => ErrorCode::NamespaceCorrupt,
         MetadataViewError::MaintenanceRequired { .. } => ErrorCode::MaintenanceRequired,
-        // A well-formed cursor whose snapshot aged out is a state condition,
-        // not a malformed request: the client's recovery is to restart the
-        // listing, same as a sub-floor change cursor.
-        MetadataViewError::SnapshotUnavailable { .. }
-        | MetadataViewError::UnsupportedHistoricalRead { .. } => ErrorCode::RebootstrapRequired,
+        // A well-formed cursor from ahead of the loaded head is a state
+        // condition, not a malformed request: the client's recovery is to
+        // restart the listing, same as a sub-floor change cursor.
+        MetadataViewError::SnapshotUnavailable { .. } => ErrorCode::RebootstrapRequired,
     }
 }
 
@@ -805,13 +797,6 @@ mod tests {
             (
                 MetadataViewError::SnapshotUnavailable {
                     requested_seq: ChangeSeq(1),
-                    head_seq,
-                },
-                ErrorCode::RebootstrapRequired,
-            ),
-            (
-                MetadataViewError::UnsupportedHistoricalRead {
-                    requested_seq: ChangeSeq(2),
                     head_seq,
                 },
                 ErrorCode::RebootstrapRequired,

--- a/crates/loonfs-core/src/path/read/listing.rs
+++ b/crates/loonfs-core/src/path/read/listing.rs
@@ -4,9 +4,11 @@ use crate::error::{CoreError, MetadataViewError, Result};
 use crate::metadata::ResolvedVisiblePath;
 use loonfs_api::{ChangeSeq, DirectoryPageCursor, InodeKind};
 
-/// A directory cursor is only honored at the head it was minted at: a cursor
-/// from the future is unanswerable, and a cursor from an older head would
-/// need a historical listing this view does not serve.
+/// A directory cursor is an ordering resume, not a snapshot pin: any head at
+/// or past the one that minted it serves the next page, resuming strictly
+/// after the last returned name key — the same forward-only drift grep and
+/// change-feed cursors tolerate. Only a cursor from the future is
+/// unanswerable.
 pub(super) fn validate_cursor_head(
     current_head_seq: ChangeSeq,
     cursor: Option<&DirectoryPageCursor>,
@@ -16,13 +18,6 @@ pub(super) fn validate_cursor_head(
     };
     if cursor.head_seq > current_head_seq {
         return Err(MetadataViewError::SnapshotUnavailable {
-            requested_seq: cursor.head_seq,
-            head_seq: current_head_seq,
-        }
-        .into());
-    }
-    if cursor.head_seq < current_head_seq {
-        return Err(MetadataViewError::UnsupportedHistoricalRead {
             requested_seq: cursor.head_seq,
             head_seq: current_head_seq,
         }

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -796,11 +796,12 @@ fn validate_file_revisions_cursor(
     head_seq: ChangeSeq,
     inode_id: InodeId,
 ) -> Result<()> {
-    if cursor.head_seq != head_seq {
-        // A stale snapshot is the same restart-from-fresh-state condition
-        // directory listing reports, not a malformed request: both answer
-        // `rebootstrap_required` (API spec, "Pagination").
-        return Err(MetadataViewError::UnsupportedHistoricalRead {
+    if cursor.head_seq > head_seq {
+        // Forward-only drift, the same rule as directory listing and grep:
+        // an older cursor resumes strictly after its last returned row at
+        // whatever head is loaded now; only a cursor from the future is
+        // unanswerable (`rebootstrap_required`).
+        return Err(MetadataViewError::SnapshotUnavailable {
             requested_seq: cursor.head_seq,
             head_seq,
         }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1385,7 +1385,7 @@ async fn http_commit_body_over_the_limit_answers_content_too_large() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn http_stale_revisions_cursor_answers_rebootstrap_required() {
+async fn http_revisions_cursor_resumes_after_head_drift_and_rejects_the_future() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let fs = bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
@@ -1438,7 +1438,8 @@ async fn http_stale_revisions_cursor_answers_rebootstrap_required() {
     .await
     .expect("join blocking task");
 
-    // Any commit advances the head and retires outstanding cursors.
+    // A commit landing mid-listing does not retire the cursor: the resume
+    // continues after the last returned revision against the new head.
     write_file_bytes(
         &fs,
         &namespace_id("demo"),
@@ -1448,6 +1449,33 @@ async fn http_stale_revisions_cursor_answers_rebootstrap_required() {
     )
     .await;
 
+    let resumed = tokio::task::spawn_blocking({
+        let cursor = cursor.clone();
+        move || {
+            let response = raw_agent()
+                .get(&format!(
+                    "http://{addr}/v0/namespaces/demo/filesystem/revisions"
+                ))
+                .set("authorization", "Bearer test-token")
+                .query("path", "/notes/file.txt")
+                .query("limit", "1")
+                .query("cursor", &cursor)
+                .call()
+                .expect("cursor resumes after head drift");
+            let body = response.into_string().expect("read resumed body");
+            serde_json::from_str::<serde_json::Value>(&body).expect("json resumed body")
+        }
+    })
+    .await
+    .expect("join blocking task");
+    assert_eq!(resumed["revisions"][0]["revision_no"], 1);
+    assert!(resumed["next_cursor"].is_null());
+
+    // A cursor from the future stays unanswerable.
+    let mut future_cursor: loonfs_api::FileRevisionsPageCursor =
+        loonfs_api::decode_cursor(&cursor).expect("decode revisions cursor");
+    future_cursor.head_seq = loonfs_api::ChangeSeq(future_cursor.head_seq.0 + 1000);
+    let future_cursor = loonfs_api::encode_cursor(&future_cursor).expect("encode future cursor");
     let error = raw_agent()
         .get(&format!(
             "http://{addr}/v0/namespaces/demo/filesystem/revisions"
@@ -1455,15 +1483,15 @@ async fn http_stale_revisions_cursor_answers_rebootstrap_required() {
         .set("authorization", "Bearer test-token")
         .query("path", "/notes/file.txt")
         .query("limit", "1")
-        .query("cursor", &cursor)
+        .query("cursor", &future_cursor)
         .call()
-        .expect_err("stale cursor should answer rebootstrap_required");
+        .expect_err("future cursor should answer rebootstrap_required");
     let ureq::Error::Status(status, response) = error else {
-        panic!("expected a status error for a stale cursor");
+        panic!("expected a status error for a future cursor");
     };
     assert_eq!(status, 409);
-    let body = response.into_string().expect("read stale-cursor body");
-    let body: serde_json::Value = serde_json::from_str(&body).expect("json stale-cursor body");
+    let body = response.into_string().expect("read future-cursor body");
+    let body: serde_json::Value = serde_json::from_str(&body).expect("json future-cursor body");
     assert_eq!(body["code"], "rebootstrap_required");
 
     server.abort();

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -52,9 +52,12 @@ impl FsReader {
 
     /// Lists a directory by aggregating every page into one response.
     ///
-    /// The envelope and every entry come from one consistent head, so an
-    /// empty directory still reports which state answered the question. Entries
-    /// are returned in canonical name-key order, matching paged listings.
+    /// Listing cursors tolerate commits landing mid-listing — each page
+    /// resumes in name-key order against the current head — so the
+    /// envelope's `head_seq` reports the newest head that served a page (an
+    /// empty directory still reports which state answered the question).
+    /// Entries are returned in canonical name-key order, matching paged
+    /// listings.
     pub async fn list_path_entries_all(
         &self,
         namespace_id: &NamespaceId,
@@ -79,6 +82,7 @@ impl FsReader {
                 entries: Vec::new(),
                 next_cursor: None,
             });
+            envelope_ref.head_seq = envelope_ref.head_seq.max(page.head_seq);
             entries.extend(page.entries);
             cursor = next_cursor;
             if cursor.is_none() {

--- a/crates/loonfs/tests/pagination.rs
+++ b/crates/loonfs/tests/pagination.rs
@@ -166,7 +166,7 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
 }
 
 #[test]
-fn directory_cursor_after_later_writes_is_rejected() {
+fn directory_cursor_resumes_after_later_writes() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-snapshot-test");
     let namespace_id = namespace_id("demo");
@@ -203,12 +203,58 @@ fn directory_cursor_after_later_writes_is_rejected() {
     )
     .expect("put later file");
 
+    // The cursor is an ordering resume: the next page continues after the
+    // last returned name key against the advanced head, so the entry
+    // committed mid-listing appears in its canonical position.
+    let second = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit,
+            cursor: Some(cursor),
+        },
+    ))
+    .expect("second directory page resumes after head drift");
+    assert_eq!(display_names(&second.entries), vec!["c.txt", "z.txt"]);
+    assert!(second.next_cursor.is_none());
+}
+
+#[test]
+fn directory_cursor_from_the_future_is_rejected() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "directory-page-future-test");
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            path,
+            path.as_bytes(),
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+    }
+
+    let first = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit: page_limit(2),
+            cursor: None,
+        },
+    ))
+    .expect("first directory page");
+    let mut cursor =
+        decode_directory_page_cursor(first.next_cursor.as_deref().expect("next cursor"));
+    cursor.head_seq = loonfs::ChangeSeq(cursor.head_seq.0 + 1000);
+
     assert_core_error_kind(
         block_on(fs.list_path_entries_page(
             &namespace_id,
             "/docs",
             PageRequest {
-                limit,
+                limit: page_limit(2),
                 cursor: Some(cursor),
             },
         )),
@@ -217,7 +263,7 @@ fn directory_cursor_after_later_writes_is_rejected() {
 }
 
 #[test]
-fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
+fn directory_cursor_resumes_across_a_wal_flush() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-floor-test");
     let namespace_id = namespace_id("demo");
@@ -254,17 +300,93 @@ fn directory_cursor_older_than_materialized_snapshot_floor_is_rejected() {
     fs.create_checkpoint_blocking(&namespace_id)
         .expect("checkpoint newer snapshot");
 
-    assert_core_error_kind(
-        block_on(fs.list_path_entries_page(
+    // Materializing the newer state into the manifest does not retire the
+    // cursor either: retained rows answer the resume at the current head.
+    let second = block_on(fs.list_path_entries_page(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit: page_limit(2),
+            cursor: Some(cursor),
+        },
+    ))
+    .expect("second directory page resumes across a flush");
+    assert_eq!(display_names(&second.entries), vec!["c.txt", "z.txt"]);
+    assert!(second.next_cursor.is_none());
+}
+
+#[test]
+fn revisions_cursor_resumes_after_later_writes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "revisions-page-drift-test");
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for body in ["one", "two", "three"] {
+        fs.put_file_bytes_blocking(
             &namespace_id,
-            "/docs",
-            PageRequest {
-                limit: page_limit(2),
-                cursor: Some(cursor),
+            "/docs/report.txt",
+            body.as_bytes(),
+            PutFileOptions {
+                behavior: DestinationBehavior::Replace,
+                ..PutFileOptions::default()
             },
-        )),
-        ErrorCode::RebootstrapRequired,
+        )
+        .expect("put revision");
+    }
+
+    let first = block_on(fs.list_file_revisions_page(
+        &namespace_id,
+        "/docs/report.txt",
+        PageRequest {
+            limit: page_limit(2),
+            cursor: None,
+        },
+    ))
+    .expect("first revisions page");
+    assert_eq!(
+        first
+            .revisions
+            .iter()
+            .map(|revision| revision.revision_no.0)
+            .collect::<Vec<_>>(),
+        vec![3, 2]
     );
+    let cursor =
+        decode_file_revisions_page_cursor(first.next_cursor.as_deref().expect("next cursor"));
+
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/report.txt",
+        b"four",
+        PutFileOptions {
+            behavior: DestinationBehavior::Replace,
+            ..PutFileOptions::default()
+        },
+    )
+    .expect("put fourth revision");
+
+    // The resume continues strictly after the last returned revision, so
+    // the in-flight listing completes; the revision committed mid-listing
+    // is newer than the whole listing and stays out of it.
+    let second = block_on(fs.list_file_revisions_page(
+        &namespace_id,
+        "/docs/report.txt",
+        PageRequest {
+            limit: page_limit(2),
+            cursor: Some(cursor),
+        },
+    ))
+    .expect("second revisions page resumes after head drift");
+    assert_eq!(
+        second
+            .revisions
+            .iter()
+            .map(|revision| revision.revision_no.0)
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert!(second.next_cursor.is_none());
 }
 
 #[test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -241,7 +241,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `upload_already_completed` | 409 | The upload session is already completed. |
 | `upload_content_conflict` | 409 | Different bytes were staged under this upload id. |
 | `query_unindexable` | 400 | The pattern has no run of at least 3 literal bytes, so the trigram index cannot narrow candidates; rewrite the pattern, or set `allow_scan` (capped by `query.grep.scan_budget_files`). |
-| `rebootstrap_required` | 409 | The resume position — a change cursor or listing snapshot — is no longer available; restart from a fresh listing or checkpoint. |
+| `rebootstrap_required` | 409 | The resume position is unanswerable — a change cursor below the retention floor, or a listing cursor minted ahead of the serving head; restart from a fresh listing or checkpoint. |
 | `not_supported` | 501 | The deployment does not implement the requested op or feature. |
 | `commit_outcome_unknown` | 503 | The publish outcome was not observed; the commit may or may not be visible. Retry with the same commit id or reconcile. |
 | `commit_queue_full` | 503 | The namespace write queue is full; back off and retry. |
@@ -698,16 +698,23 @@ shape as `stat` (directory entries leave the file-only fields out).
 Directory listing advances in canonical `name_key` order. Concatenating pages
 in cursor order yields the complete listing in that same order; clients must
 not re-sort aggregated pages. The `path` query parameter is
-required on every page; the cursor pins the snapshot and resume position, but
-the request path remains the authority for what is being listed. Responses
+required on every page; the cursor carries the resume position, but the
+request path remains the authority for what is being listed. Responses
 include `next_cursor` only when another page is available.
 
-A cursor pins the head sequence it was issued at, and v0 serves pages only
-against the current head: once any commit advances the namespace, resuming an
-older cursor answers `rebootstrap_required` — restart the listing from a
-fresh first page. Directory listing and revision listing behave identically
-here. (A malformed cursor, or one replayed against a different target, stays
-`invalid_request`.)
+A cursor is an ordering resume, not a snapshot pin. Every cursor in the API
+— directory listing, revision listing, grep, and the change feed alike —
+tolerates forward head drift: commits landing mid-listing never retire it,
+and the resumed page evaluates at the then-current head, continuing strictly
+after the last returned position. Each page is internally consistent at its
+own head, but a multi-page listing spans whatever heads its pages ran at: an
+entry created behind the resume position is missed, an entry deleted behind
+it was already returned, and a rename can surface as a duplicate or a miss.
+A client that needs one consistent cut re-issues the listing when `head_seq`
+changes between pages. Only a cursor minted ahead of the serving head
+answers `rebootstrap_required` — drift tolerance runs forward, never
+backward. (A malformed cursor, or one replayed against a different target,
+stays `invalid_request`.)
 
 ```json
 {
@@ -1137,11 +1144,10 @@ resumes strictly after the last candidate the issuing page finished
 scanning and is bound to that request — replaying it with different
 criteria is rejected as `invalid_request`.
 
-Grep cursors deliberately tolerate head drift, unlike directory listing
-cursors (section 5), which are bound to the head that minted them and must
-re-bootstrap after any commit. A grep cursor minted at an older head is
-accepted, and the resumed page evaluates at the then-current head and
-reports it: each page is internally consistent at its own head, but a
+Grep cursors tolerate head drift with the same forward-only rule as every
+other cursor in the API (section 6.5). A grep cursor minted at an older
+head is accepted, and the resumed page evaluates at the then-current head
+and reports it: each page is internally consistent at its own head, but a
 multi-page search spans whatever heads its pages ran at, and candidates
 the cursor has passed are not revisited even if later commits changed
 them. A search is a bounded sampling read over content, not an


### PR DESCRIPTION
Previously, a directory over about 1,000 entries cannot be listed while anyone writes to the namespace: listing cursors demanded the exact head they were minted at, so any commit anywhere invalidated every in-flight listing with rebootstrap_required. Directory and revision cursors were the last strict cursors in the product — grep, change-feed, and GC cursors already tolerate drift.

This makes every cursor follow the same rule: forward-only drift. A cursor resumes strictly after its last returned position against whatever head is loaded now; only a cursor minted ahead of the serving head answers rebootstrap_required. The change is mostly deletion — one comparison dropped from each of the two gates, the UnsupportedHistoricalRead variant removed, and the HTTP client's bounded restart loop deleted (it existed only to paper over the strictness, and still failed under sustained writes). Cross-page semantics now match S3 ListObjects: an entry created behind the resume position is missed, one deleted behind it was already returned; api.md documents this in the pagination section and the grep section's contrast paragraph is gone.
