### PR TITLE
refactor(grep): honest lifecycle, a status surface, and bounded index GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ name = "loonfs-grep"
 version = "0.1.1"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "ciborium",
  "clap",

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -35,8 +35,8 @@ pub use reads::{
     TrashEntry,
 };
 pub use search::{
-    DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcResponse, GrepMatch, GrepRequest,
-    GrepResponse,
+    DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest, GrepGcResponse,
+    GrepIndexLifecycle, GrepIndexStatusResponse, GrepMatch, GrepRequest, GrepResponse,
 };
 pub use uploads::{
     AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest,

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -1,7 +1,7 @@
 //! Content search (grep) request and response shapes: the `query/v0`
 //! plane's first operation (API spec, "Content search").
 
-use crate::{AbsolutePath, ChangeSeq, InodeId, NamespaceId, RevisionNo};
+use crate::{AbsolutePath, ChangeSeq, CheckpointId, InodeId, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 use xxhash_rust::xxh64::xxh64;
 
@@ -110,19 +110,93 @@ pub struct GrepResponse {
     pub next_cursor: Option<String>,
 }
 
+/// Where a namespace's grep index is in its lifecycle.
+///
+/// The phases carry different facts and never share a field: a backfill
+/// reports the sequence it is walking toward and how far the walk got, and
+/// only a steady index reports a watermark it has actually built through.
+/// A reader that wants "is this searchable, and through what?" asks the
+/// `steady` phase and nothing else.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum GrepIndexLifecycle {
+    /// No index is maintained for this namespace.
+    Disabled,
+    /// The initial walk over a pinned checkpoint is running. Nothing is
+    /// searchable yet.
+    Backfilling {
+        /// Namespace sequence the pinned checkpoint captured. Reaching it
+        /// is what completes the backfill.
+        target_seq: ChangeSeq,
+        /// Inode the walk resumes strictly after. Absent before the first
+        /// page.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cursor_inode_id: Option<InodeId>,
+        /// Checkpoint pinning the state being walked.
+        checkpoint_id: CheckpointId,
+    },
+    /// The index follows the change feed. Commits at or below the watermark
+    /// are searchable.
+    Steady {
+        /// Sequence of the commit at the index cursor.
+        built_through_seq: ChangeSeq,
+        /// Offset of the next change event within `built_through_seq`, or
+        /// zero when the whole commit is represented.
+        #[serde(default, skip_serializing_if = "is_zero")]
+        next_event_index: u32,
+    },
+}
+
+impl GrepIndexLifecycle {
+    /// Whether every commit at or below `target_seq` is represented.
+    ///
+    /// A watermark inside a commit (`next_event_index` above zero) has that
+    /// commit only partly indexed, so it counts as reached only for earlier
+    /// sequences.
+    pub fn is_built_through(&self, target_seq: ChangeSeq) -> bool {
+        match self {
+            Self::Disabled | Self::Backfilling { .. } => false,
+            Self::Steady {
+                built_through_seq,
+                next_event_index,
+            } => {
+                *built_through_seq > target_seq
+                    || (*built_through_seq == target_seq && *next_event_index == 0)
+            }
+        }
+    }
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
+}
+
 /// Result of enabling the grep index on a namespace (admin plane).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct EnableGrepIndexResponse {
     /// Namespace whose grep root was enabled.
     pub namespace_id: NamespaceId,
-    /// Sequence the index is built through when the enabling host reports
-    /// completion (an embedded host drives the backfill inside the call);
-    /// on a hosted server the backfill continues in its driver and this is
-    /// the sequence it targets.
-    pub built_through_seq: ChangeSeq,
     /// True when the namespace already carried an enabled grep root.
     pub already_enabled: bool,
+    /// The durable lifecycle this call published or found.
+    pub state: GrepIndexLifecycle,
+}
+
+/// The namespace's grep-index lifecycle and its cheap bookkeeping (admin
+/// plane).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GrepIndexStatusResponse {
+    /// Namespace the status describes.
+    pub namespace_id: NamespaceId,
+    /// Where the index is in its lifecycle.
+    pub state: GrepIndexLifecycle,
+    /// Next logical run ordinal the index will allocate.
+    pub next_run_ordinal: u64,
+    /// True while a partitioned segment reorganization is in progress.
+    pub reorganize_pending: bool,
 }
 
 /// Result of disabling the grep index on a namespace (admin plane).
@@ -133,6 +207,20 @@ pub struct DisableGrepIndexResponse {
     pub namespace_id: NamespaceId,
     /// False when the namespace had no enabled grep root.
     pub was_enabled: bool,
+}
+
+/// One explicit grep-index garbage-collection pass (admin plane).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GrepGcRequest {
+    /// Reads this pass may spend before returning with a `next_cursor`.
+    /// Omit to walk the whole grep keyspace in one call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_objects: Option<u64>,
+    /// Opaque resume token returned as `next_cursor` by an earlier pass
+    /// against the same namespace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
 /// Result of one explicit grep-index garbage-collection pass (admin plane).
@@ -151,6 +239,9 @@ pub struct GrepGcResponse {
     pub retained_candidates: u64,
     /// Whether unreadable namespace or grep state forced conservative retention.
     pub namespace_degraded: bool,
+    /// Present when the budget stopped the pass with keys left to examine.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 #[cfg(test)]
@@ -200,6 +291,68 @@ mod tests {
                 "line_truncated": false
             })
         );
+    }
+
+    #[test]
+    fn the_lifecycle_phases_never_share_a_sequence_field() {
+        let backfilling = GrepIndexLifecycle::Backfilling {
+            target_seq: ChangeSeq(9),
+            cursor_inode_id: Some(InodeId(4)),
+            checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000009")
+                .expect("checkpoint id"),
+        };
+        assert_eq!(
+            serde_json::to_value(&backfilling).expect("serialize backfilling"),
+            serde_json::json!({
+                "phase": "backfilling",
+                "target_seq": 9,
+                "cursor_inode_id": 4,
+                "checkpoint_id": "chk_00000000000000000000000000000009"
+            }),
+            "a backfill reports its target and its walk, never a watermark"
+        );
+
+        assert_eq!(
+            serde_json::to_value(GrepIndexLifecycle::Steady {
+                built_through_seq: ChangeSeq(9),
+                next_event_index: 0,
+            })
+            .expect("serialize steady"),
+            serde_json::json!({"phase": "steady", "built_through_seq": 9}),
+            "a steady index reports its watermark and no target"
+        );
+
+        assert_eq!(
+            serde_json::to_value(GrepIndexLifecycle::Disabled).expect("serialize disabled"),
+            serde_json::json!({"phase": "disabled"})
+        );
+    }
+
+    #[test]
+    fn only_a_steady_index_has_built_through_a_sequence() {
+        let backfilling = GrepIndexLifecycle::Backfilling {
+            target_seq: ChangeSeq(9),
+            cursor_inode_id: None,
+            checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000009")
+                .expect("checkpoint id"),
+        };
+        assert!(
+            !backfilling.is_built_through(ChangeSeq(0)),
+            "a backfill has indexed nothing until it turns steady"
+        );
+        assert!(!GrepIndexLifecycle::Disabled.is_built_through(ChangeSeq(0)));
+
+        let steady = |built_through_seq, next_event_index| GrepIndexLifecycle::Steady {
+            built_through_seq,
+            next_event_index,
+        };
+        assert!(steady(ChangeSeq(9), 0).is_built_through(ChangeSeq(9)));
+        assert!(steady(ChangeSeq(9), 0).is_built_through(ChangeSeq(8)));
+        assert!(!steady(ChangeSeq(9), 0).is_built_through(ChangeSeq(10)));
+        // A watermark inside a commit leaves the rest of that commit
+        // unindexed, so only earlier sequences count as reached.
+        assert!(!steady(ChangeSeq(9), 3).is_built_through(ChangeSeq(9)));
+        assert!(steady(ChangeSeq(9), 3).is_built_through(ChangeSeq(8)));
     }
 
     #[test]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -610,10 +610,45 @@ pub(crate) enum AdminCommand {
     Step(AdminStepArgs),
     /// Run a mark-and-sweep garbage-collection pass.
     Gc(AdminGcArgs),
-    /// Enable the gram content index and start its backfill.
-    IndexEnable(AdminNamespaceArgs),
+    /// Enable the gram content index and wait for its backfill to reach the
+    /// sequence the namespace was at when this command started.
+    IndexEnable(AdminIndexEnableArgs),
     /// Disable the gram content index.
     IndexDisable(AdminNamespaceArgs),
+    /// Report where the gram content index is: disabled, backfilling, or
+    /// steady at a watermark.
+    IndexStatus(AdminNamespaceArgs),
+    /// Collect the namespace's unreferenced gram-index objects.
+    IndexGc(AdminIndexGcArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct AdminIndexEnableArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    /// Return as soon as the index is enabled, without waiting for the
+    /// backfill.
+    #[arg(long)]
+    pub no_wait: bool,
+    /// Give up after this many steps: one bounded index step where the
+    /// profile is embedded, one status check where it is remote. Exits
+    /// nonzero and reports how far the index got.
+    #[arg(long)]
+    pub max_steps: Option<u64>,
+    /// Give up after this many milliseconds. Exits nonzero and reports how
+    /// far the index got.
+    #[arg(long)]
+    pub deadline_ms: Option<u64>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct AdminIndexGcArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    /// Spend at most this many reads and return after one bounded pass.
+    /// Omit to loop bounded passes through completion.
+    #[arg(long)]
+    pub max_objects: Option<u64>,
 }
 
 #[derive(Debug, Args)]
@@ -740,6 +775,8 @@ pub(crate) enum CommandKind {
     AdminGc,
     AdminIndexEnable,
     AdminIndexDisable,
+    AdminIndexStatus,
+    AdminIndexGc,
     ConfigPath,
     ConfigShow,
     Version,
@@ -783,6 +820,8 @@ impl CommandKind {
             CommandKind::AdminGc => "admin_gc",
             CommandKind::AdminIndexEnable => "admin_index_enable",
             CommandKind::AdminIndexDisable => "admin_index_disable",
+            CommandKind::AdminIndexStatus => "admin_index_status",
+            CommandKind::AdminIndexGc => "admin_index_gc",
             CommandKind::ConfigPath => "config_path",
             CommandKind::ConfigShow => "config_show",
             CommandKind::Version => "version",
@@ -837,6 +876,8 @@ impl Cli {
                 AdminCommand::Gc(_) => CommandKind::AdminGc,
                 AdminCommand::IndexEnable(_) => CommandKind::AdminIndexEnable,
                 AdminCommand::IndexDisable(_) => CommandKind::AdminIndexDisable,
+                AdminCommand::IndexStatus(_) => CommandKind::AdminIndexStatus,
+                AdminCommand::IndexGc(_) => CommandKind::AdminIndexGc,
             },
             Command::Config { command } => match command {
                 ConfigCommand::Path => CommandKind::ConfigPath,

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -9,11 +9,15 @@ use crate::render::write_stderr_warning;
 use loonfs::{
     ByteStream, ChangesResponse, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    FsAdmin, FsReader, FsWriter, ListChangesOptions, MaintenanceStepOptions, MoveOptions,
-    PutFileOptions, RestoreRevisionOptions, RuntimeError, SharedObjectStore, UndeleteOptions,
+    FsAdmin, FsReader, FsWriter, ListChangesOptions, MaintenanceJob, MaintenanceStepConclusion,
+    MaintenanceStepOptions, MoveOptions, PutFileOptions, RestoreRevisionOptions, RuntimeError,
+    SharedObjectStore, UndeleteOptions,
 };
 use loonfs_api::{
-    v0::{DisableGrepIndexResponse, EnableGrepIndexResponse},
+    v0::{
+        DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest, GrepGcResponse,
+        GrepIndexLifecycle, GrepIndexStatusResponse,
+    },
     AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
     CreateCheckpointResponse, DestinationBehavior, EffectiveLimit, ErrorCode, GrepRequest,
     GrepResponse, InodeId, ListFileRevisionsResponse, ListTrashResponse, MaintenanceStepRequest,
@@ -23,8 +27,11 @@ use loonfs_api::{
 use loonfs_client::{CommitOptions, NamespacePath};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepIndexSnapshot,
-    GrepService, GrepWorker, NamespaceReads,
+    GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
 };
+use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
+
+use super::{GrepWaitBudget, GrepWaitProgress};
 
 /// Purpose-specific handles over one shared store client: reads go through
 /// the reader, mutations through the writer, and maintenance through the
@@ -219,31 +226,136 @@ impl EmbeddedBackend {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<EnableGrepIndexResponse, BackendError> {
-        let worker = self.grep_worker();
         let grep_error = |error| map_namespace_scoped_grep_error(namespace_id, error);
-        let already_enabled = match worker.enable(namespace_id).await.map_err(grep_error)? {
-            GrepEnableOutcome::Enabled { .. } => false,
-            GrepEnableOutcome::AlreadyEnabled { .. } => true,
+        let (already_enabled, lifecycle) = match self
+            .grep_worker()
+            .enable(namespace_id)
+            .await
+            .map_err(grep_error)?
+        {
+            GrepEnableOutcome::Enabled { state } => (false, state),
+            GrepEnableOutcome::AlreadyEnabled { state } => (true, state),
             GrepEnableOutcome::Superseded => {
                 return Err(grep_error(GrepError::PublicationConflict {
                     object_key: loonfs_grep::keyspace::root_key(namespace_id),
                 }))
             }
         };
-        // A one-shot command has no driver runtime, so enable is the
-        // driver: without this the root would stay `Backfilling` and every
-        // query would answer `not_supported`. Re-running enable on an
-        // already-enabled namespace drives catch-up the same way, which is
-        // how an embedded operator advances a lagging index.
-        let built_through_seq = worker
-            .run_to_quiescence(namespace_id, GramIndexBuildPolicy::default())
-            .await
-            .map_err(grep_error)?;
+        // Enabling is one compare-and-swap and nothing else, here as on a
+        // server. Driving the backfill afterwards is the command's job, not
+        // this call's, so an embedded caller and a remote one get the same
+        // answer to the same question.
         Ok(EnableGrepIndexResponse {
             namespace_id: namespace_id.clone(),
-            built_through_seq,
             already_enabled,
+            state: GrepIndexLifecycle::from(&lifecycle),
         })
+    }
+
+    pub(super) async fn grep_index_status(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<GrepIndexStatusResponse, BackendError> {
+        let root = self
+            .grep_worker()
+            .root_state(namespace_id)
+            .await
+            .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))?;
+        let (state, next_run_ordinal, reorganize_pending) = match &root {
+            Some(root) => (
+                GrepIndexLifecycle::from(root.lifecycle()),
+                root.index().next_run_ordinal,
+                root.index().reorganize.is_some(),
+            ),
+            None => (GrepIndexLifecycle::Disabled, 0, false),
+        };
+        Ok(GrepIndexStatusResponse {
+            namespace_id: namespace_id.clone(),
+            state,
+            next_run_ordinal,
+            reorganize_pending,
+        })
+    }
+
+    pub(super) async fn gc_grep_index(
+        &self,
+        namespace_id: &NamespaceId,
+        request: &GrepGcRequest,
+    ) -> Result<GrepGcResponse, BackendError> {
+        let report = self
+            .grep_worker()
+            .garbage_collect_namespace(
+                namespace_id,
+                current_unix_ms()?,
+                &loonfs_grep::GrepGcRequest {
+                    max_objects: request.max_objects,
+                    cursor: request.cursor.clone(),
+                },
+            )
+            .await
+            .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))?;
+        Ok(GrepGcResponse {
+            namespace_id: namespace_id.clone(),
+            deleted_segments: report.deleted_segments,
+            deleted_other_objects: report.deleted_other_objects,
+            namespace_reaped: report.namespace_reaped,
+            retained_candidates: report.retained_candidates,
+            namespace_degraded: report.namespace_degraded,
+            next_cursor: report.next_cursor,
+        })
+    }
+
+    /// Runs the grep-index job's bounded steps until the index has built
+    /// through `target_seq`, or until the budget runs out.
+    ///
+    /// A one-shot command hosts no maintenance runner, so it runs the job
+    /// itself — the same executor a server registers, minus admission and
+    /// backoff, so the first failure surfaces instead of being retried. The
+    /// target is fixed before the first step, so a namespace that keeps
+    /// being written to cannot keep this loop running.
+    pub(super) async fn drive_grep_index(
+        &self,
+        namespace_id: &NamespaceId,
+        target_seq: ChangeSeq,
+        budget: GrepWaitBudget,
+    ) -> Result<GrepWaitProgress, BackendError> {
+        let worker = self.grep_worker();
+        let job = GrepMaintenanceJob::new(worker.clone(), GramIndexBuildPolicy::default());
+        let timer = StdMonotonicTimer::default();
+        let started_ms = timer.monotonic_now_ms();
+        let mut steps = 0;
+        let mut settled = false;
+        loop {
+            let state = GrepIndexLifecycle::from(
+                &worker
+                    .lifecycle(namespace_id)
+                    .await
+                    .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))?,
+            );
+            let reached = state.is_built_through(target_seq);
+            let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
+            if reached || settled || budget.spent(steps, elapsed_ms) {
+                return Ok(GrepWaitProgress {
+                    state,
+                    steps,
+                    reached,
+                });
+            }
+            let conclusion = job
+                .step(namespace_id, None)
+                .await
+                .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?
+                .conclusion;
+            steps += 1;
+            // A step that settled short of the target says the index has
+            // nothing more to do — disabled underneath us, or blocked on a
+            // budget of its own. Repeating it would only spin, so the next
+            // turn of this loop reports where it stopped.
+            settled = !matches!(
+                conclusion,
+                MaintenanceStepConclusion::Progressed | MaintenanceStepConclusion::Superseded
+            );
+        }
     }
 
     pub(super) async fn disable_grep_index(
@@ -542,6 +654,20 @@ impl EmbeddedBackend {
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
+}
+
+/// Grace windows are wall-clock policy, and this is where an embedded
+/// command enters wall time — the same boundary the server's HTTP handler
+/// is. Nothing durable replays through it.
+#[allow(clippy::disallowed_methods)]
+fn current_unix_ms() -> Result<u64, BackendError> {
+    let server_error =
+        |message: String| BackendError::new(ErrorCode::ServerError.as_str(), message);
+    let elapsed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| server_error(format!("system time is before unix epoch: {error}")))?;
+    u64::try_from(elapsed.as_millis())
+        .map_err(|error| server_error(format!("system time does not fit in milliseconds: {error}")))
 }
 
 fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendError> {

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -20,7 +20,10 @@ use crate::backend_error::BackendError;
 use crate::payload::LocalPayload;
 use crate::resolve::ResolvedTarget;
 use loonfs_api::{
-    v0::{ChangesResponse, DisableGrepIndexResponse, EnableGrepIndexResponse},
+    v0::{
+        ChangesResponse, DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest,
+        GrepGcResponse, GrepIndexLifecycle, GrepIndexStatusResponse,
+    },
     AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
     CreateCheckpointResponse, DeleteNamespaceResponse, DestinationBehavior, GrepRequest,
     GrepResponse, InodeId, ListFileRevisionsResponse, ListTrashResponse, MaintenanceStepRequest,
@@ -30,8 +33,58 @@ use loonfs_api::{
 use loonfs_client::{
     CommitOptions, CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions,
 };
+use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 
 pub(crate) use embedded::EmbeddedBackend;
+
+/// How long a remote wait rests between status checks.
+///
+/// A hosted server drives its own index, so this is only how often the
+/// command asks. Modest and fixed: the wait is bounded by the caller's own
+/// budgets, not by how fast it polls.
+const REMOTE_STATUS_POLL_INTERVAL_MS: u64 = 250;
+
+/// What a caller will spend waiting for the index to reach a target.
+///
+/// A step is one bounded index step where the profile is embedded and one
+/// status check where it is remote — the two arms do different work to
+/// advance the same wait.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct GrepWaitBudget {
+    pub max_steps: Option<u64>,
+    pub deadline_ms: Option<u64>,
+}
+
+impl GrepWaitBudget {
+    fn spent(&self, steps: u64, elapsed_ms: u64) -> bool {
+        self.max_steps.is_some_and(|max_steps| steps >= max_steps)
+            || self
+                .deadline_ms
+                .is_some_and(|deadline_ms| elapsed_ms >= deadline_ms)
+    }
+}
+
+/// Where a wait stopped and what it cost.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GrepWaitProgress {
+    /// The lifecycle last observed.
+    pub state: GrepIndexLifecycle,
+    /// Steps this wait spent.
+    pub steps: u64,
+    /// True when the index reached the target sequence.
+    pub reached: bool,
+}
+
+/// The one timer this CLI owns: how long a remote wait rests between status
+/// checks. Nothing durable depends on it — it only decides how often a
+/// command that is already waiting asks again.
+#[allow(clippy::disallowed_methods)]
+async fn rest_between_status_checks() {
+    tokio::time::sleep(std::time::Duration::from_millis(
+        REMOTE_STATUS_POLL_INTERVAL_MS,
+    ))
+    .await;
+}
 
 /// One logical LoonFS API over two transports.
 ///
@@ -170,6 +223,73 @@ impl ResolvedTarget {
         match self {
             Self::Embedded(target) => target.backend.disable_grep_index(namespace_id).await,
             Self::Remote(target) => Ok(target.client.disable_grep_index(namespace_id).await?),
+        }
+    }
+
+    /// Reads the namespace's grep-index lifecycle (admin plane).
+    pub(crate) async fn grep_index_status(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<GrepIndexStatusResponse, BackendError> {
+        match self {
+            Self::Embedded(target) => target.backend.grep_index_status(namespace_id).await,
+            Self::Remote(target) => Ok(target.client.grep_index_status(namespace_id).await?),
+        }
+    }
+
+    /// Runs one bounded grep-index garbage-collection pass (admin plane).
+    pub(crate) async fn gc_grep_index(
+        &self,
+        namespace_id: &NamespaceId,
+        request: &GrepGcRequest,
+    ) -> Result<GrepGcResponse, BackendError> {
+        match self {
+            Self::Embedded(target) => target.backend.gc_grep_index(namespace_id, request).await,
+            Self::Remote(target) => Ok(target.client.gc_grep_index(namespace_id, request).await?),
+        }
+    }
+
+    /// Waits until the grep index has built through `target_seq`, or until
+    /// the budget runs out.
+    ///
+    /// The two arms advance the same wait differently, and that is the whole
+    /// difference between them. An embedded profile has no maintenance host,
+    /// so it *is* the host: it runs the index job's bounded steps itself. A
+    /// remote profile's server drives its own index, so this only watches
+    /// the status endpoint. Both stop at the target they were given and
+    /// never chase a head that keeps moving.
+    pub(crate) async fn wait_for_grep_index(
+        &self,
+        namespace_id: &NamespaceId,
+        target_seq: ChangeSeq,
+        budget: GrepWaitBudget,
+    ) -> Result<GrepWaitProgress, BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .drive_grep_index(namespace_id, target_seq, budget)
+                    .await
+            }
+            Self::Remote(target) => {
+                let timer = StdMonotonicTimer::default();
+                let started_ms = timer.monotonic_now_ms();
+                let mut steps = 0;
+                loop {
+                    let state = target.client.grep_index_status(namespace_id).await?.state;
+                    let reached = state.is_built_through(target_seq);
+                    let elapsed_ms = timer.monotonic_now_ms().saturating_sub(started_ms);
+                    if reached || budget.spent(steps, elapsed_ms) {
+                        return Ok(GrepWaitProgress {
+                            state,
+                            steps,
+                            reached,
+                        });
+                    }
+                    rest_between_status_checks().await;
+                    steps += 1;
+                }
+            }
         }
     }
 

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -4,9 +4,12 @@
 use super::context::resolve_command_context;
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
-    AdminCheckpointArgs, AdminCheckpointReleaseArgs, AdminCommand, AdminGcArgs, AdminNamespaceArgs,
-    AdminStepArgs, ChangesArgs, CommandKind,
+    AdminCheckpointArgs, AdminCheckpointReleaseArgs, AdminCommand, AdminGcArgs,
+    AdminIndexEnableArgs, AdminIndexGcArgs, AdminNamespaceArgs, AdminStepArgs, ChangesArgs,
+    CommandKind,
 };
