### PR TITLE
feat(core): checkpoint file enumeration and bulk current-state reads

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -405,11 +405,26 @@ pub mod lookup_keys {
     use super::hex_encode_row_key_component;
     use crate::{ChangeSeq, InodeId, RevisionNo};
 
+    /// The prefix every inode row key starts with. Inode ids are
+    /// zero-padded to a fixed width after it, so a range scan over this
+    /// prefix walks the inode family in ascending inode-id order.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub const INODE_ROW_PREFIX: &str = "inode-";
+
     /// Builds the exact point-lookup key for an inode row.
     ///
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn inode_key(inode_id: InodeId) -> String {
-        format!("inode-{:020}", inode_id.0)
+        format!("{INODE_ROW_PREFIX}{:020}", inode_id.0)
+    }
+
+    /// Builds the resume bound for a scan that must continue strictly after
+    /// `inode_id`'s row.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn inode_key_after(inode_id: InodeId) -> String {
+        format!("{}\0", inode_key(inode_id))
     }
 
     /// Builds the range prefix selecting directory bindings under one parent.
@@ -695,6 +710,38 @@ mod tests {
         ChangeSeq, CommitId, InodeId, ManifestId, ManifestObjectId, MetadataTableId, NameKey,
         NamespaceId, WriterEpoch,
     };
+
+    #[test]
+    fn inode_row_keys_sort_by_ascending_inode_id() {
+        // The inode family's durable order IS ascending inode id, which is
+        // what lets a whole-namespace file walk resume from one bound.
+        let ids = [9_u64, 1, 100, 10, 2];
+        let key_of = |id: u64| super::lookup_keys::inode_key(InodeId(id));
+        let mut keys: Vec<String> = ids.iter().copied().map(key_of).collect();
+        keys.sort();
+
+        let mut ascending_ids = ids;
+        ascending_ids.sort_unstable();
+        assert_eq!(
+            keys,
+            ascending_ids
+                .iter()
+                .copied()
+                .map(key_of)
+                .collect::<Vec<_>>(),
+            "row-key order must agree with inode-id order"
+        );
+        assert!(keys
+            .iter()
+            .all(|key| key.starts_with(super::lookup_keys::INODE_ROW_PREFIX)));
+    }
+
+    #[test]
+    fn the_inode_resume_bound_skips_its_own_row_and_nothing_after_it() {
+        let resume = super::lookup_keys::inode_key_after(InodeId(7));
+        assert!(resume > super::lookup_keys::inode_key(InodeId(7)));
+        assert!(resume < super::lookup_keys::inode_key(InodeId(8)));
+    }
 
     #[test]
     fn namespace_manifest_kind_string_matches_serde() {

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -1,0 +1,231 @@
+//! Enumerating the files a checkpoint pins.
+//!
+//! A checkpoint pins one immutable manifest. This module walks that
+//! manifest's inode family in ascending inode-id order and answers, for
+//! every file visible in exactly that pinned state, the revision and content
+//! reference the checkpoint recorded for it. Nothing here consults the live
+//! head, the WAL, or any later manifest: a consumer that wants what changed
+//! after the pinned sequence reads the change feed.
+
+use super::cache::MetadataTableCache;
+use super::error::ManifestLoadError;
+use super::load::load_verified_manifest_tables_with_cache;
+use super::record::read_checkpoint_record;
+use super::scan::string_prefix_upper_bound;
+use crate::error::{CoreError, MetadataProjectionLoadError, Result};
+use crate::metadata::MetadataView;
+use loonfs_api::wire::control::{CheckpointRecordLifecycle, CheckpointRecordState};
+use loonfs_api::wire::manifest::{lookup_keys, MetadataRow, MetadataTableFamily};
+use loonfs_api::{
+    ChangeSeq, CheckpointId, ContentRef, InodeId, InodeKind, NamePolicy, NamespaceId, PageRequest,
+    RevisionNo,
+};
+use loonfs_objectstore::ObjectStore;
+
+/// Inode rows read per scan wave. Directories and invisible inodes are
+/// filtered out after the read, so a page of files may need several waves;
+/// the floor keeps a small page size from paying one scan per row.
+const INODE_SCAN_WAVE_ROWS: usize = 64;
+
+/// Where a file enumeration resumes: strictly after this inode id.
+///
+/// Enumeration order is ascending inode id, which is also the durable row
+/// order of the inode family, so a resume is one range bound — it never
+/// re-reads a row at or before `after_inode_id`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckpointFilesPageCursor {
+    /// Last inode id returned by the previous page.
+    pub after_inode_id: InodeId,
+}
+
+/// One file visible in the checkpointed state, with the content the
+/// checkpoint pinned for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckpointFile {
+    /// The file's inode identity, stable across renames and replacements.
+    pub inode_id: InodeId,
+    /// The file's current revision as of the checkpointed sequence.
+    pub revision_no: RevisionNo,
+    /// Immutable bytes that revision published.
+    pub content_ref: ContentRef,
+    /// Byte length carried by `content_ref`, lifted out for planners that
+    /// size work before reading anything.
+    pub size_bytes: u64,
+}
+
+/// One page of the files a checkpoint pins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckpointFilesPage {
+    /// The sequence the checkpoint pins. Every file in the page is the
+    /// state at this sequence, and the change feed after it is exactly what
+    /// this page does not cover.
+    pub checkpoint_seq: ChangeSeq,
+    /// Files in ascending inode-id order.
+    pub files: Vec<CheckpointFile>,
+    /// Resume position when more files remain.
+    pub next_cursor: Option<CheckpointFilesPageCursor>,
+}
+
+/// Reads one page of the files visible in the state `checkpoint_id` pins.
+///
+/// The checkpoint's own manifest is the only state read: no WAL tail is
+/// replayed over it, and no later manifest is consulted, so the answer is
+/// the namespace exactly as of `checkpoint_seq`. Visibility is the same rule
+/// every read applies — the inode exists, and no subtree tombstone covers it
+/// or any of its ancestors — evaluated against that manifest. Directories
+/// are not returned.
+///
+/// A record that is missing, released, condemned, or expired answers
+/// `checkpoint_unavailable`, and so does a pinned manifest that is already
+/// gone. There is no fallback to current state: a consumer that lost its
+/// checkpoint takes a new one and starts over.
+pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
+    store: &S,
+    table_cache: Option<&MetadataTableCache>,
+    namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+    name_policy: NamePolicy,
+    now_ms: u64,
+    request: PageRequest<CheckpointFilesPageCursor>,
+) -> Result<CheckpointFilesPage> {
+    let record = read_pinning_checkpoint_record(store, namespace_id, checkpoint_id, now_ms).await?;
+    let tables = load_verified_manifest_tables_with_cache(
+        store,
+        table_cache,
+        namespace_id,
+        &record.manifest_object_id,
+    )
+    .await
+    .map_err(|error| match error {
+        ManifestLoadError::MissingManifest { object_key } => CoreError::CheckpointUnavailable(
+            format!("checkpoint `{checkpoint_id}` pins manifest `{object_key}`, which is gone"),
+        ),
+        other => CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(other)),
+    })?;
+    let manifest = tables.manifest();
+    if manifest.payload_checksum != record.manifest_payload_checksum
+        || manifest.payload.head_seq != record.manifest_head_seq
+    {
+        return Err(CoreError::NamespaceCorrupt(format!(
+            "checkpoint `{checkpoint_id}` basis does not match its manifest"
+        )));
+    }
+
+    let checkpoint_seq = record.manifest_head_seq;
+    let view = MetadataView::over_manifest_tables(&tables, checkpoint_seq, name_policy);
+    let mut session = view.session();
+
+    // One row past the page proves whether another file exists, so a cursor
+    // is handed out only when it will answer something.
+    let wanted = request.limit.limit_plus_one();
+    let wave_rows = wanted.max(INODE_SCAN_WAVE_ROWS);
+    let mut lower_bound = match request.cursor {
+        Some(cursor) => lookup_keys::inode_key_after(cursor.after_inode_id),
+        None => lookup_keys::INODE_ROW_PREFIX.to_owned(),
+    };
+    let upper_bound = string_prefix_upper_bound(lookup_keys::INODE_ROW_PREFIX);
+    let mut files = Vec::with_capacity(wanted);
+    while files.len() < wanted {
+        let rows = tables
+            .scan_range_page_with_keys(
+                MetadataTableFamily::Inodes,
+                &lower_bound,
+                upper_bound.as_deref(),
+                wave_rows,
+            )
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+            })?;
+        let family_exhausted = rows.len() < wave_rows;
+        // Advance before consuming the wave: the next wave starts strictly
+        // after the last row this one read, whatever the filters keep.
+        match rows.last() {
+            Some((row_key, _)) => lower_bound = format!("{row_key}\0"),
+            None => break,
+        }
+        for (row_key, row) in rows {
+            let MetadataRow::Inode {
+                inode_id,
+                inode_kind,
+                ..
+            } = row
+            else {
+                return Err(CoreError::NamespaceCorrupt(format!(
+                    "inodes family returned a non-inode row at `{row_key}`"
+                )));
+            };
+            if inode_kind != InodeKind::File {
+                continue;
+            }
+            if session.visible_inode(inode_id).await?.is_none() {
+                continue;
+            }
+            let Some(revision) = session.latest_revision_head_of_visible(inode_id).await? else {
+                continue;
+            };
+            files.push(CheckpointFile {
+                inode_id,
+                revision_no: revision.revision_no,
+                size_bytes: revision.content_ref.size_bytes,
+                content_ref: revision.content_ref,
+            });
+            if files.len() == wanted {
+                break;
+            }
+        }
+        if family_exhausted {
+            break;
+        }
+    }
+
+    let has_more = files.len() > request.limit.as_usize();
+    if has_more {
+        files.truncate(request.limit.as_usize());
+    }
+    let next_cursor = has_more.then(|| CheckpointFilesPageCursor {
+        after_inode_id: files
+            .last()
+            .expect("a non-zero page limit with more files must return a file")
+            .inode_id,
+    });
+    Ok(CheckpointFilesPage {
+        checkpoint_seq,
+        files,
+        next_cursor,
+    })
+}
+
+/// Loads the record and refuses every lifecycle that does not still pin its
+/// basis, so a caller never reads state garbage collection may already be
+/// reclaiming.
+async fn read_pinning_checkpoint_record<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    checkpoint_id: &CheckpointId,
+    now_ms: u64,
+) -> Result<CheckpointRecordState> {
+    let Some(record) = read_checkpoint_record(store, namespace_id, checkpoint_id)
+        .await?
+        .map(|loaded| loaded.state)
+    else {
+        return Err(CoreError::CheckpointUnavailable(format!(
+            "checkpoint `{checkpoint_id}` does not exist in namespace `{namespace_id}`"
+        )));
+    };
+    if record.state != CheckpointRecordLifecycle::Active {
+        return Err(CoreError::CheckpointUnavailable(format!(
+            "checkpoint `{checkpoint_id}` is `{}` and no longer pins its basis",
+            record.state
+        )));
+    }
+    if record
+        .expires_at_ms
+        .is_some_and(|expires_at_ms| now_ms >= expires_at_ms)
+    {
+        return Err(CoreError::CheckpointUnavailable(format!(
+            "checkpoint `{checkpoint_id}` expired and no longer pins its basis"
+        )));
+    }
+    Ok(record)
+}

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -13,7 +13,8 @@
 //! - [`build`] segments metadata rows and writes the immutable SST objects.
 //! - [`publish`] writes manifest objects and advances `metadata/root.json`
 //!   by compare-and-swap.
