### PR TITLE
feat(api): every path mutation carries an optional commit message

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -291,6 +291,12 @@ pub enum FilesystemOperation {
 pub struct FilesystemOperationRequest {
     /// Caller-supplied idempotency key for this operation.
     pub commit_id: CommitId,
+    /// Caller annotation recorded on the commit and reported by the change
+    /// feed. Part of the operation's identity: reusing `commit_id` with a
+    /// different message is a `commit_id_reuse_conflict`, exactly as it is
+    /// for an explicit commit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
     /// Proofs for any new external content refs introduced by this operation.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub content_tokens: Vec<ValidatedContentToken>,

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -368,6 +368,11 @@ pub(crate) struct FilesystemRmArgs {
     /// subtree stays recoverable through the printed undelete handle.
     #[arg(short, long)]
     pub recursive: bool,
+    /// Annotation recorded on the commit and shown by `loon changes`. Part
+    /// of the commit's identity: resubmitting the same --commit-id with a
+    /// different message is a commit id conflict.
+    #[arg(long)]
+    pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
     #[arg(long)]
@@ -382,6 +387,11 @@ pub(crate) struct FilesystemMkdirArgs {
     /// Create missing parent directories as well.
     #[arg(short = 'p', long)]
     pub parents: bool,
+    /// Annotation recorded on the commit and shown by `loon changes`. Part
+    /// of the commit's identity: resubmitting the same --commit-id with a
+    /// different message is a commit id conflict.
+    #[arg(long)]
+    pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
     #[arg(long)]
@@ -470,6 +480,11 @@ pub(crate) struct FilesystemPutArgs {
     /// Replace the remote destination if it already exists.
     #[arg(long)]
     pub force: bool,
+    /// Annotation recorded on the commit and shown by `loon changes`. Part
+    /// of the commit's identity: resubmitting the same --commit-id with a
+    /// different message is a commit id conflict.
+    #[arg(long)]
+    pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
     #[arg(long)]
@@ -489,6 +504,11 @@ pub(crate) struct FilesystemTransferArgs {
     /// Replace the destination if it already exists.
     #[arg(long)]
     pub force: bool,
+    /// Annotation recorded on the commit and shown by `loon changes`. Part
+    /// of the commit's identity: resubmitting the same --commit-id with a
+    /// different message is a commit id conflict.
+    #[arg(long)]
+    pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
     #[arg(long)]
@@ -502,6 +522,11 @@ pub(crate) struct FilesystemRestoreArgs {
     pub path: String,
     #[arg(long)]
     pub revision: u64,
+    /// Annotation recorded on the commit and shown by `loon changes`. Part
+    /// of the commit's identity: resubmitting the same --commit-id with a
+    /// different message is a commit id conflict.
+    #[arg(long)]
+    pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
     #[arg(long)]
@@ -523,6 +548,11 @@ pub(crate) struct FilesystemUndeleteArgs {
     /// so a stale command cannot cancel a later delete.
     #[arg(long)]
     pub deleted_at: u64,
+    /// Annotation recorded on the commit and shown by `loon changes`. Part
+    /// of the commit's identity: resubmitting the same --commit-id with a
+    /// different message is a commit id conflict.
+    #[arg(long)]
+    pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
     #[arg(long)]

--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -11,15 +11,15 @@ use loonfs::{
 };
 use loonfs_api::{
     v0::{DisableGrepIndexResponse, EnableGrepIndexResponse, RepairNamespaceResponse},
-    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitId, CommitResponse,
-    CreateCheckpointRequest, CreateCheckpointResponse, DestinationBehavior, EffectiveLimit,
-    ErrorCode, GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse,
-    MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, PaginationPolicy, ReleaseCheckpointResponse, RevisionNo,
+    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
+    CreateCheckpointResponse, DestinationBehavior, EffectiveLimit, ErrorCode, GrepRequest,
+    GrepResponse, InodeId, ListFileRevisionsResponse, MaintenanceStepRequest,
+    MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
+    PaginationPolicy, ReleaseCheckpointResponse, RevisionNo,
 };
 use loonfs_client::{
     CreateDirectoryOptions as ClientCreateDirectoryOptions, DeleteOptions as ClientDeleteOptions,
-    NamespacePath, PutFileOptions as ClientPutFileOptions,
+    MutationOptions, NamespacePath, PutFileOptions as ClientPutFileOptions,
 };
 
 #[cfg(test)]
@@ -266,6 +266,7 @@ impl Backend for EmbeddedBackend {
                 PutFileOptions {
                     behavior: options.behavior,
                     commit_id: options.commit_id.clone(),
+                    message: options.message.clone(),
                 },
             )
         })
@@ -284,6 +285,7 @@ impl Backend for EmbeddedBackend {
                 DeleteOptions {
                     behavior: options.behavior,
                     commit_id: options.commit_id.clone(),
+                    message: options.message.clone(),
                     expected_inode_id: options.expected_inode_id,
                 },
             )
@@ -302,6 +304,7 @@ impl Backend for EmbeddedBackend {
                 spec.absolute_path().as_str(),
                 CreateDirectoryOptions {
                     commit_id: options.commit_id.clone(),
+                    message: options.message.clone(),
                     parents: options.parents,
                 },
             )
@@ -314,7 +317,7 @@ impl Backend for EmbeddedBackend {
         from: &NamespacePath,
         to: &NamespacePath,
         behavior: DestinationBehavior,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(from.namespace(), || {
             self.writer.move_path(
@@ -323,7 +326,8 @@ impl Backend for EmbeddedBackend {
                 to.absolute_path().as_str(),
                 MoveOptions {
                     behavior,
-                    commit_id: commit_id.clone(),
+                    commit_id: options.commit_id.clone(),
+                    message: options.message.clone(),
                 },
             )
         })
@@ -335,7 +339,7 @@ impl Backend for EmbeddedBackend {
         from: &NamespacePath,
         to: &NamespacePath,
         behavior: DestinationBehavior,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(from.namespace(), || {
             self.writer.copy_path(
@@ -344,7 +348,8 @@ impl Backend for EmbeddedBackend {
                 to.absolute_path().as_str(),
                 CopyOptions {
                     behavior,
-                    commit_id: commit_id.clone(),
+                    commit_id: options.commit_id.clone(),
+                    message: options.message.clone(),
                 },
             )
         })
@@ -355,7 +360,7 @@ impl Backend for EmbeddedBackend {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.restore_file_revision(
@@ -363,7 +368,8 @@ impl Backend for EmbeddedBackend {
                 spec.absolute_path().as_str(),
                 source_revision_no,
                 RestoreRevisionOptions {
-                    commit_id: commit_id.clone(),
+                    commit_id: options.commit_id.clone(),
+                    message: options.message.clone(),
                 },
             )
         })
@@ -375,7 +381,7 @@ impl Backend for EmbeddedBackend {
         spec: &NamespacePath,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.undelete(
@@ -384,7 +390,8 @@ impl Backend for EmbeddedBackend {
                 deleted_at_seq,
                 spec.absolute_path().as_str(),
                 UndeleteOptions {
-                    commit_id: commit_id.clone(),
+                    commit_id: options.commit_id.clone(),
+                    message: options.message.clone(),
                 },
             )
         })
@@ -704,6 +711,7 @@ mod tests {
                     PutFileOptions {
                         behavior: DestinationBehavior::NoReplace,
                         commit_id: None,
+                        message: None,
                     },
                 )
                 .await;

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -393,6 +393,7 @@ pub(crate) async fn run_filesystem_put(
             &local_path,
             remote_root.as_str(),
             args.force,
+            args.message.clone(),
             runtime,
         )
         .await;
@@ -424,6 +425,7 @@ pub(crate) async fn run_filesystem_put(
     let options = PutFileOptions {
         behavior,
         commit_id,
+        message: args.message.clone(),
     };
     let result = context
         .target
@@ -475,6 +477,7 @@ pub(crate) async fn run_filesystem_rm(
         behavior,
         expected_inode_id: Some(deleted_inode),
         commit_id,
+        message: args.message.clone(),
     };
     let result = context
         .target
@@ -509,7 +512,14 @@ pub(crate) async fn run_filesystem_restore(
     let result = context
         .target
         .backend()
-        .restore_file_revision(&spec, RevisionNo(args.revision), commit_id)
+        .restore_file_revision(
+            &spec,
+            RevisionNo(args.revision),
+            &loonfs_client::MutationOptions {
+                commit_id,
+                message: args.message.clone(),
+            },
+        )
         .await
         .map_err(|error| context.fail(kind, error))?;
 
@@ -543,7 +553,10 @@ pub(crate) async fn run_filesystem_undelete(
             &spec,
             loonfs_api::InodeId(args.inode),
             loonfs_api::ChangeSeq(args.deleted_at),
-            commit_id,
+            &loonfs_client::MutationOptions {
+                commit_id,
+                message: args.message.clone(),
+            },
         )
         .await
         .map_err(|error| context.fail(kind, error))?;
@@ -574,6 +587,7 @@ pub(crate) async fn run_filesystem_mkdir(
     let options = CreateDirectoryOptions {
         parents: args.parents,
         commit_id,
+        message: args.message.clone(),
     };
     let result = context
         .target
@@ -669,6 +683,7 @@ async fn run_filesystem_transfer(
                 from.absolute_path().as_str(),
                 to.absolute_path().as_str(),
                 args.force,
+                args.message.clone(),
                 runtime,
             )
             .await;
@@ -690,7 +705,15 @@ async fn run_filesystem_transfer(
         context
             .target
             .backend()
-            .copy_path(&from, &to, behavior, commit_id)
+            .copy_path(
+                &from,
+                &to,
+                behavior,
+                &loonfs_client::MutationOptions {
+                    commit_id,
+                    message: args.message.clone(),
+                },
+            )
             .await
     } else {
         let behavior = if args.force {
@@ -701,7 +724,15 @@ async fn run_filesystem_transfer(
         context
             .target
             .backend()
-            .move_path(&from, &to, behavior, commit_id)
+            .move_path(
+                &from,
+                &to,
+                behavior,
+                &loonfs_client::MutationOptions {
+                    commit_id,
+                    message: args.message.clone(),
+                },
+            )
             .await
     }
     .map_err(|error| context.fail(kind, error))?;

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -101,6 +101,7 @@ pub(crate) async fn run_put_tree(
     local_root: &Path,
     remote_root: &str,
     force: bool,
+    message: Option<String>,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let mut files = Vec::new();
@@ -133,6 +134,7 @@ pub(crate) async fn run_put_tree(
                 &spec,
                 &CreateDirectoryOptions {
                     commit_id: None,
+                    message: message.clone(),
                     parents: true,
                 },
             )
@@ -151,6 +153,7 @@ pub(crate) async fn run_put_tree(
     let outcomes = futures::stream::iter(files.into_iter().map(|job| {
         let backend = context.target.backend();
         let namespace = context.namespace.clone();
+        let message = message.clone();
         let remote = format!("{}/{}", remote_root.trim_end_matches('/'), job.remote);
         async move {
             let spec = match NamespacePath::parse(namespace.as_str(), &remote) {
@@ -168,6 +171,7 @@ pub(crate) async fn run_put_tree(
                     &ClientPutFileOptions {
                         behavior,
                         commit_id: None,
+                        message: message.clone(),
                     },
                 )
                 .await
@@ -275,6 +279,7 @@ pub(crate) async fn run_copy_tree(
     source_root: &str,
     destination_root: &str,
     force: bool,
+    message: Option<String>,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let listing = walk_remote_tree(context, kind, source_root).await?;
@@ -301,6 +306,7 @@ pub(crate) async fn run_copy_tree(
                 &spec,
                 &CreateDirectoryOptions {
                     commit_id: None,
+                    message: message.clone(),
                     parents: components.is_empty(),
                 },
             )
@@ -324,6 +330,7 @@ pub(crate) async fn run_copy_tree(
     let outcomes = futures::stream::iter(listing.files.into_iter().map(|job| {
         let backend = context.target.backend();
         let namespace = context.namespace.clone();
+        let message = message.clone();
         let destination = joined_remote(
             destination_root,
             &job.local
@@ -341,7 +348,15 @@ pub(crate) async fn run_copy_tree(
                 }
             };
             let result = backend
-                .copy_path(&from, &to, behavior, None)
+                .copy_path(
+                    &from,
+                    &to,
+                    behavior,
+                    &loonfs_client::MutationOptions {
+                        commit_id: None,
+                        message: message.clone(),
+                    },
+                )
                 .await
                 .map(|_| spec_target(&to))
                 .map_err(CliError::from);

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -259,6 +259,99 @@ fn concurrent_embedded_puts_land_or_report_the_fence() {
 }
 
 #[test]
+fn commit_messages_ride_the_feed_and_bind_identity() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("doc.txt");
+    fs::write(&payload, b"v1").expect("write payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/doc.txt",
+        "--message",
+        "initial import",
+    ]));
+    // The audit's motivating case: a restore is indistinguishable from an
+    // edit in the feed without a message.
+    fs::write(&payload, b"v2").expect("write payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/doc.txt",
+        "--force",
+    ]));
+    assert_success(&harness.run(&[
+        "--json",
+        "restore",
+        "--revision",
+        "1",
+        "/doc.txt",
+        "--message",
+        "roll back to the imported copy",
+    ]));
+
+    let changes = harness.run(&["--json", "changes"]);
+    assert_success(&changes);
+    let rows = json_data(&changes)["changes"]
+        .as_array()
+        .expect("changes array")
+        .clone();
+    assert_eq!(rows[0]["message"], "initial import");
+    assert!(rows[1].get("message").is_none());
+    assert_eq!(rows[2]["message"], "roll back to the imported copy");
+
+    // The message is part of the commit's identity: the same commit id with
+    // a different message conflicts instead of silently replaying.
+    let first = harness.run(&[
+        "--json",
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/pinned.txt",
+        "--commit-id",
+        "pinned-put",
+        "--message",
+        "one",
+    ]);
+    assert_success(&first);
+    let replay = harness.run(&[
+        "--json",
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/pinned.txt",
+        "--commit-id",
+        "pinned-put",
+        "--message",
+        "one",
+    ]);
+    assert_success(&replay);
+    assert_eq!(
+        json_data(&first)["committed_seq"],
+        json_data(&replay)["committed_seq"],
+        "an identical retry replays the original commit"
+    );
+    let conflicted = harness.run(&[
+        "--json",
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/pinned.txt",
+        "--commit-id",
+        "pinned-put",
+        "--message",
+        "two",
+    ]);
+    assert_failure(&conflicted);
+    assert_eq!(
+        json_error(&conflicted)["code"],
+        "commit_id_reuse_conflict",
+        "{}",
+        json_error(&conflicted)
+    );
+}
+
+#[test]
 fn recursive_transfers_roundtrip_a_tree() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-client/src/backend.rs
+++ b/crates/loonfs-client/src/backend.rs
@@ -25,11 +25,11 @@ use loonfs_api::{
     v0::{
         ChangesResponse, DisableGrepIndexResponse, EnableGrepIndexResponse, RepairNamespaceResponse,
     },
-    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitId, CommitResponse,
-    CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse,
-    DestinationBehavior, ErrorCode, ErrorDetails, GrepRequest, GrepResponse, InodeId,
-    ListFileRevisionsResponse, MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId,
-    NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RevisionNo,
+    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
+    CreateCheckpointResponse, DeleteNamespaceResponse, DestinationBehavior, ErrorCode,
+    ErrorDetails, GrepRequest, GrepResponse, InodeId, ListFileRevisionsResponse,
+    MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse,
+    NamespaceSummary, ReleaseCheckpointResponse, RevisionNo,
 };
 use thiserror::Error;
 
@@ -235,7 +235,7 @@ pub trait Backend {
         from: &NamespacePath,
         to: &NamespacePath,
         behavior: DestinationBehavior,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError>;
     /// Copies a file within a namespace; `behavior` selects create-only or
     /// replace semantics for the destination.
@@ -244,14 +244,14 @@ pub trait Backend {
         from: &NamespacePath,
         to: &NamespacePath,
         behavior: DestinationBehavior,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError>;
     /// Restores a file to one of its retained revisions.
     async fn restore_file_revision(
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError>;
     /// Recovers a deleted file or subtree to the spec's path; `inode_id`
     /// and `deleted_at_seq` are the identity and committed sequence the
@@ -261,7 +261,7 @@ pub trait Backend {
         spec: &NamespacePath,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError>;
 
     // --- maintenance/admin plane (`admin/v0`) ---
@@ -483,11 +483,10 @@ impl Backend for RemoteBackend {
         from: &NamespacePath,
         to: &NamespacePath,
         behavior: DestinationBehavior,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError> {
-        let options = MutationOptions { commit_id };
         self.client
-            .move_path(from, to, behavior, &options)
+            .move_path(from, to, behavior, options)
             .await
             .map_err(BackendError::from)
     }
@@ -497,11 +496,10 @@ impl Backend for RemoteBackend {
         from: &NamespacePath,
         to: &NamespacePath,
         behavior: DestinationBehavior,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError> {
-        let options = MutationOptions { commit_id };
         self.client
-            .copy_path(from, to, behavior, &options)
+            .copy_path(from, to, behavior, options)
             .await
             .map_err(BackendError::from)
     }
@@ -510,11 +508,10 @@ impl Backend for RemoteBackend {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError> {
-        let options = MutationOptions { commit_id };
         self.client
-            .restore_file_revision(spec, source_revision_no, &options)
+            .restore_file_revision(spec, source_revision_no, options)
             .await
             .map_err(BackendError::from)
     }
@@ -524,11 +521,10 @@ impl Backend for RemoteBackend {
         spec: &NamespacePath,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
-        commit_id: Option<CommitId>,
+        options: &MutationOptions,
     ) -> Result<CommitResponse, BackendError> {
-        let options = MutationOptions { commit_id };
         self.client
-            .undelete(spec, inode_id, deleted_at_seq, &options)
+            .undelete(spec, inode_id, deleted_at_seq, options)
             .await
             .map_err(BackendError::from)
     }

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -79,6 +79,10 @@ pub struct MutationOptions {
     /// the committed mutation instead of double-committing. A fresh id is
     /// generated when absent.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit and reported by the change feed.
+    /// Part of the commit's identity: the same `commit_id` with a different
+    /// message is a `commit_id_reuse_conflict`.
+    pub message: Option<String>,
 }
 
 impl MutationOptions {
@@ -94,6 +98,8 @@ pub struct PutFileOptions {
     pub behavior: DestinationBehavior,
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
 }
 
 impl Default for PutFileOptions {
@@ -101,6 +107,7 @@ impl Default for PutFileOptions {
         Self {
             behavior: DestinationBehavior::NoReplace,
             commit_id: None,
+            message: None,
         }
     }
 }
@@ -110,6 +117,8 @@ impl Default for PutFileOptions {
 pub struct CreateDirectoryOptions {
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
     /// Also create missing ancestor directories.
     pub parents: bool,
 }
@@ -121,6 +130,8 @@ pub struct DeleteOptions {
     pub behavior: DeleteDirectoryBehavior,
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
     /// Delete only while the path still resolves to this inode.
     pub expected_inode_id: Option<InodeId>,
 }
@@ -130,6 +141,7 @@ impl Default for DeleteOptions {
         Self {
             behavior: DeleteDirectoryBehavior::NonRecursive,
             commit_id: None,
+            message: None,
             expected_inode_id: None,
         }
     }
@@ -682,6 +694,7 @@ impl Client {
                 spec.namespace(),
                 &FilesystemOperationRequest {
                     commit_id,
+                    message: options.message.clone(),
                     content_tokens: staged.validated_content_token.into_iter().collect(),
                     operation: FilesystemOperation::PutFile {
                         path: spec.absolute_path().clone(),
@@ -705,6 +718,7 @@ impl Client {
                 spec.namespace(),
                 &FilesystemOperationRequest {
                     commit_id,
+                    message: options.message.clone(),
                     content_tokens: Vec::new(),
                     operation: FilesystemOperation::CreateDirectory {
                         path: spec.absolute_path().clone(),
@@ -727,6 +741,7 @@ impl Client {
                 spec.namespace(),
                 &FilesystemOperationRequest {
                     commit_id,
+                    message: options.message.clone(),
                     content_tokens: Vec::new(),
                     operation: FilesystemOperation::DeletePath {
                         path: spec.absolute_path().clone(),
@@ -759,6 +774,7 @@ impl Client {
                 from.namespace(),
                 &FilesystemOperationRequest {
                     commit_id,
+                    message: options.message.clone(),
                     content_tokens: Vec::new(),
                     operation: FilesystemOperation::MovePath {
                         from_path: from.absolute_path().clone(),
@@ -791,6 +807,7 @@ impl Client {
                 from.namespace(),
                 &FilesystemOperationRequest {
                     commit_id,
+                    message: options.message.clone(),
                     content_tokens: Vec::new(),
                     operation: FilesystemOperation::CopyPath {
                         from_path: from.absolute_path().clone(),
@@ -819,6 +836,7 @@ impl Client {
                 spec.namespace(),
                 &FilesystemOperationRequest {
                     commit_id,
+                    message: options.message.clone(),
                     content_tokens: Vec::new(),
                     operation: FilesystemOperation::Undelete {
                         inode_id,
@@ -843,6 +861,7 @@ impl Client {
                 spec.namespace(),
                 &FilesystemOperationRequest {
                     commit_id,
+                    message: options.message.clone(),
                     content_tokens: Vec::new(),
                     operation: FilesystemOperation::RestoreRevision {
                         path: spec.absolute_path().clone(),
@@ -1124,6 +1143,7 @@ mod tests {
                 &spec,
                 &CreateDirectoryOptions {
                     commit_id: Some(commit_id),
+                    message: None,
                     ..CreateDirectoryOptions::default()
                 },
             )

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -136,6 +136,7 @@ pub(crate) async fn write_test_file<S: ObjectStore>(
             vec![NamespaceMutationCandidate::path_prepared(
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse(commit_id).expect("commit id"),
+                    message: None,
                     absolute_path: AbsolutePath::parse(path).expect("path"),
                     content_ref,
                     behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -587,6 +587,7 @@ mod tests {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let intent = PathMutationIntent::CreateDir {
             commit_id: CommitId::parse("same-mutation").expect("valid commit id"),
+            message: None,
             absolute_path: loonfs_api::AbsolutePath::parse("/docs").expect("path"),
             parents: false,
         };

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -45,6 +45,7 @@
 //!     &publish_store,
 //!     vec![NamespaceMutationCandidate::path(PathMutationIntent::CreateDir {
 //!         commit_id: CommitId::generate(),
+//!         message: None,
 //!         absolute_path: AbsolutePath::parse("/plans").expect("path"),
 //!         parents: false,
 //!     })],

--- a/crates/loonfs-core/src/path/write/intent.rs
+++ b/crates/loonfs-core/src/path/write/intent.rs
@@ -18,6 +18,10 @@ pub enum PathMutationIntent {
     /// Create one directory.
     CreateDir {
         commit_id: CommitId,
+        /// Caller annotation recorded on the commit. Part of the intent's
+        /// identity, exactly as `message` is part of an explicit commit's
+        /// fingerprint preimage.
+        message: Option<String>,
         absolute_path: AbsolutePath,
         /// Also create missing ancestor directories, like `PutFile` does.
         parents: bool,
@@ -25,6 +29,8 @@ pub enum PathMutationIntent {
     /// Put one file at a path.
     PutFile {
         commit_id: CommitId,
+        /// Caller annotation recorded on the commit; part of intent identity.
+        message: Option<String>,
         absolute_path: AbsolutePath,
         content_ref: ContentRef,
         behavior: DestinationBehavior,
@@ -32,6 +38,8 @@ pub enum PathMutationIntent {
     /// Delete one path.
     DeletePath {
         commit_id: CommitId,
+        /// Caller annotation recorded on the commit; part of intent identity.
+        message: Option<String>,
         absolute_path: AbsolutePath,
         behavior: DeleteDirectoryBehavior,
         /// When set, the delete applies only while the path still resolves
@@ -42,6 +50,8 @@ pub enum PathMutationIntent {
     /// Move one path to another path.
     MovePath {
         commit_id: CommitId,
+        /// Caller annotation recorded on the commit; part of intent identity.
+        message: Option<String>,
         from_path: AbsolutePath,
         to_path: AbsolutePath,
         behavior: DestinationBehavior,
@@ -49,6 +59,8 @@ pub enum PathMutationIntent {
     /// Copy one file path to another path.
     CopyFilePath {
         commit_id: CommitId,
+        /// Caller annotation recorded on the commit; part of intent identity.
+        message: Option<String>,
         from_path: AbsolutePath,
         to_path: AbsolutePath,
         behavior: DestinationBehavior,
@@ -56,12 +68,16 @@ pub enum PathMutationIntent {
     /// Restore a file revision at a path.
     RestoreRevision {
         commit_id: CommitId,
+        /// Caller annotation recorded on the commit; part of intent identity.
+        message: Option<String>,
         absolute_path: AbsolutePath,
         source_revision_no: RevisionNo,
     },
     /// Recover a deleted subtree to a destination path.
     Undelete {
         commit_id: CommitId,
+        /// Caller annotation recorded on the commit; part of intent identity.
+        message: Option<String>,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
         absolute_path: AbsolutePath,
@@ -69,6 +85,19 @@ pub enum PathMutationIntent {
 }
 
 impl PathMutationIntent {
+    /// Returns the caller annotation carried by this intent.
+    pub fn message(&self) -> Option<&str> {
+        match self {
+            Self::CreateDir { message, .. }
+            | Self::PutFile { message, .. }
+            | Self::DeletePath { message, .. }
+            | Self::MovePath { message, .. }
+            | Self::CopyFilePath { message, .. }
+            | Self::RestoreRevision { message, .. }
+            | Self::Undelete { message, .. } => message.as_deref(),
+        }
+    }
+
     /// Returns the idempotency key carried by this intent.
     pub fn commit_id(&self) -> &CommitId {
         match self {

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -105,6 +105,7 @@ async fn put_prepared_file_content<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::PutFile {
             commit_id: normalized_commit_id(commit_id),
+            message: None,
             absolute_path: parse_mutation_path(absolute_path)?,
             content_ref,
             behavior,
@@ -147,6 +148,7 @@ async fn delete_path_with_behavior<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::DeletePath {
             commit_id,
+            message: None,
             absolute_path: parse_mutation_path(absolute_path)?,
             behavior,
             expected_inode_id: None,
@@ -171,6 +173,7 @@ pub(crate) async fn move_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::MovePath {
             commit_id,
+            message: None,
             from_path: parse_mutation_path(from_path)?,
             to_path: parse_mutation_path(to_path)?,
             behavior: DestinationBehavior::NoReplace,
@@ -195,6 +198,7 @@ pub(crate) async fn restore_file_revision<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::RestoreRevision {
             commit_id,
+            message: None,
             absolute_path: parse_mutation_path(absolute_path)?,
             source_revision_no,
         },

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -38,40 +38,47 @@ pub(crate) struct PlannedPathMutation {
 enum PathFingerprintInput {
     CreateDir {
         namespace_id: NamespaceId,
+        message: Option<String>,
         absolute_path: String,
         parents: bool,
     },
     PutFile {
         namespace_id: NamespaceId,
+        message: Option<String>,
         absolute_path: String,
         behavior: DestinationBehavior,
         content_ref: ContentRef,
     },
     DeletePath {
         namespace_id: NamespaceId,
+        message: Option<String>,
         absolute_path: String,
         behavior: DeleteDirectoryBehavior,
         expected_inode_id: Option<InodeId>,
     },
     MovePath {
         namespace_id: NamespaceId,
+        message: Option<String>,
         from_path: String,
         to_path: String,
         behavior: DestinationBehavior,
     },
     CopyFilePath {
         namespace_id: NamespaceId,
+        message: Option<String>,
         from_path: String,
         to_path: String,
         behavior: DestinationBehavior,
     },
     RestoreRevision {
         namespace_id: NamespaceId,
+        message: Option<String>,
         absolute_path: String,
         source_revision_no: RevisionNo,
     },
     Undelete {
         namespace_id: NamespaceId,
+        message: Option<String>,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
         absolute_path: String,
@@ -97,6 +104,7 @@ pub(crate) fn path_intent_fingerprint(
     namespace_id: &NamespaceId,
     intent: &PathMutationIntent,
 ) -> Result<PathIntentFingerprint> {
+    let message = intent.message().map(ToOwned::to_owned);
     let identity = match intent {
         PathMutationIntent::CreateDir {
             absolute_path,
@@ -104,6 +112,7 @@ pub(crate) fn path_intent_fingerprint(
             ..
         } => PathFingerprintInput::CreateDir {
             namespace_id: namespace_id.clone(),
+            message: message.clone(),
             absolute_path: absolute_path.as_str().to_owned(),
             parents: *parents,
         },
@@ -114,6 +123,7 @@ pub(crate) fn path_intent_fingerprint(
             ..
         } => PathFingerprintInput::PutFile {
             namespace_id: namespace_id.clone(),
+            message: message.clone(),
             absolute_path: absolute_path.as_str().to_owned(),
             behavior: *behavior,
             content_ref: content_ref.clone(),
@@ -130,6 +140,7 @@ pub(crate) fn path_intent_fingerprint(
             ..
         } => PathFingerprintInput::DeletePath {
             namespace_id: namespace_id.clone(),
+            message: message.clone(),
             absolute_path: absolute_path.as_str().to_owned(),
             behavior: *behavior,
             expected_inode_id: *expected_inode_id,
@@ -141,6 +152,7 @@ pub(crate) fn path_intent_fingerprint(
             ..
         } => PathFingerprintInput::MovePath {
             namespace_id: namespace_id.clone(),
+            message: message.clone(),
             from_path: from_path.as_str().to_owned(),
             to_path: to_path.as_str().to_owned(),
             behavior: *behavior,
@@ -152,6 +164,7 @@ pub(crate) fn path_intent_fingerprint(
             ..
         } => PathFingerprintInput::CopyFilePath {
             namespace_id: namespace_id.clone(),
+            message: message.clone(),
             from_path: from_path.as_str().to_owned(),
             to_path: to_path.as_str().to_owned(),
             behavior: *behavior,
@@ -162,6 +175,7 @@ pub(crate) fn path_intent_fingerprint(
             ..
         } => PathFingerprintInput::RestoreRevision {
             namespace_id: namespace_id.clone(),
+            message: message.clone(),
             absolute_path: absolute_path.as_str().to_owned(),
             source_revision_no: *source_revision_no,
         },
@@ -172,6 +186,7 @@ pub(crate) fn path_intent_fingerprint(
             ..
         } => PathFingerprintInput::Undelete {
             namespace_id: namespace_id.clone(),
+            message: message.clone(),
             inode_id: *inode_id,
             deleted_at_seq: *deleted_at_seq,
             absolute_path: absolute_path.as_str().to_owned(),
@@ -192,7 +207,7 @@ pub(crate) async fn plan_path_mutation_against_publish_view<S: ObjectStore + ?Si
         head,
         metadata_state,
     };
-    let commit_request = match intent {
+    let mut commit_request = match intent {
         PathMutationIntent::CreateDir {
             absolute_path,
             parents,
@@ -258,6 +273,9 @@ pub(crate) async fn plan_path_mutation_against_publish_view<S: ObjectStore + ?Si
                 .await?
         }
     };
+    // The annotation rides the commit request from one place; the plan
+    // functions stay focused on semantics.
+    commit_request.message = intent.message().map(ToOwned::to_owned);
     Ok(PlannedPathMutation {
         commit_id,
         path_intent_fingerprint,
@@ -297,10 +315,29 @@ mod tests {
     /// retry idempotency across versions. Do not update the literal without
     /// bumping the fingerprint scheme tag.
     #[test]
+    fn a_message_changes_path_intent_identity() {
+        // The annotation is part of what the caller asked for: replaying a
+        // commit id with a different message must conflict, exactly as it
+        // does for explicit commits, so the message joins the preimage.
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let intent = |message: Option<&str>| PathMutationIntent::CreateDir {
+            commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
+            message: message.map(ToOwned::to_owned),
+            absolute_path: AbsolutePath::parse("/docs").expect("valid path"),
+            parents: false,
+        };
+        let without = path_intent_fingerprint(&namespace_id, &intent(None)).expect("fingerprint");
+        let with = path_intent_fingerprint(&namespace_id, &intent(Some("import batch")))
+            .expect("fingerprint");
+        assert_ne!(without.as_str(), with.as_str());
+    }
+
+    #[test]
     fn path_intent_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let intent = PathMutationIntent::CreateDir {
             commit_id: CommitId::parse("c_00000000000000000000000000000042").expect("commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/docs").expect("path"),
             parents: false,
         };
@@ -313,7 +350,7 @@ mod tests {
             // semantic parameter (no deployed namespaces hold the prior
             // value); post-release this literal only moves with a scheme
             // tag bump.
-            "v0:sha256:06414b716b076c98e7a61e465ae729b2340045c133437a557c76902d73a5f33b"
+            "v0:sha256:2de2ea1159b7b8ed3fb97d77f9c7b01e7b873bb45cf5b53c1116ecfad0a51cc0"
         );
     }
 
@@ -323,6 +360,7 @@ mod tests {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let intent = PathMutationIntent::DeletePath {
             commit_id: CommitId::parse("c_00000000000000000000000000000043").expect("commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/docs").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: Some(InodeId(42)),
@@ -334,7 +372,7 @@ mod tests {
             fingerprint.as_str(),
             // Added pre-release when the delete guard became semantic
             // request content; no deployed receipts use the prior preimage.
-            "v0:sha256:6b233b1fa124c36c09104446f8a1de60b6bec76fccf6fc41e72e064c60f47715"
+            "v0:sha256:34056f22715e481a182484d34704685c8afa7469fbe737dbae67f7d93d9fcec1"
         );
     }
 
@@ -394,6 +432,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs-a").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/a").expect("path"),
                 parents: false,
             },
@@ -403,6 +442,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs-b").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/a").expect("path"),
                 parents: false,
             },
@@ -419,6 +459,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs").expect("path"),
                 parents: false,
             },
@@ -428,6 +469,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-drafts").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/drafts").expect("path"),
                 parents: false,
             },
@@ -444,6 +486,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs").expect("path"),
                 parents: false,
             },
@@ -475,6 +518,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CreateDir {
                 commit_id: CommitId::parse("mkdir-docs").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs").expect("path"),
                 parents: false,
             },
@@ -512,6 +556,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-nested").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/nested/a.txt").expect("path"),
                 content_ref: staged.content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
@@ -562,6 +607,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::MovePath {
                 commit_id: CommitId::parse("move-file").expect("valid commit id"),
+                message: None,
                 from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
                 behavior: DestinationBehavior::NoReplace,
@@ -612,6 +658,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::CopyFilePath {
                 commit_id: CommitId::parse("copy-file").expect("valid commit id"),
+                message: None,
                 from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 to_path: AbsolutePath::parse("/docs/copy.txt").expect("path"),
                 behavior: DestinationBehavior::NoReplace,
@@ -719,6 +766,7 @@ mod tests {
             &namespace_id,
             &PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-under-dead").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/dead/new.txt").expect("path"),
                 content_ref: staged.content_ref,
                 behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -122,6 +122,7 @@ mod tests {
         NamespaceMutationCandidate::path_prepared(
             PathMutationIntent::PutFile {
                 commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
                 content_ref: content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
@@ -170,6 +171,7 @@ mod tests {
 
         let first_intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("plan-a").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             content_ref: staged.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
@@ -182,6 +184,7 @@ mod tests {
 
         let second_intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("plan-b").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             content_ref: staged.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
@@ -304,6 +307,7 @@ mod tests {
                 ),
                 NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                     commit_id: CommitId::parse("delete-doomed").expect("valid commit id"),
+                    message: None,
                     absolute_path: AbsolutePath::parse("/docs/doomed.txt").expect("path"),
                     behavior: DeleteDirectoryBehavior::NonRecursive,
                     expected_inode_id: None,

--- a/crates/loonfs-core/tests/batch_publish.rs
+++ b/crates/loonfs-core/tests/batch_publish.rs
@@ -46,6 +46,7 @@ async fn delete_path_non_recursive_expecting<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: CommitId::parse(commit_id).expect("valid test commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id,
@@ -366,6 +367,7 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
         .publish_namespace_mutations_batch(vec![
             NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("delete-cycled").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
                 expected_inode_id: None,
@@ -375,6 +377,7 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("recreate-cycled").expect("valid commit id"),
+                    message: None,
                     absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
                     content_ref: staged.content_ref,
                     behavior: DestinationBehavior::NoReplace,
@@ -556,6 +559,7 @@ async fn ack_lost_head_cas_reports_unknown_outcome_and_replays_idempotently() {
         .expect("stage content");
     let intent = || PathMutationIntent::PutFile {
         commit_id: CommitId::parse("ack-lost-put").expect("valid commit id"),
+        message: None,
         absolute_path: AbsolutePath::parse("/ack.txt").expect("path"),
         content_ref: content.content_ref.clone(),
         behavior: DestinationBehavior::NoReplace,
@@ -596,6 +600,7 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
         .expect("stage content");
     let intent = PathMutationIntent::PutFile {
         commit_id: CommitId::parse("retry-after-orphan").expect("valid commit id"),
+        message: None,
         absolute_path: AbsolutePath::parse("/retry.txt").expect("path"),
         content_ref: content.content_ref,
         behavior: DestinationBehavior::NoReplace,
@@ -691,6 +696,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
             // Rejected against the durable materialization: nothing was accepted yet.
             NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
                 expected_inode_id: None,
@@ -701,6 +707,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                    message: None,
                     absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                     content_ref: content.content_ref.clone(),
                     behavior: DestinationBehavior::NoReplace,
@@ -714,6 +721,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                    message: None,
                     absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                     content_ref: content.content_ref.clone(),
                     behavior: DestinationBehavior::NoReplace,
@@ -723,6 +731,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
             // Alias of the materialization-decided rejection.
             NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
                 expected_inode_id: None,
@@ -797,6 +806,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
         vec![
             NamespaceMutationCandidate::path(PathMutationIntent::DeletePath {
                 commit_id: CommitId::parse("reject-materialization").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
                 expected_inode_id: None,
@@ -806,6 +816,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("accept-a").expect("valid commit id"),
+                    message: None,
                     absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                     content_ref: content.content_ref.clone(),
                     behavior: DestinationBehavior::NoReplace,
@@ -817,6 +828,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("reject-speculative").expect("valid commit id"),
+                    message: None,
                     absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                     content_ref: content.content_ref.clone(),
                     behavior: DestinationBehavior::NoReplace,
@@ -1294,6 +1306,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
 
     let intent = PathMutationIntent::PutFile {
         commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
+        message: None,
         absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
         content_ref: content.content_ref.clone(),
         behavior: DestinationBehavior::NoReplace,
@@ -1306,6 +1319,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
         &namespace_id,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
@@ -1321,6 +1335,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
         &namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: CommitId::parse("same-path-request").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: None,
@@ -1564,6 +1579,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
                 &namespace_id("demo"),
                 PathMutationIntent::PutFile {
                     commit_id: commit_id.clone(),
+                    message: None,
                     absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
                     content_ref: content.content_ref.clone(),
                     behavior: DestinationBehavior::NoReplace,
@@ -1589,6 +1605,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
         vec![NamespaceMutationCandidate::path(
             PathMutationIntent::PutFile {
                 commit_id,
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-core/tests/commit_validation.rs
+++ b/crates/loonfs-core/tests/commit_validation.rs
@@ -789,6 +789,7 @@ async fn path_put_file_without_admission_fails_without_reading_content() {
         vec![NamespaceMutationCandidate::path(
             PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-cold-content").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/hello.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: DestinationBehavior::NoReplace,
@@ -829,12 +830,14 @@ async fn path_batch_rejects_repeated_unadmitted_content_without_reading_it() {
         vec![
             NamespaceMutationCandidate::path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-shared-a").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
             }),
             NamespaceMutationCandidate::path(PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-shared-b").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: DestinationBehavior::NoReplace,
@@ -893,6 +896,7 @@ async fn valid_content_admission_skips_durable_content_validation() {
         vec![NamespaceMutationCandidate::path_prepared(
             PathMutationIntent::PutFile {
                 commit_id: CommitId::parse("put-admitted-content").expect("valid commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse("/docs/admitted.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-core/tests/common/mod.rs
+++ b/crates/loonfs-core/tests/common/mod.rs
@@ -294,6 +294,7 @@ pub(crate) mod mutation_split_support {
             namespace_id,
             PathMutationIntent::PutFile {
                 commit_id: test_commit_id(commit_id),
+                message: None,
                 absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
                 content_ref: content.content_ref,
                 behavior,
@@ -335,6 +336,7 @@ pub(crate) mod mutation_split_support {
             namespace_id,
             PathMutationIntent::CreateDir {
                 commit_id: test_commit_id(commit_id),
+                message: None,
                 absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
                 parents: false,
             },

--- a/crates/loonfs-core/tests/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/fork_lifecycle.rs
@@ -330,6 +330,7 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         &namespace_id,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("before-delete").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/keep.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
@@ -366,6 +367,7 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         &namespace_id,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("after-delete").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/late.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
@@ -411,6 +413,7 @@ async fn fork_clone_survives_source_delete() {
         &source,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("seed-clone").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/shared.txt").expect("path"),
             content_ref: content.content_ref,
             behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-core/tests/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/layout_acceptance.rs
@@ -45,6 +45,7 @@ async fn put_file<S: ObjectStore + ?Sized>(
             vec![NamespaceMutationCandidate::path_prepared(
                 PathMutationIntent::PutFile {
                     commit_id: loonfs_api::CommitId::generate(),
+                    message: None,
                     absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
                     content_ref,
                     behavior: loonfs_api::DestinationBehavior::NoReplace,

--- a/crates/loonfs-core/tests/path_intents.rs
+++ b/crates/loonfs-core/tests/path_intents.rs
@@ -46,6 +46,7 @@ async fn delete_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: test_commit_id(commit_id),
+            message: None,
             absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             behavior: DeleteDirectoryBehavior::Recursive,
             expected_inode_id: None,
@@ -67,6 +68,7 @@ async fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: test_commit_id(commit_id),
+            message: None,
             absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: None,
@@ -89,6 +91,7 @@ async fn move_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::MovePath {
             commit_id: test_commit_id(commit_id),
+            message: None,
             from_path: AbsolutePath::parse(from_path).expect("path"),
             to_path: AbsolutePath::parse(to_path).expect("path"),
             behavior: DestinationBehavior::NoReplace,
@@ -111,6 +114,7 @@ async fn copy_file_path<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::CopyFilePath {
             commit_id: test_commit_id(commit_id),
+            message: None,
             from_path: AbsolutePath::parse(from_path).expect("path"),
             to_path: AbsolutePath::parse(to_path).expect("path"),
             behavior: DestinationBehavior::NoReplace,
@@ -133,6 +137,7 @@ async fn restore_file_revision<S: ObjectStore + ?Sized>(
         namespace_id,
         PathMutationIntent::RestoreRevision {
             commit_id: test_commit_id(commit_id),
+            message: None,
             absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
             source_revision_no,
         },
@@ -1055,6 +1060,7 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         PathMutationIntent::PutFile {
             commit_id: CommitId::parse("put-path").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
@@ -1070,6 +1076,7 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         PathMutationIntent::MovePath {
             commit_id: CommitId::parse("move-path").expect("valid commit id"),
+            message: None,
             from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DestinationBehavior::NoReplace,
@@ -1085,6 +1092,7 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         PathMutationIntent::CopyFilePath {
             commit_id: CommitId::parse("copy-path").expect("valid commit id"),
+            message: None,
             from_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/c.txt").expect("path"),
             behavior: DestinationBehavior::NoReplace,
@@ -1100,6 +1108,7 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         PathMutationIntent::DeletePath {
             commit_id: CommitId::parse("delete-path").expect("valid commit id"),
+            message: None,
             absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: None,
@@ -1138,6 +1147,7 @@ async fn path_intents_in_one_batch_see_tentative_state() {
                 &namespace_id,
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::parse("put-batched-path").expect("valid commit id"),
+                    message: None,
                     absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                     content_ref: content.content_ref,
                     behavior: DestinationBehavior::NoReplace,
@@ -1146,6 +1156,7 @@ async fn path_intents_in_one_batch_see_tentative_state() {
             .await,
             NamespaceMutationCandidate::path(PathMutationIntent::MovePath {
                 commit_id: CommitId::parse("move-batched-path").expect("valid commit id"),
+                message: None,
                 from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
                 behavior: DestinationBehavior::NoReplace,
@@ -1731,6 +1742,7 @@ async fn move_replace_atomically_replaces_a_file_destination() {
         &namespace_id,
         PathMutationIntent::MovePath {
             commit_id: CommitId::parse("move-no-replace").expect("valid commit id"),
+            message: None,
             from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DestinationBehavior::NoReplace,
@@ -1748,6 +1760,7 @@ async fn move_replace_atomically_replaces_a_file_destination() {
         &namespace_id,
         PathMutationIntent::MovePath {
             commit_id: CommitId::parse("move-replace").expect("valid commit id"),
+            message: None,
             from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DestinationBehavior::Replace,
@@ -1797,6 +1810,7 @@ async fn move_replace_rejects_directory_destinations_and_self_moves() {
         &namespace_id,
         PathMutationIntent::MovePath {
             commit_id: CommitId::parse("move-onto-dir").expect("valid commit id"),
+            message: None,
             from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/dir").expect("path"),
             behavior: DestinationBehavior::Replace,
@@ -1813,6 +1827,7 @@ async fn move_replace_rejects_directory_destinations_and_self_moves() {
         &namespace_id,
         PathMutationIntent::MovePath {
             commit_id: CommitId::parse("move-onto-self").expect("valid commit id"),
+            message: None,
             from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             behavior: DestinationBehavior::Replace,
@@ -1865,6 +1880,7 @@ async fn copy_replace_appends_a_revision_to_the_destination_inode() {
         &namespace_id,
         PathMutationIntent::CopyFilePath {
             commit_id: CommitId::parse("copy-replace").expect("valid commit id"),
+            message: None,
             from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DestinationBehavior::Replace,

--- a/crates/loonfs-core/tests/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/visibility_equivalence.rs
@@ -71,6 +71,7 @@ impl VisibilityHarness {
         self.publish(NamespaceMutationCandidate::path(
             PathMutationIntent::CreateDir {
                 commit_id: CommitId::generate(),
+                message: None,
                 absolute_path: AbsolutePath::parse(path).expect("valid path"),
                 parents: false,
             },
@@ -96,6 +97,7 @@ impl VisibilityHarness {
         self.publish(NamespaceMutationCandidate::path_prepared(
             PathMutationIntent::PutFile {
                 commit_id: CommitId::generate(),
+                message: None,
                 absolute_path: AbsolutePath::parse(path).expect("valid path"),
                 content_ref,
                 behavior,
@@ -113,6 +115,7 @@ impl VisibilityHarness {
         self.publish(NamespaceMutationCandidate::path(
             PathMutationIntent::DeletePath {
                 commit_id: CommitId::generate(),
+                message: None,
                 absolute_path: AbsolutePath::parse(path).expect("valid path"),
                 behavior,
                 expected_inode_id: None,
@@ -125,6 +128,7 @@ impl VisibilityHarness {
         self.publish(NamespaceMutationCandidate::path(
             PathMutationIntent::MovePath {
                 commit_id: CommitId::generate(),
+                message: None,
                 from_path: AbsolutePath::parse(from_path).expect("valid source path"),
                 to_path: AbsolutePath::parse(to_path).expect("valid destination path"),
                 behavior: DestinationBehavior::NoReplace,
@@ -137,6 +141,7 @@ impl VisibilityHarness {
         self.publish(NamespaceMutationCandidate::path(
             PathMutationIntent::CopyFilePath {
                 commit_id: CommitId::generate(),
+                message: None,
                 from_path: AbsolutePath::parse(from_path).expect("valid source path"),
                 to_path: AbsolutePath::parse(to_path).expect("valid destination path"),
                 behavior: DestinationBehavior::NoReplace,
@@ -153,6 +158,7 @@ impl VisibilityHarness {
         self.publish(NamespaceMutationCandidate::path(
             PathMutationIntent::RestoreRevision {
                 commit_id: CommitId::generate(),
+                message: None,
                 absolute_path: AbsolutePath::parse(path).expect("valid path"),
                 source_revision_no,
             },
@@ -169,6 +175,7 @@ impl VisibilityHarness {
         self.publish(NamespaceMutationCandidate::path(
             PathMutationIntent::Undelete {
                 commit_id: CommitId::generate(),
+                message: None,
                 inode_id,
                 deleted_at_seq,
                 absolute_path: AbsolutePath::parse(path).expect("valid path"),

--- a/crates/loonfs-grep/src/test_seeding.rs
+++ b/crates/loonfs-grep/src/test_seeding.rs
@@ -45,6 +45,7 @@ pub(crate) async fn put_file<S: ObjectStore + Clone>(
         .publish_namespace_mutations_batch(vec![NamespaceMutationCandidate::path_prepared(
             PathMutationIntent::PutFile {
                 commit_id: CommitId::parse(commit_id).expect("commit id"),
+                message: None,
                 absolute_path: AbsolutePath::parse(path).expect("path"),
                 content_ref,
                 behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -465,6 +465,7 @@ pub(super) async fn apply_filesystem_operation(
     let namespace_id = namespace.into_id()?;
     let FilesystemOperationRequest {
         commit_id,
+        message,
         content_tokens,
         operation,
     } = request;
@@ -503,6 +504,7 @@ pub(super) async fn apply_filesystem_operation(
     let intent = match operation {
         FilesystemOperation::CreateDirectory { path, parents } => PathMutationIntent::CreateDir {
             commit_id,
+            message: message.clone(),
             absolute_path: validate_path(path)?,
             parents,
         },
@@ -512,6 +514,7 @@ pub(super) async fn apply_filesystem_operation(
             behavior,
         } => PathMutationIntent::PutFile {
             commit_id,
+            message: message.clone(),
             absolute_path: validate_path(path)?,
             content_ref,
             behavior,
@@ -522,6 +525,7 @@ pub(super) async fn apply_filesystem_operation(
             expected_inode_id,
         } => PathMutationIntent::DeletePath {
             commit_id,
+            message: message.clone(),
             absolute_path: validate_path(path)?,
             behavior,
             expected_inode_id,
@@ -532,6 +536,7 @@ pub(super) async fn apply_filesystem_operation(
             behavior,
         } => PathMutationIntent::MovePath {
             commit_id,
+            message: message.clone(),
             from_path: validate_path(from_path)?,
             to_path: validate_path(to_path)?,
             behavior,
@@ -542,6 +547,7 @@ pub(super) async fn apply_filesystem_operation(
             behavior,
         } => PathMutationIntent::CopyFilePath {
             commit_id,
+            message: message.clone(),
             from_path: validate_path(from_path)?,
             to_path: validate_path(to_path)?,
             behavior,
@@ -551,6 +557,7 @@ pub(super) async fn apply_filesystem_operation(
             source_revision_no,
         } => PathMutationIntent::RestoreRevision {
             commit_id,
+            message: message.clone(),
             absolute_path: validate_path(path)?,
             source_revision_no,
         },
@@ -560,6 +567,7 @@ pub(super) async fn apply_filesystem_operation(
             path,
         } => PathMutationIntent::Undelete {
             commit_id,
+            message: message.clone(),
             inode_id,
             deleted_at_seq,
             absolute_path: validate_path(path)?,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -658,6 +658,7 @@ async fn runtime_created_state_is_readable_through_http() {
         PutFileOptions {
             behavior: DestinationBehavior::NoReplace,
             commit_id: Some(CommitId::parse("runtime-put").expect("valid commit id")),
+            message: None,
         },
     )
     .await
@@ -1986,6 +1987,7 @@ async fn write_file_bytes(
         PutFileOptions {
             behavior: DestinationBehavior::Replace,
             commit_id: Some(CommitId::parse(commit_id).expect("valid test commit id")),
+            message: None,
         },
     )
     .await
@@ -2004,6 +2006,7 @@ async fn delete_path_recursive(
         DeleteOptions {
             behavior: DeleteDirectoryBehavior::Recursive,
             commit_id: Some(CommitId::parse(commit_id).expect("valid test commit id")),
+            message: None,
             expected_inode_id: None,
         },
     )

--- a/crates/loonfs-server/tests/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/direct_put_real_provider.rs
@@ -122,6 +122,7 @@ async fn direct_put_round_trip(config: ServerConfig) {
         namespace,
         &FilesystemOperationRequest {
             commit_id: CommitId::parse("direct-put-e2e").expect("valid commit id"),
+            message: None,
             content_tokens: vec![ValidatedContentToken {
                 content_ref: content_ref.clone(),
                 token: validated_content_token,

--- a/crates/loonfs-server/tests/http_auth.rs
+++ b/crates/loonfs-server/tests/http_auth.rs
@@ -121,6 +121,7 @@ async fn path_put_with_bad_content_token_fails_content_not_prepared() {
 
     let request = FilesystemOperationRequest {
         commit_id: CommitId::parse("bad-token-put").expect("valid commit id"),
+        message: None,
         content_tokens: vec![ValidatedContentToken {
             content_ref: completed.content_ref.clone(),
             token: "not.a.valid.token".to_owned(),
@@ -159,6 +160,7 @@ async fn path_put_without_content_token_fails_content_not_prepared() {
     let completed = stage_uploaded_content(&harness.client, &namespace, b"token missing").await;
     let request = FilesystemOperationRequest {
         commit_id: CommitId::parse("missing-token-put").expect("valid commit id"),
+        message: None,
         content_tokens: Vec::new(),
         operation: FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/missing-token.txt").expect("path"),
@@ -196,6 +198,7 @@ async fn path_put_with_valid_content_token_succeeds() {
     let completed = stage_uploaded_content(&harness.client, &namespace, bytes).await;
     let request = FilesystemOperationRequest {
         commit_id: CommitId::parse("valid-token-put").expect("valid commit id"),
+        message: None,
         content_tokens: vec![ValidatedContentToken {
             content_ref: completed.content_ref.clone(),
             token: completed
@@ -247,6 +250,7 @@ async fn landed_path_put_replays_after_content_token_is_absent_expired_or_garbag
     let content_ref = completed.content_ref.clone();
     let mut request = FilesystemOperationRequest {
         commit_id: CommitId::parse("token-replay-put").expect("valid commit id"),
+        message: None,
         content_tokens: vec![ValidatedContentToken {
             content_ref: completed.content_ref.clone(),
             token: completed
@@ -307,6 +311,7 @@ async fn path_put_with_only_an_irrelevant_token_reports_the_missing_put_proof() 
         stage_uploaded_content(&harness.client, &namespace, b"irrelevant content").await;
     let request = FilesystemOperationRequest {
         commit_id: CommitId::parse("irrelevant-token-put").expect("valid commit id"),
+        message: None,
         content_tokens: vec![ValidatedContentToken {
             content_ref: irrelevant.content_ref,
             token: irrelevant

--- a/crates/loonfs-server/tests/http_retry.rs
+++ b/crates/loonfs-server/tests/http_retry.rs
@@ -121,6 +121,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
             &PutFileOptions {
                 behavior: DestinationBehavior::NoReplace,
                 commit_id: Some(commit_id.clone()),
+                message: None,
             },
         )
         .await
@@ -135,6 +136,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
             &PutFileOptions {
                 behavior: DestinationBehavior::NoReplace,
                 commit_id: Some(commit_id.clone()),
+                message: None,
             },
         )
         .await
@@ -158,6 +160,7 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
             &PutFileOptions {
                 behavior: DestinationBehavior::NoReplace,
                 commit_id: Some(commit_id),
+                message: None,
             },
         )
         .await
@@ -202,6 +205,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
             DestinationBehavior::NoReplace,
             &MutationOptions {
                 commit_id: Some(CommitId::parse("req-v1-copy").expect("valid commit id")),
+                message: None,
             },
         )
         .await
@@ -214,6 +218,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
             DestinationBehavior::NoReplace,
             &MutationOptions {
                 commit_id: Some(CommitId::parse("req-v1-copy").expect("valid commit id")),
+                message: None,
             },
         )
         .await
@@ -241,6 +246,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
             DestinationBehavior::NoReplace,
             &MutationOptions {
                 commit_id: Some(CommitId::parse("req-v1-move").expect("valid commit id")),
+                message: None,
             },
         )
         .await
@@ -253,6 +259,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
             DestinationBehavior::NoReplace,
             &MutationOptions {
                 commit_id: Some(CommitId::parse("req-v1-move").expect("valid commit id")),
+                message: None,
             },
         )
         .await
@@ -271,6 +278,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
             &moved,
             &DeleteOptions {
                 commit_id: Some(CommitId::parse("req-v1-delete").expect("valid commit id")),
+                message: None,
                 ..DeleteOptions::default()
             },
         )
@@ -282,6 +290,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
             &moved,
             &DeleteOptions {
                 commit_id: Some(CommitId::parse("req-v1-delete").expect("valid commit id")),
+                message: None,
                 ..DeleteOptions::default()
             },
         )

--- a/crates/loonfs-server/tests/http_smoke.rs
+++ b/crates/loonfs-server/tests/http_smoke.rs
@@ -189,6 +189,7 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
             &PutFileOptions {
                 behavior: DestinationBehavior::Replace,
                 commit_id: Some(CommitId::parse("smoke-write-1").expect("valid commit id")),
+                message: None,
             },
         )
         .await

--- a/crates/loonfs/examples/embedded_local_fs.rs
+++ b/crates/loonfs/examples/embedded_local_fs.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             PutFileOptions {
                 behavior: DestinationBehavior::Replace,
                 commit_id: None,
+                message: None,
             },
         )
         .await?;

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -120,6 +120,7 @@ impl FsWriter {
             NamespaceMutationCandidate::path_prepared(
                 PathMutationIntent::PutFile {
                     commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                    message: options.message.clone(),
                     absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     content_ref,
                     behavior: options.behavior,
@@ -259,6 +260,7 @@ impl FsWriter {
             namespace_id,
             PathMutationIntent::CreateDir {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                message: options.message.clone(),
                 absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                 parents: options.parents,
             },
@@ -282,6 +284,7 @@ impl FsWriter {
             namespace_id,
             PathMutationIntent::DeletePath {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                message: options.message.clone(),
                 absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                 behavior: options.behavior,
                 expected_inode_id: options.expected_inode_id,
@@ -302,6 +305,7 @@ impl FsWriter {
             namespace_id,
             PathMutationIntent::MovePath {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                message: options.message.clone(),
                 from_path: loonfs_core::path::parse_mutation_path(from_path)?,
                 to_path: loonfs_core::path::parse_mutation_path(to_path)?,
                 behavior: options.behavior,
@@ -323,6 +327,7 @@ impl FsWriter {
             namespace_id,
             PathMutationIntent::CopyFilePath {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                message: options.message.clone(),
                 from_path: loonfs_core::path::parse_mutation_path(from_path)?,
                 to_path: loonfs_core::path::parse_mutation_path(to_path)?,
                 behavior: options.behavior,
@@ -343,6 +348,7 @@ impl FsWriter {
             namespace_id,
             PathMutationIntent::RestoreRevision {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                message: options.message.clone(),
                 absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                 source_revision_no,
             },
@@ -365,6 +371,7 @@ impl FsWriter {
             namespace_id,
             PathMutationIntent::Undelete {
                 commit_id: options.commit_id.unwrap_or_else(CommitId::generate),
+                message: options.message.clone(),
                 inode_id,
                 deleted_at_seq,
                 absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
@@ -399,7 +406,7 @@ impl FsWriter {
                 source_revision_no,
                 base_revision_no,
             }],
-            message: None,
+            message: options.message.clone(),
         };
         self.commit_operations(namespace_id, request).await
     }

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -115,6 +115,8 @@ pub struct PutFileOptions {
     pub behavior: DestinationBehavior,
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
 }
 
 impl Default for PutFileOptions {
@@ -122,6 +124,7 @@ impl Default for PutFileOptions {
         Self {
             behavior: DestinationBehavior::NoReplace,
             commit_id: None,
+            message: None,
         }
     }
 }
@@ -131,6 +134,8 @@ impl Default for PutFileOptions {
 pub struct CreateDirectoryOptions {
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
     /// Also create missing ancestor directories, like `put_file` does.
     pub parents: bool,
 }
@@ -142,6 +147,8 @@ pub struct DeleteOptions {
     pub behavior: DeleteDirectoryBehavior,
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
     /// When set, the delete applies only while the path still resolves to
     /// this inode, so a raced rebinding fails instead of deleting the
     /// wrong inode.
@@ -153,6 +160,7 @@ impl Default for DeleteOptions {
         Self {
             behavior: DeleteDirectoryBehavior::NonRecursive,
             commit_id: None,
+            message: None,
             expected_inode_id: None,
         }
     }
@@ -165,6 +173,8 @@ pub struct MoveOptions {
     pub behavior: DestinationBehavior,
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
 }
 
 /// Options for copying a file path.
@@ -174,6 +184,8 @@ pub struct CopyOptions {
     pub behavior: DestinationBehavior,
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
 }
 
 /// Options for restoring a file revision by path.
@@ -181,6 +193,8 @@ pub struct CopyOptions {
 pub struct RestoreRevisionOptions {
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
 }
 
 /// Options for recovering a deleted file or subtree.
@@ -188,6 +202,8 @@ pub struct RestoreRevisionOptions {
 pub struct UndeleteOptions {
     /// Optional idempotency key.
     pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
 }
 
 /// Options for reading the change feed.

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -331,6 +331,7 @@ fn publisher_trace_labels_are_low_cardinality() {
     ));
     let path = NamespaceMutationCandidate::path(PathMutationIntent::CreateDir {
         commit_id: CommitId::parse("path-trace").expect("valid commit id"),
+        message: None,
         absolute_path: AbsolutePath::parse("/private/path").expect("path"),
         parents: false,
     });
@@ -364,6 +365,7 @@ async fn rejected_duplicate_joins_ready_in_flight_primary() {
     let publisher = registry.publisher_for(&namespace_id).expect("publisher");
     let intent = PathMutationIntent::CreateDir {
         commit_id: CommitId::parse("ready-primary").expect("valid commit id"),
+        message: None,
         absolute_path: AbsolutePath::parse("/ready-primary").expect("path"),
         parents: false,
     };
@@ -403,6 +405,7 @@ async fn ready_duplicate_joins_rejected_in_flight_primary() {
     let publisher = registry.publisher_for(&namespace_id).expect("publisher");
     let intent = PathMutationIntent::CreateDir {
         commit_id: CommitId::parse("rejected-primary").expect("valid commit id"),
+        message: None,
         absolute_path: AbsolutePath::parse("/rejected-primary").expect("path"),
         parents: false,
     };
@@ -974,6 +977,7 @@ async fn publisher_batches_explicit_commit_and_path_intent_together() {
     };
     let path_intent = PathMutationIntent::PutFile {
         commit_id: CommitId::parse("path-put").expect("valid commit id"),
+        message: None,
         absolute_path: AbsolutePath::parse("/file.txt").expect("path"),
         content_ref: prepared_content.content_ref().clone(),
         behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs/tests/cold_stat_requests.rs
+++ b/crates/loonfs/tests/cold_stat_requests.rs
@@ -78,6 +78,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
             candidates.push(loonfs::publish::NamespaceMutationCandidate::path_prepared(
                 loonfs::publish::PathMutationIntent::PutFile {
                     commit_id: loonfs::CommitId::generate(),
+                    message: None,
                     absolute_path: AbsolutePath::parse(format!(
                         "/tree/dir-000000/file-{index:09}.txt"
                     ))

--- a/crates/loonfs/tests/content_request_accounting.rs
+++ b/crates/loonfs/tests/content_request_accounting.rs
@@ -206,6 +206,7 @@ async fn prepare_content(
 fn put_intent(commit_id: &str, path: &str, content_ref: loonfs::ContentRef) -> PathMutationIntent {
     PathMutationIntent::PutFile {
         commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+        message: None,
         absolute_path: parse_mutation_path(path).expect("valid mutation path"),
         content_ref,
         behavior: DestinationBehavior::NoReplace,
@@ -792,6 +793,7 @@ async fn explicit_restore_revision_uses_retained_metadata_without_content_io() {
             PutFileOptions {
                 behavior: DestinationBehavior::Replace,
                 commit_id: None,
+                message: None,
             },
         )
         .await
@@ -920,6 +922,7 @@ async fn new_rejected_preparation_fails_before_path_planning_without_content_ope
     harness.recording.reset();
     let intent = PathMutationIntent::CreateDir {
         commit_id: CommitId::parse("new-rejected").expect("valid commit id"),
+        message: None,
         absolute_path: parse_mutation_path("/missing/child").expect("valid mutation path"),
         parents: false,
     };
@@ -1093,6 +1096,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
                     namespace_id,
                     PathMutationIntent::CreateDir {
                         commit_id: CommitId::parse("mixed-blocker").expect("valid commit id"),
+                        message: None,
                         absolute_path: parse_mutation_path("/hold").expect("valid mutation path"),
                         parents: false,
                     },

--- a/crates/loonfs/tests/direct_put.rs
+++ b/crates/loonfs/tests/direct_put.rs
@@ -234,6 +234,7 @@ fn put_file_bytes_gates_publish_on_its_own_content_write_without_probing() {
         PutFileOptions {
             behavior: DestinationBehavior::Replace,
             commit_id: None,
+            message: None,
         },
     )
     .expect("replace file bytes");
@@ -261,6 +262,7 @@ fn put_file_bytes_retries_a_transient_content_write_failure() {
         PutFileOptions {
             behavior: DestinationBehavior::NoReplace,
             commit_id: Some(CommitId::parse("overlap-put-retry").expect("valid commit id")),
+            message: None,
         },
     )
     .expect("immutable write retries the transient failure");
@@ -289,6 +291,7 @@ fn path_mutations_return_the_commit_id_they_committed_under() {
                 b"alpha",
                 PutFileOptions {
                     commit_id: Some(commit_id.clone()),
+                    message: None,
                     ..PutFileOptions::default()
                 },
             )
@@ -306,6 +309,7 @@ fn path_mutations_return_the_commit_id_they_committed_under() {
                 b"alpha",
                 PutFileOptions {
                     commit_id: Some(commit_id.clone()),
+                    message: None,
                     ..PutFileOptions::default()
                 },
             )
@@ -391,6 +395,7 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
                 (
                     PathMutationIntent::PutFile {
                         commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+                        message: None,
                         absolute_path: parse_mutation_path(path).expect("valid mutation path"),
                         content_ref,
                         behavior: DestinationBehavior::NoReplace,
@@ -562,6 +567,7 @@ fn begin_upload_validates_controls_without_replay_reads() {
         PutFileOptions {
             behavior: DestinationBehavior::Replace,
             commit_id: None,
+            message: None,
         },
     )
     .expect("replace file");

--- a/crates/loonfs/tests/grep_service_differential.rs
+++ b/crates/loonfs/tests/grep_service_differential.rs
@@ -129,6 +129,7 @@ async fn publish_same_content_files(
             NamespaceMutationCandidate::path_prepared(
                 PathMutationIntent::PutFile {
                     commit_id: CommitId::generate(),
+                    message: None,
                     absolute_path: AbsolutePath::parse(format!("/{prefix}-{index:04}.txt"))
                         .expect("batch path"),
                     content_ref: content_ref.clone(),
@@ -358,6 +359,7 @@ async fn planless_scan_deduplicates_an_inode_revised_across_materialization() {
             PutFileOptions {
                 behavior: DestinationBehavior::Replace,
                 commit_id: None,
+                message: None,
             },
         )
         .await

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -471,6 +471,7 @@ fn put_file_bytes_and_prepare_then_put_commit_equivalent_state() {
         let commit_id = CommitId::parse("equivalent-put").expect("valid commit id");
         let options = PutFileOptions {
             commit_id: Some(commit_id.clone()),
+            message: None,
             ..PutFileOptions::default()
         };
 

--- a/crates/loonfs/tests/pagination.rs
+++ b/crates/loonfs/tests/pagination.rs
@@ -94,6 +94,7 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
     let replace = PutFileOptions {
         behavior: DestinationBehavior::Replace,
         commit_id: None,
+        message: None,
     };
     fs.put_file_bytes_blocking(&namespace_id, "/doc.txt", b"v1", PutFileOptions::default())
         .expect("put v1");

--- a/crates/loonfs/tests/publication.rs
+++ b/crates/loonfs/tests/publication.rs
@@ -106,6 +106,7 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
         let namespace_id = namespace_id.clone();
         let intent = PathMutationIntent::PutFile {
             commit_id: CommitId::parse("parked-second").expect("valid commit id"),
+            message: None,
             absolute_path: parse_mutation_path("/b.txt").expect("mutation path"),
             content_ref: prepared_content_ref,
             behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs/tests/request_accounting.rs
+++ b/crates/loonfs/tests/request_accounting.rs
@@ -158,6 +158,7 @@ async fn warm_phase_request_accounting() {
             candidates.push(loonfs::publish::NamespaceMutationCandidate::path_prepared(
                 loonfs::publish::PathMutationIntent::PutFile {
                     commit_id: loonfs::CommitId::generate(),
+                    message: None,
                     absolute_path: AbsolutePath::parse(format!("/hot/file-{index:05}.txt"))
                         .expect("path"),
                     content_ref: content_ref.clone(),
@@ -251,6 +252,7 @@ async fn warm_phase_request_accounting() {
             PutFileOptions {
                 behavior: loonfs::DestinationBehavior::Replace,
                 commit_id: None,
+                message: None,
             },
         )
         .await
@@ -267,6 +269,7 @@ async fn warm_phase_request_accounting() {
             PutFileOptions {
                 behavior: loonfs::DestinationBehavior::Replace,
                 commit_id: None,
+                message: None,
             },
         )
         .await

--- a/crates/loonfs/tests/runtime_config.rs
+++ b/crates/loonfs/tests/runtime_config.rs
@@ -118,6 +118,7 @@ fn filesystem_operations_match_core_semantics() {
         PutFileOptions {
             behavior: DestinationBehavior::Replace,
             commit_id: None,
+            message: None,
         },
     )
     .expect("replace file");
@@ -209,6 +210,7 @@ fn forked_namespace_shares_content_then_diverges() {
         PutFileOptions {
             behavior: DestinationBehavior::Replace,
             commit_id: None,
+            message: None,
         },
     )
     .expect("replace clone file");

--- a/crates/loonfs/tests/undelete.rs
+++ b/crates/loonfs/tests/undelete.rs
@@ -45,6 +45,7 @@ fn delete_options_select_recursive_behavior() {
         DeleteOptions {
             behavior: loonfs::DeleteDirectoryBehavior::Recursive,
             commit_id: None,
+            message: None,
             expected_inode_id: None,
         },
     )
@@ -79,6 +80,7 @@ fn undelete_recovers_a_deleted_file_and_generations_stay_scoped() {
         PutFileOptions {
             behavior: DestinationBehavior::Replace,
             commit_id: None,
+            message: None,
         },
     )
     .expect("put revision two");
@@ -215,6 +217,7 @@ fn undelete_recovers_a_deleted_subtree_and_rejects_covered_children() {
             DeleteOptions {
                 behavior: loonfs::DeleteDirectoryBehavior::Recursive,
                 commit_id: None,
+                message: None,
                 expected_inode_id: None,
             },
         )
@@ -292,6 +295,7 @@ fn undelete_of_an_ancestor_keeps_independently_deleted_children_hidden() {
             DeleteOptions {
                 behavior: loonfs::DeleteDirectoryBehavior::Recursive,
                 commit_id: None,
+                message: None,
                 expected_inode_id: None,
             },
         )
@@ -655,6 +659,7 @@ fn delete_with_expected_inode_refuses_a_raced_rebinding() {
             DeleteOptions {
                 behavior: loonfs::DeleteDirectoryBehavior::NonRecursive,
                 commit_id: None,
+                message: None,
                 expected_inode_id: Some(InodeId(inode_id.0 + 1)),
             },
         )
@@ -677,6 +682,7 @@ fn delete_with_expected_inode_refuses_a_raced_rebinding() {
         DeleteOptions {
             behavior: loonfs::DeleteDirectoryBehavior::NonRecursive,
             commit_id: None,
+            message: None,
             expected_inode_id: Some(inode_id),
         },
     )

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -987,7 +987,9 @@ logical commit must fingerprint identically no matter who retries it or when.
 
 Path-level mutations fingerprint the same way with domain
 `loonfs.path.intent.semantic.v0` over the canonical path intent (intent kind,
-canonical absolute paths, and the intent's semantic parameters).
+canonical absolute paths, the intent's semantic parameters, and the caller
+message — `null` when absent, mirroring explicit commits, so reusing a
+`commit_id` with a different message conflicts on either surface).
 
 The idempotency horizon is the retention floor. Commit receipts below the
 floor are dropped when metadata runs are rebuilt, so a commit retried from

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4251,6 +4251,13 @@
             },
             "description": "Proofs for any new external content refs introduced by this operation."
           },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Caller annotation recorded on the commit and reported by the change\nfeed. Part of the operation's identity: reusing `commit_id` with a\ndifferent message is a `commit_id_reuse_conflict`, exactly as it is\nfor an explicit commit."
+          },
           "operation": {
             "$ref": "#/components/schemas/FilesystemOperation",
             "description": "Operation to apply."


### PR DESCRIPTION
The commit envelope had a message field, the change feed printed a MESSAGE column, and no CLI command could populate it — every feed row read "-", and a restore was indistinguishable from an edit in the history. The field existed only on the explicit-commit surface; the path-operation surface (what put/rm/mv/cp/mkdir/restore/undelete actually use) had no slot for it anywhere between the wire request and the planners.