### PR TITLE
fix(core): a fence landing mid-load reports writer_fenced

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -734,6 +734,83 @@ mod tests {
         assert_eq!(head.writer.expect("writer block").writer_id, "writer-b");
     }
 
+    /// A takeover that lands while the loser is mid-load is still a fence,
+    /// not a head race. The loser must be told so — `stale_head` would send a
+    /// permanently fenced session back to retry.
+    #[tokio::test]
+    async fn fencing_during_publish_view_load_still_reports_writer_fenced() {
+        use loonfs_test_support::stores::{BlockingStore, KeyPredicate};
+        use std::sync::Arc as StdArc;
+
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let writer_a = context("writer-a", "session-a");
+
+        // Block the WAL tail read: it sits between the head snapshot that the
+        // fence check uses and the closing etag recheck.
+        let store = StdArc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("store"),
+            KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+            OperationClass::Read,
+        ));
+
+        bootstrap_namespace(store.inner(), &namespace_id, &writer_a, false)
+            .await
+            .expect("bootstrap");
+
+        let mut engine_a = NamespaceCommitEngine::new(namespace_id.clone());
+        engine_a
+            .publish_batch(
+                store.inner(),
+                vec![create_dir("from-a-first", "alpha")],
+                &writer_a,
+                &PublishTailOptions::default(),
+            )
+            .await
+            .results[0]
+            .as_ref()
+            .expect("writer a first commit");
+        // Force a fresh manifest load on the next publish.
+        engine_a.invalidate();
+
+        store.block_next();
+        let blocked_store = StdArc::clone(&store);
+        let publish_a = tokio::spawn(async move {
+            let mut engine = engine_a;
+            let result = engine
+                .publish_batch(
+                    blocked_store.as_ref(),
+                    vec![create_dir("from-a-second", "gamma")],
+                    &writer_a,
+                    &PublishTailOptions::default(),
+                )
+                .await;
+            result.results[0].as_ref().err().map(|error| error.code())
+        });
+
+        // A has snapshotted a head that still names it. Writer B takes the
+        // epoch while A is parked mid-load, so A is fenced by the time it
+        // rechecks the etag.
+        store.wait_until_blocked().await;
+        let writer_b = context("writer-b", "session-b");
+        let mut engine_b = NamespaceCommitEngine::new(namespace_id.clone());
+        engine_b
+            .publish_batch(
+                store.inner(),
+                vec![create_dir("from-b-first", "beta")],
+                &writer_b,
+                &PublishTailOptions::default(),
+            )
+            .await
+            .results[0]
+            .as_ref()
+            .expect("writer b takeover commit");
+        store.release();
+
+        let code = publish_a.await.expect("join publish a");
+        assert_eq!(code, Some(ErrorCode::WriterFenced));
+    }
+
     #[tokio::test]
     async fn shared_session_keeps_fencing_across_engine_rebuilds() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -10,7 +10,9 @@ use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
 use crate::namespace::catalog::{load_namespace_catalog_entry, VerifiedNamespaceCatalogEntry};
-use crate::namespace::control::{read_head_and_metadata_root, ControlObjectLoadError};
+use crate::namespace::control::{
+    read_head_and_metadata_root, read_head_object, ControlObjectLoadError,
+};
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState};
 use loonfs_api::{
@@ -197,7 +199,13 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     };
 
     let tail_state = projection.tail_state.clone();
-    ensure_publish_head_etag_still_current(store, namespace_id, &head_etag).await?;
+    ensure_publish_head_etag_still_current(
+        store,
+        namespace_id,
+        &head_etag,
+        acquired_writer.as_ref(),
+    )
+    .await?;
 
     Ok((
         PublishMetadataView {
@@ -304,10 +312,20 @@ fn ensure_publish_reconstructed_head_matches(
     Ok(())
 }
 
+/// Closes the load by confirming the head has not moved underneath it.
+///
+/// A moved head is ambiguous on its own: it means either that another
+/// publisher committed (retryable) or that another session took the writer
+/// epoch and fenced this one (terminal). The fence check at the top of the
+/// load only sees the opening snapshot, so a takeover landing mid-load would
+/// otherwise be reported as `stale_head` — telling a permanently fenced
+/// writer to retry. Re-reading the head on the mismatch path resolves which
+/// it was, at the cost of one extra read on a path that already failed.
 async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     loaded_head_etag: &str,
+    acquired_writer: Option<&AcquiredWriter>,
 ) -> Result<()> {
     let object_key = wal_head(namespace_id.as_str());
     let metadata = store
@@ -335,6 +353,16 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
         })
     })?;
     if current_head_etag != loaded_head_etag {
+        if let Some(acquired_writer) = acquired_writer {
+            let moved_head = read_head_object(store, namespace_id)
+                .await
+                .map_err(|error| {
+                    CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+                })?
+                .envelope
+                .state;
+            ensure_publish_head_matches_acquired_writer(&moved_head, acquired_writer)?;
+        }
         return Err(CoreError::MetadataProjection(
             MetadataProjectionLoadError::HeadChangedDuringLoad {
                 object_key,


### PR DESCRIPTION
18 of the last 19 CI failures were due to one failing test: `concurrent_embedded_puts_land_or_report_the_fence` (since #398). 

The publish-view load checks the writer epoch against the head it read at the start of the load, but rechecks the head etag at the end. A takeover landing inside that window passes the opening fence check and then trips the closing recheck, so a permanently fenced writer was told `stale_head` — a retryable code — instead of `writer_fenced`. That error is a metadata-projection error rather than a head-publish one, so the publisher's contention loop never retried it either, and the session never latched itself as fenced.

On the mismatch path only, re-read the head and classify: if the acquired epoch is gone it was a fence, otherwise it stays `stale_head`. One extra read on a path that had already failed, and nothing on the happy path. 
