### PR TITLE
fix(grep): embedded index-enable drives the backfill to completion

### DIFF
--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -116,8 +116,10 @@ pub struct GrepResponse {
 pub struct EnableGrepIndexResponse {
     /// Namespace whose grep root was enabled.
     pub namespace_id: NamespaceId,
-    /// Backfill covers commits at or below this sequence; later commits
-    /// arrive through WAL replay once backfill completes.
+    /// Sequence the index is built through when the enabling host reports
+    /// completion (an embedded host drives the backfill inside the call);
+    /// on a hosted server the backfill continues in its driver and this is
+    /// the sequence it targets.
     pub built_through_seq: ChangeSeq,
     /// True when the namespace already carried an enabled grep root.
     pub already_enabled: bool,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -305,13 +305,12 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         CommandData::GrepIndexEnabled(response) => {
             if response.already_enabled {
                 format!(
-                    "grep index already enabled on {} (built through seq {}); grep worker \
-                     maintenance continues independently",
+                    "grep index already enabled on {}; caught up through seq {}",
                     response.namespace_id, response.built_through_seq.0
                 )
             } else {
                 format!(
-                    "grep index enabled on {}; grep worker backfill targets seq <= {}",
+                    "grep index enabled on {}; built through seq {}",
                     response.namespace_id, response.built_through_seq.0
                 )
             }

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1264,6 +1264,55 @@ fn admin_gc_reclaims_a_deleted_namespace_instead_of_refusing() {
 }
 
 #[test]
+fn embedded_grep_works_after_index_enable() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "code"]));
+    assert_success(&harness.run(&["use", "code"]));
+
+    let payload = harness.temp_dir.path().join("main.rs");
+    fs::write(&payload, b"fn main() {}\n// TODO: expand\n").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/src/main.rs"]));
+
+    // Before the index exists, grep names the missing feature.
+    let before = harness.run(&["--json", "grep", "TODO"]);
+    assert_failure(&before);
+    assert_eq!(json_error(&before)["code"], "not_supported");
+
+    // Enable drives the backfill to completion in-process: the one-shot
+    // CLI is its own grep maintenance, so the query works immediately —
+    // no server, no driver, no state that never resolves.
+    let enabled = harness.run(&["--json", "admin", "index-enable"]);
+    assert_success(&enabled);
+    let found = harness.run(&["--json", "grep", "TODO"]);
+    assert_success(&found);
+    assert_eq!(
+        json_data(&found)["matches"]
+            .as_array()
+            .expect("json array")
+            .len(),
+        1
+    );
+
+    // Later writes catch up when enable is re-run.
+    let more = harness.temp_dir.path().join("lib.rs");
+    fs::write(&more, b"// TODO: also here\n").expect("write payload");
+    assert_success(&harness.run(&["put", more.to_str().expect("utf-8 path"), "/src/lib.rs"]));
+    let recaught = harness.run(&["--json", "admin", "index-enable"]);
+    assert_success(&recaught);
+    assert_eq!(json_data(&recaught)["already_enabled"], true);
+    let found = harness.run(&["--json", "grep", "TODO"]);
+    assert_success(&found);
+    assert_eq!(
+        json_data(&found)["matches"]
+            .as_array()
+            .expect("json array")
+            .len(),
+        2
+    );
+}
+
+#[test]
 fn index_enable_leaves_core_maintenance_decoupled() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -14,10 +14,12 @@ use thiserror::Error;
 #[non_exhaustive]
 pub enum GrepError {
     /// The namespace has no active grep root.
-    #[error("feature `grep.index` is not materialized on this namespace")]
+    #[error("feature `grep.index` is not enabled on this namespace")]
     NotEnabled,
     /// The namespace's grep backfill has not completed.
-    #[error("feature `grep.index` is not materialized on this namespace")]
+    #[error(
+        "feature `grep.index` is enabled but its backfill has not completed on this namespace"
+    )]
     Backfilling,
     /// The backing provider could not serve grep-owned state.
     #[error("object-store operation failed for grep state `{object_key}`: {message}")]

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -34,7 +34,7 @@ const GREP_INDEX_FEATURE: &str = "grep.index";
             (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 501, description = "Grep serving is disabled or the grep index is not materialized on this namespace", body = ApiError),
+            (status = 501, description = "Grep serving is disabled, the grep index is not enabled, or its backfill has not completed on this namespace", body = ApiError),
             (status = 503, description = "The index trails the head past the scan budget", body = ApiError),
             (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
         )

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -477,7 +477,7 @@ async fn grep_error_disabled_root_is_not_materialized_and_core_reads_survive() {
         result.await,
         501,
         ErrorCode::NotSupported,
-        "not materialized",
+        "not enabled",
     )
     .await;
     harness.server.abort();
