### PR TITLE
feat(core): tighten naming rules and allow case-only renames

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -96,7 +96,10 @@ pub use pagination::{
     PaginationPolicyError, TrashPageCursor, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT,
     PAGE_CURSOR_VERSION,
 };
-pub use path::{AbsolutePath, DisplayName, PathComponent, PathError, MAX_DISPLAY_NAME_BYTES};
+pub use path::{
+    AbsolutePath, DisplayName, PathComponent, PathError, MAX_DISPLAY_NAME_BYTES, MAX_PATH_BYTES,
+    MAX_PATH_DEPTH,
+};
 
 // Curated root re-exports of the common v0 HTTP surface. v0 HTTP shapes live
 // in `v0`; add here only what most consumers touch.

--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -36,6 +36,14 @@ string_id! {
 /// as given.
 pub const MAX_DISPLAY_NAME_BYTES: usize = 255;
 
+/// Largest canonical absolute path, in UTF-8 bytes. Bounded so every real
+/// filesystem, archive format, and sync client can materialize any stored
+/// tree; per-component limits alone allowed paths no target could hold.
+pub const MAX_PATH_BYTES: usize = 4_096;
+
+/// Deepest directory nesting one path may express.
+pub const MAX_PATH_DEPTH: usize = 128;
+
 /// Describes why caller-supplied path or display-name text is not admissible.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum PathError {
@@ -86,6 +94,26 @@ pub enum PathError {
     DisplayNameTooLong {
         /// UTF-8 byte length of the rejected display name.
         byte_length: usize,
+    },
+    /// Reports a path exceeding the total canonical byte bound.
+    #[error("path is {byte_length} bytes; the maximum is {MAX_PATH_BYTES} bytes")]
+    PathTooLong {
+        /// UTF-8 byte length of the rejected canonical path.
+        byte_length: usize,
+    },
+    /// Reports a path nested deeper than the depth bound.
+    #[error("path has {depth} components; the maximum is {MAX_PATH_DEPTH}")]
+    PathTooDeep {
+        /// Component count of the rejected path.
+        depth: usize,
+    },
+    /// Reports a display name no portable target filesystem can hold.
+    #[error("display name `{display_name}` {reason}")]
+    UnportableDisplayName {
+        /// The rejected spelling.
+        display_name: String,
+        /// Which portability rule it broke.
+        reason: &'static str,
     },
     /// Reports a valid display spelling whose canonical lookup key exceeds its durable bound.
     #[error(
@@ -140,6 +168,7 @@ impl AbsolutePath {
             validate_display_name(component)?;
             components.push(PathComponent(component.to_owned()));
         }
+        validate_path_bounds(value.len(), components.len())?;
 
         Ok(Self::from_components(components))
     }
@@ -325,6 +354,35 @@ fn validate_display_name(value: &str) -> Result<(), PathError> {
             byte_length: value.len(),
         });
     }
+    // Portability floor: names every target filesystem can hold. Windows
+    // cannot materialize trailing dots or spaces or its reserved device
+    // names, and an all-whitespace name is invisible in every listing.
+    // Rejecting here is free pre-release; loosening later is compatible,
+    // tightening later would strand stored names.
+    if value.chars().all(char::is_whitespace) {
+        return Err(PathError::UnportableDisplayName {
+            display_name: value.to_owned(),
+            reason: "is entirely whitespace",
+        });
+    }
+    if value.ends_with(' ') {
+        return Err(PathError::UnportableDisplayName {
+            display_name: value.to_owned(),
+            reason: "ends with a space, which Windows cannot store",
+        });
+    }
+    if value.ends_with('.') {
+        return Err(PathError::UnportableDisplayName {
+            display_name: value.to_owned(),
+            reason: "ends with a dot, which Windows cannot store",
+        });
+    }
+    if is_windows_reserved_device_name(value) {
+        return Err(PathError::UnportableDisplayName {
+            display_name: value.to_owned(),
+            reason: "is a Windows reserved device name",
+        });
+    }
     // Every stored name key is derived from an admitted display name, and
     // the derivation site treats an invalid derived key as an invariant
     // violation — so admission must guarantee the derived key stays within
@@ -341,6 +399,29 @@ fn validate_display_name(value: &str) -> Result<(), PathError> {
     Ok(())
 }
 