-//! - [`record`] and [`release`] manage durable checkpoint records.
+//! - [`record`] and [`release`] manage durable checkpoint records, and
+//!   [`files`] enumerates the files a record's manifest pins.
 //! - [`load`] and [`validate`] provide envelope-only loading and
 //!   descriptor-only table verification (full-row inspection
 //!   materialization is test-only).
@@ -32,6 +33,7 @@ mod cache;
 mod create;
 mod data_block_load;
 mod error;
+mod files;
 mod flush;
 mod grep_read;
 mod load;
@@ -54,6 +56,7 @@ pub use self::cache::{
     DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
+pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
 pub use self::grep_read::{
     load_grep_change_feed, load_grep_checkpoint_revision_page, string_prefix_upper_bound,
     GrepChangeFeed, GrepCheckpointRevisionPage, REVISION_ROW_PREFIX,
@@ -62,6 +65,7 @@ pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub(crate) use self::runs::MetadataLsmPolicy;
 
 pub(crate) use self::create::create_checkpoint;
+pub(crate) use self::files::list_checkpoint_files_page;
 pub(crate) use self::flush::flush_wal;
 pub(crate) use self::load::{
     head_from_manifest, load_basis_metadata_tables, load_namespace_manifest_envelope,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -2,6 +2,7 @@
 //! uploads, checkpoints, and maintenance.
 
 use crate::cache::{MetadataTableCache, WalTailProjectionCache};
+use crate::checkpoint::{CheckpointFilesPage, CheckpointFilesPageCursor};
 use crate::commit_engine::NamespaceMutationCandidate;
 use crate::context::MutationContext;
 use crate::error::Result;
@@ -9,14 +10,16 @@ use crate::namespace::basis::MetadataBasis;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::{bootstrap, fork, BootstrapNamespaceError};
 use crate::options::{BootstrapOptions, DeleteNamespaceOptions};
-use crate::path::read::{load_metadata_view, LoadedMetadataView, ReadLoadContext};
+use crate::path::read::{
+    load_metadata_view, CurrentFileState, LoadedMetadataView, ReadLoadContext,
+};
 use crate::storage::content_admission::PreparedContent;
 use loonfs_api::generated_id;
 use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, ChangesResponse, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, UploadContentResponse,
 };
-use loonfs_api::wire::control::{CheckpointOwner, HeadState};
+use loonfs_api::wire::control::{CheckpointOwner, HeadState, NamespaceState};
 use loonfs_api::EffectiveLimit;
 use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
@@ -250,6 +253,99 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     ) -> Result<Page<TrashEntry, TrashPageCursor>> {
         let view = self.load_read_view(context).await?;
         view.list_trash_page(request).await
+    }
+
+    /// Reads one page of the files visible in the state `checkpoint_id`
+    /// pins, in ascending inode-id order.
+    ///
+    /// The checkpoint's pinned manifest is the only state enumerated: the
+    /// context's own basis and WAL tail are deliberately not read, so a
+    /// commit landing while a consumer pages through changes nothing it
+    /// sees. Everything after the pinned sequence is the change feed's job.
+    /// The context supplies the namespace's immutable identity and proves
+    /// the namespace is still live.
+    pub async fn list_checkpoint_files_page(
+        &self,
+        checkpoint_id: &CheckpointId,
+        request: PageRequest<CheckpointFilesPageCursor>,
+        context: &RuntimeReadContext,
+    ) -> Result<CheckpointFilesPage> {
+        let catalog = self.live_catalog(context)?;
+        crate::checkpoint::list_checkpoint_files_page(
+            &self.store,
+            Some(context.table_cache.as_ref()),
+            &self.namespace_id,
+            checkpoint_id,
+            catalog.name_policy(),
+            current_time_ms()?,
+            request,
+        )
+        .await
+    }
+
+    /// Answers, for each inode id, what it looks like in the namespace's
+    /// current state: whether it is visible, its current revision, and its
+    /// current path.
+    ///
+    /// One pinned read serves the whole batch, so every answer describes the
+    /// same state, and answers come back in input order. Ids that name
+    /// nothing are answered as not visible rather than refused — a consumer
+    /// holding ids from an earlier enumeration routinely holds stale ones.
+    /// At most [`MAX_RESOLVE_CURRENT_FILES`](crate::MAX_RESOLVE_CURRENT_FILES)
+    /// ids per call; a larger batch is refused before anything is read.
+    pub async fn resolve_current_files(
+        &self,
+        inode_ids: &[InodeId],
+        context: &RuntimeReadContext,
+    ) -> Result<Vec<CurrentFileState>> {
+        crate::path::read::ensure_resolve_batch_within_cap(inode_ids.len())?;
+        let view = self.load_read_view(context).await?;
+        crate::path::read::resolve_current_files(&view, inode_ids).await
+    }
+
+    /// Reads one immutable content object by reference.
+    ///
+    /// `max_bytes` is the caller's own budget for this read, checked against
+    /// the reference's declared size before any fetch; it is independent of
+    /// any deployment-wide download limit, so a consumer sizes its own
+    /// buffers. After the fetch the bytes are verified against the
+    /// reference's size and digest, and a mismatch fails the read — there is
+    /// no partial answer and no second attempt against another key.
+    pub async fn read_content_ref(
+        &self,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+        context: &RuntimeReadContext,
+    ) -> Result<Vec<u8>> {
+        let catalog = self.live_catalog(context)?;
+        crate::path::read::ensure_within_read_limit(content_ref.size_bytes, Some(max_bytes))?;
+        let read = crate::storage::content::read_durable_content_bytes(
+            &self.store,
+            catalog.content_store_id(),
+            content_ref,
+        )
+        .await?;
+        Ok(read.bytes)
+    }
+
+    /// The namespace's immutable identity, read off the pinned head after
+    /// refusing a head that is not this namespace's or that is a tombstone.
+    ///
+    /// Reads that load a metadata view get both checks from the view load;
+    /// this is for the reads that deliberately do not load one.
+    fn live_catalog(&self, context: &RuntimeReadContext) -> Result<VerifiedNamespaceCatalogEntry> {
+        if context.head.namespace_id != self.namespace_id {
+            return Err(crate::error::CoreError::NamespaceCorrupt(format!(
+                "head namespace `{}` does not match requested namespace `{}`",
+                context.head.namespace_id, self.namespace_id
+            )));
+        }
+        if context.head.state == NamespaceState::Deleted {
+            return Err(crate::error::CoreError::NamespaceDeleted {
+                namespace_id: self.namespace_id.clone(),
+            });
+        }
+        Ok(VerifiedNamespaceCatalogEntry::from_head(&context.head))
     }
 
     /// Lists one revision page for an inode against the pinned runtime read context.

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -87,6 +87,10 @@ pub enum CoreError {
          this deployment buffers for one read"
     )]
     ContentTooLarge { size_bytes: u64, max_bytes: u64 },
