### PR TITLE
fix(gc): charge the content reference scan against the pass budget

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -436,8 +436,17 @@ pub struct GcRequest {
     /// deadlines); a smaller value is rejected as `invalid_request`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grace_window_ms: Option<u64>,
-    /// Maximum candidates examined by this invocation. Omit to retain the
-    /// run-to-completion behavior.
+    /// Maximum objects this invocation may read or decide. Omit to retain
+    /// the run-to-completion behavior.
+    ///
+    /// A completed upload session past its reclamation grace makes the pass
+    /// read every live manifest and retained WAL segment to find out
+    /// whether anything still references its content, and that read is
+    /// charged here like any other. A budget too small to finish it parks:
+    /// the pass decides nothing, returns the cursor it came in with, and a
+    /// caller looping on `next_cursor` alone would loop forever. Give a
+    /// pass at least as many objects as the namespace has live manifests
+    /// and retained segments.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_objects: Option<u64>,
     /// Opaque resume token returned as `next_cursor` by an earlier pass
@@ -470,6 +479,13 @@ pub struct GcResponse {
     /// Upload-session control objects deleted after the reap window.
     #[serde(default)]
     pub deleted_upload_sessions: u64,
+    /// Content objects reclaimed because their upload session completed,
+    /// aged past the derived reclamation grace, and nothing the namespace
+    /// can reach references them. The upload half's cleanup of abandoned
+    /// sessions is not counted here: it deletes unconditionally, whether or
+    /// not the session ever wrote anything.
+    #[serde(default)]
+    pub deleted_content_objects: u64,
     /// Active checkpoint records released because their basis manifest is
     /// verifiably gone.
     #[serde(default)]
@@ -479,9 +495,11 @@ pub struct GcResponse {
     pub retained_candidates: u64,
     /// True when ambiguous roots suppressed manifest/table deletion.
     pub degraded_retention: bool,
-    /// Opaque resume token when more candidates remain. Resuming rebuilds
-    /// every safety proof; the token carries enumeration position only and
-    /// is valid only against the same namespace.
+    /// Opaque resume token when the pass stopped with work left — either
+    /// more candidates to enumerate, or one candidate it ran out of budget
+    /// to decide. Resuming rebuilds every safety proof; the token carries
+    /// enumeration position only and is valid only against the same
+    /// namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }
@@ -498,6 +516,7 @@ impl GcResponse {
             released_fork_checkpoints: 0,
             released_expired_checkpoints: 0,
             deleted_upload_sessions: 0,
+            deleted_content_objects: 0,
             released_missing_basis_checkpoints: 0,
             retained_candidates: 0,
             degraded_retention: false,

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -442,11 +442,13 @@ pub struct GcRequest {
     /// A completed upload session past its reclamation grace makes the pass
     /// read every live manifest and retained WAL segment to find out
     /// whether anything still references its content, and that read is
-    /// charged here like any other. A budget too small to finish it parks:
-    /// the pass decides nothing, returns the cursor it came in with, and a
-    /// caller looping on `next_cursor` alone would loop forever. Give a
-    /// pass at least as many objects as the namespace has live manifests
-    /// and retained segments.
+    /// charged here like any other. A budget too small to finish it does
+    /// not stall the pass: the session is retained, the response sets
+    /// `content_reclamation_deferred`, and the sweep carries on through
+    /// everything else. What a chronically small budget costs is content
+    /// left unreclaimed, not progress. Give a pass at least as many objects
+    /// as the namespace has live manifests and retained segments for that
+    /// content to come back.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_objects: Option<u64>,
     /// Opaque resume token returned as `next_cursor` by an earlier pass
@@ -495,11 +497,16 @@ pub struct GcResponse {
     pub retained_candidates: u64,
     /// True when ambiguous roots suppressed manifest/table deletion.
     pub degraded_retention: bool,
-    /// Opaque resume token when the pass stopped with work left — either
-    /// more candidates to enumerate, or one candidate it ran out of budget
-    /// to decide. Resuming rebuilds every safety proof; the token carries
-    /// enumeration position only and is valid only against the same
-    /// namespace.
+    /// True when the pass skipped completed-content reclamation because
+    /// the reference collection it needs did not fit in `max_objects`.
+    /// Nothing was ever decided from a partial collection and the rest of
+    /// the sweep ran normally; a later pass with room for the whole scan
+    /// reclaims what this one left behind.
+    #[serde(default)]
+    pub content_reclamation_deferred: bool,
+    /// Opaque resume token when more candidates remain. Resuming rebuilds
+    /// every safety proof; the token carries enumeration position only and
+    /// is valid only against the same namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }
@@ -520,6 +527,7 @@ impl GcResponse {
             released_missing_basis_checkpoints: 0,
             retained_candidates: 0,
             degraded_retention: false,
+            content_reclamation_deferred: false,
             next_cursor: None,
         }
     }

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -114,6 +114,7 @@ fn accumulate_gc_response(total: &mut loonfs_api::GcResponse, pass: loonfs_api::
     total.released_missing_basis_checkpoints += pass.released_missing_basis_checkpoints;
     total.retained_candidates += pass.retained_candidates;
     total.degraded_retention |= pass.degraded_retention;
+    total.content_reclamation_deferred |= pass.content_reclamation_deferred;
     total.next_cursor = pass.next_cursor;
 }
 

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -110,6 +110,7 @@ fn accumulate_gc_response(total: &mut loonfs_api::GcResponse, pass: loonfs_api::
     total.deleted_checkpoint_records += pass.deleted_checkpoint_records;
     total.released_fork_checkpoints += pass.released_fork_checkpoints;
     total.deleted_upload_sessions += pass.deleted_upload_sessions;
+    total.deleted_content_objects += pass.deleted_content_objects;
     total.released_missing_basis_checkpoints += pass.released_missing_basis_checkpoints;
     total.retained_candidates += pass.retained_candidates;
     total.degraded_retention |= pass.degraded_retention;

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -8,15 +8,13 @@ use serde::Serialize;
 use std::io::{self, Write};
 
 fn gc_summary(report: &GcResponse) -> String {
-    // Content blobs live in a shared content store and are never GC
-    // candidates in v0; say so rather than letting four zero-free counters
-    // imply everything reclaimable was swept.
     let mut summary = format!(
-        "gc deleted {} wal segments, {} tables, {} manifests, {} checkpoint records ({} retained); content objects are not swept in v0",
+        "gc deleted {} wal segments, {} tables, {} manifests, {} checkpoint records, {} content objects ({} retained)",
         report.deleted_wal_segments,
         report.deleted_metadata_tables,
         report.deleted_manifests,
         report.deleted_checkpoint_records,
+        report.deleted_content_objects,
         report.retained_candidates
     );
     if report.released_fork_checkpoints > 0 {

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -26,6 +26,11 @@ fn gc_summary(report: &GcResponse) -> String {
     if report.degraded_retention {
         summary.push_str("; retention degraded: ambiguous roots suppressed deletion");
     }
+    if report.content_reclamation_deferred {
+        summary.push_str(
+            "; content reclamation deferred: the reference scan did not fit in --max-objects",
+        );
+    }
     if let Some(cursor) = &report.next_cursor {
         summary.push_str(&format!("; next_cursor: {cursor}"));
     }

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -1,0 +1,61 @@
+//! What `max_objects` meters, and what a pass does when it runs out.
+
+use super::config::GcConfig;
+
+/// The work one garbage-collection pass is allowed to do.
+///
+/// One unit is one object the pass reads or decides on a candidate's
+/// behalf:
+///
+/// * one enumerated candidate key, decided — the original meaning of
+///   `max_objects`;
+/// * one manifest opened by the content reference scan;
+/// * one page of revision rows read out of an opened manifest;
+/// * one retained WAL segment fetched by the scan.
+///
+/// Prefix listing is the one thing not metered: it is how a family finds
+/// candidates at all, and the cursor is what resumes it. Everything else a
+/// pass touches is charged, so no pass can do work proportional to the
+/// namespace while asking for a small budget.
+///
+/// The rule is deliberately coarse — it is a bound, not a cost model. A
+/// page of rows costs more than a manifest header and both count as one.
+/// What matters is that every store round trip inside the pass has a
+/// charge attached to it, and that running out stops the pass instead of
+/// letting it finish "just this one thing" unboundedly.
+#[derive(Debug)]
+pub(super) struct PassBudget {
+    max_objects: Option<u64>,
+    spent: u64,
+}
+
+impl PassBudget {
+    pub(super) fn of(config: &GcConfig) -> Self {
+        Self {
+            max_objects: config.max_objects,
+            spent: 0,
+        }
+    }
+
+    /// True once nothing further may be charged: the caller stops where it
+    /// stands and returns its cursor.
+    pub(super) fn exhausted(&self) -> bool {
+        self.max_objects
+            .is_some_and(|max_objects| self.spent >= max_objects)
+    }
+
+    /// Charges one unit for work already done.
+    pub(super) fn charge(&mut self) {
+        self.spent = self.spent.saturating_add(1);
+    }
+
+    /// Charges one unit for work about to be done. `false` means the
+    /// budget is spent and the caller must not do it.
+    pub(super) fn try_charge(&mut self) -> bool {
+        if self.exhausted() {
+            return false;
+        }
+        self.charge();
+        true
+    }
+}

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -38,7 +38,8 @@ impl PassBudget {
     }
 
     /// True once nothing further may be charged: the caller stops where it
-    /// stands and returns its cursor.
+    /// stands. The sweep returns its cursor; the content reference scan
+    /// gives up on collecting and the pass defers that reclamation.
     pub(super) fn exhausted(&self) -> bool {
         self.max_objects
             .is_some_and(|max_objects| self.spent >= max_objects)

--- a/crates/loonfs-core/src/gc/config.rs
+++ b/crates/loonfs-core/src/gc/config.rs
@@ -20,7 +20,9 @@ pub struct GcConfig {
     /// run-to-completion behavior. What one unit buys is spelled out on
     /// `gc::budget::PassBudget`; the short version is that the content
     /// reference scan pays out of the same purse as candidate enumeration,
-    /// so a budget smaller than that scan can never finish one.
+    /// so a budget smaller than that scan defers content reclamation
+    /// instead of finishing it, pass after pass, while the rest of the
+    /// sweep proceeds normally.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_objects: Option<u64>,
     /// Opaque enumeration cursor returned by an earlier invocation.

--- a/crates/loonfs-core/src/gc/config.rs
+++ b/crates/loonfs-core/src/gc/config.rs
@@ -16,8 +16,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GcConfig {
     pub grace_window_ms: u64,
-    /// Maximum sweep candidates examined by this invocation. `None` keeps
-    /// the run-to-completion behavior.
+    /// Maximum objects this invocation may read or decide. `None` keeps the
+    /// run-to-completion behavior. What one unit buys is spelled out on
+    /// `gc::budget::PassBudget`; the short version is that the content
+    /// reference scan pays out of the same purse as candidate enumeration,
+    /// so a budget smaller than that scan can never finish one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_objects: Option<u64>,
     /// Opaque enumeration cursor returned by an earlier invocation.

--- a/crates/loonfs-core/src/gc/mod.rs
+++ b/crates/loonfs-core/src/gc/mod.rs
@@ -8,6 +8,7 @@
 //! re-verification, and retain-on-ambiguity defaults close those races. When
 //! in doubt, this module retains.
 
+mod budget;
 mod config;
 mod cursor;
 mod fork_checkpoints;

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -1,6 +1,7 @@
 //! The GC entry point: orchestrates root collection, verification,
 //! and the bounded, resumable sweep.
 
+use super::budget::PassBudget;
 use super::config::GcConfig;
 use super::cursor::{CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
@@ -64,12 +65,15 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     // The cursor can skip enumeration only; it never carries safety state.
     let mark = Arc::new(collect_live_set(store, namespace_id, context).await?);
     let mut sweep = SweepVerifier::seeded(Arc::clone(&mark), reverify_chunk);
-    // Content references are collected from this same root set, lazily. The
-    // derived reclamation grace is what lets one collection stand for the
-    // whole pass: past it, no receipt survives that could add a reference.
+    // Content references are collected from this same root set, lazily and
+    // at most once per invocation. The derived reclamation grace is what
+    // lets one collection stand for every candidate that follows it: past
+    // it, no receipt survives that could add a reference. The scan is
+    // charged against the budget below like everything else, so an
+    // invocation that cannot afford it stops rather than overrunning.
     let mut references = ContentReferences::over(&mark);
     let mut report = GcResponse::empty(namespace_id.clone());
-    let mut examined = 0_u64;
+    let mut budget = PassBudget::of(config);
     let mut position = resume.clone();
 
     // Data precedes mutable records. A crash or bounded return can therefore
@@ -88,10 +92,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
             {
                 continue;
             }
-            if config
-                .max_objects
-                .is_some_and(|max_objects| examined >= max_objects)
-            {
+            if budget.exhausted() {
                 // This one-key lookahead proves work remains. It performs no
                 // candidate reads or mutations; the key is reconsidered from
                 // the exclusive last-examined position on resume.
@@ -100,7 +101,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
                 return Ok(report);
             }
 
-            process_candidate(
+            let outcome = process_candidate(
                 store,
                 namespace_id,
                 &content_store_id,
@@ -111,16 +112,38 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
                 &mark,
                 &mut sweep,
                 &mut references,
+                &mut budget,
                 &mut report,
             )
             .await?;
-            examined = examined.saturating_add(1);
+            if outcome == CandidateOutcome::Parked {
+                // The budget died inside the work this candidate needed, so
+                // it was decided neither way and the cursor stays where it
+                // was: the resume re-enumerates this key and starts its
+                // reasoning over from a complete root set. Charging nothing
+                // for it keeps the resumed pass's whole budget available
+                // for the retry.
+                report.next_cursor = Some(position.encode()?);
+                report.degraded_retention = sweep.degraded;
+                return Ok(report);
+            }
+            budget.charge();
             position = GcCursor::after(namespace_id, family, key);
         }
     }
 
     report.degraded_retention = sweep.degraded;
     Ok(report)
+}
+
+/// Whether the pass decided a candidate, or stopped short of deciding it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CandidateOutcome {
+    /// The candidate was decided; the cursor may advance past it.
+    Decided,
+    /// The budget ran out before the candidate could be decided. Nothing
+    /// was deleted for it and the cursor does not advance.
+    Parked,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -135,8 +158,9 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     mark: &LiveSet,
     sweep: &mut SweepVerifier,
     references: &mut ContentReferences<'_>,
+    budget: &mut PassBudget,
     report: &mut GcResponse,
-) -> Result<()> {
+) -> Result<CandidateOutcome> {
     if family == CandidateFamily::UploadSessions {
         return process_upload_session(
             store,
@@ -146,6 +170,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
             context,
             key,
             references,
+            budget,
             report,
         )
         .await;
@@ -165,7 +190,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         } else {
             report.retained_candidates += 1;
         }
-        return Ok(());
+        return Ok(CandidateOutcome::Decided);
     }
 
     // Preserve the existing mark selection exactly: objects reachable from
@@ -182,7 +207,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         CandidateFamily::UploadSessions => false,
     };
     if !selected {
-        return Ok(());
+        return Ok(CandidateOutcome::Decided);
     }
 
     sweep.refresh_if_due(store, namespace_id, context).await?;
@@ -218,7 +243,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         }
         CandidateFamily::UploadSessions => {}
     }
-    Ok(())
+    Ok(CandidateOutcome::Decided)
 }
 
 async fn process_checkpoint<S: ObjectStore + ?Sized>(
@@ -277,11 +302,12 @@ async fn process_upload_session<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     key: &str,
     references: &mut ContentReferences<'_>,
+    budget: &mut PassBudget,
     report: &mut GcResponse,
-) -> Result<()> {
+) -> Result<CandidateOutcome> {
     let Some(upload_id) = upload_id_of(key) else {
         report.retained_candidates += 1;
-        return Ok(());
+        return Ok(CandidateOutcome::Decided);
     };
     match sweep_upload_session(
         store,
@@ -290,20 +316,25 @@ async fn process_upload_session<S: ObjectStore + ?Sized>(
         &upload_id,
         config.grace_window_ms,
         references,
+        budget,
         context,
     )
     .await?
     {
-        UploadSessionSweep::Delete => {
+        UploadSessionSweep::Delete { reclaimed_content } => {
             store
                 .delete(key)
                 .await
                 .map_err(|error| CoreError::store(key, &error))?;
             report.deleted_upload_sessions += 1;
+            if reclaimed_content {
+                report.deleted_content_objects += 1;
+            }
         }
         UploadSessionSweep::Retain => report.retained_candidates += 1,
+        UploadSessionSweep::BudgetExhausted => return Ok(CandidateOutcome::Parked),
     }
-    Ok(())
+    Ok(CandidateOutcome::Decided)
 }
 
 fn upload_id_of(key: &str) -> Option<UploadId> {

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -69,8 +69,10 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     // at most once per invocation. The derived reclamation grace is what
     // lets one collection stand for every candidate that follows it: past
     // it, no receipt survives that could add a reference. The scan is
-    // charged against the budget below like everything else, so an
-    // invocation that cannot afford it stops rather than overrunning.
+    // charged against the budget below like everything else, and an
+    // invocation that cannot afford it skips content reclamation instead
+    // of overrunning — the sessions waiting on it are retained and the
+    // sweep continues.
     let mut references = ContentReferences::over(&mark);
     let mut report = GcResponse::empty(namespace_id.clone());
     let mut budget = PassBudget::of(config);
@@ -101,7 +103,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
                 return Ok(report);
             }
 
-            let outcome = process_candidate(
+            process_candidate(
                 store,
                 namespace_id,
                 &content_store_id,
@@ -116,17 +118,13 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
                 &mut report,
             )
             .await?;
-            if outcome == CandidateOutcome::Parked {
-                // The budget died inside the work this candidate needed, so
-                // it was decided neither way and the cursor stays where it
-                // was: the resume re-enumerates this key and starts its
-                // reasoning over from a complete root set. Charging nothing
-                // for it keeps the resumed pass's whole budget available
-                // for the retry.
-                report.next_cursor = Some(position.encode()?);
-                report.degraded_retention = sweep.degraded;
-                return Ok(report);
-            }
+            // Every candidate this loop hands to `process_candidate` comes
+            // back decided one way or the other, so the cursor always
+            // advances past it. The one thing a pass can run out of budget
+            // to answer — whether a completed session's content is still
+            // referenced — is answered by retaining the session, never by
+            // leaving it undecided and stopping: a budget below that scan's
+            // cost would otherwise pin the walk to one key forever.
             budget.charge();
             position = GcCursor::after(namespace_id, family, key);
         }
@@ -134,16 +132,6 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
 
     report.degraded_retention = sweep.degraded;
     Ok(report)
-}
-
-/// Whether the pass decided a candidate, or stopped short of deciding it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CandidateOutcome {
-    /// The candidate was decided; the cursor may advance past it.
-    Decided,
-    /// The budget ran out before the candidate could be decided. Nothing
-    /// was deleted for it and the cursor does not advance.
-    Parked,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -160,7 +148,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     references: &mut ContentReferences<'_>,
     budget: &mut PassBudget,
     report: &mut GcResponse,
-) -> Result<CandidateOutcome> {
+) -> Result<()> {
     if family == CandidateFamily::UploadSessions {
         return process_upload_session(
             store,
@@ -190,7 +178,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         } else {
             report.retained_candidates += 1;
         }
-        return Ok(CandidateOutcome::Decided);
+        return Ok(());
     }
 
     // Preserve the existing mark selection exactly: objects reachable from
@@ -207,7 +195,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         CandidateFamily::UploadSessions => false,
     };
     if !selected {
-        return Ok(CandidateOutcome::Decided);
+        return Ok(());
     }
 
     sweep.refresh_if_due(store, namespace_id, context).await?;
@@ -243,7 +231,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         }
         CandidateFamily::UploadSessions => {}
     }
-    Ok(CandidateOutcome::Decided)
+    Ok(())
 }
 
 async fn process_checkpoint<S: ObjectStore + ?Sized>(
@@ -304,10 +292,10 @@ async fn process_upload_session<S: ObjectStore + ?Sized>(
     references: &mut ContentReferences<'_>,
     budget: &mut PassBudget,
     report: &mut GcResponse,
-) -> Result<CandidateOutcome> {
+) -> Result<()> {
     let Some(upload_id) = upload_id_of(key) else {
         report.retained_candidates += 1;
-        return Ok(CandidateOutcome::Decided);
+        return Ok(());
     };
     match sweep_upload_session(
         store,
@@ -332,9 +320,16 @@ async fn process_upload_session<S: ObjectStore + ?Sized>(
             }
         }
         UploadSessionSweep::Retain => report.retained_candidates += 1,
-        UploadSessionSweep::BudgetExhausted => return Ok(CandidateOutcome::Parked),
+        UploadSessionSweep::ContentReclamationDeferred => {
+            // Retained for the same reason any undecidable session is,
+            // plus a flag, so a caller can tell a pass that swept
+            // everything from one that skipped a question it could not
+            // afford to ask.
+            report.retained_candidates += 1;
+            report.content_reclamation_deferred = true;
+        }
     }
-    Ok(CandidateOutcome::Decided)
+    Ok(())
 }
 
 fn upload_id_of(key: &str) -> Option<UploadId> {

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -638,6 +638,10 @@ async fn upload_gc_aborts_an_expired_session_then_reaps_it() {
         .await
         .expect("gc pass past the abort grace");
     assert_eq!(report.deleted_upload_sessions, 1);
+    assert_eq!(
+        report.deleted_content_objects, 0,
+        "the abort half's unconditional cleanup is not a reclamation it can count"
+    );
     assert!(store.head(&session_key).await.expect("head").is_none());
 
     let again = context(reaped.now_ms + GRACE_MS);
@@ -872,6 +876,7 @@ async fn content_gc_retains_completed_content_inside_its_grace() {
         .expect("gc pass inside the content grace");
 
     assert_eq!(report.deleted_upload_sessions, 0);
+    assert_eq!(report.deleted_content_objects, 0);
     assert!(store.head(&content_key).await.expect("head").is_some());
     assert!(read_upload_session(&store, &namespace_id, &upload_id)
         .await
@@ -902,6 +907,7 @@ async fn content_gc_reclaims_completed_content_nothing_references() {
         .expect("gc pass past the content grace");
 
     assert_eq!(report.deleted_upload_sessions, 1);
+    assert_eq!(report.deleted_content_objects, 1);
     assert!(
         store.head(&content_key).await.expect("head").is_none(),
         "completed content nothing published is reclaimable"
@@ -960,6 +966,10 @@ async fn content_gc_never_reclaims_published_content() {
             report.deleted_upload_sessions, 1,
             "materialize={materialize}"
         );
+        assert_eq!(
+            report.deleted_content_objects, 0,
+            "materialize={materialize}"
+        );
         assert!(
             store.head(&content_key).await.expect("head").is_some(),
             "published content survives its session (materialize={materialize})"
@@ -969,6 +979,200 @@ async fn content_gc_never_reclaims_published_content() {
             .is_none());
         assert!(!report.degraded_retention);
     }
+}
+
+/// Builds a namespace whose content reference scan has real work to do: a
+/// materialized manifest to open and page through, and a WAL tail to fetch
+/// on top of it.
+async fn namespace_with_a_scan_worth_bounding(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    setup: &MutationContext,
+) {
+    bootstrap_namespace(store, namespace_id, setup, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..3 {
+        write_test_file(
+            store,
+            namespace_id,
+            &format!("/docs/materialized-{index}.txt"),
+            &format!("scan-fixture-{index}"),
+            setup,
+        )
+        .await;
+    }
+    crate::checkpoint::flush_wal(store, namespace_id, setup)
+        .await
+        .expect("flush wal");
+    for index in 0..3 {
+        write_test_file(
+            store,
+            namespace_id,
+            &format!("/docs/tail-{index}.txt"),
+            &format!("scan-fixture-tail-{index}"),
+            setup,
+        )
+        .await;
+    }
+}
+
+/// The reference scan is the one place a bounded pass used to do unbounded
+/// work. A one-object budget cannot finish it, and the honest response to
+/// that is to decide nothing: the pass hands back the cursor it came in
+/// with, leaves the session and its content exactly where they were, and a
+/// resume from that cursor with room to finish the scan reaches the verdict
+/// an unbounded pass would have reached.
+#[tokio::test]
+async fn a_budget_that_dies_inside_the_reference_scan_parks_without_deciding() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&store, &namespace_id, &setup).await;
+    let (upload_id, content_ref, content_store_id, _prepared) =
+        complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
+    let content_key =
+        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+    let live = collect_live_set(&store, &namespace_id, &setup)
+        .await
+        .expect("collect live set");
+    assert!(
+        !live.manifests.is_empty() && !live.wal_segments.is_empty(),
+        "the fixture must give the scan more than one object to read"
+    );
+
+    // One object per pass: the earlier families advance a key at a time
+    // until the sweep reaches the session, and there the cursor stops
+    // moving because the scan behind it never fits.
+    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+    let mut tiny = config();
+    tiny.max_objects = Some(1);
+    let mut cursor: Option<String> = None;
+    let mut parked = None;
+    for _ in 0..64 {
+        tiny.cursor.clone_from(&cursor);
+        let pass = gc_namespace(&store, &namespace_id, &tiny, &past)
+            .await
+            .expect("one-object pass");
+        assert_eq!(pass.deleted_upload_sessions, 0);
+        assert_eq!(pass.deleted_content_objects, 0);
+        let next = pass.next_cursor.expect("work remains");
+        if cursor.as_deref() == Some(next.as_str()) {
+            parked = Some(next);
+            break;
+        }
+        cursor = Some(next);
+    }
+    let parked = parked.expect("a one-object budget parks inside the scan");
+    assert!(
+        store.head(&content_key).await.expect("head").is_some(),
+        "a parked pass reclaims nothing"
+    );
+    assert!(
+        read_upload_session(&store, &namespace_id, &upload_id)
+            .await
+            .is_some(),
+        "the session that triggered the scan is retained, not decided"
+    );
+
+    // Same cursor, a budget the scan fits inside: now it decides.
+    let mut enough = config();
+    enough.max_objects = Some(1_024);
+    enough.cursor = Some(parked);
+    let resumed = gc_namespace(&store, &namespace_id, &enough, &past)
+        .await
+        .expect("resumed pass");
+    assert_eq!(resumed.deleted_upload_sessions, 1);
+    assert_eq!(resumed.deleted_content_objects, 1);
+    assert!(store.head(&content_key).await.expect("head").is_none());
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_none());
+}
+
+/// The only reference keeping this content alive lives in the newest WAL
+/// segment, the very last root the scan reads. A pass that stopped short
+/// and answered from what it had collected would call the content
+/// unreferenced and delete it. Running every budget from one up past the
+/// whole scan's cost, each to a standstill, leaves no interleaving where a
+/// partial reference set decides anything — and the budgets that can afford
+/// the scan still reach the right verdict.
+#[tokio::test]
+async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
+    let temp_dir = tempdir().expect("tempdir");
+    let seed_root = temp_dir.path().join("seed");
+    let seed = LocalFsStore::new(&seed_root).expect("seed store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&seed, &namespace_id, &setup).await;
+    let (upload_id, content_ref, content_store_id, prepared) =
+        complete_upload_for_gc(&seed, &namespace_id, b"published-last\n", &setup).await;
+    // The publish that saves this content lands in the newest WAL segment,
+    // so the reference sorts behind everything else the scan reads.
+    publish_completed_content(
+        &seed,
+        &namespace_id,
+        "/docs/published.txt",
+        content_ref.clone(),
+        prepared,
+        &setup,
+    )
+    .await;
+    let content_key =
+        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+    let mut some_budget_reached_the_verdict = false;
+    let mut some_budget_parked_instead = false;
+
+    for max_objects in 1..=16 {
+        let trial_root = temp_dir.path().join(format!("trial-{max_objects}"));
+        copy_tree(&seed_root, &trial_root);
+        let store = LocalFsStore::new(&trial_root).expect("trial store");
+        let mut bounded = config();
+        bounded.max_objects = Some(max_objects);
+        let mut cursor: Option<String> = None;
+        for _ in 0..64 {
+            bounded.cursor.clone_from(&cursor);
+            let pass = gc_namespace(&store, &namespace_id, &bounded, &past)
+                .await
+                .expect("bounded pass");
+            assert_eq!(pass.deleted_content_objects, 0, "max_objects={max_objects}");
+            assert!(
+                store.head(&content_key).await.expect("head").is_some(),
+                "max_objects={max_objects}: referenced content survives every budget"
+            );
+            let Some(next) = pass.next_cursor else {
+                break;
+            };
+            if cursor.as_deref() == Some(next.as_str()) {
+                break;
+            }
+            cursor = Some(next);
+        }
+        assert!(
+            store.head(&content_key).await.expect("head").is_some(),
+            "max_objects={max_objects}"
+        );
+        // Reaching the referenced verdict is what deletes the record: the
+        // content is metadata's from here on. A surviving record means the
+        // budget parked instead — the case this test is really about.
+        let decided = read_upload_session(&store, &namespace_id, &upload_id)
+            .await
+            .is_none();
+        some_budget_reached_the_verdict |= decided;
+        some_budget_parked_instead |= !decided;
+    }
+
+    assert!(
+        some_budget_reached_the_verdict,
+        "a budget large enough to finish the scan must still decide the session"
+    );
+    assert!(
+        some_budget_parked_instead,
+        "the sweep must actually park mid-scan somewhere in this range, or the \
+         test proves nothing about partial reference sets"
+    );
 }
 
 #[tokio::test]
@@ -2324,6 +2528,7 @@ fn accumulate_report(total: &mut GcResponse, pass: &GcResponse) {
     total.deleted_checkpoint_records += pass.deleted_checkpoint_records;
     total.released_fork_checkpoints += pass.released_fork_checkpoints;
     total.deleted_upload_sessions += pass.deleted_upload_sessions;
+    total.deleted_content_objects += pass.deleted_content_objects;
     total.released_missing_basis_checkpoints += pass.released_missing_basis_checkpoints;
     total.retained_candidates += pass.retained_candidates;
     total.degraded_retention |= pass.degraded_retention;
@@ -2395,6 +2600,7 @@ async fn bounded_passes_delete_exactly_the_unbounded_pass_set() {
             bounded_report.deleted_manifests,
             bounded_report.deleted_checkpoint_records,
             bounded_report.deleted_upload_sessions,
+            bounded_report.deleted_content_objects,
         ),
         (
             unbounded_report.deleted_wal_segments,
@@ -2402,6 +2608,7 @@ async fn bounded_passes_delete_exactly_the_unbounded_pass_set() {
             unbounded_report.deleted_manifests,
             unbounded_report.deleted_checkpoint_records,
             unbounded_report.deleted_upload_sessions,
+            unbounded_report.deleted_content_objects,
         )
     );
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1019,12 +1019,13 @@ async fn namespace_with_a_scan_worth_bounding(
 
 /// The reference scan is the one place a bounded pass used to do unbounded
 /// work. A one-object budget cannot finish it, and the honest response to
-/// that is to decide nothing: the pass hands back the cursor it came in
-/// with, leaves the session and its content exactly where they were, and a
-/// resume from that cursor with room to finish the scan reaches the verdict
-/// an unbounded pass would have reached.
+/// that is to reclaim nothing and say so: the session and its content stay
+/// exactly where they were, `content_reclamation_deferred` reports the
+/// skip, and the walk keeps moving past the session rather than pinning
+/// itself to it. A later pass with room for the scan reaches the verdict an
+/// unbounded pass would have reached.
 #[tokio::test]
-async fn a_budget_that_dies_inside_the_reference_scan_parks_without_deciding() {
+async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -1042,47 +1043,63 @@ async fn a_budget_that_dies_inside_the_reference_scan_parks_without_deciding() {
         "the fixture must give the scan more than one object to read"
     );
 
-    // One object per pass: the earlier families advance a key at a time
-    // until the sweep reaches the session, and there the cursor stops
-    // moving because the scan behind it never fits.
+    // One object per pass: the sweep advances a key at a time until it
+    // reaches the session, and the scan behind that session never fits in
+    // one object. The walk has to get past it anyway.
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
     let mut tiny = config();
     tiny.max_objects = Some(1);
     let mut cursor: Option<String> = None;
-    let mut parked = None;
-    for _ in 0..64 {
+    let mut deferred = false;
+    let mut passes = 0;
+    loop {
+        passes += 1;
+        assert!(
+            passes <= 64,
+            "a one-object budget must still walk the namespace to the end"
+        );
         tiny.cursor.clone_from(&cursor);
         let pass = gc_namespace(&store, &namespace_id, &tiny, &past)
             .await
             .expect("one-object pass");
         assert_eq!(pass.deleted_upload_sessions, 0);
         assert_eq!(pass.deleted_content_objects, 0);
-        let next = pass.next_cursor.expect("work remains");
-        if cursor.as_deref() == Some(next.as_str()) {
-            parked = Some(next);
+        deferred |= pass.content_reclamation_deferred;
+        let Some(next) = pass.next_cursor else {
             break;
-        }
+        };
+        // The whole point of deferring rather than parking: a pass either
+        // finishes or hands back a cursor strictly past the one it came in
+        // with. It never asks to be run again from where it started.
+        assert_ne!(
+            Some(next.as_str()),
+            cursor.as_deref(),
+            "pass {passes} handed back the cursor it came in with"
+        );
         cursor = Some(next);
     }
-    let parked = parked.expect("a one-object budget parks inside the scan");
+    assert!(
+        deferred,
+        "a one-object budget cannot afford the scan, and the pass must say so"
+    );
     assert!(
         store.head(&content_key).await.expect("head").is_some(),
-        "a parked pass reclaims nothing"
+        "a deferred pass reclaims nothing"
     );
     assert!(
         read_upload_session(&store, &namespace_id, &upload_id)
             .await
             .is_some(),
-        "the session that triggered the scan is retained, not decided"
+        "the session that triggered the scan is retained, not reclaimed"
     );
 
-    // Same cursor, a budget the scan fits inside: now it decides.
+    // Try again with a budget the scan fits inside: now it decides.
     let mut enough = config();
     enough.max_objects = Some(1_024);
-    enough.cursor = Some(parked);
     let resumed = gc_namespace(&store, &namespace_id, &enough, &past)
         .await
-        .expect("resumed pass");
+        .expect("pass with room for the scan");
+    assert!(!resumed.content_reclamation_deferred);
     assert_eq!(resumed.deleted_upload_sessions, 1);
     assert_eq!(resumed.deleted_content_objects, 1);
     assert!(store.head(&content_key).await.expect("head").is_none());
@@ -1095,9 +1112,9 @@ async fn a_budget_that_dies_inside_the_reference_scan_parks_without_deciding() {
 /// segment, the very last root the scan reads. A pass that stopped short
 /// and answered from what it had collected would call the content
 /// unreferenced and delete it. Running every budget from one up past the
-/// whole scan's cost, each to a standstill, leaves no interleaving where a
-/// partial reference set decides anything — and the budgets that can afford
-/// the scan still reach the right verdict.
+/// whole scan's cost, each to the end of its walk, leaves no interleaving
+/// where a partial reference set decides anything — and the budgets that
+/// can afford the scan still reach the right verdict.
 #[tokio::test]
 async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1123,7 +1140,7 @@ async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
         loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
     let mut some_budget_reached_the_verdict = false;
-    let mut some_budget_parked_instead = false;
+    let mut some_budget_deferred_instead = false;
 
     for max_objects in 1..=16 {
         let trial_root = temp_dir.path().join(format!("trial-{max_objects}"));
@@ -1132,7 +1149,14 @@ async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
         let mut bounded = config();
         bounded.max_objects = Some(max_objects);
         let mut cursor: Option<String> = None;
-        for _ in 0..64 {
+        let mut deferred = false;
+        let mut passes = 0;
+        loop {
+            passes += 1;
+            assert!(
+                passes <= 256,
+                "max_objects={max_objects}: the walk must reach its end"
+            );
             bounded.cursor.clone_from(&cursor);
             let pass = gc_namespace(&store, &namespace_id, &bounded, &past)
                 .await
@@ -1142,12 +1166,15 @@ async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
                 store.head(&content_key).await.expect("head").is_some(),
                 "max_objects={max_objects}: referenced content survives every budget"
             );
+            deferred |= pass.content_reclamation_deferred;
             let Some(next) = pass.next_cursor else {
                 break;
             };
-            if cursor.as_deref() == Some(next.as_str()) {
-                break;
-            }
+            assert_ne!(
+                Some(next.as_str()),
+                cursor.as_deref(),
+                "max_objects={max_objects}: pass {passes} handed back its own cursor"
+            );
             cursor = Some(next);
         }
         assert!(
@@ -1156,12 +1183,18 @@ async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
         );
         // Reaching the referenced verdict is what deletes the record: the
         // content is metadata's from here on. A surviving record means the
-        // budget parked instead — the case this test is really about.
+        // budget deferred instead — the case this test is really about —
+        // and the two must line up exactly, because a session this walk
+        // passed over is a session the reference scan could not afford.
         let decided = read_upload_session(&store, &namespace_id, &upload_id)
             .await
             .is_none();
+        assert_eq!(
+            deferred, !decided,
+            "max_objects={max_objects}: the session survives exactly when the scan was deferred"
+        );
         some_budget_reached_the_verdict |= decided;
-        some_budget_parked_instead |= !decided;
+        some_budget_deferred_instead |= deferred;
     }
 
     assert!(
@@ -1169,9 +1202,9 @@ async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
         "a budget large enough to finish the scan must still decide the session"
     );
     assert!(
-        some_budget_parked_instead,
-        "the sweep must actually park mid-scan somewhere in this range, or the \
-         test proves nothing about partial reference sets"
+        some_budget_deferred_instead,
+        "the sweep must actually run out mid-scan somewhere in this range, or \
+         the test proves nothing about partial reference sets"
     );
 }
 
@@ -2532,6 +2565,7 @@ fn accumulate_report(total: &mut GcResponse, pass: &GcResponse) {
     total.released_missing_basis_checkpoints += pass.released_missing_basis_checkpoints;
     total.retained_candidates += pass.retained_candidates;
     total.degraded_retention |= pass.degraded_retention;
+    total.content_reclamation_deferred |= pass.content_reclamation_deferred;
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -16,6 +16,7 @@
 //! receipt's life plus the publication it could admit. Past the grace, the
 //! set of references to a completed session's content can no longer grow.
 
+use super::budget::PassBudget;
 use super::live_set::LiveSet;
 use crate::checkpoint::load_verified_manifest_tables;
 use crate::context::MutationContext;
@@ -35,8 +36,9 @@ use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
 
 /// Rows read from one metadata table per request while collecting content
-/// references. The scan runs at most once per pass, so this only bounds how
-/// much of a revision family is held in memory at a time.
+/// references. Each wave is one page of rows and costs one budget unit, so
+/// this sets both how much of a revision family is held in memory at a time
+/// and how finely the scan can be interrupted.
 const REVISION_SCAN_WAVE_ROWS: usize = 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,7 +46,16 @@ pub(super) enum UploadSessionSweep {
     /// The session key survives this pass. It may have advanced a state.
     Retain,
     /// The session has nothing left to say and its key may be deleted.
-    Delete,
+    Delete {
+        /// This sweep also removed the content object the session
+        /// completed and nothing ever published.
+        reclaimed_content: bool,
+    },
+    /// The pass ran out of budget before it could establish whether this
+    /// session's content is referenced. Nothing was decided and nothing was
+    /// deleted; the pass stops here and its cursor still points before this
+    /// session's key, so a resume reconsiders it from the start.
+    BudgetExhausted,
 }
 
 /// Advances one upload session and reclaims whatever it stops owning.
@@ -55,6 +66,7 @@ pub(super) enum UploadSessionSweep {
 /// always follows the durable transition: a crash in between leaves an
 /// object the next pass deletes from the terminal record, never an object
 /// deleted out from under a session that is still open.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -62,6 +74,7 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     grace_window_ms: u64,
     references: &mut ContentReferences<'_>,
+    budget: &mut PassBudget,
     context: &MutationContext,
 ) -> Result<UploadSessionSweep> {
     // Reading first only selects the arm. Nothing here acts on this
@@ -95,7 +108,15 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
             AbandonedUpload::of(&state)
                 .release(store, content_store_id)
                 .await;
-            Ok(UploadSessionSweep::Delete)
+            // Not counted as a reclaimed content object: this delete is
+            // unconditional cleanup that runs whether or not the session
+            // ever wrote anything, and it repeats on every pass until the
+            // record ages out. Only the content half's Absent verdict
+            // reports a reclamation, because only it establishes that
+            // there was something to reclaim.
+            Ok(UploadSessionSweep::Delete {
+                reclaimed_content: false,
+            })
         }
         UploadSessionLifecycle::Completed {
             completed_at_ms,
@@ -105,13 +126,16 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
                 return Ok(UploadSessionSweep::Retain);
             }
             match references
-                .lookup(store, namespace_id, &content_ref.content_id)
+                .lookup(store, namespace_id, &content_ref.content_id, budget)
                 .await?
             {
                 ContentReference::Unknown => Ok(UploadSessionSweep::Retain),
+                ContentReference::BudgetExhausted => Ok(UploadSessionSweep::BudgetExhausted),
                 // Published content answers to metadata now, not to the
                 // session that uploaded it, so the record is all that goes.
-                ContentReference::Referenced => Ok(UploadSessionSweep::Delete),
+                ContentReference::Referenced => Ok(UploadSessionSweep::Delete {
+                    reclaimed_content: false,
+                }),
                 ContentReference::Absent => {
                     delete_unpublished_content_object(
                         store,
@@ -119,7 +143,9 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
                         &content_ref.content_id,
                     )
                     .await;
-                    Ok(UploadSessionSweep::Delete)
+                    Ok(UploadSessionSweep::Delete {
+                        reclaimed_content: true,
+                    })
                 }
             }
         }
@@ -190,6 +216,9 @@ enum ContentReference {
     /// The reference set could not be established, so nothing is reclaimed
     /// (format spec, "Garbage collection", rule 5).
     Unknown,
+    /// The pass ran out of budget partway through establishing the set. It
+    /// is not an answer of any kind — see [`ScanOutcome::BudgetExhausted`].
+    BudgetExhausted,
 }
 
 enum CollectedReferences {
@@ -198,11 +227,32 @@ enum CollectedReferences {
     Referenced(BTreeSet<ContentId>),
 }
 
+/// What one attempt at the reference scan produced.
+enum ScanOutcome {
+    /// Every root was read. The set is complete and may decide deletions.
+    Complete(BTreeSet<ContentId>),
+    /// A root could not be read, so this pass has no reference set at all
+    /// (format spec, "Garbage collection", rule 5).
+    Unavailable,
+    /// The pass budget ran out before the last root was read. The ids
+    /// gathered so far are dropped: a partial set is not a smaller answer,
+    /// it is no answer. Every id it is missing looks unreferenced, so
+    /// deciding a deletion from one would delete live content.
+    BudgetExhausted,
+}
+
 /// Every content id the namespace's live metadata references, collected at
-/// most once per pass and only when a completed session has actually aged
-/// into reclamation — which in a healthy namespace is never, because
+/// most once per invocation and only when a completed session has actually
+/// aged into reclamation — which in a healthy namespace is never, because
 /// published sessions are swept before their content ever becomes a
 /// question.
+///
+/// The memo lives for one invocation, not one cursor-paged sweep. Carrying
+/// it further would mean putting "already scanned through here, found
+/// nothing" into the cursor, and the cursor is a client-supplied token that
+/// carries enumeration position only and never authorizes a deletion. So a
+/// resumed sweep collects again, and the budget above is what keeps that
+/// honest: the scan pays its own way every time it runs.
 pub(super) struct ContentReferences<'a> {
     live: &'a LiveSet,
     collected: CollectedReferences,
@@ -221,16 +271,27 @@ impl<'a> ContentReferences<'a> {
         store: &S,
         namespace_id: &NamespaceId,
         content_id: &ContentId,
+        budget: &mut PassBudget,
     ) -> Result<ContentReference> {
         if matches!(self.collected, CollectedReferences::NotYet) {
-            self.collected = if self.live.degraded {
-                CollectedReferences::Unavailable
+            if self.live.degraded {
+                self.collected = CollectedReferences::Unavailable;
             } else {
-                match collect_referenced_content(store, namespace_id, self.live).await? {
-                    Some(referenced) => CollectedReferences::Referenced(referenced),
-                    None => CollectedReferences::Unavailable,
+                match collect_referenced_content(store, namespace_id, self.live, budget).await? {
+                    ScanOutcome::Complete(referenced) => {
+                        self.collected = CollectedReferences::Referenced(referenced);
+                    }
+                    ScanOutcome::Unavailable => {
+                        self.collected = CollectedReferences::Unavailable;
+                    }
+                    // Deliberately leaves the memo unset: nothing partial
+                    // is ever remembered, and the pass is about to stop
+                    // and hand its caller a cursor anyway.
+                    ScanOutcome::BudgetExhausted => {
+                        return Ok(ContentReference::BudgetExhausted);
+                    }
                 }
-            };
+            }
         }
         Ok(match &self.collected {
             CollectedReferences::NotYet | CollectedReferences::Unavailable => {
@@ -257,23 +318,37 @@ impl<'a> ContentReferences<'a> {
 /// namespace can only name content minted by that namespace's own sessions,
 /// so those two sources are the whole reachable set.
 ///
-/// `None` means the set could not be established and nothing may be
-/// reclaimed on this pass.
+/// Every root read costs a budget unit — one per manifest opened, one per
+/// page of revision rows, one per WAL segment fetched — so this scan is
+/// part of the pass's bound rather than an exception to it. Running out
+/// stops the scan where it stands and reports
+/// [`ScanOutcome::BudgetExhausted`]; the caller retains the session that
+/// triggered it and returns its cursor. A namespace whose scan costs more
+/// than one whole budget therefore never finishes it, which is why
+/// `max_objects` has to be at least the scan's size for content
+/// reclamation to make progress at all.
 async fn collect_referenced_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     live: &LiveSet,
-) -> Result<Option<BTreeSet<ContentId>>> {
+    budget: &mut PassBudget,
+) -> Result<ScanOutcome> {
     let mut referenced = BTreeSet::new();
     for manifest_object_id in &live.manifests {
+        if !budget.try_charge() {
+            return Ok(ScanOutcome::BudgetExhausted);
+        }
         let Ok(tables) =
             load_verified_manifest_tables(store, namespace_id, manifest_object_id).await
         else {
-            return Ok(None);
+            return Ok(ScanOutcome::Unavailable);
         };
         let mut lower_bound = lookup_keys::REVISION_ROW_PREFIX.to_owned();
         let upper_bound = string_prefix_upper_bound(lookup_keys::REVISION_ROW_PREFIX);
         loop {
+            if !budget.try_charge() {
+                return Ok(ScanOutcome::BudgetExhausted);
+            }
             let Ok(rows) = tables
                 .scan_range_page_with_keys(
                     MetadataTableFamily::Revisions,
@@ -283,7 +358,7 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
                 )
                 .await
             else {
-                return Ok(None);
+                return Ok(ScanOutcome::Unavailable);
             };
             let exhausted = rows.len() < REVISION_SCAN_WAVE_ROWS;
             match rows.last() {
@@ -302,6 +377,9 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
     }
 
     for segment_key in &live.wal_segments {
+        if !budget.try_charge() {
+            return Ok(ScanOutcome::BudgetExhausted);
+        }
         let Some(bytes) = store
             .get(segment_key, None)
             .await
@@ -309,10 +387,10 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
         else {
             // A retained segment that vanished mid-pass is exactly the
             // ambiguity rule 5 is about.
-            return Ok(None);
+            return Ok(ScanOutcome::Unavailable);
         };
         let Ok(envelope) = decode_wal_segment_envelope_zstd(&bytes) else {
-            return Ok(None);
+            return Ok(ScanOutcome::Unavailable);
         };
         for record in &envelope.payload.records {
             for delta in &record.deltas {
@@ -323,5 +401,5 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
         }
     }
 
-    Ok(Some(referenced))
+    Ok(ScanOutcome::Complete(referenced))
 }

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -51,11 +51,12 @@ pub(super) enum UploadSessionSweep {
         /// completed and nothing ever published.
         reclaimed_content: bool,
     },
-    /// The pass ran out of budget before it could establish whether this
-    /// session's content is referenced. Nothing was decided and nothing was
-    /// deleted; the pass stops here and its cursor still points before this
-    /// session's key, so a resume reconsiders it from the start.
-    BudgetExhausted,
+    /// The pass could not afford the reference collection this session's
+    /// content needs. The session is retained exactly as an undecidable one
+    /// is, completed-content reclamation is off for the rest of the
+    /// invocation, and the sweep goes on to the next candidate: what the
+    /// budget could not pay for is the scan, not the sweep.
+    ContentReclamationDeferred,
 }
 
 /// Advances one upload session and reclaims whatever it stops owning.
@@ -130,7 +131,7 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
                 .await?
             {
                 ContentReference::Unknown => Ok(UploadSessionSweep::Retain),
-                ContentReference::BudgetExhausted => Ok(UploadSessionSweep::BudgetExhausted),
+                ContentReference::Deferred => Ok(UploadSessionSweep::ContentReclamationDeferred),
                 // Published content answers to metadata now, not to the
                 // session that uploaded it, so the record is all that goes.
                 ContentReference::Referenced => Ok(UploadSessionSweep::Delete {
@@ -216,14 +217,20 @@ enum ContentReference {
     /// The reference set could not be established, so nothing is reclaimed
     /// (format spec, "Garbage collection", rule 5).
     Unknown,
-    /// The pass ran out of budget partway through establishing the set. It
-    /// is not an answer of any kind — see [`ScanOutcome::BudgetExhausted`].
-    BudgetExhausted,
+    /// The set did not fit in the budget the pass had left, so content
+    /// reclamation is skipped for the rest of this invocation. It is not an
+    /// answer of any kind — see [`ScanOutcome::BudgetExhausted`].
+    Deferred,
 }
 
 enum CollectedReferences {
     NotYet,
     Unavailable,
+    /// The scan ran out of budget once, which settles it for the whole
+    /// invocation: a later candidate must not pay to start the same scan
+    /// over, and being skipped is a property of the invocation rather than
+    /// of the session that happened to ask first.
+    Deferred,
     Referenced(BTreeSet<ContentId>),
 }
 
@@ -252,7 +259,9 @@ enum ScanOutcome {
 /// nothing" into the cursor, and the cursor is a client-supplied token that
 /// carries enumeration position only and never authorizes a deletion. So a
 /// resumed sweep collects again, and the budget above is what keeps that
-/// honest: the scan pays its own way every time it runs.
+/// honest: the scan pays its own way every time it runs. A verdict of "not
+/// this time" is memoized like any other, which is what keeps one
+/// unaffordable scan from being re-attempted once per aged session.
 pub(super) struct ContentReferences<'a> {
     live: &'a LiveSet,
     collected: CollectedReferences,
@@ -284,11 +293,11 @@ impl<'a> ContentReferences<'a> {
                     ScanOutcome::Unavailable => {
                         self.collected = CollectedReferences::Unavailable;
                     }
-                    // Deliberately leaves the memo unset: nothing partial
-                    // is ever remembered, and the pass is about to stop
-                    // and hand its caller a cursor anyway.
+                    // The partial set is dropped, not remembered — but the
+                    // fact that it did not fit is, so the rest of the
+                    // invocation stops asking.
                     ScanOutcome::BudgetExhausted => {
-                        return Ok(ContentReference::BudgetExhausted);
+                        self.collected = CollectedReferences::Deferred;
                     }
                 }
             }
@@ -297,6 +306,7 @@ impl<'a> ContentReferences<'a> {
             CollectedReferences::NotYet | CollectedReferences::Unavailable => {
                 ContentReference::Unknown
             }
+            CollectedReferences::Deferred => ContentReference::Deferred,
             CollectedReferences::Referenced(referenced) => {
                 if referenced.contains(content_id) {
                     ContentReference::Referenced
@@ -323,10 +333,12 @@ impl<'a> ContentReferences<'a> {
 /// part of the pass's bound rather than an exception to it. Running out
 /// stops the scan where it stands and reports
 /// [`ScanOutcome::BudgetExhausted`]; the caller retains the session that
-/// triggered it and returns its cursor. A namespace whose scan costs more
-/// than one whole budget therefore never finishes it, which is why
-/// `max_objects` has to be at least the scan's size for content
-/// reclamation to make progress at all.
+/// triggered it, marks the pass as having deferred content reclamation,
+/// and carries on. A namespace whose scan never fits therefore keeps its
+/// completed content — `max_objects` has to be at least the scan's size
+/// for content reclamation to happen at all — but the sweep around it
+/// still advances, which is the difference between leaking content for a
+/// while and not collecting anything ever.
 async fn collect_referenced_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -564,9 +564,13 @@ rather than configured (format spec, "Garbage collection", rule 11).
 enumerates: deciding whether a completed session's content is still
 referenced means reading each live manifest and each retained WAL segment,
 and each of those reads spends the same budget. A pass that runs out partway
-through decides nothing about that session and returns its cursor, so a
-budget smaller than the namespace's live manifests plus retained segments
-never finishes the question, however many times it is resumed. Step-driven GC defaults
+through that reading skips completed-content reclamation for the rest of the
+invocation: the session is retained, `content_reclamation_deferred` is set,
+and the sweep goes on through every other candidate under the usual budget.
+Deletion only ever follows a complete collection, so a partial one decides
+nothing. A budget smaller than the namespace's live manifests plus retained
+segments therefore keeps that content rather than reclaiming it — a pass with
+room for the whole scan collects it later. Step-driven GC defaults
 `max_objects` to 1024 and returns any `next_cursor` for a later step rather
 than looping internally. Nothing sweeps unless `gc` is present.
 
@@ -583,9 +587,7 @@ Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to
 `core/v0`.
 
-GC responses carry `next_cursor` when the pass stopped with work left —
-either more candidates to enumerate, or one candidate whose decision it ran
-out of budget to reach.
+GC responses carry `next_cursor` only when more candidate enumeration remains.
 The token is opaque, tolerant of additive fields when decoded, and valid only
 against the namespace that issued it. It encodes the last examined key and
 object family, not a live set or retention proof: every resumed invocation

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -139,7 +139,7 @@ hoc.
 | --- | --- | --- |
 | `core.namespaces.create` | Creating namespaces (`POST /v0/namespaces`). | |
 | `core.namespaces.fork` | Forking namespaces (`POST /v0/namespaces/{ns}/forks`). | |
-| `core.namespaces.delete` | Deleting namespaces (`DELETE /v0/namespaces/{ns}`). | Terminal, and the id is permanently retired. Derived state becomes reclaimable through a `gc`-restricted maintenance step (section 6.3); content blobs are not reclaimed in v0. A deployment may still advertise `false` and answer `not_supported`. |
+| `core.namespaces.delete` | Deleting namespaces (`DELETE /v0/namespaces/{ns}`). | Terminal, and the id is permanently retired. Derived state becomes reclaimable through a `gc`-restricted maintenance step (section 6.3), which also reclaims the content of any upload session that completed, aged past the derived reclamation grace, and is referenced by nothing the namespace can reach. A deployment may still advertise `false` and answer `not_supported`. |
 | `core.uploads.direct_put` | Starting presigned `direct_put` upload sessions (`POST /v0/namespaces/{ns}/uploads`). | The server returns a short-lived presigned PUT capability for the exact content object. The key is present only when the selected provider profile proves the signed preconditions or the deployment explicitly opts into an unproven endpoint. Raw object keys and caller-managed object-store writes are not part of this feature. |
 | `core.uploads.direct_multipart` | Starting presigned `direct_multipart` upload sessions (`POST /v0/namespaces/{ns}/uploads`) and signing their parts (`POST /v0/namespaces/{ns}/uploads/{upload_id}/parts`). | The server opens the provider's multipart upload and returns one short-lived, checksum-bound capability per part. It rests on the same proven-endpoint condition as `core.uploads.direct_put`, plus the provider's multipart control operations, so the two keys are advertised together. |
 | `query.grep` | Content search (`POST /v0/namespaces/{ns}/query/grep`). | The serving half of a data-dependent capability: the request also requires a materialized steady-state grep root, and a namespace without one answers `not_supported` whatever this key advertises. |
@@ -559,7 +559,14 @@ unless it is present. `gc` opts into sweeping and overrides
 rejected as `invalid_request`. Upload sessions and the content they leave
 behind are not under `grace_window_ms` alone: a session carries its own
 lease, and how long a completed session's content is protected is derived
-rather than configured (format spec, "Garbage collection", rule 11). Step-driven GC defaults
+rather than configured (format spec, "Garbage collection", rule 11).
+`max_objects` bounds every object the pass reads, not only the candidates it
+enumerates: deciding whether a completed session's content is still
+referenced means reading each live manifest and each retained WAL segment,
+and each of those reads spends the same budget. A pass that runs out partway
+through decides nothing about that session and returns its cursor, so a
+budget smaller than the namespace's live manifests plus retained segments
+never finishes the question, however many times it is resumed. Step-driven GC defaults
 `max_objects` to 1024 and returns any `next_cursor` for a later step rather
 than looping internally. Nothing sweeps unless `gc` is present.
 
@@ -576,7 +583,9 @@ Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to
 `core/v0`.
 
-GC responses carry `next_cursor` only when more candidate enumeration remains.
+GC responses carry `next_cursor` when the pass stopped with work left —
+either more candidates to enumerate, or one candidate whose decision it ran
+out of budget to reach.
 The token is opaque, tolerant of additive fields when decoded, and valid only
 against the namespace that issued it. It encodes the last examined key and
 object family, not a live set or retention proof: every resumed invocation
@@ -933,8 +942,10 @@ WAL segments, metadata tables and manifests, and checkpoint records that
 protect nothing live — becomes garbage once the tombstone is in place. A
 maintenance step restricted to `gc` runs against the tombstone and ages
 that state out under the normal grace rules; the head survives as the
-tombstone so the id stays retired. Content blobs live in a shared
-content store outside the namespace prefix and are not reclaimed in v0.
+tombstone so the id stays retired. Content blobs live in a shared content
+store outside the namespace prefix, and the same pass reclaims each one
+still held by an upload-session record; a blob whose session record was
+already swept has nothing left pointing at it and is not reclaimed.
 
 The optional `expected_head_seq` query parameter deletes only if the head is
 still at that sequence, failing with `stale_head` otherwise — the same

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3861,7 +3861,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Maximum candidates examined by this invocation. Omit to retain the\nrun-to-completion behavior.",
+            "description": "Maximum objects this invocation may read or decide. Omit to retain\nthe run-to-completion behavior.\n\nA completed upload session past its reclamation grace makes the pass\nread every live manifest and retained WAL segment to find out\nwhether anything still references its content, and that read is\ncharged here like any other. A budget too small to finish it parks:\nthe pass decides nothing, returns the cursor it came in with, and a\ncaller looping on `next_cursor` alone would loop forever. Give a\npass at least as many objects as the namespace has live manifests\nand retained segments.",
             "minimum": 0
           }
         }
@@ -3888,6 +3888,12 @@
             "type": "integer",
             "format": "int64",
             "description": "Released checkpoint records deleted after their grace window.",
+            "minimum": 0
+          },
+          "deleted_content_objects": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Content objects reclaimed because their upload session completed,\naged past the derived reclamation grace, and nothing the namespace\ncan reach references them. The upload half's cleanup of abandoned\nsessions is not counted here: it deletes unconditionally, whether or\nnot the session ever wrote anything.",
             "minimum": 0
           },
           "deleted_manifests": {
@@ -3923,7 +3929,7 @@
               "string",
               "null"
             ],
-            "description": "Opaque resume token when more candidates remain. Resuming rebuilds\nevery safety proof; the token carries enumeration position only and\nis valid only against the same namespace."
+            "description": "Opaque resume token when the pass stopped with work left — either\nmore candidates to enumerate, or one candidate it ran out of budget\nto decide. Resuming rebuilds every safety proof; the token carries\nenumeration position only and is valid only against the same\nnamespace."
           },
           "released_expired_checkpoints": {
             "type": "integer",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3861,7 +3861,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Maximum objects this invocation may read or decide. Omit to retain\nthe run-to-completion behavior.\n\nA completed upload session past its reclamation grace makes the pass\nread every live manifest and retained WAL segment to find out\nwhether anything still references its content, and that read is\ncharged here like any other. A budget too small to finish it parks:\nthe pass decides nothing, returns the cursor it came in with, and a\ncaller looping on `next_cursor` alone would loop forever. Give a\npass at least as many objects as the namespace has live manifests\nand retained segments.",
+            "description": "Maximum objects this invocation may read or decide. Omit to retain\nthe run-to-completion behavior.\n\nA completed upload session past its reclamation grace makes the pass\nread every live manifest and retained WAL segment to find out\nwhether anything still references its content, and that read is\ncharged here like any other. A budget too small to finish it does\nnot stall the pass: the session is retained, the response sets\n`content_reclamation_deferred`, and the sweep carries on through\neverything else. What a chronically small budget costs is content\nleft unreclaimed, not progress. Give a pass at least as many objects\nas the namespace has live manifests and retained segments for that\ncontent to come back.",
             "minimum": 0
           }
         }
@@ -3880,6 +3880,10 @@
           "degraded_retention"
         ],
         "properties": {
+          "content_reclamation_deferred": {
+            "type": "boolean",
+            "description": "True when the pass skipped completed-content reclamation because\nthe reference collection it needs did not fit in `max_objects`.\nNothing was ever decided from a partial collection and the rest of\nthe sweep ran normally; a later pass with room for the whole scan\nreclaims what this one left behind."
+          },
           "degraded_retention": {
             "type": "boolean",
             "description": "True when ambiguous roots suppressed manifest/table deletion."
@@ -3929,7 +3933,7 @@
               "string",
               "null"
             ],
-            "description": "Opaque resume token when the pass stopped with work left — either\nmore candidates to enumerate, or one candidate it ran out of budget\nto decide. Resuming rebuilds every safety proof; the token carries\nenumeration position only and is valid only against the same\nnamespace."
+            "description": "Opaque resume token when more candidates remain. Resuming rebuilds\nevery safety proof; the token carries enumeration position only and\nis valid only against the same namespace."
           },
           "released_expired_checkpoints": {
             "type": "integer",


### PR DESCRIPTION
This PR is part 0 of the unified-maintenance project... It first fixes a defect that is in main today.

**The defect.** When a completed upload session becomes older than the grace period, GC collects all content references. This collection reads every live manifest and every retained WAL segment. The `max_objects` budget does not count this work. A pass with `max_objects = 1` can read the full namespace.

**The fix.** The pass now counts each object that it reads:

- one enumerated candidate
- one opened manifest
- one page of 1024 revision rows
- one fetched WAL segment

Prefix listing is not counted. Listing finds the candidates, and the cursor resumes it.

If the budget ends during the scan, the pass stops and returns its cursor. The pass does not decide the candidate. The next pass starts the scan again with a full budget.

**Safety rule.** GC deletes a content object only after a complete reference collection. A new test puts the only reference in the last object that the scan reads. The test runs each budget from 1 to 16. The content survives each budget. A deliberate error in the charge makes the test fail. This shows that the test can find the error.

**Why the scan does not resume across passes.** The GC cursor is a token that the client supplies. The cursor contract says that the cursor does not carry safety data. If the cursor carried scan results, an incorrect token could approve a deletion. For this reason, each pass runs the scan again, and the budget limits the cost.

**Second commit: defer instead of stall.** The review addendum changed the budget-exhaustion behavior. When the budget ends inside the reference scan, the pass no longer stops at that candidate:

- The pass keeps the candidate (no decision) and continues.
- The cursor always moves forward. It never repeats.
- The response sets `content_reclamation_deferred: true`.
- A later pass with enough budget completes the scan and reclaims.

Small budgets now trade temporary content retention for progress. They do not stall the pass. The adversarial test keeps its rule: content survives every partial state, for each budget from 1 to 16. A deliberate error in the charge makes the test fail. This check was run again after the change.
