### PR TITLE
fix(core): a gc-restricted maintenance step runs against deleted namespaces

### DIFF
--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1143,6 +1143,36 @@ fn namespace_delete_without_yes_fails_cleanly_when_not_interactive() {
 }
 
 #[test]
+fn admin_gc_reclaims_a_deleted_namespace_instead_of_refusing() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("payload.txt");
+    fs::write(&payload, b"body").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/doc.txt"]));
+    // Materialize derived state so the tombstone has something reclaimable.
+    assert_success(&harness.run(&["admin", "flush"]));
+    assert_success(&harness.run(&["--json", "namespace", "delete", "demo", "--yes"]));
+
+    // GC is the reclamation path for a tombstoned namespace: it must run
+    // and report, not refuse. (Fresh objects sit inside the grace window,
+    // so this pins reachability, not byte counts.)
+    let gc = harness.run(&["--json", "admin", "gc"]);
+    assert_success(&gc);
+    assert_eq!(json_data(&gc)["kind"], "garbage_collected");
+
+    // Everything that is not the GC-only step still reports the deletion.
+    let step = harness.run(&["--json", "admin", "step"]);
+    assert_failure(&step);
+    assert_eq!(json_error(&step)["code"], "namespace_deleted");
+    let recreate = harness.run(&["--json", "namespace", "create", "demo"]);
+    assert_failure(&recreate);
+    assert_eq!(json_error(&recreate)["code"], "namespace_deleted");
+}
+
+#[test]
 fn index_enable_leaves_core_maintenance_decoupled() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -82,7 +82,9 @@ pub mod cache {
         DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
         DEFAULT_WAL_TAIL_PROJECTION_ROWS,
     };
-    pub use crate::namespace::status::{load_namespace_head_summary, NamespaceHeadSummary};
+    pub use crate::namespace::status::{
+        load_deleted_namespace_head_summary, load_namespace_head_summary, NamespaceHeadSummary,
+    };
 }
 
 /// Typed namespace control-object loaders and verified catalog state.

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -103,3 +103,39 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
         retention_floor_seq,
     })
 }
