### PR TITLE
fix(core): fence errors name both writer sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ loon use {namespace_id}
 
 ## Running a server
 
-Embedded mode gives one process at a time direct object-store access. To share a deployment across machines and let many clients write concurrently, run the reference server and point remote profiles at it:
+Embedded mode gives one process at a time direct object-store access. Concurrent `loon` invocations against one namespace contend for the writer role: whichever acquires it last wins, and a command that loses fails with `writer_fenced`, naming both sessions. A fenced command commits nothing, so rerunning it is always safe — but fencing is a stop signal, not a retry loop, so put bulk work in one process or run the server for concurrent writers. To share a deployment across machines and let many clients write concurrently, run the reference server and point remote profiles at it:
 
 ```bash
 cargo build -p loonfs-server

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -56,6 +56,10 @@ pub struct ErrorDetails {
     /// Epoch the failing writer session held when it was displaced.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fenced_epoch: Option<WriterEpoch>,
+    /// Session id the fenced writer held. Distinguishes two processes that
+    /// share one writer id (the CLI defaults `writer_id` to the hostname).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fenced_writer_session: Option<String>,
     /// Epoch that currently owns the namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_writer_epoch: Option<WriterEpoch>,
@@ -63,6 +67,10 @@ pub struct ErrorDetails {
     /// recorded one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_writer: Option<String>,
+    /// Session id recorded by the current epoch's acquirer, when the head
+    /// recorded one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_writer_session: Option<String>,
     /// Inode the failed precondition or operation targeted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inode_id: Option<InodeId>,

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -737,4 +737,79 @@ mod tests {
                 panic!("recovery put failed: {} {}", error.code, error.message)
             });
     }
+    #[tokio::test]
+    async fn a_fenced_put_fails_terminally_and_names_both_sessions() {
+        let temp_dir = tempdir().expect("create temp dir");
+        let store = StoreConfig::LocalFs {
+            root: temp_dir.path().display().to_string(),
+            key_prefix: None,
+        };
+        // Two backends over one store model two concurrent `loon` processes:
+        // the writer id is shared (the CLI defaults it to the hostname) and
+        // only the session ids differ, so without session identity in the
+        // fence a user reads the error as their machine fencing itself.
+        let first = EmbeddedTarget::new(&store, Some("shared-host"), None)
+            .await
+            .expect("build first embedded target");
+        first
+            .backend
+            .create_namespace(&namespace_id("demo"))
+            .await
+            .expect("create namespace");
+        first
+            .backend
+            .put_file_bytes(
+                &NamespacePath::parse("demo", "/one.txt").expect("namespace path"),
+                b"one",
+                &ClientPutFileOptions::default(),
+            )
+            .await
+            .expect("first put acquires the epoch");
+
+        let rival = EmbeddedTarget::new(&store, Some("shared-host"), None)
+            .await
+            .expect("build rival embedded target");
+        rival
+            .backend
+            .put_file_bytes(
+                &NamespacePath::parse("demo", "/two.txt").expect("namespace path"),
+                b"two",
+                &ClientPutFileOptions::default(),
+            )
+            .await
+            .expect("rival put takes the epoch over");
+
+        // Fenced sessions are terminal — no silent reacquisition, matching
+        // remote mode and the core contract. The error carries both session
+        // identities so the loser is diagnosable, and the failed put
+        // committed nothing.
+        let error = first
+            .backend
+            .put_file_bytes(
+                &NamespacePath::parse("demo", "/three.txt").expect("namespace path"),
+                b"three",
+                &ClientPutFileOptions::default(),
+            )
+            .await
+            .expect_err("a fenced session is terminal");
+        assert_eq!(error.code, ErrorCode::WriterFenced.as_str());
+        assert!(
+            error.message.contains("was fenced by epoch"),
+            "{}",
+            error.message
+        );
+        assert_eq!(
+            error.message.matches("session `wrs_").count(),
+            2,
+            "both sessions named: {}",
+            error.message
+        );
+
+        let missing = rival
+            .backend
+            .stat_path(&NamespacePath::parse("demo", "/three.txt").expect("namespace path"))
+            .await
+            .expect_err("the fenced put committed nothing");
+        assert_eq!(missing.code, ErrorCode::PathNotFound.as_str());
+    }
 }

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -197,6 +197,68 @@ fn embedded_profile_filesystem_flow_works_end_to_end() {
 }
 
 #[test]
