### PR TITLE
feat(cli): rm -r deletes a directory subtree as one recoverable commit

### DIFF
--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -65,8 +65,8 @@ pub(crate) enum Command {
     Undelete(FilesystemUndeleteArgs),
     /// Create a directory.
     Mkdir(FilesystemMkdirArgs),
-    /// Delete a file or empty directory.
-    Rm(FilesystemPathMutationArgs),
+    /// Delete a file or directory.
+    Rm(FilesystemRmArgs),
     /// Move or rename a path.
     Mv(FilesystemTransferArgs),
     /// Copy a file to another path.
@@ -360,10 +360,14 @@ pub(crate) struct FilesystemPathArgs {
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct FilesystemPathMutationArgs {
+pub(crate) struct FilesystemRmArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     pub path: String,
+    /// Delete a directory and everything under it, as one commit. The whole
+    /// subtree stays recoverable through the printed undelete handle.
+    #[arg(short, long)]
+    pub recursive: bool,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
     #[arg(long)]

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -8,12 +8,12 @@ use super::context::{
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     CommandKind, FilesystemCatArgs, FilesystemGetArgs, FilesystemGrepArgs, FilesystemLsArgs,
-    FilesystemMkdirArgs, FilesystemPathArgs, FilesystemPathMutationArgs, FilesystemPutArgs,
-    FilesystemRestoreArgs, FilesystemRevisionsArgs, FilesystemTransferArgs, FilesystemUndeleteArgs,
+    FilesystemMkdirArgs, FilesystemPathArgs, FilesystemPutArgs, FilesystemRestoreArgs,
+    FilesystemRevisionsArgs, FilesystemRmArgs, FilesystemTransferArgs, FilesystemUndeleteArgs,
     RuntimeBehavior,
 };
 use crate::error::CliError;
-use loonfs_api::{CommitId, DestinationBehavior, InodeKind, RevisionNo};
+use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeKind, RevisionNo};
 use loonfs_client::{CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions};
 use std::fs;
 use std::io::Write;
@@ -375,7 +375,7 @@ pub(crate) async fn run_filesystem_put(
 
 pub(crate) async fn run_filesystem_rm(
     kind: CommandKind,
-    args: FilesystemPathMutationArgs,
+    args: FilesystemRmArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
     let allow_root = false;
@@ -394,10 +394,15 @@ pub(crate) async fn run_filesystem_rm(
         .await
         .map_err(|error| context.fail(kind, error))?
         .inode_id;
+    let behavior = if args.recursive {
+        DeleteDirectoryBehavior::Recursive
+    } else {
+        DeleteDirectoryBehavior::NonRecursive
+    };
     let options = DeleteOptions {
+        behavior,
         expected_inode_id: Some(deleted_inode),
         commit_id,
-        ..DeleteOptions::default()
     };
     let result = context
         .target

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -259,6 +259,35 @@ fn concurrent_embedded_puts_land_or_report_the_fence() {
 }
 
 #[test]
+fn rm_recursive_deletes_a_populated_directory_in_one_commit() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("payload.txt");
+    fs::write(&payload, b"body").expect("write payload");
+    for path in ["/docs/a.txt", "/docs/nested/b.txt"] {
+        assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), path]));
+    }
+
+    // Without -r a populated directory still refuses, exactly as before.
+    let refused = harness.run(&["--json", "rm", "/docs"]);
+    assert_failure(&refused);
+    assert_eq!(json_error(&refused)["code"], "directory_not_empty");
+
+    let removed = harness.run(&["--json", "rm", "-r", "/docs"]);
+    assert_success(&removed);
+    assert_eq!(json_data(&removed)["target"], "demo:/docs");
+
+    for path in ["/docs", "/docs/a.txt", "/docs/nested/b.txt"] {
+        let stat = harness.run(&["--json", "stat", path]);
+        assert_failure(&stat);
+        assert_eq!(json_error(&stat)["code"], "path_not_found");
+    }
+}
+
+#[test]
 fn embedded_profile_namespace_fork_reads_shared_content_and_diverges() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");


### PR DESCRIPTION
The audit found there is no recursive delete: removing a 10,000-file folder means 10,000 individual rm calls. The core has supported this all along — a recursive delete is a single DeleteSubtree op whose cost does not grow with the subtree — but the CLI never exposed the flag.

`loon rm -r` maps to that existing op. The whole subtree goes in one commit, the printed undelete handle recovers all of it (deletes tombstone rather than destroy, so this is safer than the trash-bin equivalents elsewhere), and rm without -r still refuses a populated directory with directory_not_empty. The now-unused shared args struct is deleted; rm gets its own.