+fn validate_path_bounds(byte_length: usize, depth: usize) -> Result<(), PathError> {
+    if byte_length > MAX_PATH_BYTES {
+        return Err(PathError::PathTooLong { byte_length });
+    }
+    if depth > MAX_PATH_DEPTH {
+        return Err(PathError::PathTooDeep { depth });
+    }
+    Ok(())
+}
+
+/// Device names Windows reserves regardless of extension or letter case:
+/// a file called `CON`, `con.txt`, or `Com1.log` cannot exist there.
+fn is_windows_reserved_device_name(value: &str) -> bool {
+    let stem = value.split('.').next().unwrap_or(value);
+    let stem = stem.trim_end_matches(' ');
+    let upper = stem.to_ascii_uppercase();
+    matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || (upper.len() == 4
+            && (upper.starts_with("COM") || upper.starts_with("LPT"))
+            && upper[3..].chars().all(|digit| digit.is_ascii_digit())
+            && &upper[3..] != "0")
+}
+
 impl PathError {
     /// Returns rejected path text suitable for an API error, omitting hostile or oversized names.
     pub fn invalid_path_input(&self) -> &str {
@@ -352,12 +433,15 @@ impl PathError {
             Self::EmptyDisplayName => "",
             Self::DisplayNameContainsSeparator { display_name }
             | Self::ReservedDisplayName { display_name } => display_name,
+            Self::UnportableDisplayName { display_name, .. } => display_name,
             // Length and control failures do not carry the offending name:
             // an oversized or hostile name must not ride along in error
             // payloads that serialize onto the wire.
             Self::DisplayNameContainsControlCharacter { .. }
             | Self::DisplayNameTooLong { .. }
-            | Self::FoldedNameKeyTooLong { .. } => "",
+            | Self::FoldedNameKeyTooLong { .. }
+            | Self::PathTooLong { .. }
+            | Self::PathTooDeep { .. } => "",
         }
     }
 }
