### PR TITLE
feat(api): reuse conflicts report where the commit landed

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -53,6 +53,12 @@ pub struct ErrorDetails {
     /// Idempotency key of the commit the error concerns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub commit_id: Option<CommitId>,
+    /// Sequence at which that commit id already landed. Present when the
+    /// failure was decided against a durable commit receipt, which is what
+    /// holds the sequence; absent when nothing has committed under the id
+    /// yet and two live requests are simply claiming it at once.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub committed_seq: Option<ChangeSeq>,
     /// Position, in the request's operation list, of the operation that
     /// failed. A commit applies all of its operations or none of them, so
     /// this names the one that stopped the whole request.

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -59,15 +59,6 @@ const DIRECT_MULTIPART_PARTS_IN_FLIGHT: usize = 4;
 /// its signature.
 const DIRECT_MULTIPART_PART_ATTEMPTS: usize = 3;
 
-/// Change-feed sequences one lookup window covers when resolving a reused
-/// commit id.
-const COMMIT_LOOKUP_WINDOW: u64 = 128;
-
-/// Windows one lookup walks back from the feed's head before giving up. A
-/// commit being retried is a recent one; past this the answer is "not
-/// found", never a guess.
-const COMMIT_LOOKUP_MAX_WINDOWS: usize = 8;
-
 /// What a retry can still say about the payload it just uploaded.
 ///
 /// A buffered put can answer any question about its bytes by hashing them
@@ -117,6 +108,19 @@ fn digest_of(content_ref: &ContentRef, algorithm: ChecksumAlgorithm) -> Option<&
     }
     match algorithm {
         ChecksumAlgorithm::Sha256 => content_ref.whole_file_sha256.as_deref(),
+        _ => None,
+    }
+}
+
+/// Where a reuse conflict says the commit id already landed.
+///
+/// The server decides the conflict against a durable receipt, and the
+/// receipt holds the sequence, so the error body carries it. It is absent
+/// only when nothing has committed under the id yet — two conflicting
+/// requests claiming it at once — and then there is nothing to read back.
+fn reported_committed_seq(error: &ClientError) -> Option<ChangeSeq> {
+    match error {
+        ClientError::Api { details, .. } => details.as_ref()?.committed_seq,
         _ => None,
     }
 }