+use crate::backend::GrepWaitBudget;
+use loonfs_api::v0::{GrepGcRequest, GrepIndexLifecycle};
 use loonfs_api::{
     ChangeSeq, CheckpointId, CreateCheckpointRequest, ErrorCode, GcRequest, MaintenanceStepKind,
     MaintenanceStepRequest,
@@ -27,6 +30,8 @@ pub(crate) async fn run_admin_command(
         AdminCommand::Gc(args) => run_admin_gc(kind, args).await,
         AdminCommand::IndexEnable(args) => run_admin_index_enable(kind, args).await,
         AdminCommand::IndexDisable(args) => run_admin_index_disable(kind, args).await,
+        AdminCommand::IndexStatus(args) => run_admin_index_status(kind, args).await,
+        AdminCommand::IndexGc(args) => run_admin_index_gc(kind, args).await,
     }
 }
 
@@ -242,9 +247,15 @@ pub(crate) async fn run_admin_changes(
     })
 }
 
+/// Enables the index and, by default, waits for it to catch up to one fixed
+/// sequence.
+///
+/// The sequence is captured before any waiting starts and never re-read:
+/// writes that land afterwards are not waited for, so a namespace that is
+/// being written to cannot keep this command running.
 async fn run_admin_index_enable(
     kind: CommandKind,
-    args: AdminNamespaceArgs,
+    args: AdminIndexEnableArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
     let response = context
@@ -252,12 +263,128 @@ async fn run_admin_index_enable(
         .enable_grep_index(&context.namespace)
         .await
         .map_err(|error| context.fail(kind, error))?;
+    let target_seq = match (args.no_wait, &response.state) {
+        // Nothing to wait for: the caller opted out, or the index is
+        // disabled, which enable would have changed if it could.
+        (true, _) | (_, GrepIndexLifecycle::Disabled) => None,
+        // A backfill already names the namespace sequence its checkpoint
+        // captured, and reaching it is what completes the backfill.
+        (_, GrepIndexLifecycle::Backfilling { target_seq, .. }) => Some(*target_seq),
+        // A steady index is asked to catch up to where the namespace is
+        // now: one read, before any stepping, so an index that is already
+        // there returns without doing anything.
+        (_, GrepIndexLifecycle::Steady { .. }) => Some(
+            context
+                .target
+                .namespace_status(&context.namespace)
+                .await
+                .map_err(|error| context.fail(kind, error))?
+                .head_seq,
+        ),
+    };
+    let waited = match target_seq {
+        Some(target_seq) => Some(
+            context
+                .target
+                .wait_for_grep_index(
+                    &context.namespace,
+                    target_seq,
+                    GrepWaitBudget {
+                        max_steps: args.max_steps,
+                        deadline_ms: args.deadline_ms,
+                    },
+                )
+                .await
+                .map_err(|error| context.fail(kind, error))?,
+        ),
+        None => None,
+    };
+
     Ok(CommandOutput {
         kind,
         profile: Some(context.profile_name),
         mode: Some(context.mode),
-        data: CommandData::GrepIndexEnabled(response),
+        data: CommandData::GrepIndexEnabled {
+            namespace_id: response.namespace_id,
+            already_enabled: response.already_enabled,
+            state: waited
+                .as_ref()
+                .map_or(response.state, |waited| waited.state.clone()),
+            waited_for_seq: target_seq,
+            steps: waited.as_ref().map_or(0, |waited| waited.steps),
+            budget_exhausted: waited.is_some_and(|waited| !waited.reached),
+        },
     })
+}
+
+async fn run_admin_index_status(
+    kind: CommandKind,
+    args: AdminNamespaceArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let response = context
+        .target
+        .grep_index_status(&context.namespace)
+        .await
+        .map_err(|error| context.fail(kind, error))?;
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::GrepIndexStatus(response),
+    })
+}
+
+/// Collects the namespace's grep keyspace, looping the cursor exactly like
+/// `admin gc`: bounded passes through completion, unless `--max-objects`
+/// asks for one pass and its resume token.
+async fn run_admin_index_gc(
+    kind: CommandKind,
+    args: AdminIndexGcArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let context = resolve_command_context(kind, &args.target).await?;
+    let single_pass = args.max_objects.is_some();
+    let mut request = GrepGcRequest {
+        max_objects: Some(args.max_objects.unwrap_or(loonfs::DEFAULT_GC_MAX_OBJECTS)),
+        cursor: None,
+    };
+    let mut response: Option<loonfs_api::v0::GrepGcResponse> = None;
+    loop {
+        let pass = context
+            .target
+            .gc_grep_index(&context.namespace, &request)
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        let next_cursor = pass.next_cursor.clone();
+        match &mut response {
+            Some(total) => accumulate_grep_gc_response(total, pass),
+            None => response = Some(pass),
+        }
+        if single_pass || next_cursor.is_none() {
+            break;
+        }
+        request.cursor = next_cursor;
+    }
+    let response = response.expect("grep GC loop should run at least once");
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(context.profile_name),
+        mode: Some(context.mode),
+        data: CommandData::GrepIndexCollected(response),
+    })
+}
+
+fn accumulate_grep_gc_response(
+    total: &mut loonfs_api::v0::GrepGcResponse,
+    pass: loonfs_api::v0::GrepGcResponse,
+) {
+    total.deleted_segments += pass.deleted_segments;
+    total.deleted_other_objects += pass.deleted_other_objects;
+    total.retained_candidates += pass.retained_candidates;
+    total.namespace_reaped |= pass.namespace_reaped;
+    total.namespace_degraded |= pass.namespace_degraded;
+    total.next_cursor = pass.next_cursor;
 }
 
 async fn run_admin_index_disable(

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -4,7 +4,10 @@ use crate::args::CommandKind;
 use crate::config::{CliConfig, ProfileConfig};
 use crate::error::CliError;
 use crate::profiles::ProfileSummary;
-use loonfs_api::v0::{ChangesResponse, DisableGrepIndexResponse, EnableGrepIndexResponse};
+use loonfs_api::v0::{
+    ChangesResponse, DisableGrepIndexResponse, GrepGcResponse, GrepIndexLifecycle,
+    GrepIndexStatusResponse,
+};
 use loonfs_api::{
     AuthoritativePathEntry, ChangeSeq, CommitId, CreateCheckpointResponse, DeleteNamespaceResponse,
     FileRevision, GcResponse, GrepMatch, InodeId, MaintenanceStepResponse, NamespaceId,
@@ -63,8 +66,26 @@ pub(crate) enum CommandData {
     CheckpointReleased(ReleaseCheckpointResponse),
     MaintenanceStepped(MaintenanceStepResponse),
     GarbageCollected(GcResponse),
-    GrepIndexEnabled(EnableGrepIndexResponse),
+    GrepIndexEnabled {
+        namespace_id: NamespaceId,
+        /// True when the namespace already carried an enabled grep root.
+        already_enabled: bool,
+        /// The lifecycle last observed: what enable published with
+        /// `--no-wait`, otherwise where the wait stopped.
+        state: GrepIndexLifecycle,
+        /// The sequence the wait drove toward. Absent with `--no-wait` and
+        /// on a namespace whose index is disabled.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        waited_for_seq: Option<ChangeSeq>,
+        /// Steps the wait spent: bounded index steps in embedded mode,
+        /// status checks in remote mode.
+        steps: u64,
+        /// True when a budget stopped the wait before the target.
+        budget_exhausted: bool,
+    },
     GrepIndexDisabled(DisableGrepIndexResponse),
+    GrepIndexStatus(GrepIndexStatusResponse),
+    GrepIndexCollected(GrepGcResponse),
     Changes(ChangesResponse),
     Trash(loonfs_api::ListTrashResponse),
     PathEntries {
@@ -145,6 +166,15 @@ impl CommandData {
     /// the process can exit nonzero without discarding the structured
     /// results a partial failure produced.
     pub(crate) fn reports_failures(&self) -> bool {
-        matches!(self, CommandData::TreeTransfer { failures, .. } if !failures.is_empty())
+        match self {
+            CommandData::TreeTransfer { failures, .. } => !failures.is_empty(),
+            // A wait that ran out of budget renders where the index got to
+            // — real data, not an error — and still exits nonzero, because
+            // the caller asked for a target that was not reached.
+            CommandData::GrepIndexEnabled {
+                budget_exhausted, ..
+            } => *budget_exhausted,
+            _ => false,
+        }
     }
 }

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -3,9 +3,41 @@
 use crate::args::CommandKind;
 use crate::commands::{CommandData, CommandFailure, CommandOutput};
 use crate::error::CliError;
+use loonfs_api::v0::GrepIndexLifecycle;
 use loonfs_api::{GcResponse, ReorganizeStepOutcome, WalFlushStepOutcome};
 use serde::Serialize;
 use std::io::{self, Write};
+
+/// One phrase for where the index is, in the terms that phase actually has.
+fn grep_index_state_summary(state: &GrepIndexLifecycle) -> String {
+    match state {
+        GrepIndexLifecycle::Disabled => "disabled".to_owned(),
+        GrepIndexLifecycle::Backfilling {
+            target_seq,
+            cursor_inode_id,
+            ..
+        } => match cursor_inode_id {
+            Some(inode_id) => format!(
+                "backfilling toward seq {}, walked through inode {}",
+                target_seq.0, inode_id.0
+            ),
+            None => format!("backfilling toward seq {}, not yet started", target_seq.0),
+        },
+        GrepIndexLifecycle::Steady {
+            built_through_seq,
+            next_event_index,
+        } => {
+            if *next_event_index == 0 {
+                format!("steady, built through seq {}", built_through_seq.0)
+            } else {
+                format!(
+                    "steady, built through seq {} up to event {}",
+                    built_through_seq.0, next_event_index
+                )
+            }
+        }
+    }
+}
 
 fn gc_summary(report: &GcResponse) -> String {
     let mut summary = format!(
@@ -395,17 +427,28 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             })
             .collect::<Vec<_>>()
             .join("\n"),
-        CommandData::GrepIndexEnabled(response) => {
-            if response.already_enabled {
+        CommandData::GrepIndexEnabled {
+            namespace_id,
+            already_enabled,
+            state,
+            waited_for_seq,
+            steps,
+            budget_exhausted,
+        } => {
+            let opening = if *already_enabled {
+                format!("grep index already enabled on {namespace_id}")
+            } else {
+                format!("grep index enabled on {namespace_id}")
+            };
+            if *budget_exhausted {
+                let target = waited_for_seq
+                    .map_or_else(|| "its target".to_owned(), |seq| format!("seq {}", seq.0));
                 format!(
-                    "grep index already enabled on {}; caught up through seq {}",
-                    response.namespace_id, response.built_through_seq.0
+                    "{opening}; gave up waiting for {target} after {steps} steps — {}",
+                    grep_index_state_summary(state)
                 )
             } else {
-                format!(
-                    "grep index enabled on {}; built through seq {}",
-                    response.namespace_id, response.built_through_seq.0
-                )
+                format!("{opening}; {}", grep_index_state_summary(state))
             }
         }
         CommandData::GrepIndexDisabled(response) => {
@@ -414,6 +457,36 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             } else {
                 format!("grep index was not enabled on {}", response.namespace_id)
             }
+        }
+        CommandData::GrepIndexStatus(response) => {
+            let mut summary = format!(
+                "grep index on {}: {}",
+                response.namespace_id,
+                grep_index_state_summary(&response.state)
+            );
+            if response.reorganize_pending {
+                summary.push_str("; a reorganization is in progress");
+            }
+            summary
+        }
+        CommandData::GrepIndexCollected(response) => {
+            let mut summary = format!(
+                "index-gc for {}: {} segments, {} other objects deleted, {} retained",
+                response.namespace_id,
+                response.deleted_segments,
+                response.deleted_other_objects,
+                response.retained_candidates
+            );
+            if response.namespace_reaped {
+                summary.push_str("; the namespace's grep state was reaped");
+            }
+            if response.namespace_degraded {
+                summary.push_str("; unreadable state forced conservative retention");
+            }
+            if let Some(cursor) = &response.next_cursor {
+                summary.push_str(&format!("; more to examine (next_cursor: {cursor})"));
+            }
+            summary
         }
         CommandData::GrepMatches {
             pattern,

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -2108,11 +2108,14 @@ fn embedded_grep_works_after_index_enable() {
     assert_failure(&before);
     assert_eq!(json_error(&before)["code"], "not_supported");
 
-    // Enable drives the backfill to completion in-process: the one-shot
-    // CLI is its own grep maintenance, so the query works immediately —
-    // no server, no driver, no state that never resolves.
+    // Enable waits for the backfill in-process: the one-shot CLI is its own
+    // grep maintenance, so the query works immediately — no server, no
+    // driver, no state that never resolves.
     let enabled = harness.run(&["--json", "admin", "index-enable"]);
     assert_success(&enabled);
+    assert_eq!(json_data(&enabled)["state"]["phase"], "steady");
+    assert_eq!(json_data(&enabled)["waited_for_seq"], 1);
+    assert_eq!(json_data(&enabled)["budget_exhausted"], false);
     let found = harness.run(&["--json", "grep", "TODO"]);
     assert_success(&found);
     assert_eq!(
@@ -2156,6 +2159,220 @@ fn index_enable_leaves_core_maintenance_decoupled() {
     assert_success(&retried);
     assert_eq!(json_data(&retried)["already_enabled"], true);
     assert!(json_data(&retried).get("backfill_step").is_none());
+}
+
+/// The index reports the phase it is in, and the phases do not share a
+/// field: a backfill names its target, a steady index names its watermark.
+#[test]
+fn index_status_reports_each_phase_in_its_own_terms() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let disabled = harness.run(&["--json", "admin", "index-status"]);
+    assert_success(&disabled);
+    assert_eq!(json_data(&disabled)["state"]["phase"], "disabled");
+    assert!(json_data(&disabled)["state"]
+        .get("built_through_seq")
+        .is_none());
+
+    // `--no-wait` returns with the root the enable published: a backfill,
+    // naming the sequence it will walk to and nothing it has indexed.
+    let enabled = harness.run(&["--json", "admin", "index-enable", "--no-wait"]);
+    assert_success(&enabled);
+    let state = &json_data(&enabled)["state"];
+    assert_eq!(state["phase"], "backfilling");
+    assert_eq!(state["target_seq"], 0);
+    assert!(state.get("built_through_seq").is_none());
+    assert!(json_data(&enabled).get("waited_for_seq").is_none());
+    assert_eq!(json_data(&enabled)["steps"], 0);
+
+    let backfilling = harness.run(&["--json", "admin", "index-status"]);
+    assert_success(&backfilling);
+    assert_eq!(json_data(&backfilling)["state"]["phase"], "backfilling");
+    assert_eq!(json_data(&backfilling)["reorganize_pending"], false);
+    assert!(backfilling_text_names_no_watermark(&harness));
+
+    // Waiting takes it steady, and only then is there a watermark.
+    assert_success(&harness.run(&["admin", "index-enable"]));
+    let steady = harness.run(&["--json", "admin", "index-status"]);
+    assert_success(&steady);
+    assert_eq!(json_data(&steady)["state"]["phase"], "steady");
+    assert_eq!(json_data(&steady)["state"]["built_through_seq"], 0);
+    assert!(json_data(&steady)["state"].get("target_seq").is_none());
+}
+
+fn backfilling_text_names_no_watermark(harness: &Harness) -> bool {
+    let rendered = stdout_string(&harness.run(&["admin", "index-status"]));
+    rendered.contains("backfilling toward seq") && !rendered.contains("built through")
+}
+
+/// The wait stops at the sequence it captured, even while a writer keeps
+/// committing past it.
+#[test]
+fn index_enable_waits_to_its_captured_target_and_not_the_live_head() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = harness.temp_dir.path().join("one.txt");
+    fs::write(&payload, b"needle one\n").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/one.txt"]));
+
+    let enabled = harness.run(&["--json", "admin", "index-enable"]);
+    assert_success(&enabled);
+    assert_eq!(json_data(&enabled)["waited_for_seq"], 1);
+
+    // A commit that lands after the capture is not waited for: the next
+    // enable is what picks it up.
+    let more = harness.temp_dir.path().join("two.txt");
+    fs::write(&more, b"needle two\n").expect("write payload");
+    assert_success(&harness.run(&["put", more.to_str().expect("utf-8 path"), "/two.txt"]));
+    let status = harness.run(&["--json", "admin", "index-status"]);
+    assert_success(&status);
+    assert_eq!(
+        json_data(&status)["state"]["built_through_seq"],
+        1,
+        "the earlier wait stopped at the target it captured"
+    );
+
+    // An index already at the namespace head returns without stepping.
+    assert_success(&harness.run(&["admin", "index-enable"]));
+    let caught_up = harness.run(&["--json", "admin", "index-enable"]);
+    assert_success(&caught_up);
+    assert_eq!(json_data(&caught_up)["already_enabled"], true);
+    assert_eq!(json_data(&caught_up)["waited_for_seq"], 2);
+    assert_eq!(
+        json_data(&caught_up)["steps"],
+        0,
+        "an index already at the captured target takes no steps"
+    );
+}
+
+/// A wait that runs out of budget reports where the index got to and exits
+/// nonzero — real progress, not an error-shaped lie.
+#[test]
+fn index_enable_budgets_exit_nonzero_and_report_progress() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = harness.temp_dir.path().join("one.txt");
+    fs::write(&payload, b"needle\n").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/one.txt"]));
+
+    for budget in [vec!["--max-steps", "0"], vec!["--deadline-ms", "0"]] {
+        let mut args = vec!["--json", "admin", "index-enable"];
+        args.extend(budget.iter().copied());
+        let stopped = harness.run(&args);
+        assert_failure(&stopped);
+        let data = json_data(&stopped);
+        assert_eq!(data["budget_exhausted"], true, "{budget:?}");
+        assert_eq!(data["steps"], 0, "{budget:?}");
+        assert_eq!(data["waited_for_seq"], 1, "{budget:?}");
+        assert_eq!(
+            data["state"]["phase"], "backfilling",
+            "the report must say where the index actually is: {budget:?}"
+        );
+    }
+
+    // The index is untouched by the give-up, and a plain wait still lands.
+    assert_success(&harness.run(&["admin", "index-enable"]));
+    let found = harness.run(&["--json", "grep", "needle"]);
+    assert_success(&found);
+}
+
+/// The remote arm answers the same questions the embedded one does, and
+/// waits the same way: the server drives its own index, so the command only
+/// watches the status endpoint until the captured target is reached.
+#[test]
+fn index_status_and_enable_answer_the_same_over_the_remote_transport() {
+    let harness = Harness::new();
+    // A config with no `[grep]` table composes no grep at all, so this
+    // deployment says so explicitly.
+    let remote_server = harness.start_external_server(harness.write_server_config_with(
+        "remote",
+        "index-remote",
+        "\n[grep]\nmode = \"serve_and_maintain\"\n",
+    ));
+    assert_success(&harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "default",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]));
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = harness.temp_dir.path().join("one.txt");
+    fs::write(&payload, b"remote needle\n").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/one.txt"]));
+
+    let disabled = harness.run(&["--json", "admin", "index-status"]);
+    assert_success(&disabled);
+    assert_eq!(json_data(&disabled)["state"]["phase"], "disabled");
+
+    let enabled = harness.run(&["--json", "admin", "index-enable"]);
+    assert_success(&enabled);
+    assert_eq!(json_data(&enabled)["waited_for_seq"], 1);
+    assert_eq!(json_data(&enabled)["budget_exhausted"], false);
+    assert_eq!(json_data(&enabled)["state"]["phase"], "steady");
+
+    let steady = harness.run(&["--json", "admin", "index-status"]);
+    assert_success(&steady);
+    assert_eq!(json_data(&steady)["state"]["built_through_seq"], 1);
+
+    let found = harness.run(&["--json", "grep", "remote needle"]);
+    assert_success(&found);
+    assert_eq!(
+        json_data(&found)["matches"]
+            .as_array()
+            .expect("json array")
+            .len(),
+        1
+    );
+
+    let collected = harness.run(&["--json", "admin", "index-gc"]);
+    assert_success(&collected);
+    assert_eq!(json_data(&collected)["namespace_reaped"], false);
+}
+
+/// `index-gc` loops the cursor like `admin gc`: one accumulated result out
+/// of however many bounded passes it took.
+#[test]
+fn index_gc_loops_its_cursor_and_accumulates() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = harness.temp_dir.path().join("one.txt");
+    fs::write(&payload, b"needle\n").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/one.txt"]));
+    assert_success(&harness.run(&["admin", "index-enable"]));
+
+    // Nothing here is past its grace window, so a full loop retains what it
+    // examines and, having walked to the end, carries no resume cursor.
+    let collected = harness.run(&["--json", "admin", "index-gc"]);
+    assert_success(&collected);
+    let data = json_data(&collected);
+    assert_eq!(data["deleted_segments"], 0);
+    assert_eq!(data["namespace_reaped"], false);
+    assert!(data.get("next_cursor").is_none(), "{data}");
+
+    // One bounded pass stops early and hands back where to resume.
+    let single = harness.run(&["--json", "admin", "index-gc", "--max-objects", "1"]);
+    assert_success(&single);
+    assert!(
+        json_data(&single)["next_cursor"].is_string(),
+        "{}",
+        json_data(&single)
+    );
 }
 
 #[test]
@@ -2218,6 +2435,8 @@ fn every_advertised_capability_maps_to_a_cli_command_path() {
                 &["admin", "gc"],
                 &["admin", "index-enable"],
                 &["admin", "index-disable"],
+                &["admin", "index-status"],
+                &["admin", "index-gc"],
             ],
         ),
     ];