@@ -366,6 +450,53 @@ impl PathError {
 mod tests {
     use super::{AbsolutePath, DisplayName, PathError};
     use crate::{name_key_for_display_name, NameKey, NamePolicy};
+
+    #[test]
+    fn unportable_names_are_rejected() {
+        for name in [
+            "   ",
+            "report ",
+            "archive.",
+            "CON",
+            "con.txt",
+            "Com1.log",
+            "lpt9",
+            "aux.files.d",
+        ] {
+            assert!(
+                DisplayName::parse(name).is_err(),
+                "`{name}` should be rejected"
+            );
+        }
+        // Names that merely resemble the reserved set stay legal.
+        for name in ["CONSOLE", "com10", "lpt10.txt", ".hidden", "a.b"] {
+            assert!(
+                DisplayName::parse(name).is_ok(),
+                "`{name}` should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn paths_are_bounded_in_bytes_and_depth() {
+        let deep = format!("/{}", vec!["d"; super::MAX_PATH_DEPTH + 1].join("/"));
+        assert!(matches!(
+            AbsolutePath::parse(&deep),
+            Err(PathError::PathTooDeep { .. })
+        ));
+        let long_component = "a".repeat(200);
+        let mut long = String::new();
+        while long.len() <= super::MAX_PATH_BYTES {
+            long.push('/');
+            long.push_str(&long_component);
+        }
+        assert!(matches!(
+            AbsolutePath::parse(&long),
+            Err(PathError::PathTooLong { .. })
+        ));
+        let fine = format!("/{}", vec!["d"; super::MAX_PATH_DEPTH].join("/"));
+        assert!(AbsolutePath::parse(&fine).is_ok());
+    }
 
     #[test]
     fn absolute_path_root_is_valid() {

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -91,33 +91,58 @@ pub(crate) fn namespace_path(
 ) -> Result<NamespacePath, CliError> {
     Ok(NamespacePath::new(
         namespace_id.clone(),
-        normalize_user_path(path, allow_root)?,
+        parse_user_path(path, allow_root)?,
     ))
 }
 
-/// Normalizes human-entered CLI path arguments before the strict API parser.
-pub(crate) fn normalize_user_path(path: &str, allow_root: bool) -> Result<AbsolutePath, CliError> {
-    if path.is_empty() || !path.starts_with('/') {
-        return AbsolutePath::parse(path)
-            .map_err(|error| CliError::invalid_input(error.to_string()));
-    }
-    let components = path
-        .split('/')
-        .filter(|component| !component.is_empty())
-        .collect::<Vec<_>>();
-    let normalized = if components.is_empty() {
-        "/".to_owned()
+/// Whether a human-entered path spelled directory intent: one trailing
+/// slash after a non-root path. `put`, `cp`, and `mv` destinations read it
+/// as "into this directory"; everywhere else the slash is simply accepted.
+pub(crate) fn directory_intent(path: &str) -> bool {
+    path.len() > 1 && path.ends_with('/') && !path.ends_with("//")
+}
+
+/// Parses a human-entered CLI path with the wire's strictness, plus exactly
+/// one concession: a single trailing slash (directory intent) is accepted
+/// and dropped. Repeated separators, `.`/`..`, and relative spellings fail
+/// here exactly as the wire rejects them — the CLI never silently rewrites
+/// a path into something the caller did not type.
+pub(crate) fn parse_user_path(path: &str, allow_root: bool) -> Result<AbsolutePath, CliError> {
+    let trimmed = if directory_intent(path) {
+        &path[..path.len() - 1]
     } else {
-        format!("/{}", components.join("/"))
+        path
     };
-    let path = AbsolutePath::parse(normalized)
-        .map_err(|error| CliError::invalid_input(error.to_string()))?;
-    if !allow_root && path.is_root() {
+    let parsed =
+        AbsolutePath::parse(trimmed).map_err(|error| CliError::invalid_input(error.to_string()))?;
+    if !allow_root && parsed.is_root() {
         return Err(CliError::invalid_input(
             "root path is not allowed for this command",
         ));
     }
-    Ok(path)
+    Ok(parsed)
+}
+
+/// Resolves a mutation destination: with directory intent the source's leaf
+/// name lands inside the named directory; otherwise the path is the full
+/// destination.
+pub(crate) fn destination_user_path(
+    raw: &str,
+    source_leaf: &str,
+    allow_root_directory: bool,
+) -> Result<AbsolutePath, CliError> {
+    if directory_intent(raw) || raw == "/" {
+        let directory = parse_user_path(raw, true)?;
+        if !allow_root_directory && directory.is_root() && raw == "/" {
+            return Err(CliError::invalid_input(
+                "root path is not allowed for this command",
+            ));
+        }
+        let leaf = loonfs_api::DisplayName::parse(source_leaf)
+            .map_err(|error| CliError::invalid_input(error.to_string()))?;
+        return Ok(directory.join(&leaf));
+    }
+    parse_user_path(raw, false)
 }
 
 pub(crate) fn default_remote_put_path(local_path: &Path) -> Result<AbsolutePath, CliError> {
@@ -135,16 +160,25 @@ pub(crate) fn destination_path_for_get(
     remote_path: &str,
     explicit_destination: Option<&str>,
 ) -> Result<PathBuf, CliError> {
-    match explicit_destination {
-        Some(path) => Ok(PathBuf::from(path)),
-        None => {
-            let file_name = Path::new(remote_path).file_name().ok_or_else(|| {
+    let remote_leaf = || {
+        Path::new(remote_path)
+            .file_name()
+            .map(PathBuf::from)
+            .ok_or_else(|| {
                 CliError::invalid_input(format!(
                     "unable to derive local destination from `{remote_path}`"
                 ))
-            })?;
-            Ok(PathBuf::from(file_name))
+            })
+    };
+    match explicit_destination {
+        // The cp habit: a trailing separator or an existing directory means
+        // the file lands inside it under its remote name, never as a file
+        // named like the directory.
+        Some(path) if path.ends_with('/') || Path::new(path).is_dir() => {
+            Ok(Path::new(path).join(remote_leaf()?))
         }
+        Some(path) => Ok(PathBuf::from(path)),
+        None => remote_leaf(),
     }
 }
 
@@ -168,23 +202,41 @@ pub(crate) fn fail(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_user_path;
+    use super::{destination_user_path, parse_user_path};
 
     #[test]
-    fn user_paths_are_normalized_only_at_the_cli_boundary() {
+    fn user_paths_keep_wire_strictness_except_directory_intent() {
+        // One trailing slash is directory intent; everything else the wire
+        // rejects, the CLI rejects too, instead of silently rewriting.
         assert_eq!(
-            normalize_user_path("//docs///A.txt/", false)
-                .expect("human path")
+            parse_user_path("/docs/", false)
+                .expect("dir intent")
                 .as_str(),
-            "/docs/A.txt"
+            "/docs"
+        );
+        assert!(parse_user_path("//docs///A.txt/", false).is_err());
+        assert!(parse_user_path("//x.txt", false).is_err());
+        assert!(parse_user_path("docs/A.txt", false).is_err());
+        assert!(parse_user_path("", false).is_err());
+        assert_eq!(parse_user_path("/", true).expect("root").as_str(), "/");
+
+        assert_eq!(
+            destination_user_path("/docs/", "report.pdf", false)
+                .expect("into directory")
+                .as_str(),
+            "/docs/report.pdf"
         );
         assert_eq!(
-            normalize_user_path("///", true)
-                .expect("human root")
+            destination_user_path("/docs/renamed.pdf", "report.pdf", false)
+                .expect("full destination")
                 .as_str(),
-            "/"
+            "/docs/renamed.pdf"
         );
-        assert!(normalize_user_path("docs/A.txt", false).is_err());
-        assert!(normalize_user_path("", false).is_err());
+        assert_eq!(
+            destination_user_path("/", "report.pdf", true)
+                .expect("into root")
+                .as_str(),
+            "/report.pdf"
+        );
     }
 }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -2,8 +2,8 @@
 //! and grep.
 
 use super::context::{
-    default_remote_put_path, destination_path_for_get, fail, namespace_path, normalize_user_path,
-    render_target, resolve_command_context,
+    default_remote_put_path, destination_path_for_get, destination_user_path, fail, namespace_path,
+    parse_user_path, render_target, resolve_command_context,
 };
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use super::recursive;
@@ -118,7 +118,7 @@ pub(crate) async fn run_filesystem_grep(
     let path_prefix = args
         .path_prefix
         .as_deref()
-        .map(|path| normalize_user_path(path, true))
+        .map(|path| parse_user_path(path, true))
         .transpose()
         .map_err(|error| context.fail(kind, error))?;
     let mut request = loonfs_api::GrepRequest {
@@ -402,7 +402,7 @@ pub(crate) async fn run_filesystem_put(
             ));
         }
         let remote_root = match args.remote_path {
-            Some(path) => normalize_user_path(&path, true),
+            Some(path) => parse_user_path(&path, true),
             None => default_remote_put_path(&local_path),
         }
         .map_err(|error| context.fail(kind, error))?;
@@ -427,8 +427,22 @@ pub(crate) async fn run_filesystem_put(
         ));
     }
 
+    let local_leaf = local_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .ok_or_else(|| {
+            context.fail(
+                kind,
+                CliError::invalid_input(format!(
+                    "unable to derive remote target from `{}`",
+                    local_path.display()
+                )),
+            )
+        })?;
     let remote_path = match args.remote_path {
-        Some(path) => normalize_user_path(&path, false),
+        // A trailing slash names the directory the file lands in — the
+        // cp/rsync habit — while a plain path is the full destination.
+        Some(path) => destination_user_path(&path, &local_leaf, true),
         None => default_remote_put_path(&local_path),
     }
     .map_err(|error| context.fail(kind, error))?;
@@ -666,7 +680,18 @@ async fn run_filesystem_transfer(
     let allow_root = false;
     let from = namespace_path(&context.namespace, &args.source_path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
-    let to = namespace_path(&context.namespace, &args.destination_path, allow_root)
+    let source_leaf = from
+        .absolute_path()
+        .final_component()
+        .map(|component| component.as_str().to_owned())
+        .ok_or_else(|| {
+            context.fail(
+                kind,
+                CliError::invalid_input("root path is not allowed for this command"),
+            )
+        })?;
+    let to = destination_user_path(&args.destination_path, &source_leaf, true)
+        .map(|path| NamespacePath::new(context.namespace.clone(), path))
         .map_err(|error| context.fail(kind, error))?;
 
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -471,6 +471,53 @@ fn human_output_shows_dates_writers_and_delta_names() {
 }
 
 #[test]
+fn naming_strictness_and_directory_intent_hold_end_to_end() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("report.pdf");
+    fs::write(&payload, b"body").expect("write payload");
+
+    // A trailing slash means into-directory, never a file named like the
+    // directory; other noncanonical spellings fail like the wire.
+    assert_success(&harness.run(&["mkdir", "/docs"]));
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/docs/"]));
+    assert_success(&harness.run(&["--json", "stat", "/docs/report.pdf"]));
+    let double_slash = harness.run(&["put", payload.to_str().expect("utf-8 path"), "//x.txt"]);
+    assert_failure(&double_slash);
+
+    // Case-only rename works in place — including without --force — and a
+    // no-op respelling stays a conflict.
+    assert_success(&harness.run(&["--json", "mv", "/docs/report.pdf", "/docs/REPORT.PDF"]));
+    let stat = harness.run(&["--json", "stat", "/docs/REPORT.PDF"]);
+    assert_success(&stat);
+    assert_eq!(json_data(&stat)["display_name"], "REPORT.PDF");
+    let noop = harness.run(&["--json", "mv", "/docs/REPORT.PDF", "/docs/REPORT.PDF"]);
+    assert_failure(&noop);
+    assert_eq!(json_error(&noop)["code"], "path_conflict");
+
+    // A normalization-equal collision names the stored spelling, so two
+    // visually identical names stop looking like the same one.
+    let collision = harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/docs/report.pdf",
+    ]);
+    assert_failure(&collision);
+    let message = stderr_string(&collision);
+    assert!(message.contains("stored as `REPORT.PDF`"), "{message}");
+    assert!(message.contains("case folding"), "{message}");
+
+    // The portability floor rejects what no target filesystem can hold.
+    for name in ["/docs/CON", "/docs/notes.", "/docs/draft "] {
+        let rejected = harness.run(&["put", payload.to_str().expect("utf-8 path"), name]);
+        assert_failure(&rejected);
+    }
+}
+
+#[test]
 fn recursive_transfers_roundtrip_a_tree() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -209,6 +209,7 @@ pub(super) async fn validate_metadata_preconditions<V: CommitValidationView>(
                 validate_rename_source(&metadata_state, *inode_id).await?;
                 let new_name_key = validate_rename_target_name_absent(
                     &metadata_state,
+                    *inode_id,
                     *new_parent_inode_id,
                     new_display_name,
                     name_policy,
@@ -524,11 +525,13 @@ async fn validate_replace_target_not_covered<V: CommitValidationView>(
 /// Requires `display_name` to be valid and unbound under `parent_inode_id`,
 /// which must be an existing directory; returns the derived name key. The
 /// error vocabulary (create vs rename) is supplied by the call site.
+#[allow(clippy::too_many_arguments)]
 async fn validate_name_absent<V: CommitValidationView>(
     metadata_state: &V,
     parent_inode_id: InodeId,
     display_name: &DisplayName,
     name_policy: NamePolicy,
+    rebinding_inode_id: Option<InodeId>,
     parent_missing: impl FnOnce() -> CommitValidationError,
     parent_not_directory: impl FnOnce(InodeKind) -> CommitValidationError,
     collision: impl FnOnce(NameKey, InodeId) -> CommitValidationError,
@@ -547,7 +550,11 @@ async fn validate_name_absent<V: CommitValidationView>(
         .visible_child(parent_inode_id, &name_key)
         .await?
     {
-        return Err(collision(name_key, existing.child_inode_id).into());
+        // A binding already held by the inode being rebound is the same
+        // directory slot getting a respelled display name, not a collision.
+        if rebinding_inode_id != Some(existing.child_inode_id) {
+            return Err(collision(name_key, existing.child_inode_id).into());
+        }
     }
 
     Ok(name_key)
@@ -564,6 +571,7 @@ async fn validate_child_name_absent<V: CommitValidationView>(
         parent_inode_id,
         display_name,
         name_policy,
+        None,
         || CommitValidationError::CreateParentMissing { parent_inode_id },
         |actual_kind| CommitValidationError::CreateParentNotDirectory {
             parent_inode_id,
@@ -580,6 +588,7 @@ async fn validate_child_name_absent<V: CommitValidationView>(
 
 async fn validate_rename_target_name_absent<V: CommitValidationView>(
     metadata_state: &V,
+    renaming_inode_id: InodeId,
     parent_inode_id: InodeId,
     display_name: &DisplayName,
     name_policy: NamePolicy,
@@ -589,6 +598,7 @@ async fn validate_rename_target_name_absent<V: CommitValidationView>(
         parent_inode_id,
         display_name,
         name_policy,
+        Some(renaming_inode_id),
         || CommitValidationError::RenameTargetParentMissing { parent_inode_id },
         |actual_kind| CommitValidationError::RenameTargetParentNotDirectory {
             parent_inode_id,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -95,8 +95,15 @@ pub enum CoreError {
     DirectoryNotEmpty(String),
     #[error("cannot mutate root path")]
     RootMutationForbidden,
-    #[error("destination already exists at `{0}`")]
-    DestinationExists(String),
+    #[error("{}", destination_exists_message(.path, .existing_display_name.as_deref()))]
+    DestinationExists {
+        path: String,
+        /// Stored spelling of the occupying entry, when the planner had it.
+        /// Rendered when it differs from what the caller typed, because
+        /// sibling names collide after NFC normalization and case folding
+        /// and the two spellings can look identical.
+        existing_display_name: Option<String>,
+    },
     #[error("commit id conflict for `{0}`")]
     CommitIdReuseConflict(String),
     #[error(transparent)]
@@ -388,7 +395,7 @@ impl CoreError {
             CoreError::RebootstrapRequired { .. } => ErrorCode::RebootstrapRequired,
             CoreError::ExpectedFile { .. }
             | CoreError::ExpectedDirectory { .. }
-            | CoreError::DestinationExists(_) => ErrorCode::PathConflict,
+            | CoreError::DestinationExists { .. } => ErrorCode::PathConflict,
             CoreError::DirectoryNotEmpty(_) => ErrorCode::DirectoryNotEmpty,
             CoreError::TombstoneConflict { .. } => ErrorCode::TombstoneConflict,
             CoreError::WriterFenced(_) => ErrorCode::WriterFenced,
@@ -449,6 +456,17 @@ pub struct WriterFence {
     pub active_writer: Option<String>,
     /// Session id recorded by the winning acquirer, when known.
     pub active_session_id: Option<String>,
+}
+
+fn destination_exists_message(path: &str, existing_display_name: Option<&str>) -> String {
+    let typed_leaf = path.rsplit('/').next().unwrap_or(path);
+    match existing_display_name {
+        Some(existing) if existing != typed_leaf => format!(
+            "destination already exists at `{path}` (stored as `{existing}`; sibling names \
+             collide after Unicode NFC normalization and case folding)"
+        ),
+        _ => format!("destination already exists at `{path}`"),
+    }
 }
 
 impl std::fmt::Display for WriterFence {

--- a/crates/loonfs-core/src/path/write/plan_create.rs
+++ b/crates/loonfs-core/src/path/write/plan_create.rs
@@ -30,10 +30,11 @@ pub(super) async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
         .resolve_visible_path(absolute_path)
         .await
     {
-        Ok(_) => {
-            return Err(CoreError::DestinationExists(
-                absolute_path.as_str().to_owned(),
-            ));
+        Ok(existing) => {
+            return Err(CoreError::DestinationExists {
+                path: absolute_path.as_str().to_owned(),
+                existing_display_name: Some(existing.display_name),
+            });
         }
         Err(error) if is_missing_visible_path(&error) => {}
         Err(error) => return Err(error),
@@ -92,10 +93,11 @@ pub(super) async fn plan_publish_undelete<S: ObjectStore + ?Sized>(
         .resolve_visible_path(absolute_path)
         .await
     {
-        Ok(_) => {
-            return Err(CoreError::DestinationExists(
-                absolute_path.as_str().to_owned(),
-            ));
+        Ok(existing) => {
+            return Err(CoreError::DestinationExists {
+                path: absolute_path.as_str().to_owned(),
+                existing_display_name: Some(existing.display_name),
+            });
         }
         Err(error) if is_missing_visible_path(&error) => {}
         Err(error) => return Err(error),
@@ -148,9 +150,10 @@ pub(super) async fn plan_publish_put_file_content_ref<S: ObjectStore + ?Sized>(
     match target {
         Ok(existing) => {
             if behavior == DestinationBehavior::NoReplace {
-                return Err(CoreError::DestinationExists(
-                    absolute_path.as_str().to_owned(),
-                ));
+                return Err(CoreError::DestinationExists {
+                    path: absolute_path.as_str().to_owned(),
+                    existing_display_name: Some(existing.display_name.clone()),
+                });
             }
             if existing.inode_kind != InodeKind::File {
                 return Err(CoreError::ExpectedFile {

--- a/crates/loonfs-core/src/path/write/plan_transfer.rs
+++ b/crates/loonfs-core/src/path/write/plan_transfer.rs
@@ -1,5 +1,6 @@
 //! Publish plans that move or copy visible paths.
 
+use super::planning_helpers::ReplaceDestination;
 use super::planning_helpers::{
     publish_binding_is_precondition, publish_child_name_absent_precondition,
     publish_reject_tombstoned_path_ancestor, publish_resolve_parent_directory,
@@ -40,7 +41,7 @@ pub(super) async fn plan_publish_move_path<S: ObjectStore + ?Sized>(
     let mut ops = Vec::new();
     let mut preconditions = vec![publish_binding_is_precondition(view, &source).await?];
     match &replaced {
-        Some(existing) => {
+        ReplaceDestination::Replaced(existing) => {
             ops.push(ApiCommitOp::DeleteFile {
                 inode_id: existing.inode_id,
             });
@@ -49,12 +50,26 @@ pub(super) async fn plan_publish_move_path<S: ObjectStore + ?Sized>(
                 inode_id: existing.inode_id,
             });
         }
-        None => {
+        ReplaceDestination::Vacant => {
             preconditions.push(publish_child_name_absent_precondition(
                 view,
                 target_parent,
                 &target_name,
             ));
+        }
+        // The destination is the source's own binding: a same-slot
+        // respelling (case-only rename, normalization-equal spelling). The
+        // name is legitimately present — bound to the source — so no
+        // absence precondition and nothing to delete; the rename alone
+        // rebinds the new spelling. An unchanged spelling stays a
+        // conflict: there is nothing to rename.
+        ReplaceDestination::SameInode => {
+            if target_name.as_str() == source.display_name {
+                return Err(CoreError::DestinationExists {
+                    path: to_path.as_str().to_owned(),
+                    existing_display_name: Some(source.display_name.clone()),
+                });
+            }
         }
     }
     ops.push(ApiCommitOp::Rename {
@@ -123,7 +138,16 @@ pub(super) async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
         },
     ];
     match &replaced {
-        Some(existing) => {
+        // Copying a file onto its own binding would delete the source to
+        // make room for its copy; that is a conflict, with or without
+        // `Replace` — the same-file rule every copy tool applies.
+        ReplaceDestination::SameInode => {
+            return Err(CoreError::DestinationExists {
+                path: to_path.as_str().to_owned(),
+                existing_display_name: Some(source.display_name.clone()),
+            })
+        }
+        ReplaceDestination::Replaced(existing) => {
             let existing_revision = view
                 .metadata_state
                 .latest_revision_head(existing.inode_id)
@@ -143,7 +167,7 @@ pub(super) async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
                 inode_id: existing.inode_id,
             });
         }
-        None => {
+        ReplaceDestination::Vacant => {
             ops.push(ApiCommitOp::CreateFile {
                 parent_inode_id: target_parent,
                 display_name: target_name.clone(),

--- a/crates/loonfs-core/src/path/write/planning_helpers.rs
+++ b/crates/loonfs-core/src/path/write/planning_helpers.rs
@@ -100,30 +100,46 @@ pub(super) async fn publish_reject_tombstoned_path_ancestor<S: ObjectStore + ?Si
     Ok(())
 }
 
+/// How the shared move/copy destination rule resolved.
+pub(super) enum ReplaceDestination {
+    /// Nothing visible occupies the destination.
+    Vacant,
+    /// A distinct file occupies it and `Replace` accepted it.
+    Replaced(ResolvedVisiblePath),
+    /// The destination resolves to the moving inode itself: a same-slot
+    /// respelling, such as a case-only rename, whose name key already
+    /// belongs to the source.
+    SameInode,
+}
+
 /// Resolves the shared move/copy destination rule: replacement accepts a
-/// distinct file and rejects every other visible destination.
+/// distinct file, a move may respell its own binding, and everything else
+/// visible at the destination is a conflict.
 pub(super) async fn publish_resolve_replace_destination<S: ObjectStore + ?Sized>(
     view: &PublishPathPlanningView<'_, '_, '_, S>,
     to_path: &AbsolutePath,
     behavior: DestinationBehavior,
     source_inode_id: InodeId,
-) -> Result<Option<ResolvedVisiblePath>> {
+) -> Result<ReplaceDestination> {
     Ok(
         match view.metadata_state.resolve_visible_path(to_path).await {
-            Ok(existing)
-                if behavior == DestinationBehavior::Replace
-                    && existing.inode_id != source_inode_id =>
-            {
+            Ok(existing) if existing.inode_id == source_inode_id => ReplaceDestination::SameInode,
+            Ok(existing) if behavior == DestinationBehavior::Replace => {
                 if existing.inode_kind != InodeKind::File {
                     return Err(CoreError::ExpectedFile {
                         path: to_path.as_str().to_owned(),
                         kind: existing.inode_kind,
                     });
                 }
-                Some(existing)
+                ReplaceDestination::Replaced(existing)
             }
-            Ok(_) => return Err(CoreError::DestinationExists(to_path.as_str().to_owned())),
-            Err(error) if is_missing_visible_path(&error) => None,
+            Ok(existing) => {
+                return Err(CoreError::DestinationExists {
+                    path: to_path.as_str().to_owned(),
+                    existing_display_name: Some(existing.display_name),
+                })
+            }
+            Err(error) if is_missing_visible_path(&error) => ReplaceDestination::Vacant,
             Err(error) => return Err(error),
         },
     )

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -285,7 +285,7 @@ mod tests {
         results[0].as_ref().expect("first create succeeds");
         let error = results[1].as_ref().expect_err("duplicate create rejected");
         assert_eq!(error.code(), ErrorCode::PathConflict);
-        assert!(matches!(error, CoreError::DestinationExists(_)));
+        assert!(matches!(error, CoreError::DestinationExists { .. }));
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/tests/path_intents.rs
+++ b/crates/loonfs-core/tests/path_intents.rs
@@ -1236,6 +1236,60 @@ async fn move_path_into_occupied_target_is_path_conflict() {
 }
 
 #[tokio::test]
+async fn move_path_respells_the_same_slot_without_a_conflict() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let context = mutation_context();
+    bootstrap_namespace(&store, &namespace_id("demo"), &context, false)
+        .await
+        .expect("bootstrap namespace");
+    write_file_bytes(
+        &store,
+        &namespace_id("demo"),
+        "/docs/report.pdf",
+        b"alpha",
+        &context,
+        Some("seed-respell"),
+    )
+    .await
+    .expect("seed respell");
+    let before = resolve_path_latest(&store, &namespace_id("demo"), "/docs/report.pdf")
+        .await
+        .expect("resolve before respell");
+
+    // Case-only rename: same name key under the same parent, new spelling.
+    move_path(
+        &store,
+        &namespace_id("demo"),
+        "/docs/report.pdf",
+        "/docs/REPORT.PDF",
+        &context,
+        Some("respell"),
+    )
+    .await
+    .expect("case-only respelling lands");
+
+    let after = resolve_path_latest(&store, &namespace_id("demo"), "/docs/report.pdf")
+        .await
+        .expect("resolve after respell");
+    assert_eq!(named_entry(&after), "REPORT.PDF");
+    assert_eq!(after.inode_id, before.inode_id);
+
+    // Repeating the identical spelling changes nothing and stays a conflict.
+    let error = move_path(
+        &store,
+        &namespace_id("demo"),
+        "/docs/REPORT.PDF",
+        "/docs/REPORT.PDF",
+        &context,
+        Some("respell-noop"),
+    )
+    .await
+    .expect_err("unchanged spelling");
+    assert_eq!(error.code(), ErrorCode::PathConflict);
+}
+
+#[tokio::test]
 async fn move_path_directory_cycle_is_would_cycle() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
@@ -1751,7 +1805,7 @@ async fn move_replace_atomically_replaces_a_file_destination() {
     )
     .await
     .expect_err("no-replace move onto an occupied name fails");
-    assert!(matches!(error, CoreError::DestinationExists(_)));
+    assert!(matches!(error, CoreError::DestinationExists { .. }));
 
     // Replace compiles to one commit: the destination file's delete and the
     // source's rebind land atomically.
@@ -1836,7 +1890,7 @@ async fn move_replace_rejects_directory_destinations_and_self_moves() {
     )
     .await
     .expect_err("replace move onto itself fails");
-    assert!(matches!(error, CoreError::DestinationExists(_)));
+    assert!(matches!(error, CoreError::DestinationExists { .. }));
 }
 
 #[tokio::test]

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -448,7 +448,12 @@ A path can change even when the underlying item has not.
 Display names are stored as given and validated at admission. A display name
 must be non-empty, must not contain `/` or any Unicode control character
 (general category `Cc`, which covers NUL, C0, and C1), must not be `.` or
-`..`, and must not exceed 255 UTF-8 bytes as stored. Name keys obey the same
+`..`, and must not exceed 255 UTF-8 bytes as stored. Names also satisfy a
+portability floor — the set every target filesystem can hold: a name must
+not be entirely whitespace, must not end with a space or a dot, and must not
+be a Windows reserved device name (`CON`, `PRN`, `AUX`, `NUL`, `COM1`-`COM9`,
+`LPT1`-`LPT9`, compared case-insensitively and ignoring any extension).
+Name keys obey the same
 character rules with a 768-byte cap: case folding expands at most threefold
 in bytes, so every key derivable from a valid display name is admissible.
 Requests carrying a name or key outside this grammar fail validation; nothing
@@ -457,7 +462,9 @@ is truncated or normalized on the caller's behalf.
 An absolute path has one canonical spelling: exactly one leading `/`, no empty
 components or repeated separators, and no trailing `/` except for the root
 path `/`. Wire decoders reject every noncanonical spelling rather than
-normalizing it.
+normalizing it. A canonical path is bounded at 4,096 UTF-8 bytes and 128
+components, so any stored tree can materialize on a real filesystem, in an
+archive, or through a sync client.
 
 #### 2.3.1 NamePolicy
 


### PR DESCRIPTION
- **Case-only renames work now.** `loon mv /docs/report.pdf /docs/REPORT.PDF` used to be impossible: the destination resolved to the source file itself and was rejected as a conflict. A move whose destination is the moving file's own binding is now a same-slot respelling — the planner skips the delete and the name-absent precondition, and commit validation exempts the binding held by the renaming inode. Re-issuing the identical spelling stays a conflict (there is nothing to rename), and copying a file onto itself stays a conflict with or without `--force`.
- **Collision errors explain the fold.** `destination already exists` now names the stored spelling when it differs from what was typed: ``destination already exists at `/docs/Report.PDF` (stored as `REPORT.PDF`; sibling names collide after Unicode NFC normalization and case folding)``. Before, the error looked wrong whenever the listing showed a different spelling than the one the user typed.
- **Paths are bounded.** Canonical paths are capped at 4,096 UTF-8 bytes and 128 components, checked at parse on every surface. Per-component limits alone allowed paths no real filesystem, archive format, or sync client could materialize.
- **Display names get a portability floor.** All-whitespace names, names ending in a space or a dot, and Windows reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1`-`COM9`, `LPT1`-`LPT9`, with any extension) are rejected at parse. These names cannot exist on the largest desktop platform, so accepting them just strands a future sync client.
- **The CLI understands directory intent.** One trailing slash on a destination means "into that directory": `loon put report.pdf /docs/` writes `/docs/report.pdf`, and the same works for `cp`, `mv`, and `get` destinations. `get` also treats an existing local directory as a directory destination, the way `cp` does — before, `loon get /docs/report.pdf .` tried to write a file named `.`. Everything else keeps wire strictness — `//x.txt` stays rejected.