+
+/// Summarizes a namespace whose head is a deletion tombstone.
+///
+/// Reads only the two control objects that outlive reclamation — the head
+/// and the WAL floor — because garbage collection may already have reaped
+/// the manifest and chain a live summary would consult. Callers reach for
+/// this only after [`load_namespace_head_summary`] reported the deletion;
+/// a live head here is an invariant breach, not a state to serve.
+pub async fn load_deleted_namespace_head_summary<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace_id: &NamespaceId,
+) -> Result<NamespaceHeadSummary> {
+    let (loaded_head, _loaded_root) = read_head_and_metadata_root(store, expected_namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?;
+    let head = loaded_head.envelope.state;
+    if head.state != NamespaceState::Deleted {
+        return Err(CoreError::Internal(format!(
+            "namespace `{expected_namespace_id}` is not deleted; the live head summary serves it"
+        )));
+    }
+    let retention_floor_seq = read_wal_floor_seq_or_zero(store, expected_namespace_id)
+        .await
+        .map_err(|error| {
+            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+        })?;
+    Ok(NamespaceHeadSummary {
+        namespace_id: head.namespace_id,
+        head_seq: head.seq,
+        current_manifest_id: None,
+        wal_tail_segments: 0,
+        retention_floor_seq,
+    })
+}

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -84,7 +84,35 @@ impl FsAdmin {
         }
 
         let runs = |kind: MaintenanceStepKind| options.only.is_none_or(|only| only == kind);
-        let status_before = self.namespace_status(namespace_id).await?;
+        let status_before = match self.namespace_status(namespace_id).await {
+            Ok(status) => status,
+            // A tombstoned namespace keeps reclaimable derived state — WAL
+            // segments, tables, manifests, checkpoint records — until GC
+            // ages it out, and a GC-only step is the reclamation path. It
+            // proceeds against the tombstone; the summary comes from the
+            // two control objects that outlive reclamation, because the
+            // manifest and chain a live summary consults may already be
+            // reaped. Full steps still refuse: a tombstone has nothing to
+            // flush or reorganize.
+            Err(RuntimeError::Core(error))
+                if error.code() == ErrorCode::NamespaceDeleted
+                    && options.only == Some(MaintenanceStepKind::Gc) =>
+            {
+                let summary = loonfs_core::cache::load_deleted_namespace_head_summary(
+                    self.core.store(),
+                    namespace_id,
+                )
+                .await?;
+                NamespaceStatusResponse {
+                    namespace_id: summary.namespace_id,
+                    head_seq: summary.head_seq,
+                    current_manifest_id: summary.current_manifest_id,
+                    wal_tail_segments: summary.wal_tail_segments,
+                    retention_floor_seq: summary.retention_floor_seq,
+                }
+            }
+            Err(error) => return Err(error),
+        };
         let observed_head_seq = status_before.head_seq;
 
         let wal_flush = if runs(MaintenanceStepKind::WalFlush)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -136,7 +136,7 @@ hoc.
 | --- | --- | --- |
 | `core.namespaces.create` | Creating namespaces (`POST /v0/namespaces`). | |
 | `core.namespaces.fork` | Forking namespaces (`POST /v0/namespaces/{ns}/forks`). | |
-| `core.namespaces.delete` | Deleting namespaces (`DELETE /v0/namespaces/{ns}`). | Terminal, and the id is permanently retired. Deletion does not reclaim storage in v0. A deployment may still advertise `false` and answer `not_supported`. |
+| `core.namespaces.delete` | Deleting namespaces (`DELETE /v0/namespaces/{ns}`). | Terminal, and the id is permanently retired. Derived state becomes reclaimable through a `gc`-restricted maintenance step (section 6.3); content blobs are not reclaimed in v0. A deployment may still advertise `false` and answer `not_supported`. |
 | `core.uploads.direct_put` | Starting presigned `direct_put` upload sessions (`POST /v0/namespaces/{ns}/uploads`). | The server returns a short-lived presigned PUT capability for the exact content object. The key is present only when the selected provider profile proves the signed preconditions or the deployment explicitly opts into an unproven endpoint. Raw object keys and caller-managed object-store writes are not part of this feature. |
 | `query.grep` | Content search (`POST /v0/namespaces/{ns}/query/grep`). | The serving half of a data-dependent capability: the request also requires a materialized steady-state grep root, and a namespace without one answers `not_supported` whatever this key advertises. |
 
@@ -635,7 +635,15 @@ deletion"). It linearizes at the head swap: commits acknowledged before it
 stay committed; everything that observes the deleted namespace afterwards —
 reads, commits, forks, status, re-creation of the id — fails with
 `namespace_deleted` (410). Deleting an already-deleted namespace is also
-`namespace_deleted`. Storage is not reclaimed in v0.
+`namespace_deleted`.
+
+Deletion itself reclaims nothing, but a deleted namespace's derived state —
+WAL segments, metadata tables and manifests, and checkpoint records that
+protect nothing live — becomes garbage once the tombstone is in place. A
+maintenance step restricted to `gc` runs against the tombstone and ages
+that state out under the normal grace rules; the tombstone (descriptor and
+head) survives so the id stays retired. Content blobs live in a shared
+content store outside the namespace prefix and are not reclaimed in v0.
 
 The optional `expected_head_seq` query parameter deletes only if the head is
 still at that sequence, failing with `stale_head` otherwise — the same


### PR DESCRIPTION
The audit found that deleting a namespace strands its storage forever: `loon admin gc` refuses with "namespace is deleted", so the reclaim-down-to-the-tombstone behavior that landed in the lifecycle wave (terminally deleted namespaces shrink their GC live set to the tombstone) was reachable by nobody — not the CLI, not the HTTP step, not the server background step. The machinery existed; the entry point never opened.

The refusal came from the maintenance step's status precondition, not from GC itself, which handles tombstones fine. The step now tolerates `namespace_deleted` exactly when it is restricted to the gc sub-step — the reclamation path — and builds its status snapshot from the two control objects that outlive reclamation (head and floor), because the manifest and chain a live summary consults may already be reaped. Full steps still refuse: a tombstone has nothing to flush or reorganize. The tombstone itself survives every pass, so the id stays retired, and content blobs (shared content store, outside the namespace prefix) remain out of scope for v0; api.md 6.3 now states all of this instead of a blanket "storage is not reclaimed".