+fn concurrent_embedded_puts_land_or_report_the_fence() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let mut payloads = Vec::new();
+    for index in 0..4 {
+        let path = harness.temp_dir.path().join(format!("payload-{index}.txt"));
+        fs::write(&path, format!("payload {index}")).expect("write payload");
+        payloads.push(path);
+    }
+
+    // Four simultaneous processes: each is its own writer session, so they
+    // fence each other on acquisition. Fencing is terminal — no silent
+    // reacquisition — so the contract is honesty, not recovery: every
+    // process either lands its put or reports `writer_fenced`, the last
+    // acquirer always lands, and a fenced put commits nothing.
+    let children: Vec<Child> = payloads
+        .iter()
+        .enumerate()
+        .map(|(index, path)| {
+            Command::new(loon_binary_path())
+                .env("HOME", &harness.home_dir)
+                .args([
+                    "--json",
+                    "put",
+                    path.to_str().expect("utf-8 path"),
+                    &format!("/docs/file-{index}.txt"),
+                ])
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn loon put")
+        })
+        .collect();
+    let mut landed = Vec::new();
+    for (index, child) in children.into_iter().enumerate() {
+        let output = child.wait_with_output().expect("join loon put");
+        if output.status.success() {
+            landed.push(index);
+        } else {
+            assert_eq!(json_error(&output)["code"], "writer_fenced");
+        }
+    }
+    assert!(
+        !landed.is_empty(),
+        "the last writer to acquire faces no later fence and must land"
+    );
+
+    for index in 0..4 {
+        let stat = harness.run(&["--json", "stat", &format!("/docs/file-{index}.txt")]);
+        if landed.contains(&index) {
+            assert_success(&stat);
+        } else {
+            assert_failure(&stat);
+            assert_eq!(json_error(&stat)["code"], "path_not_found");
+        }
+    }
+}
+
+#[test]
 fn embedded_profile_namespace_fork_reads_shared_content_and_diverges() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -415,8 +415,10 @@ impl CoreError {
         match self {
             CoreError::WriterFenced(fence) => Some(ErrorDetails {
                 fenced_epoch: Some(fence.fenced_epoch),
+                fenced_writer_session: Some(fence.fenced_session_id.clone()),
                 active_writer_epoch: Some(fence.active_epoch),
                 active_writer: fence.active_writer.clone(),
+                active_writer_session: fence.active_session_id.clone(),
                 ..ErrorDetails::default()
             }),
             CoreError::CommitIdReuseConflict(commit_id) => Some(ErrorDetails {
@@ -438,26 +440,34 @@ impl CoreError {
 }
 
 /// The fencing event a writer session observed: the epoch the session held,
-/// the epoch that displaced it, and the winner's writer id when the head
-/// recorded one.
+/// the epoch that displaced it, and the winner's identity when the head
+/// recorded one. Session ids matter because writer ids are process labels —
+/// every CLI invocation on one machine shares the hostname — so without them
+/// a fence between two local processes reads as a machine fencing itself.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriterFence {
     /// Epoch the fenced session held.
     pub fenced_epoch: WriterEpoch,
+    /// Session id the fenced writer held.
+    pub fenced_session_id: String,
     /// Epoch that owns the namespace now.
     pub active_epoch: WriterEpoch,
     /// Writer id recorded by the winning acquirer, when known.
     pub active_writer: Option<String>,
+    /// Session id recorded by the winning acquirer, when known.
+    pub active_session_id: Option<String>,
 }
 
 impl std::fmt::Display for WriterFence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "epoch {} was fenced by epoch {} (writer `{}`)",
+            "epoch {} (session `{}`) was fenced by epoch {} (writer `{}`, session `{}`)",
             self.fenced_epoch,
+            self.fenced_session_id,
             self.active_epoch,
-            self.active_writer.as_deref().unwrap_or("unknown")
+            self.active_writer.as_deref().unwrap_or("unknown"),
+            self.active_session_id.as_deref().unwrap_or("unknown")
         )
     }
 }
