### PR TITLE
feat(cli): message flag on mutating commands

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -67,6 +67,10 @@ Filesystem operations
     --profile <name>
     --namespace <name>
 
+  Commands that commit (put, mkdir, rm, mv, cp, restore) also accept:
+    -m, --message <message>
+      Annotation recorded on the commit and shown by `loon changes`
+
   loon ls [--profile <name>] [--namespace <name>] [path]
     List entries at a path
 
@@ -79,25 +83,25 @@ Filesystem operations
   loon get [--profile <name>] [--namespace <name>] [--revision <n>] <remote-path> [local-destination]
     Download a remote file
 
-  loon put [--profile <name>] [--namespace <name>] <local-path> [remote-path] [--force]
+  loon put [--profile <name>] [--namespace <name>] <local-path> [remote-path] [--force] [-m <message>]
     Upload a local file
 
   loon revisions [--profile <name>] [--namespace <name>] [--limit <n>] [--cursor <cursor>] <path>
     List file revisions newest-first
 
-  loon mkdir [--profile <name>] [--namespace <name>] <path>
+  loon mkdir [--profile <name>] [--namespace <name>] [-m <message>] <path>
     Create a directory
 
-  loon restore [--profile <name>] [--namespace <name>] --revision <n> <path>
+  loon restore [--profile <name>] [--namespace <name>] [-m <message>] --revision <n> <path>
     Restore a file to a prior revision
 
-  loon rm [--profile <name>] [--namespace <name>] <path>
+  loon rm [--profile <name>] [--namespace <name>] [-m <message>] <path>
     Remove a path
 
-  loon mv [--profile <name>] [--namespace <name>] <source-path> <dest-path>
+  loon mv [--profile <name>] [--namespace <name>] [-m <message>] <source-path> <dest-path>
     Move or rename a path
 
-  loon cp [--profile <name>] [--namespace <name>] <source-path> <dest-path>
+  loon cp [--profile <name>] [--namespace <name>] [-m <message>] <source-path> <dest-path>
     Copy a path
 
 Profile options

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -374,7 +374,7 @@ pub(crate) struct FilesystemRmArgs {
     /// Annotation recorded on the commit and shown by `loon changes`. Part
     /// of the commit's identity: resubmitting the same --commit-id with a
     /// different message is a commit id conflict.
-    #[arg(long)]
+    #[arg(short = 'm', long)]
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
@@ -393,7 +393,7 @@ pub(crate) struct FilesystemMkdirArgs {
     /// Annotation recorded on the commit and shown by `loon changes`. Part
     /// of the commit's identity: resubmitting the same --commit-id with a
     /// different message is a commit id conflict.
-    #[arg(long)]
+    #[arg(short = 'm', long)]
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
@@ -490,7 +490,7 @@ pub(crate) struct FilesystemPutArgs {
     /// Annotation recorded on the commit and shown by `loon changes`. Part
     /// of the commit's identity: resubmitting the same --commit-id with a
     /// different message is a commit id conflict.
-    #[arg(long)]
+    #[arg(short = 'm', long)]
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
@@ -514,7 +514,7 @@ pub(crate) struct FilesystemTransferArgs {
     /// Annotation recorded on the commit and shown by `loon changes`. Part
     /// of the commit's identity: resubmitting the same --commit-id with a
     /// different message is a commit id conflict.
-    #[arg(long)]
+    #[arg(short = 'm', long)]
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
@@ -532,7 +532,7 @@ pub(crate) struct FilesystemRestoreArgs {
     /// Annotation recorded on the commit and shown by `loon changes`. Part
     /// of the commit's identity: resubmitting the same --commit-id with a
     /// different message is a commit id conflict.
-    #[arg(long)]
+    #[arg(short = 'm', long)]
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
@@ -558,7 +558,7 @@ pub(crate) struct FilesystemUndeleteArgs {
     /// Annotation recorded on the commit and shown by `loon changes`. Part
     /// of the commit's identity: resubmitting the same --commit-id with a
     /// different message is a commit id conflict.
-    #[arg(long)]
+    #[arg(short = 'm', long)]
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -418,7 +418,7 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
         "put",
         payload.to_str().expect("utf-8 path"),
         "/doc.txt",
-        "--message",
+        "-m",
         "initial import",
     ]));
     // The audit's motivating case: a restore is indistinguishable from an
@@ -436,7 +436,7 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
         "--revision",
         "1",
         "/doc.txt",
-        "--message",
+        "-m",
         "roll back to the imported copy",
     ]));
 
