### PR TITLE
refactor(error): delete tombstone_conflict and expose the acquisition stamp

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -138,7 +138,6 @@ error_codes! {
     DirectoryNotEmpty => "directory_not_empty",
     StaleHead => "stale_head",
     StaleRevision => "stale_revision",
-    TombstoneConflict => "tombstone_conflict",
     NotDeleted => "not_deleted",
     WriterFenced => "writer_fenced",
     WouldCycle => "would_cycle",
@@ -206,7 +205,6 @@ impl ErrorCode {
             | ErrorCode::DirectoryNotEmpty
             | ErrorCode::StaleHead
             | ErrorCode::StaleRevision
-            | ErrorCode::TombstoneConflict
             // Undelete's target is not the root of a live deletion: a
             // state conflict, resolved by re-reading namespace state.
             | ErrorCode::NotDeleted

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -68,6 +68,11 @@ pub struct ErrorDetails {
     /// recorded one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_writer: Option<String>,
+    /// Unix milliseconds at which the current epoch's acquirer took it, when
+    /// the head recorded one. Writer ids are process labels, so two runs on
+    /// one machine can share one; the stamp is what tells them apart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_acquired_at_ms: Option<u64>,
     /// Inode the failed precondition or operation targeted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inode_id: Option<InodeId>,

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -12,6 +12,7 @@ use super::build_commit_plan;
 use crate::commit::{
     materialize_commit, CommitOpResult, CommitValidationError, MutationFingerprint, PreparedCommit,
 };
+use crate::error::{CoreError, ErrorCode};
 use crate::metadata::MetadataState;
 use loonfs_api::wire::control::{HeadState, WriterBlock};
 use loonfs_api::wire::wal::WalDelta;
@@ -249,8 +250,14 @@ async fn failed_multi_op_plan_uses_preview_without_mutating_base_metadata() {
         .is_none());
 }
 
+/// The rows here are deliberately corrupt: the tombstone lands without the
+/// unbind a real delete emits with it, so `readme.txt` stays bound under a
+/// tombstoned directory. No client history produces that — planning resolves
+/// through visible bindings, and a visible inode is one no tombstone covers
+/// — so the guards fire only on self-contradicting stored state and classify
+/// as corruption.
 #[tokio::test]
-async fn create_and_replace_under_ancestor_tombstone_are_rejected() {
+async fn create_and_replace_under_ancestor_tombstone_report_corruption() {
     let metadata_state = metadata_state_after(&[
         wal_create_directory(0, InodeId(2), InodeId(1), "docs".to_owned()),
         wal_create_file(
@@ -288,6 +295,10 @@ async fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             ..
         }
     ));
+    assert_eq!(
+        CoreError::from(create_error).code(),
+        ErrorCode::NamespaceCorrupt
+    );
 
     let replace_error = build_commit_plan(
         &CommitRequest {
@@ -313,6 +324,10 @@ async fn create_and_replace_under_ancestor_tombstone_are_rejected() {
             ..
         }
     ));
+    assert_eq!(
+        CoreError::from(replace_error).code(),
+        ErrorCode::NamespaceCorrupt
+    );
 }
 
 #[tokio::test]
@@ -553,8 +568,11 @@ async fn restore_revision_can_reference_restore_created_earlier_in_same_request(
     ));
 }
 
+/// Same corrupt shape as the create/replace guards above: a tombstone with
+/// no matching unbind leaves a live binding under it, which is the only way
+/// this guard can fire.
 #[tokio::test]
-async fn restore_revision_under_tombstoned_ancestor_is_rejected() {
+async fn restore_revision_under_tombstoned_ancestor_reports_corruption() {
     let metadata_state = metadata_state_after(&[
         wal_create_directory(0, InodeId(2), InodeId(1), "docs".to_owned()),
         wal_create_file(
@@ -584,7 +602,7 @@ async fn restore_revision_under_tombstoned_ancestor_is_rejected() {
         &context,
     )
     .await
-    .expect_err("restore tombstone conflict");
+    .expect_err("restore under a covering tombstone");
     assert!(matches!(
         error,
         CommitValidationError::RestoreRevisionUnderSubtreeTombstone {
@@ -592,6 +610,7 @@ async fn restore_revision_under_tombstoned_ancestor_is_rejected() {
             ..
         }
     ));
+    assert_eq!(CoreError::from(error).code(), ErrorCode::NamespaceCorrupt);
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -156,14 +156,6 @@ pub enum CoreError {
         after_seq: ChangeSeq,
         retention_floor_seq: ChangeSeq,
     },
-    #[error(
-        "path `{path}` is covered by subtree tombstone rooted at inode `{root_inode_id}` from seq `{tombstone_seq}`"
-    )]
-    TombstoneConflict {
-        path: String,
-        root_inode_id: InodeId,
-        tombstone_seq: ChangeSeq,
-    },
     #[error("path component `{0}` is not a directory")]
     NonDirectoryPathComponent(String),
     #[error("namespace corrupt: {0}")]
@@ -397,7 +389,6 @@ impl CoreError {
             | CoreError::ExpectedDirectory { .. }
             | CoreError::DestinationExists { .. } => ErrorCode::PathConflict,
             CoreError::DirectoryNotEmpty(_) => ErrorCode::DirectoryNotEmpty,
-            CoreError::TombstoneConflict { .. } => ErrorCode::TombstoneConflict,
             CoreError::WriterFenced(_) => ErrorCode::WriterFenced,
             CoreError::NamespaceCorrupt(_) => ErrorCode::NamespaceCorrupt,
             // Naming which operation stopped a batch says nothing new about
@@ -673,6 +664,15 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> ErrorCode 
         CommitValidationError::RestoreRevisionSourceRevisionMissing { .. } => {
             ErrorCode::RevisionNotFound
         }
+        // Corruption guards, not caller-actionable conflicts. Every inode an
+        // operation names is either freshly allocated by the same commit or
+        // resolved through visible bindings, and a visible binding already
+        // implies no covering tombstone (`metadata::visibility`: a visible
+        // inode is one no tombstone covers, and a delete unbinds and
+        // tombstones in the same commit). So a covered target here means the
+        // stored rows contradict themselves — a live binding under a
+        // tombstone — which is repair work, not something a caller can fix by
+        // re-reading and retrying.
         CommitValidationError::CreateUnderSubtreeTombstone { .. }
         | CommitValidationError::ReplaceFileUnderSubtreeTombstone { .. }
         | CommitValidationError::RestoreRevisionUnderSubtreeTombstone { .. }
@@ -680,7 +680,7 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> ErrorCode 
         | CommitValidationError::RenameInodeUnderSubtreeTombstone { .. }
         | CommitValidationError::RenameTargetParentUnderSubtreeTombstone { .. }
         | CommitValidationError::DeleteSubtreeRootCoveredByTombstone { .. } => {
-            ErrorCode::TombstoneConflict
+            ErrorCode::NamespaceCorrupt
         }
         CommitValidationError::CreateChildNameCollision { .. }
         | CommitValidationError::NamePreconditionParentNotDirectory { .. }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -423,6 +423,7 @@ impl CoreError {
                 fenced_epoch: Some(fence.fenced_epoch),
                 active_writer_epoch: Some(fence.active_epoch),
                 active_writer: fence.active_writer.clone(),
+                active_acquired_at_ms: fence.active_acquired_at_ms,
                 ..ErrorDetails::default()
             }),
             CoreError::CommitIdReuseConflict(commit_id) => Some(ErrorDetails {
@@ -866,6 +867,7 @@ mod tests {
         assert_eq!(details.fenced_epoch, Some(WriterEpoch(3)));
         assert_eq!(details.active_writer_epoch, Some(WriterEpoch(4)));
         assert_eq!(details.active_writer.as_deref(), Some("writer-b"));
+        assert_eq!(details.active_acquired_at_ms, Some(2_000));
         assert!(fenced
             .to_string()
             .contains("epoch 3 was fenced by epoch 4 (writer `writer-b`, acquired at 2000 ms)"));

--- a/crates/loonfs-core/src/path/write/planning_helpers.rs
+++ b/crates/loonfs-core/src/path/write/planning_helpers.rs
@@ -90,9 +90,13 @@ pub(super) fn publish_child_name_absent_precondition(
 /// tombstone. The walk observes only visible bindings, so its answer cannot
 /// change when compaction drops rows no retained sequence observes: a deleted
 /// (unbound) name simply ends the walk, and recreating it plans as a fresh
-/// subtree. A visible-but-covered component cannot arise from legal writer
-/// histories; hitting one means corrupt state, and failing the plan is the
-/// safe answer.
+/// subtree.
+///
+/// A visible-but-covered component cannot arise from legal writer histories:
+/// a delete unbinds and tombstones in one commit, and visibility already
+/// excludes a covered inode (`metadata::visibility`). Hitting one means the
+/// stored rows contradict themselves, so this reports corruption rather than
+/// a conflict a caller could resolve.
 pub(super) async fn publish_reject_tombstoned_path_ancestor<S: ObjectStore + ?Sized>(
     view: &PublishPathPlanningView<'_, '_, '_, S>,
     absolute_path: &AbsolutePath,
@@ -117,11 +121,13 @@ pub(super) async fn publish_reject_tombstoned_path_ancestor<S: ObjectStore + ?Si
             .covering_subtree_tombstone(bound_child.child_inode_id)
             .await?
         {
-            return Err(CoreError::TombstoneConflict {
-                path: visible_path.as_str().to_owned(),
-                root_inode_id: tombstone.root_inode_id,
-                tombstone_seq: tombstone.tombstone_seq,
-            });
+            return Err(CoreError::NamespaceCorrupt(format!(
+                "path `{}` is visible but covered by the subtree tombstone rooted at inode \
+                 `{}` from seq `{}`",
+                visible_path.as_str(),
+                tombstone.root_inode_id,
+                tombstone.tombstone_seq,
+            )));
         }
         current_inode = bound_child.child_inode_id;
         current_path = visible_path;

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -341,8 +341,32 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
             .put_file_bytes(&host_c_target, b"host a again\n", &replace_file_options())
             .await
         {
-            Err(ClientError::Api { code, .. }) => {
-                assert_eq!(code, "writer_fenced", "attempt {attempt}")
+            Err(ClientError::Api {
+                code,
+                message,
+                details,
+                ..
+            }) => {
+                assert_eq!(code, "writer_fenced", "attempt {attempt}");
+                // The details name the winner and when it acquired. Writer
+                // ids are process labels, so two runs on one machine can
+                // share one; the stamp is what separates them, and carrying
+                // it structurally means a caller never parses the message.
+                let details = details.expect("a fenced error carries structured details");
+                assert_eq!(
+                    details.active_writer.as_deref(),
+                    Some("loonfs-server-b"),
+                    "attempt {attempt}"
+                );
+                let acquired_at_ms = details
+                    .active_acquired_at_ms
+                    .expect("fenced details carry the winner's acquisition stamp");
+                assert!(
+                    message.contains(&format!(
+                        "(writer `loonfs-server-b`, acquired at {acquired_at_ms} ms)"
+                    )),
+                    "the structured stamp should be the one the message renders: {message}"
+                );
             }
             other => unreachable!("expected writer_fenced on attempt {attempt}, got {other:?}"),
         }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -172,7 +172,8 @@ Every error response is a JSON body:
   "details": {
     "fenced_epoch": 3,
     "active_writer_epoch": 4,
-    "active_writer": "server-b"
+    "active_writer": "server-b",
+    "active_acquired_at_ms": 1739459200000
   }
 }
 ```
@@ -200,7 +201,7 @@ The codes that populate it:
 
 | Code | Detail fields |
 | --- | --- |
-| `writer_fenced` | `fenced_epoch`, `active_writer_epoch`, `active_writer` (when the head recorded the winner's writer id) |
+| `writer_fenced` | `fenced_epoch`, `active_writer_epoch`, plus `active_writer` and `active_acquired_at_ms` when the head recorded a writer block. Writer ids are process labels, so two runs on one machine can share one; the acquisition stamp is what tells them apart |
 | `stale_revision` | `inode_id`, `expected_revision`, `actual_revision` (absent when the inode has no current revision) |
 | `commit_id_reuse_conflict` | `commit_id` |
 | `rebootstrap_required` | `after_seq`, `retention_floor_seq` |

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -235,7 +235,6 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `directory_not_empty` | 409 | The directory has children and the operation is not recursive. |
 | `stale_head` | 409 | The write raced a head advance; retry against fresh state. |
 | `stale_revision` | 409 | A caller-supplied base revision is no longer current. |
-| `tombstone_conflict` | 409 | The path is covered by a subtree tombstone. |
 | `not_deleted` | 409 | The undelete target is not the root of a live deletion; nothing to recover. |
 | `writer_fenced` | 409 | The writer epoch was superseded by another session. |
 | `would_cycle` | 409 | The rename would create a directory cycle. |

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2686,6 +2686,15 @@
         "type": "object",
         "description": "Structured, machine-readable context accompanying an [`ApiError`].\n\nEvery field is optional: a code populates the fields that apply to it\n(API spec, \"Standard error contract\"), and clients must tolerate absent\nfields exactly as they tolerate unknown codes. Retry decisions still key\noff the code; these fields carry the identity a caller needs to act —\nwhich commit to resubmit, which epoch displaced it, which revision the\nprecondition saw.",
         "properties": {
+          "active_acquired_at_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix milliseconds at which the current epoch's acquirer took it, when\nthe head recorded one. Writer ids are process labels, so two runs on\none machine can share one; the stamp is what tells them apart.",
+            "minimum": 0
+          },
           "active_deletion_seq": {
             "oneOf": [
               {


### PR DESCRIPTION
Two follow-up changes: 

- Commit 1 deletes `tombstone_conflict`.

- Commit 2 adds `active_acquired_at_ms` to `ErrorDetails`, beside `active_writer` 