### PR TITLE
fix: repairable configs, sanitized provider errors, and scoped admin errors

### DIFF
--- a/crates/loonfs-cli/src/backend.rs
+++ b/crates/loonfs-cli/src/backend.rs
@@ -129,7 +129,7 @@ impl Backend for EmbeddedBackend {
             .writer
             .delete_namespace(namespace_id, options)
             .await
-            .map_err(map_runtime_error);
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error));
         self.settle_background_work_after(result).await
     }
 
@@ -142,7 +142,7 @@ impl Backend for EmbeddedBackend {
             .writer
             .fork_namespace(source_namespace_id, new_namespace_id)
             .await
-            .map_err(map_runtime_error);
+            .map_err(|error| map_namespace_scoped_runtime_error(source_namespace_id, error));
         self.settle_background_work_after(result).await
     }
 
@@ -392,8 +392,9 @@ impl Backend for EmbeddedBackend {
     }
 
     // The admin methods mirror the server handlers' error scoping exactly:
-    // checkpoint/retention map runtime errors unscoped, the change feed is
-    // namespace-scoped. Parity keeps embedded and remote outputs identical.
+    // every operation addressing an existing namespace names it when the
+    // runtime reports namespace_not_found. Parity keeps embedded and remote
+    // outputs identical.
 
     async fn create_checkpoint(
         &self,
@@ -403,7 +404,7 @@ impl Backend for EmbeddedBackend {
         self.admin
             .create_checkpoint(namespace_id, CreateCheckpointOptions::from_request(request))
             .await
-            .map_err(map_runtime_error)
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
     async fn release_checkpoint(
@@ -414,7 +415,7 @@ impl Backend for EmbeddedBackend {
         self.admin
             .release_checkpoint(namespace_id, checkpoint_id)
             .await
-            .map_err(map_runtime_error)
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
     async fn maintenance_step(
@@ -426,7 +427,7 @@ impl Backend for EmbeddedBackend {
         self.admin
             .maintenance_step_namespace(namespace_id, options)
             .await
-            .map_err(map_runtime_error)
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
     async fn repair_namespace(

--- a/crates/loonfs-cli/src/commands/config.rs
+++ b/crates/loonfs-cli/src/commands/config.rs
@@ -5,7 +5,8 @@ use super::output::{CommandData, CommandFailure, CommandOutput};
 use super::profile_config::{build_profile_from_create_spec, create_profile_spec_from_init};
 use crate::args::{CommandKind, ConfigCommand, InitArgs, RuntimeBehavior};
 use crate::config::{
-    default_config_path, load_config, load_or_default_config, save_config, ProfileConfig,
+    default_config_path, load_config_for_repair, load_or_default_config, redacted_config_table,
+    save_config, ConfigLoad, ProfileConfig,
 };
 use crate::error::CliError;
 use crate::profiles::add_profile;
@@ -67,15 +68,27 @@ pub(crate) fn run_config_command(
             },
         }),
         ConfigCommand::Show => {
-            let config =
-                load_config(&config_path).map_err(|error| fail(kind, None, None, error))?;
+            let loaded = load_config_for_repair(&config_path)
+                .map_err(|error| fail(kind, None, None, error))?;
+            let data = match loaded {
+                ConfigLoad::Valid(config) => CommandData::ConfigShow {
+                    config: config.redacted(),
+                },
+                // Show is a repair command: a config the strict decoder
+                // rejects still renders (secrets masked) with the failure on
+                // top, so the file can be inspected with the tool that reads
+                // it.
+                ConfigLoad::Degraded { table, error } => CommandData::ConfigShowDegraded {
+                    error: error.message,
+                    config_toml: toml::to_string_pretty(&redacted_config_table(&table))
+                        .unwrap_or_else(|_| "failed to render config".to_owned()),
+                },
+            };
             Ok(CommandOutput {
                 kind,
                 profile: None,
                 mode: None,
-                data: CommandData::ConfigShow {
-                    config: config.redacted(),
-                },
+                data,
             })
         }
     }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -294,7 +294,7 @@ pub(crate) async fn run_filesystem_get(
                 if !args.force && error.kind() == std::io::ErrorKind::AlreadyExists {
                     return context.fail(kind, CliError::destination_exists(&destination));
                 }
-                let mut error = CliError::io(error);
+                let mut error = CliError::io_for_path(&destination, error);
                 if derived_name {
                     error.message.push_str(
                         "; if the remote name exceeds local filesystem limits, pass an \
@@ -413,7 +413,8 @@ pub(crate) async fn run_filesystem_put(
     }
     .map_err(|error| context.fail(kind, error))?;
     let spec = NamespacePath::new(context.namespace.clone(), remote_path);
-    let bytes = fs::read(&local_path).map_err(|error| context.fail(kind, CliError::io(error)))?;
+    let bytes = fs::read(&local_path)
+        .map_err(|error| context.fail(kind, CliError::io_for_path(&local_path, error)))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
     let behavior = if args.force {

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -126,6 +126,12 @@ pub(crate) enum CommandData {
     ConfigShow {
         config: CliConfig,
     },
+    /// `config show` when the file no longer strict-decodes: the failure and
+    /// the file as parsed (secrets masked), so the user can see what to fix.
+    ConfigShowDegraded {
+        error: String,
+        config_toml: String,
+    },
     Version {
         version: String,
         /// Git commit the binary was built from ("unknown" without git).

--- a/crates/loonfs-cli/src/commands/profile.rs
+++ b/crates/loonfs-cli/src/commands/profile.rs
@@ -10,12 +10,13 @@ use crate::args::{
     CommandKind, ProfileCommand, ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavior,
 };
 use crate::config::{
-    default_config_path, load_config, load_config_if_exists, load_or_default_config, save_config,
-    ProfileConfig,
+    default_config_path, load_config, load_config_for_repair, load_config_if_exists,
+    load_or_default_config, save_config, save_config_table, ConfigLoad, ProfileConfig,
 };
 use crate::error::CliError;
 use crate::profiles::{
-    add_profile, delete_profile, list_profiles, make_default_profile, show_profile, update_profile,
+    add_profile, delete_profile, delete_profile_in_table, list_profiles, make_default_profile,
+    make_default_profile_in_table, show_profile, update_profile,
 };
 use crate::prompt;
 use std::path::Path;
@@ -144,17 +145,43 @@ fn run_profile_delete(
         }
     }
 
-    let mut config =
-        load_config(config_path).map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    let removed = delete_profile(&mut config, name)
+    // Delete is a repair command: it operates on the loose table when the
+    // strict decode fails, so the profile that broke the config can still be
+    // removed with the tool that manages it.
+    let loaded = load_config_for_repair(config_path)
         .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    let mode = removed.mode.clone();
-    save_config(config_path, &config)
-        .map_err(|error| fail(kind, Some(name.to_owned()), Some(mode.clone()), error))?;
+    let removed = match loaded {
+        ConfigLoad::Valid(mut config) => {
+            let removed = delete_profile(&mut config, name)
+                .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+            save_config(config_path, &config).map_err(|error| {
+                fail(
+                    kind,
+                    Some(name.to_owned()),
+                    Some(removed.mode.clone()),
+                    error,
+                )
+            })?;
+            removed
+        }
+        ConfigLoad::Degraded { mut table, .. } => {
+            let removed = delete_profile_in_table(&mut table, name)
+                .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+            save_config_table(config_path, &table).map_err(|error| {
+                fail(
+                    kind,
+                    Some(name.to_owned()),
+                    Some(removed.mode.clone()),
+                    error,
+                )
+            })?;
+            removed
+        }
+    };
     Ok(CommandOutput {
         kind,
         profile: Some(name.to_owned()),
-        mode: Some(mode),
+        mode: Some(removed.mode.clone()),
         data: CommandData::ProfileSummary(removed),
     })
 }
@@ -164,12 +191,24 @@ fn run_profile_use(
     config_path: &Path,
     name: &str,
 ) -> Result<CommandOutput, CommandFailure> {
-    let mut config =
-        load_config(config_path).map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    make_default_profile(&mut config, name)
+    // Use is a repair command like delete: switching the default away from a
+    // profile that broke the config must not require hand-editing the file.
+    let loaded = load_config_for_repair(config_path)
         .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
-    save_config(config_path, &config)
-        .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+    match loaded {
+        ConfigLoad::Valid(mut config) => {
+            make_default_profile(&mut config, name)
+                .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+            save_config(config_path, &config)
+                .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+        }
+        ConfigLoad::Degraded { mut table, .. } => {
+            make_default_profile_in_table(&mut table, name)
+                .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+            save_config_table(config_path, &table)
+                .map_err(|error| fail(kind, Some(name.to_owned()), None, error))?;
+        }
+    }
     Ok(CommandOutput {
         kind,
         profile: Some(name.to_owned()),

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -206,17 +206,85 @@ fn profile_field(name: &str, field: &str) -> String {
 }
 
 pub(crate) fn load_config(path: &Path) -> Result<CliConfig, CliError> {
+    let table = load_config_table(path)?;
+    decode_config_table(path, table)
+}
+
+/// A config load for the repair commands. When the strict decode rejects the
+/// file, they get the loose TOML table instead, so a typo in one profile
+/// never bricks the commands that would fix it.
+pub(crate) enum ConfigLoad {
+    Valid(CliConfig),
+    Degraded {
+        table: toml::Table,
+        /// The strict-decode failure, reported alongside the degraded output.
+        error: Box<CliError>,
+    },
+}
+
+pub(crate) fn load_config_for_repair(path: &Path) -> Result<ConfigLoad, CliError> {
+    let table = load_config_table(path)?;
+    match decode_config_table(path, table.clone()) {
+        Ok(config) => Ok(ConfigLoad::Valid(config)),
+        Err(error) => Ok(ConfigLoad::Degraded {
+            table,
+            error: Box::new(error),
+        }),
+    }
+}
+
+/// Stage one of loading: bytes to a loose TOML table, plus the version
+/// probe. Unknown fields and per-profile shape problems survive this stage;
+/// unreadable files, TOML syntax errors, and other config versions do not.
+fn load_config_table(path: &Path) -> Result<toml::Table, CliError> {
     let bytes = fs::read(path).map_err(|err| {
         if err.kind() == std::io::ErrorKind::NotFound {
             CliError::invalid_config(format!("config file does not exist: {}", path.display()))
         } else {
-            CliError::invalid_config(format!("failed to read config: {err}"))
+            CliError::invalid_config(format!("failed to read config {}: {err}", path.display()))
         }
     })?;
-    let contents = std::str::from_utf8(&bytes)
-        .map_err(|err| CliError::invalid_config(format!("failed to decode config: {err}")))?;
-    let config: CliConfig = toml::from_str(contents)
-        .map_err(|err| CliError::invalid_config(format!("failed to decode config: {err}")))?;
+    let contents = std::str::from_utf8(&bytes).map_err(|err| {
+        CliError::invalid_config(format!("failed to decode config {}: {err}", path.display()))
+    })?;
+    let table: toml::Table = toml::from_str(contents).map_err(|err| {
+        CliError::invalid_config(format!("failed to decode config {}: {err}", path.display()))
+    })?;
+    // Version before shape: a config written for another version should say
+    // so directly, not surface as unknown-field noise from the strict decode.
+    match table.get("config_version") {
+        None => {
+            return Err(CliError::invalid_config(format!(
+                "config {} is missing `config_version`",
+                path.display()
+            )));
+        }
+        Some(value) => match value.as_integer() {
+            Some(version) if version == i64::from(CONFIG_VERSION) => {}
+            Some(version) => {
+                return Err(CliError::invalid_config(format!(
+                    "config {} declares `config_version = {version}`; this build supports \
+                     `{CONFIG_VERSION}`",
+                    path.display()
+                )));
+            }
+            None => {
+                return Err(CliError::invalid_config(format!(
+                    "config {}: `config_version` must be an integer",
+                    path.display()
+                )));
+            }
+        },
+    }
+    Ok(table)
+}
+
+/// Stage two of loading: the strict typed decode (`deny_unknown_fields`)
+/// plus semantic validation.
+fn decode_config_table(path: &Path, table: toml::Table) -> Result<CliConfig, CliError> {
+    let config: CliConfig = toml::Value::Table(table).try_into().map_err(|err| {
+        CliError::invalid_config(format!("failed to decode config {}: {err}", path.display()))
+    })?;
     config.validate()?;
     Ok(config)
 }
@@ -234,6 +302,21 @@ pub(crate) fn load_or_default_config(path: &Path) -> Result<CliConfig, CliError>
 
 pub(crate) fn save_config(path: &Path, config: &CliConfig) -> Result<(), CliError> {
     config.validate()?;
+    let contents = toml::to_string_pretty(config)
+        .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
+    persist_config_contents(path, &contents)
+}
+
+/// Persists a loose config table as-is (atomic, owner-only), for the repair
+/// commands when the file no longer strict-decodes: round-tripping through
+/// [`CliConfig`] would drop the content the user still needs to fix.
+pub(crate) fn save_config_table(path: &Path, table: &toml::Table) -> Result<(), CliError> {
+    let contents = toml::to_string_pretty(table)
+        .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
+    persist_config_contents(path, &contents)
+}
+
+fn persist_config_contents(path: &Path, contents: &str) -> Result<(), CliError> {
     let parent = path.parent().ok_or_else(|| {
         CliError::invalid_config(format!(
             "config path has no parent directory: {}",
@@ -243,8 +326,6 @@ pub(crate) fn save_config(path: &Path, config: &CliConfig) -> Result<(), CliErro
     fs::create_dir_all(parent).map_err(|err| {
         CliError::invalid_config(format!("failed to create config directory: {err}"))
     })?;
-    let contents = toml::to_string_pretty(config)
-        .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
     let tmp_path = path.with_extension("tmp");
     write_owner_only(&tmp_path, contents.as_bytes())?;
     fs::rename(&tmp_path, path).map_err(|err| {
@@ -254,6 +335,42 @@ pub(crate) fn save_config(path: &Path, config: &CliConfig) -> Result<(), CliErro
         ))
     })?;
     Ok(())
+}
+
+/// Key names whose values never leave the file unmasked, whatever shape the
+/// config is in. Mirrors the typed redaction: the `SecretString` store
+/// fields plus the remote profile's `auth_token`.
+const SECRET_CONFIG_KEYS: &[&str] = &[
+    "access_key",
+    "access_key_id",
+    "auth_token",
+    "secret_access_key",
+    "session_token",
+];
+
+/// Deep-masks secret-named keys in a loose config table so degraded
+/// `config show` output stays as safe to paste as the typed redaction.
+pub(crate) fn redacted_config_table(table: &toml::Table) -> toml::Table {
+    table
+        .iter()
+        .map(|(key, value)| (key.clone(), redacted_config_value(Some(key), value)))
+        .collect()
+}
+
+fn redacted_config_value(key: Option<&str>, value: &toml::Value) -> toml::Value {
+    if key.is_some_and(|key| SECRET_CONFIG_KEYS.contains(&key)) {
+        return toml::Value::String("<redacted>".to_owned());
+    }
+    match value {
+        toml::Value::Table(table) => toml::Value::Table(redacted_config_table(table)),
+        toml::Value::Array(items) => toml::Value::Array(
+            items
+                .iter()
+                .map(|item| redacted_config_value(None, item))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
 }
 
 fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<(), CliError> {
@@ -492,6 +609,115 @@ secret_access_key = "secret"
             examples >= 2,
             "expected at least 2 CLI example configs, found {examples}"
         );
+    }
+
+    #[test]
+    fn load_errors_name_the_file_and_probe_the_version_first() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        let write = |contents: &str| std::fs::write(&path, contents).expect("write config");
+        let shown_path = path.display().to_string();
+
+        let missing = super::load_config(&path).expect_err("missing file");
+        assert!(missing.message.contains(&shown_path), "{}", missing.message);
+
+        write("config_version = ");
+        let syntax = super::load_config(&path).expect_err("syntax error");
+        assert!(syntax.message.contains(&shown_path), "{}", syntax.message);
+
+        // The version verdict beats unknown-field noise: a config written
+        // for another version says so directly.
+        write("config_version = 2\nfuture_setting = true\n");
+        let version = super::load_config(&path).expect_err("future version");
+        assert!(
+            version.message.contains("`config_version = 2`"),
+            "{}",
+            version.message
+        );
+        assert!(
+            !version.message.contains("future_setting"),
+            "{}",
+            version.message
+        );
+
+        write("default_profile = \"x\"\n");
+        let unversioned = super::load_config(&path).expect_err("missing version");
+        assert!(
+            unversioned.message.contains("missing `config_version`"),
+            "{}",
+            unversioned.message
+        );
+
+        write("config_version = 1\ndefault_profil = \"typo\"\n");
+        let unknown = super::load_config(&path).expect_err("unknown field");
+        assert!(unknown.message.contains(&shown_path), "{}", unknown.message);
+        assert!(
+            unknown.message.contains("default_profil"),
+            "{}",
+            unknown.message
+        );
+    }
+
+    #[test]
+    fn repair_load_keeps_the_loose_table_and_masks_secrets() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+config_version = 1
+default_profile = "broken"
+
+[profiles.broken]
+mode = "remote"
+server_url = "https://loonfs.example.com"
+auth_token = "degraded-auth-token"
+unknown_knob = true
+
+[profiles.ok]
+mode = "embedded"
+
+[profiles.ok.store]
+kind = "local-fs"
+root = "/tmp/store"
+"#,
+        )
+        .expect("write config");
+
+        let super::ConfigLoad::Degraded { mut table, error } =
+            super::load_config_for_repair(&path).expect("stage one holds")
+        else {
+            panic!("unknown_knob must fail the strict decode");
+        };
+        assert!(error.message.contains("unknown_knob"), "{}", error.message);
+
+        let redacted = toml::to_string_pretty(&super::redacted_config_table(&table))
+            .expect("render redacted table");
+        assert!(!redacted.contains("degraded-auth-token"), "{redacted}");
+        assert!(redacted.contains("<redacted>"), "{redacted}");
+        assert!(redacted.contains("unknown_knob"), "{redacted}");
+
+        // Deleting the broken profile through the table heals the file: the
+        // strict decoder accepts what remains.
+        let removed =
+            crate::profiles::delete_profile_in_table(&mut table, "broken").expect("delete broken");
+        assert_eq!(removed.mode, "remote");
+        crate::profiles::make_default_profile_in_table(&mut table, "ok").expect("switch default");
+        assert!(
+            crate::profiles::make_default_profile_in_table(&mut table, "gone").is_err(),
+            "unknown profile must not become the default"
+        );
+        super::save_config_table(&path, &table).expect("save repaired table");
+
+        match super::load_config_for_repair(&path).expect("reload") {
+            super::ConfigLoad::Valid(config) => {
+                assert_eq!(config.default_profile.as_deref(), Some("ok"));
+                assert!(!config.profiles.contains_key("broken"));
+            }
+            super::ConfigLoad::Degraded { error, .. } => {
+                panic!("repaired config must strict-decode: {}", error.message)
+            }
+        }
     }
 
     #[test]

--- a/crates/loonfs-cli/src/profiles.rs
+++ b/crates/loonfs-cli/src/profiles.rs
@@ -94,11 +94,59 @@ pub(crate) fn delete_profile(
     })
 }
 
+/// [`delete_profile`] over the loose table of a degraded config, so a
+/// profile the strict decoder rejects can still be deleted.
+pub(crate) fn delete_profile_in_table(
+    table: &mut toml::Table,
+    name: &str,
+) -> Result<ProfileSummary, CliError> {
+    let removed = table
+        .get_mut("profiles")
+        .and_then(toml::Value::as_table_mut)
+        .and_then(|profiles| profiles.remove(name))
+        .ok_or_else(|| CliError::profile_not_found(name))?;
+    if table.get("default_profile").and_then(toml::Value::as_str) == Some(name) {
+        table.remove("default_profile");
+    }
+    Ok(ProfileSummary {
+        name: name.to_owned(),
+        mode: removed
+            .get("mode")
+            .and_then(toml::Value::as_str)
+            .unwrap_or("unknown")
+            .to_owned(),
+        store_kind: removed
+            .get("store")
+            .and_then(|store| store.get("kind"))
+            .and_then(toml::Value::as_str)
+            .map(ToOwned::to_owned),
+    })
+}
+
 pub(crate) fn make_default_profile(config: &mut CliConfig, name: &str) -> Result<(), CliError> {
     if !config.profiles.contains_key(name) {
         return Err(CliError::profile_not_found(name));
     }
     config.default_profile = Some(name.to_owned());
+    Ok(())
+}
+
+/// [`make_default_profile`] over the loose table of a degraded config.
+pub(crate) fn make_default_profile_in_table(
+    table: &mut toml::Table,
+    name: &str,
+) -> Result<(), CliError> {
+    let exists = table
+        .get("profiles")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|profiles| profiles.contains_key(name));
+    if !exists {
+        return Err(CliError::profile_not_found(name));
+    }
+    table.insert(
+        "default_profile".to_owned(),
+        toml::Value::String(name.to_owned()),
+    );
     Ok(())
 }
 

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -470,6 +470,11 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         CommandData::ConfigShow { config } => {
             toml::to_string_pretty(config).unwrap_or_else(|_| "failed to render config".to_owned())
         }
+        CommandData::ConfigShowDegraded { error, config_toml } => {
+            format!(
+                "warning: {error}\nshowing the file as parsed, secrets masked:\n\n{config_toml}"
+            )
+        }
         CommandData::Version {
             version,
             commit,

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -80,6 +80,108 @@ fn profile_create_list_show_delete_work() {
 }
 
 #[test]
+fn broken_configs_stay_repairable_with_the_repair_commands() {
+    let harness = Harness::new();
+    harness.write_cli_config(format!(
+        r#"config_version = 1
+default_profile = "broken"
+
+[profiles.broken]
+mode = "remote"
+server_url = "https://loonfs.example.com"
+auth_token = "secret-degraded-token"
+unknown_knob = true
+
+[profiles.keeper]
+mode = "embedded"
+
+[profiles.keeper.store]
+kind = "local-fs"
+root = "{}"
+"#,
+        harness.store_root("keeper").display()
+    ));
+
+    // Ordinary commands reject the file, naming it and the offending key.
+    let list = harness.run(&["profile", "list"]);
+    assert_failure(&list);
+    let message = stderr_string(&list);
+    assert!(message.contains("config.toml"), "{message}");
+    assert!(message.contains("unknown_knob"), "{message}");
+
+    // The repair commands still work. Show renders the file as parsed, with
+    // the failure on top and secrets masked.
+    let show = harness.run(&["config", "show"]);
+    assert_success(&show);
+    let shown = stdout_string(&show);
+    assert!(shown.contains("warning:"), "{shown}");
+    assert!(shown.contains("unknown_knob"), "{shown}");
+    assert!(shown.contains("<redacted>"), "{shown}");
+    assert!(!shown.contains("secret-degraded-token"), "{shown}");
+
+    // Use switches the default while the file is still degraded; delete then
+    // removes the broken profile, which heals the file for every command.
+    assert_success(&harness.run(&["profile", "use", "keeper"]));
+    let delete = harness.run(&["--json", "profile", "delete", "broken"]);
+    assert_success(&delete);
+    assert_eq!(json_data(&delete)["name"], "broken");
+    assert_eq!(json_data(&delete)["mode"], "remote");
+
+    let healed = harness.run(&["--json", "profile", "list"]);
+    assert_success(&healed);
+    let healed_data = json_data(&healed);
+    assert_eq!(healed_data["default_profile"], "keeper");
+    assert_eq!(
+        healed_data["profiles"]
+            .as_array()
+            .expect("json array")
+            .len(),
+        1
+    );
+
+    // A config for another version is a hard error, named before any
+    // unknown-field noise; repair commands do not edit files written for a
+    // different version.
+    harness.write_cli_config("config_version = 2\nfuture_setting = true\n");
+    let future = harness.run(&["config", "show"]);
+    assert_failure(&future);
+    let future_message = stderr_string(&future);
+    assert!(
+        future_message.contains("`config_version = 2`"),
+        "{future_message}"
+    );
+    assert!(
+        !future_message.contains("future_setting"),
+        "{future_message}"
+    );
+}
+
+#[test]
+fn unreachable_servers_are_named_with_their_url() {
+    let harness = Harness::new();
+    // A port that was just free with nothing listening: connection refused.
+    let dead_url = format!("http://127.0.0.1:{}", available_port());
+    let create = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "dead",
+        "--mode",
+        "remote",
+        "--server-url",
+        &dead_url,
+    ]);
+    assert_success(&create);
+
+    let attempt = harness.run(&["namespace", "create", "ghost"]);
+    assert_failure(&attempt);
+    let message = stderr_string(&attempt);
+    assert!(message.contains("cannot connect to"), "{message}");
+    assert!(message.contains(&dead_url), "{message}");
+    assert!(message.contains("`server_url`"), "{message}");
+}
+
+#[test]
 fn embedded_profile_filesystem_flow_works_end_to_end() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
@@ -1776,6 +1878,12 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         ]);
         assert_failure(&missing);
         assert_eq!(json_error(&missing)["code"], "namespace_not_found");
+        // Both modes name the namespace: the CLI mapper mirrors the server
+        // handler's scoping.
+        assert_eq!(
+            json_error(&missing)["message"],
+            "namespace `missing` does not exist"
+        );
 
         shapes_by_mode.push((
             sorted_object_keys(&changes_data),

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -213,14 +213,14 @@ impl Client {
 
         let response = builder.send().await.map_err(|err| FailedAttempt {
             transport: true,
-            error: ClientError::Http(err.to_string()),
+            error: ClientError::Http(describe_send_error(&request.url, &err)),
         })?;
         let status = response.status();
         let bytes = response.bytes().await.map_err(|err| FailedAttempt {
             // The status arrived but the body did not: the connection failed
             // mid-response, which is a transport failure like any other.
             transport: true,
-            error: ClientError::Http(err.to_string()),
+            error: ClientError::Http(describe_send_error(&request.url, &err)),
         })?;
         if status.is_success() {
             return Ok(bytes.to_vec());
@@ -258,6 +258,46 @@ pub(crate) fn map_status_error(status: u16, body: &[u8]) -> ClientError {
         Err(err) => ClientError::Http(format!(
             "http status {status} with a non-envelope body: {err}"
         )),
+    }
+}
+
+/// Renders a request-send failure with its root cause visible. Reqwest's
+/// own `Display` stops at "error sending request", hiding the
+/// connection-refused or DNS cause underneath — the one line that tells an
+/// operator whether the server is down or `server_url` points at the wrong
+/// place.
+fn describe_send_error(url: &str, error: &reqwest::Error) -> String {
+    render_send_error(url, error, error.is_connect(), error.is_timeout())
+}
+
+/// [`describe_send_error`] with the reqwest classification lifted out, so
+/// the composition is testable without manufacturing reqwest errors.
+fn render_send_error(
+    url: &str,
+    error: &(dyn std::error::Error + 'static),
+    connect_failure: bool,
+    timed_out: bool,
+) -> String {
+    let mut detail = error.to_string();
+    let mut source = error.source();
+    while let Some(cause) = source {
+        let rendered = cause.to_string();
+        // Wrapper layers usually restate their child; keep layers that add text.
+        if !detail.contains(&rendered) {
+            detail.push_str(": ");
+            detail.push_str(&rendered);
+        }
+        source = cause.source();
+    }
+    if connect_failure {
+        format!(
+            "cannot connect to `{url}`: {detail}; check that the server is running and that the \
+             profile's `server_url` points at it"
+        )
+    } else if timed_out {
+        format!("request to `{url}` timed out: {detail}")
+    } else {
+        format!("request to `{url}` failed: {detail}")
     }
 }
 
@@ -373,5 +413,69 @@ pub(crate) mod test_transport {
                 Outcome::Success(body) => Ok(body),
             })
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_send_error;
+
+    #[derive(Debug)]
+    struct Layered {
+        message: &'static str,
+        cause: Option<Box<Layered>>,
+    }
+
+    impl std::fmt::Display for Layered {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.message)
+        }
+    }
+
+    impl std::error::Error for Layered {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.cause
+                .as_deref()
+                .map(|cause| cause as &(dyn std::error::Error + 'static))
+        }
+    }
+
+    #[test]
+    fn send_errors_surface_the_root_cause_and_the_url() {
+        let error = Layered {
+            message: "error sending request",
+            cause: Some(Box::new(Layered {
+                message: "client error (Connect)",
+                cause: Some(Box::new(Layered {
+                    message: "tcp connect error: Connection refused (os error 61)",
+                    cause: None,
+                })),
+            })),
+        };
+
+        let connect = render_send_error("http://127.0.0.1:9/v0/namespaces", &error, true, false);
+        assert!(
+            connect.contains("cannot connect to `http://127.0.0.1:9/v0/namespaces`"),
+            "{connect}"
+        );
+        assert!(connect.contains("Connection refused"), "{connect}");
+        assert!(connect.contains("`server_url`"), "{connect}");
+
+        let timeout = render_send_error("http://h/v0", &error, false, true);
+        assert!(timeout.contains("timed out"), "{timeout}");
+
+        // A layer that restates its child is not repeated.
+        let repeated = Layered {
+            message: "outer: inner detail",
+            cause: Some(Box::new(Layered {
+                message: "inner detail",
+                cause: None,
+            })),
+        };
+        let rendered = render_send_error("http://h/v0", &repeated, false, false);
+        assert_eq!(
+            rendered,
+            "request to `http://h/v0` failed: outer: inner detail"
+        );
     }
 }

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -838,20 +838,107 @@ fn map_provider_error(object_key: &str, err: provider_store::Error) -> ObjectSto
             )
         }
         provider_store::Error::Generic { source, .. } => {
-            ObjectStoreError::transport(object_key, source.to_string())
+            ObjectStoreError::transport(object_key, sanitize_provider_message(&source.to_string()))
         }
         provider_store::Error::JoinError { source } => {
-            ObjectStoreError::transport(object_key, source.to_string())
+            ObjectStoreError::transport(object_key, sanitize_provider_message(&source.to_string()))
         }
         provider_store::Error::PermissionDenied { source, .. }
         | provider_store::Error::Unauthenticated { source, .. } => {
             ObjectStoreError::PermissionDenied {
                 object_key: object_key.to_owned(),
-                message: source.to_string(),
+                message: sanitize_provider_message(&source.to_string()),
             }
         }
-        other => ObjectStoreError::transport(object_key, other.to_string()),
+        other => {
+            ObjectStoreError::transport(object_key, sanitize_provider_message(&other.to_string()))
+        }
     }
+}
+
+/// Query parameters whose values are credential material when they appear in
+/// a URL a provider error echoes back (signed and presigned requests).
+const CREDENTIAL_QUERY_PARAMS: &[&str] = &[
+    "X-Amz-Signature",
+    "X-Amz-Credential",
+    "X-Amz-Security-Token",
+    "AWSAccessKeyId",
+    "Signature",
+    "sig",
+];
+
+/// Response-body XML elements that echo signing inputs back to the caller in
+/// provider auth failures (`SignatureDoesNotMatch` and friends).
+const CREDENTIAL_XML_ELEMENTS: &[&str] = &[
+    "StringToSign",
+    "StringToSignBytes",
+    "CanonicalRequest",
+    "SignatureProvided",
+    "AWSAccessKeyId",
+];
+
+/// Strips credential material from free-text provider errors before they
+/// enter the error chain: signature/credential query parameters in echoed
+/// URLs, and the signing-input elements auth-failure bodies quote back.
+/// The diagnosable parts (status, provider error code, cause) stay.
+fn sanitize_provider_message(message: &str) -> String {
+    let mut sanitized = message.to_owned();
+    for param in CREDENTIAL_QUERY_PARAMS {
+        sanitized = mask_query_param_values(&sanitized, param);
+    }
+    for element in CREDENTIAL_XML_ELEMENTS {
+        sanitized = mask_xml_element_text(&sanitized, element);
+    }
+    sanitized
+}
+
+/// Replaces every `?param=value` / `&param=value` occurrence's value with
+/// `<redacted>`. Matches only at a query-parameter boundary so `Signature=`
+/// does not fire inside `X-Amz-Signature=`.
+fn mask_query_param_values(message: &str, param: &str) -> String {
+    let needle = format!("{param}=");
+    let mut out = String::with_capacity(message.len());
+    let mut cursor = 0;
+    while let Some(found) = message[cursor..].find(&needle) {
+        let start = cursor + found;
+        let value_start = start + needle.len();
+        out.push_str(&message[cursor..value_start]);
+        cursor = value_start;
+        let at_boundary = start > 0 && matches!(message.as_bytes()[start - 1], b'?' | b'&');
+        if at_boundary {
+            let value_len = message[cursor..]
+                .find(|c: char| {
+                    matches!(c, '&' | '"' | '\'' | ')' | '<' | '>' | ':' | ',') || c.is_whitespace()
+                })
+                .unwrap_or(message.len() - cursor);
+            out.push_str("<redacted>");
+            cursor += value_len;
+        }
+    }
+    out.push_str(&message[cursor..]);
+    out
+}
+
+/// Replaces the text inside `<element>...</element>` with `<redacted>`; if
+/// the closing tag never arrives (truncated body), everything after the
+/// opening tag goes.
+fn mask_xml_element_text(message: &str, element: &str) -> String {
+    let open = format!("<{element}>");
+    let close = format!("</{element}>");
+    let mut out = String::with_capacity(message.len());
+    let mut rest = message;
+    while let Some(position) = rest.find(&open) {
+        let text_start = position + open.len();
+        out.push_str(&rest[..text_start]);
+        out.push_str("<redacted>");
+        rest = &rest[text_start..];
+        match rest.find(&close) {
+            Some(text_end) => rest = &rest[text_end..],
+            None => rest = "",
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 #[cfg(test)]
@@ -871,6 +958,67 @@ mod tests {
             },
         )
         .expect("provider store")
+    }
+
+    #[test]
+    fn provider_messages_drop_credential_material_and_keep_the_diagnosis() {
+        let presigned = sanitize_provider_message(
+            "Generic S3 error: error sending request for url \
+             (https://bucket.s3.amazonaws.com/k?X-Amz-Algorithm=AWS4-HMAC-SHA256\
+             &X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20260726%2Fus-east-1%2Fs3%2Faws4_request\
+             &X-Amz-Signature=deadbeefcafe): operation timed out",
+        );
+        assert!(!presigned.contains("AKIAIOSFODNN7EXAMPLE"), "{presigned}");
+        assert!(!presigned.contains("deadbeefcafe"), "{presigned}");
+        assert!(
+            presigned.contains("X-Amz-Signature=<redacted>"),
+            "{presigned}"
+        );
+        assert!(presigned.contains("operation timed out"), "{presigned}");
+        assert!(
+            presigned.contains("bucket.s3.amazonaws.com/k"),
+            "{presigned}"
+        );
+
+        let signature_mismatch = sanitize_provider_message(
+            "Client error with status 403 Forbidden: <Error>\
+             <Code>SignatureDoesNotMatch</Code>\
+             <StringToSign>AWS4-HMAC-SHA256 20260726T000000Z scope digest</StringToSign>\
+             <SignatureProvided>cafe0123</SignatureProvided>\
+             <AWSAccessKeyId>AKIAIOSFODNN7EXAMPLE</AWSAccessKeyId></Error>",
+        );
+        assert!(
+            !signature_mismatch.contains("AKIAIOSFODNN7EXAMPLE"),
+            "{signature_mismatch}"
+        );
+        assert!(
+            !signature_mismatch.contains("cafe0123"),
+            "{signature_mismatch}"
+        );
+        assert!(
+            !signature_mismatch.contains("20260726T000000Z"),
+            "{signature_mismatch}"
+        );
+        assert!(
+            signature_mismatch.contains("SignatureDoesNotMatch"),
+            "{signature_mismatch}"
+        );
+        assert!(
+            signature_mismatch.contains("403 Forbidden"),
+            "{signature_mismatch}"
+        );
+
+        let azure_sas = sanitize_provider_message(
+            "error for url https://account.blob.core.windows.net/c/k?sv=2021-08-06\
+             &se=2026-07-26&sig=aGVsbG8: 403",
+        );
+        assert!(!azure_sas.contains("aGVsbG8"), "{azure_sas}");
+        assert!(azure_sas.contains("sig=<redacted>"), "{azure_sas}");
+
+        // A bare name inside a longer parameter is not a boundary match.
+        let unrelated = sanitize_provider_message("policy?ResponseSignature=keep&sigil=keep2");
+        assert!(unrelated.contains("keep2"), "{unrelated}");
+        assert!(!unrelated.contains("Signature=<redacted>"), "{unrelated}");
     }
 
     #[tokio::test]

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -293,7 +293,7 @@ pub(super) async fn create_checkpoint(
             loonfs::CreateCheckpointOptions::from_request(request),
         )
         .await
-        .map_err(ApiResponseError::runtime)?;
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -331,7 +331,7 @@ pub(super) async fn release_checkpoint(
         .admin
         .release_checkpoint(&namespace_id, &checkpoint_id)
         .await
-        .map_err(ApiResponseError::runtime)?;
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
 }
 
@@ -380,6 +380,6 @@ pub(super) async fn maintenance_step(
         .admin
         .maintenance_step_namespace(&namespace_id, options)
         .await
-        .map_err(ApiResponseError::runtime)?;
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(result))
 }


### PR DESCRIPTION
changes:

- **A broken config no longer bricks the commands that repair it.** Loading is now two-stage: a loose TOML parse plus a `config_version` probe first (so a config written for another version says exactly that, instead of surfacing as unknown-field noise), then the strict `deny_unknown_fields` decode. Every load error names the file. When the strict decode fails, `config show` still renders the file as parsed — failure on top, secrets masked — and `profile delete` / `profile use` operate on the loose table, so deleting the one broken profile heals the file. Other commands keep rejecting the file outright.
- **Provider error text is sanitized for real.** `ObjectStoreError` docs promised "credential material removed", but provider messages passed through verbatim — echoed presigned URLs carry `X-Amz-Signature`/`X-Amz-Credential` values, and `SignatureDoesNotMatch` bodies quote back `StringToSign` and `SignatureProvided`. Those values are now masked at the mapping boundary; the status, provider error code, and cause stay.
- **Namespace errors name the namespace, in both modes.** The server's checkpoint create/release and maintenance-step handlers now scope `namespace_not_found` the way every other namespace handler does, and the CLI's embedded backend mirrors it (checkpoints, maintenance step, delete, fork). Before, `loon admin checkpoint --namespace missing` printed the internal object key (`missing control object namespaces/missing/namespace.json`); now both modes say ``namespace `missing` does not exist``, pinned by the existing both-modes parity test.
- **Unreachable servers are diagnosable.** Reqwest's display stops at "error sending request", hiding the connection-refused or DNS cause underneath. Send failures now render the cause chain and the URL: ``cannot connect to `http://...`: ... Connection refused ...; check that the server is running and that the profile's `server_url` points at it``.
- **The last two path-less file errors name their file** (`put` reading the local file, `get` writing the download), using the `io_for_path` helper the recursive transfers introduced.