@@ -496,6 +496,127 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
         "{}",
         json_error(&conflicted)
     );
+}
+
+/// Every mutating command takes `-m`, and each one lands its annotation on
+/// its own commit. Reading the feed back through `loon changes` covers the
+/// flag, the threading, and the rendering in a single pass.
+#[test]
+fn every_mutating_command_records_its_message() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("doc.txt");
+    fs::write(&payload, b"body").expect("write payload");
+    let local = payload.to_str().expect("utf-8 path");
+
+    assert_success(&harness.run(&["mkdir", "/dir", "-m", "mkdir message"]));
+    assert_success(&harness.run(&["put", local, "/dir/doc.txt", "-m", "put message"]));
+    assert_success(&harness.run(&["cp", "/dir/doc.txt", "/dir/copy.txt", "-m", "cp message"]));
+    assert_success(&harness.run(&["mv", "/dir/copy.txt", "/dir/moved.txt", "-m", "mv message"]));
+    assert_success(&harness.run(&[
+        "put",
+        local,
+        "/dir/doc.txt",
+        "--force",
+        "-m",
+        "second put message",
+    ]));
+    assert_success(&harness.run(&[
+        "restore",
+        "--revision",
+        "1",
+        "/dir/doc.txt",
+        "-m",
+        "restore message",
+    ]));
+    let removed = harness.run(&["--json", "rm", "/dir/moved.txt", "-m", "rm message"]);
+    assert_success(&removed);
+    let inode_id = json_data(&removed)["inode_id"]
+        .as_u64()
+        .expect("rm reports the deleted inode id");
+    let deleted_at = json_data(&removed)["committed_seq"]
+        .as_u64()
+        .expect("rm reports the committed seq");
+    assert_success(&harness.run(&[
+        "undelete",
+        "/dir/moved.txt",
+        "--inode",
+        &inode_id.to_string(),
+        "--deleted-at",
+        &deleted_at.to_string(),
+        "-m",
+        "undelete message",
+    ]));
+
+    assert_eq!(
+        feed_messages(&harness),
+        vec![
+            "mkdir message",
+            "put message",
+            "cp message",
+            "mv message",
+            "second put message",
+            "restore message",
+            "rm message",
+            "undelete message",
+        ]
+    );
+}
+
+/// The remote arm has to hand the message to the client's mutation options,
+/// not just the embedded arm. Same flag, same feed rows, over HTTP.
+#[test]
+fn commit_messages_ride_the_feed_over_the_remote_transport() {
+    let harness = Harness::new();
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "message-remote"));
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "default",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]);
+    assert_success(&add_remote);
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("doc.txt");
+    fs::write(&payload, b"body").expect("write payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/doc.txt",
+        "-m",
+        "landed over http",
+    ]));
+    assert_success(&harness.run(&["mkdir", "/dir", "-m", "made over http"]));
+
+    assert_eq!(
+        feed_messages(&harness),
+        vec!["landed over http", "made over http"]
+    );
+}
+
+/// Reads the namespace's change feed through the CLI and returns the
+/// annotations in commit order, dropping the rows that carry none.
+fn feed_messages(harness: &Harness) -> Vec<String> {
+    let changes = harness.run(&["--json", "changes"]);
+    assert_success(&changes);
+    json_data(&changes)["changes"]
+        .as_array()
+        .expect("changes array")
+        .iter()
+        .filter_map(|row| row["message"].as_str().map(ToOwned::to_owned))
+        .collect()
 }
 
 #[test]


### PR DESCRIPTION
Enhancing `--message`:

- the `-m` short alias (all seven commands: put, mkdir, rm, mv, cp, restore, undelete; no short-flag collisions)
- cross-transport coverage: `every_mutating_command_records_its_message` drives all seven commands with `-m` and asserts the exact ordered message list in `changes`; a second test proves the same round trip over a real HTTP server
- README rows for the flag

Identity semantics untouched (same commit id with a different message stays a `commit_id_reuse_conflict`, already covered).
