### PR TITLE
feat(client): one-pass bounded-memory puts on every transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
 name = "loonfs-cli"
 version = "0.1.1"
 dependencies = [
+ "bytes",
  "clap",
  "dialoguer",
  "futures",
@@ -1174,6 +1175,8 @@ dependencies = [
 name = "loonfs-client"
 version = "0.1.1"
 dependencies = [
+ "bytes",
+ "futures",
  "http",
  "loonfs-api",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ fs4 = "0.13"
 getrandom = "0.3"
 object_store = { version = "=0.12.4", default-features = false, features = ["aws", "gcp", "azure"] }
 regex = { version = "1.11", default-features = false, features = ["std", "perf"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "stream"] }
 regex-syntax = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -13,6 +13,7 @@ name = "loon"
 path = "src/main.rs"
 
 [dependencies]
+bytes.workspace = true
 clap.workspace = true
 futures.workspace = true
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
@@ -27,7 +28,9 @@ serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+# `io-std` is what makes standard input an asynchronous source, which is
+# how `loon put -` reads a payload of unknown length.
+tokio = { workspace = true, features = ["io-std"] }
 toml.workspace = true
 walkdir.workspace = true
 

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -83,8 +83,8 @@ Filesystem operations
   loon get [--profile <name>] [--namespace <name>] [--revision <n>] <remote-path> [local-destination]
     Download a remote file
 
-  loon put [--profile <name>] [--namespace <name>] <local-path> [remote-path] [--force] [-m <message>]
-    Upload a local file
+  loon put [--profile <name>] [--namespace <name>] <local-path|-> [remote-path] [--force] [-m <message>]
+    Upload a local file, or standard input when <local-path> is `-`
 
   loon revisions [--profile <name>] [--namespace <name>] [--limit <n>] [--cursor <cursor>] <path>
     List file revisions newest-first
@@ -178,6 +178,13 @@ Behavior notes
   `--json` is rejected for streaming output commands
 
   If `loon put` omits the remote path, the CLI uses `/<local-filename>`
+
+  `loon put -` reads standard input and needs an explicit remote path,
+  because a pipe has no local name to derive one from
+
+  `loon put` reads a large file or a pipe once, a piece at a time, so what
+  it costs in memory follows the transfer and not the payload's size; a
+  file small enough to hold is still uploaded in one request
 
   If `loon get` omits the local destination, the CLI writes to `./<remote-filename>`
 

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -473,6 +473,10 @@ pub(crate) struct FilesystemGetArgs {
 pub(crate) struct FilesystemPutArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
+    /// Local file to upload, or `-` to read standard input. A large file
+    /// and a pipe are both read once and never held whole, so what a put
+    /// costs in memory does not follow what it uploads. Reading `-` needs
+    /// an explicit remote path.
     pub local_path: String,
     pub remote_path: Option<String>,
     /// Upload the directory tree rooted at `local_path`. Every file lands

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -7,7 +7,7 @@ use crate::backend_error::{
 };
 use crate::render::write_stderr_warning;
 use loonfs::{
-    ChangesResponse, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
+    ByteStream, ChangesResponse, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
     FsAdmin, FsReader, FsWriter, ListChangesOptions, MaintenanceStepOptions, MoveOptions,
     PutFileOptions, RestoreRevisionOptions, RuntimeError, SharedObjectStore, UndeleteOptions,
@@ -341,6 +341,34 @@ impl EmbeddedBackend {
             )
         })
         .await
+    }
+
+    /// Writes a file from a payload read once, straight into the runtime's
+    /// streaming staging path.
+    ///
+    /// Unlike the buffered call this one makes a single attempt. The
+    /// `maintenance_required` recovery above works by resubmitting, and a
+    /// stream is consumed by the attempt that reads it: there is no second
+    /// attempt to make. A gated publish commits nothing, so rerunning the
+    /// command — with the same `--commit-id` if the caller wants the retry
+    /// to be idempotent — is the honest recovery.
+    pub(super) async fn put_file_stream(
+        &self,
+        spec: &NamespacePath,
+        body: ByteStream,
+        options: &PutFileOptions,
+    ) -> Result<CommitResponse, BackendError> {
+        let result = self
+            .writer
+            .put_file_stream(
+                spec.namespace(),
+                spec.absolute_path().as_str(),
+                body,
+                options.clone(),
+            )
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error));
+        self.settle_background_work_after(result).await
     }
 
     pub(super) async fn delete_path(

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -17,6 +17,7 @@
 mod embedded;
 
 use crate::backend_error::BackendError;
+use crate::payload::LocalPayload;
 use crate::resolve::ResolvedTarget;
 use loonfs_api::{
     v0::{ChangesResponse, DisableGrepIndexResponse, EnableGrepIndexResponse},
@@ -241,6 +242,29 @@ impl ResolvedTarget {
         match self {
             Self::Embedded(target) => target.backend.put_file_bytes(spec, bytes, options).await,
             Self::Remote(target) => Ok(target.client.put_file_bytes(spec, bytes, options).await?),
+        }
+    }
+
+    /// Writes a file from a payload read once from its source, in bounded
+    /// memory whichever transport answers.
+    ///
+    /// The payload is opened per arm rather than shared: the two runtimes
+    /// spell a byte stream in their own terms, and only one arm ever runs.
+    pub(crate) async fn put_file_stream(
+        &self,
+        spec: &NamespacePath,
+        payload: &LocalPayload,
+        options: &PutFileOptions,
+    ) -> Result<CommitResponse, BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                let body = payload.open_byte_stream().await?;
+                target.backend.put_file_stream(spec, body, options).await
+            }
+            Self::Remote(target) => {
+                let source = payload.open_source().await?;
+                Ok(target.client.put_file_stream(spec, source, options).await?)
+            }
         }
     }
 

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -3,7 +3,7 @@
 
 use super::context::{
     default_remote_put_path, destination_path_for_get, destination_user_path, fail, namespace_path,
-    parse_user_path, render_target, resolve_command_context,
+    parse_user_path, render_target, resolve_command_context, CommandContext,
 };
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use super::recursive;
@@ -14,6 +14,7 @@ use crate::args::{
     RuntimeBehavior, TrashArgs,
 };
 use crate::error::CliError;
+use crate::payload::{read_whole_file, LocalPayload, STDIN_PATH};
 use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeKind, RevisionNo};
 use loonfs_client::{CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions};
 use std::fs;
@@ -364,13 +365,8 @@ pub(crate) async fn run_filesystem_put(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
     let local_path = PathBuf::from(&args.local_path);
-    if local_path == Path::new("-") {
-        return Err(fail(
-            kind,
-            Some(context.profile_name),
-            Some(context.mode),
-            CliError::invalid_input("`-` is not supported for `put`"),
-        ));
+    if local_path == Path::new(STDIN_PATH) {
+        return run_filesystem_put_stdin(kind, args, context).await;
     }
 
     let metadata = fs::metadata(&local_path)
@@ -431,18 +427,89 @@ pub(crate) async fn run_filesystem_put(
                 )),
             )
         })?;
-    let remote_path = match args.remote_path {
+    let remote_path = match args.remote_path.as_deref() {
         // A trailing slash names the directory the file lands in — the
         // cp/rsync habit — while a plain path is the full destination.
-        Some(path) => destination_user_path(&path, &local_leaf, true),
+        Some(path) => destination_user_path(path, &local_leaf, true),
         None => default_remote_put_path(&local_path),
     }
     .map_err(|error| context.fail(kind, error))?;
     let spec = NamespacePath::new(context.namespace.clone(), remote_path);
-    let bytes = fs::read(&local_path)
-        .map_err(|error| context.fail(kind, CliError::io_for_path(&local_path, error)))?;
-    let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
-        .map_err(|error| context.fail(kind, error))?;
+    let payload = LocalPayload::file(&local_path, metadata.len());
+    let options = put_file_options(&args).map_err(|error| context.fail(kind, error))?;
+    commit_put(kind, &context, &spec, &payload, &options).await
+}
+
+/// `loon put - <remote>`: standard input, whose length is not knowable, so
+/// it is always read once and never held.
+///
+/// The remote path has to be spelled out. Every other `put` derives a
+/// default from the local file's name, and a pipe has none to derive from.
+async fn run_filesystem_put_stdin(
+    kind: CommandKind,
+    args: FilesystemPutArgs,
+    context: CommandContext,
+) -> Result<CommandOutput, CommandFailure> {
+    if args.recursive {
+        return Err(context.fail(
+            kind,
+            CliError::invalid_input("`-` streams one file; a tree needs a directory"),
+        ));
+    }
+    let Some(remote_path) = args.remote_path.as_deref() else {
+        return Err(context.fail(
+            kind,
+            CliError::invalid_input(
+                "reading from `-` needs an explicit remote path; there is no local name to \
+                 derive one from",
+            ),
+        ));
+    };
+    let remote_path =
+        parse_user_path(remote_path, false).map_err(|error| context.fail(kind, error))?;
+    let spec = NamespacePath::new(context.namespace.clone(), remote_path);
+    let options = put_file_options(&args).map_err(|error| context.fail(kind, error))?;
+    commit_put(kind, &context, &spec, &LocalPayload::Stdin, &options).await
+}
+
+/// Writes one payload and renders what the commit did.
+///
+/// The payload decides how it travels: one that is small enough to hold
+/// goes as bytes, and one that is large — or that cannot say how large it
+/// is — is read once, in pieces, whichever transport the profile selects.
+async fn commit_put(
+    kind: CommandKind,
+    context: &CommandContext,
+    spec: &NamespacePath,
+    payload: &LocalPayload,
+    options: &PutFileOptions,
+) -> Result<CommandOutput, CommandFailure> {
+    let result = match payload.holdable_file() {
+        Some(path) => {
+            let bytes = read_whole_file(path)
+                .await
+                .map_err(|error| context.fail(kind, error))?;
+            context.target.put_file_bytes(spec, &bytes, options).await
+        }
+        None => context.target.put_file_stream(spec, payload, options).await,
+    }
+    .map_err(|error| context.fail(kind, error))?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name.clone()),
+        mode: Some(context.mode.clone()),
+        data: CommandData::FileMutation {
+            target: render_target(&context.namespace, spec.absolute_path()),
+            committed_seq: result.committed_seq,
+            commit_id: result.commit_id,
+            inode_id: None,
+        },
+    })
+}
+
+fn put_file_options(args: &FilesystemPutArgs) -> Result<PutFileOptions, CliError> {
+    let commit_id = parse_commit_id_arg(args.commit_id.as_deref())?;
     let expected_revision_no = args.expected_revision.map(RevisionNo);
     // The revision guard is a stronger replace statement, so it implies
     // --force rather than demanding both flags.
@@ -451,28 +518,11 @@ pub(crate) async fn run_filesystem_put(
     } else {
         DestinationBehavior::NoReplace
     };
-    let options = PutFileOptions {
+    Ok(PutFileOptions {
         behavior,
         commit_id,
         message: args.message.clone(),
         expected_revision_no,
-    };
-    let result = context
-        .target
-        .put_file_bytes(&spec, &bytes, &options)
-        .await
-        .map_err(|error| context.fail(kind, error))?;
-
-    Ok(CommandOutput {
-        kind,
-        profile: Some(context.profile_name),
-        mode: Some(context.mode),
-        data: CommandData::FileMutation {
-            target: render_target(&context.namespace, spec.absolute_path()),
-            committed_seq: result.committed_seq,
-            commit_id: result.commit_id,
-            inode_id: None,
-        },
     })
 }
 

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -10,6 +10,7 @@ mod backend_error;
 mod commands;
 mod config;
 mod error;
+mod payload;
 mod profiles;
 mod prompt;
 mod render;

--- a/crates/loonfs-cli/src/payload.rs
+++ b/crates/loonfs-cli/src/payload.rs
@@ -1,0 +1,114 @@
+//! Where a `put` reads its bytes, and how each transport is handed them.
+//!
+//! One description of the payload serves all three transports. It has to be
+//! opened once per transport rather than shared, because the two runtimes
+//! spell a stream differently — the embedded runtime in the object store's
+//! terms, the client in its own — but what is read, and how much of it is
+//! held at a time, is the same either way.
+
+use crate::backend_error::BackendError;
+use crate::error::CliError;
+use futures::stream::StreamExt;
+use loonfs::{ByteStream, ObjectStoreError};
+use loonfs_client::{PayloadSource, STREAMING_PUT_MIN_BYTES};
+use std::path::{Path, PathBuf};
+
+/// Standard input's spelling on the command line.
+pub(crate) const STDIN_PATH: &str = "-";
+
+/// Where one `put` reads its payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LocalPayload {
+    /// A file on disk, whose length is known before the first byte moves.
+    File { path: PathBuf, size_bytes: u64 },
+    /// Standard input: bytes of no knowable length, which is why it can
+    /// only be uploaded by a path that never needs to know one.
+    Stdin,
+}
+
+impl LocalPayload {
+    /// Describes a local file that is already known to exist.
+    pub(crate) fn file(path: impl Into<PathBuf>, size_bytes: u64) -> Self {
+        Self::File {
+            path: path.into(),
+            size_bytes,
+        }
+    }
+
+    /// The file this payload names, when it is small enough to hold whole.
+    ///
+    /// This is the one decision about how a put travels. A payload under
+    /// the threshold takes the buffered path it always took; anything at or
+    /// past it, and anything whose length nobody knows, is read once
+    /// instead — and a source with no length can never answer here, which
+    /// is exactly right, because it cannot be held.
+    pub(crate) fn holdable_file(&self) -> Option<&Path> {
+        match self {
+            Self::File { path, size_bytes } if *size_bytes < STREAMING_PUT_MIN_BYTES => Some(path),
+            _ => None,
+        }
+    }
+
+    /// Opens the payload for the in-process runtime.
+    pub(crate) async fn open_byte_stream(&self) -> Result<ByteStream, BackendError> {
+        Ok(as_object_store_stream(self.open_source().await?))
+    }
+
+    /// Opens the payload for the HTTP client.
+    pub(crate) async fn open_source(&self) -> Result<PayloadSource, BackendError> {
+        match self {
+            Self::File { path, .. } => PayloadSource::open_file(path).await.map_err(|error| {
+                BackendError::io_error(format!("i/o error for `{}`: {error}", path.display()))
+            }),
+            Self::Stdin => Ok(PayloadSource::reader(tokio::io::stdin())),
+        }
+    }
+}
+
+/// Restates a source in the object store's terms, which is how the embedded
+/// runtime's staging path takes a payload.
+///
+/// A read failure becomes a transport error against the same "upload body"
+/// name the server's own streaming path uses, so a truncated local read and
+/// a truncated request body read alike.
+fn as_object_store_stream(source: PayloadSource) -> ByteStream {
+    let (stream, _) = source.into_stream();
+    stream
+        .map(|chunk| {
+            chunk.map_err(|error| ObjectStoreError::transport("upload body", error.to_string()))
+        })
+        .boxed()
+}
+
+/// Bytes of a payload the caller decided to hold whole.
+pub(crate) async fn read_whole_file(path: &Path) -> Result<Vec<u8>, CliError> {
+    tokio::fs::read(path)
+        .await
+        .map_err(|error| CliError::io_for_path(path, error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The threshold is a property of the payload, not of the transport:
+    /// the same file streams or does not regardless of which arm takes it.
+    #[test]
+    fn only_large_or_unmeasured_payloads_stream() {
+        assert!(LocalPayload::file("/tmp/small", 0)
+            .holdable_file()
+            .is_some());
+        assert!(
+            LocalPayload::file("/tmp/small", STREAMING_PUT_MIN_BYTES - 1)
+                .holdable_file()
+                .is_some()
+        );
+        assert!(LocalPayload::file("/tmp/big", STREAMING_PUT_MIN_BYTES)
+            .holdable_file()
+            .is_none());
+        assert!(
+            LocalPayload::Stdin.holdable_file().is_none(),
+            "a source of unknown length can never be held"
+        );
+    }
+}

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1,9 +1,10 @@
 use serde_json::Value;
 use std::env;
 use std::fs;
+use std::io::Write;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Output};
+use std::process::{Child, Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -545,6 +546,141 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
         "{}",
         json_error(&conflicting)
     );
+}
+
+/// A payload past the size at which a put stops holding its bytes whole.
+/// It is the smallest payload that exercises the streaming path at all.
+fn streaming_payload() -> Vec<u8> {
+    let len = 8 * 1024 * 1024 + 1_024;
+    (0..len).map(|offset| (offset % 251) as u8).collect()
+}
+
+/// Reads a remote file back through the CLI and returns its bytes.
+fn download(harness: &Harness, remote_path: &str, name: &str) -> Vec<u8> {
+    let local = harness.temp_dir.path().join(name);
+    assert_success(&harness.run(&[
+        "get",
+        remote_path,
+        local.to_str().expect("utf-8 path"),
+        "--force",
+    ]));
+    fs::read(&local).expect("read downloaded file")
+}
+
+/// A large file and a pipe both round-trip through an embedded profile,
+/// and the retry contract holds for them exactly as it does for a payload
+/// small enough to hold.
+#[test]
+fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = streaming_payload();
+
+    let local = harness.temp_dir.path().join("big.bin");
+    fs::write(&local, &payload).expect("write payload");
+    let local_path = local.to_str().expect("utf-8 path");
+    let first = harness.run(&[
+        "--json",
+        "put",
+        local_path,
+        "/big.bin",
+        "--commit-id",
+        "pinned-big",
+    ]);
+    assert_success(&first);
+    assert_eq!(download(&harness, "/big.bin", "big-back.bin"), payload);
+
+    // The same reconciliation the buffered path has: the rerun uploads
+    // again, conflicts on identity, and resolves to the commit that landed.
+    let rerun = harness.run(&[
+        "--json",
+        "put",
+        local_path,
+        "/big.bin",
+        "--commit-id",
+        "pinned-big",
+        "--force",
+    ]);
+    assert_success(&rerun);
+    assert_eq!(
+        json_data(&rerun)["committed_seq"],
+        json_data(&first)["committed_seq"],
+        "rerunning an identical large put must report the commit that already landed"
+    );
+
+    let mut changed = payload.clone();
+    changed[0] ^= 0xff;
+    let changed_path = harness.temp_dir.path().join("changed.bin");
+    fs::write(&changed_path, &changed).expect("write changed payload");
+    let conflicting = harness.run(&[
+        "--json",
+        "put",
+        changed_path.to_str().expect("utf-8 path"),
+        "/big.bin",
+        "--commit-id",
+        "pinned-big",
+        "--force",
+    ]);
+    assert_failure(&conflicting);
+    assert_eq!(
+        json_error(&conflicting)["code"],
+        "commit_id_reuse_conflict",
+        "{}",
+        json_error(&conflicting)
+    );
+
+    // Standard input has no length to declare and no name to derive a
+    // destination from, so it needs one spelled out and takes the same
+    // read-once path.
+    assert_success(&harness.run_with_stdin(&["--json", "put", "-", "/piped.bin"], &payload));
+    assert_eq!(download(&harness, "/piped.bin", "piped-back.bin"), payload);
+
+    let no_destination = harness.run_with_stdin(&["--json", "put", "-"], b"anything");
+    assert_failure(&no_destination);
+    assert_eq!(json_error(&no_destination)["code"], "invalid_input");
+}
+
+/// The same two payloads over the remote transport. This deployment stores
+/// to a local filesystem, so it cannot authorize direct part uploads and
+/// the payload streams through the server instead — the fallback the client
+/// picks from the capability document rather than from a guess.
+#[test]
+fn large_and_piped_puts_round_trip_over_the_remote_transport() {
+    let harness = Harness::new();
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "streaming-remote"));
+    assert_success(&harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "default",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]));
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = streaming_payload();
+
+    let local = harness.temp_dir.path().join("big.bin");
+    fs::write(&local, &payload).expect("write payload");
+    assert_success(&harness.run(&[
+        "--json",
+        "put",
+        local.to_str().expect("utf-8 path"),
+        "/big.bin",
+    ]));
+    assert_eq!(download(&harness, "/big.bin", "big-back.bin"), payload);
+
+    // No `Content-Length` to send: this body is chunked, and the server's
+    // own incremental accounting is what bounds it.
+    assert_success(&harness.run_with_stdin(&["--json", "put", "-", "/piped.bin"], &payload));
+    assert_eq!(download(&harness, "/piped.bin", "piped-back.bin"), payload);
 }
 
 /// Every mutating command takes `-m`, and each one lands its annotation on