@@ -2572,6 +2791,12 @@ impl Harness {
     }
 
     fn write_server_config(&self, name: &str, key_prefix: &str) -> PathBuf {
+        self.write_server_config_with(name, key_prefix, "")
+    }
+
+    /// A server config with `extra` appended, for tests that need a table
+    /// the default deployment leaves out.
+    fn write_server_config_with(&self, name: &str, key_prefix: &str, extra: &str) -> PathBuf {
         let bind = format!("127.0.0.1:{}", available_port());
         let path = self
             .temp_dir
@@ -2589,7 +2814,7 @@ writer_id = "{name}"
 kind = "local-fs"
 root = "{}"
 key_prefix = "{key_prefix}"
-"#,
+{extra}"#,
             store_root.display()
         );
         fs::write(&path, contents).expect("write server config");

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -24,9 +24,10 @@ use loonfs_api::{
         CommitResponse as ApiCommitResponse, CommittedChange, CompleteUploadRequest,
         CompleteUploadResponse, CompletedUploadPart, DirectMultipartContentClaim,
         DirectMultipartUploadOptions, DirectPutContentClaim, DisableGrepIndexResponse,
-        EnableGrepIndexResponse, FilesystemChange, GrepGcResponse, ObjectTransferAccess,
-        SignUploadPartsRequest, SignUploadPartsResponse, SignedUploadPart, UploadContentResponse,
-        UploadMode, UploadPartChecksumClaim, ValidatedContentToken,
+        EnableGrepIndexResponse, FilesystemChange, GrepGcRequest, GrepGcResponse,
+        GrepIndexStatusResponse, ObjectTransferAccess, SignUploadPartsRequest,
+        SignUploadPartsResponse, SignedUploadPart, UploadContentResponse, UploadMode,
+        UploadPartChecksumClaim, ValidatedContentToken,
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId,
     ChecksumAlgorithm, CommitId, CommitRequest, ContentRef, Crc64Nvme, CreateCheckpointRequest,
@@ -854,6 +855,21 @@ impl Client {
         self.request_json(self.post(&url), Some(request)).await
     }
 
+    /// Reads the namespace's grep-index lifecycle (admin plane): disabled,
+    /// backfilling toward a captured sequence, or steady at a watermark.
+    /// One grep root read on the server, with no side effects.
+    pub async fn grep_index_status(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<GrepIndexStatusResponse> {
+        let url = format!(
+            "{}/v0/admin/namespaces/{namespace_id}/grep/index",
+            self.base_url
+        );
+        self.request_json::<(), GrepIndexStatusResponse>(self.get(&url), None)
+            .await
+    }
+
     /// Enables the namespace's grep root (admin plane); embedded mode starts
     /// that namespace's event-driven backfill. Idempotent.
     pub async fn enable_grep_index(
@@ -883,13 +899,19 @@ impl Client {
     }
 
     /// Runs one explicit grep-index garbage-collection pass for a namespace.
-    pub async fn gc_grep_index(&self, namespace_id: &NamespaceId) -> Result<GrepGcResponse> {
+    ///
+    /// `max_objects` bounds the reads the pass spends; when keys remain the
+    /// response carries a `next_cursor` to resume from.
+    pub async fn gc_grep_index(
+        &self,
+        namespace_id: &NamespaceId,
+        request: &GrepGcRequest,
+    ) -> Result<GrepGcResponse> {
         let url = format!(
             "{}/v0/admin/namespaces/{namespace_id}/grep/index/gc",
             self.base_url
         );
-        self.request_json::<(), GrepGcResponse>(self.post(&url), None)
-            .await
+        self.request_json(self.post(&url), Some(request)).await
     }
 
     /// Applies one commit: its operations land together, in order, under

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait.workspace = true
+base64.workspace = true
 bytes.workspace = true
 clap.workspace = true
 futures.workspace = true

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -43,10 +43,10 @@
 //! grep in-process and registers [`GrepMaintenanceJob`] with the writer's
 //! maintenance runner, nudged by the publish observer; a query-serving
 //! deployment answers searches while an external `loonfs-grep` process runs
-//! the same bounded steps; a one-shot host (the CLI) calls
-//! [`GrepWorker::run_to_quiescence`] where a scheduler would be. All three
-//! run the identical durable protocol, so which one is running is a
-//! deployment choice, not a format.
+//! the same bounded steps; a one-shot host (the CLI) runs that same job's
+//! steps itself, until the index reaches a sequence it captured before it
+//! started. All three run the identical durable protocol, so which one is
+//! running is a deployment choice, not a format.
 //!
 //! **An extension owns its keyspace and its garbage.** Grep's durable state
 //! lives under each namespace's `extensions/grep/` prefix and is
@@ -86,6 +86,6 @@ pub use service::{
 };
 pub use worker::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepBuildReport, GrepDisableOutcome, GrepEnableOutcome,
-    GrepGcReport, GrepReorganizeOutcome, GrepReorganizeReport, GrepWorker,
+    GrepGcReport, GrepGcRequest, GrepReorganizeOutcome, GrepReorganizeReport, GrepWorker,
     GREP_BACKFILL_CHECKPOINT_TTL_MS, GREP_GC_GRACE_WINDOW_MS,
 };

--- a/crates/loonfs-grep/src/main.rs
+++ b/crates/loonfs-grep/src/main.rs
@@ -9,7 +9,7 @@
 use clap::Parser;
 use loonfs::{FsAdmin, FsReader, MaintenanceJob, MaintenanceProbe, MaintenanceStepConclusion};
 use loonfs_api::NamespaceId;
-use loonfs_grep::{GrepMaintenanceJob, GrepWorker, GrepWorkerConfig};
+use loonfs_grep::{GrepGcRequest, GrepMaintenanceJob, GrepWorker, GrepWorkerConfig};
 use loonfs_objectstore::{SharedObjectStore, StoreConfig};
 use serde::Deserialize;
 use std::collections::BTreeSet;
@@ -281,8 +281,10 @@ async fn collect_assigned(
 ) -> Result<(), StandaloneError> {
     let now_ms = current_time_ms()?;
     for namespace_id in namespace_ids {
+        // An assigned host collects the whole keyspace: it has no operator
+        // waiting on the call, so it spends no budget and takes no cursor.
         let report = worker
-            .garbage_collect_namespace(namespace_id, now_ms)
+            .garbage_collect_namespace(namespace_id, now_ms, &GrepGcRequest::default())
             .await?;
         tracing::info!(
             namespace_id = %namespace_id,

--- a/crates/loonfs-grep/src/main_tests.rs
+++ b/crates/loonfs-grep/src/main_tests.rs
@@ -8,7 +8,7 @@
 use super::{maintain_namespace, NamespaceJob, PollShutdown};
 use loonfs::{FsAdmin, FsReader, FsWriter};
 use loonfs_api::{ChangeSeq, GrepRequest, NamespaceId};
-use loonfs_grep::root::{load_grep_root, GrepLifecycle};
+use loonfs_grep::root::load_grep_root;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepIndexSnapshot, GrepMaintenanceJob, GrepService, GrepWorker,
     NamespaceReads,
@@ -193,9 +193,7 @@ async fn wait_for_steady(
                 .await
                 .expect("load polled root")
             {
-                if matches!(root.state().lifecycle(), GrepLifecycle::Steady)
-                    && root.state().index().built_through_seq == built_through_seq
-                {
+                if root.state().lifecycle().steady_watermark() == Some((built_through_seq, 0)) {
                     return;
                 }
             }

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -103,11 +103,13 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
             GrepLifecycle::Backfilling { .. } => Ok(MaintenanceProbe::Due),
             // A watermark inside a commit has the rest of that commit left,
             // which no question about later commits would reveal.
-            GrepLifecycle::Steady if root.state().index().next_event_index != 0 => {
-                Ok(MaintenanceProbe::Due)
-            }
-            GrepLifecycle::Steady => {
-                let built_through_seq = root.state().index().built_through_seq;
+            GrepLifecycle::Steady {
+                next_event_index, ..
+            } if *next_event_index != 0 => Ok(MaintenanceProbe::Due),
+            GrepLifecycle::Steady {
+                built_through_seq, ..
+            } => {
+                let built_through_seq = *built_through_seq;
                 match self
                     .worker
                     .reads(namespace_id)

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -13,7 +13,13 @@ const SHA256_PREFIX: &str = "sha256:";
 const SHA256_HEX_LEN: usize = 64;
 
 /// Version of the grep index state nested inside a v1 manifest.
-pub const GREP_INDEX_FORMAT_VERSION: u32 = 1;
+///
+/// Version 2 moved the phase-only watermark fields out of the index-wide
+/// bookkeeping and into the lifecycle variant that owns them. A version-1
+/// root is rejected outright: it spelled a backfill's target and a steady
+/// index's real progress with the same field, and nothing can tell those
+/// apart after the fact.
+pub const GREP_INDEX_FORMAT_VERSION: u32 = 2;
 
 /// Content-derived identity of one immutable grep manifest payload.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -147,23 +153,87 @@ impl GrepRootPointer {
 }
 
 /// Durable lifecycle of grep indexing for one namespace.
+///
+/// Each phase carries its own position and nothing else's. A backfill knows
+/// the sequence it is walking toward and how far the walk got; a steady
+/// index knows the sequence it has really built through. Neither can report
+/// the other's number, because neither has a field to put it in.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum GrepLifecycle {
     /// Initial materialization is walking the checkpointed file set.
     Backfilling {
+        /// Namespace sequence the pinned checkpoint captured. The walk ends
+        /// at exactly this state however far the namespace has moved since.
+        target_seq: ChangeSeq,
         /// Inode the next backfill step resumes strictly after; absent means
         /// the start. Checkpoint file enumeration is ordered by ascending
         /// inode id, so one id is the whole resume position.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        backfill_cursor: Option<InodeId>,
+        cursor: Option<InodeId>,
         /// User-checkpoint pin backing this immutable manifest walk.
         checkpoint_id: CheckpointId,
     },
     /// Backfill is complete and changes are consumed incrementally.
-    Steady,
+    Steady {
+        /// Sequence of the commit at the index cursor. Everything at or
+        /// below it is indexed, subject to `next_event_index`.
+        built_through_seq: ChangeSeq,
+        /// Offset of the next change event within `built_through_seq`, or
+        /// zero when the cursor is at the commit boundary and the whole
+        /// commit is represented.
+        ///
+        /// A commit's events are one per committed operation in request
+        /// order, derived from its durable delta vector; incremental
+        /// indexing relies on that stable order when a step's budget stops
+        /// it inside a commit.
+        #[serde(default, skip_serializing_if = "is_zero")]
+        next_event_index: u32,
+    },
     /// Grep indexing and queries are disabled for this namespace.
     Disabled,
+}
+
+impl GrepLifecycle {
+    /// The steady watermark pair, or `None` in any phase that has none.
+    pub fn steady_watermark(&self) -> Option<(ChangeSeq, u32)> {
+        match self {
+            Self::Steady {
+                built_through_seq,
+                next_event_index,
+            } => Some((*built_through_seq, *next_event_index)),
+            Self::Backfilling { .. } | Self::Disabled => None,
+        }
+    }
+}
+
+/// The durable lifecycle as the admin plane reports it.
+///
+/// The wire enum mirrors the durable one phase for phase, so a reader of
+/// either sees the same facts under the same names and no host has to
+/// invent a number for a phase that does not have one.
+impl From<&GrepLifecycle> for loonfs_api::v0::GrepIndexLifecycle {
+    fn from(lifecycle: &GrepLifecycle) -> Self {
+        match lifecycle {
+            GrepLifecycle::Disabled => Self::Disabled,
+            GrepLifecycle::Backfilling {
+                target_seq,
+                cursor,
+                checkpoint_id,
+            } => Self::Backfilling {
+                target_seq: *target_seq,
+                cursor_inode_id: *cursor,
+                checkpoint_id: checkpoint_id.clone(),
+            },
+            GrepLifecycle::Steady {
+                built_through_seq,
+                next_event_index,
+            } => Self::Steady {
+                built_through_seq: *built_through_seq,
+                next_event_index: *next_event_index,
+            },
+        }
+    }
 }
 
 /// Resumable state for one partitioned segment reorganize.
@@ -182,21 +252,15 @@ pub struct GrepReorganizeState {
 }
 
 /// Durable index bookkeeping paired with the visible segment set.
+///
+/// What lives here is what every phase has: segments are written and folded
+/// during a backfill and during steady indexing alike, so the reorganize
+/// state and the run allocator belong to the index rather than to a phase.
+/// Anything only one phase has lives in [`GrepLifecycle`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GrepIndexState {
     /// Version of this nested index-state schema.
     pub format_version: u32,
-    /// Sequence of the commit at the index cursor.
-    pub built_through_seq: ChangeSeq,
-    /// Offset of the next change event within `built_through_seq`, or zero
-    /// when the cursor is at the commit boundary and the whole commit is
-    /// represented.
-    ///
-    /// A commit's events are one per committed operation in request order,
-    /// derived from its durable delta vector; incremental indexing relies on
-    /// that stable order when a step's budget stops it inside a commit.
-    #[serde(default, skip_serializing_if = "is_zero")]
-    pub next_event_index: u32,
     /// One in-progress partitioned reorganize, if present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reorganize: Option<GrepReorganizeState>,
@@ -250,16 +314,9 @@ impl ChangeFeedResume {
 
 impl GrepIndexState {
     /// Creates index bookkeeping in the current grep-owned format.
-    pub fn new(
-        built_through_seq: ChangeSeq,
-        next_event_index: u32,
-        reorganize: Option<GrepReorganizeState>,
-        next_run_ordinal: u64,
-    ) -> Self {
+    pub fn new(reorganize: Option<GrepReorganizeState>, next_run_ordinal: u64) -> Self {
         Self {
             format_version: GREP_INDEX_FORMAT_VERSION,
-            built_through_seq,
-            next_event_index,
             reorganize,
             next_run_ordinal,
         }

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -181,13 +181,17 @@ impl GrepIndexSnapshot {
     }
 
     fn from_state(root: &GrepRootState) -> Self {
-        match root.lifecycle() {
+        // Only a steady root has a watermark, and only a watermark makes an
+        // index answerable: the other two phases refuse the query outright
+        // rather than borrow a sequence they do not own.
+        let (built_through_seq, next_event_index) = match root.lifecycle() {
             GrepLifecycle::Disabled => return Self::from_error(GrepError::NotEnabled),
-            GrepLifecycle::Backfilling { .. } => {
-                return Self::from_error(GrepError::Backfilling);
-            }
-            GrepLifecycle::Steady => {}
-        }
+            GrepLifecycle::Backfilling { .. } => return Self::from_error(GrepError::Backfilling),
+            GrepLifecycle::Steady {
+                built_through_seq,
+                next_event_index,
+            } => (*built_through_seq, *next_event_index),
+        };
         let segments = root
             .segments()
             .iter()
@@ -203,8 +207,8 @@ impl GrepIndexSnapshot {
             .collect();
         Self {
             state: Ok(MaterializedGrepIndexSnapshot {
-                built_through_seq: root.index().built_through_seq,
-                next_event_index: root.index().next_event_index,
+                built_through_seq,
+                next_event_index,
                 segments,
             }),
         }

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -26,7 +26,9 @@ use crate::root::{
 };
 use crate::service::is_indexable_text_content;
 use crate::{GrepError, Result};
+use base64::Engine as _;
 use futures::future::try_join_all;
+use futures::StreamExt as _;
 use loonfs::{
     CheckpointFilesPageCursor, CoreError, CreateCheckpointOptions, FsAdmin, FsReader, RuntimeError,
     StoreFailureClass, METADATA_PUBLICATION_BUDGET_MS,
@@ -41,6 +43,7 @@ use loonfs_api::{
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
@@ -102,10 +105,15 @@ impl Default for GramIndexBuildPolicy {
 }
 
 /// Result of enabling grep for one namespace.
+///
+/// Both settled outcomes answer with the durable lifecycle itself rather
+/// than a sequence number, because the two phases do not have the same
+/// number to give: a fresh enable publishes a backfill with a target, and an
+/// already-enabled namespace may be mid-backfill or steady.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GrepEnableOutcome {
-    Enabled { target_seq: ChangeSeq },
-    AlreadyEnabled { built_through_seq: ChangeSeq },
+    Enabled { state: GrepLifecycle },
+    AlreadyEnabled { state: GrepLifecycle },
     Superseded,
 }
 
@@ -167,14 +175,26 @@ pub enum GrepReorganizeOutcome {
     Superseded,
 }
 
+/// Budgets and resume position for one grep garbage-collection pass.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GrepGcRequest {
+    /// Reads this pass may spend before returning a resume cursor. `None`
+    /// walks the whole grep keyspace in one call.
+    pub max_objects: Option<u64>,
+    /// Opaque token an earlier pass over the same namespace returned.
+    pub cursor: Option<String>,
+}
+
 /// Counts from one namespace's grep garbage-collection pass.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GrepGcReport {
     pub deleted_segments: u64,
     pub deleted_other_objects: u64,
     pub namespace_reaped: bool,
     pub retained_candidates: u64,
     pub namespace_degraded: bool,
+    /// Present when the budget stopped the pass with keys left to examine.
+    pub next_cursor: Option<String>,
 }
 
 /// Namespace-independent writer for the grep-owned durable keyspace.
@@ -238,7 +258,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         {
             if !matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
                 return Ok(GrepEnableOutcome::AlreadyEnabled {
-                    built_through_seq: current.state().index().built_through_seq,
+                    state: current.state().lifecycle().clone(),
                 });
             }
         }
@@ -256,7 +276,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 )
                 .await?;
                 return Ok(GrepEnableOutcome::AlreadyEnabled {
-                    built_through_seq: current.state().index().built_through_seq,
+                    state: current.state().lifecycle().clone(),
                 });
             }
         }
@@ -274,8 +294,8 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             None => self.seed_root(&next).await,
         };
         match published {
-            Ok(_) => Ok(GrepEnableOutcome::Enabled {
-                target_seq: checkpoint.checkpoint_seq,
+            Ok(published) => Ok(GrepEnableOutcome::Enabled {
+                state: published.state().lifecycle().clone(),
             }),
             Err(GrepRootError::Conflict { .. }) => {
                 self.release_superseded_checkpoint_if_unreferenced(
@@ -304,17 +324,12 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         }
         let checkpoint_id = match current.state().lifecycle() {
             GrepLifecycle::Backfilling { checkpoint_id, .. } => Some(checkpoint_id.clone()),
-            GrepLifecycle::Steady | GrepLifecycle::Disabled => None,
+            GrepLifecycle::Steady { .. } | GrepLifecycle::Disabled => None,
         };
         let next = GrepRootState::new(
             namespace_id.clone(),
             GrepLifecycle::Disabled,
-            GrepIndexState::new(
-                current.state().index().built_through_seq,
-                0,
-                None,
-                current.state().index().next_run_ordinal,
-            ),
+            GrepIndexState::new(None, current.state().index().next_run_ordinal),
             Vec::new(),
         )
         .map_err(core_state_error)?;
@@ -350,38 +365,38 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
 
         let collected = match current.state().lifecycle() {
             GrepLifecycle::Backfilling {
-                backfill_cursor,
+                target_seq,
+                cursor,
                 checkpoint_id,
+            } => collect_backfill_unit(&reads, checkpoint_id, *target_seq, *cursor, policy).await,
+            GrepLifecycle::Steady {
+                built_through_seq,
+                next_event_index,
             } => {
-                collect_backfill_unit(
-                    &reads,
-                    checkpoint_id,
-                    current.state().index().built_through_seq,
-                    *backfill_cursor,
-                    policy,
-                )
-                .await
-            }
-            GrepLifecycle::Steady => {
-                collect_incremental_unit(
-                    &reads,
-                    current.state().index().built_through_seq,
-                    current.state().index().next_event_index,
-                    policy,
-                )
-                .await
+                collect_incremental_unit(&reads, *built_through_seq, *next_event_index, policy)
+                    .await
             }
             GrepLifecycle::Disabled => unreachable!("disabled returned above"),
         };
 
         let unit = match collected {
             Ok(Some(unit)) => unit,
+            // Only a steady root can be up to date: a backfill always has
+            // its next page, and answering `None` there would be a claim
+            // about a watermark it does not have.
             Ok(None) => {
+                let built_through_seq = current
+                    .state()
+                    .lifecycle()
+                    .steady_watermark()
+                    .map(|(built_through_seq, _)| built_through_seq)
+                    .ok_or_else(|| GrepError::CorruptIndex {
+                        message: "a backfilling grep root reported nothing left to index"
+                            .to_owned(),
+                    })?;
                 return Ok(build_report(
                     namespace_id,
-                    GrepBuildOutcome::UpToDate {
-                        built_through_seq: current.state().index().built_through_seq,
-                    },
+                    GrepBuildOutcome::UpToDate { built_through_seq },
                 ));
             }
             // The projection's basis is gone. Either the change feed no
@@ -401,36 +416,27 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .await
     }
 
-    /// Runs bounded build and fold steps until this namespace's index is
-    /// caught up with nothing left to fold, and answers the watermark it
-    /// reached.
+    /// Reads this namespace's durable grep lifecycle, or `Disabled` where no
+    /// root has ever been published.
     ///
-    /// This is what a host with no scheduler — a one-shot command, a test —
-    /// calls where a long-lived host registers
-    /// [`GrepMaintenanceJob`](crate::GrepMaintenanceJob): the same pair
-    /// loop, minus admission and backoff, so a synchronous caller surfaces
-    /// the first error instead of retrying. Every non-final outcome makes
-    /// progress (a batch built or a unit folded), so the loop terminates
-    /// without an iteration cap.
-    pub async fn run_to_quiescence(
-        &self,
-        namespace_id: &NamespaceId,
-        policy: GramIndexBuildPolicy,
-    ) -> Result<ChangeSeq> {
-        loop {
-            let build = self.build_step(namespace_id, policy).await?;
-            let reorganize = self.reorganize_step(namespace_id, policy).await?;
-            if matches!(build.outcome, GrepBuildOutcome::NotEnabled)
-                || matches!(reorganize.outcome, GrepReorganizeOutcome::NotEnabled)
-            {
-                return Err(GrepError::NotEnabled);
-            }
-            if let GrepBuildOutcome::UpToDate { built_through_seq } = build.outcome {
-                if matches!(reorganize.outcome, GrepReorganizeOutcome::NotNeeded { .. }) {
-                    return Ok(built_through_seq);
-                }
-            }
-        }
+    /// One object read and no side effects: this is what a status surface
+    /// and a caller waiting on a captured target both ask.
+    pub async fn lifecycle(&self, namespace_id: &NamespaceId) -> Result<GrepLifecycle> {
+        Ok(load_grep_root(&self.store, namespace_id)
+            .await
+            .map_err(GrepError::from)?
+            .map_or(GrepLifecycle::Disabled, |root| {
+                root.state().lifecycle().clone()
+            }))
+    }
+
+    /// Reads the whole durable root, for a caller that wants the index
+    /// bookkeeping beside the lifecycle. `None` where no root exists.
+    pub async fn root_state(&self, namespace_id: &NamespaceId) -> Result<Option<GrepRootState>> {
+        Ok(load_grep_root(&self.store, namespace_id)
+            .await
+            .map_err(GrepError::from)?
+            .map(|root| root.state().clone()))
     }
 
     async fn seed_root(
@@ -510,7 +516,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     ) -> Result<GrepBuildReport> {
         let previous_checkpoint_id = match current.state().lifecycle() {
             GrepLifecycle::Backfilling { checkpoint_id, .. } => Some(checkpoint_id.clone()),
-            GrepLifecycle::Steady | GrepLifecycle::Disabled => None,
+            GrepLifecycle::Steady { .. } | GrepLifecycle::Disabled => None,
         };
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
         let next = backfilling_root(
@@ -571,30 +577,45 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         segments.extend(new_segments);
         let next_run_ordinal =
             current.state().index().next_run_ordinal + u64::from(segments_written > 0);
+        // A finished backfill turns steady at exactly the sequence its
+        // checkpoint captured: the walk answered that state and no other, so
+        // the watermark it hands the change feed is the target it reached.
         let (lifecycle, completed_checkpoint_id) = match current.state().lifecycle() {
-            GrepLifecycle::Backfilling { checkpoint_id, .. } => match unit.backfill_cursor {
+            GrepLifecycle::Backfilling {
+                target_seq,
+                checkpoint_id,
+                ..
+            } => match unit.backfill_cursor {
                 Some(after_inode_id) => (
                     GrepLifecycle::Backfilling {
-                        backfill_cursor: Some(after_inode_id),
+                        target_seq: *target_seq,
+                        cursor: Some(after_inode_id),
                         checkpoint_id: checkpoint_id.clone(),
                     },
                     None,
                 ),
-                None => (GrepLifecycle::Steady, Some(checkpoint_id.clone())),
+                None => (
+                    GrepLifecycle::Steady {
+                        built_through_seq: unit.built_through_seq,
+                        next_event_index: unit.next_event_index,
+                    },
+                    Some(checkpoint_id.clone()),
+                ),
             },
-            GrepLifecycle::Steady => (GrepLifecycle::Steady, None),
+            GrepLifecycle::Steady { .. } => (
+                GrepLifecycle::Steady {
+                    built_through_seq: unit.built_through_seq,
+                    next_event_index: unit.next_event_index,
+                },
+                None,
+            ),
             GrepLifecycle::Disabled => unreachable!("disabled returned before collection"),
         };
-        let materialized = matches!(lifecycle, GrepLifecycle::Steady);
+        let materialized = matches!(lifecycle, GrepLifecycle::Steady { .. });
         let next = GrepRootState::new(
             namespace_id.clone(),
             lifecycle,
-            GrepIndexState::new(
-                unit.built_through_seq,
-                unit.next_event_index,
-                current.state().index().reorganize.clone(),
-                next_run_ordinal,
-            ),
+            GrepIndexState::new(current.state().index().reorganize.clone(), next_run_ordinal),
             segments,
         )
         .map_err(core_state_error)?;
@@ -640,10 +661,11 @@ fn backfilling_root(
     GrepRootState::new(
         namespace_id.clone(),
         GrepLifecycle::Backfilling {
-            backfill_cursor: None,
+            target_seq,
+            cursor: None,
             checkpoint_id,
         },
-        GrepIndexState::new(target_seq, 0, None, next_run_ordinal),
+        GrepIndexState::new(None, next_run_ordinal),
         Vec::new(),
     )
     .map_err(core_state_error)
@@ -1106,11 +1128,14 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         )
         .await?;
         let rows = gram_postings_rows(merged.postings)?;
+        // Only an empty snapshot falls through, and an empty one merges no
+        // rows and writes no segment for this to stamp. The lifecycle's
+        // watermark is not a substitute: a backfilling root has none.
         let run_seq = snapshot
             .iter()
             .map(|segment| segment.run_seq)
             .max()
-            .unwrap_or(current.state().index().built_through_seq);
+            .unwrap_or(ChangeSeq(0));
         let timer = StdMonotonicTimer::default();
         let publication_started_ms = timer.monotonic_now_ms();
         let new_segments = write_index_segments(
@@ -1145,12 +1170,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let next = GrepRootState::new(
             namespace_id.clone(),
             current.state().lifecycle().clone(),
-            GrepIndexState::new(
-                current.state().index().built_through_seq,
-                current.state().index().next_event_index,
-                reorganize,
-                next_run_ordinal,
-            ),
+            GrepIndexState::new(reorganize, next_run_ordinal),
             segments,
         )
         .map_err(core_state_error)?;
@@ -1172,101 +1192,259 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         }
     }
 
-    /// Collects one namespace's grep keyspace. A live namespace retains its
-    /// verified root and every segment it names; a deleted or absent namespace
-    /// has its entire grep prefix reaped after the grace window.
+    /// Collects one namespace's grep keyspace under a read budget. A live
+    /// namespace retains its verified root and every segment it names; a
+    /// deleted or absent namespace has its entire grep prefix reaped after
+    /// the grace window.
+    ///
+    /// The pass enumerates the prefix as a stream and stops when
+    /// `max_objects` reads are spent, answering the position it stopped at
+    /// so the next call resumes there. Like core garbage collection, that
+    /// cursor is an enumeration shortcut and nothing else: every resumed
+    /// pass re-reads liveness and the grep root before it deletes anything,
+    /// so losing the cursor costs a repeated walk and never a wrong delete.
+    ///
+    /// A pass always examines at least one key, whatever the budget. The
+    /// budget bounds how much work one call does; it may not stop a caller
+    /// looping the cursor from ever finishing.
     pub async fn garbage_collect_namespace(
         &self,
         namespace_id: &NamespaceId,
         now_ms: u64,
+        request: &GrepGcRequest,
     ) -> Result<GrepGcReport> {
-        let prefix = namespace_prefix(namespace_id);
-        let keys = self
-            .store
-            .list_prefix(&prefix)
-            .await
-            .map_err(|error| core_store_error(&prefix, &error))?;
+        let resume = match request.cursor.as_deref() {
+            Some(token) => GrepGcCursor::decode(token, namespace_id)?,
+            None => GrepGcCursor::initial(namespace_id),
+        };
         let mut report = GrepGcReport::default();
-        self.collect_namespace_garbage(namespace_id, &keys, now_ms, &mut report)
-            .await?;
+        let mut budget = GcBudget::new(request.max_objects);
+        let reads = self.reads(namespace_id);
+        // Liveness is decided once per pass — and re-decided per candidate
+        // below, which is what authorizes a delete. This first read is
+        // charged like any other.
+        budget.charge();
+        let liveness = namespace_liveness(&reads).await;
+        if liveness == NamespaceLiveness::Unknown {
+            report.namespace_degraded = true;
+        }
+
+        let prefix = namespace_prefix(namespace_id);
+        let mut keys = self.store.list_prefix_stream(&prefix);
+        let mut position = resume.clone();
+        let mut deleted_any = false;
+        let mut examined = 0_u64;
+        while let Some(key) = keys.next().await {
+            let key = key.map_err(|error| core_store_error(&prefix, &error))?;
+            if resume.covers(&key) {
+                continue;
+            }
+            // The first key of a pass is examined whatever the budget: the
+            // cursor must advance, or a caller looping it never finishes.
+            if examined > 0 && budget.exhausted() {
+                // Proof that work remains, at the cost of one listed key and
+                // no reads. The key is reconsidered from the exclusive
+                // last-examined position on resume.
+                report.next_cursor = Some(position.encode()?);
+                break;
+            }
+            budget.charge();
+            let deleted = self
+                .collect_one_key(
+                    namespace_id,
+                    &reads,
+                    liveness,
+                    &key,
+                    now_ms,
+                    &mut budget,
+                    &mut report,
+                )
+                .await?;
+            deleted_any |= deleted;
+            examined += 1;
+            position = GrepGcCursor::after(namespace_id, key);
+        }
+        if deleted_any && liveness == NamespaceLiveness::Gone {
+            report.namespace_reaped = true;
+        }
         Ok(report)
     }
 
-    async fn collect_namespace_garbage(
+    /// Decides one candidate key against freshly re-read state.
+    ///
+    /// Answers whether the key was deleted. Selection may be stale — the
+    /// listing is a snapshot — but every decision here re-reads what
+    /// authorizes it, which is what makes resuming from a cursor safe.
+    #[allow(clippy::too_many_arguments)]
+    async fn collect_one_key(
         &self,
         namespace_id: &NamespaceId,
-        keys: &[String],
+        reads: &NamespaceReads<'_>,
+        liveness: NamespaceLiveness,
+        key: &str,
         now_ms: u64,
+        budget: &mut GcBudget,
         report: &mut GrepGcReport,
-    ) -> Result<()> {
-        let reads = self.reads(namespace_id);
-        match namespace_liveness(&reads).await {
+    ) -> Result<bool> {
+        match liveness {
+            // A verified deleted namespace head is already the absorbing
+            // gate for this pointer: `enable` refuses that tombstone, so no
+            // legal writer can re-reference grep state after this liveness
+            // check. Pointer deletion needs no second state.
             NamespaceLiveness::Gone => {
-                // A verified deleted namespace head is already the absorbing
-                // gate for this pointer: `enable` refuses that tombstone, so
-                // no legal writer can re-reference grep state after this
-                // liveness check. Pointer deletion needs no second state.
-                let mut deleted_any = false;
-                for key in keys {
-                    if namespace_liveness(&reads).await != NamespaceLiveness::Gone {
-                        report.retained_candidates += 1;
-                        continue;
-                    }
-                    if delete_if_aged(&self.store, key, now_ms, report).await? {
-                        count_deleted_key(key, report);
-                        deleted_any = true;
-                    }
+                budget.charge();
+                if namespace_liveness(reads).await != NamespaceLiveness::Gone {
+                    report.retained_candidates += 1;
+                    return Ok(false);
                 }
-                if deleted_any {
-                    report.namespace_reaped = true;
-                }
+                budget.charge();
+                Ok(self.delete_if_unreferenced(key, now_ms, report).await?)
             }
+            // Grep segments and manifests are immutable. An identical
+            // rebuild can only recreate the same derived bytes at the same
+            // key; pointer advance verifies and heals its manifest after
+            // CAS, so aged unreachable objects need no condemned state
+            // before deletion.
             NamespaceLiveness::Live => {
+                budget.charge();
                 let root = match load_grep_root(&self.store, namespace_id).await {
                     Ok(root) => root,
                     Err(_) => {
                         report.namespace_degraded = true;
-                        report.retained_candidates += keys.len() as u64;
-                        return Ok(());
+                        report.retained_candidates += 1;
+                        return Ok(false);
                     }
                 };
                 let live = root
                     .as_ref()
                     .map(live_grep_keys)
                     .unwrap_or_else(|| BTreeSet::from([root_key(namespace_id)]));
-                // Grep segments and manifests are immutable. An identical
-                // rebuild can only recreate the same derived bytes at the
-                // same key; pointer advance verifies and heals its manifest
-                // after CAS, so aged unreachable objects need no condemned
-                // state before deletion.
-                for key in keys.iter().filter(|key| !live.contains(*key)) {
-                    let fresh = match load_grep_root(&self.store, namespace_id).await {
-                        Ok(root) => root,
-                        Err(_) => {
-                            report.namespace_degraded = true;
-                            report.retained_candidates += 1;
-                            continue;
-                        }
-                    };
-                    if fresh
-                        .as_ref()
-                        .is_some_and(|root| live_grep_keys(root).contains(key))
-                    {
-                        report.retained_candidates += 1;
-                        continue;
-                    }
-                    if delete_if_aged(&self.store, key, now_ms, report).await? {
-                        count_deleted_key(key, report);
-                    }
+                if live.contains(key) {
+                    return Ok(false);
                 }
+                budget.charge();
+                Ok(self.delete_if_unreferenced(key, now_ms, report).await?)
             }
             NamespaceLiveness::Unknown => {
-                report.namespace_degraded = true;
-                report.retained_candidates += keys.len() as u64;
+                report.retained_candidates += 1;
+                Ok(false)
             }
         }
-        Ok(())
     }
+
+    async fn delete_if_unreferenced(
+        &self,
+        key: &str,
+        now_ms: u64,
+        report: &mut GrepGcReport,
+    ) -> Result<bool> {
+        if delete_if_aged(&self.store, key, now_ms, report).await? {
+            count_deleted_key(key, report);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+}
+
+/// The reads one garbage-collection pass may spend.
+///
+/// A key costs more than its listing: deciding it re-reads liveness or the
+/// grep root, and reading its age is another round trip. Charging those to
+/// the same budget is what keeps `max_objects` a bound on the work the pass
+/// does rather than only on the keys it names.
+struct GcBudget {
+    max_objects: Option<u64>,
+    spent: u64,
+}
+
+impl GcBudget {
+    fn new(max_objects: Option<u64>) -> Self {
+        Self {
+            max_objects,
+            spent: 0,
+        }
+    }
+
+    fn charge(&mut self) {
+        self.spent = self.spent.saturating_add(1);
+    }
+
+    fn exhausted(&self) -> bool {
+        self.max_objects
+            .is_some_and(|max_objects| self.spent >= max_objects)
+    }
+}
+
+/// Opaque, namespace-bound resume position for a bounded grep collection.
+///
+/// It carries where the enumeration stopped and nothing else. Grep's whole
+/// keyspace is one prefix, so one key is the whole position — and because
+/// every resumed pass re-reads liveness and the root, a stale or forged
+/// cursor can only re-examine work or defer it to a later pass.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct GrepGcCursor {
+    namespace_id: NamespaceId,
+    #[serde(default)]
+    last_key: Option<String>,
+}
+
+impl GrepGcCursor {
+    fn initial(namespace_id: &NamespaceId) -> Self {
+        Self {
+            namespace_id: namespace_id.clone(),
+            last_key: None,
+        }
+    }
+
+    fn after(namespace_id: &NamespaceId, key: String) -> Self {
+        Self {
+            namespace_id: namespace_id.clone(),
+            last_key: Some(key),
+        }
+    }
+
+    /// Whether an earlier pass already examined this key.
+    fn covers(&self, key: &str) -> bool {
+        self.last_key
+            .as_deref()
+            .is_some_and(|last_key| key <= last_key)
+    }
+
+    fn decode(token: &str, namespace_id: &NamespaceId) -> Result<Self> {
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(token)
+            .map_err(|_| malformed_gc_cursor())?;
+        let cursor: Self = serde_json::from_slice(&bytes).map_err(|_| malformed_gc_cursor())?;
+        if cursor.namespace_id != *namespace_id {
+            return Err(GrepError::Runtime(RuntimeError::Core(
+                CoreError::InvalidGcConfig("cursor belongs to a different namespace".to_owned()),
+            )));
+        }
+        let prefix = namespace_prefix(namespace_id);
+        if cursor
+            .last_key
+            .as_ref()
+            .is_some_and(|key| !key.starts_with(&prefix))
+        {
+            return Err(malformed_gc_cursor());
+        }
+        Ok(cursor)
+    }
+
+    fn encode(&self) -> Result<String> {
+        let bytes = serde_json::to_vec(self).map_err(|error| {
+            GrepError::Runtime(RuntimeError::Core(CoreError::Internal(format!(
+                "failed to encode grep GC cursor: {error}"
+            ))))
+        })?;
+        Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+    }
+}
+
+fn malformed_gc_cursor() -> GrepError {
+    GrepError::Runtime(RuntimeError::Core(CoreError::InvalidGcConfig(
+        "cursor is malformed".to_owned(),
+    )))
 }
 
 fn reorganize_report(

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -7,12 +7,13 @@
 
 #![allow(dead_code)]
 
-use loonfs::{FsAdmin, FsReader, SharedObjectStore};
-use loonfs_api::v0::{DisableGrepIndexResponse, EnableGrepIndexResponse};
-use loonfs_api::{GrepRequest, GrepResponse, NamespaceId};
+use loonfs::{FsAdmin, FsReader, MaintenanceJob, MaintenanceStepConclusion, SharedObjectStore};
+use loonfs_api::v0::{DisableGrepIndexResponse, EnableGrepIndexResponse, GrepIndexLifecycle};
+use loonfs_api::{ChangeSeq, GrepRequest, GrepResponse, NamespaceId};
+use loonfs_grep::root::GrepLifecycle;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepIndexSnapshot,
-    GrepService, GrepWorker, NamespaceReads,
+    GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
 };
 
 pub(crate) struct GrepHost {
@@ -61,30 +62,71 @@ impl GrepHost {
         .await
     }
 
-    /// Enables grep and drives the backfill to quiescence, the way a host
-    /// with no driver runtime does.
+    /// Enables grep and drives the index up to the namespace's current
+    /// sequence, the way a host with no maintenance runner does.
+    ///
+    /// The target is captured once, before any stepping, so this returns
+    /// even while another writer keeps committing — the same captured-target
+    /// wait `loonfs admin index-enable` performs, minus its budgets, so a
+    /// test surfaces the first failure instead of retrying it.
     pub(crate) async fn enable_grep_index(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<EnableGrepIndexResponse, GrepError> {
-        let already_enabled = match self.worker.enable(namespace_id).await? {
-            GrepEnableOutcome::Enabled { .. } => false,
-            GrepEnableOutcome::AlreadyEnabled { .. } => true,
+        let (already_enabled, lifecycle) = match self.worker.enable(namespace_id).await? {
+            GrepEnableOutcome::Enabled { state } => (false, state),
+            GrepEnableOutcome::AlreadyEnabled { state } => (true, state),
             GrepEnableOutcome::Superseded => {
                 return Err(GrepError::PublicationConflict {
                     object_key: loonfs_grep::keyspace::root_key(namespace_id),
                 })
             }
         };
-        let built_through_seq = self
-            .worker
-            .run_to_quiescence(namespace_id, GramIndexBuildPolicy::default())
-            .await?;
+        let target_seq = match &lifecycle {
+            GrepLifecycle::Disabled => None,
+            GrepLifecycle::Backfilling { target_seq, .. } => Some(*target_seq),
+            GrepLifecycle::Steady { .. } => Some(
+                NamespaceReads::new(&self.reader, namespace_id)
+                    .head_seq()
+                    .await?,
+            ),
+        };
+        let state = match target_seq {
+            Some(target_seq) => self.catch_up_grep_index(namespace_id, target_seq).await?,
+            None => lifecycle,
+        };
         Ok(EnableGrepIndexResponse {
             namespace_id: namespace_id.clone(),
-            built_through_seq,
             already_enabled,
+            state: GrepIndexLifecycle::from(&state),
         })
+    }
+
+    /// Runs the index job's bounded steps until the index has built through
+    /// `target_seq`, or until a step settles short of it.
+    pub(crate) async fn catch_up_grep_index(
+        &self,
+        namespace_id: &NamespaceId,
+        target_seq: ChangeSeq,
+    ) -> Result<GrepLifecycle, GrepError> {
+        let job = GrepMaintenanceJob::new(self.worker.clone(), GramIndexBuildPolicy::default());
+        loop {
+            let lifecycle = self.worker.lifecycle(namespace_id).await?;
+            if GrepIndexLifecycle::from(&lifecycle).is_built_through(target_seq) {
+                return Ok(lifecycle);
+            }
+            match job
+                .step(namespace_id, None)
+                .await
+                .map_err(GrepError::Runtime)?
+                .conclusion
+            {
+                MaintenanceStepConclusion::Progressed | MaintenanceStepConclusion::Superseded => {}
+                // Nothing this loop does next would move the index, so the
+                // caller sees where it stopped rather than a spin.
+                _ => return self.worker.lifecycle(namespace_id).await,
+            }
+        }
     }
 
     pub(crate) async fn disable_grep_index(

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -77,8 +77,10 @@ async fn grams_built_through_seq(
         .expect("load grep root")
         .expect("grep root exists")
         .state()
-        .index()
-        .built_through_seq
+        .lifecycle()
+        .steady_watermark()
+        .expect("a steady grep root has a watermark")
+        .0
 }
 
 #[tokio::test]
@@ -437,12 +439,14 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
         .await
         .expect("load partial grep root")
         .expect("partial grep root");
-    assert_eq!(
-        partial.state().index().built_through_seq,
-        commit.committed_seq
-    );
+    let (partial_seq, partial_event_index) = partial
+        .state()
+        .lifecycle()
+        .steady_watermark()
+        .expect("the partial root is steady");
+    assert_eq!(partial_seq, commit.committed_seq);
     assert!(
-        partial.state().index().next_event_index > 0,
+        partial_event_index > 0,
         "the first step must stop within the atomic commit"
     );
     let prefix_segment_ids: BTreeSet<_> = partial
@@ -510,10 +514,13 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
         .expect("load complete grep root")
         .expect("complete grep root");
     assert_eq!(
-        complete.state().index().built_through_seq,
-        commit.committed_seq
+        complete
+            .state()
+            .lifecycle()
+            .steady_watermark()
+            .expect("the complete root is steady"),
+        (commit.committed_seq, 0)
     );
-    assert_eq!(complete.state().index().next_event_index, 0);
     let complete_segment_ids: BTreeSet<_> = complete
         .state()
         .segments()

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -23,8 +23,8 @@ use loonfs_grep::root::{
     GrepRootState,
 };
 use loonfs_grep::{
-    GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepReorganizeOutcome, GrepService,
-    GrepWorker, GREP_GC_GRACE_WINDOW_MS,
+    GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepGcReport, GrepGcRequest,
+    GrepReorganizeOutcome, GrepService, GrepWorker, GREP_GC_GRACE_WINDOW_MS,
 };
 use loonfs_objectstore::keys::{
     checkpoint_prefix, checkpoint_record, metadata_manifest_object, metadata_manifest_prefix,
@@ -294,7 +294,7 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
         loonfs_grep::GrepDisableOutcome::Disabled
     );
     worker
-        .garbage_collect_namespace(&namespace_id, u64::MAX)
+        .garbage_collect_namespace(&namespace_id, u64::MAX, &GrepGcRequest::default())
         .await
         .expect("collect disabled segments");
     assert!(
@@ -521,14 +521,15 @@ async fn assert_fresh_backfill_attempt(
         .expect("load grep root")
         .expect("grep root exists");
     let GrepLifecycle::Backfilling {
-        backfill_cursor,
+        cursor,
         checkpoint_id,
+        ..
     } = root.state().lifecycle()
     else {
         panic!("expected a checkpointed backfill: {:?}", root.state());
     };
     assert_eq!(
-        *backfill_cursor, None,
+        *cursor, None,
         "a rebootstrap restarts the walk from the beginning"
     );
     assert!(
@@ -572,8 +573,10 @@ async fn grep_built_through_seq(
         .expect("load grep root")
         .expect("grep root exists")
         .state()
-        .index()
-        .built_through_seq
+        .lifecycle()
+        .steady_watermark()
+        .expect("a steady grep root has a watermark")
+        .0
 }
 
 fn matched_paths(response: &GrepResponse) -> Vec<String> {
@@ -1118,8 +1121,8 @@ async fn planless_scan_covers_wal_revisions_at_or_below_index_watermark() {
         .expect("load grep root")
         .expect("grep root exists");
     assert_eq!(
-        grep_root.state().index().built_through_seq,
-        head.seq,
+        grep_root.state().lifecycle().steady_watermark(),
+        Some((head.seq, 0)),
         "the independent worker can advance past metadata materialization"
     );
 
@@ -1525,8 +1528,6 @@ async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
         namespace_id.clone(),
         current_state.lifecycle().clone(),
         GrepIndexState::new(
-            current_state.index().built_through_seq,
-            current_state.index().next_event_index,
             current_state.index().reorganize.clone(),
             current_state.index().next_run_ordinal + 1,
         ),
@@ -1552,7 +1553,7 @@ async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
         blocking.wait_until_blocked().await;
         let report = worker(&store)
             .await
-            .garbage_collect_namespace(&namespace_id, u64::MAX)
+            .garbage_collect_namespace(&namespace_id, u64::MAX, &GrepGcRequest::default())
             .await;
         let candidate_after_gc = store.head(&candidate_key).await;
         blocking.unblock();
@@ -1749,19 +1750,35 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .await
         .expect("delete namespace");
     let live_report = worker
-        .garbage_collect_namespace(&live_namespace, GREP_GC_GRACE_WINDOW_MS + 1)
+        .garbage_collect_namespace(
+            &live_namespace,
+            GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest::default(),
+        )
         .await
         .expect("collect live namespace");
     let deleted_report = worker
-        .garbage_collect_namespace(&deleted_namespace, GREP_GC_GRACE_WINDOW_MS + 1)
+        .garbage_collect_namespace(
+            &deleted_namespace,
+            GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest::default(),
+        )
         .await
         .expect("collect deleted namespace");
     let corrupt_report = worker
-        .garbage_collect_namespace(&corrupt_namespace, GREP_GC_GRACE_WINDOW_MS + 1)
+        .garbage_collect_namespace(
+            &corrupt_namespace,
+            GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest::default(),
+        )
         .await
         .expect("collect corrupt namespace");
     let absent_report = worker
-        .garbage_collect_namespace(&absent_namespace, GREP_GC_GRACE_WINDOW_MS + 1)
+        .garbage_collect_namespace(
+            &absent_namespace,
+            GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest::default(),
+        )
         .await
         .expect("collect absent namespace");
     assert!(live_report.deleted_segments >= 1);
@@ -1851,5 +1868,403 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
             .is_some(),
         "core GC must not learn grep keys"
     );
+    writer.shutdown_background().await.expect("shutdown");
+}
+
+/// Seeds one namespace with an index plus a fixed set of aged orphans, so
+/// two stores can be built identically and collected differently.
+async fn seed_collectable_namespace(root: &Path, namespace_id: &NamespaceId) -> SharedObjectStore {
+    let store: SharedObjectStore = Arc::new(AgedMetadataStore::new(root));
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("gc-budget-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    for index in 0..4u32 {
+        writer
+            .put_file_bytes(
+                namespace_id,
+                &format!("/file-{index}.txt"),
+                format!("budget needle {index}\n").as_bytes(),
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("write file");
+    }
+    let worker = worker(&store).await;
+    worker.enable(namespace_id).await.expect("enable");
+    drive_worker_to_current(&worker, namespace_id, GramIndexBuildPolicy::default()).await;
+    for orphan_key in orphan_keys(namespace_id) {
+        store
+            .put(
+                &orphan_key,
+                Bytes::from_static(b"orphan"),
+                PutMode::CreateIfAbsent,
+            )
+            .await
+            .expect("write orphan");
+    }
+    writer.shutdown_background().await.expect("shutdown");
+    store
+}
+
+/// Aged, unreferenced segment keys with fixed ids, so two independently
+/// seeded stores hold the same collectable garbage under the same names —
+/// the live segment and manifest ids are content-derived and cannot match.
+fn orphan_keys(namespace_id: &NamespaceId) -> Vec<String> {
+    (0..6u8)
+        .map(|index| {
+            let orphan =
+                IndexSegmentId::parse(format!("idx_{index:032x}")).expect("orphan segment id");
+            segment_key(namespace_id, &orphan)
+        })
+        .collect()
+}
+
+/// A budgeted, resumed collection reaches everything one unbudgeted pass
+/// would.
+///
+/// Two identically seeded stores are collected two ways: one whole-prefix
+/// pass, and a cursor loop with a budget small enough that a page cannot
+/// even finish deciding one key. The counters and the surviving keys must
+/// agree — that is what makes the cursor an enumeration shortcut rather
+/// than a second opinion about what is live.
+#[tokio::test]
+async fn a_budgeted_grep_collection_walks_everything_an_unbudgeted_one_does() {
+    let namespace_id = NamespaceId::parse("gc-budget").expect("namespace id");
+    let whole_dir = tempdir().expect("tempdir");
+    let paged_dir = tempdir().expect("tempdir");
+    let whole_store = seed_collectable_namespace(whole_dir.path(), &namespace_id).await;
+    let paged_store = seed_collectable_namespace(paged_dir.path(), &namespace_id).await;
+    let now_ms = GREP_GC_GRACE_WINDOW_MS + 1;
+    let orphans = orphan_keys(&namespace_id);
+    let whole_before = whole_store
+        .list_prefix(&namespace_prefix(&namespace_id))
+        .await
+        .expect("list whole-store keys");
+    let paged_before = paged_store
+        .list_prefix(&namespace_prefix(&namespace_id))
+        .await
+        .expect("list paged-store keys");
+    // The live segment and manifest ids are content-derived and differ
+    // between the two stores; what must match is how many keys there are
+    // and which of them are collectable.
+    assert_eq!(
+        whole_before.len(),
+        paged_before.len(),
+        "the two stores must start alike for the comparison to mean anything"
+    );
+    for orphan in &orphans {
+        assert!(whole_before.contains(orphan) && paged_before.contains(orphan));
+    }
+
+    let whole = worker(&whole_store)
+        .await
+        .garbage_collect_namespace(&namespace_id, now_ms, &GrepGcRequest::default())
+        .await
+        .expect("collect the whole prefix");
+    assert_eq!(whole.next_cursor, None);
+    assert!(whole.deleted_segments >= 6, "{whole:?}");
+
+    let paged_worker = worker(&paged_store).await;
+    let mut paged = GrepGcReport::default();
+    let mut request = GrepGcRequest {
+        max_objects: Some(1),
+        cursor: None,
+    };
+    let mut passes = 0;
+    loop {
+        let pass = paged_worker
+            .garbage_collect_namespace(&namespace_id, now_ms, &request)
+            .await
+            .expect("collect one page");
+        passes += 1;
+        assert!(passes < 256, "the cursor loop must terminate");
+        paged.deleted_segments += pass.deleted_segments;
+        paged.deleted_other_objects += pass.deleted_other_objects;
+        paged.retained_candidates += pass.retained_candidates;
+        paged.namespace_reaped |= pass.namespace_reaped;
+        paged.namespace_degraded |= pass.namespace_degraded;
+        let Some(next_cursor) = pass.next_cursor else {
+            break;
+        };
+        request.cursor = Some(next_cursor);
+    }
+    assert!(
+        passes > 1,
+        "a one-read budget must stop the pass before the prefix ends"
+    );
+
+    assert_eq!(
+        (
+            paged.deleted_segments,
+            paged.deleted_other_objects,
+            paged.retained_candidates,
+            paged.namespace_reaped,
+            paged.namespace_degraded,
+        ),
+        (
+            whole.deleted_segments,
+            whole.deleted_other_objects,
+            whole.retained_candidates,
+            whole.namespace_reaped,
+            whole.namespace_degraded,
+        ),
+        "resuming under a budget must decide exactly what one pass decides"
+    );
+    let whole_after = whole_store
+        .list_prefix(&namespace_prefix(&namespace_id))
+        .await
+        .expect("list surviving whole-store keys");
+    let paged_after = paged_store
+        .list_prefix(&namespace_prefix(&namespace_id))
+        .await
+        .expect("list surviving paged-store keys");
+    assert_eq!(
+        whole_after.len(),
+        paged_after.len(),
+        "the two collections must leave the same amount behind"
+    );
+    for orphan in &orphans {
+        assert!(
+            !whole_after.contains(orphan) && !paged_after.contains(orphan),
+            "both collections must reach `{orphan}`"
+        );
+    }
+}
+
+/// The budget counts reads, not listed keys.
+///
+/// Deciding one key costs three: its listing, the liveness or root re-read
+/// that authorizes the decision, and the age probe. A deleted namespace is
+/// where that is countable — every key there is decided and deleted — so a
+/// budget of seven reaps exactly two keys, where a budget that only counted
+/// listings would have reaped seven.
+#[tokio::test]
+async fn the_collection_budget_charges_each_key_the_reads_it_costs() {
+    let namespace_id = NamespaceId::parse("gc-charge").expect("namespace id");
+    let temp_dir = tempdir().expect("tempdir");
+    let store = seed_collectable_namespace(temp_dir.path(), &namespace_id).await;
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("gc-charge-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .delete_namespace(&namespace_id, DeleteNamespaceOptions::default())
+        .await
+        .expect("delete namespace");
+    writer.shutdown_background().await.expect("shutdown");
+    let keys_before = store
+        .list_prefix(&namespace_prefix(&namespace_id))
+        .await
+        .expect("list keys");
+    assert!(keys_before.len() > 2, "{keys_before:?}");
+
+    let pass = worker(&store)
+        .await
+        .garbage_collect_namespace(
+            &namespace_id,
+            GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest {
+                // One for the pass's liveness read, then three per key.
+                max_objects: Some(7),
+                cursor: None,
+            },
+        )
+        .await
+        .expect("collect under a seven-read budget");
+    assert_eq!(
+        pass.deleted_segments + pass.deleted_other_objects,
+        2,
+        "the budget must pay for each key's own reads, not just its listing: {pass:?}"
+    );
+    assert!(pass.next_cursor.is_some(), "{pass:?}");
+    assert_eq!(
+        store
+            .list_prefix(&namespace_prefix(&namespace_id))
+            .await
+            .expect("list keys after the bounded pass")
+            .len(),
+        keys_before.len() - 2
+    );
+}
+
+/// However small the budget, a pass examines one key — otherwise a caller
+/// looping the cursor would never finish.
+#[tokio::test]
+async fn a_budget_too_small_for_one_key_still_advances_the_cursor() {
+    let namespace_id = NamespaceId::parse("gc-progress").expect("namespace id");
+    let temp_dir = tempdir().expect("tempdir");
+    let store = seed_collectable_namespace(temp_dir.path(), &namespace_id).await;
+    let worker = worker(&store).await;
+    let first = worker
+        .garbage_collect_namespace(
+            &namespace_id,
+            GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest {
+                max_objects: Some(1),
+                cursor: None,
+            },
+        )
+        .await
+        .expect("collect under a one-read budget");
+    let cursor = first.next_cursor.expect("a stopped pass resumes somewhere");
+    let second = worker
+        .garbage_collect_namespace(
+            &namespace_id,
+            GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest {
+                max_objects: Some(1),
+                cursor: Some(cursor.clone()),
+            },
+        )
+        .await
+        .expect("collect the next page");
+    assert_ne!(
+        second.next_cursor.as_ref(),
+        Some(&cursor),
+        "a resumed pass must not hand back the position it was given"
+    );
+}
+
+/// A cursor is bound to the namespace that minted it and to grep's own
+/// prefix; anything else is refused as an invalid request.
+#[tokio::test]
+async fn a_collection_cursor_is_refused_outside_the_namespace_that_minted_it() {
+    let namespace_id = NamespaceId::parse("gc-cursor").expect("namespace id");
+    let other_namespace = NamespaceId::parse("gc-cursor-other").expect("namespace id");
+    let temp_dir = tempdir().expect("tempdir");
+    let store = seed_collectable_namespace(temp_dir.path(), &namespace_id).await;
+    let worker = worker(&store).await;
+    let cursor = worker
+        .garbage_collect_namespace(
+            &namespace_id,
+            GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest {
+                max_objects: Some(1),
+                cursor: None,
+            },
+        )
+        .await
+        .expect("collect one page")
+        .next_cursor
+        .expect("a stopped pass carries a resume cursor");
+
+    for (namespace, token) in [
+        (&other_namespace, cursor.clone()),
+        (&namespace_id, "not-a-cursor".to_owned()),
+    ] {
+        let error = worker
+            .garbage_collect_namespace(
+                namespace,
+                GREP_GC_GRACE_WINDOW_MS + 1,
+                &GrepGcRequest {
+                    max_objects: None,
+                    cursor: Some(token),
+                },
+            )
+            .await
+            .expect_err("a foreign or malformed cursor is refused");
+        assert_eq!(error.code(), ErrorCode::InvalidRequest);
+    }
+}
+
+/// A backfilling root has no watermark, and nothing on the way out invents
+/// one for it.
+#[tokio::test]
+async fn a_backfilling_root_never_reports_a_built_through_sequence() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("enable-honesty").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("enable-honesty-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/note.txt",
+            b"honest needle\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write file");
+    let worker = worker(&store).await;
+
+    let loonfs_grep::GrepEnableOutcome::Enabled { state } =
+        worker.enable(&namespace_id).await.expect("enable")
+    else {
+        panic!("a fresh enable publishes a backfill");
+    };
+    let backfilling = loonfs_api::v0::GrepIndexLifecycle::from(&state);
+    assert_eq!(
+        backfilling,
+        loonfs_api::v0::GrepIndexLifecycle::Backfilling {
+            target_seq: ChangeSeq(1),
+            cursor_inode_id: None,
+            checkpoint_id: match &state {
+                GrepLifecycle::Backfilling { checkpoint_id, .. } => checkpoint_id.clone(),
+                other => panic!("expected a backfill: {other:?}"),
+            },
+        }
+    );
+    let rendered = serde_json::to_string(&backfilling).expect("serialize the reported lifecycle");
+    assert!(
+        !rendered.contains("built_through_seq"),
+        "a backfill must not report a watermark anywhere: {rendered}"
+    );
+    assert_eq!(
+        worker
+            .lifecycle(&namespace_id)
+            .await
+            .expect("read lifecycle"),
+        state,
+        "the enable response reports the lifecycle it published"
+    );
+
+    // Re-enabling an active root reports the same phase, still without a
+    // watermark.
+    let loonfs_grep::GrepEnableOutcome::AlreadyEnabled { state: again } = worker
+        .enable(&namespace_id)
+        .await
+        .expect("idempotent enable")
+    else {
+        panic!("re-enabling an active root reports it as already enabled");
+    };
+    assert_eq!(again, state);
+
+    // Once the walk finishes, the steady root carries the target it reached
+    // as its own watermark, and no target field survives.
+    drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
+    let steady = loonfs_api::v0::GrepIndexLifecycle::from(
+        &worker
+            .lifecycle(&namespace_id)
+            .await
+            .expect("read steady lifecycle"),
+    );
+    assert_eq!(
+        steady,
+        loonfs_api::v0::GrepIndexLifecycle::Steady {
+            built_through_seq: ChangeSeq(1),
+            next_event_index: 0,
+        }
+    );
+    assert!(!serde_json::to_string(&steady)
+        .expect("serialize the steady lifecycle")
+        .contains("target_seq"));
     writer.shutdown_background().await.expect("shutdown");
 }

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -330,7 +330,12 @@ async fn wait_for_watermark<S: ObjectStore + 'static>(
                 .await
                 .expect("load grep root")
             {
-                if root.state().index().built_through_seq >= built_through_seq {
+                if root
+                    .state()
+                    .lifecycle()
+                    .steady_watermark()
+                    .is_some_and(|(reached, _)| reached >= built_through_seq)
+                {
                     return;
                 }
             }

--- a/crates/loonfs-grep/tests/it/root_format.rs
+++ b/crates/loonfs-grep/tests/it/root_format.rs
@@ -11,25 +11,35 @@ use loonfs_grep::root::{
 };
 use loonfs_test_support::ids::namespace_id;
 
-// Frozen v1 format pins. These byte strings are the durable compatibility
-// fixtures: changing field names, ordering, enum tags, or omission rules must
-// change them deliberately. Together they represent every lifecycle state.
-const BACKFILLING_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:a629f619356fda3c1d5789df1082221494bdec8ae182b6883748c73346a0fae9","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":1,"built_through_seq":7,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const STEADY_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:c7d26cf67191665af1c6985ad742fa9ef36cfe635a6577b4e02d79e112fe02cf","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_event_index":5,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const DISABLED_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
-const ADDITIVE_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:2582065ee15d356cbaf1b40d245207ab8e2b61e3ae2a86a108957baf41336be9","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","future_lifecycle":"ignored"},"index":{"format_version":1,"built_through_seq":11,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
+// Frozen format pins. These byte strings are the durable fixtures: changing
+// field names, ordering, enum tags, or omission rules must change them
+// deliberately. Together they represent every lifecycle state.
+//
+// The envelope is still `v1`; what version 2 changed is the index state
+// nested inside it, which moved each phase's own watermark into the phase.
+const BACKFILLING_V2: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:5002cd1db3aef16bdc6cc413185add75a3d392f66f80f51a54e37278d413bbdf","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","target_seq":7,"cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":2,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_V2: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"next_event_index":5},"index":{"format_version":2,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const DISABLED_V2: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":2,"next_run_ordinal":4},"segments":[]}}"#;
+const ADDITIVE_V2: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:f015075bf0949612b508d5d3a765028264cdbbcb01be060bd997c4d1904621b2","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"future_lifecycle":"ignored"},"index":{"format_version":2,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
 
-const BACKFILLING_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:78a84cf100fdaf5f53e97b0d3c1a5e372206039af4b2ac7d5da64df0b9f6643a","payload":{"namespace_id":"docs","manifest_id":"a629f619356fda3c1d5789df1082221494bdec8ae182b6883748c73346a0fae9"}}"#;
-const STEADY_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:8f61fb899bc4e50d17620a54379c072f10a8bc5f3aff110c60beb684173c2af0","payload":{"namespace_id":"docs","manifest_id":"c7d26cf67191665af1c6985ad742fa9ef36cfe635a6577b4e02d79e112fe02cf"}}"#;
-const DISABLED_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:e5c0fbe19e4bee1cfb5ddf3a99f7c4439a83e4c323b1a6054bfa62e16a9c1d73","payload":{"namespace_id":"docs","manifest_id":"70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c"}}"#;
+const BACKFILLING_POINTER_V2: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:c5573e40ba68f25bb977c0527efad030fa92eaa6c8303308ce6af5c7a4f6bc5a","payload":{"namespace_id":"docs","manifest_id":"5002cd1db3aef16bdc6cc413185add75a3d392f66f80f51a54e37278d413bbdf"}}"#;
+const STEADY_POINTER_V2: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:ca61e2f34ae4808e7a8de27df7457c3d477d8374c35178982d65512e4a891c74","payload":{"namespace_id":"docs","manifest_id":"b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff"}}"#;
+const DISABLED_POINTER_V2: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:a40f6d8acfcc8a1c11bc625ab46ab782885deb521277943e4ced2a5d74c4ef46","payload":{"namespace_id":"docs","manifest_id":"cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc"}}"#;
 const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:b09014e32fe81501ef34ca037c33ad6b3cbdf4424a16bd376462f84dd2d1b4bc","payload":{"namespace_id":"docs","manifest_id":"9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad","future_pointer":true},"future_envelope":{"retained":true}}"#;
 
+// Version-1 index states, kept only to prove they are refused. Each spelled
+// a backfill's target and a steady index's progress with one field, so a
+// decoder that accepted them could not tell which meaning it had read.
+const BACKFILLING_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:a629f619356fda3c1d5789df1082221494bdec8ae182b6883748c73346a0fae9","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":1,"built_through_seq":7,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:c7d26cf67191665af1c6985ad742fa9ef36cfe635a6577b4e02d79e112fe02cf","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_event_index":5,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const DISABLED_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
+
 #[test]
-fn encoded_manifests_and_pointers_match_frozen_v1_bytes() {
+fn encoded_manifests_and_pointers_match_frozen_bytes() {
     let cases = [
-        (sample_backfilling_root(), BACKFILLING_V1),
-        (sample_steady_root(ChangeSeq(11), 5), STEADY_V1),
-        (sample_disabled_root(), DISABLED_V1),
+        (sample_backfilling_root(), BACKFILLING_V2),
+        (sample_steady_root(ChangeSeq(11), 5), STEADY_V2),
+        (sample_disabled_root(), DISABLED_V2),
     ];
 
     for (state, expected) in cases {
@@ -47,18 +57,47 @@ fn encoded_manifests_and_pointers_match_frozen_v1_bytes() {
         let actual = String::from_utf8(encode_grep_root(&pointer).expect("encode grep pointer"))
             .expect("pointer JSON is UTF-8");
         let expected = match manifest.state().lifecycle() {
-            GrepLifecycle::Backfilling { .. } => BACKFILLING_POINTER_V1,
-            GrepLifecycle::Steady => STEADY_POINTER_V1,
-            GrepLifecycle::Disabled => DISABLED_POINTER_V1,
+            GrepLifecycle::Backfilling { .. } => BACKFILLING_POINTER_V2,
+            GrepLifecycle::Steady { .. } => STEADY_POINTER_V2,
+            GrepLifecycle::Disabled => DISABLED_POINTER_V2,
         };
         assert_eq!(actual, expected);
     }
 }
 
+/// Every phase survives a round trip carrying exactly its own fields, and
+/// the encoded bytes never name the other phase's sequence.
 #[test]
-fn immutable_manifest_decoder_reads_frozen_v1_bytes_with_additive_fields() {
+fn every_lifecycle_phase_round_trips_carrying_only_its_own_position() {
+    for (state, absent_field) in [
+        (sample_backfilling_root(), "built_through_seq"),
+        (sample_steady_root(ChangeSeq(11), 5), "target_seq"),
+        (sample_disabled_root(), "built_through_seq"),
+    ] {
+        let encoded = encode_grep_manifest(
+            &GrepManifestEnvelope::from_state(state.clone()).expect("build manifest envelope"),
+        )
+        .expect("encode grep manifest");
+        assert!(
+            !String::from_utf8(encoded.clone())
+                .expect("manifest JSON is UTF-8")
+                .contains(absent_field),
+            "{:?} must not spell `{absent_field}`",
+            state.lifecycle()
+        );
+        assert_eq!(
+            decode_grep_manifest(&encoded)
+                .expect("decode grep manifest")
+                .state(),
+            &state
+        );
+    }
+}
+
+#[test]
+fn immutable_manifest_decoder_reads_frozen_bytes_with_additive_fields() {
     let decoded =
-        decode_grep_manifest(ADDITIVE_V1.as_bytes()).expect("decode additive manifest fixture");
+        decode_grep_manifest(ADDITIVE_V2.as_bytes()).expect("decode additive manifest fixture");
 
     assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11), 0));
 }
@@ -66,7 +105,7 @@ fn immutable_manifest_decoder_reads_frozen_v1_bytes_with_additive_fields() {
 #[test]
 fn mutable_pointer_payload_rejects_unknown_fields_as_corruption() {
     let mut document: serde_json::Value =
-        serde_json::from_str(STEADY_POINTER_V1).expect("decode pointer fixture");
+        serde_json::from_str(STEADY_POINTER_V2).expect("decode pointer fixture");
     document["payload"]["field_from_the_future"] = serde_json::Value::from(true);
     let payload = serde_json::to_string(&document["payload"]).expect("encode edited payload");
     document["payload_checksum"] =
@@ -90,10 +129,39 @@ fn mutable_pointer_envelope_rejects_unknown_fields_as_corruption() {
     ));
 }
 
+/// Version 1 is refused outright, with no shim and no salvage.
+///
+/// Its `built_through_seq` meant the backfill's target in one phase and real
+/// indexed progress in another, and nothing in the bytes says which. A
+/// disabled root — whose lifecycle happens to still parse — proves the
+/// version guard itself does the refusing, not just the changed field
+/// shapes.
+#[test]
+fn decoder_rejects_version_one_index_state_without_a_shim() {
+    assert!(matches!(
+        decode_grep_manifest(DISABLED_INDEX_V1.as_bytes()),
+        Err(GrepRootCodecError::InvalidState(
+            GrepRootStateError::UnsupportedIndexFormatVersion {
+                found: 1,
+                supported: 2
+            }
+        ))
+    ));
+
+    // The other two cannot even be read into the current shape: their
+    // phases no longer carry the fields version 1 put beside them.
+    for fixture in [BACKFILLING_INDEX_V1, STEADY_INDEX_V1] {
+        assert!(matches!(
+            decode_grep_manifest(fixture.as_bytes()),
+            Err(GrepRootCodecError::PayloadDecode { .. })
+        ));
+    }
+}
+
 #[test]
 fn decoder_rejects_unknown_version_without_fallback() {
     let wrong_version =
-        STEADY_V1.replacen("\"format_version\":\"v1\"", "\"format_version\":\"v7\"", 1);
+        STEADY_V2.replacen("\"format_version\":\"v1\"", "\"format_version\":\"v7\"", 1);
 
     assert!(matches!(
         decode_grep_manifest(wrong_version.as_bytes()),
@@ -104,7 +172,7 @@ fn decoder_rejects_unknown_version_without_fallback() {
 
 #[test]
 fn decoder_rejects_corrupted_checksum() {
-    let corrupted = STEADY_V1.replacen("\"steady\"", "\"disabled\"", 1);
+    let corrupted = STEADY_V2.replacen("\"steady\"", "\"disabled\"", 1);
 
     assert!(matches!(
         decode_grep_manifest(corrupted.as_bytes()),
@@ -114,7 +182,7 @@ fn decoder_rejects_corrupted_checksum() {
 
 #[test]
 fn decoder_rejects_truncated_payload() {
-    let truncated = &STEADY_V1.as_bytes()[..STEADY_V1.len() - 8];
+    let truncated = &STEADY_V2.as_bytes()[..STEADY_V2.len() - 8];
 
     assert!(matches!(
         decode_grep_manifest(truncated),
@@ -124,7 +192,7 @@ fn decoder_rejects_truncated_payload() {
 
 #[test]
 fn constructor_rejects_fold_segment_mismatch() {
-    let mut index = GrepIndexState::new(ChangeSeq(7), 0, None, 2);
+    let mut index = GrepIndexState::new(None, 2);
     index.reorganize = Some(GrepReorganizeState {
         snapshot_segment_ids: vec![segment_id(9)],
         output_segment_ids: Vec::new(),
@@ -136,7 +204,10 @@ fn constructor_rejects_fold_segment_mismatch() {
     assert!(matches!(
         GrepRootState::new(
             namespace_id("docs"),
-            GrepLifecycle::Steady,
+            GrepLifecycle::Steady {
+                built_through_seq: ChangeSeq(7),
+                next_event_index: 0,
+            },
             index,
             vec![segment_ref(1, 1, 0, 0)]
         ),
@@ -155,11 +226,12 @@ fn sample_backfilling_root() -> GrepRootState {
     GrepRootState::new(
         namespace_id("docs"),
         GrepLifecycle::Backfilling {
-            backfill_cursor: Some(InodeId(7)),
+            target_seq: ChangeSeq(7),
+            cursor: Some(InodeId(7)),
             checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000009")
                 .expect("valid checkpoint id"),
         },
-        GrepIndexState::new(ChangeSeq(7), 0, Some(fold), 4),
+        GrepIndexState::new(Some(fold), 4),
         vec![
             segment_ref(1, 1, 0, 0),
             segment_ref(2, 2, 0, 0),
@@ -172,8 +244,11 @@ fn sample_backfilling_root() -> GrepRootState {
 fn sample_steady_root(built_through_seq: ChangeSeq, next_event_index: u32) -> GrepRootState {
     GrepRootState::new(
         namespace_id("docs"),
-        GrepLifecycle::Steady,
-        GrepIndexState::new(built_through_seq, next_event_index, None, 2),
+        GrepLifecycle::Steady {
+            built_through_seq,
+            next_event_index,
+        },
+        GrepIndexState::new(None, 2),
         vec![segment_ref(1, 1, 0, 0)],
     )
     .expect("valid steady root")
@@ -183,7 +258,7 @@ fn sample_disabled_root() -> GrepRootState {
     GrepRootState::new(
         namespace_id("docs"),
         GrepLifecycle::Disabled,
-        GrepIndexState::new(ChangeSeq(15), 0, None, 4),
+        GrepIndexState::new(None, 4),
         Vec::new(),
     )
     .expect("valid disabled root")

--- a/crates/loonfs-grep/tests/it/root_store.rs
+++ b/crates/loonfs-grep/tests/it/root_store.rs
@@ -139,7 +139,10 @@ async fn racing_advancers_have_one_winner_and_loser_can_reload_and_retry() {
         .await
         .expect("final load succeeds")
         .expect("root exists");
-    assert_eq!(final_root.state().index().built_through_seq, ChangeSeq(3));
+    assert_eq!(
+        final_root.state().lifecycle().steady_watermark(),
+        Some((ChangeSeq(3), 0))
+    );
 }
 
 #[tokio::test]
@@ -163,8 +166,11 @@ async fn stale_etag_advance_fails_after_concurrent_advance() {
 fn root(namespace_id: NamespaceId, built_through_seq: ChangeSeq) -> GrepRootState {
     GrepRootState::new(
         namespace_id,
-        GrepLifecycle::Steady,
-        GrepIndexState::new(built_through_seq, 0, None, 0),
+        GrepLifecycle::Steady {
+            built_through_seq,
+            next_event_index: 0,
+        },
+        GrepIndexState::new(None, 0),
         Vec::new(),
     )
     .expect("valid root")

--- a/crates/loonfs-grep/tests/it/standalone.rs
+++ b/crates/loonfs-grep/tests/it/standalone.rs
@@ -54,10 +54,19 @@ async fn standalone_once_after_external_enable_indexes_in_one_sweep_and_is_idemp
         .await
         .expect("load root")
         .expect("root exists");
-    assert_eq!(first_root.state().index().built_through_seq.0, 1);
+    assert_eq!(
+        first_root
+            .state()
+            .lifecycle()
+            .steady_watermark()
+            .expect("the first root is steady")
+            .0
+             .0,
+        1
+    );
     assert!(matches!(
         first_root.state().lifecycle(),
-        GrepLifecycle::Steady
+        GrepLifecycle::Steady { .. }
     ));
     assert!(!first_root.state().segments().is_empty());
     let first_root_bytes = store
@@ -194,7 +203,7 @@ async fn standalone_namespace_list_is_exact_and_long_running_poll_catches_new_wr
         .expect("assigned root");
     assert!(matches!(
         assigned_root.state().lifecycle(),
-        GrepLifecycle::Steady
+        GrepLifecycle::Steady { .. }
     ));
     let unassigned_root = load_grep_root(&*store, &unassigned)
         .await
@@ -321,7 +330,12 @@ async fn wait_for_watermark(store: &Arc<LocalFsStore>, namespace_id: &NamespaceI
             .await
             .expect("load polled root")
             .expect("polled root");
-        if root.state().index().built_through_seq.0 >= target {
+        if root
+            .state()
+            .lifecycle()
+            .steady_watermark()
+            .is_some_and(|(reached, _)| reached.0 >= target)
+        {
             return;
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -7,7 +7,8 @@ use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::Json;
 use loonfs_api::v0::{
-    DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcResponse, GrepRequest, GrepResponse,
+    DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest, GrepGcResponse,
+    GrepIndexLifecycle, GrepIndexStatusResponse, GrepRequest, GrepResponse,
 };
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -104,7 +105,7 @@ pub(super) async fn grep_index_not_maintained(
         path = "/v0/admin/namespaces/{namespace}/grep/index/enable",
         tag = "admin",
         summary = "Enable the grep index",
-        description = "Enables the namespace's grep root and asks this deployment's maintenance runner for the backfill's first step. Idempotent. Requires this deployment to maintain the grep index.",
+        description = "Enables the namespace's grep root and asks this deployment's maintenance runner for the backfill's first step. The response reports the durable lifecycle it published or found: a fresh enable is `backfilling` with the sequence its checkpoint captured, while an already-enabled namespace answers with whichever phase it is in. Idempotent. Requires this deployment to maintain the grep index.",
         params(("namespace" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Grep root enabled or already enabled", body = EnableGrepIndexResponse),
@@ -131,17 +132,12 @@ pub(super) async fn enable_grep_index(
         .enable(&namespace_id)
         .await
         .map_err(|error| map_grep_error(&namespace_id, error))?;
-    let response = match outcome {
-        GrepEnableOutcome::Enabled { target_seq } => EnableGrepIndexResponse {
-            namespace_id: namespace_id.clone(),
-            built_through_seq: target_seq,
-            already_enabled: false,
-        },
-        GrepEnableOutcome::AlreadyEnabled { built_through_seq } => EnableGrepIndexResponse {
-            namespace_id: namespace_id.clone(),
-            built_through_seq,
-            already_enabled: true,
-        },
+    // The two settled outcomes differ in one bit — whether this call did the
+    // enabling — and report the same durable lifecycle either way. Nothing
+    // here converts a backfill target into a watermark.
+    let (already_enabled, lifecycle) = match outcome {
+        GrepEnableOutcome::Enabled { state } => (false, state),
+        GrepEnableOutcome::AlreadyEnabled { state } => (true, state),
         GrepEnableOutcome::Superseded => {
             return Err(map_grep_error(
                 &namespace_id,
@@ -151,11 +147,66 @@ pub(super) async fn enable_grep_index(
             ));
         }
     };
+    let response = EnableGrepIndexResponse {
+        namespace_id: namespace_id.clone(),
+        already_enabled,
+        state: GrepIndexLifecycle::from(&lifecycle),
+    };
     // The root is durable now; the backfill is one nudge away from starting.
     if let Some(maintenance) = &state.grep_maintenance {
         maintenance.nudge(&namespace_id);
     }
     Ok(Json(response))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/admin/namespaces/{namespace}/grep/index",
+        tag = "admin",
+        summary = "Read the grep index's lifecycle",
+        description = "Reports where the namespace's grep index is: `disabled`, `backfilling` with the sequence it walks toward and how far the walk got, or `steady` with the watermark it has built through. One grep root read, no side effects. A namespace that never enabled the index reads as `disabled`. Requires this deployment to maintain the grep index.",
+        params(("namespace" = String, Path, description = "Namespace id")),
+        responses(
+            (status = 200, description = "The index's lifecycle and bookkeeping", body = GrepIndexStatusResponse),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
+            (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
+        )
+    )
+)]
+pub(super) async fn grep_index_status(
+    State(state): State<AppState>,
+    namespace: NamespaceIdPath,
+    headers: HeaderMap,
+) -> Result<Json<GrepIndexStatusResponse>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    let namespace_id = namespace.into_id()?;
+    let root = state
+        .grep_worker
+        .as_ref()
+        .expect("grep routes should carry a grep worker")
+        .root_state(&namespace_id)
+        .await
+        .map_err(|error| map_grep_error(&namespace_id, error))?;
+    let (lifecycle, next_run_ordinal, reorganize_pending) = match &root {
+        Some(root) => (
+            GrepIndexLifecycle::from(root.lifecycle()),
+            root.index().next_run_ordinal,
+            root.index().reorganize.is_some(),
+        ),
+        // No root was ever published, which is the same answer as a root
+        // that was disabled: nothing is being maintained here.
+        None => (GrepIndexLifecycle::Disabled, 0, false),
+    };
+    Ok(Json(GrepIndexStatusResponse {
+        namespace_id,
+        state: lifecycle,
+        next_run_ordinal,
+        reorganize_pending,
+    }))
 }
 
 #[cfg_attr(
@@ -225,10 +276,12 @@ pub(super) async fn disable_grep_index(
         path = "/v0/admin/namespaces/{namespace}/grep/index/gc",
         tag = "admin",
         summary = "Collect grep-index garbage",
-        description = "Runs one explicit garbage-collection pass over only this namespace's grep-owned extension keyspace. A tombstoned or absent namespace has aged extension state reaped; no grep garbage collection runs implicitly. Requires this deployment to maintain the grep index.",
+        description = "Runs one explicit garbage-collection pass over only this namespace's grep-owned extension keyspace. A tombstoned or absent namespace has aged extension state reaped; no grep garbage collection runs implicitly. `max_objects` bounds the reads the pass spends and returns a `next_cursor` when keys remain; resuming re-reads liveness and the grep root, so a cursor only skips enumeration. Requires this deployment to maintain the grep index.",
         params(("namespace" = String, Path, description = "Namespace id")),
+        request_body = GrepGcRequest,
         responses(
             (status = 200, description = "Namespace grep garbage collection completed", body = GrepGcResponse),
+            (status = 400, description = "Invalid budget or cursor", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
@@ -240,6 +293,7 @@ pub(super) async fn gc_grep_index(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
     headers: HeaderMap,
+    AppJson(request): AppJson<GrepGcRequest>,
 ) -> Result<Json<GrepGcResponse>, ApiResponseError> {
     authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
@@ -247,7 +301,14 @@ pub(super) async fn gc_grep_index(
         .grep_worker
         .as_ref()
         .expect("grep routes should carry a grep worker")
-        .garbage_collect_namespace(&namespace_id, current_unix_ms()?)
+        .garbage_collect_namespace(
+            &namespace_id,
+            current_unix_ms()?,
+            &loonfs_grep::GrepGcRequest {
+                max_objects: request.max_objects,
+                cursor: request.cursor,
+            },
+        )
         .await
         .map_err(|error| map_grep_error(&namespace_id, error))?;
     Ok(Json(GrepGcResponse {
@@ -257,6 +318,7 @@ pub(super) async fn gc_grep_index(
         namespace_reaped: report.namespace_reaped,
         retained_candidates: report.retained_candidates,
         namespace_degraded: report.namespace_degraded,
+        next_cursor: report.next_cursor,
     }))
 }
 

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -34,7 +34,7 @@ use self::handlers_namespace::{
 };
 use self::handlers_query::{
     disable_grep_index, enable_grep_index, gc_grep_index, grep, grep_index_not_maintained,
-    grep_queries_not_served,
+    grep_index_status, grep_queries_not_served,
 };
 use self::handlers_uploads::{
     abort_upload, begin_upload, complete_upload, read_upload_status, sign_upload_parts,
@@ -108,6 +108,14 @@ fn router(state: AppState) -> Router {
     } else {
         post(grep_index_not_maintained)
     };
+    // Reading the index's lifecycle is administering it, not serving it: a
+    // deployment that only answers searches has no authority over the state
+    // this reports, so it gates with the mutating three.
+    let grep_status_route = if maintains_index {
+        get(grep_index_status)
+    } else {
+        get(grep_index_not_maintained)
+    };
     Router::new()
         .route("/health", get(health))
         .route("/readiness", get(readiness))
@@ -128,6 +136,10 @@ fn router(state: AppState) -> Router {
             get(get_file_bytes),
         )
         .route("/v0/namespaces/:namespace/query/grep", grep_route)
+        .route(
+            "/v0/admin/namespaces/:namespace/grep/index",
+            grep_status_route,
+        )
         .route(
             "/v0/admin/namespaces/:namespace/grep/index/enable",
             enable_grep_route,

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -61,6 +61,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         crate::http::handlers_namespace::release_checkpoint,
         crate::http::handlers_namespace::maintenance_step,
         crate::http::handlers_query::grep,
+        crate::http::handlers_query::grep_index_status,
         crate::http::handlers_query::enable_grep_index,
         crate::http::handlers_query::disable_grep_index,
         crate::http::handlers_query::gc_grep_index
@@ -131,8 +132,11 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         loonfs_api::v0::GrepRequest,
         loonfs_api::v0::GrepMatch,
         loonfs_api::v0::GrepResponse,
+        loonfs_api::v0::GrepIndexLifecycle,
+        loonfs_api::v0::GrepIndexStatusResponse,
         loonfs_api::v0::EnableGrepIndexResponse,
         loonfs_api::v0::DisableGrepIndexResponse,
+        loonfs_api::v0::GrepGcRequest,
         loonfs_api::v0::GrepGcResponse
     )),
     tags(

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -469,8 +469,10 @@ async fn built_through_seq(state: &AppState, namespace_id: &NamespaceId) -> Chan
         .expect("load grep root")
         .expect("an enabled namespace has a grep root")
         .state()
-        .index()
-        .built_through_seq
+        .lifecycle()
+        .steady_watermark()
+        .expect("a steady grep root has a watermark")
+        .0
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -7,7 +7,9 @@ use axum::http::{Method, Request, StatusCode};
 use axum::Router;
 use loonfs::{CreateNamespaceOptions, FsWriter, PutFileOptions};
 use loonfs::{FsAdmin, FsReader};
-use loonfs_api::v0::GrepGcResponse;
+use loonfs_api::v0::{
+    EnableGrepIndexResponse, GrepGcResponse, GrepIndexLifecycle, GrepIndexStatusResponse,
+};
 use loonfs_api::{
     ApiError, CapabilityDocument, ChangeSeq, GrepRequest, GrepResponse, NamespaceId,
     FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
@@ -57,6 +59,8 @@ async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
         assert_eq!(error.code, "not_supported");
         assert_eq!(error.feature.as_deref(), Some(FEATURE_QUERY_GREP));
     }
+    let status = send(&router, Method::GET, &status_path(&namespace_id), None).await;
+    assert_eq!(status.status(), StatusCode::NOT_IMPLEMENTED);
     lifecycle.shutdown().await.expect("drain lifecycle");
 }
 
@@ -68,9 +72,68 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
         .await
         .expect("build app");
     assert!(lifecycle.maintains_grep_index());
-    assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
+    // Before anything is enabled the status route answers honestly rather
+    // than inventing a namespace-not-found.
+    assert_eq!(
+        index_status(&router, &namespace_id).await.state,
+        GrepIndexLifecycle::Disabled
+    );
+
+    let enabled: EnableGrepIndexResponse = response_json(
+        send(
+            &router,
+            Method::POST,
+            &format!("/v0/admin/namespaces/{namespace_id}/grep/index/enable"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    assert!(!enabled.already_enabled);
+    // A fresh enable publishes a backfill and reports the sequence its
+    // checkpoint captured — not a watermark it has not reached.
+    assert!(
+        matches!(
+            enabled.state,
+            GrepIndexLifecycle::Backfilling {
+                target_seq: ChangeSeq(0),
+                cursor_inode_id: None,
+                ..
+            }
+        ),
+        "{:?}",
+        enabled.state
+    );
+    assert_eq!(
+        index_status(&router, &namespace_id).await.state,
+        enabled.state,
+        "the status route and the enable response describe the same root"
+    );
     settle(&lifecycle).await;
     assert_eq!(watermark(&store, &namespace_id).await, ChangeSeq(0));
+    let steady = index_status(&router, &namespace_id).await;
+    assert_eq!(
+        steady.state,
+        GrepIndexLifecycle::Steady {
+            built_through_seq: ChangeSeq(0),
+            next_event_index: 0,
+        }
+    );
+    assert!(!steady.reorganize_pending);
+
+    // Re-enabling an active root reports the phase it found, still tagged.
+    let again: EnableGrepIndexResponse = response_json(
+        send(
+            &router,
+            Method::POST,
+            &format!("/v0/admin/namespaces/{namespace_id}/grep/index/enable"),
+            None,
+        )
+        .await,
+    )
+    .await;
+    assert!(again.already_enabled);
+    assert_eq!(again.state, steady.state);
 
     // The file lands through a writer of its own, so nothing in this server
     // observed the publish: the index stays where it was until a request
@@ -136,12 +199,16 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
             &router,
             Method::POST,
             &format!("/v0/admin/namespaces/{namespace_id}/grep/index/gc"),
-            None,
+            Some(b"{}".to_vec()),
         )
         .await,
     )
     .await;
     assert_eq!(gc.namespace_id, namespace_id);
+    assert_eq!(
+        gc.next_cursor, None,
+        "an unbudgeted pass walks the whole grep keyspace"
+    );
 
     assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
     settle(&lifecycle).await;
@@ -287,6 +354,16 @@ async fn serve_only_answers_searches_over_an_index_it_refuses_to_administer() {
             error.message
         );
     }
+    // Reading the index's lifecycle is administering it: a deployment that
+    // maintains nothing has no authority over the state it would report.
+    let status = send(&router, Method::GET, &status_path(&namespace_id), None).await;
+    assert_eq!(status.status(), StatusCode::NOT_IMPLEMENTED);
+    let error: ApiError = response_json(status).await;
+    assert!(
+        error.message.contains("does not maintain"),
+        "{}",
+        error.message
+    );
 
     let worker = grep_worker(&store, "external-grep-worker").await;
     worker.enable(&namespace_id).await.expect("enable grep");
@@ -301,9 +378,9 @@ async fn serve_only_answers_searches_over_an_index_it_refuses_to_administer() {
         .expect("write file");
     settle(&lifecycle).await;
     assert_eq!(
-        watermark(&store, &namespace_id).await,
-        ChangeSeq(0),
-        "a deployment that maintains nothing must not advance the watermark"
+        lifecycle_of(&store, &namespace_id).await.steady_watermark(),
+        None,
+        "a deployment that maintains nothing must leave the backfill where it was"
     );
 
     drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
@@ -361,7 +438,10 @@ async fn maintain_only_keeps_the_index_built_without_serving_searches() {
         .await
         .expect("load root")
         .expect("maintained root");
-    assert!(matches!(root.state().lifecycle(), GrepLifecycle::Steady));
+    assert!(matches!(
+        root.state().lifecycle(),
+        GrepLifecycle::Steady { .. }
+    ));
     assert!(
         !root.state().segments().is_empty(),
         "the index this deployment maintains holds real segments"
@@ -420,16 +500,24 @@ async fn settle(lifecycle: &ServerLifecycle) {
         .expect("settle maintenance");
 }
 
-/// The sequence this namespace's index is built through, or `None` when it
-/// has no grep root at all.
+/// The sequence this namespace's index is built through.
 async fn watermark(store: &SharedObjectStore, namespace_id: &NamespaceId) -> ChangeSeq {
+    lifecycle_of(store, namespace_id)
+        .await
+        .steady_watermark()
+        .expect("a steady grep root has a watermark")
+        .0
+}
+
+/// This namespace's durable grep lifecycle, read where an operator reads it.
+async fn lifecycle_of(store: &SharedObjectStore, namespace_id: &NamespaceId) -> GrepLifecycle {
     load_grep_root(&**store, namespace_id)
         .await
         .expect("load grep root")
         .expect("an enabled namespace has a grep root")
         .state()
-        .index()
-        .built_through_seq
+        .lifecycle()
+        .clone()
 }
 
 fn grep_paths(namespace_id: &NamespaceId) -> Vec<String> {
@@ -443,6 +531,16 @@ fn admin_grep_paths(namespace_id: &NamespaceId) -> Vec<String> {
         .into_iter()
         .map(|action| format!("/v0/admin/namespaces/{namespace_id}/grep/index/{action}"))
         .collect()
+}
+
+fn status_path(namespace_id: &NamespaceId) -> String {
+    format!("/v0/admin/namespaces/{namespace_id}/grep/index")
+}
+
+async fn index_status(router: &Router, namespace_id: &NamespaceId) -> GrepIndexStatusResponse {
+    let response = send(router, Method::GET, &status_path(namespace_id), None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    response_json(response).await
 }
 
 async fn enable_grep(router: &Router, namespace_id: &NamespaceId) -> StatusCode {

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -113,14 +113,21 @@ Segments live under
 `namespaces/{namespace}/extensions/grep/segments/`. The small mutable
 `extensions/grep/root.json` pointer names an immutable, content-derived
 manifest under `extensions/grep/manifests/`; that manifest records the
-query-visible segments, the incremental
-`(built_through_seq, next_event_index)` cursor, lifecycle, run-ordinal
-allocation, and any in-progress reorganization snapshot, outputs, and cursor. A zero
-or absent `next_event_index` is the commit boundary; a nonzero value resumes
-at that offset in the watermark commit's ordered change events, one per
-committed operation. The pointer and manifests are independent of the
-namespace manifest, so core never has to understand grep state to read the
-filesystem.
+query-visible segments, the lifecycle, run-ordinal allocation, and any
+in-progress reorganization snapshot, outputs, and cursor. The pointer and
+manifests are independent of the namespace manifest, so core never has to
+understand grep state to read the filesystem.
+
+Each lifecycle phase carries its own position and nothing else's. A
+`backfilling` root carries the namespace sequence its checkpoint captured
+and the inode its walk resumes after; a `steady` root carries the
+incremental `(built_through_seq, next_event_index)` cursor. A zero or absent
+`next_event_index` is the commit boundary; a nonzero value resumes at that
+offset in the watermark commit's ordered change events, one per committed
+operation. Neither phase can report the other's sequence, because neither
+has a field to put it in — which is what lets a status reader trust the
+number it sees. A finished backfill turns steady at exactly the sequence it
+walked to, and the change feed takes over from there.
 
 Publication writes the immutable manifest first and installs the pointer by
 one etag CAS. A CAS loser's manifest and segments are unreachable derived
@@ -131,7 +138,15 @@ Disabling writes a manifest with lifecycle `disabled` and no segment
 references, then CAS-publishes its pointer. The old objects become candidates for grep-owned collection;
 the disable call never deletes them synchronously. Grep GC retains every
 object named by a verified live root and deletes unreferenced grep objects
-only after its grace window. A fork does not copy a grep root, so it begins
+only after its grace window. It walks the prefix as a stream under a read
+budget, like core collection: `max_objects` bounds what one pass spends —
+each key's listing plus the liveness or root re-read that authorizes its
+deletion and the probe that reads its age — and the pass answers an opaque,
+namespace-bound cursor when keys remain. That cursor skips enumeration and
+nothing else: every resumed pass re-reads liveness and the root before it
+deletes anything, so losing it costs a repeated walk and never a wrong
+delete. Collection stays explicit and per namespace; it is not registered
+with the runner. A fork does not copy a grep root, so it begins
 unmaterialized and can be enabled independently.
 
 ## Building
@@ -173,11 +188,17 @@ namespace. A server that only serves queries registers no job and refuses
 the routes that would mutate a grep root.
 
 A library-embedded host (the CLI's embedded mode) schedules nothing, so
-enabling the index is the schedule: the host calls
-`GrepWorker::run_to_quiescence`, the same build-and-fold pair loop run
-synchronously until the index is caught up, and re-running enable on an
-already-enabled namespace drives catch-up the same way. Between enables, small write tails are served by the query-time
-exhaustive tail scan within its budget.
+enabling the index is the schedule: `loonfs admin index-enable` captures one
+namespace sequence before it starts — the target a fresh backfill's
+checkpoint pinned, or the namespace's current head for an index that is
+already steady — and then runs the same job's bounded steps itself until the
+index has built through that sequence. It stops there even if writes keep
+landing, so a busy namespace cannot keep the command running; `--no-wait`
+skips the waiting entirely, and `--max-steps` and `--deadline-ms` bound it,
+reporting how far the index got and exiting nonzero rather than pretending
+to have finished. Re-running enable on an already-enabled namespace is how
+an embedded operator advances a lagging index. Between enables, small write
+tails are served by the query-time exhaustive tail scan within its budget.
 
 Detached maintenance is explicitly assigned with repeatable
 `loonfs-grep --namespace <id>` flags. `--once` catches up only those namespaces

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -532,9 +532,24 @@ A representative v0 binding is shown below.
 | Release a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoints/{checkpoint_id}/release` (idempotent and one-way; fork-owned records are rejected) |
 | Run a maintenance step | `POST /v0/admin/namespaces/{ns}/maintenance/step` (the one maintenance entry point; see below) |
 | Content search | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires a materialized steady-state grep root) |
+| Read the grep index's lifecycle | `GET /v0/admin/namespaces/{ns}/grep/index` (one grep root read, no side effects; requires a deployment that maintains the index) |
 | Enable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/enable` (CAS-publishes the independent grep root into checkpointed backfill and nudges the deployment's maintenance runner; requires a deployment that maintains the index; idempotent) |
 | Disable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/disable` (CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
-| Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (one explicit pass over only that namespace's grep extension; also reaps aged state for an absent or tombstoned namespace) |
+| Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (one explicit pass over only that namespace's grep extension; `max_objects` bounds the reads it spends and returns a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
+
+The status route and the enable response both report the index's lifecycle
+as a tagged `state`, and the phases never share a field:
+
+| `phase` | Carries | Means |
+| --- | --- | --- |
+| `disabled` | — | No index is maintained here. Also the answer for a namespace that never enabled one. |
+| `backfilling` | `target_seq`, `cursor_inode_id`, `checkpoint_id` | The initial walk over a pinned checkpoint is running. `target_seq` is the namespace sequence that checkpoint captured; reaching it completes the backfill. Nothing is searchable yet, and no watermark exists to report. |
+| `steady` | `built_through_seq`, `next_event_index` | The index follows the change feed. Commits at or below `built_through_seq` are searchable, except that a non-zero `next_event_index` leaves the rest of that one commit unindexed. |
+
+A backfill therefore never reports a `built_through_seq`, and a steady index
+never reports a `target_seq`. A client waiting for the index to catch up
+captures one sequence before it starts waiting and stops there, rather than
+chasing a head that keeps moving.
 
 One maintenance step does four things in order: folds the visible WAL tail
 into metadata tables and advances the metadata root once the tail reaches

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1727,6 +1727,23 @@ fold, run-allocation, and segment invariants at every boundary. The mutable
 root-pointer decoder rejects unknown envelope and payload fields; the
 immutable manifest decoder tolerates additive fields.
 
+The nested `index` object carries its own `format_version`, currently `2`.
+It holds what every phase has — the in-progress `reorganize` state and the
+`next_run_ordinal` allocator — while each phase's own position lives in the
+`lifecycle` tag beside it:
+
+- `backfilling`: `target_seq` (the namespace sequence the pinned checkpoint
+  captured), optional `cursor` (the inode the walk resumes strictly after),
+  and `checkpoint_id`;
+- `steady`: `built_through_seq` and an optional `next_event_index`;
+- `disabled`: no fields, no segments, and no reorganization.
+
+A phase carrying another phase's sequence is not representable. Version 1
+put one `built_through_seq` in the index object for every phase, where it
+meant the backfill's target in one phase and real indexed progress in
+another; the decoder rejects that version outright, with no shim, and the
+namespace rebuilds its index from a fresh checkpoint.
+
 A gram-index segment uses the section 4.2.1 block grammar unchanged —
 prefix-compressed data blocks, one bloom filter block, one index block,
 handles and checksums in the grep-manifest descriptor — with a grep-owned row

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -236,6 +236,79 @@
         }
       }
     },
+    "/v0/admin/namespaces/{namespace}/grep/index": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Read the grep index's lifecycle",
+        "description": "Reports where the namespace's grep index is: `disabled`, `backfilling` with the sequence it walks toward and how far the walk got, or `steady` with the watermark it has built through. One grep root read, no side effects. A namespace that never enabled the index reads as `disabled`. Requires this deployment to maintain the grep index.",
+        "operationId": "grep_index_status",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The index's lifecycle and bookkeeping",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GrepIndexStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The backing store rejected its configured credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The grep index is corrupt or its backing store is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "This deployment does not maintain the grep index",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v0/admin/namespaces/{namespace}/grep/index/disable": {
       "post": {
         "tags": [
@@ -335,7 +408,7 @@
           "admin"
         ],
         "summary": "Enable the grep index",
-        "description": "Enables the namespace's grep root and asks this deployment's maintenance runner for the backfill's first step. Idempotent. Requires this deployment to maintain the grep index.",
+        "description": "Enables the namespace's grep root and asks this deployment's maintenance runner for the backfill's first step. The response reports the durable lifecycle it published or found: a fresh enable is `backfilling` with the sequence its checkpoint captured, while an already-enabled namespace answers with whichever phase it is in. Idempotent. Requires this deployment to maintain the grep index.",
         "operationId": "enable_grep_index",
         "parameters": [
           {
@@ -428,7 +501,7 @@
           "admin"
         ],
         "summary": "Collect grep-index garbage",
-        "description": "Runs one explicit garbage-collection pass over only this namespace's grep-owned extension keyspace. A tombstoned or absent namespace has aged extension state reaped; no grep garbage collection runs implicitly. Requires this deployment to maintain the grep index.",
+        "description": "Runs one explicit garbage-collection pass over only this namespace's grep-owned extension keyspace. A tombstoned or absent namespace has aged extension state reaped; no grep garbage collection runs implicitly. `max_objects` bounds the reads the pass spends and returns a `next_cursor` when keys remain; resuming re-reads liveness and the grep root, so a cursor only skips enumeration. Requires this deployment to maintain the grep index.",
         "operationId": "gc_grep_index",
         "parameters": [
           {
@@ -441,6 +514,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrepGcRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Namespace grep garbage collection completed",
@@ -448,6 +531,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GrepGcResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid budget or cursor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
                 }
               }
             }
@@ -3184,21 +3277,21 @@
         "description": "Result of enabling the grep index on a namespace (admin plane).",
         "required": [
           "namespace_id",
-          "built_through_seq",
-          "already_enabled"
+          "already_enabled",
+          "state"
         ],
         "properties": {
           "already_enabled": {
             "type": "boolean",
             "description": "True when the namespace already carried an enabled grep root."
           },
-          "built_through_seq": {
-            "$ref": "#/components/schemas/ChangeSeq",
-            "description": "Sequence the index is built through when the enabling host reports\ncompletion (an embedded host drives the backfill inside the call);\non a hosted server the backfill continues in its driver and this is\nthe sequence it targets."
-          },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Namespace whose grep root was enabled."
+          },
+          "state": {
+            "$ref": "#/components/schemas/GrepIndexLifecycle",
+            "description": "The durable lifecycle this call published or found."
           }
         }
       },
@@ -3961,6 +4054,28 @@
           }
         }
       },
+      "GrepGcRequest": {
+        "type": "object",
+        "description": "One explicit grep-index garbage-collection pass (admin plane).",
+        "properties": {
+          "cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque resume token returned as `next_cursor` by an earlier pass\nagainst the same namespace."
+          },
+          "max_objects": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Reads this pass may spend before returning with a `next_cursor`.\nOmit to walk the whole grep keyspace in one call.",
+            "minimum": 0
+          }
+        }
+      },
       "GrepGcResponse": {
         "type": "object",
         "description": "Result of one explicit grep-index garbage-collection pass (admin plane).",
@@ -3997,11 +4112,130 @@
             "type": "boolean",
             "description": "Whether an absent or tombstoned namespace had extension state reaped."
           },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Present when the budget stopped the pass with keys left to examine."
+          },
           "retained_candidates": {
             "type": "integer",
             "format": "int64",
             "description": "Young or concurrently revived candidates retained by the pass.",
             "minimum": 0
+          }
+        }
+      },
+      "GrepIndexLifecycle": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "No index is maintained for this namespace.",
+            "required": [
+              "phase"
+            ],
+            "properties": {
+              "phase": {
+                "type": "string",
+                "enum": [
+                  "disabled"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "The initial walk over a pinned checkpoint is running. Nothing is\nsearchable yet.",
+            "required": [
+              "target_seq",
+              "checkpoint_id",
+              "phase"
+            ],
+            "properties": {
+              "checkpoint_id": {
+                "$ref": "#/components/schemas/CheckpointId",
+                "description": "Checkpoint pinning the state being walked."
+              },
+              "cursor_inode_id": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InodeId",
+                    "description": "Inode the walk resumes strictly after. Absent before the first\npage."
+                  }
+                ]
+              },
+              "phase": {
+                "type": "string",
+                "enum": [
+                  "backfilling"
+                ]
+              },
+              "target_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Namespace sequence the pinned checkpoint captured. Reaching it\nis what completes the backfill."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "The index follows the change feed. Commits at or below the watermark\nare searchable.",
+            "required": [
+              "built_through_seq",
+              "phase"
+            ],
+            "properties": {
+              "built_through_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Sequence of the commit at the index cursor."
+              },
+              "next_event_index": {
+                "type": "integer",
+                "format": "int32",
+                "description": "Offset of the next change event within `built_through_seq`, or\nzero when the whole commit is represented.",
+                "minimum": 0
+              },
+              "phase": {
+                "type": "string",
+                "enum": [
+                  "steady"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Where a namespace's grep index is in its lifecycle.\n\nThe phases carry different facts and never share a field: a backfill\nreports the sequence it is walking toward and how far the walk got, and\nonly a steady index reports a watermark it has actually built through.\nA reader that wants \"is this searchable, and through what?\" asks the\n`steady` phase and nothing else."
+      },
+      "GrepIndexStatusResponse": {
+        "type": "object",
+        "description": "The namespace's grep-index lifecycle and its cheap bookkeeping (admin\nplane).",
+        "required": [
+          "namespace_id",
+          "state",
+          "next_run_ordinal",
+          "reorganize_pending"
+        ],
+        "properties": {
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace the status describes."
+          },
+          "next_run_ordinal": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Next logical run ordinal the index will allocate.",
+            "minimum": 0
+          },
+          "reorganize_pending": {
+            "type": "boolean",
+            "description": "True while a partitioned segment reorganization is in progress."
+          },
+          "state": {
+            "$ref": "#/components/schemas/GrepIndexLifecycle",
+            "description": "Where the index is in its lifecycle."
           }
         }
       },


### PR DESCRIPTION
This PR is part 4 of the unified-maintenance project: The grep lifecycle stops overloading its fields, the index gets a statuses, index GC gets a budget and a cursor, and `index-enable` waits to a captured target.

Better lifecycle: Phase-only fields now live in the lifecycle variants:

- `Backfilling { target_seq, cursor, checkpoint_id }` — the target is the head captured at enable time, with one meaning.
- `Steady { built_through_seq, next_event_index }` — the watermark is real indexed progress, with one meaning.
- A backfilling root reports progress through its cursor. It never reports a sequence it has not indexed.

The grep root format version is now 2. Version 1 is rejected with no shim. The goldens include a rejection test for the old encoding.

Tagged wire surfaces: The enable response carries the tagged state instead of one field with two meanings. A new status route (`GET /v0/admin/namespaces/{ns}/grep/index`) returns the same tagged state plus the run ordinal and reorganize pending flag. The route gates on maintain-ness, like the other index admin routes. The client and `loonfs admin index-status` use it.

Bounded index GC: The collection now takes `max_objects` and an opaque cursor, and returns `next_cursor`, like core GC. The budget charges each key the reads that key costs. An equivalence test proves a `max_objects: 1` cursor loop reclaims exactly what one unbudgeted pass reclaims. A pass always examines at least one key, so a tiny budget cannot return the cursor it was given. `loonfs admin index-gc` loops the cursor like `admin gc`.

Captured-target wait: `loonfs admin index-enable` now:

1. Captures a target: the enable response's `target_seq`, or the namespace head for an already-steady index.
2. Drives bounded steps (embedded) or polls the status route (remote).
3. Stops at the captured target, even while a writer keeps committing. A test proves the chase is gone.

Flags: `--no-wait`, `--max-steps N`, `--deadline-ms T`. A spent budget prints real progress and exits nonzero. `GrepWorker::run_to_quiescence` — the last unbounded loop in the product — is deleted.