+    /// A batch read asked for more items than one call answers. The caller
+    /// splits the batch; nothing was read.
+    #[error("asked for {requested} items, over the {max} one batch answers")]
+    BatchTooLarge { requested: usize, max: usize },
     #[error("expected file at `{path}` but found `{kind}`")]
     ExpectedFile { path: String, kind: InodeKind },
     #[error("expected directory at `{path}` but found `{kind}`")]
@@ -356,6 +360,7 @@ impl CoreError {
             | CoreError::InvalidQuery(_)
             | CoreError::InvalidUploadContent(_)
             | CoreError::InvalidCursor(_)
+            | CoreError::BatchTooLarge { .. }
             | CoreError::NonDirectoryPathComponent(_) => ErrorCode::InvalidRequest,
             CoreError::PathNotFound(_) => ErrorCode::PathNotFound,
             CoreError::RevisionNotFound { .. } => ErrorCode::RevisionNotFound,

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -115,7 +115,10 @@ pub mod publish {
     pub use crate::storage::content_admission::PreparedContent;
 }
 
-pub use checkpoint::{MetadataReorganizeOutcome, MetadataReorganizeReport};
+pub use checkpoint::{
+    CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, MetadataReorganizeOutcome,
+    MetadataReorganizeReport,
+};
 pub use context::MutationContext;
 pub use engine::RuntimeReadContext;
 pub use engine::{BeginDirectPutUploadTargetResponse, DirectPutUploadTarget};
@@ -127,6 +130,7 @@ pub use error::{
 pub use gc::{gc_namespace, GcConfig};
 pub use namespace::BootstrapNamespaceError;
 pub use options::{BootstrapOptions, DeleteNamespaceOptions, WriteOptions};
+pub use path::read::{CurrentFileState, MAX_RESOLVE_CURRENT_FILES};
 pub use timing::{MonotonicTimer, StdMonotonicTimer};
 
 /// Concrete read-view types consumed by `loonfs-grep`.

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -160,6 +160,34 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         }
     }
 
+    /// A view of exactly one manifest's tables at the sequence they
+    /// materialize, with nothing layered over them.
+    ///
+    /// [`Self::from_loaded_head`] answers "the namespace as of its live
+    /// head" by replaying the WAL tail over a basis; this answers "the
+    /// namespace exactly as this manifest recorded it". Callers that pin an
+    /// immutable manifest — a checkpoint's basis — read through this, so no
+    /// row committed after the manifest can leak into the answer.
+    pub(crate) fn over_manifest_tables(
+        tables: &'a VerifiedMetadataTables<'store, S>,
+        materialized_seq: ChangeSeq,
+        name_policy: NamePolicy,
+    ) -> Self {
+        Self {
+            snapshot: MetadataSnapshot {
+                visible_seq: materialized_seq,
+                name_policy,
+            },
+            sources: MetadataSourceStack {
+                overlay: None,
+                wal_tail: None,
+                manifest: Some(tables),
+                in_memory_base: None,
+                durable_cache: None,
+            },
+        }
+    }
+
     pub(crate) fn name_policy(&self) -> NamePolicy {
         self.snapshot.name_policy
     }

