### PR TITLE
docs(core): the idempotency horizon is a stated contract

### DIFF
--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -674,9 +674,11 @@ pub(super) fn drop_rows_below_retention_floor(
         });
     }
 
-    // The idempotency horizon is the retention floor: a commit retried from
-    // below it re-bootstraps like any sub-floor cursor, so its receipt no
-    // longer needs to be carried forward.
+    // The idempotency horizon is the retention floor: a receipt dropped
+    // here makes its id indistinguishable from one never used, so a commit
+    // retried from below the floor commits AGAIN as a new mutation (format
+    // spec §3.3; pinned by `a_retry_past_the_receipt_horizon_commits_again`).
+    // Replay is guaranteed exactly as long as retained history.
     if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::CommitReceipts) {
         rows.retain(|row| match row {
             MetadataRow::CommitReceipt { committed_seq, .. } => {

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -11,7 +11,8 @@ use crate::common::{open_runtime_async, store, TestRuntime};
 use bytes::Bytes;
 use futures::StreamExt;
 use loonfs::{
-    ByteStream, CommitId, CreateNamespaceOptions, DestinationBehavior, NamespaceId, PutFileOptions,
+    ByteStream, CommitId, CreateNamespaceOptions, DestinationBehavior, MaintenanceStepKind,
+    MaintenanceStepOptions, NamespaceId, PutFileOptions, ReorganizeStepOutcome,
 };
 use loonfs_api::ErrorCode;
 use tempfile::tempdir;
@@ -187,6 +188,124 @@ async fn a_retention_trimmed_commit_seq_leaves_the_conflict_standing() {
             .bytes,
         b"stable bytes\n",
         "the refused rerun changed nothing"
+    );
+}
+
+/// The idempotency horizon, pinned end to end: once the retention floor
+/// passes a commit AND reorganization drops its receipt, the id no longer
+/// replays — a late retry commits again as a new mutation. That is the
+/// documented contract (api spec, "safe retry"): replay is guaranteed only
+/// while the receipt lives, and receipts live exactly as long as retained
+/// history. This test exists so the behavior stays deliberate; if it ever
+/// starts failing because a late retry replays or errors instead, the spec
+/// and this pin must move together.
+#[tokio::test]
+async fn a_retry_past_the_receipt_horizon_commits_again() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+
+    let first = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
+        .await
+        .expect("first put");
+
+    // Move the floor strictly past the pinned commit, and pile up enough
+    // flushed runs that reorganization has real folding to do — receipts
+    // are dropped when the runs holding them are rebuilt, and rebuilding
+    // waits for enough L0 runs to accumulate.
+    // Nine rounds: the first flush builds the base run, and the next eight
+    // accumulate the L0 runs that reach the fold trigger
+    // (`DEFAULT_MAX_CHECKPOINT_L0_RUNS`).
+    let mut last_seq = first.committed_seq;
+    for round in 0..9 {
+        let filler = runtime
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/docs/filler-{round}.txt"),
+                b"filler\n",
+                options(&CommitId::parse(format!("filler-{round}")).expect("valid commit id")),
+            )
+            .await
+            .expect("filler put");
+        last_seq = filler.committed_seq;
+        runtime
+            .create_checkpoint(&namespace_id)
+            .await
+            .expect("create checkpoint");
+    }
+    let advanced = runtime
+        .admin
+        .advance_retention_floor(&namespace_id)
+        .await
+        .expect("advance retention floor");
+    assert!(
+        advanced.retention_floor_seq > first.committed_seq,
+        "the floor must pass the commit for this to test anything: floor {:?}, commit {:?}",
+        advanced.retention_floor_seq,
+        first.committed_seq
+    );
+
+    // The floor alone leaves the receipt answering (the conflict test above
+    // proves it). Drain reorganization until it reports nothing left, so
+    // the run families holding the receipt have been rebuilt above the
+    // floor.
+    let mut folded = false;
+    for _ in 0..32 {
+        let step = runtime
+            .admin
+            .maintenance_step_namespace(
+                &namespace_id,
+                MaintenanceStepOptions {
+                    only: Some(MaintenanceStepKind::Reorganize),
+                    ..MaintenanceStepOptions::default()
+                },
+            )
+            .await
+            .expect("reorganize step");
+        if matches!(step.reorganize, ReorganizeStepOutcome::NotNeeded) {
+            break;
+        }
+        folded = true;
+    }
+    assert!(
+        folded,
+        "reorganization must actually rebuild runs for this to test anything"
+    );
+
+    // The live session's caches still answer the receipt (a conservative,
+    // longer in-process window — a rerun in the same process still replays
+    // or conflicts). The horizon is a durable-state fact, and the late
+    // retry it governs is a cross-process event, so reopen on the same
+    // store to read what the reorganization actually kept.
+    drop(runtime);
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-b").await;
+
+    // Same id, same bytes — but the receipt is gone, so this is not a
+    // replay (which would return the original sequence without committing)
+    // and not a conflict: it commits again.
+    let retried = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
+        .await
+        .expect("a retry past the horizon is admitted as a new commit");
+    assert!(
+        retried.committed_seq > last_seq,
+        "the late retry landed as a new commit: first {:?}, retry {:?}",
+        first.committed_seq,
+        retried.committed_seq
+    );
+
+    // The blast radius the spec documents: a duplicate revision of
+    // identical content. The file still reads back the same bytes.
+    assert_eq!(
+        runtime
+            .reader
+            .get_file_bytes(&namespace_id, PATH)
+            .await
+            .expect("read file")
+            .bytes,
+        b"stable bytes\n",
     );
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -388,6 +388,21 @@ The retry rule has three cases:
   `commit_id_reuse_conflict`.
 - Retrying with a new `commit_id` is a new logical commit.
 
+**The replay guarantee has a horizon.** A commit's receipt lives exactly as
+long as retained history: when the retention floor passes a commit and
+metadata runs are rebuilt, its receipt is dropped, and from then on the id
+is indistinguishable from one never used. A retry past that horizon does
+not replay and does not conflict — **it commits again as a new mutation.**
+The effects are bounded and mostly self-announcing: creates fail
+`destination_exists`, moves and deletes fail against the already-moved
+state, and a put lays down a duplicate revision of identical content
+(the read surface is unchanged; revision history gains one entry). Retries
+should therefore happen promptly — within the retention window, they are
+fully guaranteed — and a caller that must reuse ids beyond the window is
+responsible for its own reconciliation. LoonFS chooses this documented
+horizon over an unbounded receipt index deliberately: detecting a dropped
+id would require remembering every id forever.
+
 Caller-supplied race guards (`expected_inode_id` on delete,
 `expected_revision_no` on put) are part of the commit's semantic identity,
 so changing, adding, or removing a guard while reusing a `commit_id` fails

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1243,9 +1243,12 @@ operation and a request carrying a one-element operation list are the same
 request, so they fingerprint identically by construction.
 
 The idempotency horizon is the retention floor. Commit receipts below the
-floor are dropped when metadata runs are rebuilt, so a commit retried from
-below the floor may be treated as new — the same re-bootstrap contract the change
-feed gives sub-floor cursors.
+floor are dropped when metadata runs are rebuilt, and a dropped id is
+indistinguishable from one never used: a commit retried from below the
+floor is admitted as a new mutation and commits again. Replay is guaranteed
+exactly while the receipt lives — the same window as retained history. This
+is deliberate: rejecting late reuse loudly would require an unbounded index
+of every id ever committed, and the durable format does not carry one.
 
 A reused `commit_id` with an equal fingerprint replays the originally
 committed response; an unequal fingerprint is rejected as


### PR DESCRIPTION

- api.md section 5.2 gains the "horizon" paragraph
- format.md section 3.3 stops hinting ("may be treated as new — the same re-bootstrap contract") and states the fact: a sub-floor retry is admitted as a new mutation.
- The reorganize comment says the same at the drop site.