@@ -505,7 +505,7 @@ async fn grep_error_mid_backfill_is_not_materialized_and_core_reads_survive() {
         result.await,
         501,
         ErrorCode::NotSupported,
-        "not materialized",
+        "backfill has not completed",
     )
     .await;
     harness.server.abort();

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -274,7 +274,15 @@ impl FsAdmin {
         Ok(Some(self.gc_namespace(namespace_id, config).await?))
     }
 
-    /// Enables the independent grep root and starts checkpointed backfill.
+    /// Enables the independent grep root and drives its checkpointed
+    /// backfill to quiescence.
+    ///
+    /// The reference server runs the backfill in per-namespace drivers; an
+    /// embedded host has no driver runtime, so the enable call is the
+    /// driver — without this the root would stay `Backfilling` forever and
+    /// every query would answer `not_supported`. Re-running enable on an
+    /// already-enabled namespace drives catch-up the same way, which is how
+    /// an embedded operator advances a lagging index.
     pub async fn enable_grep_index(
         &self,
         namespace_id: &NamespaceId,
@@ -284,24 +292,62 @@ impl FsAdmin {
             .enable(namespace_id)
             .await
             .map_err(RuntimeError::Grep)?;
-        match outcome {
-            loonfs_grep::GrepEnableOutcome::Enabled { target_seq } => Ok(EnableGrepIndexResponse {
-                namespace_id: namespace_id.clone(),
-                built_through_seq: target_seq,
-                already_enabled: false,
-            }),
-            loonfs_grep::GrepEnableOutcome::AlreadyEnabled { built_through_seq } => {
-                Ok(EnableGrepIndexResponse {
-                    namespace_id: namespace_id.clone(),
-                    built_through_seq,
-                    already_enabled: true,
-                })
+        let already_enabled = match outcome {
+            loonfs_grep::GrepEnableOutcome::Enabled { .. } => false,
+            loonfs_grep::GrepEnableOutcome::AlreadyEnabled { .. } => true,
+            loonfs_grep::GrepEnableOutcome::Superseded => {
+                return Err(RuntimeError::Grep(
+                    loonfs_grep::GrepError::PublicationConflict {
+                        object_key: loonfs_grep::keyspace::root_key(namespace_id),
+                    },
+                ))
             }
-            loonfs_grep::GrepEnableOutcome::Superseded => Err(RuntimeError::Grep(
-                loonfs_grep::GrepError::PublicationConflict {
-                    object_key: loonfs_grep::keyspace::root_key(namespace_id),
-                },
-            )),
+        };
+        let built_through_seq = self.drive_grep_index_to_quiescence(namespace_id).await?;
+        Ok(EnableGrepIndexResponse {
+            namespace_id: namespace_id.clone(),
+            built_through_seq,
+            already_enabled,
+        })
+    }
+
+    /// Runs bounded build and fold steps until the grep index reports
+    /// caught-up and nothing left to fold — the same pair loop the server's
+    /// driver runs, minus its channel and backoff machinery: a synchronous
+    /// caller surfaces the first error instead of retrying. Every non-final
+    /// outcome makes progress (a batch built or a unit folded), so the loop
+    /// terminates without an iteration cap.
+    async fn drive_grep_index_to_quiescence(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<loonfs_api::ChangeSeq> {
+        let worker = self.grep_worker();
+        let policy = loonfs_grep::GramIndexBuildPolicy::default();
+        loop {
+            let build = worker
+                .build_step(namespace_id, policy)
+                .await
+                .map_err(RuntimeError::Grep)?;
+            let reorganize = worker
+                .reorganize_step(namespace_id, policy)
+                .await
+                .map_err(RuntimeError::Grep)?;
+            if matches!(build.outcome, loonfs_grep::GrepBuildOutcome::NotEnabled)
+                || matches!(
+                    reorganize.outcome,
+                    loonfs_grep::GrepReorganizeOutcome::NotEnabled
+                )
+            {
+                return Err(RuntimeError::Grep(loonfs_grep::GrepError::NotEnabled));
+            }
+            if let loonfs_grep::GrepBuildOutcome::UpToDate { built_through_seq } = build.outcome {
+                if matches!(
+                    reorganize.outcome,
+                    loonfs_grep::GrepReorganizeOutcome::NotNeeded { .. }
+                ) {
+                    return Ok(built_through_seq);
+                }
+            }
         }
     }
 

--- a/crates/loonfs/tests/grams_index.rs
+++ b/crates/loonfs/tests/grams_index.rs
@@ -238,11 +238,6 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
         .build()
         .await
         .expect("build writer");
-    let admin = FsAdmin::builder_with_store(store.clone())
-        .actor_id("grams-auto-admin")
-        .build()
-        .await
-        .expect("build admin");
     let reader = FsReader::builder_with_store(store.clone())
         .build()
         .await
@@ -253,10 +248,13 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    admin
-        .enable_grep_index(&namespace_id)
-        .await
-        .expect("enable");
+    // Worker-level enable publishes the backfilling root without driving
+    // it (the admin surface drives to quiescence), so the test can observe
+    // that nothing else drives it either.
+    match grep_worker.enable(&namespace_id).await.expect("enable") {
+        loonfs_grep::GrepEnableOutcome::Enabled { .. } => {}
+        outcome => panic!("expected fresh enable, got {outcome:?}"),
+    }
 
     writer
         .put_file_bytes(

--- a/crates/loonfs/tests/grep_worker.rs
+++ b/crates/loonfs/tests/grep_worker.rs
@@ -674,11 +674,11 @@ fn assert_not_enabled_error(case: &str, result: loonfs::Result<GrepResponse>) {
             assert_eq!(error.code(), ErrorCode::NotSupported, "code for {case}");
             assert_eq!(
                 error.to_string(),
-                "feature `grep.index` is not materialized on this namespace",
+                "feature `grep.index` is not enabled on this namespace",
                 "error text for {case}"
             );
         }
-        outcome => panic!("expected not-materialized error for {case}, got {outcome:?}"),
+        outcome => panic!("expected not-enabled error for {case}, got {outcome:?}"),
     }
 }
 
@@ -688,7 +688,8 @@ fn assert_backfilling_error(case: &str, result: loonfs::Result<GrepResponse>) {
             assert_eq!(error.code(), ErrorCode::NotSupported, "code for {case}");
             assert_eq!(
                 error.to_string(),
-                "feature `grep.index` is not materialized on this namespace",
+                "feature `grep.index` is enabled but its backfill has not completed on this \
+                 namespace",
                 "error text for {case}"
             );
         }

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -163,6 +163,13 @@ head. That first-touch path resumes durable work after a restart without a
 scan. `serve_only` serves the same queries and administration operations but
 starts no drivers.
 
+A library-embedded host (the CLI's embedded mode) has no driver runtime, so
+enabling the index is the driver: `FsAdmin::enable_grep_index` runs the same
+build-and-fold pair loop synchronously until the index is caught up, and
+re-running enable on an already-enabled namespace drives catch-up the same
+way. Between enables, small write tails are served by the query-time
+exhaustive tail scan within its budget.
+
 Detached maintenance is explicitly assigned with repeatable
 `loonfs-grep --namespace <id>` flags. `--once` catches up only those namespaces
 and exits. The long-running form polls each assigned namespace's own head at

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2139,7 +2139,7 @@
             }
           },
           "501": {
-            "description": "Grep serving is disabled or the grep index is not materialized on this namespace",
+            "description": "Grep serving is disabled, the grep index is not enabled, or its backfill has not completed on this namespace",
             "content": {
               "application/json": {
                 "schema": {
@@ -3824,7 +3824,7 @@
           },
           "built_through_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
-            "description": "Backfill covers commits at or below this sequence; later commits\narrive through WAL replay once backfill completes."
+            "description": "Sequence the index is built through when the enabling host reports\ncompletion (an embedded host drives the backfill inside the call);\non a hosted server the backfill continues in its driver and this is\nthe sequence it targets."
           },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
@@ -3864,6 +3864,13 @@
                 "description": "Epoch that currently owns the namespace."
               }
             ]
+          },
+          "active_writer_session": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Session id recorded by the current epoch's acquirer, when the head\nrecorded one."
           },
           "actual_revision": {
             "oneOf": [
@@ -3919,6 +3926,13 @@
                 "description": "Epoch the failing writer session held when it was displaced."
               }
             ]