--- a/crates/loonfs-core/src/path/read/current_files.rs
+++ b/crates/loonfs-core/src/path/read/current_files.rs
@@ -1,0 +1,186 @@
+//! Answering "where is this inode now?" for a batch of inode ids.
+//!
+//! A consumer that holds inode ids from an earlier enumeration asks this
+//! what became of them: whether each is still visible, which revision it
+//! carries now, and where it currently sits. Stale ids are ordinary input —
+//! a candidate generator routinely holds ids that were deleted since — so
+//! an unknown id is answered, not refused.
+
+use super::materialized_view::LoadedMetadataView;
+use crate::error::{CoreError, Result};
+use crate::metadata::MetadataViewSession;
+use loonfs_api::{AbsolutePath, InodeId, InodeKind, RevisionNo, ROOT_INODE_ID};
+use loonfs_objectstore::ObjectStore;
+use std::collections::{HashMap, HashSet};
+
+/// The most inode ids [`resolve_current_files`] answers in one call.
+///
+/// One item costs about what one row of a listing page costs, so the batch
+/// is bounded by the same number: the pagination policy's maximum page limit
+/// ([`loonfs_api::DEFAULT_MAX_PAGE_LIMIT`]).
+pub const MAX_RESOLVE_CURRENT_FILES: usize = loonfs_api::DEFAULT_MAX_PAGE_LIMIT as usize;
+
+/// What one inode looks like in the namespace's current state.
+///
+/// The shape is file-oriented but tolerant of anything an id can name: a
+/// directory answers `visible` with a path and no revision, and an id that
+/// names nothing answers not visible with nothing else filled in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentFileState {
+    /// The inode this answer is about, echoed so batched answers stay
+    /// self-describing.
+    pub inode_id: InodeId,
+    /// Whether the inode is currently visible: it exists, no subtree
+    /// tombstone covers it or an ancestor, and its bindings still reach the
+    /// namespace root.
+    pub visible: bool,
+    /// The current revision number — `Some` only for a visible file that
+    /// has one.
+    pub current_revision_no: Option<RevisionNo>,
+    /// Where the inode currently sits — `Some` exactly when `visible`.
+    pub current_path: Option<AbsolutePath>,
+}
+
+/// Refuses an oversized batch before anything is loaded.
+///
+/// Called at the API boundary so an over-cap request costs no reads.
+pub(crate) fn ensure_resolve_batch_within_cap(requested: usize) -> Result<()> {
+    if requested > MAX_RESOLVE_CURRENT_FILES {
+        return Err(CoreError::BatchTooLarge {
+            requested,
+            max: MAX_RESOLVE_CURRENT_FILES,
+        });
+    }
+    Ok(())
+}
+
+/// Resolves every inode id against one loaded view, in input order.
+///
+/// The whole batch reads one view, so every answer describes the same
+/// namespace state. Ancestor walks are shared: the batch memoizes each
+/// ancestor directory's path the first time a walk passes through it, so
+/// files under one directory pay for that chain once — the walking cost is
+/// bounded by the number of distinct ancestors in the batch, not by the
+/// number of items.
+pub(crate) async fn resolve_current_files<S: ObjectStore + ?Sized>(
+    view: &LoadedMetadataView<'_, S>,
+    inode_ids: &[InodeId],
+) -> Result<Vec<CurrentFileState>> {
+    ensure_resolve_batch_within_cap(inode_ids.len())?;
+    let mut session = view.metadata_view().session();
+    let mut ancestor_paths = HashMap::new();
+    let mut states = Vec::with_capacity(inode_ids.len());
+    for &inode_id in inode_ids {
+        states.push(resolve_one(&mut session, &mut ancestor_paths, inode_id).await?);
+    }
+    Ok(states)
+}
+
+async fn resolve_one<S: ObjectStore + ?Sized>(
+    session: &mut MetadataViewSession<'_, '_, S>,
+    ancestor_paths: &mut HashMap<InodeId, AbsolutePath>,
+    inode_id: InodeId,
+) -> Result<CurrentFileState> {
+    let Some(inode) = session.visible_inode(inode_id).await? else {
+        return Ok(missing(inode_id));
+    };
+    let Some(current_path) = current_path(session, ancestor_paths, inode_id).await? else {
+        return Ok(missing(inode_id));
+    };
+    let current_revision_no = if inode.inode_kind == InodeKind::File {
+        session
+            .latest_revision_head_of_visible(inode_id)
+            .await?
+            .map(|revision| revision.revision_no)
+    } else {
+        None
+    };
+    Ok(CurrentFileState {
+        inode_id,
+        visible: true,
+        current_revision_no,
+        current_path: Some(current_path),
+    })
+}
+
+fn missing(inode_id: InodeId) -> CurrentFileState {
+    CurrentFileState {
+        inode_id,
+        visible: false,
+        current_revision_no: None,
+        current_path: None,
+    }
+}
+
+/// Derives the inode's current path by following parent bindings up to the
+/// root, then spelling the chain back out.
+///
+/// This is the same binding relation a path resolution walks downward, read
+/// from the other end. `None` means the chain never reaches the root — a
+/// binding cycle, or a dead end — which commit validation prevents; the walk
+/// reports it as "not visible" rather than inventing a path for state it
+/// cannot name.
+async fn current_path<S: ObjectStore + ?Sized>(
+    session: &mut MetadataViewSession<'_, '_, S>,
+    ancestor_paths: &mut HashMap<InodeId, AbsolutePath>,
+    inode_id: InodeId,
+) -> Result<Option<AbsolutePath>> {
+    let mut climbed = Vec::new();
+    let mut visited = HashSet::new();
+    let mut current = inode_id;
+    let base = loop {
+        if current == ROOT_INODE_ID {
+            break AbsolutePath::root();
+        }
+        if let Some(known) = ancestor_paths.get(&current) {
+            break known.clone();
+        }
+        if !visited.insert(current) {
+            return Ok(None);
+        }
+        let Some(binding) = session.current_parent_binding_for_child(current).await? else {
+            return Ok(None);
+        };
+        current = binding.parent_inode_id;
+        climbed.push(binding);
+    };
+
+    // `climbed` runs leaf-first; spelling it out from the known base
+    // downward names every directory passed on the way, which is what the
+    // next item under the same directory reuses.
+    let mut path = base;
+    for binding in climbed.iter().rev() {
+        path = path.join(&binding.display_name);
+        ancestor_paths.insert(binding.child_inode_id, path.clone());
+    }
+    Ok(Some(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_resolve_batch_within_cap, MAX_RESOLVE_CURRENT_FILES};
+    use loonfs_api::{ErrorCode, PaginationPolicy};
+
+    #[test]
+    fn the_batch_cap_is_the_pagination_maximum() {
+        assert_eq!(
+            MAX_RESOLVE_CURRENT_FILES,
+            PaginationPolicy::default().max_limit().get() as usize,
+            "the batch cap is the page limit, not a second number"
+        );
+    }
+
+    #[test]
+    fn a_batch_at_the_cap_is_accepted_and_one_past_it_names_the_cap() {
+        assert!(ensure_resolve_batch_within_cap(MAX_RESOLVE_CURRENT_FILES).is_ok());
+        let error = ensure_resolve_batch_within_cap(MAX_RESOLVE_CURRENT_FILES + 1)
+            .expect_err("one past the cap is refused");
+        assert_eq!(error.code(), ErrorCode::InvalidRequest);
+        assert!(
+            error
+                .to_string()
+                .contains(&MAX_RESOLVE_CURRENT_FILES.to_string()),
+            "the refusal should name the cap: {error}"
+        );
+    }
+}

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -827,7 +827,10 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
 /// Refuses a buffered content read whose resolved size exceeds the caller's
 /// budget. The check runs on metadata, before any content fetch, so an
 /// over-limit read costs no object-store traffic and allocates nothing.
-fn ensure_within_read_limit(size_bytes: u64, max_content_bytes: Option<u64>) -> Result<()> {
+pub(crate) fn ensure_within_read_limit(
+    size_bytes: u64,
+    max_content_bytes: Option<u64>,
+) -> Result<()> {
     match max_content_bytes {
         Some(max_bytes) if size_bytes > max_bytes => Err(CoreError::ContentTooLarge {
             size_bytes,

--- a/crates/loonfs-core/src/path/read/mod.rs
+++ b/crates/loonfs-core/src/path/read/mod.rs
@@ -1,8 +1,11 @@
 //! Path-oriented reads over a loaded metadata view: resolution, listings,
 //! revision history, and the narrow read view consumed by `loonfs-grep`.
 
+mod current_files;
 mod listing;
 mod materialized_view;
 
+pub(crate) use current_files::{ensure_resolve_batch_within_cap, resolve_current_files};
+pub use current_files::{CurrentFileState, MAX_RESOLVE_CURRENT_FILES};
 pub use materialized_view::LoadedMetadataView;
-pub(crate) use materialized_view::{load_metadata_view, ReadLoadContext};
+pub(crate) use materialized_view::{ensure_within_read_limit, load_metadata_view, ReadLoadContext};

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -1,13 +1,15 @@
 //! [`FsReader`]'s read operations: stat, list, content, grep, revision
-//! reads, and the change feed.
+//! reads, the change feed, and the whole-namespace reads a consumer that
+//! derives its own data from the filesystem walks.
 
 use super::core::{default_page_limit, file_revisions_page_response};
 use crate::FsReader;
 use crate::Result;
 use crate::{
-    AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ChangesResponse, CoreError,
-    ListChangesOptions, ListFileRevisionsResponse, ListPathEntriesResponse, NamespaceId,
-    RevisionNo, RuntimeError,
+    AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ChangesResponse,
+    CheckpointFilesPage, CheckpointFilesPageCursor, CheckpointId, ContentRef, CoreError,
+    CurrentFileState, InodeId, ListChangesOptions, ListFileRevisionsResponse,
+    ListPathEntriesResponse, NamespaceId, RevisionNo, RuntimeError,
 };
 use loonfs_api::{
     encode_cursor, AbsolutePath, DirectoryPageCursor, FileRevisionsPageCursor, GrepRequest,
@@ -190,6 +192,79 @@ impl FsReader {
             .cache_stats
             .record_latest_metadata_view_read();
         Ok(response)
+    }
+
+    /// Reads one page of the files visible in the state a checkpoint pins,
+    /// in ascending inode-id order.
+    ///
+    /// The checkpoint's pinned manifest is the whole answer: no WAL is
+    /// replayed over it, so a commit landing mid-enumeration changes
+    /// nothing a consumer sees, and everything after
+    /// [`CheckpointFilesPage::checkpoint_seq`] is what
+    /// [`Self::list_changes`] reports. Directories are not returned.
+    ///
+    /// A checkpoint that was released, expired, or reaped answers
+    /// `checkpoint_unavailable`; the enumeration never silently falls back
+    /// to current state. A consumer that loses its checkpoint takes a new
+    /// one and starts over.
+    pub async fn list_checkpoint_files_page(
+        &self,
+        namespace_id: &NamespaceId,
+        checkpoint_id: &CheckpointId,
+        request: PageRequest<CheckpointFilesPageCursor>,
+    ) -> Result<CheckpointFilesPage> {
+        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        Ok(engine
+            .list_checkpoint_files_page(checkpoint_id, request, &read_context)
+            .await?)
+    }
+
+    /// Answers, for each inode id, what it looks like right now: whether it
+    /// is visible, its current revision, and its current path.
+    ///
+    /// One pinned read serves the batch, so every answer describes the same
+    /// state, and answers come back in input order. Ids that name nothing
+    /// answer `visible: false` instead of failing — a consumer holding ids
+    /// from an earlier enumeration routinely holds stale ones. A directory
+    /// id answers visible with a path and no revision.
+    ///
+    /// At most [`MAX_RESOLVE_CURRENT_FILES`](crate::MAX_RESOLVE_CURRENT_FILES)
+    /// ids per call; a larger batch is refused with `invalid_request`
+    /// before anything is read.
+    pub async fn resolve_current_files(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_ids: &[InodeId],
+    ) -> Result<Vec<CurrentFileState>> {
+        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let states = engine
+            .resolve_current_files(inode_ids, &read_context)
+            .await?;
+        self.core
+            .inner
+            .cache_stats
+            .record_latest_metadata_view_read();
+        Ok(states)
+    }
+
+    /// Reads one immutable content object by reference.
+    ///
+    /// `max_bytes` is this caller's own budget, checked against the
+    /// reference's declared size before any fetch, and deliberately
+    /// independent of the deployment's configured download limit — a
+    /// consumer that streams work through a fixed buffer says so here. The
+    /// fetched bytes are verified against the reference's size and digest,
+    /// and a mismatch fails the read.
+    pub async fn read_content_ref(
+        &self,
+        namespace_id: &NamespaceId,
+        content_ref: &ContentRef,
+        max_bytes: u64,
+    ) -> Result<Vec<u8>> {
+        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        Ok(engine
+            .read_content_ref(content_ref, max_bytes, &read_context)
+            .await?)
     }
 
     /// Lists one page of the namespace's recoverable deletions, ascending

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -65,8 +65,9 @@ pub use loonfs_api::{
 pub use loonfs_core::cache::MetadataTableCacheConfig;
 pub use loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS;
 pub use loonfs_core::{
-    BootstrapNamespaceError, DeleteNamespaceOptions, Error as CoreError, ErrorCode, ErrorKind,
-    GcConfig, WriterFence,
+    BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor,
+    CurrentFileState, DeleteNamespaceOptions, Error as CoreError, ErrorCode, ErrorKind, GcConfig,
+    WriterFence, MAX_RESOLVE_CURRENT_FILES,
 };
 pub use loonfs_grep::GrepError;
 pub use publisher::PublishObserver;

--- a/crates/loonfs/tests/bulk_file_reads.rs
+++ b/crates/loonfs/tests/bulk_file_reads.rs
@@ -1,0 +1,940 @@
+//! Whole-namespace reads for a consumer that derives its own data from the
+//! filesystem: enumerating the files a checkpoint pinned, asking where those
+//! files are now, and reading one content object by reference.
+
+#![allow(clippy::panic)]
+// Runtime integration tests use panic in helper assertions for precise diagnostics.
+
+mod common;
+
+use common::*;
+use loonfs::{
+    CheckpointFile, CheckpointFilesPageCursor, ContentRef, CreateCheckpointOptions,
+    CreateNamespaceOptions, CurrentFileState, DeleteDirectoryBehavior, DeleteOptions,
+    DestinationBehavior, ErrorCode, FsReader, InodeId, InodeKind, MoveOptions, NamespaceId,
+    PageRequest, PutFileOptions, RevisionNo, RuntimeError, SharedObjectStore, StoreConfig,
+    UndeleteOptions,
+};
+use loonfs_test_support::ids::{namespace_id, page_limit};
+use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn store_config(root: &Path) -> StoreConfig {
+    StoreConfig::LocalFs {
+        root: root.to_string_lossy().into_owned(),
+        key_prefix: None,
+    }
+}
+
+/// One file as the ordinary read surface sees it, for comparing an
+/// enumeration against a recursive listing taken at the same moment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ListedFile {
+    absolute_path: String,
+    revision_no: RevisionNo,
+    size_bytes: u64,
+    content_ref: ContentRef,
+}
+
+/// Every visible file in the namespace right now, by inode, found by walking
+/// directories through the ordinary listing surface.
+async fn listed_files(
+    reader: &FsReader,
+    namespace_id: &NamespaceId,
+) -> BTreeMap<InodeId, ListedFile> {
+    let mut found = BTreeMap::new();
+    let mut directories = vec!["/".to_owned()];
+    while let Some(directory) = directories.pop() {
+        let entries = reader
+            .list_path_entries_all(namespace_id, &directory)
+            .await
+            .expect("list directory")
+            .entries;
+        for entry in entries {
+            match entry.inode_kind {
+                InodeKind::Directory => directories.push(entry.absolute_path.as_str().to_owned()),
+                InodeKind::File => {
+                    found.insert(
+                        entry.inode_id,
+                        ListedFile {
+                            absolute_path: entry.absolute_path.as_str().to_owned(),
+                            revision_no: entry.revision_no.expect("a file carries a revision"),
+                            size_bytes: entry.size_bytes.expect("a file carries a size"),
+                            content_ref: entry.content_ref.expect("a file carries a content ref"),
+                        },
+                    );
+                }
+            }
+        }
+    }
+    found
+}
+
+/// Every file a checkpoint pins, read one page at a time so the paging path
+/// carries every assertion.
+async fn checkpoint_files(
+    reader: &FsReader,
+    namespace_id: &NamespaceId,
+    checkpoint_id: &loonfs::CheckpointId,
+    limit: usize,
+) -> Vec<CheckpointFile> {
+    let mut files = Vec::new();
+    let mut cursor = None;
+    let mut seen: BTreeSet<InodeId> = BTreeSet::new();
+    loop {
+        let page = reader
+            .list_checkpoint_files_page(
+                namespace_id,
+                checkpoint_id,
+                PageRequest {
+                    limit: page_limit(limit),
+                    cursor,
+                },
+            )
+            .await
+            .expect("read a checkpoint files page");
+        assert!(
+            page.files.len() <= limit,
+            "a page returned {} files over the {limit} limit",
+            page.files.len()
+        );
+        for file in &page.files {
+            assert!(
+                seen.insert(file.inode_id),
+                "inode `{}` was returned twice across pages",
+                file.inode_id
+            );
+        }
+        let page_inodes: Vec<InodeId> = page.files.iter().map(|file| file.inode_id).collect();
+        let mut ascending = page_inodes.clone();
+        ascending.sort_unstable();
+        assert_eq!(page_inodes, ascending, "a page was not in inode order");
+        if let (Some(next), Some(last)) = (page.next_cursor, page.files.last()) {
+            assert_eq!(
+                next.after_inode_id, last.inode_id,
+                "a cursor must resume after the last file it handed back"
+            );
+        }
+        files.extend(page.files);
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            return files;
+        }
+    }
+}
+
+/// A namespace with the shapes an enumeration has to get right: nested
+/// directories, a replaced file, a deleted subtree, an undeleted file, and a
+/// directory holding no files at all.
+async fn build_mixed_namespace(fs: &TestRuntime, namespace_id: &NamespaceId) {
+    fs.create_namespace(namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for (path, bytes) in [
+        ("/docs/alpha.txt", &b"alpha"[..]),
+        ("/docs/deep/bravo.txt", &b"bravo"[..]),
+        ("/docs/deep/charlie.txt", &b"charlie"[..]),
+        ("/scratch/discarded.txt", &b"discarded"[..]),
+        ("/notes/recovered.txt", &b"recovered"[..]),
+    ] {
+        fs.put_file_bytes(namespace_id, path, bytes, PutFileOptions::default())
+            .await
+            .expect("put file");
+    }
+    fs.writer
+        .create_directory(
+            namespace_id,
+            "/empty",
+            loonfs::CreateDirectoryOptions::default(),
+        )
+        .await
+        .expect("create a directory holding no files");
+
+    // A replaced file: the enumeration must report the newer revision.
+    fs.put_file_bytes(
+        namespace_id,
+        "/docs/deep/charlie.txt",
+        b"charlie again",
+        PutFileOptions {
+            behavior: DestinationBehavior::Replace,
+            ..PutFileOptions::default()
+        },
+    )
+    .await
+    .expect("replace file");
+
+    // A deleted subtree: neither the directory nor the file below it is
+    // visible any more.
+    fs.writer
+        .delete_path(
+            namespace_id,
+            "/scratch",
+            DeleteOptions {
+                behavior: DeleteDirectoryBehavior::Recursive,
+                ..DeleteOptions::default()
+            },
+        )
+        .await
+        .expect("delete subtree");
+
+    // An undeleted file: visible again, at a new path.
+    let recovered_inode_id = fs
+        .stat_path(namespace_id, "/notes/recovered.txt")
+        .await
+        .expect("stat before delete")
+        .inode_id;
+    let deleted_at_seq = fs
+        .writer
+        .delete_path(
+            namespace_id,
+            "/notes/recovered.txt",
+            DeleteOptions::default(),
+        )
+        .await
+        .expect("delete file")
+        .committed_seq;
+    fs.writer
+        .undelete(
+            namespace_id,
+            recovered_inode_id,
+            deleted_at_seq,
+            "/notes/restored.txt",
+            UndeleteOptions::default(),
+        )
+        .await
+        .expect("undelete file");
+}
+
+#[tokio::test]
+async fn checkpoint_enumeration_answers_the_state_it_pinned() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "checkpoint-files-test").await;
+    let namespace_id = namespace_id("demo");
+    build_mixed_namespace(&fs, &namespace_id).await;
+
+    // Ground truth, collected through the ordinary read surface BEFORE the
+    // later writes land.
+    let at_checkpoint = listed_files(&fs.reader, &namespace_id).await;
+    let checkpoint = fs
+        .create_checkpoint(&namespace_id)
+        .await
+        .expect("create checkpoint");
+
+    // Everything after the checkpoint is the change feed's job, so none of
+    // it may show up in the enumeration.
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/added-later.txt",
+        b"added later",
+        PutFileOptions::default(),
+    )
+    .await
+    .expect("create a file after the checkpoint");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha again",
+        PutFileOptions {
+            behavior: DestinationBehavior::Replace,
+            ..PutFileOptions::default()
+        },
+    )
+    .await
+    .expect("replace a file after the checkpoint");
+    fs.writer
+        .delete_path(
+            &namespace_id,
+            "/docs/deep/bravo.txt",
+            DeleteOptions::default(),
+        )
+        .await
+        .expect("delete a file after the checkpoint");
+    fs.writer
+        .move_path(
+            &namespace_id,
+            "/docs/deep/charlie.txt",
+            "/docs/charlie.txt",
+            MoveOptions::default(),
+        )
+        .await
+        .expect("move a file after the checkpoint");
+
+    let enumerated =
+        checkpoint_files(&fs.reader, &namespace_id, &checkpoint.checkpoint_id, 2).await;
+    let by_inode: BTreeMap<InodeId, CheckpointFile> = enumerated
+        .iter()
+        .map(|file| (file.inode_id, file.clone()))
+        .collect();
+
+    assert_eq!(
+        by_inode.keys().copied().collect::<Vec<_>>(),
+        at_checkpoint.keys().copied().collect::<Vec<_>>(),
+        "the enumeration must name exactly the files visible when the checkpoint was taken"
+    );
+    for (inode_id, listed) in &at_checkpoint {
+        let file = &by_inode[inode_id];
+        assert_eq!(
+            file.revision_no, listed.revision_no,
+            "wrong revision for `{}`",
+            listed.absolute_path
+        );
+        assert_eq!(file.content_ref, listed.content_ref);
+        assert_eq!(file.size_bytes, listed.size_bytes);
+        assert_eq!(file.size_bytes, file.content_ref.size_bytes);
+    }
+
+    let checkpoint_paths: BTreeSet<&str> = at_checkpoint
+        .values()
+        .map(|listed| listed.absolute_path.as_str())
+        .collect();
+    assert_eq!(
+        checkpoint_paths,
+        BTreeSet::from([
+            "/docs/alpha.txt",
+            "/docs/deep/bravo.txt",
+            "/docs/deep/charlie.txt",
+            "/notes/restored.txt",
+        ]),
+        "the pinned state should hold the undeleted file and neither the \
+         deleted subtree nor anything written later"
+    );
+
+    // The live namespace has moved on; the checkpoint has not.
+    let now = listed_files(&fs.reader, &namespace_id).await;
+    assert!(
+        now.values()
+            .any(|listed| listed.absolute_path == "/docs/added-later.txt"),
+        "the later write should be visible at head"
+    );
+    assert!(
+        !enumerated.iter().any(|file| {
+            now.get(&file.inode_id)
+                .is_some_and(|listed| listed.absolute_path == "/docs/added-later.txt")
+        }),
+        "a file created after the checkpoint must not appear in the enumeration"
+    );
+    let alpha_inode_id = at_checkpoint
+        .iter()
+        .find(|(_, listed)| listed.absolute_path == "/docs/alpha.txt")
+        .map(|(inode_id, _)| *inode_id)
+        .expect("alpha was visible at checkpoint time");
+    assert_eq!(
+        by_inode[&alpha_inode_id].revision_no,
+        RevisionNo(1),
+        "the replacement landed after the checkpoint, so the pinned revision stays"
+    );
+    assert_eq!(
+        now[&alpha_inode_id].revision_no,
+        RevisionNo(2),
+        "the live namespace should carry the replacement"
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_files_page_without_gaps_or_duplicates() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "checkpoint-files-paging-test").await;
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for index in 0..5 {
+        fs.put_file_bytes(
+            &namespace_id,
+            &format!("/docs/file-{index}.txt"),
+            format!("body {index}").as_bytes(),
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("put file");
+    }
+    let checkpoint = fs
+        .create_checkpoint(&namespace_id)
+        .await
+        .expect("create checkpoint");
+
+    let whole = checkpoint_files(&fs.reader, &namespace_id, &checkpoint.checkpoint_id, 100).await;
+    assert_eq!(whole.len(), 5);
+    let one_at_a_time =
+        checkpoint_files(&fs.reader, &namespace_id, &checkpoint.checkpoint_id, 1).await;
+    assert_eq!(
+        one_at_a_time, whole,
+        "paging one file at a time must produce the same sequence as one page"
+    );
+
+    // Resuming from every cursor position lands exactly on the remaining
+    // tail: no row is re-read, and none is skipped.
+    for (index, file) in whole.iter().enumerate() {
+        let resumed = fs
+            .reader
+            .list_checkpoint_files_page(
+                &namespace_id,
+                &checkpoint.checkpoint_id,
+                PageRequest {
+                    limit: page_limit(100),
+                    cursor: Some(CheckpointFilesPageCursor {
+                        after_inode_id: file.inode_id,
+                    }),
+                },
+            )
+            .await
+            .expect("resume from a cursor");
+        assert_eq!(resumed.files, whole[index + 1..]);
+        assert!(resumed.next_cursor.is_none());
+        assert_eq!(resumed.checkpoint_seq, checkpoint.checkpoint_seq);
+    }
+}
+
+#[tokio::test]
+async fn an_empty_namespace_answers_one_empty_page() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "checkpoint-files-empty-test").await;
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let checkpoint = fs
+        .create_checkpoint(&namespace_id)
+        .await
+        .expect("create checkpoint");
+
+    let page = fs
+        .reader
+        .list_checkpoint_files_page(
+            &namespace_id,
+            &checkpoint.checkpoint_id,
+            PageRequest {
+                limit: page_limit(10),
+                cursor: None,
+            },
+        )
+        .await
+        .expect("enumerate an empty namespace");
+    assert!(page.files.is_empty());
+    assert!(page.next_cursor.is_none());
+    assert_eq!(page.checkpoint_seq, checkpoint.checkpoint_seq);
+}
+
+#[tokio::test]
+async fn a_fork_targets_checkpoint_enumerates_the_source_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let fs = open_runtime_async(store.clone(), "checkpoint-files-fork-test").await;
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+    fs.create_namespace(&source, CreateNamespaceOptions::default())
+        .await
+        .expect("create source namespace");
+    for (path, bytes) in [
+        ("/docs/alpha.txt", &b"alpha"[..]),
+        ("/docs/deep/bravo.txt", &b"bravo"[..]),
+    ] {
+        fs.put_file_bytes(&source, path, bytes, PutFileOptions::default())
+            .await
+            .expect("put file");
+    }
+    let at_fork = listed_files(&fs.reader, &source).await;
+
+    fs.writer
+        .fork_namespace(&source, &target)
+        .await
+        .expect("fork namespace");
+
+    // The target has published nothing of its own, so its checkpoint's
+    // manifest names metadata files the source owns.
+    let checkpoint = fs
+        .admin
+        .create_checkpoint(
+            &target,
+            CreateCheckpointOptions {
+                name: "fork-pin".to_owned(),
+                ttl_ms: None,
+            },
+        )
+        .await
+        .expect("checkpoint the unflushed fork target");
+    assert!(
+        foreign_metadata_file_owners(&store, &target)
+            .await
+            .contains(&source),
+        "the fork target's basis manifest should still name source-owned metadata files"
+    );
+
+    let enumerated = checkpoint_files(&fs.reader, &target, &checkpoint.checkpoint_id, 1).await;
+    assert_eq!(
+        enumerated
+            .iter()
+            .map(|file| (file.inode_id, file.revision_no, file.content_ref.clone()))
+            .collect::<Vec<_>>(),
+        at_fork
+            .iter()
+            .map(|(inode_id, listed)| (*inode_id, listed.revision_no, listed.content_ref.clone()))
+            .collect::<Vec<_>>(),
+        "a fork target's checkpoint should enumerate the source state at the fork point"
+    );
+}
+
+/// Which namespaces own the metadata files a namespace's current manifest
+/// names.
+async fn foreign_metadata_file_owners(
+    store: &SharedObjectStore,
+    namespace_id: &NamespaceId,
+) -> BTreeSet<NamespaceId> {
+    let root =
+        loonfs_core::control::load_namespace_metadata_root_control(store.as_ref(), namespace_id)
+            .await
+            .expect("load metadata root")
+            .state;
+    let key = loonfs_objectstore::keys::metadata_manifest_object(
+        namespace_id.as_str(),
+        &root.manifest_object_id,
+    );
+    let bytes = store
+        .get(&key, None)
+        .await
+        .expect("read manifest")
+        .expect("manifest object exists");
+    loonfs_api::wire::manifest::decode_namespace_manifest_json(&bytes)
+        .expect("decode manifest")
+        .payload
+        .metadata_files
+        .into_iter()
+        .map(|file| file.owner_namespace_id)
+        .collect()
+}
+
+#[tokio::test]
+async fn a_released_checkpoint_refuses_enumeration_instead_of_answering_current_state() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "checkpoint-files-release-test").await;
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha",
+        PutFileOptions::default(),
+    )
+    .await
+    .expect("put file");
+    let checkpoint = fs
+        .create_checkpoint(&namespace_id)
+        .await
+        .expect("create checkpoint");
+    fs.admin
+        .release_checkpoint(&namespace_id, &checkpoint.checkpoint_id)
+        .await
+        .expect("release checkpoint");
+
+    let error = fs
+        .reader
+        .list_checkpoint_files_page(
+            &namespace_id,
+            &checkpoint.checkpoint_id,
+            PageRequest {
+                limit: page_limit(10),
+                cursor: None,
+            },
+        )
+        .await
+        .expect_err("a released checkpoint pins nothing to enumerate");
+    assert_eq!(error.code(), ErrorCode::CheckpointUnavailable);
+
+    let missing = loonfs::CheckpointId::parse("chk_0123456789abcdef0123456789abcdef")
+        .expect("valid checkpoint id");
+    let error = fs
+        .reader
+        .list_checkpoint_files_page(
+            &namespace_id,
+            &missing,
+            PageRequest {
+                limit: page_limit(10),
+                cursor: None,
+            },
+        )
+        .await
+        .expect_err("a checkpoint that never existed pins nothing either");
+    assert_eq!(error.code(), ErrorCode::CheckpointUnavailable);
+}
+
+#[tokio::test]
+async fn resolve_current_files_answers_the_whole_matrix_in_input_order() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "resolve-current-files-test").await;
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for (path, bytes) in [
+        ("/m/unchanged.txt", &b"unchanged"[..]),
+        ("/m/replaced.txt", &b"first"[..]),
+        ("/m/moved.txt", &b"moved"[..]),
+        ("/m/carried/inside.txt", &b"inside"[..]),
+        ("/m/deleted.txt", &b"deleted"[..]),
+        ("/m/subtree/child.txt", &b"child"[..]),
+        ("/m/recovered.txt", &b"recovered"[..]),
+    ] {
+        fs.put_file_bytes(&namespace_id, path, bytes, PutFileOptions::default())
+            .await
+            .expect("put file");
+    }
+    let inode_of = |path: &'static str| {
+        let fs = &fs;
+        let namespace_id = &namespace_id;
+        async move {
+            fs.stat_path(namespace_id, path)
+                .await
+                .expect("stat path")
+                .inode_id
+        }
+    };
+    let unchanged = inode_of("/m/unchanged.txt").await;
+    let replaced = inode_of("/m/replaced.txt").await;
+    let moved = inode_of("/m/moved.txt").await;
+    let carried = inode_of("/m/carried/inside.txt").await;
+    let deleted = inode_of("/m/deleted.txt").await;
+    let in_deleted_subtree = inode_of("/m/subtree/child.txt").await;
+    let recovered = inode_of("/m/recovered.txt").await;
+    let directory = inode_of("/m").await;
+
+    fs.put_file_bytes(
+        &namespace_id,
+        "/m/replaced.txt",
+        b"second",
+        PutFileOptions {
+            behavior: DestinationBehavior::Replace,
+            ..PutFileOptions::default()
+        },
+    )
+    .await
+    .expect("replace file");
+    fs.writer
+        .move_path(
+            &namespace_id,
+            "/m/moved.txt",
+            "/m/moved-away.txt",
+            MoveOptions::default(),
+        )
+        .await
+        .expect("move file");
+    fs.writer
+        .move_path(
+            &namespace_id,
+            "/m/carried",
+            "/m/carried-elsewhere",
+            MoveOptions::default(),
+        )
+        .await
+        .expect("move directory");
+    fs.writer
+        .delete_path(&namespace_id, "/m/deleted.txt", DeleteOptions::default())
+        .await
+        .expect("delete file");
+    fs.writer
+        .delete_path(
+            &namespace_id,
+            "/m/subtree",
+            DeleteOptions {
+                behavior: DeleteDirectoryBehavior::Recursive,
+                ..DeleteOptions::default()
+            },
+        )
+        .await
+        .expect("delete subtree");
+    let recovered_deleted_at_seq = fs
+        .writer
+        .delete_path(&namespace_id, "/m/recovered.txt", DeleteOptions::default())
+        .await
+        .expect("delete file")
+        .committed_seq;
+    fs.writer
+        .undelete(
+            &namespace_id,
+            recovered,
+            recovered_deleted_at_seq,
+            "/m/recovered-again.txt",
+            UndeleteOptions::default(),
+        )
+        .await
+        .expect("undelete file");
+
+    let unknown = InodeId(999_999);
+    let requested = vec![
+        unchanged,
+        replaced,
+        moved,
+        carried,
+        deleted,
+        in_deleted_subtree,
+        recovered,
+        unknown,
+        directory,
+    ];
+    let states = fs
+        .reader
+        .resolve_current_files(&namespace_id, &requested)
+        .await
+        .expect("resolve current files");
+
+    assert_eq!(
+        states
+            .iter()
+            .map(|state| state.inode_id)
+            .collect::<Vec<_>>(),
+        requested,
+        "answers must come back in the order they were asked for"
+    );
+    assert_eq!(
+        states,
+        vec![
+            visible_file(unchanged, RevisionNo(1), "/m/unchanged.txt"),
+            visible_file(replaced, RevisionNo(2), "/m/replaced.txt"),
+            visible_file(moved, RevisionNo(1), "/m/moved-away.txt"),
+            visible_file(carried, RevisionNo(1), "/m/carried-elsewhere/inside.txt"),
+            gone(deleted),
+            gone(in_deleted_subtree),
+            visible_file(recovered, RevisionNo(1), "/m/recovered-again.txt"),
+            gone(unknown),
+            CurrentFileState {
+                inode_id: directory,
+                visible: true,
+                current_revision_no: None,
+                current_path: Some(
+                    loonfs_api::AbsolutePath::parse("/m").expect("valid absolute path")
+                ),
+            },
+        ]
+    );
+}
+
+fn visible_file(inode_id: InodeId, revision_no: RevisionNo, path: &str) -> CurrentFileState {
+    CurrentFileState {
+        inode_id,
+        visible: true,
+        current_revision_no: Some(revision_no),
+        current_path: Some(loonfs_api::AbsolutePath::parse(path).expect("valid absolute path")),
+    }
+}
+
+fn gone(inode_id: InodeId) -> CurrentFileState {
+    CurrentFileState {
+        inode_id,
+        visible: false,
+        current_revision_no: None,
+        current_path: None,
+    }
+}
+
+#[tokio::test]
+async fn resolve_current_files_refuses_a_batch_over_the_cap() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "resolve-current-files-cap-test").await;
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha",
+        PutFileOptions::default(),
+    )
+    .await
+    .expect("put file");
+    let alpha = fs
+        .stat_path(&namespace_id, "/docs/alpha.txt")
+        .await
+        .expect("stat file")
+        .inode_id;
+
+    let at_cap = vec![alpha; loonfs::MAX_RESOLVE_CURRENT_FILES];
+    let states = fs
+        .reader
+        .resolve_current_files(&namespace_id, &at_cap)
+        .await
+        .expect("a batch at the cap is answered");
+    assert_eq!(states.len(), loonfs::MAX_RESOLVE_CURRENT_FILES);
+    assert!(states.iter().all(|state| state.visible));
+
+    let mut over_cap = at_cap;
+    over_cap.push(alpha);
+    let error = fs
+        .reader
+        .resolve_current_files(&namespace_id, &over_cap)
+        .await
+        .expect_err("one past the cap is refused");
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
+    assert!(
+        error
+            .to_string()
+            .contains(&loonfs::MAX_RESOLVE_CURRENT_FILES.to_string()),
+        "the refusal should name the cap: {error}"
+    );
+}
+
+#[tokio::test]
+async fn read_content_ref_answers_bytes_and_refuses_over_budget_before_fetching() {
+    let temp_dir = tempdir().expect("tempdir");
+    let counting = Arc::new(CountingStore::new(
+        loonfs_objectstore::local_fs_store::LocalFsStore::new(temp_dir.path())
+            .expect("create local-fs store"),
+        KeyPredicate::content_blob(),
+    ));
+    let fs = open_runtime_async(counting.clone(), "read-content-ref-test").await;
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha bytes",
+        PutFileOptions::default(),
+    )
+    .await
+    .expect("put file");
+    let content_ref = fs
+        .stat_path(&namespace_id, "/docs/alpha.txt")
+        .await
+        .expect("stat file")
+        .content_ref
+        .expect("a file carries a content ref");
+
+    counting.reset();
+    let bytes = fs
+        .reader
+        .read_content_ref(&namespace_id, &content_ref, content_ref.size_bytes)
+        .await
+        .expect("read content by reference");
+    assert_eq!(bytes, b"alpha bytes");
+    assert_eq!(
+        counting.count(OperationClass::Read),
+        1,
+        "one reference read is one content-object read"
+    );
+
+    counting.reset();
+    let error = fs
+        .reader
+        .read_content_ref(&namespace_id, &content_ref, content_ref.size_bytes - 1)
+        .await
+        .expect_err("a reference larger than the budget is refused");
+    assert_eq!(error.code(), ErrorCode::ContentTooLarge);
+    assert_eq!(
+        counting.count(OperationClass::Read),
+        0,
+        "the budget is checked against the reference, before any fetch"
+    );
+}
+
+#[tokio::test]
+async fn read_content_ref_refuses_bytes_that_do_not_match_the_reference() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let fs = open_runtime_async(store.clone(), "read-content-ref-digest-test").await;
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    fs.put_file_bytes(
+        &namespace_id,
+        "/docs/alpha.txt",
+        b"alpha bytes",
+        PutFileOptions::default(),
+    )
+    .await
+    .expect("put file");
+    let content_ref = fs
+        .stat_path(&namespace_id, "/docs/alpha.txt")
+        .await
+        .expect("stat file")
+        .content_ref
+        .expect("a file carries a content ref");
+
+    // Same length, different bytes: the size check passes and the digest
+    // check is what has to catch it.
+    let content_store_id =
+        loonfs_core::control::load_namespace_catalog_entry(store.as_ref(), &namespace_id)
+            .await
+            .expect("load namespace catalog")
+            .content_store_id()
+            .clone();
+    let object_key =
+        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.digest)
+            .expect("content blob key");
+    store
+        .put_overwrite(&object_key, bytes::Bytes::from_static(b"other bytes"))
+        .await
+        .expect("corrupt the stored content object");
+
+    let error = fs
+        .reader
+        .read_content_ref(&namespace_id, &content_ref, content_ref.size_bytes)
+        .await
+        .expect_err("bytes that do not hash to the reference are refused");
+    assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+    assert!(
+        matches!(&error, RuntimeError::Core(error) if error.to_string().contains("digest mismatch")),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn a_standalone_reader_serves_every_operation() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "standalone-reader-test").await;
+    let namespace_id = namespace_id("demo");
+    build_mixed_namespace(&fs, &namespace_id).await;
+    let checkpoint = fs
+        .create_checkpoint(&namespace_id)
+        .await
+        .expect("create checkpoint");
+    fs.writer
+        .move_path(
+            &namespace_id,
+            "/docs/alpha.txt",
+            "/docs/alpha-moved.txt",
+            MoveOptions::default(),
+        )
+        .await
+        .expect("move a file after the checkpoint");
+
+    // No writer identity anywhere on this path: the reader opens its own
+    // store client from configuration.
+    let reader = FsReader::builder(store_config(temp_dir.path()))
+        .build()
+        .await
+        .expect("build a standalone reader");
+
+    let files = checkpoint_files(&reader, &namespace_id, &checkpoint.checkpoint_id, 2).await;
+    assert_eq!(files.len(), 4);
+
+    let states = reader
+        .resolve_current_files(
+            &namespace_id,
+            &files.iter().map(|file| file.inode_id).collect::<Vec<_>>(),
+        )
+        .await
+        .expect("resolve current files through a standalone reader");
+    assert!(states.iter().all(|state| state.visible));
+    assert!(
+        states.iter().any(|state| state
+            .current_path
+            .as_ref()
+            .is_some_and(|path| path.as_str() == "/docs/alpha-moved.txt")),
+        "the standalone reader should see the move that landed after the checkpoint"
+    );
+
+    for file in &files {
+        let bytes = reader
+            .read_content_ref(&namespace_id, &file.content_ref, file.size_bytes)
+            .await
+            .expect("read content through a standalone reader");
+        assert_eq!(bytes.len() as u64, file.size_bytes);
+    }
+}


### PR DESCRIPTION
First PR of the grep-extension plan: the generic operations a derived consumer (an indexer, a thumbnailer, a classifier) needs from the filesystem, with no consumer-specific names anywhere. Everything is keyed by the existing CheckpointId — no new snapshot vocabulary.

FsReader gains three operations. list_checkpoint_files_page enumerates the files visible in the exact checkpointed basis — the manifest-only view construction carries no WAL tail by type, so 'no overlay' is structural — in ascending inode order with bounded per-page work (the inode row key is already fixed-width, so the durable order is the cursor order; the resume grammar lives beside the key constructor with a pinning test). resolve_current_files answers visibility, current revision, and current path for a bounded batch of inode ids against one pinned view, memoizing shared ancestor walks; unknown ids answer not-visible rather than erroring, since a candidate generator routinely holds stale ids. read_content_ref reads one immutable content object through the instrumented store under a caller-supplied byte cap (checked before the fetch, digest-verified after) that is deliberately independent of the server download limit.

Embedded surface only: no routes, no wire types, no capability or spec changes. Grep is untouched — the next PR migrates it onto these and deletes the core grep seams. 