@@ -828,16 +838,20 @@ mod tests {
     fn identity_bearing_errors_expose_structured_wire_details() {
         let fenced = CoreError::WriterFenced(WriterFence {
             fenced_epoch: WriterEpoch(3),
+            fenced_session_id: "wrs-a".to_owned(),
             active_epoch: WriterEpoch(4),
             active_writer: Some("writer-b".to_owned()),
+            active_session_id: Some("wrs-b".to_owned()),
         });
         let details = fenced.details().expect("fence details");
         assert_eq!(details.fenced_epoch, Some(WriterEpoch(3)));
+        assert_eq!(details.fenced_writer_session.as_deref(), Some("wrs-a"));
         assert_eq!(details.active_writer_epoch, Some(WriterEpoch(4)));
         assert_eq!(details.active_writer.as_deref(), Some("writer-b"));
-        assert!(fenced
-            .to_string()
-            .contains("epoch 3 was fenced by epoch 4 (writer `writer-b`)"));
+        assert_eq!(details.active_writer_session.as_deref(), Some("wrs-b"));
+        assert!(fenced.to_string().contains(
+            "epoch 3 (session `wrs-a`) was fenced by epoch 4 (writer `writer-b`, session `wrs-b`)"
+        ));
 
         let reuse = CoreError::CommitIdReuseConflict("retry-key-1".to_owned());
         let details = reuse.details().expect("reuse details");

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -65,8 +65,13 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
         if head.writer_epoch != acquired_writer.writer_epoch {
             return Err(CoreError::WriterFenced(crate::error::WriterFence {
                 fenced_epoch: acquired_writer.writer_epoch,
+                fenced_session_id: acquired_writer.writer_session_id.clone(),
                 active_epoch: head.writer_epoch,
                 active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
+                active_session_id: head
+                    .writer
+                    .as_ref()
+                    .map(|writer| writer.writer_session_id.clone()),
             }));
         }
 

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -220,8 +220,13 @@ fn ensure_publish_head_matches_acquired_writer(
     if head.writer_epoch != acquired_writer.writer_epoch {
         return Err(CoreError::WriterFenced(crate::error::WriterFence {
             fenced_epoch: acquired_writer.writer_epoch,
+            fenced_session_id: acquired_writer.writer_session_id.clone(),
             active_epoch: head.writer_epoch,
             active_writer: head.writer.as_ref().map(|writer| writer.writer_id.clone()),
+            active_session_id: head
+                .writer
+                .as_ref()
+                .map(|writer| writer.writer_session_id.clone()),
         }));
     }
     Ok(())


### PR DESCRIPTION
Every CLI process on a host shares the hostname as its writer id and the fence error never mentioned sessions, so two racing `loon put` invocations both printed "epoch 1 was fenced by epoch 2 (writer `Mac`)" — a machine apparently fencing itself. WriterFence now carries both session ids, the message names them, and the wire error details gained the same two fields.

The behavioral half stays deliberately unchanged, and the new tests pin that instead of papering over it. Fencing is terminal by design. The contract under concurrent invocations is honesty, not recovery: every process either lands its put or exits nonzero with writer_fenced, the last acquirer always lands, and a fenced put commits nothing, so rerunning the losing command is always safe. 