### PR TITLE
refactor(loonfs): split the runtime into a read core and writer/admin services

### DIFF
--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -77,24 +77,35 @@ pub struct BeginDirectPutUploadTargetResponse {
     pub target: DirectPutUploadTarget,
 }
 
-/// A namespace-scoped core API.
-///
-/// `NamespaceEngine` owns an object store handle plus the writer identity used
-/// for mutations. It is the main entrypoint for direct reads, path writes,
-/// explicit commits, uploads, checkpoints, and retention work.
+/// The actor identity a mutating engine publishes under.
 #[derive(Debug)]
-pub struct NamespaceEngine<S> {
-    store: S,
-    namespace_id: NamespaceId,
+struct EngineWriter {
     writer_id: String,
     writer_session_id: String,
     writer_version: String,
 }
 
+/// A namespace-scoped core API.
+///
+/// `NamespaceEngine` owns an object store handle plus, for a mutating engine,
+/// the writer identity used for mutations. It is the main entrypoint for
+/// direct reads, path writes, explicit commits, uploads, checkpoints, and
+/// retention work.
+///
+/// An engine built by [`NamespaceEngineBuilder::build_reader`] carries no
+/// writer identity: it serves reads, and every mutation refuses.
+#[derive(Debug)]
+pub struct NamespaceEngine<S> {
+    store: S,
+    namespace_id: NamespaceId,
+    writer: Option<EngineWriter>,
+}
+
 impl<S: ObjectStore> NamespaceEngine<S> {
     /// Starts an engine builder for the supplied object store.
     ///
-    /// The builder requires a namespace id and writer id before it can build.
+    /// The builder requires a namespace id, and a writer id unless it is
+    /// finished with [`NamespaceEngineBuilder::build_reader`].
     pub fn builder(store: S) -> NamespaceEngineBuilder<S> {
         NamespaceEngineBuilder {
             store,
@@ -110,19 +121,26 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         &self.namespace_id
     }
 
-    /// Returns the writer id used for epoch acquisition and commit publication.
-    pub fn writer_id(&self) -> &str {
-        &self.writer_id
+    /// Returns the writer id used for epoch acquisition and commit
+    /// publication, or `None` for a read-only engine.
+    pub fn writer_id(&self) -> Option<&str> {
+        self.writer.as_ref().map(|writer| writer.writer_id.as_str())
     }
 
-    /// Returns the unique writer session id for this engine instance.
-    pub fn writer_session_id(&self) -> &str {
-        &self.writer_session_id
+    /// Returns the unique writer session id for this engine instance, or
+    /// `None` for a read-only engine.
+    pub fn writer_session_id(&self) -> Option<&str> {
+        self.writer
+            .as_ref()
+            .map(|writer| writer.writer_session_id.as_str())
     }
 
-    /// Returns the writer version reported in mutation context.
-    pub fn writer_version(&self) -> &str {
-        &self.writer_version
+    /// Returns the writer version reported in mutation context, or `None`
+    /// for a read-only engine.
+    pub fn writer_version(&self) -> Option<&str> {
+        self.writer
+            .as_ref()
+            .map(|writer| writer.writer_version.as_str())
     }
 
     /// Creates the namespace if it does not already exist.
@@ -495,11 +513,22 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
+    /// The identity every mutation publishes under.
+    ///
+    /// A read-only engine has none, so this fails instead of inventing one.
+    /// Nothing routes that error: the runtime hands read-only engines only to
+    /// read paths, and this exists so a wiring mistake fails honestly rather
+    /// than publishing under a fabricated writer.
     fn mutation_context(&self) -> Result<MutationContext> {
+        let writer = self.writer.as_ref().ok_or_else(|| {
+            crate::error::CoreError::Internal(
+                "engine built without writer identity cannot mutate".to_owned(),
+            )
+        })?;
         Ok(MutationContext {
-            writer_id: self.writer_id.clone(),
-            writer_session_id: self.writer_session_id.clone(),
-            writer_version: self.writer_version.clone(),
+            writer_id: writer.writer_id.clone(),
+            writer_session_id: writer.writer_session_id.clone(),
+            writer_version: writer.writer_version.clone(),
             now_ms: current_time_ms()?,
         })
     }
@@ -544,7 +573,7 @@ impl<S: ObjectStore> NamespaceEngineBuilder<S> {
         self
     }
 
-    /// Builds the engine after required fields are present.
+    /// Builds a mutating engine after required fields are present.
     pub fn build(self) -> std::result::Result<NamespaceEngine<S>, NamespaceEngineBuildError> {
         let namespace_id = self
             .namespace_id
@@ -562,11 +591,31 @@ impl<S: ObjectStore> NamespaceEngineBuilder<S> {
         Ok(NamespaceEngine {
             store: self.store,
             namespace_id,
-            writer_id,
-            writer_session_id: self
-                .writer_session_id
-                .unwrap_or_else(|| generated_id("wrs")),
-            writer_version: self.writer_version,
+            writer: Some(EngineWriter {
+                writer_id,
+                writer_session_id: self
+                    .writer_session_id
+                    .unwrap_or_else(|| generated_id("wrs")),
+                writer_version: self.writer_version,
+            }),
+        })
+    }
+
+    /// Builds a read-only engine: no writer identity, and therefore no
+    /// writer session id minted for a caller that will never mutate.
+    ///
+    /// Only the namespace is required. Any writer identity set on the
+    /// builder is dropped — a read-only engine carries none by definition.
+    pub fn build_reader(
+        self,
+    ) -> std::result::Result<NamespaceEngine<S>, NamespaceEngineBuildError> {
+        let namespace_id = self
+            .namespace_id
+            .ok_or(NamespaceEngineBuildError::MissingNamespace)?;
+        Ok(NamespaceEngine {
+            store: self.store,
+            namespace_id,
+            writer: None,
         })
     }
 }
@@ -622,8 +671,80 @@ mod tests {
             .expect("engine builds");
 
         assert_eq!(engine.namespace_id(), &namespace_id);
-        assert_eq!(engine.writer_id(), "writer-a");
-        assert!(!engine.writer_version().is_empty());
+        assert_eq!(engine.writer_id(), Some("writer-a"));
+        assert!(engine.writer_session_id().is_some());
+        assert!(!engine.writer_version().expect("writer version").is_empty());
+    }
+
+    #[test]
+    fn reader_engine_builds_without_any_writer_identity() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        let engine = NamespaceEngine::builder(store)
+            .namespace_id(namespace_id.clone())
+            .build_reader()
+            .expect("reader engine builds without a writer");
+
+        assert_eq!(engine.namespace_id(), &namespace_id);
+        assert_eq!(engine.writer_id(), None);
+        assert_eq!(
+            engine.writer_session_id(),
+            None,
+            "a reader must not mint a writer session id"
+        );
+        assert_eq!(engine.writer_version(), None);
+    }
+
+    #[tokio::test]
+    async fn reader_engine_still_serves_reads() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        NamespaceEngine::builder(LocalFsStore::new(temp_dir.path()).expect("store"))
+            .namespace_id(namespace_id.clone())
+            .writer_id("writer-a")
+            .build()
+            .expect("engine builds")
+            .bootstrap_namespace(BootstrapOptions::default())
+            .await
+            .expect("bootstrap namespace");
+
+        let reader = NamespaceEngine::builder(LocalFsStore::new(temp_dir.path()).expect("store"))
+            .namespace_id(namespace_id.clone())
+            .build_reader()
+            .expect("reader engine builds");
+        let changes = reader
+            .list_changes_after(
+                ChangeSeq(0),
+                loonfs_api::PaginationPolicy::default()
+                    .resolve_limit(None)
+                    .expect("default limit"),
+            )
+            .await
+            .expect("a reader-built engine serves reads");
+        assert_eq!(changes.namespace_id, namespace_id);
+    }
+
+    #[tokio::test]
+    async fn reader_engine_refuses_to_mutate() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let reader = NamespaceEngine::builder(store)
+            .namespace_id(NamespaceId::parse("demo").expect("valid namespace id"))
+            .build_reader()
+            .expect("reader engine builds");
+
+        let error = reader
+            .flush_wal()
+            .await
+            .expect_err("a reader-built engine must refuse mutations");
+        assert!(
+            error
+                .to_string()
+                .contains("engine built without writer identity cannot mutate"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -456,7 +456,8 @@ pub(super) async fn apply_filesystem_operation(
                 ),
             };
             state
-                .publisher
+                .writer
+                .publisher()
                 .submit_candidate(namespace_id.clone(), candidate)
                 .await
         }
@@ -464,7 +465,8 @@ pub(super) async fn apply_filesystem_operation(
         .await
     } else {
         state
-            .publisher
+            .writer
+            .publisher()
             .submit_path_intent(namespace_id.clone(), intent)
             .await
     };

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -182,7 +182,8 @@ pub(super) async fn delete_namespace(
         expected_head_seq: query.expected_head_seq.map(ChangeSeq),
     };
     let response = state
-        .publisher
+        .writer
+        .publisher()
         .submit_delete(namespace_id.clone(), options)
         .await
         .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -260,7 +260,7 @@ async fn start_driver_for_query_if_needed(
     let Some(drivers) = &state.grep_drivers else {
         return;
     };
-    let Ok(Some(root)) = load_grep_root(&*state.store, namespace_id).await else {
+    let Ok(Some(root)) = load_grep_root(&*state.writer.object_store(), namespace_id).await else {
         return;
     };
     let needs_catch_up = match root.state().lifecycle() {

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -243,7 +243,7 @@ async fn health() -> &'static str {
     )
 )]
 async fn readiness(State(state): State<AppState>) -> Result<&'static str, ApiResponseError> {
-    if state.publisher.is_admission_closed() {
+    if state.writer.publisher().is_admission_closed() {
         return Err(ApiResponseError::new(
             StatusCode::SERVICE_UNAVAILABLE,
             ErrorCode::ShuttingDown,

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -4,7 +4,9 @@ use super::router;
 use crate::config::{ServerConfig, ServerConfigError};
 use crate::grep_drivers::GrepDrivers;
 use axum::Router;
-use loonfs::metrics::{JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder};
+use loonfs::metrics::{
+    InstrumentedObjectStore, JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder,
+};
 use loonfs::publisher::PublisherRegistry;
 use loonfs::{
     FsAdmin, FsBackgroundWork, FsReader, FsWriter, SharedObjectStore, TraceMode, TraceStoreKind,
@@ -21,18 +23,19 @@ use tokio::sync::Semaphore;
 const OBJECT_STORE_METRICS_JSONL_ENV: &str = "LOONFS_OBJECT_STORE_METRICS_JSONL";
 
 /// Purpose-specific handles over one shared store client: read endpoints go
-/// through `reader`, mutations through `writer` (and its publisher),
-/// maintenance endpoints through `admin`. Shutdown-relevant handles also
-/// live in the [`ServerLifecycle`] returned beside the router.
+/// through `reader`, mutations through `writer` (and the publication service
+/// it hands out), maintenance endpoints through `admin`. Shutdown-relevant
+/// handles also live in the [`ServerLifecycle`] returned beside the router.
+///
+/// `reader` is a cheap clone derived from `writer` at construction, kept as
+/// its own field because most handlers only read.
 #[derive(Clone)]
 pub(super) struct AppState {
     pub(super) config: Arc<ServerConfig>,
     pub(super) writer: FsWriter,
     pub(super) reader: FsReader,
     pub(super) admin: FsAdmin,
-    pub(super) publisher: PublisherRegistry,
     pub(super) transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
-    pub(super) store: SharedObjectStore,
     pub(super) grep_worker: Option<GrepWorker<SharedObjectStore>>,
     pub(super) grep_drivers: Option<GrepDrivers>,
     /// Bounds concurrently buffered proxied-upload bodies; with the
@@ -145,6 +148,14 @@ pub(super) async fn app_with_store_and_transfer_issuer(
     store: SharedObjectStore,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
 ) -> Result<(Router, ServerLifecycle, AppState), ServerConfigError> {
+    // Instrumentation is installed once, here, so every LoonFS-owned request
+    // the process makes is measured — the handles' own traffic and the
+    // grep-owned traffic that used to run on a second, raw client.
+    let store = instrumented_store(
+        &config,
+        store,
+        std::env::var_os(OBJECT_STORE_METRICS_JSONL_ENV),
+    )?;
     let grep_worker = config.grep.mode.serves_grep().then(|| {
         GrepWorker::new(
             store.clone(),
@@ -173,13 +184,11 @@ pub(super) async fn app_with_store_and_transfer_issuer(
     } else {
         None
     };
-    let (writer, reader, admin) =
-        build_handles(&config, store.clone(), grep_drivers.clone()).await?;
+    let (writer, reader, admin) = build_handles(&config, store, grep_drivers.clone()).await?;
     let config = Arc::new(config);
-    let publisher = writer.publisher();
     let lifecycle = ServerLifecycle {
         writer: writer.clone(),
-        publisher: publisher.clone(),
+        publisher: writer.publisher(),
         grep_drivers: grep_drivers.clone(),
     };
     let state = AppState {
@@ -193,27 +202,29 @@ pub(super) async fn app_with_store_and_transfer_issuer(
         writer,
         reader,
         admin,
-        publisher,
         transfer_issuer,
-        store,
         grep_worker,
         grep_drivers,
     };
     Ok((router(state.clone()), lifecycle, state))
 }
 
-async fn build_handles(
+/// Wraps the store for object-store metrics when a recorder is configured.
+///
+/// One wrapper serves the whole process: the handles are built on it, and so
+/// is the grep worker, so no LoonFS-owned request escapes measurement.
+fn instrumented_store(
     config: &ServerConfig,
     store: SharedObjectStore,
-    grep_drivers: Option<GrepDrivers>,
-) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
-    build_handles_with_metrics_and_grep(
-        config,
-        store,
-        std::env::var_os(OBJECT_STORE_METRICS_JSONL_ENV),
-        grep_drivers,
-    )
-    .await
+    metrics_jsonl_path: Option<OsString>,
+) -> Result<SharedObjectStore, ServerConfigError> {
+    let Some(recorder) = object_store_metrics_recorder(metrics_jsonl_path)? else {
+        return Ok(store);
+    };
+    Ok(Arc::new(
+        InstrumentedObjectStore::new(store, recorder)
+            .store_kind(TraceStoreKind::from(config.store.kind()).as_str()),
+    ) as SharedObjectStore)
 }
 
 #[cfg(test)]
@@ -222,16 +233,15 @@ pub(super) async fn build_handles_with_metrics_jsonl_path(
     store: SharedObjectStore,
     metrics_jsonl_path: Option<OsString>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
-    build_handles_with_metrics_and_grep(config, store, metrics_jsonl_path, None).await
+    let store = instrumented_store(config, store, metrics_jsonl_path)?;
+    build_handles(config, store, None).await
 }
 
-async fn build_handles_with_metrics_and_grep(
+async fn build_handles(
     config: &ServerConfig,
     store: SharedObjectStore,
-    metrics_jsonl_path: Option<OsString>,
     grep_drivers: Option<GrepDrivers>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
-    let metrics_recorder = object_store_metrics_recorder(metrics_jsonl_path)?;
     let trace_store_kind = TraceStoreKind::from(config.store.kind());
     let runtime_error = |error: loonfs::RuntimeError| ServerConfigError::InvalidField {
         field: "runtime",
@@ -254,9 +264,6 @@ async fn build_handles_with_metrics_and_grep(
         .runtime_cache(config.runtime_cache_config())
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
-    if let Some(recorder) = metrics_recorder.clone() {
-        writer_builder = writer_builder.metrics_recorder(recorder);
-    }
     if let Some(drivers) = grep_drivers {
         writer_builder = writer_builder.publish_observer(move |namespace_id, _committed_seq| {
             drivers.nudge_existing(namespace_id);
@@ -265,7 +272,7 @@ async fn build_handles_with_metrics_and_grep(
     let writer = writer_builder.build().await.map_err(runtime_error)?;
     let reader = writer.reader();
 
-    let mut admin_builder = FsAdmin::builder_with_store(store)
+    let admin_builder = FsAdmin::builder_with_store(store)
         .actor_id(format!("{}-admin", config.writer_id))
         .actor_version(config.writer_version.clone())
         // The admin honors the configured cache sizing and shares the
@@ -276,9 +283,6 @@ async fn build_handles_with_metrics_and_grep(
         .shared_metadata_table_cache(&writer)
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
-    if let Some(recorder) = metrics_recorder {
-        admin_builder = admin_builder.metrics_recorder(recorder);
-    }
     let admin = admin_builder.build().await.map_err(runtime_error)?;
 
     Ok((writer, reader, admin))

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1690,7 +1690,7 @@ async fn readiness_answers_ready_then_shutting_down_once_admission_closes() {
         .expect("readiness body");
     assert_eq!(body, "ready");
 
-    state.publisher.close_admission();
+    state.writer.publisher().close_admission();
 
     tokio::task::spawn_blocking(move || match raw_agent().get(&ready_url).call() {
         Err(ureq::Error::Status(503, response)) => {

--- a/crates/loonfs/src/background.rs
+++ b/crates/loonfs/src/background.rs
@@ -1,9 +1,10 @@
 //! Writer-scheduled background maintenance: the policy knob, the
 //! per-namespace singleflight, and the task registry a shutdown drains.
 //!
-//! LoonFS never creates a hidden runtime for maintenance. Work a handle
-//! schedules for itself is spawned on the handle's owning Tokio runtime and
-//! stays visible to shutdown through the registry here.
+//! LoonFS never creates a hidden runtime for maintenance. Work a writer
+//! schedules for itself is spawned on the writer's owning Tokio runtime and
+//! stays visible to shutdown through the registry here. Only a writer owns
+//! one of these: readers and admins schedule nothing.
 
 use crate::{NamespaceId, Result, RuntimeError};
 use std::collections::BTreeSet;
@@ -61,15 +62,6 @@ struct BackgroundState {
 }
 
 impl BackgroundWork {
-    pub(crate) fn inert() -> Self {
-        Self::new(
-            FsBackgroundWork::ManualOnly,
-            None,
-            NonZeroUsize::new(crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE)
-                .expect("default maintenance concurrency should be nonzero"),
-        )
-    }
-
     pub(crate) fn new(
         policy: FsBackgroundWork,
         runtime: Option<tokio::runtime::Handle>,

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -1,10 +1,10 @@
 //! Runtime caching: control-object reads and WAL-tail projections, plus the
-//! cache-management half of [`FsCore`].
+//! cache-management half of [`ReadCore`].
 //!
 //! Every cache revalidates against durable state before its contents are
 //! used; nothing here weakens read-after-write consistency.
 
-use crate::fs::{should_invalidate_after_result, FsCore};
+use crate::fs::{should_invalidate_after_result, ReadCore};
 use crate::{CommitResponse, CoreError, NamespaceId};
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
@@ -220,7 +220,7 @@ impl RuntimeControlCache {
     }
 }
 
-impl FsCore {
+impl ReadCore {
     pub(crate) async fn load_namespace_head_cached(
         &self,
         namespace_id: &NamespaceId,
@@ -388,7 +388,7 @@ impl FsCore {
         );
         let head = head?;
         let read_context = self.runtime_read_context(&head, catalog?);
-        Ok((self.namespace_engine(namespace_id), read_context))
+        Ok((self.reader_engine(namespace_id), read_context))
     }
 
     /// Returns the namespace's immutable catalog pair through the control
@@ -417,16 +417,6 @@ impl FsCore {
             self.inner.config.runtime_cache.max_cached_namespaces,
         );
         Ok(Some(loaded))
-    }
-
-    #[tracing::instrument(
-        level = "info",
-        name = "loonfs.phase",
-        skip_all,
-        fields(phase = "update_cache")
-    )]
-    pub(crate) fn invalidate_namespace_cache(&self, namespace_id: &NamespaceId) {
-        self.invalidate_namespace_read_cache(namespace_id);
     }
 
     /// Namespace-terminal invalidation: the whole entry is removed, because
@@ -479,6 +469,16 @@ impl FsCore {
         );
     }
 
+    /// Drops the namespace's read caches. The publish-side view of the same
+    /// state — a namespace publisher's WAL tail projection — is stale for
+    /// exactly the same reasons, so a caller that owns a publication service
+    /// drops that too; see `FsWriter::invalidate_namespace`.
+    #[tracing::instrument(
+        level = "info",
+        name = "loonfs.phase",
+        skip_all,
+        fields(phase = "update_cache")
+    )]
     pub(crate) fn invalidate_namespace_read_cache(&self, namespace_id: &NamespaceId) {
         self.inner
             .control_cache()
@@ -486,23 +486,13 @@ impl FsCore {
         self.inner
             .wal_tail_projection_cache
             .invalidate_namespace(namespace_id);
-        // The namespace's publish-side view of the same state: its WAL tail
-        // projection is stale for exactly the reasons the read caches are.
-        self.inner.publisher.invalidate_engine(namespace_id);
     }
 
-    pub(crate) fn finish_namespace_mutation<T>(
-        &self,
-        namespace_id: &NamespaceId,
-        result: Result<T>,
-    ) -> Result<T> {
-        if should_invalidate_after_result(&result) {
-            self.invalidate_namespace_cache(namespace_id);
-        }
-        result
-    }
-
-    pub(crate) fn invalidate_namespace_cache_after_batch(
+    /// Drops the read caches after a publication batch that may have moved
+    /// the namespace on. The publisher's own engine needs no invalidation
+    /// here: it is the engine that just published, and it revalidates
+    /// against the live head on its next unit of work.
+    pub(crate) fn invalidate_read_cache_after_batch(
         &self,
         namespace_id: &NamespaceId,
         results: &[Result<CommitResponse>],

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -1,5 +1,6 @@
-//! Runtime configuration: writer identity, publication pacing, and cache
-//! sizing, with the defaults the rest of the crate advertises.
+//! Runtime configuration: read-side limits and cache sizing, plus the
+//! writer-identity validation the write-capable builders apply, with the
+//! defaults the rest of the crate advertises.
 
 use crate::trace::{TraceMode, TraceStoreKind};
 use crate::{MetadataTableCacheConfig, Result, RuntimeError};
@@ -26,17 +27,13 @@ pub(crate) const DEFAULT_MIN_PUBLISH_INTERVAL_MS: u64 = 15;
 /// publish that observes the namespace still over its threshold.
 pub const DEFAULT_MAX_CONCURRENT_MAINTENANCE: usize = 2;
 
-/// Configuration for one runtime core, assembled by the handle builders.
+/// Configuration for one read core, assembled by the handle builders.
+///
+/// Everything here governs reading and caching, so every handle carries it.
+/// Writer-side settings — the actor identity and publication pacing — belong
+/// to the write-capable handles and never reach a reader.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct FsConfig {
-    /// Writer id used for namespace epoch acquisition and commits.
-    pub writer_id: String,
-    /// Writer version reported in mutation context.
-    pub writer_version: String,
-    /// Minimum interval between publication starts per namespace, in
-    /// milliseconds; zero keeps only the batching that in-flight
-    /// publications force.
-    pub min_publish_interval_ms: u64,
+pub(crate) struct ReadConfig {
     /// Largest file content the buffered read APIs will materialize for one
     /// call, checked against resolved metadata before any content fetch.
     /// `None` (the embedded default) reads files of any size; servers set
@@ -100,13 +97,17 @@ pub(crate) fn default_writer_version() -> String {
     format!("loonfs/{}", env!("CARGO_PKG_VERSION"))
 }
 
-pub(crate) fn validate_config(config: &FsConfig) -> Result<()> {
-    if config.writer_id.trim().is_empty() {
+/// Checks the actor identity a write-capable handle will publish under.
+///
+/// Only the writer and admin builders call this; a reader has no identity to
+/// check.
+pub(crate) fn validate_writer_identity(writer_id: &str, writer_version: &str) -> Result<()> {
+    if writer_id.trim().is_empty() {
         return Err(RuntimeError::Config(
             "writer_id must not be empty".to_owned(),
         ));
     }
-    if config.writer_version.trim().is_empty() {
+    if writer_version.trim().is_empty() {
         return Err(RuntimeError::Config(
             "writer_version must not be empty".to_owned(),
         ));

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -1,9 +1,10 @@
-//! [`FsCore`]: the shared runtime state behind the handles, its
-//! constructor, and the background-step bookkeeping.
+//! [`ReadCore`]: the read-side runtime state every handle shares, and the
+//! writer-side state — actor identity, background work, publish observer —
+//! that only a write-capable handle owns on top of it.
 
 use crate::background::BackgroundWork;
 use crate::cache::{RuntimeCacheStatsInner, RuntimeControlCache};
-use crate::config::{validate_config, FsConfig};
+use crate::config::{validate_writer_identity, ReadConfig};
 use crate::publisher::{PublishObserver, PublisherRegistry};
 use crate::time::current_time_ms;
 use crate::{
@@ -27,35 +28,70 @@ use loonfs_grep::GrepService;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-/// Shared runtime core. [`FsWriter`](crate::FsWriter),
-/// [`FsReader`](crate::FsReader), and [`FsAdmin`](crate::FsAdmin) each wrap
-/// one; handles derived from the same core share its caches and store.
+/// Shared read-side runtime state: the object-store client, the read caches,
+/// and the grep service. [`FsWriter`](crate::FsWriter),
+/// [`FsReader`](crate::FsReader), and [`FsAdmin`](crate::FsAdmin) each hold
+/// one; handles built from the same core share its caches and store.
 ///
-/// `FsCore` is cheap to clone.
+/// A read core carries no actor identity, owns no publisher, and starts no
+/// background work — it is what a read needs and nothing more. `ReadCore` is
+/// cheap to clone.
 #[derive(Clone)]
-pub(crate) struct FsCore {
-    pub(crate) inner: Arc<FsInner>,
+pub(crate) struct ReadCore {
+    pub(crate) inner: Arc<ReadCoreInner>,
 }
 
-pub(crate) struct FsInner {
+pub(crate) struct ReadCoreInner {
     pub(crate) store: SharedObjectStore,
-    pub(crate) config: FsConfig,
-    pub(crate) writer_session_id: String,
+    pub(crate) config: ReadConfig,
     pub(crate) control_cache: Mutex<RuntimeControlCache>,
     pub(crate) metadata_table_cache: Arc<MetadataTableCache>,
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
     pub(crate) grep_service: GrepService,
     pub(crate) cache_stats: RuntimeCacheStatsInner,
-    pub(crate) background: BackgroundWork,
+}
+
+/// The actor identity a write-capable handle publishes under: immutable
+/// plain data, minted once when the handle is built.
+#[derive(Clone)]
+pub(crate) struct WriterIdentity {
+    pub(crate) writer_id: String,
+    pub(crate) writer_session_id: String,
+    pub(crate) writer_version: String,
+}
+
+/// What a publisher worker needs from the writer that owns it, in one
+/// allocation the worker can hold weakly: dropping the writer drops these,
+/// and admitted work then settles as `shutting_down` instead of publishing
+/// under an identity nobody owns any more.
+pub(crate) struct WriterBits {
+    pub(crate) identity: WriterIdentity,
+    pub(crate) background: Arc<BackgroundWork>,
     /// Optional synchronous notification after a mutation batch durably
     /// advances a namespace. Callers promise that it does not block.
     pub(crate) publish_observer: Option<PublishObserver>,
-    /// The core's publication service: every mutation — direct handle
-    /// calls and server submissions alike — publishes through it. Its
-    /// per-namespace publishers own the commit engines and writer sessions,
-    /// deliberately outside every rebuildable cache. It holds this core
-    /// weakly, so the ownership does not cycle.
-    pub(crate) publisher: PublisherRegistry,
+}
+
+impl WriterIdentity {
+    /// Mints an identity with a fresh session id, rejecting an empty actor
+    /// id or version.
+    pub(crate) fn new(writer_id: String, writer_version: String) -> Result<Self> {
+        validate_writer_identity(&writer_id, &writer_version)?;
+        Ok(Self {
+            writer_id,
+            writer_session_id: generated_id("wrs"),
+            writer_version,
+        })
+    }
+
+    pub(crate) fn mutation_context(&self) -> Result<MutationContext> {
+        Ok(MutationContext {
+            writer_id: self.writer_id.clone(),
+            writer_session_id: self.writer_session_id.clone(),
+            writer_version: self.writer_version.clone(),
+            now_ms: current_time_ms()?,
+        })
+    }
 }
 
 /// Lock accessors for the runtime caches.
@@ -63,7 +99,7 @@ pub(crate) struct FsInner {
 /// Poisoning is propagated as a panic: a poisoned cache means another thread
 /// panicked mid-update, and serving from it could violate the consistency the
 /// caches promise.
-impl FsInner {
+impl ReadCoreInner {
     pub(crate) fn control_cache(&self) -> MutexGuard<'_, RuntimeControlCache> {
         self.control_cache
             .lock()
@@ -71,22 +107,19 @@ impl FsInner {
     }
 }
 
-impl FsCore {
-    /// Opens a runtime core. `shared_metadata_table_cache` substitutes an
+impl ReadCore {
+    /// Opens a read core. `shared_metadata_table_cache` substitutes an
     /// existing decoded-block cache for a freshly sized one, so handles
     /// with distinct actor identities can still share warmed blocks —
     /// sound across cores because entries are keyed by immutable
     /// identities (payload checksums and manifest object keys); the
     /// sharing caller owns the sizing decision, and
     /// `config.runtime_cache.metadata_table_cache` goes unused.
-    pub(crate) fn open_with_background(
+    pub(crate) fn open(
         store: SharedObjectStore,
-        config: FsConfig,
-        background: BackgroundWork,
+        config: ReadConfig,
         shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
-        publish_observer: Option<PublishObserver>,
-    ) -> Result<Self> {
-        validate_config(&config)?;
+    ) -> Self {
         let metadata_table_cache = shared_metadata_table_cache.unwrap_or_else(|| {
             Arc::new(MetadataTableCache::new(
                 config.runtime_cache.metadata_table_cache.clone(),
@@ -100,36 +133,17 @@ impl FsCore {
                     .runtime_cache
                     .max_cached_wal_tail_projection_decoded_bytes,
             }));
-        let min_publish_interval = std::time::Duration::from_millis(config.min_publish_interval_ms);
-        let trace_mode = config.trace_mode.as_str();
-        let trace_store_kind = config.trace_store_kind.as_str();
-        // Cyclic by design: the core owns its publication service, and the
-        // service reaches back into the core through a weak reference.
-        Ok(Self {
-            inner: Arc::new_cyclic(|weak| FsInner {
+        Self {
+            inner: Arc::new(ReadCoreInner {
                 store,
                 config,
-                writer_session_id: generated_id("wrs"),
                 control_cache: Mutex::new(RuntimeControlCache::default()),
                 metadata_table_cache,
                 wal_tail_projection_cache,
                 grep_service: GrepService::new(),
                 cache_stats: RuntimeCacheStatsInner::default(),
-                background,
-                publish_observer,
-                publisher: PublisherRegistry::from_core(
-                    weak.clone(),
-                    min_publish_interval,
-                    trace_mode,
-                    trace_store_kind,
-                ),
             }),
-        })
-    }
-
-    /// The core's publication service; see [`crate::publisher`].
-    pub(crate) fn publisher(&self) -> &PublisherRegistry {
-        &self.inner.publisher
+        }
     }
 
     /// This runtime's shared decoded-block cache handle, for builders
@@ -138,9 +152,17 @@ impl FsCore {
         Arc::clone(&self.inner.metadata_table_cache)
     }
 
+    pub(crate) fn trace_mode(&self) -> &'static str {
+        self.inner.config.trace_mode.as_str()
+    }
+
+    pub(crate) fn trace_store_kind(&self) -> &'static str {
+        self.inner.config.trace_store_kind.as_str()
+    }
+
     pub(super) fn record_trace_context(&self, span: &tracing::Span) {
-        span.record("mode", self.inner.config.trace_mode.as_str());
-        span.record("store_kind", self.inner.config.trace_store_kind.as_str());
+        span.record("mode", self.trace_mode());
+        span.record("store_kind", self.trace_store_kind());
     }
 
     /// Returns the capability document for this embedded build (API spec,
@@ -200,66 +222,60 @@ impl FsCore {
         )
     }
 
-    /// Waits until every scheduled background maintenance step has finished.
-    ///
-    /// Call this to quiesce before shutdown, or in tests that assert on
-    /// post-maintenance state. Panicked steps surface as a runtime-task
-    /// error.
-    pub(crate) async fn wait_for_background_maintenance(&self) -> Result<()> {
-        self.inner.background.drain().await
-    }
-
-    /// Rejects any further background maintenance scheduling.
-    pub(crate) fn shut_down_background(&self) {
-        self.inner.background.shut_down();
-    }
-
     pub(crate) fn store(&self) -> &dyn ObjectStore {
         self.inner.store.as_ref()
     }
 
-    pub(crate) fn namespace_engine(
+    /// This core's object-store client, for the few in-process consumers
+    /// that read LoonFS-owned objects outside the handle surface.
+    pub(crate) fn shared_store(&self) -> SharedObjectStore {
+        Arc::clone(&self.inner.store)
+    }
+
+    /// A read-only engine: no actor identity, so a reader mints no writer
+    /// session id and cannot mutate even by mistake.
+    pub(crate) fn reader_engine(
         &self,
         namespace_id: &NamespaceId,
     ) -> NamespaceEngine<SharedObjectStore> {
-        self.namespace_engine_with_store(namespace_id, self.inner.store.clone())
-    }
-
-    pub(crate) fn namespace_engine_with_store<S: ObjectStore>(
-        &self,
-        namespace_id: &NamespaceId,
-        store: S,
-    ) -> NamespaceEngine<S> {
-        NamespaceEngine::builder(store)
+        NamespaceEngine::builder(self.inner.store.clone())
             .namespace_id(namespace_id.clone())
-            .writer_id(self.inner.config.writer_id.clone())
-            .writer_session_id(self.inner.writer_session_id.clone())
-            .writer_version(self.inner.config.writer_version.clone())
-            .build()
-            .expect("validated runtime config should build namespace engine")
+            .build_reader()
+            .expect("a namespace id is the reader engine's only requirement")
     }
 
-    pub(crate) fn mutation_context(&self) -> Result<MutationContext> {
-        Ok(MutationContext {
-            writer_id: self.inner.config.writer_id.clone(),
-            writer_session_id: self.inner.writer_session_id.clone(),
-            writer_version: self.inner.config.writer_version.clone(),
-            now_ms: current_time_ms()?,
-        })
+    /// A mutating engine bound to one actor identity.
+    pub(crate) fn writer_engine(
+        &self,
+        actor: &WriterIdentity,
+        namespace_id: &NamespaceId,
+    ) -> NamespaceEngine<SharedObjectStore> {
+        NamespaceEngine::builder(self.inner.store.clone())
+            .namespace_id(namespace_id.clone())
+            .writer_id(actor.writer_id.clone())
+            .writer_session_id(actor.writer_session_id.clone())
+            .writer_version(actor.writer_version.clone())
+            .build()
+            .expect("a validated actor identity should build a namespace engine")
     }
 }
 
 /// Holds a background singleflight claim across a spawned step. Dropping —
 /// on completion, panic, or a task discarded with its runtime — releases the
 /// namespace for the next scheduling decision.
+///
+/// The claim holds the writer's bits strongly on purpose: a scheduled step is
+/// the writer's own work, and it dies with the task that runs it.
 pub(super) struct BackgroundStepClaim {
-    pub(super) fs: FsCore,
+    pub(super) core: ReadCore,
+    pub(super) bits: Arc<WriterBits>,
+    pub(super) publisher: PublisherRegistry,
     pub(super) namespace_id: NamespaceId,
 }
 
 impl Drop for BackgroundStepClaim {
     fn drop(&mut self) {
-        self.fs.inner.background.release(&self.namespace_id);
+        self.bits.background.release(&self.namespace_id);
     }
 }
 

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -8,13 +8,42 @@ use crate::{
     AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
     ErrorCode, FlushWalOutcome, FlushWalResponse, MaintenanceStepKind, MaintenanceStepOptions,
     MaintenanceStepResponse, NamespaceId, ReleaseCheckpointResponse, ReorganizeStepOutcome,
-    WalFlushStepOutcome,
+    SharedObjectStore, WalFlushStepOutcome,
 };
 use crate::{Result, RuntimeError};
 use loonfs_api::v0::{DisableGrepIndexResponse, EnableGrepIndexResponse};
 use loonfs_core::cache::load_namespace_head_summary;
 
 impl FsAdmin {
+    /// A mutating engine under this handle's actor identity.
+    fn engine(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> loonfs_core::NamespaceEngine<SharedObjectStore> {
+        self.core.writer_engine(&self.actor, namespace_id)
+    }
+
+    /// Drops everything this runtime caches for a namespace: the read
+    /// caches, and — when this handle runs over a writer's runtime — the
+    /// rebuildable half of that namespace's publisher state.
+    fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
+        self.core.invalidate_namespace_read_cache(namespace_id);
+        if let Some(publisher) = &self.publisher {
+            publisher.invalidate_engine(namespace_id);
+        }
+    }
+
+    fn finish_namespace_mutation<T>(
+        &self,
+        namespace_id: &NamespaceId,
+        result: Result<T>,
+    ) -> Result<T> {
+        if crate::fs::should_invalidate_after_result(&result) {
+            self.invalidate_namespace(namespace_id);
+        }
+        result
+    }
+
     /// Summarizes a namespace's current head: manifest, latest checkpoint,
     /// WAL tail, and retention floor.
     pub async fn namespace_status(
@@ -201,8 +230,7 @@ impl FsAdmin {
         namespace_id: &NamespaceId,
     ) -> Result<loonfs_core::MetadataReorganizeOutcome> {
         let report = self
-            .core
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .reorganize_metadata()
             .await
             .map_err(RuntimeError::Core)?;
@@ -216,7 +244,7 @@ impl FsAdmin {
                 decoded_input_bytes,
                 ..
             } => {
-                self.core.invalidate_namespace_cache(namespace_id);
+                self.invalidate_namespace(namespace_id);
                 tracing::info!(
                     families = ?families,
                     folded_l0_rows,
@@ -381,10 +409,10 @@ impl FsAdmin {
 
     fn grep_worker(&self) -> loonfs_grep::GrepWorker<crate::SharedObjectStore> {
         loonfs_grep::GrepWorker::new(
-            self.core.inner.store.clone(),
-            self.core.inner.config.writer_id.clone(),
-            self.core.inner.writer_session_id.clone(),
-            self.core.inner.config.writer_version.clone(),
+            self.core.shared_store(),
+            self.actor.writer_id.clone(),
+            self.actor.writer_session_id.clone(),
+            self.actor.writer_version.clone(),
         )
     }
 
@@ -402,13 +430,13 @@ impl FsAdmin {
             self.core.store(),
             namespace_id,
             config,
-            &self.core.mutation_context()?,
+            &self.actor.mutation_context()?,
         )
         .await
         .map_err(RuntimeError::Core)?;
         // Sweeping can remove objects cached views still reference; drop the
         // namespace caches rather than trusting them across a collection.
-        self.core.invalidate_namespace_read_cache(namespace_id);
+        self.invalidate_namespace(namespace_id);
         Ok(report)
     }
 
@@ -420,11 +448,11 @@ impl FsAdmin {
         let response = loonfs_core::repair_namespace(
             self.core.store(),
             namespace_id,
-            &self.core.mutation_context()?,
+            &self.actor.mutation_context()?,
         )
         .await
         .map_err(RuntimeError::Core)?;
-        self.core.invalidate_namespace_read_cache(namespace_id);
+        self.invalidate_namespace(namespace_id);
         Ok(response)
     }
 
@@ -453,12 +481,11 @@ impl FsAdmin {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
         let result = self
-            .core
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .create_checkpoint(options.name, options.ttl_ms)
             .await
             .map_err(RuntimeError::from);
-        self.core.finish_namespace_mutation(namespace_id, result)
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     /// Releases a user-owned checkpoint by id. Idempotent.
@@ -468,12 +495,11 @@ impl FsAdmin {
         checkpoint_id: &CheckpointId,
     ) -> Result<ReleaseCheckpointResponse> {
         let result = self
-            .core
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .release_checkpoint(checkpoint_id)
             .await
             .map_err(RuntimeError::from);
-        self.core.finish_namespace_mutation(namespace_id, result)
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     /// Flushes the WAL tail and advances the metadata root, creating no
@@ -493,12 +519,11 @@ impl FsAdmin {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
         let result = self
-            .core
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .flush_wal()
             .await
             .map_err(RuntimeError::from);
-        self.core.finish_namespace_mutation(namespace_id, result)
+        self.finish_namespace_mutation(namespace_id, result)
     }
 
     /// Advances the namespace retention floor when a verified checkpoint
@@ -508,11 +533,10 @@ impl FsAdmin {
         namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse> {
         let result = self
-            .core
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .advance_retention_floor()
             .await
             .map_err(RuntimeError::from);
-        self.core.finish_namespace_mutation(namespace_id, result)
+        self.finish_namespace_mutation(namespace_id, result)
     }
 }

--- a/crates/loonfs/src/fs/mod.rs
+++ b/crates/loonfs/src/fs/mod.rs
@@ -1,5 +1,5 @@
-//! The shared runtime core behind the purpose-specific handles: caches,
-//! writer session identity, and the operation surface, each method a thin,
+//! The read core every handle shares, the writer-side state a write-capable
+//! handle owns on top of it, and the operation surface — each method a thin,
 //! cache-aware delegation to `loonfs-core`.
 
 mod core;
@@ -11,4 +11,6 @@ mod tests;
 mod uploads;
 mod writes;
 
-pub(crate) use core::{should_invalidate_after_result, FsCore, FsInner};
+pub(crate) use core::{should_invalidate_after_result, ReadCore, WriterBits, WriterIdentity};
+pub(crate) use namespaces::delete_namespace_with_engine;
+pub(crate) use writes::publish_batch_with_engine;

--- a/crates/loonfs/src/fs/namespaces.rs
+++ b/crates/loonfs/src/fs/namespaces.rs
@@ -1,24 +1,25 @@
 //! Namespace lifecycle: create, fork, and delete.
 
-use super::core::{should_invalidate_after_result, FsCore};
+use super::core::{should_invalidate_after_result, ReadCore, WriterIdentity};
+use crate::FsWriter;
 use crate::{
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, NamespaceId,
     NamespaceSummary,
 };
 use crate::{Result, RuntimeError};
 
-impl FsCore {
+impl FsWriter {
     /// Creates a namespace, bootstrapping its durable state.
     ///
     /// With `options.allow_existing`, an already-existing namespace is
     /// treated as success.
-    pub(crate) async fn create_namespace(
+    pub async fn create_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
     ) -> Result<NamespaceSummary> {
         let result = self
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .bootstrap_namespace(loonfs_core::BootstrapOptions {
                 allow_existing: options.allow_existing,
             })
@@ -30,21 +31,21 @@ impl FsCore {
     /// Forks `source` into `target` at the source's current head.
     ///
     /// The fork shares immutable file bytes but gets its own metadata history.
-    pub(crate) async fn fork_namespace(
+    pub async fn fork_namespace(
         &self,
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> Result<NamespaceSummary> {
         let result = self
-            .namespace_engine(source)
+            .engine(source)
             .fork_namespace(target)
             .await
             .map_err(RuntimeError::from);
         if should_invalidate_after_result(&result) {
-            self.invalidate_namespace_cache(source);
+            self.invalidate_namespace(source);
         }
         if result.is_ok() {
-            self.invalidate_namespace_cache(target);
+            self.invalidate_namespace(target);
         }
         result
     }
@@ -58,39 +59,39 @@ impl FsCore {
     /// Sequenced as a barrier through the publication service: mutations
     /// admitted before the delete publish first, and mutations admitted
     /// after it fail once it succeeds.
-    pub(crate) async fn delete_namespace(
+    pub async fn delete_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: DeleteNamespaceOptions,
     ) -> Result<DeleteNamespaceResponse> {
-        self.inner
-            .publisher
+        self.publisher
             .submit_delete(namespace_id.clone(), options)
             .await
             .map_err(RuntimeError::Core)
     }
+}
 
-    /// The delete itself, run by the publication service once the barrier
-    /// admits it, through the publisher's own commit engine: the session
-    /// epoch and fencing that govern this namespace's publications govern
-    /// its tombstone swap too. Only the service calls this; everything else
-    /// must go through [`Self::delete_namespace`] so the barrier holds.
-    pub(crate) async fn delete_namespace_with_engine(
-        &self,
-        namespace_id: &NamespaceId,
-        engine: &mut loonfs_core::publish::NamespaceCommitEngine,
-        options: DeleteNamespaceOptions,
-    ) -> Result<DeleteNamespaceResponse> {
-        let result = engine
-            .delete_namespace(self.store(), options, &self.mutation_context()?)
-            .await
-            .map_err(RuntimeError::from);
-        if result.is_ok() {
-            // Only a namespace that is actually gone drops its cached state:
-            // a failed delete (a fenced deleter, say) leaves the namespace
-            // live, and its cached reads valid.
-            self.invalidate_namespace_cache_for_delete(namespace_id);
-        }
-        result
+/// The delete itself, run by the publication service once the barrier
+/// admits it, through the publisher's own commit engine: the session
+/// epoch and fencing that govern this namespace's publications govern
+/// its tombstone swap too. Only the service calls this; everything else
+/// must go through [`FsWriter::delete_namespace`] so the barrier holds.
+pub(crate) async fn delete_namespace_with_engine(
+    core: &ReadCore,
+    actor: &WriterIdentity,
+    namespace_id: &NamespaceId,
+    engine: &mut loonfs_core::publish::NamespaceCommitEngine,
+    options: DeleteNamespaceOptions,
+) -> Result<DeleteNamespaceResponse> {
+    let result = engine
+        .delete_namespace(core.store(), options, &actor.mutation_context()?)
+        .await
+        .map_err(RuntimeError::from);
+    if result.is_ok() {
+        // Only a namespace that is actually gone drops its cached state:
+        // a failed delete (a fenced deleter, say) leaves the namespace
+        // live, and its cached reads valid.
+        core.invalidate_namespace_cache_for_delete(namespace_id);
     }
+    result
 }

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -283,7 +283,7 @@ impl FsReader {
         };
         Ok(self
             .core
-            .namespace_engine(namespace_id)
+            .reader_engine(namespace_id)
             .list_changes_after(after_seq, limit)
             .await?)
     }

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -17,11 +17,7 @@ impl FsWriter {
         namespace_id: &NamespaceId,
         request: BeginUploadRequest,
     ) -> Result<BeginUploadResponse> {
-        Ok(self
-            .core
-            .namespace_engine(namespace_id)
-            .begin_upload(request)
-            .await?)
+        Ok(self.engine(namespace_id).begin_upload(request).await?)
     }
 
     /// Starts a direct-put upload session and returns the internal target for server-side signing.
@@ -31,8 +27,7 @@ impl FsWriter {
         content_ref: ContentRef,
     ) -> Result<BeginDirectPutUploadTargetResponse> {
         Ok(self
-            .core
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .begin_direct_put_upload_target(content_ref)
             .await?)
     }
@@ -45,8 +40,7 @@ impl FsWriter {
         bytes: &[u8],
     ) -> Result<UploadContentResponse> {
         Ok(self
-            .core
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .upload_content(upload_id, bytes)
             .await?)
     }
@@ -78,8 +72,7 @@ impl FsWriter {
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
         Ok(self
-            .core
-            .namespace_engine(namespace_id)
+            .engine(namespace_id)
             .complete_upload_prepared_with_catalog(&catalog, upload_id, request)
             .await?)
     }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -1,7 +1,8 @@
 //! [`FsWriter`]'s path mutations, commits, and the publication pipeline.
 
-use super::core::BackgroundStepClaim;
+use super::core::{BackgroundStepClaim, ReadCore, WriterBits};
 use crate::publish::{NamespaceMutationCandidate, PathMutationIntent, PreparedContent};
+use crate::publisher::PublisherRegistry;
 use crate::FsWriter;
 use crate::{
     ChangeSeq, CommitId, CommitRequest, CommitResponse, ContentRef, CopyOptions, CoreError,
@@ -9,8 +10,36 @@ use crate::{
     NamespaceId, PutFileOptions, RestoreRevisionOptions, RevisionNo, UndeleteOptions,
 };
 use crate::{Result, RuntimeError};
+use loonfs_core::NamespaceEngine;
+use std::sync::Arc;
 
 impl FsWriter {
+    /// A mutating engine under this writer's identity.
+    pub(crate) fn engine(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> NamespaceEngine<crate::SharedObjectStore> {
+        self.core.writer_engine(&self.bits.identity, namespace_id)
+    }
+
+    /// Drops everything this runtime caches for a namespace: the read
+    /// caches, and the rebuildable half of its publisher's publish state.
+    pub(crate) fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
+        self.core.invalidate_namespace_read_cache(namespace_id);
+        self.publisher.invalidate_engine(namespace_id);
+    }
+
+    pub(crate) fn finish_namespace_mutation<T>(
+        &self,
+        namespace_id: &NamespaceId,
+        result: Result<T>,
+    ) -> Result<T> {
+        if super::should_invalidate_after_result(&result) {
+            self.invalidate_namespace(namespace_id);
+        }
+        result
+    }
+
     /// Writes file bytes to a path.
     ///
     /// The bytes become durable content first; metadata referencing them is
@@ -431,193 +460,204 @@ impl FsWriter {
         namespace_id: &NamespaceId,
         candidate: NamespaceMutationCandidate,
     ) -> Result<CommitResponse> {
-        self.core
-            .inner
-            .publisher
+        self.publisher
             .submit_candidate(namespace_id.clone(), candidate)
             .await
             .map_err(RuntimeError::Core)
     }
+}
 
-    /// Publishes already-classified candidates as one batch — one WAL
-    /// segment, one head compare-and-swap — through the namespace
-    /// publisher's own commit engine, and settles the runtime state the
-    /// batch produced: read caches, publish observer, maintenance.
-    ///
-    /// Only the publication service calls this: it owns the engine, and
-    /// borrowing it here keeps engine construction and locking in that one
-    /// place. Results match candidates in order.
-    pub(crate) async fn publish_batch_with_engine(
-        &self,
-        namespace_id: &NamespaceId,
-        engine: &mut loonfs_core::publish::NamespaceCommitEngine,
-        candidates: Vec<NamespaceMutationCandidate>,
-    ) -> Vec<Result<CommitResponse>> {
-        let batch_size = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
-        let store = self.core.store();
-        let context = match self.core.mutation_context() {
-            Ok(context) => context,
-            Err(error) => return candidates.iter().map(|_| Err(error.clone())).collect(),
-        };
-        let cache_config = &self.core.inner.config.runtime_cache;
-        let tail_options = loonfs_core::publish::PublishTailOptions {
-            max_tail_rows: cache_config.max_cached_wal_tail_projection_rows,
-            max_tail_decoded_bytes: cache_config.max_cached_wal_tail_projection_decoded_bytes,
-        };
-        // Boxing erases the engine's deeply nested publish future; without
-        // it, callers awaiting a put or commit (CLI, server, embedding
-        // crates) exceed rustc's type-recursion depth.
-        let mut publish =
-            Box::pin(engine.publish_batch(&store, candidates, &context, &tail_options)).await;
-        if !self.core.control_cache_enabled() {
-            // Diagnostic mode: the publisher's engine outlives the publish
-            // even with caches off, so drop the tail projection it just
-            // built. Every publish then reads what a cold engine reads.
-            engine.invalidate();
-        }
-        {
-            let _span = tracing::info_span!(
-                "loonfs.phase",
-                phase = "batch_update_cache",
-                mode = self.core.inner.config.trace_mode.as_str(),
-                store_kind = self.core.inner.config.trace_store_kind.as_str(),
-                batch_size
-            )
-            .entered();
-            match publish.resulting_read_state.take() {
-                // A landed publish hands the caches exactly the state a
-                // rebuild would recompute; use it instead of dropping.
-                Some(state) => self.core.seed_namespace_read_cache(namespace_id, state),
-                None => {
-                    let runtime_results = publish
-                        .results
-                        .iter()
-                        .map(|result| result.clone().map_err(RuntimeError::Core))
-                        .collect::<Vec<_>>();
-                    self.core
-                        .invalidate_namespace_cache_after_batch(namespace_id, &runtime_results);
-                }
+/// Publishes already-classified candidates as one batch — one WAL
+/// segment, one head compare-and-swap — through the namespace
+/// publisher's own commit engine, and settles the runtime state the
+/// batch produced: read caches, publish observer, maintenance.
+///
+/// Only the publication service calls this: it owns the engine, and
+/// borrowing it here keeps engine construction and locking in that one
+/// place. `publisher` is the registry a scheduled maintenance step
+/// invalidates engines through; it is absent only for a publisher whose
+/// registry is already gone. Results match candidates in order.
+pub(crate) async fn publish_batch_with_engine(
+    core: &ReadCore,
+    writer: &Arc<WriterBits>,
+    publisher: Option<&PublisherRegistry>,
+    namespace_id: &NamespaceId,
+    engine: &mut loonfs_core::publish::NamespaceCommitEngine,
+    candidates: Vec<NamespaceMutationCandidate>,
+) -> Vec<Result<CommitResponse>> {
+    let batch_size = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
+    let store = core.store();
+    let context = match writer.identity.mutation_context() {
+        Ok(context) => context,
+        Err(error) => return candidates.iter().map(|_| Err(error.clone())).collect(),
+    };
+    let cache_config = &core.inner.config.runtime_cache;
+    let tail_options = loonfs_core::publish::PublishTailOptions {
+        max_tail_rows: cache_config.max_cached_wal_tail_projection_rows,
+        max_tail_decoded_bytes: cache_config.max_cached_wal_tail_projection_decoded_bytes,
+    };
+    // Boxing erases the engine's deeply nested publish future; without
+    // it, callers awaiting a put or commit (CLI, server, embedding
+    // crates) exceed rustc's type-recursion depth.
+    let mut publish =
+        Box::pin(engine.publish_batch(&store, candidates, &context, &tail_options)).await;
+    if !core.control_cache_enabled() {
+        // Diagnostic mode: the publisher's engine outlives the publish
+        // even with caches off, so drop the tail projection it just
+        // built. Every publish then reads what a cold engine reads.
+        engine.invalidate();
+    }
+    {
+        let _span = tracing::info_span!(
+            "loonfs.phase",
+            phase = "batch_update_cache",
+            mode = core.trace_mode(),
+            store_kind = core.trace_store_kind(),
+            batch_size
+        )
+        .entered();
+        match publish.resulting_read_state.take() {
+            // A landed publish hands the caches exactly the state a
+            // rebuild would recompute; use it instead of dropping.
+            Some(state) => core.seed_namespace_read_cache(namespace_id, state),
+            None => {
+                let runtime_results = publish
+                    .results
+                    .iter()
+                    .map(|result| result.clone().map_err(RuntimeError::Core))
+                    .collect::<Vec<_>>();
+                core.invalidate_read_cache_after_batch(namespace_id, &runtime_results);
             }
         }
-        let wal_tail_segments = publish.wal_tail_segments;
-        let results = publish
-            .results
-            .into_iter()
-            .map(|result| result.map_err(RuntimeError::Core))
-            .collect::<Vec<_>>();
-        self.notify_publish_observer(namespace_id, &results);
-        self.maybe_auto_step_after_publish(namespace_id, wal_tail_segments);
-        results
     }
+    let wal_tail_segments = publish.wal_tail_segments;
+    let results = publish
+        .results
+        .into_iter()
+        .map(|result| result.map_err(RuntimeError::Core))
+        .collect::<Vec<_>>();
+    notify_publish_observer(writer, namespace_id, &results);
+    maybe_auto_step_after_publish(core, writer, publisher, namespace_id, wal_tail_segments);
+    results
+}
 
-    fn notify_publish_observer(
-        &self,
-        namespace_id: &NamespaceId,
-        results: &[Result<CommitResponse>],
-    ) {
-        let Some(observer) = &self.core.inner.publish_observer else {
-            return;
-        };
-        if let Some(committed_seq) = results
-            .iter()
-            .filter_map(|result| result.as_ref().ok())
-            .map(|response| response.committed_seq)
-            .max()
-        {
-            observer(namespace_id, committed_seq);
-        }
+fn notify_publish_observer(
+    writer: &WriterBits,
+    namespace_id: &NamespaceId,
+    results: &[Result<CommitResponse>],
+) {
+    let Some(observer) = &writer.publish_observer else {
+        return;
+    };
+    if let Some(committed_seq) = results
+        .iter()
+        .filter_map(|result| result.as_ref().ok())
+        .map(|response| response.committed_seq)
+        .max()
+    {
+        observer(namespace_id, committed_seq);
     }
+}
 
-    /// Schedules a maintenance step after a publish that observed the WAL
-    /// tail at or past the checkpoint threshold. Steps are spawned on the
-    /// handle's owning runtime — never on a hidden LoonFS runtime — so no
-    /// writer (and no server batch pipeline) waits behind a checkpoint or
-    /// base rebuild. The per-namespace singleflight claim dedupes concurrent
-    /// publishers and is released on every outcome, including step panics
-    /// and dropped tasks.
-    fn maybe_auto_step_after_publish(&self, namespace_id: &NamespaceId, wal_tail_segments: u64) {
-        let options = MaintenanceStepOptions::default();
-        if wal_tail_segments < options.max_wal_tail_segments {
-            return;
-        }
-        if !self.core.inner.background.try_claim(namespace_id) {
-            return;
-        }
-        let claim = BackgroundStepClaim {
-            fs: self.core.clone(),
-            namespace_id: namespace_id.clone(),
-        };
-        self.spawn_claimed_auto_maintenance(claim, options);
+/// Schedules a maintenance step after a publish that observed the WAL
+/// tail at or past the checkpoint threshold. Steps are spawned on the
+/// writer's owning runtime — never on a hidden LoonFS runtime — so no
+/// writer (and no server batch pipeline) waits behind a checkpoint or
+/// base rebuild. The per-namespace singleflight claim dedupes concurrent
+/// publishers and is released on every outcome, including step panics
+/// and dropped tasks.
+fn maybe_auto_step_after_publish(
+    core: &ReadCore,
+    writer: &Arc<WriterBits>,
+    publisher: Option<&PublisherRegistry>,
+    namespace_id: &NamespaceId,
+    wal_tail_segments: u64,
+) {
+    let options = MaintenanceStepOptions::default();
+    if wal_tail_segments < options.max_wal_tail_segments {
+        return;
     }
+    // No registry means the publication service that would own the step is
+    // already gone; there is nothing left to schedule maintenance for.
+    let Some(publisher) = publisher else {
+        return;
+    };
+    if !writer.background.try_claim(namespace_id) {
+        return;
+    }
+    let claim = BackgroundStepClaim {
+        core: core.clone(),
+        bits: Arc::clone(writer),
+        publisher: publisher.clone(),
+        namespace_id: namespace_id.clone(),
+    };
+    spawn_claimed_auto_maintenance(claim, options);
+}
 
-    fn spawn_claimed_auto_maintenance(
-        &self,
-        claim: BackgroundStepClaim,
-        options: MaintenanceStepOptions,
-    ) {
-        // Type erasure lets a finishing task transfer its claim and spawn the
-        // next queued namespace without forming a recursive future type.
-        let future: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
-            Box::pin(async move {
-                let mut claim = claim;
-                loop {
-                    if let Err(error) = FsWriter::from_core(claim.fs.clone())
-                        .run_auto_maintenance(&claim.namespace_id, options.clone())
-                        .await
-                    {
-                        tracing::info!(
-                            phase = "auto_maintenance_step",
-                            result = "error",
-                            error = %error,
-                            "post-publish maintenance step failed"
-                        );
-                    }
-                    let Some(next_namespace_id) = claim
-                        .fs
-                        .inner
-                        .background
-                        .finish_or_rerun(&claim.namespace_id)
-                    else {
-                        break;
-                    };
-                    if next_namespace_id == claim.namespace_id {
-                        // Preserve the existing own-namespace rerun in this
-                        // task before handing its slot to global queued work.
-                        continue;
-                    }
-                    claim.namespace_id = next_namespace_id;
-                    let writer = FsWriter::from_core(claim.fs.clone());
-                    writer.spawn_claimed_auto_maintenance(claim, options);
-                    return;
+fn spawn_claimed_auto_maintenance(claim: BackgroundStepClaim, options: MaintenanceStepOptions) {
+    // Type erasure lets a finishing task transfer its claim and spawn the
+    // next queued namespace without forming a recursive future type.
+    let background = Arc::clone(&claim.bits.background);
+    let future: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> =
+        Box::pin(async move {
+            let mut claim = claim;
+            loop {
+                if let Err(error) = run_auto_maintenance(&claim, options.clone()).await {
+                    tracing::info!(
+                        phase = "auto_maintenance_step",
+                        result = "error",
+                        error = %error,
+                        "post-publish maintenance step failed"
+                    );
                 }
-            });
-        self.core.inner.background.spawn(future);
-    }
+                let Some(next_namespace_id) =
+                    claim.bits.background.finish_or_rerun(&claim.namespace_id)
+                else {
+                    break;
+                };
+                if next_namespace_id == claim.namespace_id {
+                    // Preserve the existing own-namespace rerun in this
+                    // task before handing its slot to global queued work.
+                    continue;
+                }
+                claim.namespace_id = next_namespace_id;
+                spawn_claimed_auto_maintenance(claim, options);
+                return;
+            }
+        });
+    background.spawn(future);
+}
 
-    async fn run_auto_maintenance(
-        &self,
-        namespace_id: &NamespaceId,
-        options: MaintenanceStepOptions,
-    ) -> Result<()> {
-        // Background maintenance runs the same operations an operator runs,
-        // through the same handle, rather than a private copy of them.
-        let admin = crate::FsAdmin::from_core(self.core.clone());
-        let started = tokio::time::Instant::now();
-        let step = admin
-            .maintenance_step_namespace(namespace_id, options)
-            .await?;
-        admin.drain_reorganization_backlog(namespace_id).await?;
-        // Quiet conclusions (`NotNeeded`) emit nothing at default levels;
-        // this is the only record that a background step ran at all.
-        tracing::debug!(
-            phase = "auto_maintenance_step",
-            namespace_id = %step.namespace_id,
-            wal_tail_segments_before = step.status_before.wal_tail_segments,
-            wal_flush = ?step.wal_flush,
-            reorganize = ?step.reorganize,
-            elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
-            "background maintenance step concluded"
-        );
-        Ok(())
-    }
+async fn run_auto_maintenance(
+    claim: &BackgroundStepClaim,
+    options: MaintenanceStepOptions,
+) -> Result<()> {
+    // Background maintenance runs the same operations an operator runs,
+    // through the same handle, rather than a private copy of them — over
+    // the writer's own runtime, so its invalidations reach the writer's
+    // caches and publisher engines.
+    let admin = crate::FsAdmin::from_writer_parts(
+        claim.core.clone(),
+        claim.bits.identity.clone(),
+        claim.publisher.clone(),
+    );
+    let started = tokio::time::Instant::now();
+    let step = admin
+        .maintenance_step_namespace(&claim.namespace_id, options)
+        .await?;
+    admin
+        .drain_reorganization_backlog(&claim.namespace_id)
+        .await?;
+    // Quiet conclusions (`NotNeeded`) emit nothing at default levels;
+    // this is the only record that a background step ran at all.
+    tracing::debug!(
+        phase = "auto_maintenance_step",
+        namespace_id = %step.namespace_id,
+        wal_tail_segments_before = step.status_before.wal_tail_segments,
+        wal_flush = ?step.wal_flush,
+        reorganize = ?step.reorganize,
+        elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        "background maintenance step concluded"
+    );
+    Ok(())
 }

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -1,10 +1,10 @@
 //! The administrative and maintenance runtime handle.
 
 use super::HandleBuilderCore;
-use crate::background::BackgroundWork;
 use crate::config::default_writer_version;
-use crate::fs::FsCore;
+use crate::fs::{ReadCore, WriterIdentity};
 use crate::metrics::ObjectStoreMetricsRecorder;
+use crate::publisher::PublisherRegistry;
 use crate::{
     Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig,
     TraceMode, TraceStoreKind,
@@ -23,7 +23,14 @@ use std::sync::Arc;
 /// `actor_id` for tracing, reports, and auditability.
 #[derive(Clone)]
 pub struct FsAdmin {
-    pub(crate) core: FsCore,
+    pub(crate) core: ReadCore,
+    pub(crate) actor: WriterIdentity,
+    /// `invalidate_engine` matters only where a publisher exists for the
+    /// namespace, so a standalone admin holds `None` — its
+    /// engines-to-invalidate do not exist — and an admin built over a
+    /// writer's runtime for background maintenance holds that writer's
+    /// registry.
+    pub(crate) publisher: Option<PublisherRegistry>,
 }
 
 impl FsAdmin {
@@ -42,11 +49,21 @@ impl FsAdmin {
         FsAdminBuilder::new(HandleBuilderCore::from_store(store))
     }
 
-    /// Wraps a shared runtime core. Writer-scheduled background maintenance
-    /// uses this so it runs the same operations an operator runs, rather
-    /// than a private copy of them.
-    pub(crate) fn from_core(core: FsCore) -> Self {
-        Self { core }
+    /// Builds an admin over a writer's own runtime: its read core, its
+    /// identity, and its publication service. Writer-scheduled background
+    /// maintenance uses this so it runs the same operations an operator
+    /// runs — and so its invalidations reach the writer's caches and
+    /// publisher engines rather than a private copy of them.
+    pub(crate) fn from_writer_parts(
+        core: ReadCore,
+        actor: WriterIdentity,
+        publisher: PublisherRegistry,
+    ) -> Self {
+        Self {
+            core,
+            actor,
+            publisher: Some(publisher),
+        }
     }
 
     /// Snapshots the runtime cache counters, so maintenance work driven
@@ -56,13 +73,6 @@ impl FsAdmin {
     }
 
     // Maintenance operations live in `fs/maintenance.rs`.
-
-    /// Shuts down handle-owned background work. Admin calls are one-shot in
-    /// the caller's task, so this settles immediately; it exists so every
-    /// handle shares one shutdown shape.
-    pub async fn shutdown_background(&self) -> Result<()> {
-        Ok(())
-    }
 }
 
 /// Builder for [`FsAdmin`].
@@ -108,7 +118,7 @@ impl FsAdminBuilder {
     /// writer's byte budget: [`Self::runtime_cache`] still sizes this
     /// handle's other caches, but its decoded-block budget goes unused.
     pub fn shared_metadata_table_cache(mut self, writer: &super::FsWriter) -> Self {
-        self.core.shared_metadata_table_cache = Some(writer.core().metadata_table_cache());
+        self.core.shared_metadata_table_cache = Some(writer.metadata_table_cache());
         self
     }
 
@@ -139,9 +149,11 @@ impl FsAdminBuilder {
         let actor_id = self
             .actor_id
             .ok_or_else(|| RuntimeError::Config("actor_id is required".to_owned()))?;
-        let background = BackgroundWork::inert();
+        let actor = WriterIdentity::new(actor_id, self.actor_version)?;
         Ok(FsAdmin {
-            core: self.core.open(actor_id, self.actor_version, background)?,
+            core: self.core.open_read_core()?,
+            actor,
+            publisher: None,
         })
     }
 }

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -1,13 +1,12 @@
 //! Shared plumbing for the three handle builders: where the store comes
-//! from, the common builder state, and the runtime the handles bind to.
+//! from, the read-side builder state, and the runtime the handles bind to.
 
-use crate::background::BackgroundWork;
-use crate::config::FsConfig;
-use crate::fs::FsCore;
+use crate::config::ReadConfig;
+use crate::fs::ReadCore;
 use crate::metrics::ObjectStoreMetricsRecorder;
 use crate::{
-    PublishObserver, Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig,
-    TraceMode, TraceStoreKind,
+    Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
+    TraceStoreKind,
 };
 use loonfs_core::cache::MetadataTableCache;
 use loonfs_objectstore::metrics::InstrumentedObjectStore;
@@ -22,19 +21,18 @@ pub(super) enum StoreSource {
 }
 
 /// Builder state every handle shares: the store source, cache sizing, and
-/// trace/metrics wiring.
+/// trace/metrics wiring. Everything here feeds the read core, so all three
+/// builders carry exactly this and nothing more.
 pub(super) struct HandleBuilderCore {
     pub(super) source: StoreSource,
-    pub(super) min_publish_interval_ms: u64,
     pub(super) max_read_content_bytes: Option<u64>,
     pub(super) runtime_cache: RuntimeCacheConfig,
     /// An existing decoded-block cache to share instead of sizing a fresh
-    /// one from `runtime_cache`; see [`FsCore::open_with_background`].
+    /// one from `runtime_cache`; see [`ReadCore::open`].
     pub(super) shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
     pub(super) trace_mode: TraceMode,
     pub(super) trace_store_kind: Option<TraceStoreKind>,
     pub(super) metrics_recorder: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
-    pub(super) publish_observer: Option<PublishObserver>,
 }
 
 impl HandleBuilderCore {
@@ -49,23 +47,19 @@ impl HandleBuilderCore {
     pub(super) fn new(source: StoreSource) -> Self {
         Self {
             source,
-            min_publish_interval_ms: crate::config::DEFAULT_MIN_PUBLISH_INTERVAL_MS,
             max_read_content_bytes: None,
             runtime_cache: RuntimeCacheConfig::default(),
             shared_metadata_table_cache: None,
             trace_mode: TraceMode::Embedded,
             trace_store_kind: None,
             metrics_recorder: None,
-            publish_observer: None,
         }
     }
 
-    pub(super) fn open(
-        self,
-        writer_id: String,
-        writer_version: String,
-        background: BackgroundWork,
-    ) -> Result<FsCore> {
+    /// Resolves the object-store client, wraps it for metrics when the
+    /// builder was given a recorder, and opens the read core every handle
+    /// is built on.
+    pub(super) fn open_read_core(self) -> Result<ReadCore> {
         let (store, derived_kind) = match self.source {
             StoreSource::Config(config) => {
                 let kind = TraceStoreKind::from(config.kind());
@@ -83,21 +77,16 @@ impl HandleBuilderCore {
             ) as SharedObjectStore,
             None => store,
         };
-        FsCore::open_with_background(
+        Ok(ReadCore::open(
             store,
-            FsConfig {
-                writer_id,
-                writer_version,
-                min_publish_interval_ms: self.min_publish_interval_ms,
+            ReadConfig {
                 max_read_content_bytes: self.max_read_content_bytes,
                 runtime_cache: self.runtime_cache,
                 trace_mode: self.trace_mode,
                 trace_store_kind,
             },
-            background,
             self.shared_metadata_table_cache,
-            self.publish_observer,
-        )
+        ))
     }
 }
 

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -1,9 +1,7 @@
 //! The read-only runtime handle.
 
 use super::HandleBuilderCore;
-use crate::background::BackgroundWork;
-use crate::config::default_writer_version;
-use crate::fs::FsCore;
+use crate::fs::ReadCore;
 use crate::metrics::ObjectStoreMetricsRecorder;
 use crate::{
     CapabilityDocument, Result, RuntimeCacheConfig, RuntimeCacheStats, SharedObjectStore,
@@ -14,17 +12,17 @@ use std::sync::Arc;
 /// Read-only handle for latest namespace views.
 ///
 /// `FsReader` serves stat, list, read, revision, and change-feed queries. It
-/// owns no writer session, publishes nothing, and never schedules
-/// maintenance, so read-only workers cannot accidentally participate in
-/// writer scheduling. Reads revalidate cached control state against durable
-/// state, so a standalone reader stays consistent without any writer
-/// coordination.
+/// carries no actor identity at all — no writer id, no writer session —
+/// publishes nothing, and never schedules maintenance, so read-only workers
+/// cannot accidentally participate in writer scheduling. Reads revalidate
+/// cached control state against durable state, so a standalone reader stays
+/// consistent without any writer coordination.
 ///
 /// The handle is runtime-bound: open it with `build().await` inside the
 /// Tokio runtime that will drive its reads. `FsReader` is cheap to clone.
 #[derive(Clone)]
 pub struct FsReader {
-    pub(crate) core: FsCore,
+    pub(crate) core: ReadCore,
 }
 
 impl FsReader {
@@ -43,8 +41,8 @@ impl FsReader {
         FsReaderBuilder::new(HandleBuilderCore::from_store(store))
     }
 
-    /// Wraps a shared runtime core; used by [`FsWriter::reader`](crate::FsWriter::reader).
-    pub(super) fn from_core(core: FsCore) -> Self {
+    /// Wraps a shared read core; used by [`FsWriter::reader`](crate::FsWriter::reader).
+    pub(super) fn from_read_core(core: ReadCore) -> Self {
         Self { core }
     }
 
@@ -60,13 +58,6 @@ impl FsReader {
     }
 
     // Read operations live in `fs/reads.rs`.
-
-    /// Shuts down handle-owned background work. Readers own none, so this
-    /// settles immediately; it exists so every handle shares one shutdown
-    /// shape.
-    pub async fn shutdown_background(&self) -> Result<()> {
-        Ok(())
-    }
 }
 
 /// Builder for [`FsReader`].
@@ -116,16 +107,12 @@ impl FsReaderBuilder {
     }
 
     /// Opens the reader inside the Tokio runtime that will drive its reads.
+    ///
+    /// Async for uniformity with the other handle builders; a reader owns no
+    /// background work, so it needs no ambient runtime of its own.
     pub async fn build(self) -> Result<FsReader> {
-        // Readers never mutate, so the engine identity below is inert; it
-        // exists because shared internals require a non-empty actor.
-        let background = BackgroundWork::inert();
         Ok(FsReader {
-            core: self.core.open(
-                "loonfs-reader".to_owned(),
-                default_writer_version(),
-                background,
-            )?,
+            core: self.core.open_read_core()?,
         })
     }
 }

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -3,13 +3,14 @@
 use super::{owning_runtime, FsReader, HandleBuilderCore};
 use crate::background::{BackgroundWork, FsBackgroundWork};
 use crate::config::default_writer_version;
-use crate::fs::FsCore;
+use crate::fs::{ReadCore, WriterBits, WriterIdentity};
 use crate::metrics::ObjectStoreMetricsRecorder;
+use crate::publisher::{PublishObserver, PublisherRegistry};
 use crate::{
-    CapabilityDocument, ChangeSeq, CreateNamespaceOptions, DeleteNamespaceOptions,
-    DeleteNamespaceResponse, NamespaceId, NamespaceSummary, Result, RuntimeCacheConfig,
-    RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
+    CapabilityDocument, ChangeSeq, NamespaceId, Result, RuntimeCacheConfig, RuntimeCacheStats,
+    RuntimeError, SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
+use loonfs_core::cache::MetadataTableCache;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -29,7 +30,13 @@ use std::sync::Arc;
 /// background-work state.
 #[derive(Clone)]
 pub struct FsWriter {
-    pub(crate) core: FsCore,
+    pub(crate) core: ReadCore,
+    /// The writer half of the runtime: the session identity, the
+    /// background-work policy, and the publish observer. Publisher workers
+    /// hold this weakly, so dropping every clone of this handle stops new
+    /// publication work.
+    pub(crate) bits: Arc<WriterBits>,
+    pub(crate) publisher: PublisherRegistry,
 }
 
 impl FsWriter {
@@ -55,19 +62,24 @@ impl FsWriter {
     /// process, such as a server's read endpoints. For a reader driven by a
     /// different runtime, open one with [`FsReader::builder`].
     pub fn reader(&self) -> FsReader {
-        FsReader::from_core(self.core.clone())
+        FsReader::from_read_core(self.core.clone())
     }
 
-    /// Wraps a shared runtime core. The publication service and
-    /// writer-scheduled maintenance use this so background work runs the same
-    /// mutation path a caller runs, rather than a private copy of it.
-    pub(crate) fn from_core(core: FsCore) -> Self {
-        Self { core }
+    /// This writer's shared decoded-block cache handle, for builders that
+    /// open another core sharing it.
+    pub(crate) fn metadata_table_cache(&self) -> Arc<MetadataTableCache> {
+        self.core.metadata_table_cache()
     }
 
-    /// Shared runtime core, for in-crate front-ends.
-    pub(crate) fn core(&self) -> &FsCore {
-        &self.core
+    /// This writer's object-store client, instrumented exactly as the
+    /// handle's own traffic is.
+    ///
+    /// Server integrations that read LoonFS-owned objects outside the handle
+    /// surface — the grep root and the grep worker's keyspace — use this so
+    /// their requests are measured like every other request instead of
+    /// escaping instrumentation on a second, raw client.
+    pub fn object_store(&self) -> SharedObjectStore {
+        self.core.shared_store()
     }
 
     /// This writer's publication service (see [`crate::publisher`]).
@@ -76,8 +88,8 @@ impl FsWriter {
     /// service; hosts that classify their own mutation candidates — the
     /// reference server, for example — submit here directly. Clones share
     /// the writer's per-namespace publishers.
-    pub fn publisher(&self) -> crate::publisher::PublisherRegistry {
-        self.core.publisher().clone()
+    pub fn publisher(&self) -> PublisherRegistry {
+        self.publisher.clone()
     }
 
     /// Returns the capability document for this embedded build (API spec,
@@ -91,50 +103,14 @@ impl FsWriter {
         self.core.runtime_cache_stats()
     }
 
-    /// Creates a namespace, bootstrapping its durable state.
-    ///
-    /// With `options.allow_existing`, an already-existing namespace is
-    /// treated as success.
-    pub async fn create_namespace(
-        &self,
-        namespace_id: &NamespaceId,
-        options: CreateNamespaceOptions,
-    ) -> Result<NamespaceSummary> {
-        self.core.create_namespace(namespace_id, options).await
-    }
-
-    /// Forks `source` into `target` at the source's current head.
-    ///
-    /// The fork shares immutable file bytes but gets its own metadata history.
-    pub async fn fork_namespace(
-        &self,
-        source: &NamespaceId,
-        target: &NamespaceId,
-    ) -> Result<NamespaceSummary> {
-        self.core.fork_namespace(source, target).await
-    }
-
-    /// Deletes a namespace: a fenced, terminal head transition (format
-    /// spec, "Tombstones and deletion"). Commits acknowledged before the
-    /// swap stay committed; reads, writes, forks, and re-creation of the id
-    /// fail with `namespace_deleted` afterward. Deletion does not reclaim
-    /// storage; reclamation is explicit garbage collection.
-    pub async fn delete_namespace(
-        &self,
-        namespace_id: &NamespaceId,
-        options: DeleteNamespaceOptions,
-    ) -> Result<DeleteNamespaceResponse> {
-        self.core.delete_namespace(namespace_id, options).await
-    }
-
-    // Mutation, commit, and upload operations live in `fs/writes.rs`
-    // and `fs/uploads.rs`.
+    // Namespace lifecycle lives in `fs/namespaces.rs`; mutation, commit,
+    // and upload operations in `fs/writes.rs` and `fs/uploads.rs`.
 
     /// Waits until every writer-scheduled maintenance task has finished,
     /// without closing the handle. Panicked tasks surface as a runtime-task
     /// error.
     pub async fn wait_for_background_work(&self) -> Result<()> {
-        self.core.wait_for_background_maintenance().await
+        self.bits.background.drain().await
     }
 
     /// Shuts down writer-scheduled background work: settles admitted
@@ -158,9 +134,9 @@ impl FsWriter {
         // step settles. Draining without closing admission keeps the
         // handle usable; a caller that keeps submitting concurrently just
         // keeps the drain waiting.
-        self.core.publisher().drain().await?;
-        self.core.shut_down_background();
-        self.core.wait_for_background_maintenance().await
+        self.publisher.drain().await?;
+        self.bits.background.shut_down();
+        self.bits.background.drain().await
     }
 }
 
@@ -171,6 +147,8 @@ pub struct FsWriterBuilder {
     writer_version: String,
     background_work: FsBackgroundWork,
     max_concurrent_maintenance: usize,
+    min_publish_interval_ms: u64,
+    publish_observer: Option<PublishObserver>,
 }
 
 impl FsWriterBuilder {
@@ -181,6 +159,8 @@ impl FsWriterBuilder {
             writer_version: default_writer_version(),
             background_work: FsBackgroundWork::ManualOnly,
             max_concurrent_maintenance: crate::config::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
+            min_publish_interval_ms: crate::config::DEFAULT_MIN_PUBLISH_INTERVAL_MS,
+            publish_observer: None,
         }
     }
 
@@ -238,7 +218,7 @@ impl FsWriterBuilder {
     /// durable, visible result. Defaults to 15 ms; zero keeps only the
     /// batching that in-flight publications force.
     pub fn min_publish_interval_ms(mut self, min_publish_interval_ms: u64) -> Self {
-        self.core.min_publish_interval_ms = min_publish_interval_ms;
+        self.min_publish_interval_ms = min_publish_interval_ms;
         self
     }
 
@@ -283,16 +263,22 @@ impl FsWriterBuilder {
         mut self,
         observer: impl Fn(&NamespaceId, ChangeSeq) + Send + Sync + 'static,
     ) -> Self {
-        self.core.publish_observer = Some(Arc::new(observer));
+        self.publish_observer = Some(Arc::new(observer));
         self
     }
 
     /// Opens the writer inside the Tokio runtime that will own it. Any
     /// background work the writer schedules is spawned on that runtime.
+    ///
+    /// Construction runs one way only, so nothing here is cyclic: the read
+    /// core opens first, the writer's bits are built on top of it, and the
+    /// publication service is created last, holding the core strongly and
+    /// the bits weakly.
     pub async fn build(self) -> Result<FsWriter> {
         let writer_id = self
             .writer_id
             .ok_or_else(|| RuntimeError::Config("writer_id is required".to_owned()))?;
+        let identity = WriterIdentity::new(writer_id, self.writer_version)?;
         let max_concurrent_maintenance = NonZeroUsize::new(self.max_concurrent_maintenance)
             .ok_or_else(|| {
                 RuntimeError::Config(
@@ -301,13 +287,28 @@ impl FsWriterBuilder {
                         .to_owned(),
                 )
             })?;
-        let background = BackgroundWork::new(
+        let background = Arc::new(BackgroundWork::new(
             self.background_work,
             Some(owning_runtime()?),
             max_concurrent_maintenance,
+        ));
+        let core = self.core.open_read_core()?;
+        let bits = Arc::new(WriterBits {
+            identity,
+            background,
+            publish_observer: self.publish_observer,
+        });
+        let publisher = PublisherRegistry::new(
+            core.clone(),
+            Arc::downgrade(&bits),
+            std::time::Duration::from_millis(self.min_publish_interval_ms),
+            core.trace_mode(),
+            core.trace_store_kind(),
         );
         Ok(FsWriter {
-            core: self.core.open(writer_id, self.writer_version, background)?,
+            core,
+            bits,
+            publisher,
         })
     }
 }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -23,9 +23,11 @@
 //! # Ok(()) }
 //! ```
 //!
-//! LoonFS never creates a hidden maintenance runtime: any background work a
-//! handle starts is spawned on that handle's owning runtime, and each handle
-//! has an async `shutdown_background()` that settles what it owns.
+//! Background work belongs to the writer — publications, and the maintenance
+//! a publication schedules. LoonFS never creates a hidden maintenance
+//! runtime: that work is spawned on the writer's own owning runtime, and
+//! [`FsWriter::shutdown_background`] settles it. Readers and admins start no
+//! background work at all, so they have nothing to shut down.
 #![warn(missing_docs)]
 
 mod background;

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -22,7 +22,7 @@
 //! and the delete barrier run through one engine, under one session epoch,
 //! on one worker task draining one queue.
 //!
-//! Every runtime core owns one registry, and the direct
+//! Every writer owns one registry, and the direct
 //! [`FsWriter`](crate::FsWriter) mutation methods, the reference server,
 //! and any embedded host with many in-process writer agents all submit
 //! through it — one publication implementation, one batching policy, one
@@ -52,7 +52,7 @@
 //! [`FsWriter::shutdown_background`](crate::FsWriter::shutdown_background)
 //! drains without closing, so the handle stays usable.
 
-use crate::fs::{FsCore, FsInner};
+use crate::fs::{ReadCore, WriterBits};
 use crate::publish::{NamespaceMutationCandidate, PathMutationIntent, PreparedContent};
 use crate::{CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeError};
 use futures::FutureExt;
@@ -88,7 +88,7 @@ pub type PublishObserver = Arc<dyn Fn(&NamespaceId, loonfs_api::ChangeSeq) + Sen
 /// `commit_queue_full`.
 const MAX_BATCH_CANDIDATES: usize = 1024;
 
-/// Shared front door to the per-namespace publishers of one runtime core.
+/// Shared front door to the per-namespace publishers of one writer.
 ///
 /// Cloning is cheap; clones share the same per-namespace publishers, so
 /// every writer in the process should submit through clones of one
@@ -101,10 +101,15 @@ const MAX_BATCH_CANDIDATES: usize = 1024;
 #[derive(Clone)]
 pub struct PublisherRegistry {
     shared: Arc<RegistryShared>,
-    /// Weak: the runtime core owns this registry, so a strong reference
-    /// back would cycle the runtime into a leak. Publish work upgrades per
-    /// use and reports `shutting_down` once the core is gone.
-    core: Weak<FsInner>,
+    /// Strong: the read core owns neither this registry nor the writer, so
+    /// holding it here cannot cycle. Publications read through its caches
+    /// and seed them with what they produce.
+    read_core: ReadCore,
+    /// Weak: the writer owns its bits, and a publication is the writer's
+    /// work. Publish work upgrades per unit and reports `shutting_down`
+    /// once the writer is gone, so dropping the writer stops new work
+    /// without ever leaving the caches or store dangling.
+    writer: Weak<WriterBits>,
     min_publish_interval: Duration,
     trace_mode: &'static str,
     trace_store_kind: &'static str,
@@ -142,12 +147,13 @@ impl RegistryShared {
 }
 
 impl PublisherRegistry {
-    /// Creates the registry a runtime core owns. Batches publish through
-    /// each publisher's own commit engine and writer session, and the
-    /// core's [`FsBackgroundWork`](crate::FsBackgroundWork) policy governs
-    /// any post-publish maintenance.
-    pub(crate) fn from_core(
-        core: Weak<FsInner>,
+    /// Creates the registry a writer owns. Batches publish through each
+    /// publisher's own commit engine and writer session, and the writer's
+    /// [`FsBackgroundWork`](crate::FsBackgroundWork) policy governs any
+    /// post-publish maintenance.
+    pub(crate) fn new(
+        read_core: ReadCore,
+        writer: Weak<WriterBits>,
         min_publish_interval: Duration,
         trace_mode: &'static str,
         trace_store_kind: &'static str,
@@ -160,7 +166,8 @@ impl PublisherRegistry {
                 }),
                 panicked_units: AtomicUsize::new(0),
             }),
-            core,
+            read_core,
+            writer,
             min_publish_interval,
             trace_mode,
             trace_store_kind,
@@ -258,7 +265,8 @@ impl PublisherRegistry {
             .or_insert_with(|| {
                 NamespacePublisher::new(
                     namespace_id.clone(),
-                    self.core.clone(),
+                    self.read_core.clone(),
+                    self.writer.clone(),
                     Arc::downgrade(&self.shared),
                     self.min_publish_interval,
                     self.trace_mode,
@@ -322,9 +330,10 @@ impl PublisherRegistry {
 #[derive(Clone)]
 struct NamespacePublisher {
     namespace_id: NamespaceId,
-    /// Weak for the same reason as the registry's reference: the core owns
-    /// the registry that owns this publisher.
-    core: Weak<FsInner>,
+    read_core: ReadCore,
+    /// Weak for the same reason as the registry's reference: a publication
+    /// is the owning writer's work, and it stops when that writer is gone.
+    writer: Weak<WriterBits>,
     state: Arc<Mutex<NamespacePublisherState>>,
     /// Locked only by the worker, across one publication or delete, and by
     /// [`Self::invalidate_engine`], which never waits for it.
@@ -420,7 +429,8 @@ struct InFlightRequest {
 impl NamespacePublisher {
     fn new(
         namespace_id: NamespaceId,
-        core: Weak<FsInner>,
+        read_core: ReadCore,
+        writer: Weak<WriterBits>,
         shared: Weak<RegistryShared>,
         min_publish_interval: Duration,
         trace_mode: &'static str,
@@ -428,7 +438,8 @@ impl NamespacePublisher {
     ) -> Self {
         Self {
             namespace_id,
-            core,
+            read_core,
+            writer,
             state: Arc::new(Mutex::new(NamespacePublisherState {
                 queue: VecDeque::new(),
                 in_flight: HashMap::new(),
@@ -448,11 +459,18 @@ impl NamespacePublisher {
         }
     }
 
-    /// The owning runtime core, while it is still alive. `None` means the
-    /// core was dropped without draining; admitted work then settles as
-    /// `shutting_down`.
-    fn core(&self) -> Option<FsCore> {
-        self.core.upgrade().map(|inner| FsCore { inner })
+    /// A registry handle over the same shared state — what a clone of the
+    /// owning registry is — for the writer-side work a publication
+    /// schedules. `None` once that registry is gone.
+    fn registry(&self) -> Option<PublisherRegistry> {
+        Some(PublisherRegistry {
+            shared: self.shared.upgrade()?,
+            read_core: self.read_core.clone(),
+            writer: self.writer.clone(),
+            min_publish_interval: self.min_publish_interval,
+            trace_mode: self.trace_mode,
+            trace_store_kind: self.trace_store_kind,
+        })
     }
 
     /// Recovers a poisoned lock rather than propagating, for the same reason
@@ -748,14 +766,14 @@ impl NamespacePublisher {
                     .iter()
                     .map(|candidate| candidate.candidate.clone())
                     .collect::<Vec<_>>();
-                let Some(core) = self.core() else {
+                let Some(writer) = self.writer.upgrade() else {
                     results = candidates
                         .iter()
                         .map(|_| Err(CoreError::ShuttingDown))
                         .collect();
                     break;
                 };
-                results = self.publish_through_engine(&core, batch_candidates).await;
+                results = self.publish_through_engine(&writer, batch_candidates).await;
                 if !results.iter().any(is_retryable_head_publish) {
                     break;
                 }
@@ -780,17 +798,24 @@ impl NamespacePublisher {
     /// engine, one writer session, for the publisher's whole life.
     async fn publish_through_engine(
         &self,
-        core: &FsCore,
+        writer: &Arc<WriterBits>,
         candidates: Vec<NamespaceMutationCandidate>,
     ) -> Vec<CommitResult> {
+        let registry = self.registry();
         let mut slot = self.engine.lock().await;
-        let engine = self.engine_for(&mut slot, core).await;
-        crate::FsWriter::from_core(core.clone())
-            .publish_batch_with_engine(&self.namespace_id, engine, candidates)
-            .await
-            .into_iter()
-            .map(|result| result.map_err(runtime_error_to_core))
-            .collect()
+        let engine = self.engine_for(&mut slot).await;
+        crate::fs::publish_batch_with_engine(
+            &self.read_core,
+            writer,
+            registry.as_ref(),
+            &self.namespace_id,
+            engine,
+            candidates,
+        )
+        .await
+        .into_iter()
+        .map(|result| result.map_err(runtime_error_to_core))
+        .collect()
     }
 
     /// The publisher's engine, built on first use. A new engine starts from
@@ -800,16 +825,16 @@ impl NamespacePublisher {
     async fn engine_for<'slot>(
         &self,
         slot: &'slot mut EngineSlot,
-        core: &FsCore,
     ) -> &'slot mut NamespaceCommitEngine {
         if slot.engine.is_none() {
-            let catalog = core
+            let catalog = self
+                .read_core
                 .load_namespace_catalog_cached(&self.namespace_id)
                 .await
                 .ok()
                 .flatten();
             let mut engine = NamespaceCommitEngine::new(self.namespace_id.clone())
-                .table_cache(core.metadata_table_cache())
+                .table_cache(self.read_core.metadata_table_cache())
                 .writer_session(Arc::clone(&slot.session));
             if let Some(catalog) = catalog {
                 engine = engine.catalog_entry(catalog);
@@ -880,14 +905,20 @@ impl NamespacePublisher {
     }
 
     async fn delete_through_engine(&self, options: DeleteNamespaceOptions) -> DeleteResult {
-        let Some(core) = self.core() else {
+        let Some(writer) = self.writer.upgrade() else {
             return Err(CoreError::ShuttingDown);
         };
         let mut slot = self.engine.lock().await;
-        let engine = self.engine_for(&mut slot, &core).await;
-        core.delete_namespace_with_engine(&self.namespace_id, engine, options)
-            .await
-            .map_err(runtime_error_to_core)
+        let engine = self.engine_for(&mut slot).await;
+        crate::fs::delete_namespace_with_engine(
+            &self.read_core,
+            &writer.identity,
+            &self.namespace_id,
+            engine,
+            options,
+        )
+        .await
+        .map_err(runtime_error_to_core)
     }
 
     fn namespace_deleted(&self) -> CoreError {

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -4,9 +4,10 @@
 // Publisher tests use panic in async result helpers for precise diagnostics.
 
 use super::*;
-use crate::background::BackgroundWork;
-use crate::config::FsConfig;
+use crate::background::{BackgroundWork, FsBackgroundWork};
+use crate::config::ReadConfig;
 use crate::content_tokens::ContentTokenError;
+use crate::fs::WriterIdentity;
 use crate::publish::{ContentPreparationError, NamespaceMutation};
 use crate::{
     BeginUploadRequest, CreateNamespaceOptions, ErrorCode, RuntimeCacheConfig,
@@ -189,25 +190,44 @@ fn lost_head_cas_ack_store(
     .apply_then_fail()
 }
 
-fn test_fs(store: SharedStore) -> FsCore {
-    FsCore::open_with_background(
+fn test_read_core(store: SharedStore) -> ReadCore {
+    ReadCore::open(
         store,
-        FsConfig {
-            writer_id: "writer-a".to_owned(),
-            writer_version: "test".to_owned(),
-            // The publisher under test is itself the coalescer; direct
-            // windows would only add latency to these tests.
-            min_publish_interval_ms: 0,
+        ReadConfig {
             max_read_content_bytes: None,
             runtime_cache: RuntimeCacheConfig::default(),
             trace_mode: TraceMode::Remote,
             trace_store_kind: TraceStoreKind::LocalFs,
         },
-        BackgroundWork::inert(),
-        None,
         None,
     )
-    .expect("open runtime")
+}
+
+fn test_writer_bits() -> Arc<WriterBits> {
+    Arc::new(WriterBits {
+        identity: WriterIdentity::new("writer-a".to_owned(), "test".to_owned())
+            .expect("valid writer identity"),
+        background: Arc::new(BackgroundWork::new(
+            FsBackgroundWork::ManualOnly,
+            None,
+            std::num::NonZeroUsize::new(1).expect("nonzero"),
+        )),
+        publish_observer: None,
+    })
+}
+
+/// A read core plus the writer bits a standalone publisher publishes
+/// under. The caller keeps both alive; the publisher holds the bits weakly.
+struct TestRuntime {
+    core: ReadCore,
+    bits: Arc<WriterBits>,
+}
+
+fn test_runtime(store: SharedStore) -> TestRuntime {
+    TestRuntime {
+        core: test_read_core(store),
+        bits: test_writer_bits(),
+    }
 }
 
 async fn test_writer(store: SharedStore) -> crate::FsWriter {
@@ -229,8 +249,16 @@ async fn test_writer_with_interval(
         .expect("build writer")
 }
 
-async fn create_namespace(fs: &FsCore, namespace_id: &NamespaceId) {
-    fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
+/// Bootstraps a namespace under the identity the standalone publisher will
+/// publish with, so its first publication continues the writer session the
+/// bootstrap left behind — the same continuity a writer handle has.
+async fn create_namespace(runtime: &TestRuntime, namespace_id: &NamespaceId) {
+    runtime
+        .core
+        .writer_engine(&runtime.bits.identity, namespace_id)
+        .bootstrap_namespace(loonfs_core::BootstrapOptions {
+            allow_existing: false,
+        })
         .await
         .expect("bootstrap");
 }
@@ -279,15 +307,16 @@ async fn wait_for_queued_delete(publisher: &NamespacePublisher) {
 
 /// A publisher with no owning registry, exercising the unowned-task
 /// fallback the production paths reserve for a dropped registry. The
-/// caller keeps `fs` alive; the publisher holds it weakly.
-fn standalone_publisher(namespace_id: &NamespaceId, fs: &FsCore) -> NamespacePublisher {
+/// caller keeps `runtime` alive; the publisher holds its bits weakly.
+fn standalone_publisher(namespace_id: &NamespaceId, runtime: &TestRuntime) -> NamespacePublisher {
     NamespacePublisher::new(
         namespace_id.clone(),
-        Arc::downgrade(&fs.inner),
+        runtime.core.clone(),
+        Arc::downgrade(&runtime.bits),
         Weak::new(),
         TEST_STANDALONE_PACING,
-        fs.inner.config.trace_mode.as_str(),
-        fs.inner.config.trace_store_kind.as_str(),
+        runtime.core.trace_mode(),
+        runtime.core.trace_store_kind(),
     )
 }
 
@@ -399,7 +428,10 @@ async fn rejected_duplicate_joins_ready_in_flight_primary() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let writer = test_writer(store).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let registry = writer.publisher();
     let publisher = registry.publisher_for(&namespace_id).expect("publisher");
     let intent = PathMutationIntent::CreateDir {
@@ -439,7 +471,10 @@ async fn ready_duplicate_joins_rejected_in_flight_primary() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let writer = test_writer(store).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let registry = writer.publisher();
     let publisher = registry.publisher_for(&namespace_id).expect("publisher");
     let intent = PathMutationIntent::CreateDir {
@@ -481,9 +516,9 @@ async fn publisher_admits_pending_batch_while_active_publish_blocks() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared.clone());
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     store.block_next();
     let active = admit_commit(
@@ -524,9 +559,9 @@ async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared.clone());
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     store.block_next();
     let active = admit_commit(
@@ -565,9 +600,9 @@ async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared.clone());
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     store.block_next();
     let active = admit_commit(
@@ -634,9 +669,9 @@ async fn publisher_takes_a_cold_full_batch_immediately() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared.clone());
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     store.block_next();
     let mut receivers = Vec::with_capacity(MAX_BATCH_CANDIDATES);
@@ -671,9 +706,9 @@ async fn cold_submission_publishes_without_a_coalescing_delay() {
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let fs = test_fs(store);
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(store);
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     let receiver = admit_commit(
         &publisher,
@@ -698,7 +733,10 @@ async fn hot_submissions_wait_out_the_pacing_interval() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let writer = test_writer_with_interval(store.clone(), 400).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let registry = writer.publisher();
 
     let warmup_started = Instant::now();
@@ -728,9 +766,9 @@ async fn publisher_resolves_unknown_head_outcome_by_replaying_receipt() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(lost_head_cas_ack_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared);
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared);
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     // The commit lands but the CAS acknowledgement is lost. The publisher
     // retries with the same commit id and replays the durable receipt
@@ -755,9 +793,9 @@ async fn publisher_survives_publish_panic_and_keeps_serving() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(PanicHeadCasStore::new(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared.clone());
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     store.arm_blocking_panic();
     let doomed = admit_commit(
@@ -807,9 +845,9 @@ async fn delete_barrier_publishes_admitted_work_and_rejects_later_work() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared.clone());
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     // A publishes and blocks at its head CAS; B queues behind it.
     store.block_next();
@@ -887,9 +925,9 @@ async fn second_delete_during_inflight_delete_settles_both() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared.clone());
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     // One publication first, so the session already holds its writer epoch:
     // the next head compare-and-swap is the delete's own tombstone swap.
@@ -960,9 +998,9 @@ async fn mutations_admitted_after_a_queued_delete_wait_behind_it() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
-    let fs = test_fs(shared.clone());
-    create_namespace(&fs, &namespace_id).await;
-    let publisher = standalone_publisher(&namespace_id, &fs);
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
 
     store.block_next();
     let before = admit_commit(
@@ -1019,7 +1057,10 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let writer = test_writer_with_interval(store.clone(), 400).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let registry = writer.publisher();
 
     // Warm the namespace: a cold one publishes its first submission
@@ -1076,7 +1117,10 @@ async fn publisher_batches_explicit_commit_and_path_intent_together() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let writer = test_writer_with_interval(store.clone(), 400).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let upload = writer
         .begin_upload(
             &namespace_id,
@@ -1171,7 +1215,10 @@ async fn registry_close_admission_refuses_new_work_while_admitted_work_drains() 
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
     let writer = test_writer(shared.clone()).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let registry = writer.publisher();
 
     // An admitted publication blocks at its head CAS...
@@ -1237,7 +1284,10 @@ async fn worker_survives_panic_and_processes_later_queue_items() {
     let store = Arc::new(PanicHeadCasStore::new(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
     let writer = test_writer(shared.clone()).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let registry = writer.publisher();
 
     store.arm_blocking_panic();
@@ -1303,7 +1353,10 @@ async fn successful_delete_evicts_the_namespace_publisher() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let writer = test_writer(store.clone()).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let registry = writer.publisher();
 
     registry
@@ -1371,7 +1424,10 @@ async fn delete_queued_mid_publish_waits_behind_admitted_work() {
     let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
     let shared = store.clone() as SharedStore;
     let writer = test_writer(shared.clone()).await;
-    create_namespace(writer.core(), &namespace_id).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
     let registry = writer.publisher();
 
     // Park the first publication at its head CAS, batch a second commit

--- a/crates/loonfs/tests/handles.rs
+++ b/crates/loonfs/tests/handles.rs
@@ -434,18 +434,135 @@ fn writer_reader_and_admin_share_a_namespace_through_store_config() {
         // cache counters, like writer and reader work through theirs.
         let _ = admin.runtime_cache_stats();
 
-        standalone
+        // Only the writer owns background work, so only the writer has
+        // anything to shut down.
+        writer
             .shutdown_background()
             .await
-            .expect("shut down standalone reader background work");
-        derived
-            .shutdown_background()
+            .expect("shut down writer background work");
+    });
+}
+
+/// A standalone reader carries no actor identity at all: its engines are
+/// reader-built, so there is no writer id and — the part that used to be
+/// fabricated — no writer session id minted for a handle that never
+/// mutates.
+#[test]
+fn standalone_reader_builds_without_writer_identity() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    block_on(async {
+        let writer = writer(temp_dir.path(), FsBackgroundWork::ManualOnly).await;
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
             .await
-            .expect("shut down derived reader background work");
-        admin
-            .shutdown_background()
+            .expect("create namespace");
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/hello.txt",
+                b"hello",
+                PutFileOptions::default(),
+            )
             .await
-            .expect("shut down admin background work");
+            .expect("put file");
+
+        let reader = FsReader::builder(store_config(temp_dir.path()))
+            .build()
+            .await
+            .expect("build standalone reader");
+        // The reader serves the full read surface without an identity.
+        let stat = reader
+            .stat_path(&namespace_id, "/docs/hello.txt")
+            .await
+            .expect("stat through standalone reader");
+        assert_eq!(stat.size_bytes, Some(5));
+        let entries = reader
+            .list_path_entries_all(&namespace_id, "/docs")
+            .await
+            .expect("list through standalone reader")
+            .entries;
+        assert_eq!(entries.len(), 1);
+
+        // The identity the reader would have carried is the writer session
+        // recorded on the head. Only the writer's own session is there: a
+        // read minted none of its own.
+        let store = LocalFsStore::new(temp_dir.path()).expect("open store for inspection");
+        let head = loonfs_core::control::load_namespace_head_control(&store, &namespace_id)
+            .await
+            .expect("load head")
+            .state;
+        let writer_block = head.writer.expect("head records the writer that published");
+        assert_eq!(writer_block.writer_id, "handle-test-writer");
+        assert_ne!(
+            writer_block.writer_session_id, "",
+            "the writer's own session is the only session in play"
+        );
+    });
+}
+
+/// Writer-scheduled maintenance runs as an admin over the writer's own
+/// runtime, so its invalidations land on the caches the writer reads
+/// through: after the scheduled step rewrites the namespace's metadata
+/// root, a read on the same runtime observes post-maintenance state
+/// instead of failing on a cached view of reaped objects.
+#[test]
+fn admin_over_writer_core_invalidates_shared_caches() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    block_on(async {
+        let writer = writer(temp_dir.path(), FsBackgroundWork::Enabled).await;
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        let reader = writer.reader();
+        fill_wal_tail_past_threshold(&writer, &namespace_id).await;
+        writer
+            .wait_for_background_work()
+            .await
+            .expect("background maintenance quiesces");
+
+        // The scheduled step ran: it published a manifest and bounded the
+        // tail, both through the writer's own runtime.
+        let admin = FsAdmin::builder(store_config(temp_dir.path()))
+            .actor_id("handle-test-admin")
+            .build()
+            .await
+            .expect("build admin");
+        let status = admin
+            .namespace_status(&namespace_id)
+            .await
+            .expect("status after the scheduled step");
+        assert!(
+            status.current_manifest_id > Some(ManifestId(0)),
+            "the scheduled step should have published a manifest: {status:?}"
+        );
+        assert!(
+            status.wal_tail_segments < wal_tail_segment_threshold(),
+            "the scheduled step should have bounded the tail: {status:?}"
+        );
+
+        // Reads and writes on the writer's own runtime see the state the
+        // step left behind, with no stale-cache error in between.
+        reader
+            .stat_path(&namespace_id, "/docs/file-0.txt")
+            .await
+            .expect("read after maintenance is served from revalidated caches");
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/after-maintenance.txt",
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("writes continue against the post-maintenance head");
+        reader
+            .stat_path(&namespace_id, "/docs/after-maintenance.txt")
+            .await
+            .expect("read after write on the shared core");
+
         writer
             .shutdown_background()
             .await


### PR DESCRIPTION
Every handle wrapped one full FsCore, so a standalone reader fabricated a writer identity (loonfs-core's engine refused to build without one) and minted a session id it never used, an admin carried an inert publisher registry, readers and admins exposed no-op shutdown methods to honor a crate-doc promise, and the core needed Arc::new_cyclic so its publisher could point back at it.

The runtime is now a ReadCore (store, read config, caches, grep block cache) plus what each handle actually owns: FsWriter adds its identity, background work, and the publisher registry; FsAdmin adds an actor identity and, only when it runs as the writer's background maintenance, the writer's registry. The publisher holds the ReadCore strongly and the writer's bits weakly, which kills the cyclic constructor without changing shutdown semantics — dropping the writer still settles admitted work as shutting_down. loonfs-core gains build_reader(): a reader-built engine carries no writer identity and refuses mutations with a typed internal error, so FsReader now runs with no writer identity anywhere.