@@ -2387,6 +2523,26 @@ impl Harness {
             .args(args)
             .output()
             .expect("run loon")
+    }
+
+    /// Runs the CLI with a payload on standard input, which is the one
+    /// source whose length is not knowable before it is read.
+    fn run_with_stdin(&self, args: &[&str], stdin: &[u8]) -> Output {
+        let mut child = Command::new(loon_binary_path())
+            .env("HOME", &self.home_dir)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn loon");
+        child
+            .stdin
+            .take()
+            .expect("piped stdin")
+            .write_all(stdin)
+            .expect("write stdin");
+        child.wait_with_output().expect("run loon")
     }
 
     fn store_root(&self, name: &str) -> PathBuf {

--- a/crates/loonfs-client/Cargo.toml
+++ b/crates/loonfs-client/Cargo.toml
@@ -8,6 +8,8 @@ description = "Async HTTP client for a LoonFS server."
 repository.workspace = true
 
 [dependencies]
+bytes.workspace = true
+futures.workspace = true
 http.workspace = true
 loonfs-api = { path = "../loonfs-api" }
 reqwest.workspace = true

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -14,11 +14,13 @@
 
 mod config;
 mod error;
+mod payload;
 mod transport;
 
+use bytes::Bytes;
 use loonfs_api::{
     v0::{
-        BeginUploadRequest, BeginUploadResponse, ChangesResponse,
+        AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, ChangesResponse,
         CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
         CompleteUploadResponse, CompletedUploadPart, DirectMultipartContentClaim,
         DirectMultipartUploadOptions, DirectPutContentClaim, DisableGrepIndexResponse,
@@ -27,7 +29,7 @@ use loonfs_api::{
         UploadMode, UploadPartChecksumClaim, ValidatedContentToken,
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId,
-    ChecksumAlgorithm, CommitId, CommitRequest, ContentRef, CreateCheckpointRequest,
+    ChecksumAlgorithm, CommitId, CommitRequest, ContentRef, Crc64Nvme, CreateCheckpointRequest,
     CreateCheckpointResponse, CreateNamespaceRequest, DeleteNamespaceResponse, DestinationBehavior,
     ErrorCode, FilesystemOperation, ForkNamespaceRequest, GrepRequest, GrepResponse, InodeId,
     ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest,
@@ -35,17 +37,27 @@ use loonfs_api::{
     ReleaseCheckpointResponse, RevisionNo, StorageChecksum, UploadId,
     FEATURE_UPLOADS_DIRECT_MULTIPART,
 };
+use payload::PartReader;
 use std::sync::{Arc, OnceLock};
 
-/// Payload size from which the client prefers a direct multipart upload,
-/// when the deployment offers one. It mirrors the server's part size, so
-/// anything smaller would be a one-part multipart upload with extra round
-/// trips and nothing to gain.
-const DIRECT_MULTIPART_MIN_BYTES: u64 = 8 * 1024 * 1024;
+/// Payload size from which a put stops holding its bytes whole.
+///
+/// It mirrors the server's multipart part size, and that one number answers
+/// two questions the same way: below it a direct multipart upload would be a
+/// one-part upload with extra round trips and nothing to gain, and a payload
+/// that fits in a single part is not worth streaming either. At or above it
+/// — and for any payload whose length is not known in advance — a put reads
+/// its source once, in bounded pieces.
+pub const STREAMING_PUT_MIN_BYTES: u64 = 8 * 1024 * 1024;
 
-/// Parts in flight at once. Each holds its bytes, so this is the memory the
-/// parallelism costs.
+/// Parts in flight at once. Each holds its bytes, so a one-pass upload's
+/// memory is this many parts and no more.
 const DIRECT_MULTIPART_PARTS_IN_FLIGHT: usize = 4;
+
+/// Attempts one part gets before its upload gives up. A retry re-asks for
+/// the part's URL, because the first thing that goes stale about a part is
+/// its signature.
+const DIRECT_MULTIPART_PART_ATTEMPTS: usize = 3;
 
 /// Change-feed sequences one lookup window covers when resolving a reused
 /// commit id.
@@ -55,6 +67,59 @@ const COMMIT_LOOKUP_WINDOW: u64 = 128;
 /// commit being retried is a recent one; past this the answer is "not
 /// found", never a guess.
 const COMMIT_LOOKUP_MAX_WINDOWS: usize = 8;
+
+/// What a retry can still say about the payload it just uploaded.
+///
+/// A buffered put can answer any question about its bytes by hashing them
+/// again. A one-pass put cannot: its payload went by once and is gone, and
+/// what it kept instead is the verified description the server gave back.
+/// Both are evidence about the same bytes; they differ only in which
+/// questions they can answer, and a question neither can answer is reported
+/// as such rather than guessed at.
+#[derive(Debug, Clone, Copy)]
+enum UploadedContent<'a> {
+    /// The payload itself, which can produce any digest this build knows.
+    Bytes(&'a [u8]),
+    /// The reference the server minted for a payload that was streamed
+    /// past: its length, and the digest whoever hashed it reported.
+    Streamed(&'a ContentRef),
+}
+
+impl UploadedContent<'_> {
+    /// Complete length of what was uploaded.
+    fn size_bytes(&self) -> u64 {
+        match self {
+            Self::Bytes(bytes) => bytes.len() as u64,
+            Self::Streamed(content_ref) => content_ref.size_bytes,
+        }
+    }
+
+    /// Whether the upload's bytes produce this checksum.
+    ///
+    /// `None` is a refusal to answer — the algorithm is one this build
+    /// cannot recompute, or one nobody computed over the streamed payload —
+    /// and a caller must never read it as agreement.
+    fn matches(&self, expected: &StorageChecksum) -> Option<bool> {
+        match self {
+            Self::Bytes(bytes) => expected.matches(bytes),
+            Self::Streamed(content_ref) => {
+                let observed = digest_of(content_ref, expected.algorithm)?;
+                Some(observed == expected.value)
+            }
+        }
+    }
+}
+
+/// The digest a reference carries under one algorithm, if it carries one.
+fn digest_of(content_ref: &ContentRef, algorithm: ChecksumAlgorithm) -> Option<&str> {
+    if content_ref.storage_checksum.algorithm == algorithm {
+        return Some(&content_ref.storage_checksum.value);
+    }
+    match algorithm {
+        ChecksumAlgorithm::Sha256 => content_ref.whole_file_sha256.as_deref(),
+        _ => None,
+    }
+}
 
 /// The content one committed change wrote, if it wrote any.
 fn committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
@@ -67,6 +132,7 @@ fn committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
 
 pub use config::ClientConfig;
 pub use error::ClientError;
+pub use payload::{PayloadSource, PayloadStream};
 use transport::{WireRequest, IO_INACTIVITY_TIMEOUT};
 pub use ClientError as Error;
 
@@ -97,6 +163,97 @@ pub struct Client {
 struct StagedContent {
     content_ref: ContentRef,
     validated_content_token: Option<ValidatedContentToken>,
+}
+
+/// What a multipart upload has to work with.
+///
+/// The two arms exist so that neither caller pays for the other's shape: a
+/// caller holding its payload should not have it copied whole to be
+/// uploaded, and a caller reading a stream cannot be asked for a length it
+/// does not have. Past this point the upload cannot tell them apart.
+enum MultipartPayload<'a> {
+    /// A payload the caller already holds.
+    Held(&'a [u8]),
+    /// A payload read once, in pieces, as it is uploaded.
+    Streamed(PayloadStream),
+}
+
+impl<'a> MultipartPayload<'a> {
+    /// Binds the payload to the geometry the server chose.
+    fn into_parts_of(self, part_bytes: usize) -> MultipartParts<'a> {
+        match self {
+            Self::Held(bytes) => MultipartParts::Held {
+                bytes,
+                offset: 0,
+                part_bytes: part_bytes.max(1),
+            },
+            Self::Streamed(stream) => MultipartParts::Streamed(PartReader::new(stream, part_bytes)),
+        }
+    }
+}
+
+/// A payload cut into the parts it will be uploaded as.
+enum MultipartParts<'a> {
+    Held {
+        bytes: &'a [u8],
+        offset: usize,
+        part_bytes: usize,
+    },
+    Streamed(PartReader),
+}
+
+impl MultipartParts<'_> {
+    /// The next part, or `None` once the payload is spent. Both arms hand
+    /// out one part's worth of bytes and no more.
+    async fn next_part(&mut self) -> Result<Option<Bytes>> {
+        match self {
+            Self::Held {
+                bytes,
+                offset,
+                part_bytes,
+            } => {
+                if *offset >= bytes.len() {
+                    return Ok(None);
+                }
+                let end = bytes.len().min(*offset + *part_bytes);
+                let part = Bytes::copy_from_slice(&bytes[*offset..end]);
+                *offset = end;
+                Ok(Some(part))
+            }
+            Self::Streamed(reader) => reader
+                .next_part()
+                .await
+                .map_err(|error| ClientError::Http(format!("reading the payload failed: {error}"))),
+        }
+    }
+}
+
+/// One part waiting to be uploaded, with the checksum its URL is signed
+/// against.
+struct PendingPart {
+    claim: UploadPartChecksumClaim,
+    bytes: Bytes,
+}
+
+/// What one pass over a payload produced: the assembled object's length and
+/// digest, and the parts it was written as.
+struct UploadedObject {
+    size_bytes: u64,
+    crc64nvme: StorageChecksum,
+    parts: Vec<CompletedUploadPart>,
+}
+
+/// Picks one part's authorization out of a signing response.
+fn signed_access(signed: &[SignedUploadPart], part_number: u32) -> Result<ObjectTransferAccess> {
+    signed
+        .iter()
+        .find(|part| part.part_number == part_number)
+        .map(|part| part.access.clone())
+        .ok_or_else(|| {
+            ClientError::Http(format!(
+                "server authorized no upload for part {part_number}"
+            ))
+        })
 }
 
 /// A path qualified by namespace.
@@ -464,7 +621,7 @@ impl Client {
         part_number: u32,
         access: &ObjectTransferAccess,
         crc64nvme: String,
-        bytes: &[u8],
+        bytes: Bytes,
     ) -> Result<CompletedUploadPart> {
         let ObjectTransferAccess::PresignedUrl {
             method,
@@ -485,7 +642,7 @@ impl Client {
         // provider takes the last write, and the checksum rides the
         // signature either way.
         let response = self
-            .call_with_transient_retry_headers(&request, Some(bytes))
+            .call_with_transient_retry_headers(&request, Some(&bytes))
             .await?;
         let etag = response
             .get(http::header::ETAG)
@@ -524,7 +681,9 @@ impl Client {
             request = request.header(name, value);
         }
         // A successful create-only PUT may replay as a provider precondition error, not success.
-        self.call_once(&request, Some(bytes)).await.map(|_| ())
+        self.call_once(&request, Some(&Bytes::copy_from_slice(bytes)))
+            .await
+            .map(|_| ())
     }
 
     pub async fn upload_content(
@@ -533,19 +692,71 @@ impl Client {
         upload_id: &UploadId,
         bytes: &[u8],
     ) -> Result<UploadContentResponse> {
+        let request = self.upload_content_request(namespace_id, upload_id);
+        // Proxied uploads are the request most likely to hit the server's
+        // concurrency cap; staging the same bytes again is idempotent.
+        let response = self
+            .call_with_transient_retry(&request, Some(&Bytes::copy_from_slice(bytes)))
+            .await?;
+        serde_json::from_slice(&response).map_err(|err| ClientError::Json(err.to_string()))
+    }
+
+    /// Stages a payload that arrives in pieces, forwarding it to the server
+    /// as it is read.
+    ///
+    /// This is [`Self::upload_content`] for a caller that does not hold its
+    /// bytes: the payload crosses the client in bounded chunks and the
+    /// server hashes it as it forwards it on, so neither side ever holds the
+    /// object. A source whose length is unknown is sent with chunked
+    /// transfer encoding, and the server's own limit is what bounds it.
+    ///
+    /// Unlike the buffered call this one never resends: a stream is consumed
+    /// by the attempt that reads it, so a failure here is the caller's to
+    /// handle with a fresh source.
+    pub async fn upload_streamed_content(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        source: PayloadSource,
+    ) -> Result<UploadContentResponse> {
+        let request = self.upload_content_request(namespace_id, upload_id);
+        let (stream, size_bytes) = source.into_stream();
+        let response = self
+            .call_streamed_once(&request, stream, size_bytes)
+            .await?;
+        serde_json::from_slice(&response).map_err(|err| ClientError::Json(err.to_string()))
+    }
+
+    fn upload_content_request(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+    ) -> WireRequest {
         let url = format!(
             "{}/v0/namespaces/{namespace_id}/uploads/{upload_id}/content",
             self.base_url
         );
-        let request = self
-            .put(&url)
-            .header("content-type", "application/octet-stream");
-        // Proxied uploads are the request most likely to hit the server's
-        // concurrency cap; staging the same bytes again is idempotent.
-        let response = self
-            .call_with_transient_retry(&request, Some(bytes))
-            .await?;
-        serde_json::from_slice(&response).map_err(|err| ClientError::Json(err.to_string()))
+        self.put(&url)
+            .header("content-type", "application/octet-stream")
+    }
+
+    /// Ends an open upload session and deletes the object it was writing.
+    ///
+    /// Repeating it succeeds and reports the abort that stands. This is what
+    /// a one-pass upload does when its source fails partway: the session it
+    /// opened must not be left holding a half-written object.
+    pub async fn abort_upload(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+    ) -> Result<AbortUploadResponse> {
+        let url = format!(
+            "{}/v0/namespaces/{namespace_id}/uploads/{upload_id}/abort",
+            self.base_url
+        );
+        // Aborting is idempotent: a repeat reports the abort that stands.
+        self.request_json::<(), AbortUploadResponse>(self.post(&url), None)
+            .await
     }
 
     pub async fn complete_upload(
@@ -707,61 +918,94 @@ impl Client {
         namespace_id: &NamespaceId,
         bytes: &[u8],
     ) -> Result<StagedContent> {
-        if bytes.len() as u64 >= DIRECT_MULTIPART_MIN_BYTES
-            && self
-                .capabilities()
-                .await
-                .is_ok_and(|capabilities| capabilities.supports(FEATURE_UPLOADS_DIRECT_MULTIPART))
-        {
-            return self.stage_bytes_via_multipart(namespace_id, bytes).await;
+        if bytes.len() as u64 >= STREAMING_PUT_MIN_BYTES && self.offers_direct_multipart().await {
+            return self
+                .stage_via_multipart(namespace_id, MultipartPayload::Held(bytes))
+                .await;
         }
         self.stage_bytes_via_server(namespace_id, bytes).await
     }
 
-    /// Uploads one object straight to object storage in parallel parts.
+    /// Makes a streamed payload durable, choosing the transport the source
+    /// and the deployment allow.
+    ///
+    /// Either way the source is read once, forward, and never held whole.
+    /// A deployment that can authorize direct part uploads gets them; one
+    /// that cannot receives the same source as a streaming request body.
+    async fn stage_source_as_content_ref(
+        &self,
+        namespace_id: &NamespaceId,
+        source: PayloadSource,
+    ) -> Result<StagedContent> {
+        // A source that knows it is small has nothing to gain from parts,
+        // exactly as a held payload of that size does not. A source that
+        // does not know its length cannot make that judgement, so it takes
+        // the transport that can carry any length.
+        let known_small = source
+            .size_bytes()
+            .is_some_and(|size_bytes| size_bytes < STREAMING_PUT_MIN_BYTES);
+        if !known_small && self.offers_direct_multipart().await {
+            let (stream, _) = source.into_stream();
+            return self
+                .stage_via_multipart(namespace_id, MultipartPayload::Streamed(stream))
+                .await;
+        }
+        self.stage_source_via_server(namespace_id, source).await
+    }
+
+    /// Whether this deployment authorizes direct part uploads.
+    async fn offers_direct_multipart(&self) -> bool {
+        self.capabilities()
+            .await
+            .is_ok_and(|capabilities| capabilities.supports(FEATURE_UPLOADS_DIRECT_MULTIPART))
+    }
+
+    /// Uploads one object straight to object storage in bounded waves of
+    /// parts.
     ///
     /// The whole-object checksum is folded part by part as the payload is
     /// cut, so the same pass that produces what the provider enforces on
     /// each part also produces what completion verifies the assembly
     /// against — and because the claim is only needed at completion, that
-    /// one pass is the only pass a caller ever has to make over its bytes.
-    async fn stage_bytes_via_multipart(
+    /// one pass is the only pass over the bytes anyone has to make. Nothing
+    /// here needs the payload's length in advance, which is what lets a
+    /// stream with no length take this path unchanged.
+    ///
+    /// A session that fails partway is aborted rather than left open.
+    async fn stage_via_multipart(
         &self,
         namespace_id: &NamespaceId,
-        bytes: &[u8],
+        payload: MultipartPayload<'_>,
     ) -> Result<StagedContent> {
-        let whole_object = StorageChecksum::crc64nvme(bytes);
         let begin = self
             .begin_direct_multipart(namespace_id, DirectMultipartUploadOptions::default())
             .await?;
         let upload_id = begin.upload_id.clone();
-        let multipart = begin.direct_multipart.ok_or_else(|| {
-            ClientError::Http("server accepted direct_multipart without part geometry".to_owned())
-        })?;
-
-        let part_size = usize::try_from(multipart.part_size_bytes)
-            .map_err(|_| ClientError::Http("part size does not fit this platform".to_owned()))?;
-        let chunks: Vec<&[u8]> = if bytes.is_empty() {
-            vec![&[]]
-        } else {
-            bytes.chunks(part_size.max(1)).collect()
+        let Some(multipart) = begin.direct_multipart else {
+            return Err(ClientError::Http(
+                "server accepted direct_multipart without part geometry".to_owned(),
+            ));
         };
-        let claims = chunks
-            .iter()
-            .enumerate()
-            .map(|(index, chunk)| UploadPartChecksumClaim {
-                part_number: index as u32 + 1,
-                crc64nvme: StorageChecksum::crc64nvme(chunk).value,
-            })
-            .collect::<Vec<_>>();
-        let signed = self
-            .sign_upload_parts(namespace_id, &upload_id, claims.clone())
-            .await?;
-
-        let mut parts = self
-            .upload_signed_parts(&signed.parts, &claims, &chunks)
-            .await?;
-        parts.sort_by_key(|part| part.part_number);
+        let uploaded = self
+            .upload_every_part(namespace_id, &upload_id, payload, multipart.part_size_bytes)
+            .await;
+        let uploaded = match uploaded {
+            Ok(uploaded) => uploaded,
+            Err(error) => {
+                // The session owns an object this upload will never finish
+                // writing. Ending it is best-effort: the original failure is
+                // what the caller needs to see, and abandoned sessions are
+                // collected either way.
+                let _ = self.abort_upload(namespace_id, &upload_id).await;
+                return Err(error);
+            }
+        };
+        if uploaded.parts.is_empty() {
+            // The source was empty, and a provider has no empty assembly to
+            // make. The payload is nothing, so staging it costs nothing.
+            let _ = self.abort_upload(namespace_id, &upload_id).await;
+            return self.stage_bytes_via_server(namespace_id, &[]).await;
+        }
 
         let response = self
             .complete_upload(
@@ -769,56 +1013,152 @@ impl Client {
                 &upload_id,
                 &CompleteUploadRequest::for_multipart(
                     DirectMultipartContentClaim {
-                        size_bytes: bytes.len() as u64,
-                        crc64nvme: whole_object.value.clone(),
+                        size_bytes: uploaded.size_bytes,
+                        crc64nvme: uploaded.crc64nvme.value,
                     },
-                    parts,
+                    uploaded.parts,
                 ),
             )
             .await?;
         Ok(Self::staged_from_completion(response))
     }
 
-    /// Uploads parts with a bounded number in flight.
+    /// Cuts the payload into parts and uploads them, holding at most
+    /// [`DIRECT_MULTIPART_PARTS_IN_FLIGHT`] of them at a time.
     ///
-    /// The window exists because each in-flight part holds its bytes: the
-    /// point of this path is that a large object crosses the network once
-    /// and in parallel, not that it is all in flight at once.
-    async fn upload_signed_parts(
+    /// The window is the memory bound: each in-flight part holds its bytes,
+    /// and nothing outside the window does. One wave asks for its part URLs
+    /// in a single request, uploads them together, and only then reads the
+    /// next wave — so the payload's length never enters into how much of it
+    /// is resident.
+    async fn upload_every_part(
         &self,
-        signed: &[SignedUploadPart],
-        claims: &[UploadPartChecksumClaim],
-        chunks: &[&[u8]],
-    ) -> Result<Vec<CompletedUploadPart>> {
-        let mut uploaded = Vec::with_capacity(signed.len());
-        for wave in signed.chunks(DIRECT_MULTIPART_PARTS_IN_FLIGHT) {
-            let mut in_flight = tokio::task::JoinSet::new();
-            for part in wave {
-                let index = part.part_number as usize - 1;
-                let (Some(claim), Some(chunk)) = (claims.get(index), chunks.get(index)) else {
-                    return Err(ClientError::Http(format!(
-                        "server signed part {} which this upload does not have",
-                        part.part_number
-                    )));
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        payload: MultipartPayload<'_>,
+        part_size_bytes: u64,
+    ) -> Result<UploadedObject> {
+        let part_size = usize::try_from(part_size_bytes)
+            .map_err(|_| ClientError::Http("part size does not fit this platform".to_owned()))?;
+        let mut source = payload.into_parts_of(part_size);
+        let mut whole_object = Crc64Nvme::new();
+        let mut size_bytes = 0u64;
+        let mut parts = Vec::new();
+        let mut next_part_number = 1u32;
+
+        loop {
+            let mut wave = Vec::with_capacity(DIRECT_MULTIPART_PARTS_IN_FLIGHT);
+            while wave.len() < DIRECT_MULTIPART_PARTS_IN_FLIGHT {
+                let Some(bytes) = source.next_part().await? else {
+                    break;
                 };
-                let client = self.clone();
-                let access = part.access.clone();
-                let crc64nvme = claim.crc64nvme.clone();
-                let part_number = part.part_number;
-                let chunk = chunk.to_vec();
-                in_flight.spawn(async move {
-                    client
-                        .upload_part_via_presigned_url(part_number, &access, crc64nvme, &chunk)
-                        .await
+                whole_object.update(&bytes);
+                size_bytes += bytes.len() as u64;
+                wave.push(PendingPart {
+                    claim: UploadPartChecksumClaim {
+                        part_number: next_part_number,
+                        crc64nvme: StorageChecksum::crc64nvme(&bytes).value,
+                    },
+                    bytes,
                 });
+                next_part_number += 1;
             }
-            while let Some(joined) = in_flight.join_next().await {
-                uploaded.push(joined.map_err(|err| {
-                    ClientError::Http(format!("part upload task failed: {err}"))
-                })??);
+            if wave.is_empty() {
+                break;
+            }
+            let complete = wave.len() == DIRECT_MULTIPART_PARTS_IN_FLIGHT;
+            parts.extend(self.upload_wave(namespace_id, upload_id, wave).await?);
+            if !complete {
+                // A short wave is the only proof the source ended.
+                break;
             }
         }
-        Ok(uploaded)
+
+        parts.sort_by_key(|part| part.part_number);
+        Ok(UploadedObject {
+            size_bytes,
+            crc64nvme: whole_object.finish(),
+            parts,
+        })
+    }
+
+    /// Authorizes and uploads one wave of parts together.
+    async fn upload_wave(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        wave: Vec<PendingPart>,
+    ) -> Result<Vec<CompletedUploadPart>> {
+        let claims = wave.iter().map(|part| part.claim.clone()).collect();
+        let signed = self
+            .sign_upload_parts(namespace_id, upload_id, claims)
+            .await?;
+        let mut in_flight = tokio::task::JoinSet::new();
+        for part in wave {
+            let access = signed_access(&signed.parts, part.claim.part_number)?;
+            let client = self.clone();
+            let namespace_id = namespace_id.clone();
+            let upload_id = upload_id.clone();
+            in_flight.spawn(async move {
+                client
+                    .upload_one_part(&namespace_id, &upload_id, part, access)
+                    .await
+            });
+        }
+        let mut uploaded = Vec::new();
+        let mut failure = None;
+        while let Some(joined) = in_flight.join_next().await {
+            match joined.map_err(|err| ClientError::Http(format!("part upload task failed: {err}")))
+            {
+                // Every task is drained before the first failure surfaces,
+                // so no part upload outlives the wave that started it.
+                Ok(Ok(part)) => uploaded.push(part),
+                Ok(Err(error)) | Err(error) => failure = failure.or(Some(error)),
+            }
+        }
+        match failure {
+            Some(error) => Err(error),
+            None => Ok(uploaded),
+        }
+    }
+
+    /// Uploads one part, re-asking for its URL if the upload fails.
+    ///
+    /// Re-asking is the retry: a part's signature is the first thing about
+    /// it that goes stale, and a repeated part is last-write-wins at the
+    /// provider, so nothing is lost by writing it again.
+    async fn upload_one_part(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        part: PendingPart,
+        mut access: ObjectTransferAccess,
+    ) -> Result<CompletedUploadPart> {
+        let part_number = part.claim.part_number;
+        for attempt in 1..=DIRECT_MULTIPART_PART_ATTEMPTS {
+            let result = self
+                .upload_part_via_presigned_url(
+                    part_number,
+                    &access,
+                    part.claim.crc64nvme.clone(),
+                    part.bytes.clone(),
+                )
+                .await;
+            match result {
+                Ok(uploaded) => return Ok(uploaded),
+                Err(error) if attempt == DIRECT_MULTIPART_PART_ATTEMPTS => return Err(error),
+                Err(_) => {
+                    let signed = self
+                        .sign_upload_parts(namespace_id, upload_id, vec![part.claim.clone()])
+                        .await?;
+                    access = signed_access(&signed.parts, part_number)?;
+                }
+            }
+        }
+        // The loop above returns on its last attempt.
+        Err(ClientError::Http(format!(
+            "part {part_number} upload made no attempt"
+        )))
     }
 
     async fn stage_bytes_via_server(
@@ -832,10 +1172,47 @@ impl Client {
         let staged = self
             .upload_content(namespace_id, &upload.upload_id, bytes)
             .await?;
+        self.complete_staged(namespace_id, &upload.upload_id, staged)
+            .await
+    }
+
+    /// Stages a streamed payload through the server, which hashes it as it
+    /// forwards it on.
+    ///
+    /// The session is aborted if the transfer fails, for the same reason a
+    /// multipart session is: it owns an object nothing will finish writing.
+    async fn stage_source_via_server(
+        &self,
+        namespace_id: &NamespaceId,
+        source: PayloadSource,
+    ) -> Result<StagedContent> {
+        let upload = self
+            .begin_upload(namespace_id, &BeginUploadRequest::default())
+            .await?;
+        let staged = self
+            .upload_streamed_content(namespace_id, &upload.upload_id, source)
+            .await;
+        let staged = match staged {
+            Ok(staged) => staged,
+            Err(error) => {
+                let _ = self.abort_upload(namespace_id, &upload.upload_id).await;
+                return Err(error);
+            }
+        };
+        self.complete_staged(namespace_id, &upload.upload_id, staged)
+            .await
+    }
+
+    async fn complete_staged(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        staged: UploadContentResponse,
+    ) -> Result<StagedContent> {
         let response = self
             .complete_upload(
                 namespace_id,
-                &upload.upload_id,
+                upload_id,
                 &CompleteUploadRequest::for_content_ref(staged.content_ref),
             )
             .await?;
@@ -878,10 +1255,63 @@ impl Client {
         bytes: &[u8],
         options: &PutFileOptions,
     ) -> Result<ApiCommitResponse> {
-        let commit_id = options.commit_id.clone().unwrap_or_else(CommitId::generate);
         let staged = self
             .stage_bytes_as_content_ref(spec.namespace(), bytes)
             .await?;
+        self.commit_staged_file(spec, staged, options, UploadedContent::Bytes(bytes))
+            .await
+    }
+
+    /// Uploads a payload read once from its source and commits it at a path.
+    ///
+    /// This is [`Self::put_file_bytes`] for a caller that should not hold
+    /// its payload: the source is read forward in bounded pieces, hashed as
+    /// it goes, and never assembled. What the memory costs is the transport's
+    /// window and nothing about the payload's size — so a file larger than
+    /// this process could hold, or a pipe whose length nobody knows, both
+    /// upload the same way.
+    ///
+    /// Where the deployment authorizes direct part uploads the payload goes
+    /// straight to object storage in parts, and otherwise it streams through
+    /// the server. One bound is worth knowing on the direct path: a provider
+    /// assembles at most 10,000 parts, so a session carries at most
+    /// `part_size_bytes × 10_000` and a longer payload is refused when it
+    /// asks to authorize the part past that ceiling. A caller that knows its
+    /// payload is enormous should not be taking the default geometry.
+    ///
+    /// Retrying with a `commit_id` that already committed is safe here in
+    /// the same way it is for [`Self::put_file_bytes`], and by the same
+    /// evidence: this pass measured the payload's length and folded its
+    /// digest, which is what the reconciliation compares. The digest is
+    /// CRC-64/NVME on the direct path, because that is what a provider
+    /// computes over an assembled object.
+    pub async fn put_file_stream(
+        &self,
+        spec: &NamespacePath,
+        source: PayloadSource,
+        options: &PutFileOptions,
+    ) -> Result<ApiCommitResponse> {
+        let staged = self
+            .stage_source_as_content_ref(spec.namespace(), source)
+            .await?;
+        // The staged reference is what the server verified about the bytes
+        // that just went past, and with the payload gone it is the only
+        // description of them that still exists.
+        let uploaded = staged.content_ref.clone();
+        self.commit_staged_file(spec, staged, options, UploadedContent::Streamed(&uploaded))
+            .await
+    }
+
+    /// Commits one staged payload at a path, reconciling a reused commit id
+    /// against what was just uploaded.
+    async fn commit_staged_file(
+        &self,
+        spec: &NamespacePath,
+        staged: StagedContent,
+        options: &PutFileOptions,
+        uploaded: UploadedContent<'_>,
+    ) -> Result<ApiCommitResponse> {
+        let commit_id = options.commit_id.clone().unwrap_or_else(CommitId::generate);
         let response = self
             .commit(
                 spec.namespace(),
@@ -901,7 +1331,7 @@ impl Client {
         match response {
             Ok(response) => Ok(response),
             Err(error) if error.code() == Some(ErrorCode::CommitIdReuseConflict) => {
-                self.reconcile_commit_id_reuse(spec.namespace(), &commit_id, bytes, error)
+                self.reconcile_commit_id_reuse(spec.namespace(), &commit_id, uploaded, error)
                     .await
             }
             Err(error) => Err(error),
@@ -918,7 +1348,7 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         commit_id: &CommitId,
-        bytes: &[u8],
+        uploaded: UploadedContent<'_>,
         conflict: ClientError,
     ) -> Result<ApiCommitResponse> {
         let Some(committed) = self.find_committed_change(namespace_id, commit_id).await? else {
@@ -927,7 +1357,7 @@ impl Client {
         let Some(content_ref) = committed_content_ref(&committed) else {
             return Err(conflict);
         };
-        if content_ref.size_bytes != bytes.len() as u64 {
+        if content_ref.size_bytes != uploaded.size_bytes() {
             return Err(conflict);
         }
 
@@ -942,7 +1372,7 @@ impl Client {
             },
             None => content_ref.storage_checksum.clone(),
         };
-        match evidence.matches(bytes) {
+        match uploaded.matches(&evidence) {
             Some(true) => Ok(ApiCommitResponse {
                 namespace_id: namespace_id.clone(),
                 commit_id: committed.commit_id,
@@ -951,8 +1381,8 @@ impl Client {
             Some(false) => Err(conflict),
             None => Err(ClientError::Http(format!(
                 "commit `{commit_id}` already committed content checksummed with \
-                 `{}`, which this client cannot recompute, so it cannot tell whether \
-                 this is the same upload retried",
+                 `{}`, which this client cannot compare against what it just \
+                 uploaded, so it cannot tell whether this is the same upload retried",
                 evidence.algorithm
             ))),
         }
@@ -1214,6 +1644,9 @@ fn append_query_param(url: &mut String, has_query: &mut bool, name: &str, value:
     url.push('=');
     url.push_str(&urlencoding::encode(value));
 }
+
+#[cfg(test)]
+mod streaming_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/loonfs-client/src/payload.rs
+++ b/crates/loonfs-client/src/payload.rs
@@ -1,0 +1,273 @@
+//! Where a streaming put reads its bytes, and how it cuts them into parts.
+//!
+//! A [`PayloadSource`] is read exactly once, forward, in pieces. That is the
+//! whole contract: it is what lets one put serve a file on disk and a pipe
+//! with no length equally well, and what keeps the memory a large put costs
+//! independent of how large it is.
+
+use bytes::{Bytes, BytesMut};
+use futures::stream::{BoxStream, StreamExt};
+use std::io;
+use std::path::Path;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+/// Bytes read from a source in one go before they are handed on.
+///
+/// Sized like an HTTP body's chunk rather than a transfer part: this is the
+/// slack a bounded uploader carries on top of the parts it holds, so it
+/// should stay small next to a part.
+const SOURCE_CHUNK_BYTES: usize = 64 * 1024;
+
+/// A payload delivered in pieces, for a put that must not hold it whole.
+///
+/// Chunk boundaries carry no meaning — an uploader regroups them into
+/// whatever units its transport wants. A chunk error ends the upload.
+pub type PayloadStream = BoxStream<'static, io::Result<Bytes>>;
+
+/// Where one put reads its payload, and what it knows about it up front.
+///
+/// The length is a hint and never a promise: a source that knows it lets the
+/// put pick the cheaper transport and declare a `Content-Length`, and a
+/// source that does not know it — a pipe, a socket, standard input — takes
+/// exactly the same path and discovers the length as it goes.
+pub struct PayloadSource {
+    stream: PayloadStream,
+    size_bytes: Option<u64>,
+}
+
+impl std::fmt::Debug for PayloadSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PayloadSource")
+            .field("size_bytes", &self.size_bytes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PayloadSource {
+    /// A source of unknown length.
+    pub fn stream(stream: PayloadStream) -> Self {
+        Self {
+            stream,
+            size_bytes: None,
+        }
+    }
+
+    /// A source whose complete length the caller already knows.
+    ///
+    /// The length is used to choose a transport and to frame the request; a
+    /// source that delivers a different number of bytes is still uploaded
+    /// faithfully, and it is the bytes that decide what is stored.
+    pub fn sized_stream(stream: PayloadStream, size_bytes: u64) -> Self {
+        Self {
+            stream,
+            size_bytes: Some(size_bytes),
+        }
+    }
+
+    /// A source of unknown length reading from anything asynchronous —
+    /// standard input, a socket, a decompressor.
+    pub fn reader<R>(reader: R) -> Self
+    where
+        R: AsyncRead + Send + Unpin + 'static,
+    {
+        Self::stream(read_in_chunks(reader))
+    }
+
+    /// A source reading one local file, whose length is known before the
+    /// first byte moves.
+    pub async fn open_file(path: impl AsRef<Path>) -> io::Result<Self> {
+        let file = tokio::fs::File::open(path.as_ref()).await?;
+        let size_bytes = file.metadata().await?.len();
+        Ok(Self::sized_stream(read_in_chunks(file), size_bytes))
+    }
+
+    /// Complete length when the source knows it.
+    pub fn size_bytes(&self) -> Option<u64> {
+        self.size_bytes
+    }
+
+    /// Splits the source into the stream to read and the length it
+    /// declared, for a caller that has to restate it in another crate's
+    /// terms.
+    pub fn into_stream(self) -> (PayloadStream, Option<u64>) {
+        (self.stream, self.size_bytes)
+    }
+}
+
+/// Reads an asynchronous source into modest chunks until it ends.
+fn read_in_chunks<R>(reader: R) -> PayloadStream
+where
+    R: AsyncRead + Send + Unpin + 'static,
+{
+    futures::stream::unfold(Some(reader), |reader| async move {
+        let mut reader = reader?;
+        let mut buffer = BytesMut::with_capacity(SOURCE_CHUNK_BYTES);
+        match reader.read_buf(&mut buffer).await {
+            // A read of zero is the end of the source, and the only thing
+            // that ends it: a short read is just a short read.
+            Ok(0) => None,
+            Ok(_) => Some((Ok(buffer.freeze()), Some(reader))),
+            Err(error) => Some((Err(error), None)),
+        }
+    })
+    .boxed()
+}
+
+/// Cuts a source into fixed-size parts, holding one at a time.
+///
+/// Chunk boundaries in the source carry no meaning, so a chunk that overruns
+/// the part being cut is split and its tail carried into the next one. The
+/// last part is whatever is left when the source ends, and a source that
+/// ends exactly on a boundary produces no final part.
+pub(crate) struct PartReader {
+    stream: PayloadStream,
+    /// The tail of a chunk that overran the part being cut.
+    carry: Option<Bytes>,
+    part_bytes: usize,
+    exhausted: bool,
+}
+
+impl PartReader {
+    pub(crate) fn new(stream: PayloadStream, part_bytes: usize) -> Self {
+        Self {
+            stream,
+            carry: None,
+            part_bytes: part_bytes.max(1),
+            exhausted: false,
+        }
+    }
+
+    /// Cuts the next part: exactly `part_bytes`, or whatever is left when
+    /// the source ends. `None` once nothing is left.
+    ///
+    /// A full part is returned without reading further, so a caller cannot
+    /// conclude from a full part that more is coming — only a short part
+    /// proves the source ended.
+    pub(crate) async fn next_part(&mut self) -> io::Result<Option<Bytes>> {
+        let mut buffer: Option<BytesMut> = None;
+        loop {
+            let filled = buffer.as_ref().map_or(0, BytesMut::len);
+            if filled >= self.part_bytes {
+                break;
+            }
+            let mut chunk = match self.carry.take() {
+                Some(chunk) => chunk,
+                None if self.exhausted => break,
+                None => match self.stream.next().await {
+                    Some(chunk) => chunk?,
+                    None => {
+                        self.exhausted = true;
+                        break;
+                    }
+                },
+            };
+            let take = (self.part_bytes - filled).min(chunk.len());
+            let taken = chunk.split_to(take);
+            if !chunk.is_empty() {
+                self.carry = Some(chunk);
+            }
+            match &mut buffer {
+                Some(buffer) => buffer.extend_from_slice(&taken),
+                // A chunk that fills a part on its own is handed straight
+                // through. Nothing is copied, and the part is a view of the
+                // source's own buffer rather than a second copy of it.
+                None if taken.len() == self.part_bytes => return Ok(Some(taken)),
+                None => {
+                    let mut fresh = BytesMut::with_capacity(self.part_bytes);
+                    fresh.extend_from_slice(&taken);
+                    buffer = Some(fresh);
+                }
+            }
+        }
+        Ok(buffer
+            .filter(|buffer| !buffer.is_empty())
+            .map(BytesMut::freeze))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(chunks: Vec<&'static [u8]>) -> PayloadStream {
+        futures::stream::iter(chunks.into_iter().map(|chunk| Ok(Bytes::from(chunk)))).boxed()
+    }
+
+    async fn cut(reader: &mut PartReader) -> Vec<Vec<u8>> {
+        let mut parts = Vec::new();
+        while let Some(part) = reader.next_part().await.expect("cut a part") {
+            parts.push(part.to_vec());
+        }
+        parts
+    }
+
+    /// Source chunks and part boundaries are unrelated: a chunk that
+    /// straddles a boundary is split, and its tail opens the next part.
+    #[tokio::test]
+    async fn parts_are_cut_regardless_of_how_the_source_chunked_them() {
+        let mut reader = PartReader::new(source(vec![b"abcde", b"fg", b"hijkl"]), 4);
+        assert_eq!(
+            cut(&mut reader).await,
+            vec![b"abcd".to_vec(), b"efgh".to_vec(), b"ijkl".to_vec()]
+        );
+    }
+
+    /// A source that ends exactly on a boundary produces no trailing empty
+    /// part, and one that does not ends with a short one.
+    #[tokio::test]
+    async fn the_last_part_is_whatever_is_left() {
+        let mut reader = PartReader::new(source(vec![b"abcdef"]), 4);
+        assert_eq!(
+            cut(&mut reader).await,
+            vec![b"abcd".to_vec(), b"ef".to_vec()]
+        );
+
+        let mut reader = PartReader::new(source(vec![b"abcd"]), 4);
+        assert_eq!(cut(&mut reader).await, vec![b"abcd".to_vec()]);
+    }
+
+    /// An empty source produces no parts at all, which is what tells a
+    /// one-pass uploader that it has nothing to assemble.
+    #[tokio::test]
+    async fn an_empty_source_produces_no_parts() {
+        let mut reader = PartReader::new(source(vec![]), 4);
+        assert!(reader.next_part().await.expect("cut a part").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_file_source_knows_its_length() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("payload.bin");
+        std::fs::write(&path, vec![7u8; 5_000]).expect("write payload");
+
+        let source = PayloadSource::open_file(&path).await.expect("open payload");
+        assert_eq!(source.size_bytes(), Some(5_000));
+
+        let (stream, _) = source.into_stream();
+        let mut reader = PartReader::new(stream, 4_096);
+        let first = reader.next_part().await.expect("cut").expect("first part");
+        let second = reader.next_part().await.expect("cut").expect("second part");
+        assert_eq!(first.len(), 4_096);
+        assert_eq!(second.len(), 904);
+        assert!(reader.next_part().await.expect("cut").is_none());
+    }
+
+    /// A reader-backed source declares no length, which is exactly the
+    /// case a pipe presents.
+    #[tokio::test]
+    async fn a_reader_source_declares_no_length() {
+        let source = PayloadSource::reader(std::io::Cursor::new(vec![1u8; 100]));
+        assert_eq!(source.size_bytes(), None);
+        let (stream, _) = source.into_stream();
+        let mut reader = PartReader::new(stream, 64);
+        assert_eq!(
+            reader.next_part().await.expect("cut").expect("part").len(),
+            64
+        );
+        assert_eq!(
+            reader.next_part().await.expect("cut").expect("part").len(),
+            36
+        );
+        assert!(reader.next_part().await.expect("cut").is_none());
+    }
+}

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -1,0 +1,487 @@
+//! What a one-pass put costs in memory, and that it still reconciles a
+//! retried commit id.
+//!
+//! The measurement here is retention, not resident size: the source hands
+//! out chunks whose owners report when they are released, so the peak is
+//! how much of the payload the uploader was holding at once — a number that
+//! is exact, deterministic, and says nothing about the allocator.
+
+use super::*;
+use crate::transport::test_transport::{self, Outcome};
+use futures::stream::StreamExt;
+use loonfs_api::v0::{DirectMultipartUpload, UploadMode};
+use loonfs_api::{CapabilityDocument, ContentId, ContentRef, PROFILE_CORE_V0, PROTOCOL_VERSION};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Part geometry the scripted server hands back. Smaller than the default
+/// so the test's payload stays cheap, and a server is free to choose it.
+const TEST_PART_BYTES: u64 = 1024 * 1024;
+/// A payload just past the size at which a put stops holding its bytes
+/// whole — which is what puts it on the streaming path at all — cut into
+/// eight full parts and a short ninth, so the source's end is discovered
+/// rather than computed.
+const TEST_PAYLOAD_BYTES: usize = STREAMING_PUT_MIN_BYTES as usize + 1_000;
+/// Parts [`TEST_PAYLOAD_BYTES`] is cut into at [`TEST_PART_BYTES`].
+const TEST_PAYLOAD_PARTS: u32 = 9;
+
+/// How much of a payload its consumer is holding, tracked by the payload
+/// itself.
+#[derive(Debug, Default)]
+struct Retention {
+    live_bytes: AtomicU64,
+    peak_live_bytes: AtomicU64,
+    live_chunks: AtomicUsize,
+    peak_live_chunks: AtomicUsize,
+    total_bytes: AtomicU64,
+}
+
+impl Retention {
+    fn handed_out(&self, len: usize) {
+        let live = self.live_bytes.fetch_add(len as u64, Ordering::SeqCst) + len as u64;
+        self.peak_live_bytes.fetch_max(live, Ordering::SeqCst);
+        let chunks = self.live_chunks.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak_live_chunks.fetch_max(chunks, Ordering::SeqCst);
+        self.total_bytes.fetch_add(len as u64, Ordering::SeqCst);
+    }
+
+    fn released(&self, len: usize) {
+        self.live_bytes.fetch_sub(len as u64, Ordering::SeqCst);
+        self.live_chunks.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    fn peak_live_bytes(&self) -> u64 {
+        self.peak_live_bytes.load(Ordering::SeqCst)
+    }
+
+    fn peak_live_chunks(&self) -> usize {
+        self.peak_live_chunks.load(Ordering::SeqCst)
+    }
+
+    fn total_bytes(&self) -> u64 {
+        self.total_bytes.load(Ordering::SeqCst)
+    }
+}
+
+/// One chunk of a watched payload. Its `Drop` is what marks the bytes
+/// released, so the live count falls exactly when the consumer lets go —
+/// including when a part is a view of this chunk rather than a copy of it.
+struct WatchedChunk {
+    bytes: Vec<u8>,
+    retention: Arc<Retention>,
+}
+
+impl AsRef<[u8]> for WatchedChunk {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl Drop for WatchedChunk {
+    fn drop(&mut self) {
+        self.retention.released(self.bytes.len());
+    }
+}
+
+/// A payload that reports how much of itself is being held.
+///
+/// Chunks are cut at the part size on purpose: the part reader hands a
+/// part-filling chunk straight through instead of copying it, so a part
+/// keeps its chunk alive for exactly as long as the uploader keeps the
+/// part. A source chunked more finely would be copied into part buffers and
+/// released early, which would measure the source rather than the uploader.
+fn watched_source(payload: &[u8], chunk_bytes: usize) -> (PayloadSource, Arc<Retention>) {
+    let retention = Arc::new(Retention::default());
+    let chunks: Vec<Vec<u8>> = payload
+        .chunks(chunk_bytes)
+        .map(<[u8]>::to_vec)
+        .collect::<Vec<_>>();
+    let handed = Arc::clone(&retention);
+    let stream = futures::stream::iter(chunks.into_iter().map(move |bytes| {
+        handed.handed_out(bytes.len());
+        Ok(Bytes::from_owner(WatchedChunk {
+            bytes,
+            retention: Arc::clone(&handed),
+        }))
+    }))
+    .boxed();
+    let size_bytes = payload.len() as u64;
+    (PayloadSource::sized_stream(stream, size_bytes), retention)
+}
+
+fn payload(len: usize) -> Vec<u8> {
+    (0..len).map(|offset| (offset % 251) as u8).collect()
+}
+
+fn namespace_id() -> NamespaceId {
+    NamespaceId::parse("demo").expect("valid namespace id")
+}
+
+fn spec() -> NamespacePath {
+    NamespacePath::parse("demo", "/big.bin").expect("valid namespace path")
+}
+
+fn upload_id() -> UploadId {
+    UploadId::parse("upl_00000000000000000000000000000001").expect("valid upload id")
+}
+
+fn client() -> Client {
+    Client::new(ClientConfig {
+        server_url: "http://example.invalid".to_owned(),
+        auth_token: None,
+        request_timeout_ms: None,
+        disable_transient_retry: false,
+    })
+    .expect("valid client config")
+}
+
+fn json(value: &impl serde::Serialize) -> Outcome {
+    Outcome::Success(serde_json::to_vec(value).expect("serialize scripted response"))
+}
+
+/// A capability document advertising whichever upload transports the test
+/// wants the deployment to offer.
+fn capabilities(direct_multipart: bool) -> Outcome {
+    let document = CapabilityDocument {
+        protocol_version: PROTOCOL_VERSION.to_owned(),
+        profiles: vec![PROFILE_CORE_V0.to_owned()],
+        features: std::collections::BTreeMap::from([(
+            FEATURE_UPLOADS_DIRECT_MULTIPART.to_owned(),
+            direct_multipart,
+        )]),
+        limits: std::collections::BTreeMap::new(),
+    };
+    json(&document)
+}
+
+fn begin_multipart() -> Outcome {
+    json(&BeginUploadResponse {
+        namespace_id: namespace_id(),
+        upload_id: upload_id(),
+        mode: UploadMode::DirectMultipart,
+        direct_put: None,
+        direct_multipart: Some(DirectMultipartUpload {
+            part_size_bytes: TEST_PART_BYTES,
+        }),
+    })
+}
+
+fn begin_proxied() -> Outcome {
+    json(&BeginUploadResponse {
+        namespace_id: namespace_id(),
+        upload_id: upload_id(),
+        mode: UploadMode::ServiceProxied,
+        direct_put: None,
+        direct_multipart: None,
+    })
+}
+
+/// Authorizes `count` parts starting at `first`, as one wave's signing
+/// response would.
+fn signed_parts(first: u32, count: u32) -> Outcome {
+    json(&SignUploadPartsResponse {
+        namespace_id: namespace_id(),
+        upload_id: upload_id(),
+        parts: (first..first + count)
+            .map(|part_number| SignedUploadPart {
+                part_number,
+                access: ObjectTransferAccess::PresignedUrl {
+                    method: "PUT".to_owned(),
+                    url: format!("http://provider.invalid/part/{part_number}"),
+                    headers: std::collections::BTreeMap::new(),
+                    expires_at_ms: 1,
+                },
+            })
+            .collect(),
+    })
+}
+
+fn content_ref(bytes: &[u8]) -> ContentRef {
+    ContentRef::blob_v1(ContentId::generate(), bytes)
+}
+
+fn completed(content_ref: ContentRef) -> Outcome {
+    json(&CompleteUploadResponse {
+        namespace_id: namespace_id(),
+        upload_id: upload_id(),
+        content_ref,
+        validated_content_token: None,
+    })
+}
+
+fn commit_landed() -> Outcome {
+    json(&ApiCommitResponse {
+        namespace_id: namespace_id(),
+        commit_id: CommitId::parse("c_00000000000000000000000000000001").expect("valid commit id"),
+        committed_seq: ChangeSeq(1),
+    })
+}
+
+/// The scripted conversation a direct-multipart put has: capabilities,
+/// begin, then per wave one signing request and one upload per part, then
+/// completion and the commit.
+fn multipart_script(parts: u32, uploaded: ContentRef) -> Vec<Outcome> {
+    let mut script = vec![capabilities(true), begin_multipart()];
+    let window = DIRECT_MULTIPART_PARTS_IN_FLIGHT as u32;
+    let mut next = 1;
+    while next <= parts {
+        let wave = window.min(parts + 1 - next);
+        script.push(signed_parts(next, wave));
+        for part_number in next..next + wave {
+            script.push(Outcome::PartAccepted(format!("\"etag-{part_number}\"")));
+        }
+        next += wave;
+    }
+    // A payload that ends on a wave boundary needs one more wave to be told
+    // the source is done; this one does not.
+    script.push(completed(uploaded));
+    script.push(commit_landed());
+    script
+}
+
+/// A large put reads its source once and never holds more of it than the
+/// window it uploads in.
+#[tokio::test]
+async fn a_direct_multipart_put_holds_only_its_window() {
+    let payload = payload(TEST_PAYLOAD_BYTES);
+    let (source, retention) = watched_source(&payload, TEST_PART_BYTES as usize);
+    let _transport =
+        test_transport::script(multipart_script(TEST_PAYLOAD_PARTS, content_ref(&payload)));
+
+    client()
+        .put_file_stream(&spec(), source, &PutFileOptions::default())
+        .await
+        .expect("a scripted multipart put should land");
+
+    let window_bound = DIRECT_MULTIPART_PARTS_IN_FLIGHT as u64 * TEST_PART_BYTES;
+    assert_eq!(
+        retention.total_bytes(),
+        TEST_PAYLOAD_BYTES as u64,
+        "every payload byte crossed the source boundary exactly once"
+    );
+    assert!(
+        retention.peak_live_bytes() <= window_bound,
+        "the put held {} bytes at once, past its {window_bound}-byte window",
+        retention.peak_live_bytes()
+    );
+    assert!(
+        retention.peak_live_chunks() <= DIRECT_MULTIPART_PARTS_IN_FLIGHT,
+        "the put held {} parts at once",
+        retention.peak_live_chunks()
+    );
+}
+
+/// Nothing about the flow depends on knowing the length first: a source
+/// that cannot say how long it is takes the same path and the same window.
+#[tokio::test]
+async fn an_unknown_length_source_uploads_the_same_way() {
+    let payload = payload(TEST_PAYLOAD_BYTES);
+    let (sized, retention) = watched_source(&payload, TEST_PART_BYTES as usize);
+    let (stream, size_bytes) = sized.into_stream();
+    assert_eq!(size_bytes, Some(TEST_PAYLOAD_BYTES as u64));
+    // Throw the length away: this is the pipe's view of the same bytes.
+    let source = PayloadSource::stream(stream);
+    assert_eq!(source.size_bytes(), None);
+    let _transport =
+        test_transport::script(multipart_script(TEST_PAYLOAD_PARTS, content_ref(&payload)));
+
+    client()
+        .put_file_stream(&spec(), source, &PutFileOptions::default())
+        .await
+        .expect("a length-less source should upload");
+
+    assert_eq!(retention.total_bytes(), TEST_PAYLOAD_BYTES as u64);
+    assert!(
+        retention.peak_live_bytes() <= DIRECT_MULTIPART_PARTS_IN_FLIGHT as u64 * TEST_PART_BYTES,
+        "peak was {}",
+        retention.peak_live_bytes()
+    );
+}
+
+/// A deployment that cannot authorize part uploads gets the same source as
+/// a request body, and the client accumulates none of it.
+#[tokio::test]
+async fn a_proxied_put_streams_its_body() {
+    let payload = payload(TEST_PAYLOAD_BYTES);
+    let chunk_bytes = 16 * 1024;
+    let (source, retention) = watched_source(&payload, chunk_bytes);
+    let uploaded = content_ref(&payload);
+    let _transport = test_transport::script(vec![
+        capabilities(false),
+        begin_proxied(),
+        json(&UploadContentResponse {
+            namespace_id: namespace_id(),
+            upload_id: upload_id(),
+            content_ref: uploaded.clone(),
+        }),
+        completed(uploaded),
+        commit_landed(),
+    ]);
+
+    client()
+        .put_file_stream(&spec(), source, &PutFileOptions::default())
+        .await
+        .expect("a scripted proxied put should land");
+
+    assert_eq!(
+        retention.total_bytes(),
+        TEST_PAYLOAD_BYTES as u64,
+        "the whole payload was forwarded"
+    );
+    assert!(
+        retention.peak_live_bytes() <= (2 * chunk_bytes) as u64,
+        "a forwarded body should never accumulate; peak was {}",
+        retention.peak_live_bytes()
+    );
+}
+
+/// A source the deployment cannot take parts from, and that says it is
+/// small, goes through the server rather than opening a one-part multipart
+/// session.
+#[tokio::test]
+async fn a_small_sized_source_skips_the_part_machinery() {
+    let payload = payload(1_000);
+    let uploaded = content_ref(&payload);
+    let (source, _) = watched_source(&payload, 512);
+    let _transport = test_transport::script(vec![
+        // No capability request at all: a source that knows it is small
+        // never asks whether parts are on offer.
+        begin_proxied(),
+        json(&UploadContentResponse {
+            namespace_id: namespace_id(),
+            upload_id: upload_id(),
+            content_ref: uploaded.clone(),
+        }),
+        completed(uploaded),
+        commit_landed(),
+    ]);
+
+    client()
+        .put_file_stream(&spec(), source, &PutFileOptions::default())
+        .await
+        .expect("a small streamed put should land");
+}
+
+/// Sends one streamed body to a socket that only reads and reports the
+/// request head, so the framing the client chose is observable.
+async fn request_head_for(source: PayloadSource) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind a probe socket");
+    let address = listener.local_addr().expect("probe address");
+    let served = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept the request");
+        let mut buffer = vec![0u8; 4096];
+        let read = tokio::io::AsyncReadExt::read(&mut socket, &mut buffer)
+            .await
+            .expect("read the request head");
+        let _ = tokio::io::AsyncWriteExt::write_all(
+            &mut socket,
+            b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\n{}",
+        )
+        .await;
+        String::from_utf8_lossy(&buffer[..read]).to_lowercase()
+    });
+
+    let client = Client::new(ClientConfig {
+        server_url: format!("http://{address}"),
+        auth_token: None,
+        request_timeout_ms: None,
+        disable_transient_retry: true,
+    })
+    .expect("valid client config");
+    // The response is not the point; the request head is.
+    let _ = client
+        .upload_streamed_content(&namespace_id(), &upload_id(), source)
+        .await;
+    served.await.expect("probe task")
+}
+
+/// A source that knows its length declares it, so the server can refuse an
+/// oversized body before reading it.
+#[tokio::test]
+async fn a_sized_source_frames_its_body_with_a_content_length() {
+    let stream = futures::stream::iter(vec![Ok(Bytes::from_static(b"0123456789"))]).boxed();
+    let head = request_head_for(PayloadSource::sized_stream(stream, 10)).await;
+
+    assert!(head.contains("content-length: 10"), "{head}");
+    assert!(
+        !head.contains("chunked"),
+        "a body of known length is not chunked: {head}"
+    );
+}
+
+/// A source that cannot know its length is framed chunked, which is the
+/// only honest framing for it — and the case the server's incremental cap
+/// exists to bound.
+#[tokio::test]
+async fn an_unsized_source_frames_its_body_chunked() {
+    let stream = futures::stream::iter(vec![Ok(Bytes::from_static(b"0123456789"))]).boxed();
+    let head = request_head_for(PayloadSource::stream(stream)).await;
+
+    assert!(head.contains("transfer-encoding: chunked"), "{head}");
+    assert!(
+        !head.contains("content-length"),
+        "a body of unknown length cannot declare one: {head}"
+    );
+}
+
+/// The evidence a streamed put keeps is the reference the server minted for
+/// it, and it answers only what it actually knows.
+#[test]
+fn streamed_evidence_answers_only_the_digests_it_has() {
+    let bytes = b"the same bytes twice";
+    let sha256 = ContentRef::blob_v1(ContentId::generate(), bytes);
+    let streamed = UploadedContent::Streamed(&sha256);
+    assert_eq!(streamed.size_bytes(), bytes.len() as u64);
+    assert_eq!(
+        streamed.matches(&StorageChecksum::sha256(bytes)),
+        Some(true)
+    );
+    assert_eq!(
+        streamed.matches(&StorageChecksum::sha256(b"other bytes entirely")),
+        Some(false)
+    );
+    // A provider-assembled object is described by a CRC, and a SHA-256
+    // reference cannot be compared against it. That is a refusal, not
+    // agreement.
+    assert_eq!(
+        streamed.matches(&StorageChecksum::crc64nvme(bytes)),
+        None,
+        "a digest nobody computed over this payload must not be answered"
+    );
+
+    let assembled = ContentRef {
+        kind: sha256.kind,
+        content_id: sha256.content_id.clone(),
+        size_bytes: sha256.size_bytes,
+        storage_checksum: StorageChecksum::crc64nvme(bytes),
+        whole_file_sha256: None,
+    };
+    let streamed = UploadedContent::Streamed(&assembled);
+    assert_eq!(
+        streamed.matches(&StorageChecksum::crc64nvme(bytes)),
+        Some(true),
+        "the digest one pass folded is what a multipart retry compares"
+    );
+    assert_eq!(
+        streamed.matches(&StorageChecksum::crc64nvme(b"different bytes here")),
+        Some(false)
+    );
+    assert_eq!(streamed.matches(&StorageChecksum::sha256(bytes)), None);
+}
+
+/// Held bytes can answer any digest this build knows, which is why the
+/// buffered path never has to refuse.
+#[test]
+fn held_evidence_recomputes_whatever_it_is_asked() {
+    let bytes = b"held in memory";
+    let held = UploadedContent::Bytes(bytes);
+    assert_eq!(held.size_bytes(), bytes.len() as u64);
+    assert_eq!(held.matches(&StorageChecksum::sha256(bytes)), Some(true));
+    assert_eq!(held.matches(&StorageChecksum::crc64nvme(bytes)), Some(true));
+    assert_eq!(
+        held.matches(&StorageChecksum::sha256(b"something else")),
+        Some(false)
+    );
+}

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -1,7 +1,8 @@
 //! The HTTP transport: request building, the bounded transient retry, and
 //! response-to-error mapping.
 
-use crate::{Client, ClientError, Result};
+use crate::{Client, ClientError, PayloadStream, Result};
+use bytes::Bytes;
 use loonfs_api::{ApiError, ErrorCode};
 use reqwest::Method;
 use std::time::Duration;
@@ -119,7 +120,9 @@ impl Client {
             Some(body) => {
                 // Serialized once: every retry attempt resends identical
                 // bytes when this call site permits a resend.
-                Some(serde_json::to_vec(body).map_err(|err| ClientError::Json(err.to_string()))?)
+                Some(Bytes::from(
+                    serde_json::to_vec(body).map_err(|err| ClientError::Json(err.to_string()))?,
+                ))
             }
             None => None,
         };
@@ -128,10 +131,10 @@ impl Client {
             None => request,
         };
         let bytes = if retry {
-            self.call_with_transient_retry(&request, body.as_deref())
+            self.call_with_transient_retry(&request, body.as_ref())
                 .await?
         } else {
-            self.call_once(&request, body.as_deref()).await?
+            self.call_once(&request, body.as_ref()).await?
         };
         serde_json::from_slice(&bytes).map_err(|err| ClientError::Json(err.to_string()))
     }
@@ -146,9 +149,29 @@ impl Client {
     pub(crate) async fn call_once(
         &self,
         request: &WireRequest,
-        body: Option<&[u8]>,
+        body: Option<&Bytes>,
     ) -> Result<Vec<u8>> {
         self.send(request, body)
+            .await
+            .map(|response| response.bytes)
+            .map_err(|attempt| attempt.error)
+    }
+
+    /// Sends one request whose body arrives in pieces, and never resends it.
+    ///
+    /// A stream is consumed by the attempt that reads it, so there is no
+    /// second attempt to make: this is the one call whose failure is always
+    /// the caller's to handle. `size_bytes` declares the length when the
+    /// source knows it, and its absence is what puts the request on chunked
+    /// transfer encoding — which is the honest framing for a payload whose
+    /// length nobody knows yet.
+    pub(crate) async fn call_streamed_once(
+        &self,
+        request: &WireRequest,
+        body: PayloadStream,
+        size_bytes: Option<u64>,
+    ) -> Result<Vec<u8>> {
+        self.send_streamed(request, body, size_bytes)
             .await
             .map(|response| response.bytes)
             .map_err(|attempt| attempt.error)
@@ -170,7 +193,7 @@ impl Client {
     pub(crate) async fn call_with_transient_retry(
         &self,
         request: &WireRequest,
-        body: Option<&[u8]>,
+        body: Option<&Bytes>,
     ) -> Result<Vec<u8>> {
         self.call_with_transient_retry_headers(request, body)
             .await
@@ -185,7 +208,7 @@ impl Client {
     pub(crate) async fn call_with_transient_retry_headers(
         &self,
         request: &WireRequest,
-        body: Option<&[u8]>,
+        body: Option<&Bytes>,
     ) -> Result<WireResponse> {
         let mut attempts = 0;
         loop {
@@ -208,12 +231,46 @@ impl Client {
     async fn send(
         &self,
         request: &WireRequest,
-        body: Option<&[u8]>,
+        body: Option<&Bytes>,
     ) -> std::result::Result<WireResponse, FailedAttempt> {
         #[cfg(test)]
         if let Some(outcome) = test_transport::next() {
-            return outcome.map(WireResponse::without_headers);
+            return outcome;
         }
+        let mut builder = self.build(request);
+        if let Some(bytes) = body {
+            // Cloning a `Bytes` shares the allocation rather than copying
+            // it. That is what keeps a part upload's memory equal to the
+            // part the caller is already holding, instead of twice it.
+            builder = builder.body(bytes.clone());
+        }
+        self.dispatch(request, builder).await
+    }
+
+    /// [`Self::send`] for a body that arrives in pieces.
+    async fn send_streamed(
+        &self,
+        request: &WireRequest,
+        body: PayloadStream,
+        size_bytes: Option<u64>,
+    ) -> std::result::Result<WireResponse, FailedAttempt> {
+        #[cfg(test)]
+        if let Some(outcome) = test_transport::next() {
+            // Drain the body so a scripted test still observes the source
+            // being read exactly once, as a real send would.
+            let mut body = body;
+            while futures::StreamExt::next(&mut body).await.is_some() {}
+            return outcome;
+        }
+        let mut builder = self.build(request).body(reqwest::Body::wrap_stream(body));
+        if let Some(size_bytes) = size_bytes {
+            builder = builder.header(http::header::CONTENT_LENGTH, size_bytes);
+        }
+        self.dispatch(request, builder).await
+    }
+
+    /// The parts of a request that do not depend on its body.
+    fn build(&self, request: &WireRequest) -> reqwest::RequestBuilder {
         let mut builder = self.http.request(request.method.clone(), &request.url);
         if request.authenticate {
             if let Some(token) = &self.auth_token {
@@ -223,10 +280,15 @@ impl Client {
         for (name, value) in &request.headers {
             builder = builder.header(name.as_str(), value.as_str());
         }
-        if let Some(bytes) = body {
-            builder = builder.body(bytes.to_vec());
-        }
+        builder
+    }
 
+    /// Sends a built request and reads its response.
+    async fn dispatch(
+        &self,
+        request: &WireRequest,
+        builder: reqwest::RequestBuilder,
+    ) -> std::result::Result<WireResponse, FailedAttempt> {
         let response = builder.send().await.map_err(|err| FailedAttempt {
             transport: true,
             error: ClientError::Http(describe_send_error(&request.url, &err)),
@@ -265,14 +327,6 @@ impl WireResponse {
         name: reqwest::header::HeaderName,
     ) -> Option<&reqwest::header::HeaderValue> {
         self.headers.get(name)
-    }
-
-    #[cfg(test)]
-    fn without_headers(bytes: Vec<u8>) -> Self {
-        Self {
-            headers: reqwest::header::HeaderMap::new(),
-            bytes,
-        }
     }
 }
 
@@ -379,14 +433,18 @@ async fn transient_retry_pause(backoff: Duration) {
 
 #[cfg(test)]
 pub(crate) mod test_transport {
-    use super::FailedAttempt;
+    use super::{FailedAttempt, WireResponse};
     use crate::ClientError;
     use std::cell::RefCell;
     use std::collections::VecDeque;
 
-    enum Outcome {
+    /// One response a scripted transport serves, in order.
+    pub(crate) enum Outcome {
         TransportFailure,
         Success(Vec<u8>),
+        /// A provider's answer to a part upload, whose result is its etag
+        /// header rather than its body.
+        PartAccepted(String),
     }
 
     struct State {
@@ -429,6 +487,12 @@ pub(crate) mod test_transport {
         install([Outcome::TransportFailure, Outcome::Success(body)])
     }
 
+    /// Serves a scripted conversation: one outcome per request the client
+    /// makes, in the order it makes them.
+    pub(crate) fn script(outcomes: impl IntoIterator<Item = Outcome>) -> Guard {
+        install(outcomes)
+    }
+
     fn install(outcomes: impl IntoIterator<Item = Outcome>) -> Guard {
         STATE.with(|state| {
             let replaced = state.borrow_mut().replace(State {
@@ -440,7 +504,7 @@ pub(crate) mod test_transport {
         Guard
     }
 
-    pub(super) fn next() -> Option<Result<Vec<u8>, FailedAttempt>> {
+    pub(super) fn next() -> Option<Result<WireResponse, FailedAttempt>> {
         STATE.with(|state| {
             let mut state = state.borrow_mut();
             let state = state.as_mut()?;
@@ -454,7 +518,21 @@ pub(crate) mod test_transport {
                     transport: true,
                     error: ClientError::Http("injected transport failure".to_owned()),
                 }),
-                Outcome::Success(body) => Ok(body),
+                Outcome::Success(bytes) => Ok(WireResponse {
+                    headers: reqwest::header::HeaderMap::new(),
+                    bytes,
+                }),
+                Outcome::PartAccepted(etag) => {
+                    let mut headers = reqwest::header::HeaderMap::new();
+                    headers.insert(
+                        reqwest::header::ETAG,
+                        etag.parse().expect("etag is a valid header value"),
+                    );
+                    Ok(WireResponse {
+                        headers,
+                        bytes: Vec::new(),
+                    })
+                }
             })
         })
     }

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -56,11 +56,12 @@ pub struct ServerConfig {
     #[serde(default = "default_min_publish_interval_ms")]
     pub min_publish_interval_ms: u64,
     /// Largest request body accepted for service-proxied upload content
-    /// requests (`PUT .../uploads/{upload_id}/content`). The server buffers
-    /// each upload body in memory, so this bounds per-request memory;
-    /// clients may use `direct_put` for larger transfers when the capability
-    /// is advertised. Advertised as the `upload.max_content_bytes`
-    /// capability limit.
+    /// requests (`PUT .../uploads/{upload_id}/content`). Enforced
+    /// incrementally while the body streams to the store, so it bounds the
+    /// accepted transfer size, not per-request memory (streamed writes hold
+    /// at most one internal part). Clients may use `direct_put` or direct
+    /// multipart for larger transfers when the capability is advertised.
+    /// Advertised as the `upload.max_content_bytes` capability limit.
     #[serde(default = "default_max_upload_bytes")]
     pub max_upload_bytes: u64,
     /// Largest file content a service-proxied read (`GET .../filesystem/
@@ -70,9 +71,10 @@ pub struct ServerConfig {
     /// `download.max_content_bytes` capability limit.
     #[serde(default = "default_max_download_bytes")]
     pub max_download_bytes: u64,
-    /// How many proxied upload bodies the server will buffer at once;
-    /// requests past the cap answer `server_busy` before any buffering.
-    /// Worst-case upload memory is this times `max_upload_bytes`.
+    /// How many proxied upload bodies the server will stream at once;
+    /// requests past the cap answer `server_busy` before any transfer.
+    /// Worst-case upload memory is this times one streamed part, since
+    /// bodies forward to the store incrementally instead of buffering.
     #[serde(default = "default_max_concurrent_uploads")]
     pub max_concurrent_uploads: usize,
     /// How many proxied content reads the server will materialize at once;

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -1,6 +1,8 @@
 // Ignored real-provider tests exercise the full server/client/direct-object-store path.
 
 use crate::common::{start_server, test_config};
+use bytes::Bytes;
+use futures::StreamExt;
 use loonfs_api::{
     v0::{
         CompleteUploadRequest, DirectMultipartContentClaim, DirectMultipartUploadOptions,
@@ -10,7 +12,7 @@ use loonfs_api::{
     ChangeSeq, CommitId, CommitRequest, CommitResponse, DestinationBehavior, FilesystemOperation,
     NamespaceId, StorageChecksum,
 };
-use loonfs_client::{Client, ClientError, NamespacePath};
+use loonfs_client::{Client, ClientError, NamespacePath, PayloadSource};
 use loonfs_objectstore::ObjectStore;
 use loonfs_server::{ServerConfig, StoreConfig};
 use std::fmt;
@@ -527,10 +529,10 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
         let index = part.part_number as usize - 1;
         let client = harness.client.clone();
         let crc64nvme = claims[index].crc64nvme.clone();
-        let chunk = chunks[index].to_vec();
+        let chunk = Bytes::copy_from_slice(chunks[index]);
         in_flight.spawn(async move {
             client
-                .upload_part_via_presigned_url(part.part_number, &part.access, crc64nvme, &chunk)
+                .upload_part_via_presigned_url(part.part_number, &part.access, crc64nvme, chunk)
                 .await
         });
     }
@@ -545,7 +547,7 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
             repeated.part_number,
             &repeated.access,
             claims[1].crc64nvme.clone(),
-            chunks[1],
+            Bytes::copy_from_slice(chunks[1]),
         )
         .await
         .expect("re-uploading a part is allowed and last-write-wins");
@@ -652,8 +654,85 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
         .expect("rerunning identical bytes is idempotent without a sha256");
     assert_eq!(replayed_rerun, rerun);
 
+    one_pass_puts_against_the_provider(&harness, namespace).await;
+
     harness.server.abort();
     delete_everything_under_the_run_prefix(&store_config).await;
+}
+
+/// The one-pass path, against the provider that has to accept it.
+///
+/// Both puts here are what `loon put` runs: a payload that is never held
+/// whole, cut into parts as it is read, with the object's length and digest
+/// discovered on the way past and claimed at completion. The first reads a
+/// real file from disk — the size that matters is the file's, not this
+/// process's — and the second reads a source that cannot say how long it
+/// is, which is the case a pipe presents and the one no amount of buffering
+/// would rescue.
+async fn one_pass_puts_against_the_provider(harness: &crate::common::TestServer, namespace: &str) {
+    // Three parts and a bit at the deployment's geometry, so the pass
+    // crosses a wave boundary and ends on a short part.
+    let payload: Vec<u8> = (0..3 * MULTIPART_PART_SIZE + 4_096)
+        .map(|offset| (offset % 251) as u8)
+        .collect();
+
+    let file = tempfile::NamedTempFile::new().expect("temp file for the one-pass put");
+    std::fs::write(file.path(), &payload).expect("write the payload to disk");
+    let from_file = NamespacePath::parse(namespace, "/one-pass-file.bin").expect("file target");
+    harness
+        .client
+        .put_file_stream(
+            &from_file,
+            PayloadSource::open_file(file.path())
+                .await
+                .expect("open the payload file"),
+            &put_options("one-pass-file"),
+        )
+        .await
+        .expect("a file streams straight into object storage");
+    assert_eq!(
+        harness
+            .client
+            .get_file_bytes(&from_file)
+            .await
+            .expect("read the file back"),
+        payload,
+        "the object the provider assembled is the file that was read"
+    );
+
+    // The same flow with the length withheld. Nothing in the transport
+    // needed it: begin declares nothing, and the claim is produced by the
+    // pass itself.
+    let piped = NamespacePath::parse(namespace, "/one-pass-piped.bin").expect("piped target");
+    let chunks: Vec<Bytes> = payload
+        .chunks(64 * 1024)
+        .map(Bytes::copy_from_slice)
+        .collect();
+    let source = PayloadSource::stream(futures::stream::iter(chunks.into_iter().map(Ok)).boxed());
+    assert_eq!(source.size_bytes(), None, "this source declares no length");
+    harness
+        .client
+        .put_file_stream(&piped, source, &put_options("one-pass-piped"))
+        .await
+        .expect("a source of unknown length uploads the same way");
+    assert_eq!(
+        harness
+            .client
+            .get_file_bytes(&piped)
+            .await
+            .expect("read the piped payload back"),
+        payload,
+        "a payload nobody measured up front still lands byte for byte"
+    );
+}
+
+fn put_options(commit_id: &str) -> loonfs_client::PutFileOptions {
+    loonfs_client::PutFileOptions {
+        behavior: DestinationBehavior::NoReplace,
+        commit_id: Some(CommitId::parse(commit_id).expect("valid commit id")),
+        message: None,
+        expected_revision_no: None,
+    }
 }
 
 /// Removes every object this run wrote.

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -26,6 +26,50 @@ const COMMIT_LOOKUP_WINDOW: NonZeroU32 = NonZeroU32::new(128).expect("non-zero w
 /// found", never a guess.
 const COMMIT_LOOKUP_MAX_WINDOWS: usize = 8;
 
+/// What a retry can still say about the payload it just staged.
+///
+/// A buffered put can answer any question about its bytes by hashing them
+/// again. A streamed put cannot: the payload went by once and is gone, and
+/// what it kept instead is the reference the write path built while hashing
+/// it. Both describe the same bytes; they differ only in which questions
+/// they can answer, and a question neither can answer is reported as such
+/// rather than guessed at.
+#[derive(Debug, Clone, Copy)]
+enum StagedPayload<'a> {
+    /// The payload itself, which can produce any digest this build knows.
+    Bytes(&'a [u8]),
+    /// The reference built for a payload that was streamed past.
+    Streamed(&'a ContentRef),
+}
+
+impl StagedPayload<'_> {
+    /// Complete length of what was staged.
+    fn size_bytes(&self) -> u64 {
+        match self {
+            Self::Bytes(bytes) => bytes.len() as u64,
+            Self::Streamed(content_ref) => content_ref.size_bytes,
+        }
+    }
+
+    /// Whether the staged bytes produce this checksum. `None` is a refusal
+    /// to answer, never agreement.
+    fn matches(&self, expected: &StorageChecksum) -> Option<bool> {
+        match self {
+            Self::Bytes(bytes) => expected.matches(bytes),
+            Self::Streamed(content_ref) => {
+                let observed = if content_ref.storage_checksum.algorithm == expected.algorithm {
+                    Some(content_ref.storage_checksum.value.as_str())
+                } else if expected.algorithm == ChecksumAlgorithm::Sha256 {
+                    content_ref.whole_file_sha256.as_deref()
+                } else {
+                    None
+                };
+                Some(observed? == expected.value)
+            }
+        }
+    }
+}
+
 /// The content one committed change wrote, if it wrote any.
 fn committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
     change.events.iter().find_map(|event| match event {
@@ -107,11 +151,81 @@ impl FsWriter {
         let published = self
             .put_file_prepared(namespace_id, absolute_path, prepared_content, options)
             .await;
+        self.settle_put(
+            namespace_id,
+            commit_id,
+            published,
+            StagedPayload::Bytes(bytes),
+        )
+        .await
+    }
+
+    /// Writes a file from a payload read once from its source.
+    ///
+    /// This is [`Self::put_file_bytes`] for a caller that should not hold
+    /// its payload: the stream is hashed as it is forwarded to object
+    /// storage and never held whole, so a large file costs one transfer
+    /// part of memory rather than its own size. Everything after the bytes
+    /// land is identical — same trusted whole-file SHA-256, same
+    /// publication, same retry reconciliation — so a caller that already
+    /// holds its bytes has no reason to come here.
+    ///
+    /// Retrying with a `commit_id` that already committed is safe in the
+    /// same way it is for the buffered call. The evidence is different only
+    /// because the payload is gone: what this pass measured and hashed on
+    /// the way past is what the reconciliation compares.
+    #[tracing::instrument(
+        level = "info",
+        name = "loonfs.put",
+        err,
+        skip_all,
+        fields(
+            operation = "put",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            payload_class = "streamed",
+        )
+    )]
+    pub async fn put_file_stream(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        body: ByteStream,
+        options: PutFileOptions,
+    ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
+        let commit_id = options.commit_id.clone();
+        let prepared_content = self.prepare_file_stream(namespace_id, body).await?;
+        // The prepared reference describes the bytes that just went past,
+        // and with the payload gone it is the only description of them that
+        // still exists.
+        let staged = prepared_content.content_ref().clone();
+        let published = self
+            .put_file_prepared(namespace_id, absolute_path, prepared_content, options)
+            .await;
+        self.settle_put(
+            namespace_id,
+            commit_id,
+            published,
+            StagedPayload::Streamed(&staged),
+        )
+        .await
+    }
+
+    /// Turns a reused-commit-id rejection into the answer the retry
+    /// deserves, and passes everything else through.
+    async fn settle_put(
+        &self,
+        namespace_id: &NamespaceId,
+        commit_id: Option<CommitId>,
+        published: Result<CommitResponse>,
+        staged: StagedPayload<'_>,
+    ) -> Result<CommitResponse> {
         match (published, commit_id) {
             (Err(error), Some(commit_id))
                 if error.code() == loonfs_core::ErrorCode::CommitIdReuseConflict =>
             {
-                self.reconcile_commit_id_reuse(namespace_id, &commit_id, bytes, error)
+                self.reconcile_commit_id_reuse(namespace_id, &commit_id, staged, error)
                     .await
             }
             (published, _) => published,
@@ -128,7 +242,7 @@ impl FsWriter {
         &self,
         namespace_id: &NamespaceId,
         commit_id: &CommitId,
-        bytes: &[u8],
+        staged: StagedPayload<'_>,
         conflict: RuntimeError,
     ) -> Result<CommitResponse> {
         let Some(committed) = self.find_committed_change(namespace_id, commit_id).await? else {
@@ -137,7 +251,7 @@ impl FsWriter {
         let Some(content_ref) = committed_content_ref(&committed) else {
             return Err(conflict);
         };
-        if content_ref.size_bytes != bytes.len() as u64 {
+        if content_ref.size_bytes != staged.size_bytes() {
             return Err(conflict);
         }
 
@@ -151,7 +265,7 @@ impl FsWriter {
             },
             None => content_ref.storage_checksum.clone(),
         };
-        match evidence.matches(bytes) {
+        match staged.matches(&evidence) {
             Some(true) => Ok(CommitResponse {
                 namespace_id: namespace_id.clone(),
                 commit_id: committed.commit_id,
@@ -160,8 +274,8 @@ impl FsWriter {
             Some(false) => Err(conflict),
             None => Err(RuntimeError::Config(format!(
                 "commit `{commit_id}` already committed content checksummed with `{}`, \
-                 which this build cannot recompute, so it cannot tell whether this is \
-                 the same upload retried",
+                 which this build cannot compare against what it just staged, so it \
+                 cannot tell whether this is the same upload retried",
                 evidence.algorithm
             ))),
         }

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -8,11 +8,25 @@
 //! counts as agreement.
 
 use crate::common::{open_runtime_async, store, TestRuntime};
-use loonfs::{CommitId, CreateNamespaceOptions, DestinationBehavior, NamespaceId, PutFileOptions};
+use bytes::Bytes;
+use futures::StreamExt;
+use loonfs::{
+    ByteStream, CommitId, CreateNamespaceOptions, DestinationBehavior, NamespaceId, PutFileOptions,
+};
 use loonfs_api::ErrorCode;
 use tempfile::tempdir;
 
 const PATH: &str = "/docs/retry.txt";
+
+/// A payload delivered the way a large one is: in pieces, with nothing
+/// holding it whole.
+fn streamed(payload: &[u8], chunk_bytes: usize) -> ByteStream {
+    let chunks: Vec<Bytes> = payload
+        .chunks(chunk_bytes)
+        .map(Bytes::copy_from_slice)
+        .collect();
+    futures::stream::iter(chunks.into_iter().map(Ok)).boxed()
+}
 
 fn options(commit_id: &CommitId) -> PutFileOptions {
     PutFileOptions {
@@ -149,4 +163,125 @@ async fn an_unused_commit_id_is_an_ordinary_commit() {
         .expect("a fresh commit id is a fresh commit");
 
     assert!(second.committed_seq > first.committed_seq);
+}
+
+/// The same reconciliation for a payload nobody held: rerunning a streamed
+/// put with the same commit id and the same bytes replays the commit that
+/// already landed. The evidence is what the pass measured and hashed,
+/// because the bytes themselves are long gone.
+#[tokio::test]
+async fn rerunning_a_streamed_put_with_the_same_commit_id_replays_on_identical_bytes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-stream").expect("valid commit id");
+    let payload = vec![7u8; 300_000];
+
+    let first = runtime
+        .writer
+        .put_file_stream(
+            &namespace_id,
+            PATH,
+            streamed(&payload, 64 * 1024),
+            options(&commit_id),
+        )
+        .await
+        .expect("first streamed put");
+    let rerun = runtime
+        .writer
+        .put_file_stream(
+            &namespace_id,
+            PATH,
+            streamed(&payload, 7_919),
+            options(&commit_id),
+        )
+        .await
+        .expect("rerunning identical bytes is idempotent");
+
+    assert_eq!(
+        rerun, first,
+        "the same bytes reconcile however the source chunked them"
+    );
+    assert_eq!(
+        runtime
+            .reader
+            .get_file_bytes(&namespace_id, PATH)
+            .await
+            .expect("read file")
+            .bytes,
+        payload
+    );
+}
+
+/// Different bytes under the same commit id are a different operation
+/// whether or not anyone held them. Same length, too, so only the digest
+/// can tell them apart.
+#[tokio::test]
+async fn different_streamed_bytes_under_a_used_commit_id_still_conflict() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-stream").expect("valid commit id");
+
+    runtime
+        .writer
+        .put_file_stream(
+            &namespace_id,
+            PATH,
+            streamed(&vec![7u8; 300_000], 64 * 1024),
+            options(&commit_id),
+        )
+        .await
+        .expect("first streamed put");
+    let error = runtime
+        .writer
+        .put_file_stream(
+            &namespace_id,
+            PATH,
+            streamed(&vec![9u8; 300_000], 64 * 1024),
+            options(&commit_id),
+        )
+        .await
+        .expect_err("different bytes are a different commit");
+
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+    assert_eq!(
+        runtime
+            .reader
+            .get_file_bytes(&namespace_id, PATH)
+            .await
+            .expect("read file")
+            .bytes,
+        vec![7u8; 300_000],
+        "the refused rerun changed nothing"
+    );
+}
+
+/// A streamed put and a buffered put of the same bytes are the same
+/// operation and reconcile against each other: both hash the whole payload
+/// themselves, so both produce the same trusted digest.
+#[tokio::test]
+async fn a_streamed_rerun_reconciles_against_a_buffered_first_run() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-either-way").expect("valid commit id");
+    let payload = vec![3u8; 100_000];
+
+    let first = runtime
+        .put_file_bytes(&namespace_id, PATH, &payload, options(&commit_id))
+        .await
+        .expect("first buffered put");
+    let rerun = runtime
+        .writer
+        .put_file_stream(
+            &namespace_id,
+            PATH,
+            streamed(&payload, 8_192),
+            options(&commit_id),
+        )
+        .await
+        .expect("the same bytes, read differently, are the same commit");
+
+    assert_eq!(rerun, first);
 }

--- a/crates/loonfs/tests/it/main.rs
+++ b/crates/loonfs/tests/it/main.rs
@@ -22,4 +22,5 @@ mod publication;
 mod publish_observer;
 mod request_accounting;
 mod runtime_config;
+mod streamed_put;
 mod undelete;

--- a/crates/loonfs/tests/it/streamed_put.rs
+++ b/crates/loonfs/tests/it/streamed_put.rs
@@ -1,0 +1,103 @@
+//! What an embedded streamed put costs in memory.
+//!
+//! The claim is that a put's memory follows the transfer's part size and
+//! not the payload's length, and the proof is retention at the store
+//! boundary: every payload buffer handed to the store reports when it is
+//! released, so the peak is exact rather than sampled. No resident-size
+//! reading and no timing are involved.
+
+use crate::common::{open_runtime_async, TestRuntime};
+use bytes::Bytes;
+use futures::StreamExt;
+use loonfs::{
+    ByteStream, CreateNamespaceOptions, DestinationBehavior, NamespaceId, PutFileOptions,
+    SharedObjectStore,
+};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::PROVIDER_MULTIPART_PART_BYTES;
+use loonfs_test_support::stores::BufferWatchStore;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+const PATH: &str = "/big.bin";
+/// Three parts and a bit: enough that holding the payload whole would show
+/// up plainly against holding one part of it.
+const PAYLOAD_BYTES: usize = 3 * PROVIDER_MULTIPART_PART_BYTES as usize + 4_096;
+/// Chunks the size of a source's reads, not the store's parts, so the
+/// store's own regrouping is what the bound has to survive.
+const CHUNK_BYTES: usize = 64 * 1024;
+
+fn payload(len: usize) -> Vec<u8> {
+    (0..len).map(|offset| (offset % 251) as u8).collect()
+}
+
+fn streamed(payload: &[u8]) -> ByteStream {
+    let chunks: Vec<Bytes> = payload
+        .chunks(CHUNK_BYTES)
+        .map(Bytes::copy_from_slice)
+        .collect();
+    futures::stream::iter(chunks.into_iter().map(Ok)).boxed()
+}
+
+async fn namespace(runtime: &TestRuntime) -> NamespaceId {
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    runtime
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    namespace_id
+}
+
+/// A streamed put never holds more of its payload than one transfer part,
+/// and every byte crosses the store boundary exactly once.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_streamed_put_holds_one_part_of_its_payload() {
+    let temp_dir = tempdir().expect("tempdir");
+    let watched = Arc::new(BufferWatchStore::watching_content(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+    ));
+    let store: SharedObjectStore = watched.clone();
+    let runtime = open_runtime_async(store, "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let payload = payload(PAYLOAD_BYTES);
+
+    runtime
+        .writer
+        .put_file_stream(
+            &namespace_id,
+            PATH,
+            streamed(&payload),
+            PutFileOptions {
+                behavior: DestinationBehavior::Replace,
+                ..PutFileOptions::default()
+            },
+        )
+        .await
+        .expect("streamed put");
+
+    let peaks = watched.peaks();
+    assert_eq!(
+        peaks.total_bytes, PAYLOAD_BYTES as u64,
+        "every payload byte crossed the store boundary exactly once"
+    );
+    assert!(
+        peaks.largest_buffer_bytes <= PROVIDER_MULTIPART_PART_BYTES,
+        "no single buffer may exceed one part: largest was {}",
+        peaks.largest_buffer_bytes
+    );
+    assert!(
+        peaks.peak_live_bytes <= PROVIDER_MULTIPART_PART_BYTES,
+        "the put held {} bytes at once, past its one-part window",
+        peaks.peak_live_bytes
+    );
+    assert_eq!(
+        runtime
+            .reader
+            .get_file_bytes(&namespace_id, PATH)
+            .await
+            .expect("read file")
+            .bytes,
+        payload,
+        "the file that landed is the payload that was streamed"
+    );
+}

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -414,9 +414,18 @@ bytes. A client that composes upload and commit must, on
 
 1. Find what that `commit_id` committed. There is no read keyed by commit
    id, so this reads the change feed and matches on `commit_id`.
-2. Compare the committed content against the bytes just uploaded: the
+2. Compare the committed content against what was just uploaded: the
    content's `whole_file_sha256` when it has one, and otherwise its
    `storage_checksum`, after checking `size_bytes`.
+
+   A client that still holds its bytes recomputes whichever digest the
+   comparison calls for. A client that streamed its payload no longer has
+   the bytes, and compares the length it measured and the digest it folded
+   during that one pass instead — for a `direct_multipart` upload, the
+   `crc64nvme` it claimed at completion, which is also what the reference
+   the server minted carries. Both are evidence about the same bytes; they
+   differ only in which digests they can answer for, and a digest the
+   upload never computed falls to rule 4 rather than being guessed at.
 3. Equal content means the logical operation had already succeeded: report
    the commit that landed, with its original `committed_seq`.
 4. Anything else surfaces a failure. Different content is the
@@ -1269,6 +1278,43 @@ final (format spec, section 3.10). What that means at the API:
   it. This is also what a completion sees when server-side cleanup aborted
   the session first; if the completion lands first instead, the cleanup's
   conditional write fails and the completed session is retained.
+
+**The one-pass client obligation.** A client uploads a large payload by
+reading its source once, forward, and never holding it whole. Nothing in the
+transport requires more than that, and every part of the flow is arranged so
+it does not have to:
+
+1. Begin a `direct_multipart` session. It declares no length and no digest,
+   so a source that cannot state its length starts uploading immediately.
+   The response settles the part geometry and nothing else.
+2. Read the source part by part. For each part, compute its `crc64nvme` for
+   the URL the server signs, and fold the same bytes into a running
+   `crc64nvme` over the whole object. One pass produces both.
+3. Ask for part URLs in waves rather than all at once — a signing request
+   names at most 1,000 parts — upload the wave's parts, and record each
+   part's `{part_number, etag, crc64nvme}`. Part bookkeeping is the
+   client's, exactly as it is in the provider's own multipart API.
+4. Hold no more than a bounded window of parts at a time. The window is the
+   memory the upload costs, and it does not depend on the payload's length.
+   A part that fails is retried by re-asking for its URL: a repeated part is
+   last-write-wins at the provider.
+5. Complete with the part list plus the `{size_bytes, crc64nvme}` this pass
+   discovered. The claim arrives here because this is the first moment a
+   one-pass uploader can produce it.
+
+A session whose upload fails partway is aborted rather than abandoned; it
+owns an object nothing will finish writing.
+
+Two bounds are worth planning for. A provider assembles at most 10,000
+parts, so a session carries at most `part_size_bytes × 10_000` bytes and a
+longer payload is refused when it asks to authorize the part past that
+ceiling — a client that knows its payload is very large asks for a larger
+part size at begin. And a deployment that does not advertise
+`core.uploads.direct_multipart` cannot authorize part uploads at all; the
+same source then goes to `PUT /content` as a streaming request body, which
+the server hashes as it forwards it on. A body whose length is unknown is
+sent with chunked transfer encoding, and the server's incremental
+accounting against `upload.max_content_bytes` is what bounds it.
 
 **Receipt expiry and re-minting.** The `validated_content_token` is the
 upload's receipt: it is minted only from a session the store already says is


### PR DESCRIPTION
This completes the content-identity arc: a large `put` now runs in bounded memory, one pass over the source, on every transport — and `loon put -` reads stdin.

The source abstraction: `PayloadSource` wraps a byte stream plus an optional length hint — the hint picks the transport and frames the request but is never a promise, so known-size files and unknown-length streams share one code path. Targets without direct multipart stream the same source through the proxy body (chunked encoding when the length is unknown); embedded targets drive 4A's streaming staging. Below 8 MiB everything keeps the existing simple path.

The measured bound is exact: 4,194,304 bytes peak for direct multipart at a 1 MiB part size.

Retry stays honest on the streaming path: rerunning an identical large put with `--commit-id` reconciles to success by size + CRC-64/NVME (computed during the pass); different bytes conflict.

Deliberate omissions: no client-side copy of the 10,000-part constant (the server owns and enforces it; the ceiling is documented), one attempt for embedded streamed puts (a stream is consumed by the attempt that reads it), and no abort on ambiguous completion failures .

Second commit: three doc comments in server config that still described pre-4A body buffering now describe the streaming path.