+          },
+          "fenced_writer_session": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Session id the fenced writer held. Distinguishes two processes that\nshare one writer id (the CLI defaults `writer_id` to the hostname)."
           },
           "inode_id": {
             "oneOf": [


### PR DESCRIPTION
The audit found that grep never works in embedded mode: index-enable reported success, but every query answered "not materialized" forever. The reference server runs the backfill in per-namespace drivers; an embedded one-shot process has no driver runtime, so the enable call published a Backfilling root and nothing ever advanced it — a state that never resolves, with no command that could resolve it.

In embedded mode the enable call is now the driver: FsAdmin::enable_grep_index runs the same bounded build-and-fold pair loop the server driver runs (minus its channel and backoff machinery) until the index reports caught up, and re-running enable on an already-enabled namespace drives catch-up the same way — that is how an embedded operator advances a lagging index between enables, while small write tails ride the query-time tail scan. The server's HTTP enable path is untouched; it kicks its driver as before.

The not-enabled and mid-backfill errors also carried byte-identical messages, which is why an operator could not tell "never enabled" from "enabled but nothing drove it"; they now say which one it is.

The end-to-end test is the audit's exact repro reversed: put, index-enable, grep finds the match immediately; write more, re-enable, grep finds both. One existing test asserted the root stays Backfilling after admin enable as a proxy for "background metadata work never drives grep" — that invariant still holds and the test now pins it via a worker-level enable, which is the path that does not drive.