### PR TITLE
feat(core): cap commit messages at 4096 bytes

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -108,6 +108,15 @@ impl MutationCandidate {
                 crate::limits::MAX_COMMIT_OPERATIONS
             )));
         }
+        if let Some(message) = &self.request.message {
+            if message.len() > crate::limits::MAX_COMMIT_MESSAGE_BYTES {
+                return Err(CoreError::InvalidCommitRequest(format!(
+                    "mutation message is {} bytes; maximum is {}",
+                    message.len(),
+                    crate::limits::MAX_COMMIT_MESSAGE_BYTES
+                )));
+            }
+        }
         let prepared_count = match &self.content {
             ContentPreparation::Ready(content) => content.len(),
             ContentPreparation::Rejected(_) => 0,
@@ -605,6 +614,18 @@ mod tests {
         oversized_proofs
             .semantic_identity(&namespace_id)
             .expect("prepared proof limits must not affect identity");
+
+        let oversized_message = MutationCandidate::new(MutationRequest {
+            commit_id: CommitId::parse("too-long-message").expect("valid commit id"),
+            message: Some("m".repeat(crate::limits::MAX_COMMIT_MESSAGE_BYTES + 1)),
+            operations: vec![FilesystemOperation::CreateDir {
+                absolute_path: loonfs_api::AbsolutePath::parse("/docs").expect("valid path"),
+                parents: false,
+            }],
+        });
+        oversized_message
+            .semantic_identity(&namespace_id)
+            .expect("message limits must not affect identity");
     }
 
     /// A batch past the operation ceiling is refused before it can occupy
@@ -642,6 +663,35 @@ mod tests {
         at_ceiling
             .validate_request_limits()
             .expect("a batch at the ceiling is admitted");
+    }
+
+    /// A message past the byte ceiling is refused before it can enter the
+    /// durable record or the fingerprint path.
+    #[test]
+    fn a_message_past_the_byte_ceiling_is_rejected() {
+        let operations = vec![FilesystemOperation::CreateDir {
+            absolute_path: loonfs_api::AbsolutePath::parse("/docs").expect("valid path"),
+            parents: false,
+        }];
+
+        let oversized = MutationCandidate::new(MutationRequest {
+            commit_id: CommitId::parse("oversized-message").expect("valid commit id"),
+            message: Some("m".repeat(crate::limits::MAX_COMMIT_MESSAGE_BYTES + 1)),
+            operations: operations.clone(),
+        });
+        let error = oversized
+            .validate_request_limits()
+            .expect_err("the message is over the byte ceiling");
+        assert_eq!(error.code(), ErrorCode::InvalidRequest);
+
+        let at_ceiling = MutationCandidate::new(MutationRequest {
+            commit_id: CommitId::parse("largest-message").expect("valid commit id"),
+            message: Some("m".repeat(crate::limits::MAX_COMMIT_MESSAGE_BYTES)),
+            operations,
+        });
+        at_ceiling
+            .validate_request_limits()
+            .expect("a message at the ceiling is admitted");
     }
 
     fn create_dir(commit_id: &str, display_name: &str) -> MutationCandidate {

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -26,6 +26,12 @@ pub const MAX_COMMIT_CONTENT_TOKENS: usize = 4096;
 /// its in-memory coverage work while it occupies the serialized publisher.
 pub const MAX_COMMIT_EXTERNAL_CONTENT_REFS: usize = 4096;
 
+/// Maximum byte length of a commit's optional `message` annotation, which is
+/// stored in every durable WAL record, hashed into the mutation fingerprint,
+/// and replayed by the change feed. This is the only bound on the message:
+/// no transport-level body limit is relied on.
+pub const MAX_COMMIT_MESSAGE_BYTES: usize = 4096;
+
 /// Maximum attempts for a bounded compare-and-swap or allocation contention loop.
 pub const CONTENTION_RETRY_LIMIT: usize = 8;
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -318,6 +318,8 @@ idempotency key that must be reused verbatim for safe retries — an optional
 identity), and an ordered, non-empty list of path operations. A request with
 one operation is the same shape as a request with many, so a convenience
 call and a one-element list are the same mutation and fingerprint alike.
+A `message` is at most 4096 bytes; a longer one is rejected with
+`invalid_request` before planning, on every transport.
 
 The operations of one request commit together, in order, as one logical
 commit. Operation `k` is planned against authoritative namespace state plus


### PR DESCRIPTION
`message` had no explicit bound — embedded submissions were unbounded, remote ones only incidentally capped by axum's 2 MiB whole-body default, while sibling `commit_id` is capped at 128 bytes.

One constant (`MAX_COMMIT_MESSAGE_BYTES = 4096`, matching the house ceiling aesthetic), enforced in the shared `validate_request_limits` check