### PR TITLE
feat(cli): human output shows dates, writers, and delta names

### DIFF
--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -37,6 +37,67 @@ fn gc_summary(report: &GcResponse) -> String {
     summary
 }
 
+/// Renders Unix milliseconds as `YYYY-MM-DD HH:MM:SSZ`. Hand-rolled
+/// civil-from-days arithmetic (Howard Hinnant's algorithm), matching the
+/// presign signer's approach, so the CLI takes no date dependency.
+fn format_utc_ms(unix_ms: u64) -> String {
+    let seconds = unix_ms / 1_000;
+    let days = i64::try_from(seconds / 86_400).unwrap_or(0);
+    let second_of_day = seconds % 86_400;
+    let (hh, mm, ss) = (
+        second_of_day / 3_600,
+        (second_of_day % 3_600) / 60,
+        second_of_day % 60,
+    );
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { year + 1 } else { year };
+    format!("{year:04}-{month:02}-{day:02} {hh:02}:{mm:02}:{ss:02}Z")
+}
+
+/// Compact human descriptor for one feed delta, now that deltas carry the
+/// names a person typed.
+fn delta_descriptor(delta: &loonfs_api::v0::CommitDelta) -> String {
+    use loonfs_api::v0::CommitDelta;
+    match delta {
+        CommitDelta::CreateInode { inode_id, .. } => format!("inode {inode_id}"),
+        CommitDelta::BindDirentry { display_name, .. } => format!("bind '{display_name}'"),
+        CommitDelta::UnbindDirentry { display_name, .. } => {
+            format!("unbind '{display_name}'")
+        }
+        CommitDelta::AppendFileRevision { revision_no, .. } => {
+            format!("revision #{}", revision_no.0)
+        }
+        CommitDelta::TombstoneSubtree { root_inode_id, .. } => {
+            format!("delete inode {root_inode_id}")
+        }
+        CommitDelta::RevokeSubtreeTombstone {
+            root_inode_id,
+            target_seq,
+            ..
+        } => format!("undelete inode {root_inode_id}@{}", target_seq.0),
+    }
+}
+
+fn delta_summary(deltas: &[loonfs_api::v0::CommitDelta]) -> String {
+    const SHOWN: usize = 3;
+    if deltas.is_empty() {
+        return "-".to_owned();
+    }
+    let mut shown: Vec<String> = deltas.iter().take(SHOWN).map(delta_descriptor).collect();
+    if deltas.len() > SHOWN {
+        shown.push(format!("+{} more", deltas.len() - SHOWN));
+    }
+    shown.join("; ")
+}
+
 const FORMAT_VERSION: u32 = 1;
 
 #[derive(Debug, Serialize)]
@@ -281,14 +342,15 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                     "changes for {} after seq {} (through seq {})",
                     response.namespace_id, response.after_seq.0, response.through_seq.0
                 ),
-                "SEQ\tCOMMIT_ID\tDELTAS\tMESSAGE".to_owned(),
+                "SEQ\tDATE\tWRITER\tDELTAS\tMESSAGE".to_owned(),
             ];
             for change in &response.changes {
                 lines.push(format!(
-                    "{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}",
                     change.seq.0,
-                    change.commit_id,
-                    change.deltas.len(),
+                    format_utc_ms(change.committed_at_ms),
+                    change.writer_id,
+                    delta_summary(&change.deltas),
                     change.message.as_deref().unwrap_or("-")
                 ));
             }
@@ -368,6 +430,9 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             if let Some(revision) = entry.revision_no {
                 lines.push(format!("revision: {}", revision.0));
             }
+            if let Some(committed_at_ms) = entry.committed_at_ms {
+                lines.push(format!("modified: {}", format_utc_ms(committed_at_ms)));
+            }
             if let Some(content_ref) = &entry.content_ref {
                 lines.push(format!("content_ref: {}", content_ref.digest));
                 lines.push(format!("content_kind: {}", content_ref.kind));
@@ -381,12 +446,13 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         } => {
             let mut lines = vec![
                 format!("revisions for {target}"),
-                "REVISION\tSEQ\tSIZE\tDIGEST".to_owned(),
+                "REVISION\tDATE\tSEQ\tSIZE\tDIGEST".to_owned(),
             ];
             for revision in revisions {
                 lines.push(format!(
-                    "{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}",
                     revision.revision_no.0,
+                    format_utc_ms(revision.committed_at_ms),
                     revision.committed_seq.0,
                     revision.content_ref.size_bytes,
                     revision.content_ref.digest

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -352,6 +352,53 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
 }
 
 #[test]
+fn human_output_shows_dates_writers_and_delta_names() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("doc.txt");
+    fs::write(&payload, b"v1").expect("write payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/docs/Report.PDF",
+    ]));
+    assert_success(&harness.run(&["rm", "/docs/Report.PDF"]));
+
+    let changes = harness.run(&["changes"]);
+    assert_success(&changes);
+    let feed = stdout_string(&changes);
+    assert!(
+        feed.contains("SEQ\tDATE\tWRITER\tDELTAS\tMESSAGE"),
+        "{feed}"
+    );
+    assert!(feed.contains("bind 'Report.PDF'"), "{feed}");
+    assert!(feed.contains("unbind 'Report.PDF'"), "{feed}");
+    // Dates render as UTC wall-clock, not raw milliseconds.
+    assert!(feed.contains("Z\t"), "{feed}");
+
+    fs::write(&payload, b"v2").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/doc.txt"]));
+    let revisions = harness.run(&["revisions", "/doc.txt"]);
+    assert_success(&revisions);
+    let table = stdout_string(&revisions);
+    assert!(
+        table.contains("REVISION\tDATE\tSEQ\tSIZE\tDIGEST"),
+        "{table}"
+    );
+
+    let stat_file = harness.run(&["stat", "/doc.txt"]);
+    assert_success(&stat_file);
+    assert!(
+        stdout_string(&stat_file).contains("modified: "),
+        "{}",
+        stdout_string(&stat_file)
+    );
+}
+
+#[test]
 fn recursive_transfers_roundtrip_a_tree() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");


### PR DESCRIPTION
stat gains a modified line, revisions gains a DATE column, and the change feed table becomes SEQ / DATE / WRITER / DELTAS / MESSAGE, where DELTAS now renders compact descriptors from the names deltas carry since #405 — bind 'Report.PDF', unbind 'Report.PDF', revision #3, delete inode 7, undelete inode 7@9 — truncated past three with a +N more tail. Timestamps render as UTC wall-clock via the same hand-rolled civil-from-days arithmetic the presign signer uses, so the CLI takes no date dependency. JSON output is unchanged — it always carried the raw fields.