@@ -1341,9 +1345,10 @@ impl Client {
     /// Decides whether a reused commit id already did this exact work.
     ///
     /// The evidence is the committed content itself, read back from the
-    /// change feed by commit id, and compared against the bytes that were
-    /// just uploaded. Nothing weaker counts: a comparison this build cannot
-    /// make is reported as a conflict that names why, never as agreement.
+    /// change feed at the sequence the conflict reported, and compared
+    /// against the bytes that were just uploaded. Nothing weaker counts: a
+    /// comparison this build cannot make is reported as a conflict that
+    /// names why, never as agreement.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,
@@ -1351,7 +1356,13 @@ impl Client {
         uploaded: UploadedContent<'_>,
         conflict: ClientError,
     ) -> Result<ApiCommitResponse> {
-        let Some(committed) = self.find_committed_change(namespace_id, commit_id).await? else {
+        let Some(committed_seq) = reported_committed_seq(&conflict) else {
+            return Err(conflict);
+        };
+        let Some(committed) = self
+            .read_committed_change(namespace_id, commit_id, committed_seq)
+            .await?
+        else {
             return Err(conflict);
         };
         let Some(content_ref) = committed_content_ref(&committed) else {
@@ -1388,45 +1399,34 @@ impl Client {
         }
     }
 
-    /// Finds one committed change by its commit id.
+    /// Reads the one change a reuse conflict said the commit id landed at.
     ///
-    /// There is no by-commit-id read on the wire, so this walks the change
-    /// feed backwards from its head in bounded windows. Backwards because a
-    /// commit being retried is a recent one, and bounded because a feed is
-    /// unbounded: past the budget this reports "not found", which the
-    /// caller turns into the conflict rather than into a guess.
-    async fn find_committed_change(
+    /// There is no by-commit-id read on the wire, but the conflict already
+    /// named the sequence, so this is one feed page positioned on it rather
+    /// than a search. `None` means the evidence is not there to compare —
+    /// the sequence has fallen below the retention floor, or the row at it
+    /// belongs to some other commit — and the caller turns that into the
+    /// conflict rather than into a guess.
+    async fn read_committed_change(
         &self,
         namespace_id: &NamespaceId,
         commit_id: &CommitId,
+        committed_seq: ChangeSeq,
     ) -> Result<Option<CommittedChange>> {
-        let head = self
-            .list_changes(namespace_id, ChangeSeq(0), Some(1))
-            .await?
-            .through_seq;
-        let mut upper = head.0;
-        for _ in 0..COMMIT_LOOKUP_MAX_WINDOWS {
-            let lower = upper.saturating_sub(COMMIT_LOOKUP_WINDOW);
-            let page = self
-                .list_changes(
-                    namespace_id,
-                    ChangeSeq(lower),
-                    Some(COMMIT_LOOKUP_WINDOW as u32),
-                )
-                .await?;
-            if let Some(found) = page
-                .changes
-                .into_iter()
-                .find(|change| &change.commit_id == commit_id)
-            {
-                return Ok(Some(found));
+        let after_seq = ChangeSeq(committed_seq.0.saturating_sub(1));
+        let page = match self.list_changes(namespace_id, after_seq, Some(1)).await {
+            Ok(page) => page,
+            // Retention gave up the replay promise below the floor: the
+            // commit landed, but what it wrote can no longer be read back.
+            Err(error) if error.code() == Some(ErrorCode::RebootstrapRequired) => {
+                return Ok(None);
             }
-            if lower == 0 {
-                break;
-            }
-            upper = lower;
-        }
-        Ok(None)
+            Err(error) => return Err(error),
+        };
+        Ok(page
+            .changes
+            .into_iter()
+            .find(|change| change.seq == committed_seq && &change.commit_id == commit_id))
     }
 
     pub async fn create_directory(

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -109,8 +109,16 @@ pub enum CoreError {
         /// and the two spellings can look identical.
         existing_display_name: Option<String>,
     },
-    #[error("commit id conflict for `{0}`")]
-    CommitIdReuseConflict(String),
+    #[error("commit id conflict for `{commit_id}`")]
+    CommitIdReuseConflict {
+        commit_id: String,
+        /// Sequence the commit id already landed at, when the conflict was
+        /// decided against a durable receipt — the receipt is what holds
+        /// it. Absent when nothing has committed under the id yet and two
+        /// live requests are claiming it at once, which is the one case a
+        /// caller cannot reconcile by reading the feed.
+        committed_seq: Option<ChangeSeq>,
+    },
     #[error(transparent)]
     ContentPreparation(#[from] ContentPreparationError),
     #[error("commit queue is full; slow down and retry")]
@@ -369,7 +377,7 @@ impl CoreError {
             CoreError::ContentTooLarge { .. } => ErrorCode::ContentTooLarge,
             CoreError::NamespaceExists { .. } => ErrorCode::NamespaceExists,
             CoreError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
-            CoreError::CommitIdReuseConflict(_) => ErrorCode::CommitIdReuseConflict,
+            CoreError::CommitIdReuseConflict { .. } => ErrorCode::CommitIdReuseConflict,
             CoreError::ContentPreparation(_) => ErrorCode::ContentNotPrepared,
             CoreError::CommitQueueFull => ErrorCode::CommitQueueFull,
             CoreError::ShuttingDown => ErrorCode::ShuttingDown,
@@ -426,8 +434,12 @@ impl CoreError {
                 active_acquired_at_ms: fence.active_acquired_at_ms,
                 ..ErrorDetails::default()
             }),
-            CoreError::CommitIdReuseConflict(commit_id) => Some(ErrorDetails {
+            CoreError::CommitIdReuseConflict {
+                commit_id,
+                committed_seq,
+            } => Some(ErrorDetails {
                 commit_id: CommitId::parse(commit_id).ok(),
+                committed_seq: *committed_seq,
                 ..ErrorDetails::default()
             }),
             CoreError::RebootstrapRequired {
@@ -884,12 +896,26 @@ mod tests {
             .to_string()
             .ends_with("epoch 3 was fenced by epoch 4"));
 
-        let reuse = CoreError::CommitIdReuseConflict("retry-key-1".to_owned());
+        // A conflict decided against a durable receipt names where the
+        // commit id landed, which is what a retry reads back.
+        let reuse = CoreError::CommitIdReuseConflict {
+            commit_id: "retry-key-1".to_owned(),
+            committed_seq: Some(ChangeSeq(9)),
+        };
         let details = reuse.details().expect("reuse details");
         assert_eq!(
             details.commit_id,
             Some(CommitId::parse("retry-key-1").expect("valid commit id"))
         );
+        assert_eq!(details.committed_seq, Some(ChangeSeq(9)));
+
+        // A conflict between two live claims has no landed commit to name.
+        let contended = CoreError::CommitIdReuseConflict {
+            commit_id: "retry-key-1".to_owned(),
+            committed_seq: None,
+        };
+        let details = contended.details().expect("reuse details");
+        assert_eq!(details.committed_seq, None);
 
         let stale =
             CoreError::CommitValidation(CommitValidationError::ReplaceFileBaseRevisionMismatch {

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -76,8 +76,14 @@ impl BatchDedup {
             return None;
         };
         if existing.semantic_identity != *semantic_identity {
+            // Neither claim has committed, so there is no landed commit to
+            // name: the caller cannot reconcile this one by reading the
+            // feed, and the conflict is the whole answer.
             return Some(CandidateAdmission::Settled(Err(
-                CoreError::CommitIdReuseConflict(commit_id.to_string()),
+                CoreError::CommitIdReuseConflict {
+                    commit_id: commit_id.to_string(),
+                    committed_seq: None,
+                },
             )));
         }
         Some(CandidateAdmission::AliasOf(existing.primary_index))
@@ -194,7 +200,12 @@ async fn resolve_commit_id_reuse<S: ObjectStore + ?Sized>(
     if let Some(existing) = view.find_commit_receipt(commit_id).await? {
         return Ok(Some(CandidateAdmission::Settled(
             if existing.semantic_commit_fingerprint != semantic_identity.as_str() {
-                Err(CoreError::CommitIdReuseConflict(commit_id.to_string()))
+                // The receipt holds where the id landed; reporting it is
+                // what turns a caller's reconciliation into one feed read.
+                Err(CoreError::CommitIdReuseConflict {
+                    commit_id: commit_id.to_string(),
+                    committed_seq: Some(existing.committed_seq),
+                })
             } else {
                 Ok(commit_response_from_commit_receipt(namespace_id, &existing))
             },

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -1283,9 +1283,12 @@ async fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
 
     responses[0].as_ref().expect("primary commit");
     let error = responses[1].as_ref().expect_err("duplicate conflict");
+    // Neither claim had committed when the batch admitted them, so the
+    // conflict has no landed sequence to name.
     assert!(matches!(
         error,
-        CoreError::CommitIdReuseConflict(commit_id) if commit_id == "req-conflict"
+        CoreError::CommitIdReuseConflict { commit_id, committed_seq: None }
+            if commit_id == "req-conflict"
     ));
 
     let wal_keys = store
@@ -1356,9 +1359,12 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
     )
     .await
     .expect_err("conflicting retry");
+    // The receipt decided this one, so the conflict names where the id
+    // landed — the sequence a retry reads back to reconcile.
     assert!(matches!(
         conflict,
-        CoreError::CommitIdReuseConflict(commit_id) if commit_id == "same-path-request"
+        CoreError::CommitIdReuseConflict { commit_id, committed_seq }
+            if commit_id == "same-path-request" && committed_seq == Some(first.committed_seq)
     ));
 
     let wal_keys = store
@@ -1479,7 +1485,8 @@ async fn delete_path_commit_id_reuse_includes_expected_inode_id() {
         .expect_err("changed guard must conflict");
         assert!(matches!(
             error,
-            CoreError::CommitIdReuseConflict(reused) if reused == commit_id
+            CoreError::CommitIdReuseConflict { commit_id: reused, committed_seq: Some(_) }
+                if reused == commit_id
         ));
     }
 

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -2,7 +2,9 @@
 
 use crate::common::http_split_support::*;
 use crate::common::start_server;
-use loonfs_api::v0::ValidatedContentToken;
+use loonfs_api::v0::{
+    CreateCheckpointRequest, MaintenanceStepKind, MaintenanceStepRequest, ValidatedContentToken,
+};
 use loonfs_api::{AbsolutePath, CommitId, CommitRequest, DestinationBehavior, FilesystemOperation};
 use loonfs_client::{ClientError, CommitOptions, DeleteOptions, NamespacePath, PutFileOptions};
 use loonfs_test_support::ids::namespace_id;
@@ -26,7 +28,7 @@ async fn http_operation_rejects_same_commit_id_with_different_payload() {
         .expect("create namespace");
 
     let commit_id = CommitId::parse("req-phase-2a-conflict").expect("valid commit id");
-    harness
+    let first = harness
         .client
         .put_file_bytes(
             &NamespacePath::parse("demo", "/first.txt").expect("first target"),
@@ -62,9 +64,12 @@ async fn http_operation_rejects_same_commit_id_with_different_payload() {
             assert_eq!(code, "commit_id_reuse_conflict");
             // The error carries the caller's reconciliation identity as
             // structured fields, not prose (API spec, "Standard error
-            // contract").
+            // contract"). The server decided this against the durable
+            // receipt, so it reports where the id landed too — the one read
+            // a retry needs, instead of a search of the feed.
             let details = details.expect("structured details");
             assert_eq!(details.commit_id, Some(commit_id));
+            assert_eq!(details.committed_seq, Some(first.committed_seq));
             let request_id = request_id.expect("request id");
             assert!(request_id.starts_with("req_"), "got `{request_id}`");
         }
@@ -188,6 +193,100 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
         }
         other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
     }
+
+    harness.server.abort();
+}
+
+/// The client reconciles by reading the feed at the sequence the conflict
+/// reported. Once retention has surrendered incremental replay below that
+/// sequence, the feed cannot answer for it, so there is nothing to compare
+/// and the conflict stands — identical bytes included. A comparison that
+/// cannot be made is never reported as success.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_put_conflict_stands_when_retention_trimmed_the_committed_seq() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-trimmed",
+        "http-trimmed",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let target = NamespacePath::parse("demo", "/docs/trimmed.txt").expect("target");
+    let commit_id = CommitId::parse("req-trimmed-put").expect("valid commit id");
+    let options = || PutFileOptions {
+        behavior: DestinationBehavior::Replace,
+        commit_id: Some(commit_id.clone()),
+        message: None,
+        expected_revision_no: None,
+    };
+
+    let first = harness
+        .client
+        .put_file_bytes(&target, b"stable bytes\n", &options())
+        .await
+        .expect("first put");
+
+    // Pin the head, then give up incremental replay below it.
+    harness
+        .client
+        .create_checkpoint(
+            &namespace,
+            &CreateCheckpointRequest {
+                name: "trimmed".to_owned(),
+                ttl_ms: None,
+            },
+        )
+        .await
+        .expect("create checkpoint");
+    let advanced = harness
+        .client
+        .maintenance_step(
+            &namespace,
+            &MaintenanceStepRequest {
+                only: Some(MaintenanceStepKind::Retention),
+                ..MaintenanceStepRequest::default()
+            },
+        )
+        .await
+        .expect("advance retention floor");
+    assert!(
+        advanced.retention_floor_seq >= first.committed_seq,
+        "the floor must cover the commit for this to test anything: floor {:?}, commit {:?}",
+        advanced.retention_floor_seq,
+        first.committed_seq
+    );
+
+    match harness
+        .client
+        .put_file_bytes(&target, b"stable bytes\n", &options())
+        .await
+    {
+        Err(ClientError::Api { code, details, .. }) => {
+            assert_eq!(code, "commit_id_reuse_conflict");
+            // The server still knows where the id landed; the feed just
+            // cannot answer for that sequence any more.
+            let details = details.expect("structured details");
+            assert_eq!(details.committed_seq, Some(first.committed_seq));
+        }
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
+    let bytes = harness
+        .client
+        .get_file_bytes(&target)
+        .await
+        .expect("read file");
+    assert_eq!(
+        bytes, b"stable bytes\n",
+        "the refused rerun changed nothing"
+    );
 
     harness.server.abort();
 }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -12,19 +12,10 @@ use crate::{
 };
 use crate::{ChecksumAlgorithm, CommittedChange, FilesystemChange};
 use crate::{Result, RuntimeError};
-use loonfs_api::{EffectiveLimit, StorageChecksum};
+use loonfs_api::{EffectiveLimit, ErrorCode, StorageChecksum};
 use loonfs_core::NamespaceEngine;
 use std::num::NonZeroU32;
 use std::sync::Arc;
-
-/// Change-feed sequences one lookup window covers when resolving a reused
-/// commit id.
-const COMMIT_LOOKUP_WINDOW: NonZeroU32 = NonZeroU32::new(128).expect("non-zero window");
-
-/// Windows one lookup walks back from the feed's head before giving up. A
-/// commit being retried is a recent one; past this the answer is "not
-/// found", never a guess.
-const COMMIT_LOOKUP_MAX_WINDOWS: usize = 8;
 
 /// What a retry can still say about the payload it just staged.
 ///
@@ -67,6 +58,21 @@ impl StagedPayload<'_> {
                 Some(observed? == expected.value)
             }
         }
+    }
+}
+
+/// Where a reuse conflict says the commit id already landed.
+///
+/// The publisher decides the conflict against a durable receipt, and the
+/// receipt holds the sequence, so the error carries it. It is absent only
+/// when nothing has committed under the id yet — two conflicting requests
+/// claiming it at once — and then there is nothing to read back.
+fn reported_committed_seq(error: &RuntimeError) -> Option<ChangeSeq> {
+    match error {
+        RuntimeError::Core(CoreError::CommitIdReuseConflict { committed_seq, .. }) => {
+            *committed_seq
+        }
+        _ => None,
     }
 }
 
@@ -222,9 +228,7 @@ impl FsWriter {
         staged: StagedPayload<'_>,
     ) -> Result<CommitResponse> {
         match (published, commit_id) {
-            (Err(error), Some(commit_id))
-                if error.code() == loonfs_core::ErrorCode::CommitIdReuseConflict =>
-            {
+            (Err(error), Some(commit_id)) if error.code() == ErrorCode::CommitIdReuseConflict => {
                 self.reconcile_commit_id_reuse(namespace_id, &commit_id, staged, error)
                     .await
             }
@@ -234,10 +238,11 @@ impl FsWriter {
 
     /// Decides whether a reused commit id already did this exact work.
     ///
-    /// The evidence is the committed content itself, found in the change
-    /// feed by commit id and compared against the bytes just staged.
-    /// Nothing weaker counts: a comparison this build cannot make is
-    /// reported as a conflict that names why, never as agreement.
+    /// The evidence is the committed content itself, read from the change
+    /// feed at the sequence the conflict reported and compared against the
+    /// bytes just staged. Nothing weaker counts: a comparison this build
+    /// cannot make is reported as a conflict that names why, never as
+    /// agreement.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,
@@ -245,7 +250,13 @@ impl FsWriter {
         staged: StagedPayload<'_>,
         conflict: RuntimeError,
     ) -> Result<CommitResponse> {
-        let Some(committed) = self.find_committed_change(namespace_id, commit_id).await? else {
+        let Some(committed_seq) = reported_committed_seq(&conflict) else {
+            return Err(conflict);
+        };
+        let Some(committed) = self
+            .read_committed_change(namespace_id, commit_id, committed_seq)
+            .await?
+        else {
             return Err(conflict);
         };
         let Some(content_ref) = committed_content_ref(&committed) else {
@@ -281,41 +292,36 @@ impl FsWriter {
         }
     }
 
-    /// Finds one committed change by its commit id.
+    /// Reads the one change a reuse conflict said the commit id landed at.
     ///
-    /// There is no by-commit-id read, so this walks the change feed
-    /// backwards from its head in bounded windows. Backwards because a
-    /// commit being retried is a recent one, and bounded because a feed is
-    /// unbounded: past the budget this reports "not found", which the
-    /// caller turns into the conflict rather than into a guess.
-    async fn find_committed_change(
+    /// There is no by-commit-id read, but the conflict already named the
+    /// sequence, so this is one feed page positioned on it rather than a
+    /// search. `None` means the evidence is not there to compare — the
+    /// sequence has fallen below the retention floor, or the row at it
+    /// belongs to some other commit — and the caller turns that into the
+    /// conflict rather than into a guess.
+    async fn read_committed_change(
         &self,
         namespace_id: &NamespaceId,
         commit_id: &CommitId,
+        committed_seq: ChangeSeq,
     ) -> Result<Option<CommittedChange>> {
-        let engine = self.engine(namespace_id);
-        let window = EffectiveLimit::new(COMMIT_LOOKUP_WINDOW);
-        let head = engine
-            .list_changes_after(ChangeSeq(0), EffectiveLimit::new(NonZeroU32::MIN))
-            .await?
-            .through_seq;
-        let mut upper = head.0;
-        for _ in 0..COMMIT_LOOKUP_MAX_WINDOWS {
-            let lower = upper.saturating_sub(u64::from(COMMIT_LOOKUP_WINDOW.get()));
-            let page = engine.list_changes_after(ChangeSeq(lower), window).await?;
-            if let Some(found) = page
-                .changes
-                .into_iter()
-                .find(|change| &change.commit_id == commit_id)
-            {
-                return Ok(Some(found));
-            }
-            if lower == 0 {
-                break;
-            }
-            upper = lower;
-        }
-        Ok(None)
+        let after_seq = ChangeSeq(committed_seq.0.saturating_sub(1));
+        let page = match self
+            .engine(namespace_id)
+            .list_changes_after(after_seq, EffectiveLimit::new(NonZeroU32::MIN))
+            .await
+        {
+            Ok(page) => page,
+            // Retention gave up the replay promise below the floor: the
+            // commit landed, but what it wrote can no longer be read back.
+            Err(error) if error.code() == ErrorCode::RebootstrapRequired => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        Ok(page
+            .changes
+            .into_iter()
+            .find(|change| change.seq == committed_seq && &change.commit_id == commit_id))
     }
 
     /// Stages file bytes as durable content for later publication.

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -517,7 +517,12 @@ impl NamespacePublisher {
         }
         if let Some(existing) = state.in_flight.get_mut(&commit_id) {
             if existing.semantic_identity != semantic_identity {
-                return Err(CoreError::CommitIdReuseConflict(commit_id.to_string()));
+                // Both claims are still in flight, so nothing has landed
+                // under this id for the caller to read back.
+                return Err(CoreError::CommitIdReuseConflict {
+                    commit_id: commit_id.to_string(),
+                    committed_seq: None,
+                });
             }
             existing.waiters.push(waiter);
             self.trace_enqueue(queued_candidates(&state), "duplicate");

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -546,9 +546,11 @@ async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
         &namespace_id,
         create_directory_request("active", "different-active"),
     );
+    // Both claims are still in flight, so there is no landed sequence.
     assert!(matches!(
         conflict,
-        Err(CoreError::CommitIdReuseConflict(commit_id)) if commit_id == "active"
+        Err(CoreError::CommitIdReuseConflict { commit_id, committed_seq: None })
+            if commit_id == "active"
     ));
 
     store.release();
@@ -598,7 +600,8 @@ async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
     );
     assert!(matches!(
         conflict,
-        Err(CoreError::CommitIdReuseConflict(commit_id)) if commit_id == "pending-0"
+        Err(CoreError::CommitIdReuseConflict { commit_id, committed_seq: None })
+            if commit_id == "pending-0"
     ));
 
     let overflow = try_admit_commit(

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -135,6 +135,61 @@ async fn same_length_different_bytes_conflict() {
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
 }
 
+/// Reconciliation reads the feed at the sequence the conflict reported, so
+/// once retention has surrendered the replay promise below that sequence
+/// there is no committed content left to compare against. Identical bytes
+/// and all, the conflict stands: a comparison that cannot be made is never
+/// reported as success.
+#[tokio::test]
+async fn a_retention_trimmed_commit_seq_leaves_the_conflict_standing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+
+    let first = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
+        .await
+        .expect("first put");
+
+    // Pin the head, then give up incremental replay below it. The commit's
+    // receipt still binds the id, so a rerun still conflicts and the
+    // conflict still names where the commit landed — but the change feed no
+    // longer answers for that sequence.
+    runtime
+        .create_checkpoint(&namespace_id)
+        .await
+        .expect("create checkpoint");
+    let advanced = runtime
+        .admin
+        .advance_retention_floor(&namespace_id)
+        .await
+        .expect("advance retention floor");
+    assert!(
+        advanced.retention_floor_seq >= first.committed_seq,
+        "the floor must cover the commit for this to test anything: floor {:?}, commit {:?}",
+        advanced.retention_floor_seq,
+        first.committed_seq
+    );
+
+    let error = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
+        .await
+        .expect_err("evidence that cannot be read cannot reconcile to success");
+
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+    assert_eq!(
+        runtime
+            .reader
+            .get_file_bytes(&namespace_id, PATH)
+            .await
+            .expect("read file")
+            .bytes,
+        b"stable bytes\n",
+        "the refused rerun changed nothing"
+    );
+}
+
 /// A commit id that never committed anything is not a retry of anything,
 /// so a rerun against an unrelated id behaves like a first run.
 #[tokio::test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -205,7 +205,7 @@ The codes that populate it:
 | --- | --- |
 | `writer_fenced` | `fenced_epoch`, `active_writer_epoch`, plus `active_writer` and `active_acquired_at_ms` when the head recorded a writer block. Writer ids are process labels, so two runs on one machine can share one; the acquisition stamp is what tells them apart |
 | `stale_revision` | `inode_id`, `expected_revision`, `actual_revision` (absent when the inode has no current revision) |
-| `commit_id_reuse_conflict` | `commit_id` |
+| `commit_id_reuse_conflict` | `commit_id`, plus `committed_seq` when the conflict was decided against a durable commit receipt — the sequence that `commit_id` already landed at. Absent when nothing has committed under the id yet and two live requests are claiming it at once |
 | `rebootstrap_required` | `after_seq`, `retention_floor_seq` |
 | `not_deleted` | `inode_id`, plus `requested_deletion_seq` and `active_deletion_seq` when a live deletion exists at a different generation |
 | any failed commit | `commit_id` — the idempotency key the request committed under, echoed so failed and uncertain outcomes carry the caller's reconciliation handle (section 5.2) |
@@ -413,7 +413,12 @@ bytes. A client that composes upload and commit must, on
 `commit_id_reuse_conflict`, resolve it as follows before surfacing it:
 
 1. Find what that `commit_id` committed. There is no read keyed by commit
-   id, so this reads the change feed and matches on `commit_id`.
+   id, but the error names where it landed: read the change feed once at
+   `details.committed_seq` — cursor `after_seq = committed_seq - 1`, limit 1
+   — and take the row whose `commit_id` matches. If `details.committed_seq`
+   is absent, or the feed answers `rebootstrap_required` because retention
+   has moved past that sequence, or the row there names some other commit,
+   there is nothing to compare: go straight to rule 4.
 2. Compare the committed content against what was just uploaded: the
    content's `whole_file_sha256` when it has one, and otherwise its
    `storage_checksum`, after checking `size_bytes`.
@@ -429,11 +434,12 @@ bytes. A client that composes upload and commit must, on
 3. Equal content means the logical operation had already succeeded: report
    the commit that landed, with its original `committed_seq`.
 4. Anything else surfaces a failure. Different content is the
-   `commit_id_reuse_conflict` unchanged. Content the client *cannot*
-   compare — a checksum algorithm it does not implement, or a commit it
-   could not locate — is reported as a failure naming why it could not
-   reconcile. **A comparison that cannot be made is never reported as
-   success.**
+   `commit_id_reuse_conflict` unchanged, and so is a commit the client
+   could not locate — an absent `committed_seq`, or a sequence retention no
+   longer answers for. Content the client *cannot* compare — a checksum
+   algorithm it does not implement — is reported as a failure naming why it
+   could not reconcile. **A comparison that cannot be made is never
+   reported as success.**
 
 The duplicate content object the rerun uploaded is then referenced by
 nothing. That is by design: it is a completed upload whose content no
@@ -455,10 +461,11 @@ attempt for namespace create, fork, and delete, upload-session begin, and
 presigned direct PUT.
 
 Commits record a durable receipt binding the `commit_id` to its
-`committed_seq`; replay reads that receipt. Receipts are currently retained
-for the life of the namespace. When receipt retention becomes bounded, this
-contract will state the replay window explicitly, and resubmission after the
-window must fail loudly rather than silently committing again.
+`committed_seq`; replay reads that receipt, and a reuse conflict reports the
+`committed_seq` it read. The replay window is the namespace's retention
+floor: metadata reorganization drops receipts whose `committed_seq` has
+fallen below the floor, so resubmitting from below the window is a new
+logical commit rather than a replay of the original.
 
 ### 5.3 Writer topology and fencing
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3277,6 +3277,17 @@
               }
             ]
           },
+          "committed_seq": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Sequence at which that commit id already landed. Present when the\nfailure was decided against a durable commit receipt, which is what\nholds the sequence; absent when nothing has committed under the id\nyet and two live requests are simply claiming it at once."
+              }
+            ]
+          },
           "expected_revision": {
             "oneOf": [
               {


### PR DESCRIPTION
`commit_id_reuse_conflict` now carries `details.committed_seq` when the durable receipt is available, so retry reconciliation is one targeted feed read (page of one at the reported seq, with a `seq ==` guard that also makes seq 0 safe) instead of the windowed backwards scan — which is deleted from both the runtime and client implementations, zero references remaining.