### PR TITLE
test(runtime): isolate the tracing-capture test in its own binary

### DIFF
--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -23,11 +23,11 @@ use loonfs_api::{
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId, CommitId,
     ContentRef, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
-    DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior,
-    FilesystemOperation, FilesystemOperationRequest, ForkNamespaceRequest, GrepRequest,
-    GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
-    MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo, UploadId,
+    DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior, FilesystemOperation,
+    FilesystemOperationRequest, ForkNamespaceRequest, GrepRequest, GrepResponse, InodeId,
+    ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceStepRequest,
+    MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
+    ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo, UploadId,
 };
 use std::sync::{Arc, OnceLock};
 

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -20,7 +20,7 @@ use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tempfile::tempdir;
 use tokio::time::{timeout, Duration};
 
@@ -859,66 +859,4 @@ fn enabled_writer_drains_reorganization_backlog_without_admin() {
              a leftover run means the drain stopped early"
         );
     });
-}
-
-#[test]
-fn background_step_conclusions_emit_debug_events() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("demo");
-    let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let sink = Arc::clone(&captured);
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .with_ansi(false)
-        .with_writer(move || CaptureWriter(Arc::clone(&sink)))
-        .finish();
-    // Thread-local so the capture cannot leak into other tests; the
-    // current-thread runtime keeps spawned background steps on this thread.
-    let _guard = tracing::subscriber::set_default(subscriber);
-
-    block_on(async {
-        let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
-        writer
-            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
-            .await
-            .expect("create namespace");
-        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
-        writer
-            .wait_for_background_work()
-            .await
-            .expect("background maintenance quiesces");
-    });
-
-    let log = String::from_utf8(captured.lock().expect("capture lock").clone())
-        .expect("captured log is utf8");
-    let conclusion = log
-        .lines()
-        .find(|line| line.contains("background maintenance step concluded"))
-        .unwrap_or_else(|| {
-            panic!("background step conclusion missing from captured tracing:\n{log}")
-        });
-    for field in [
-        "wal_flush",
-        "reorganize",
-        "wal_tail_segments_before",
-        "elapsed_ms",
-    ] {
-        assert!(
-            conclusion.contains(field),
-            "missing `{field}` in: {conclusion}"
-        );
-    }
-}
-
-struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
-
-impl std::io::Write for CaptureWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().expect("capture lock").extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
 }

--- a/crates/loonfs/tests/tracing_capture.rs
+++ b/crates/loonfs/tests/tracing_capture.rs
@@ -1,0 +1,121 @@
+#![allow(clippy::panic)]
+// Tracing-capture tests panic in helper assertions for precise diagnostics.
+
+//! Asserts background maintenance conclusions are observable at debug level.
+//!
+//! This lives in its own test binary — its own process — on purpose.
+//! Tracing caches per-callsite interest process-globally, and a callsite
+//! first exercised on a thread with no subscriber can race the interest
+//! rebuild that `set_default` performs. Sibling tests that drive background
+//! maintenance on subscriber-less threads hit exactly the callsites this
+//! capture greps for, so sharing a binary with them made the capture lose
+//! events intermittently under parallel test execution. Alone in its
+//! process, the callsites are first hit with the capture subscriber
+//! installed, and the assertion is deterministic.
+
+use loonfs::{
+    CreateNamespaceOptions, FsBackgroundWork, FsWriter, MaintenanceStepOptions, NamespaceId,
+    PutFileOptions, StoreConfig,
+};
+use loonfs_test_support::block_on::block_on;
+use loonfs_test_support::ids::namespace_id;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+fn store_config(root: &Path) -> StoreConfig {
+    StoreConfig::LocalFs {
+        root: root.to_string_lossy().into_owned(),
+        key_prefix: None,
+    }
+}
+
+fn writes_past_wal_tail_threshold() -> u32 {
+    u32::try_from(MaintenanceStepOptions::default().max_wal_tail_segments + 1)
+        .expect("WAL tail threshold plus one should fit in u32")
+}
+
+async fn writer(root: &Path) -> FsWriter {
+    FsWriter::builder(store_config(root))
+        .writer_id("tracing-capture-writer")
+        .background_work(FsBackgroundWork::Enabled)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+async fn fill_wal_tail_past_threshold(writer: &FsWriter, namespace_id: &NamespaceId) {
+    for round in 0..writes_past_wal_tail_threshold() {
+        writer
+            .put_file_bytes(
+                namespace_id,
+                &format!("/docs/file-{round}.txt"),
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("put file");
+    }
+}
+
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn background_step_conclusions_emit_debug_events() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&captured);
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_ansi(false)
+        .with_writer(move || CaptureWriter(Arc::clone(&sink)))
+        .finish();
+    // Thread-local so the capture cannot leak into other tests; the
+    // current-thread runtime keeps spawned background steps on this thread.
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    block_on(async {
+        let writer = writer(temp_dir.path()).await;
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("background maintenance quiesces");
+    });
+
+    let log = String::from_utf8(captured.lock().expect("capture lock").clone())
+        .expect("captured log is utf8");
+    let conclusion = log
+        .lines()
+        .find(|line| line.contains("background maintenance step concluded"))
+        .unwrap_or_else(|| {
+            panic!("background step conclusion missing from captured tracing:\n{log}")
+        });
+    for field in [
+        "wal_flush",
+        "reorganize",
+        "wal_tail_segments_before",
+        "elapsed_ms",
+    ] {
+        assert!(
+            conclusion.contains(field),
+            "missing `{field}` in: {conclusion}"
+        );
+    }
+}


### PR DESCRIPTION
Two CI breakages on main after the audit-wave merges.

The rustfmt failure is a five-line import reflow in loonfs-client that a merge resolution left unformatted; fixed by running rustfmt.

The test failure is background_step_conclusions_emit_debug_events, which failed most warm parallel runs of the handles binary while passing every serial and single-test run. The test now lives in its own test binary.