### PR TITLE
feat(cli): recursive put, get, and cp transfer whole trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dialoguer",
+ "futures",
  "hostname",
  "http",
  "insta",
@@ -1140,6 +1141,7 @@ dependencies = [
  "tokio",
  "toml",
  "ureq",
+ "walkdir",
 ]
 
 [[package]]
@@ -1821,6 +1823,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2521,6 +2532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +2716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait.workspace = true
 clap.workspace = true
+futures.workspace = true
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 hostname = "0.4"
 http.workspace = true
@@ -27,6 +28,7 @@ serde_json.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 toml.workspace = true
+walkdir.workspace = true
 
 [dev-dependencies]
 ureq.workspace = true

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -53,9 +53,9 @@ pub(crate) enum Command {
     Cat(FilesystemCatArgs),
     /// Search file content through the grep index.
     Grep(FilesystemGrepArgs),
-    /// Download a file to a local path (or `-` for stdout).
+    /// Download a file (or directory tree with -r) to a local path.
     Get(FilesystemGetArgs),
-    /// Upload a local file to a namespace path.
+    /// Upload a local file (or directory tree with -r) to a namespace path.
     Put(FilesystemPutArgs),
     /// List a file's revision history, newest first.
     Revisions(FilesystemRevisionsArgs),
@@ -69,7 +69,7 @@ pub(crate) enum Command {
     Rm(FilesystemRmArgs),
     /// Move or rename a path.
     Mv(FilesystemTransferArgs),
-    /// Copy a file to another path.
+    /// Copy a file (or directory tree with -r) to another path.
     Cp(FilesystemTransferArgs),
     /// List committed changes after a sequence number.
     Changes(ChangesArgs),
@@ -444,6 +444,10 @@ pub(crate) struct FilesystemGetArgs {
     /// Local destination (defaults to the remote basename; `-` streams to
     /// stdout).
     pub local_destination: Option<String>,
+    /// Download the directory tree rooted at `remote_path`, with bounded
+    /// concurrency and per-file outcomes.
+    #[arg(short, long)]
+    pub recursive: bool,
     /// Download this revision instead of the current content.
     #[arg(long)]
     pub revision: Option<u64>,
@@ -458,6 +462,11 @@ pub(crate) struct FilesystemPutArgs {
     pub target: TargetSelectorArgs,
     pub local_path: String,
     pub remote_path: Option<String>,
+    /// Upload the directory tree rooted at `local_path`. Every file lands
+    /// as its own commit with bounded concurrency, so progress is per file
+    /// and a partial failure reruns per file.
+    #[arg(short, long)]
+    pub recursive: bool,
     /// Replace the remote destination if it already exists.
     #[arg(long)]
     pub force: bool,
@@ -473,6 +482,10 @@ pub(crate) struct FilesystemTransferArgs {
     pub target: TargetSelectorArgs,
     pub source_path: String,
     pub destination_path: String,
+    /// Copy the directory tree rooted at `source_path` (cp only; mv moves
+    /// a directory in one commit without -r).
+    #[arg(short, long)]
+    pub recursive: bool,
     /// Replace the destination if it already exists.
     #[arg(long)]
     pub force: bool,

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -6,6 +6,7 @@ use super::context::{
     render_target, resolve_command_context,
 };
 use super::output::{CommandData, CommandFailure, CommandOutput};
+use super::recursive;
 use crate::args::{
     CommandKind, FilesystemCatArgs, FilesystemGetArgs, FilesystemGrepArgs, FilesystemLsArgs,
     FilesystemMkdirArgs, FilesystemPathArgs, FilesystemPutArgs, FilesystemRestoreArgs,
@@ -32,7 +33,7 @@ fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliE
 
 /// Writes via a same-directory temp file and an atomic rename, so a failed
 /// or interrupted download never leaves a truncated file at the target.
-fn write_local_file_atomically(
+pub(super) fn write_local_file_atomically(
     destination: &Path,
     bytes: &[u8],
     force: bool,
@@ -211,7 +212,7 @@ pub(crate) async fn run_filesystem_get(
         ));
     }
 
-    let allow_root = false;
+    let allow_root = args.recursive;
     let spec = namespace_path(&context.namespace, &args.remote_path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
     let entry = context
@@ -220,11 +221,48 @@ pub(crate) async fn run_filesystem_get(
         .stat_path(&spec)
         .await
         .map_err(|error| context.fail(kind, error))?;
+    if args.recursive {
+        if entry.inode_kind != InodeKind::Directory {
+            return Err(context.fail(
+                kind,
+                CliError::invalid_input(format!(
+                    "`{}` is not a directory; drop -r to download one file",
+                    spec.absolute_path()
+                )),
+            ));
+        }
+        if args.revision.is_some() {
+            return Err(context.fail(
+                kind,
+                CliError::invalid_input("--revision applies to one file, not a tree"),
+            ));
+        }
+        let local_root = match args.local_destination.as_deref() {
+            Some("-") => {
+                return Err(context.fail(
+                    kind,
+                    CliError::invalid_input("`-` streams one file; a tree needs a directory"),
+                ))
+            }
+            Some(destination) => PathBuf::from(destination),
+            None => destination_path_for_get(spec.absolute_path().as_str(), None)
+                .map_err(|error| context.fail(kind, error))?,
+        };
+        return recursive::run_get_tree(
+            kind,
+            &context,
+            spec.absolute_path().as_str(),
+            &local_root,
+            args.force,
+            runtime,
+        )
+        .await;
+    }
     if entry.inode_kind == InodeKind::Directory {
         return Err(context.fail(
             kind,
             CliError::invalid_input(format!(
-                "directory operations are not available for `{}`",
+                "`{}` is a directory; use `loon get -r` to download the tree",
                 spec.absolute_path()
             )),
         ));
@@ -311,6 +349,7 @@ pub(crate) async fn run_filesystem_revisions(
 pub(crate) async fn run_filesystem_put(
     kind: CommandKind,
     args: FilesystemPutArgs,
+    runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
     let local_path = PathBuf::from(&args.local_path);
@@ -323,13 +362,46 @@ pub(crate) async fn run_filesystem_put(
         ));
     }
 
-    let metadata =
-        fs::metadata(&local_path).map_err(|error| context.fail(kind, CliError::io(error)))?;
+    let metadata = fs::metadata(&local_path)
+        .map_err(|error| context.fail(kind, CliError::io_for_path(&local_path, error)))?;
+    if args.recursive {
+        if !metadata.is_dir() {
+            return Err(context.fail(
+                kind,
+                CliError::invalid_input(format!(
+                    "`{}` is not a directory; drop -r to upload one file",
+                    local_path.display()
+                )),
+            ));
+        }
+        if args.commit_id.is_some() {
+            return Err(context.fail(
+                kind,
+                CliError::invalid_input(
+                    "--commit-id names one commit; a recursive upload makes one commit per file",
+                ),
+            ));
+        }
+        let remote_root = match args.remote_path {
+            Some(path) => normalize_user_path(&path, true),
+            None => default_remote_put_path(&local_path),
+        }
+        .map_err(|error| context.fail(kind, error))?;
+        return recursive::run_put_tree(
+            kind,
+            &context,
+            &local_path,
+            remote_root.as_str(),
+            args.force,
+            runtime,
+        )
+        .await;
+    }
     if metadata.is_dir() {
         return Err(context.fail(
             kind,
             CliError::invalid_input(format!(
-                "directory operations are not available for `{}`",
+                "`{}` is a directory; use `loon put -r` to upload the tree",
                 local_path.display()
             )),
         ));
@@ -526,15 +598,17 @@ pub(crate) async fn run_filesystem_mkdir(
 pub(crate) async fn run_filesystem_mv(
     kind: CommandKind,
     args: FilesystemTransferArgs,
+    runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    run_filesystem_transfer(kind, args, TransferKind::Move).await
+    run_filesystem_transfer(kind, args, TransferKind::Move, runtime).await
 }
 
 pub(crate) async fn run_filesystem_cp(
     kind: CommandKind,
     args: FilesystemTransferArgs,
+    runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    run_filesystem_transfer(kind, args, TransferKind::Copy).await
+    run_filesystem_transfer(kind, args, TransferKind::Copy, runtime).await
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -547,8 +621,15 @@ async fn run_filesystem_transfer(
     kind: CommandKind,
     args: FilesystemTransferArgs,
     transfer_kind: TransferKind,
+    runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
+    if args.recursive && transfer_kind == TransferKind::Move {
+        return Err(context.fail(
+            kind,
+            CliError::invalid_input("mv moves a directory in one commit; -r is not needed"),
+        ));
+    }
     let allow_root = false;
     let from = namespace_path(&context.namespace, &args.source_path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -564,11 +645,39 @@ async fn run_filesystem_transfer(
             .stat_path(&from)
             .await
             .map_err(|error| context.fail(kind, error))?;
+        if args.recursive {
+            if entry.inode_kind != InodeKind::Directory {
+                return Err(context.fail(
+                    kind,
+                    CliError::invalid_input(format!(
+                        "`{}` is not a directory; drop -r to copy one file",
+                        from.absolute_path()
+                    )),
+                ));
+            }
+            if args.commit_id.is_some() {
+                return Err(context.fail(
+                    kind,
+                    CliError::invalid_input(
+                        "--commit-id names one commit; a recursive copy makes one commit per item",
+                    ),
+                ));
+            }
+            return recursive::run_copy_tree(
+                kind,
+                &context,
+                from.absolute_path().as_str(),
+                to.absolute_path().as_str(),
+                args.force,
+                runtime,
+            )
+            .await;
+        }
         if entry.inode_kind == InodeKind::Directory {
             return Err(context.fail(
                 kind,
                 CliError::invalid_input(format!(
-                    "directory operations are not available for `{}`",
+                    "`{}` is a directory; use `loon cp -r` to copy the tree",
                     from.absolute_path()
                 )),
             ));

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod namespace;
 mod output;
 mod profile;
 mod profile_config;
+mod recursive;
 
 pub(crate) use self::output::{CommandData, CommandFailure, CommandOutput};
 
@@ -51,14 +52,14 @@ pub(crate) async fn run(
         Command::Cat(args) => fs::run_filesystem_cat(kind, args).await,
         Command::Grep(args) => fs::run_filesystem_grep(kind, args).await,
         Command::Get(args) => fs::run_filesystem_get(kind, args, runtime).await,
-        Command::Put(args) => fs::run_filesystem_put(kind, args).await,
+        Command::Put(args) => fs::run_filesystem_put(kind, args, runtime).await,
         Command::Revisions(args) => fs::run_filesystem_revisions(kind, args).await,
         Command::Restore(args) => fs::run_filesystem_restore(kind, args).await,
         Command::Undelete(args) => fs::run_filesystem_undelete(kind, args).await,
         Command::Mkdir(args) => fs::run_filesystem_mkdir(kind, args).await,
         Command::Rm(args) => fs::run_filesystem_rm(kind, args).await,
-        Command::Mv(args) => fs::run_filesystem_mv(kind, args).await,
-        Command::Cp(args) => fs::run_filesystem_cp(kind, args).await,
+        Command::Mv(args) => fs::run_filesystem_mv(kind, args, runtime).await,
+        Command::Cp(args) => fs::run_filesystem_cp(kind, args, runtime).await,
         Command::Changes(args) => admin::run_admin_changes(kind, args).await,
         Command::Admin { command } => admin::run_admin_command(kind, command).await,
     }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -14,6 +14,15 @@ use loonfs_api::{
 };
 use serde::Serialize;
 
+/// One failed item inside a recursive transfer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct TreeTransferFailure {
+    /// The path that failed — remote for uploads and copies, whichever side
+    /// failed for downloads.
+    pub path: String,
+    pub error: CliError,
+}
+
 pub(crate) struct CommandOutput {
     pub kind: CommandKind,
     pub profile: Option<String>,
@@ -85,6 +94,16 @@ pub(crate) enum CommandData {
         destination: String,
         bytes_written: u64,
     },
+    /// A recursive transfer's summary: per-item successes are counted, not
+    /// listed (a tree can hold tens of thousands of entries), and every
+    /// failure is listed with its own error.
+    TreeTransfer {
+        source: String,
+        destination: String,
+        files: u64,
+        directories: u64,
+        failures: Vec<TreeTransferFailure>,
+    },
     FileMutation {
         target: String,
         committed_seq: ChangeSeq,
@@ -115,4 +134,13 @@ pub(crate) enum CommandData {
         commit_date: String,
     },
     StreamBytes(Vec<u8>),
+}
+
+impl CommandData {
+    /// Whether this success-shaped output still reports failed items, so
+    /// the process can exit nonzero without discarding the structured
+    /// results a partial failure produced.
+    pub(crate) fn reports_failures(&self) -> bool {
+        matches!(self, CommandData::TreeTransfer { failures, .. } if !failures.is_empty())
+    }
 }

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -1,0 +1,510 @@
+//! Client-side recursive transfers: `put -r`, `get -r`, and `cp -r`.
+//!
+//! Traversal is client-side and unpinned (API spec, section 9.3): remote
+//! walks read each directory at its own head through drift-tolerant
+//! listings, and every file rides the same per-file operation its singular
+//! command uses, as its own independent commit. One process holds one
+//! writer session, so concurrent submissions coalesce into batched WAL
+//! segments; the transfer runs with bounded concurrency and reports
+//! per-file outcomes, so a partial failure reruns per file instead of
+//! aborting a giant transaction.
+
+use super::context::CommandContext;
+use super::output::{CommandData, CommandFailure, CommandOutput, TreeTransferFailure};
+use crate::args::{CommandKind, RuntimeBehavior};
+use crate::error::CliError;
+use crate::render::write_stderr_progress;
+use futures::StreamExt;
+use loonfs_api::DestinationBehavior;
+use loonfs_api::InodeKind;
+use loonfs_client::{
+    CreateDirectoryOptions, NamespacePath, PutFileOptions as ClientPutFileOptions,
+};
+use std::path::{Path, PathBuf};
+
+/// How many per-file operations run at once. Matches the reference server's
+/// default upload concurrency; deliberately a constant, not a flag, until a
+/// real workload needs tuning.
+const TREE_TRANSFER_CONCURRENCY: usize = 8;
+
+/// One file or directory job, as namespace-absolute remote path plus the
+/// local half when one exists.
+struct FileJob {
+    local: PathBuf,
+    remote: String,
+}
+
+struct TreeTally {
+    files: u64,
+    directories: u64,
+    failures: Vec<TreeTransferFailure>,
+}
+
+impl TreeTally {
+    fn new() -> Self {
+        Self {
+            files: 0,
+            directories: 0,
+            failures: Vec::new(),
+        }
+    }
+
+    fn fail(&mut self, path: impl Into<String>, error: CliError) {
+        self.failures.push(TreeTransferFailure {
+            path: path.into(),
+            error,
+        });
+    }
+}
+
+fn joined_remote(root: &str, components: &[String]) -> String {
+    let mut remote = root.trim_end_matches('/').to_owned();
+    for component in components {
+        remote.push('/');
+        remote.push_str(component);
+    }
+    if remote.is_empty() {
+        "/".to_owned()
+    } else {
+        remote
+    }
+}
+
+fn output(
+    kind: CommandKind,
+    context: &CommandContext,
+    source: String,
+    destination: String,
+    tally: TreeTally,
+) -> CommandOutput {
+    CommandOutput {
+        kind,
+        profile: Some(context.profile_name.clone()),
+        mode: Some(context.mode.clone()),
+        data: CommandData::TreeTransfer {
+            source,
+            destination,
+            files: tally.files,
+            directories: tally.directories,
+            failures: tally.failures,
+        },
+    }
+}
+
+/// Uploads a local directory tree. Ancestor directories materialize through
+/// each file's own commit (`parents` semantics), so only subtrees holding no
+/// files need explicit `mkdir`s — which also keeps the two paths from racing
+/// each other over the same directory.
+pub(crate) async fn run_put_tree(
+    kind: CommandKind,
+    context: &CommandContext,
+    local_root: &Path,
+    remote_root: &str,
+    force: bool,
+    runtime: RuntimeBehavior,
+) -> Result<CommandOutput, CommandFailure> {
+    let mut files = Vec::new();
+    let mut empty_dirs = Vec::new();
+    let mut tally = TreeTally::new();
+    collect_local_tree(local_root, &mut files, &mut empty_dirs, &mut tally)
+        .map_err(|error| context.fail(kind, error))?;
+
+    let behavior = if force {
+        DestinationBehavior::Replace
+    } else {
+        DestinationBehavior::NoReplace
+    };
+
+    // Empty subtrees first: nothing else creates them, and their ancestors
+    // auto-create exactly like a file's would.
+    for components in empty_dirs {
+        let remote = joined_remote(remote_root, &components);
+        let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
+            Ok(spec) => spec,
+            Err(error) => {
+                tally.fail(remote, CliError::invalid_input(error.to_string()));
+                continue;
+            }
+        };
+        match context
+            .target
+            .backend()
+            .create_directory(
+                &spec,
+                &CreateDirectoryOptions {
+                    commit_id: None,
+                    parents: true,
+                },
+            )
+            .await
+        {
+            Ok(_) => {
+                tally.directories += 1;
+                if !runtime.json {
+                    write_stderr_progress(format_args!("created {}", spec_target(&spec)));
+                }
+            }
+            Err(error) => tally.fail(remote, error.into()),
+        }
+    }
+
+    let outcomes = futures::stream::iter(files.into_iter().map(|job| {
+        let backend = context.target.backend();
+        let namespace = context.namespace.clone();
+        let remote = format!("{}/{}", remote_root.trim_end_matches('/'), job.remote);
+        async move {
+            let spec = match NamespacePath::parse(namespace.as_str(), &remote) {
+                Ok(spec) => spec,
+                Err(error) => return (remote, Err(CliError::invalid_input(error.to_string()))),
+            };
+            let bytes = match std::fs::read(&job.local) {
+                Ok(bytes) => bytes,
+                Err(error) => return (remote, Err(CliError::io_for_path(&job.local, error))),
+            };
+            let result = backend
+                .put_file_bytes(
+                    &spec,
+                    &bytes,
+                    &ClientPutFileOptions {
+                        behavior,
+                        commit_id: None,
+                    },
+                )
+                .await
+                .map(|_| spec_target(&spec))
+                .map_err(CliError::from);
+            (remote, result)
+        }
+    }))
+    .buffer_unordered(TREE_TRANSFER_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+    for (remote, result) in outcomes {
+        match result {
+            Ok(target) => {
+                tally.files += 1;
+                if !runtime.json {
+                    write_stderr_progress(format_args!("stored {target}"));
+                }
+            }
+            Err(error) => tally.fail(remote, error),
+        }
+    }
+
+    Ok(output(
+        kind,
+        context,
+        local_root.display().to_string(),
+        format!("{}:{}", context.namespace, remote_root),
+        tally,
+    ))
+}
+
+/// Downloads a directory tree. Local directories are created for every
+/// remote directory — including empty ones — before any file lands.
+pub(crate) async fn run_get_tree(
+    kind: CommandKind,
+    context: &CommandContext,
+    remote_root: &str,
+    local_root: &Path,
+    force: bool,
+    runtime: RuntimeBehavior,
+) -> Result<CommandOutput, CommandFailure> {
+    let listing = walk_remote_tree(context, kind, remote_root).await?;
+    let mut tally = TreeTally::new();
+
+    for components in &listing.directories {
+        let local_dir = local_root.join(components.join("/"));
+        match std::fs::create_dir_all(&local_dir) {
+            Ok(()) => tally.directories += 1,
+            Err(error) => tally.fail(
+                local_dir.display().to_string(),
+                CliError::io_for_path(&local_dir, error),
+            ),
+        }
+    }
+
+    let outcomes = futures::stream::iter(listing.files.into_iter().map(|job| {
+        let backend = context.target.backend();
+        let namespace = context.namespace.clone();
+        let local = local_root.join(job.local);
+        async move {
+            let spec = match NamespacePath::parse(namespace.as_str(), &job.remote) {
+                Ok(spec) => spec,
+                Err(error) => return (job.remote, Err(CliError::invalid_input(error.to_string()))),
+            };
+            let bytes = match backend.get_file_bytes(&spec).await {
+                Ok(bytes) => bytes,
+                Err(error) => return (job.remote, Err(error.into())),
+            };
+            let written = super::fs::write_local_file_atomically(&local, &bytes, force)
+                .map(|()| local.display().to_string())
+                .map_err(|error| CliError::io_for_path(&local, error));
+            (job.remote, written)
+        }
+    }))
+    .buffer_unordered(TREE_TRANSFER_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+    for (remote, result) in outcomes {
+        match result {
+            Ok(local) => {
+                tally.files += 1;
+                if !runtime.json {
+                    write_stderr_progress(format_args!("wrote {local}"));
+                }
+            }
+            Err(error) => tally.fail(remote, error),
+        }
+    }
+
+    Ok(output(
+        kind,
+        context,
+        format!("{}:{}", context.namespace, remote_root),
+        local_root.display().to_string(),
+        tally,
+    ))
+}
+
+/// Copies a directory tree server-side: directories in parent-first order,
+/// then files as content-reference copies that move no bytes.
+pub(crate) async fn run_copy_tree(
+    kind: CommandKind,
+    context: &CommandContext,
+    source_root: &str,
+    destination_root: &str,
+    force: bool,
+    runtime: RuntimeBehavior,
+) -> Result<CommandOutput, CommandFailure> {
+    let listing = walk_remote_tree(context, kind, source_root).await?;
+    let mut tally = TreeTally::new();
+
+    // The destination root materializes its own ancestors; every deeper
+    // directory arrives in parent-first walk order, so plain `mkdir`
+    // suffices and never races a sibling job.
+    let mut directories = vec![Vec::new()];
+    directories.extend(listing.directories);
+    for components in &directories {
+        let remote = joined_remote(destination_root, components);
+        let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
+            Ok(spec) => spec,
+            Err(error) => {
+                tally.fail(remote, CliError::invalid_input(error.to_string()));
+                continue;
+            }
+        };
+        match context
+            .target
+            .backend()
+            .create_directory(
+                &spec,
+                &CreateDirectoryOptions {
+                    commit_id: None,
+                    parents: components.is_empty(),
+                },
+            )
+            .await
+        {
+            Ok(_) => {
+                tally.directories += 1;
+                if !runtime.json {
+                    write_stderr_progress(format_args!("created {}", spec_target(&spec)));
+                }
+            }
+            Err(error) => tally.fail(remote, error.into()),
+        }
+    }
+
+    let behavior = if force {
+        DestinationBehavior::Replace
+    } else {
+        DestinationBehavior::NoReplace
+    };
+    let outcomes = futures::stream::iter(listing.files.into_iter().map(|job| {
+        let backend = context.target.backend();
+        let namespace = context.namespace.clone();
+        let destination = joined_remote(
+            destination_root,
+            &job.local
+                .components()
+                .map(|component| component.as_os_str().to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+        );
+        async move {
+            let from = NamespacePath::parse(namespace.as_str(), &job.remote);
+            let to = NamespacePath::parse(namespace.as_str(), &destination);
+            let (from, to) = match (from, to) {
+                (Ok(from), Ok(to)) => (from, to),
+                (Err(error), _) | (_, Err(error)) => {
+                    return (job.remote, Err(CliError::invalid_input(error.to_string())))
+                }
+            };
+            let result = backend
+                .copy_path(&from, &to, behavior, None)
+                .await
+                .map(|_| spec_target(&to))
+                .map_err(CliError::from);
+            (job.remote, result)
+        }
+    }))
+    .buffer_unordered(TREE_TRANSFER_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+    for (remote, result) in outcomes {
+        match result {
+            Ok(target) => {
+                tally.files += 1;
+                if !runtime.json {
+                    write_stderr_progress(format_args!("copied {target}"));
+                }
+            }
+            Err(error) => tally.fail(remote, error),
+        }
+    }
+
+    Ok(output(
+        kind,
+        context,
+        format!("{}:{}", context.namespace, source_root),
+        format!("{}:{}", context.namespace, destination_root),
+        tally,
+    ))
+}
+
+fn spec_target(spec: &NamespacePath) -> String {
+    super::context::render_target(spec.namespace(), spec.absolute_path())
+}
+
+/// Collects a local tree into file jobs (with relative remote components in
+/// `remote`) plus the component paths of subtrees holding no files at all.
+/// Entries that are neither files nor directories (symlinks, sockets)
+/// become per-path failures rather than silent skips.
+fn collect_local_tree(
+    root: &Path,
+    files: &mut Vec<FileJob>,
+    empty_dirs: &mut Vec<Vec<String>>,
+    tally: &mut TreeTally,
+) -> Result<(), CliError> {
+    let mut dirs_with_files = std::collections::BTreeSet::new();
+    let mut all_dirs = Vec::new();
+    for entry in walkdir::WalkDir::new(root).sort_by_file_name() {
+        let entry = entry.map_err(|error| {
+            CliError::invalid_input(format!("failed to walk `{}`: {error}", root.display()))
+        })?;
+        let relative = entry
+            .path()
+            .strip_prefix(root)
+            .expect("walkdir yields paths under its root");
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        let components: Vec<String> = relative
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        if entry.file_type().is_dir() {
+            all_dirs.push(components);
+        } else if entry.file_type().is_file() {
+            for depth in 1..components.len() {
+                dirs_with_files.insert(components[..depth].to_vec());
+            }
+            files.push(FileJob {
+                local: entry.path().to_path_buf(),
+                remote: components.join("/"),
+            });
+        } else {
+            tally.fail(
+                entry.path().display().to_string(),
+                CliError::invalid_input(
+                    "only regular files and directories transfer; symlinks and special \
+                     files do not",
+                ),
+            );
+        }
+    }
+    // A directory is worth an explicit mkdir only when no descendant file
+    // will create it — and its ancestors come along through `parents`.
+    let mut candidates: Vec<Vec<String>> = all_dirs
+        .into_iter()
+        .filter(|dir| {
+            !dirs_with_files
+                .iter()
+                .any(|with_files| with_files.starts_with(dir.as_slice()))
+        })
+        .collect();
+    // Keep only the deepest directory of each empty chain: its `parents`
+    // mkdir materializes the ancestors, and sequential creation means no
+    // sibling job races a shared parent.
+    candidates.sort();
+    let deepest: Vec<Vec<String>> = candidates
+        .iter()
+        .filter(|dir| {
+            !candidates
+                .iter()
+                .any(|other| other.len() > dir.len() && other.starts_with(dir.as_slice()))
+        })
+        .cloned()
+        .collect();
+    empty_dirs.extend(deepest);
+    Ok(())
+}
+
+struct RemoteTree {
+    /// Relative component paths of every directory, parent-first.
+    directories: Vec<Vec<String>>,
+    /// File jobs: `local` holds the relative path, `remote` the absolute
+    /// namespace path.
+    files: Vec<FileJob>,
+}
+
+/// Breadth-first remote walk from `root`. Each directory lists at its own
+/// head (drift-tolerant listings), so the walk is not a snapshot — the
+/// same contract as section 9.3's client-side traversal.
+async fn walk_remote_tree(
+    context: &CommandContext,
+    kind: CommandKind,
+    root: &str,
+) -> Result<RemoteTree, CommandFailure> {
+    let mut tree = RemoteTree {
+        directories: Vec::new(),
+        files: Vec::new(),
+    };
+    let mut queue = std::collections::VecDeque::new();
+    queue.push_back((root.trim_end_matches('/').to_owned(), Vec::<String>::new()));
+    while let Some((remote_dir, components)) = queue.pop_front() {
+        let listed = if remote_dir.is_empty() {
+            "/"
+        } else {
+            &remote_dir
+        };
+        let spec = NamespacePath::parse(context.namespace.as_str(), listed)
+            .map_err(|error| context.fail(kind, CliError::invalid_input(error.to_string())))?;
+        let entries = context
+            .target
+            .backend()
+            .list_path_entries_all(&spec)
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        for entry in entries {
+            let Some(name) = entry.display_name.as_ref() else {
+                continue;
+            };
+            let mut child_components = components.clone();
+            child_components.push(name.as_str().to_owned());
+            match entry.inode_kind {
+                InodeKind::Directory => {
+                    tree.directories.push(child_components.clone());
+                    queue.push_back((format!("{remote_dir}/{name}", name = name.as_str()), {
+                        child_components
+                    }));
+                }
+                InodeKind::File => tree.files.push(FileJob {
+                    local: PathBuf::from(child_components.join("/")),
+                    remote: format!("{remote_dir}/{name}", name = name.as_str()),
+                }),
+            }
+        }
+    }
+    Ok(tree)
+}

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -52,6 +52,15 @@ impl From<loonfs_client::backend::BackendError> for CliError {
 }
 
 impl CliError {
+    /// An `io_error` that names the file it concerns, so a failure inside a
+    /// loop over many files stays attributable.
+    pub(crate) fn io_for_path(path: &std::path::Path, error: std::io::Error) -> Self {
+        Self::new(
+            "io_error",
+            format!("i/o error for `{}`: {error}", path.display()),
+        )
+    }
+
     pub(crate) fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code: code.into(),

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -24,6 +24,9 @@ pub async fn main() -> ExitCode {
 
     match commands::run(cli, runtime).await {
         Ok(output) => match render::render_success(&output, runtime.json) {
+            // A recursive transfer renders its per-item outcomes as success
+            // data but still exits nonzero when any item failed.
+            Ok(()) if output.data.reports_failures() => ExitCode::FAILURE,
             Ok(()) => ExitCode::SUCCESS,
             Err(err) => {
                 let failure = commands::CommandFailure {

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -100,6 +100,12 @@ pub(crate) fn write_stderr_warning(message: impl std::fmt::Display) {
     let _ = writeln!(io::stderr().lock(), "warning: {message}");
 }
 
+/// Per-item progress for long-running recursive transfers, on stderr so
+/// stdout stays the machine-readable summary.
+pub(crate) fn write_stderr_progress(message: impl std::fmt::Display) {
+    let _ = writeln!(io::stderr().lock(), "{message}");
+}
+
 pub(crate) fn json_success(output: &CommandOutput) -> io::Result<String> {
     match &output.data {
         CommandData::StreamBytes(_) => Err(io::Error::new(
@@ -389,6 +395,34 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             if let Some(cursor) = next_cursor {
                 lines.push(format!("next_cursor: {cursor}"));
             }
+            lines.join("\n")
+        }
+        CommandData::TreeTransfer {
+            source,
+            destination,
+            files,
+            directories,
+            failures,
+        } => {
+            let verb = match output.kind {
+                CommandKind::FilesystemGet => "downloaded",
+                CommandKind::FilesystemCp => "copied",
+                _ => "stored",
+            };
+            let mut lines = Vec::new();
+            for failure in failures {
+                lines.push(format!(
+                    "failed {}: {}: {}",
+                    failure.path, failure.error.code, failure.error.message
+                ));
+            }
+            let mut summary = format!(
+                "{verb} {files} files and {directories} directories ({source} -> {destination})"
+            );
+            if !failures.is_empty() {
+                summary.push_str(&format!("; {} failed", failures.len()));
+            }
+            lines.push(summary);
             lines.join("\n")
         }
         CommandData::FileTransfer {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -259,6 +259,126 @@ fn concurrent_embedded_puts_land_or_report_the_fence() {
 }
 
 #[test]
+fn recursive_transfers_roundtrip_a_tree() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    // A local tree with nesting, an empty directory chain, and a root file.
+    let tree = harness.temp_dir.path().join("tree");
+    fs::create_dir_all(tree.join("docs/nested")).expect("create tree dirs");
+    fs::create_dir_all(tree.join("empty/inner")).expect("create empty chain");
+    fs::write(tree.join("top.txt"), b"top").expect("write top");
+    fs::write(tree.join("docs/a.txt"), b"alpha").expect("write a");
+    fs::write(tree.join("docs/nested/b.txt"), b"beta").expect("write b");
+
+    // A plain put on a directory names the recursive flag.
+    let plain = harness.run(&["--json", "put", tree.to_str().expect("utf-8 path"), "/up"]);
+    assert_failure(&plain);
+    assert!(json_error(&plain)["message"]
+        .as_str()
+        .expect("error message")
+        .contains("put -r"),);
+
+    let put = harness.run(&[
+        "--json",
+        "put",
+        "-r",
+        tree.to_str().expect("utf-8 path"),
+        "/up",
+    ]);
+    assert_success(&put);
+    let put_data = json_data(&put);
+    assert_eq!(put_data["kind"], "tree_transfer");
+    assert_eq!(put_data["files"], 3);
+    assert_eq!(put_data["directories"], 1);
+    assert_eq!(put_data["failures"].as_array().expect("failures").len(), 0);
+    for path in ["/up/top.txt", "/up/docs/nested/b.txt", "/up/empty/inner"] {
+        assert_success(&harness.run(&["--json", "stat", path]));
+    }
+
+    // Rerunning without --force reports per-file conflicts and exits
+    // nonzero while the summary stays structured; --force replaces cleanly.
+    let rerun = harness.run(&[
+        "--json",
+        "put",
+        "-r",
+        tree.to_str().expect("utf-8 path"),
+        "/up",
+    ]);
+    assert_failure(&rerun);
+    let rerun_data = json_data(&rerun);
+    assert_eq!(rerun_data["files"], 0);
+    assert_eq!(
+        rerun_data["failures"].as_array().expect("failures").len(),
+        4
+    );
+    assert_eq!(
+        rerun_data["failures"][0]["error"]["code"], "path_conflict",
+        "{rerun_data}"
+    );
+    let forced = harness.run(&[
+        "--json",
+        "put",
+        "-r",
+        tree.to_str().expect("utf-8 path"),
+        "/up",
+        "--force",
+    ]);
+    assert_failure(&forced);
+    let forced_data = json_data(&forced);
+    assert_eq!(forced_data["files"], 3);
+    assert_eq!(
+        forced_data["failures"].as_array().expect("failures").len(),
+        1,
+        "the empty directory still conflicts: {forced_data}"
+    );
+
+    // Download the tree and compare bytes; empty directories materialize.
+    let downloaded = harness.temp_dir.path().join("downloaded");
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "-r",
+        "/up",
+        downloaded.to_str().expect("utf-8 path"),
+    ]);
+    assert_success(&get);
+    let get_data = json_data(&get);
+    assert_eq!(get_data["files"], 3);
+    assert_eq!(
+        fs::read(downloaded.join("docs/nested/b.txt")).expect("downloaded bytes"),
+        b"beta"
+    );
+    assert!(downloaded.join("empty/inner").is_dir());
+
+    // Server-side copy: the tree lands without moving bytes — the copied
+    // file shares its source's content reference.
+    let cp = harness.run(&["--json", "cp", "-r", "/up", "/copy"]);
+    assert_success(&cp);
+    let cp_data = json_data(&cp);
+    assert_eq!(cp_data["files"], 3);
+    assert_eq!(cp_data["directories"], 5);
+    let source = harness.run(&["--json", "stat", "/up/docs/a.txt"]);
+    let copy = harness.run(&["--json", "stat", "/copy/docs/a.txt"]);
+    assert_success(&source);
+    assert_success(&copy);
+    assert_eq!(
+        json_data(&source)["content_ref"],
+        json_data(&copy)["content_ref"]
+    );
+    assert_success(&harness.run(&["--json", "stat", "/copy/empty/inner"]));
+
+    // mv still moves a directory in one commit, no flag involved.
+    assert_success(&harness.run(&["--json", "mv", "/copy", "/moved"]));
+    assert_success(&harness.run(&["--json", "stat", "/moved/docs/a.txt"]));
+    let mv_recursive = harness.run(&["--json", "mv", "-r", "/moved", "/again"]);
+    assert_failure(&mv_recursive);
+    assert_eq!(json_error(&mv_recursive)["code"], "invalid_input");
+}
+
+#[test]
 fn rm_recursive_deletes_a_populated_directory_in_one_commit() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -23,11 +23,11 @@ use loonfs_api::{
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId, CommitId,
     ContentRef, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
-    DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior,
-    FilesystemOperation, FilesystemOperationRequest, ForkNamespaceRequest, GrepRequest,
-    GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse,
-    MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo, UploadId,
+    DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior, FilesystemOperation,
+    FilesystemOperationRequest, ForkNamespaceRequest, GrepRequest, GrepResponse, InodeId,
+    ListFileRevisionsResponse, ListPathEntriesResponse, MaintenanceStepRequest,
+    MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
+    ReleaseCheckpointResponse, RestoreFileRevisionRequest, RevisionNo, UploadId,
 };
 use std::sync::{Arc, OnceLock};
 

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -20,7 +20,7 @@ use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tempfile::tempdir;
 use tokio::time::{timeout, Duration};
 
@@ -859,66 +859,4 @@ fn enabled_writer_drains_reorganization_backlog_without_admin() {
              a leftover run means the drain stopped early"
         );
     });
-}
-
-#[test]
-fn background_step_conclusions_emit_debug_events() {
-    let temp_dir = tempdir().expect("tempdir");
-    let namespace_id = namespace_id("demo");
-    let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let sink = Arc::clone(&captured);
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .with_ansi(false)
-        .with_writer(move || CaptureWriter(Arc::clone(&sink)))
-        .finish();
-    // Thread-local so the capture cannot leak into other tests; the
-    // current-thread runtime keeps spawned background steps on this thread.
-    let _guard = tracing::subscriber::set_default(subscriber);
-
-    block_on(async {
-        let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
-        writer
-            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
-            .await
-            .expect("create namespace");
-        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
-        writer
-            .wait_for_background_work()
-            .await
-            .expect("background maintenance quiesces");
-    });
-
-    let log = String::from_utf8(captured.lock().expect("capture lock").clone())
-        .expect("captured log is utf8");
-    let conclusion = log
-        .lines()
-        .find(|line| line.contains("background maintenance step concluded"))
-        .unwrap_or_else(|| {
-            panic!("background step conclusion missing from captured tracing:\n{log}")
-        });
-    for field in [
-        "wal_flush",
-        "reorganize",
-        "wal_tail_segments_before",
-        "elapsed_ms",
-    ] {
-        assert!(
-            conclusion.contains(field),
-            "missing `{field}` in: {conclusion}"
-        );
-    }
-}
-
-struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
-
-impl std::io::Write for CaptureWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().expect("capture lock").extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
 }

--- a/crates/loonfs/tests/tracing_capture.rs
+++ b/crates/loonfs/tests/tracing_capture.rs
@@ -1,0 +1,121 @@
+#![allow(clippy::panic)]
+// Tracing-capture tests panic in helper assertions for precise diagnostics.
+
+//! Asserts background maintenance conclusions are observable at debug level.
+//!
+//! This lives in its own test binary — its own process — on purpose.
+//! Tracing caches per-callsite interest process-globally, and a callsite
+//! first exercised on a thread with no subscriber can race the interest
+//! rebuild that `set_default` performs. Sibling tests that drive background
+//! maintenance on subscriber-less threads hit exactly the callsites this
+//! capture greps for, so sharing a binary with them made the capture lose
+//! events intermittently under parallel test execution. Alone in its
+//! process, the callsites are first hit with the capture subscriber
+//! installed, and the assertion is deterministic.
+
+use loonfs::{
+    CreateNamespaceOptions, FsBackgroundWork, FsWriter, MaintenanceStepOptions, NamespaceId,
+    PutFileOptions, StoreConfig,
+};
+use loonfs_test_support::block_on::block_on;
+use loonfs_test_support::ids::namespace_id;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+fn store_config(root: &Path) -> StoreConfig {
+    StoreConfig::LocalFs {
+        root: root.to_string_lossy().into_owned(),
+        key_prefix: None,
+    }
+}
+
+fn writes_past_wal_tail_threshold() -> u32 {
+    u32::try_from(MaintenanceStepOptions::default().max_wal_tail_segments + 1)
+        .expect("WAL tail threshold plus one should fit in u32")
+}
+
+async fn writer(root: &Path) -> FsWriter {
+    FsWriter::builder(store_config(root))
+        .writer_id("tracing-capture-writer")
+        .background_work(FsBackgroundWork::Enabled)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+async fn fill_wal_tail_past_threshold(writer: &FsWriter, namespace_id: &NamespaceId) {
+    for round in 0..writes_past_wal_tail_threshold() {
+        writer
+            .put_file_bytes(
+                namespace_id,
+                &format!("/docs/file-{round}.txt"),
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("put file");
+    }
+}
+
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn background_step_conclusions_emit_debug_events() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&captured);
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_ansi(false)
+        .with_writer(move || CaptureWriter(Arc::clone(&sink)))
+        .finish();
+    // Thread-local so the capture cannot leak into other tests; the
+    // current-thread runtime keeps spawned background steps on this thread.
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    block_on(async {
+        let writer = writer(temp_dir.path()).await;
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("background maintenance quiesces");
+    });
+
+    let log = String::from_utf8(captured.lock().expect("capture lock").clone())
+        .expect("captured log is utf8");
+    let conclusion = log
+        .lines()
+        .find(|line| line.contains("background maintenance step concluded"))
+        .unwrap_or_else(|| {
+            panic!("background step conclusion missing from captured tracing:\n{log}")
+        });
+    for field in [
+        "wal_flush",
+        "reorganize",
+        "wal_tail_segments_before",
+        "elapsed_ms",
+    ] {
+        assert!(
+            conclusion.contains(field),
+            "missing `{field}` in: {conclusion}"
+        );
+    }
+}


### PR DESCRIPTION
Previously, you could not upload, download, or copy a folder, and the practical ceiling was 10,000 serial puts (over about 3.4 hours!). Per the chunked-commits decision, every file rides the same per-file operation its singular command already uses, as its own independent commit, driven with bounded concurrency (8-wide) — so progress lands file by file and a partial failure reruns per file instead of aborting a giant transaction. This needed no new wire or core surface at all: one process holds one writer session, and concurrent submissions coalesce into batched WAL segments through the existing publisher (embedded) or the server's own batching (remote). 

put -r walks the local tree (empty subtrees get explicit mkdirs — the deepest of each chain, so `parents` materializes ancestors without racing sibling jobs; symlinks and special files are reported failures, never silent skips). get -r walks the remote tree through the drift-tolerant listings and downloads with atomic local writes, materializing empty directories. cp -r creates directories parent-first and copies files as server-side content-reference copies that move no bytes. mv is untouched — it moves a directory in one commit and says so if handed -r.