### PR TITLE
feat(cli): admin run hosts assigned-namespace maintenance

### DIFF
--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -8,10 +8,15 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-local"
 
-# Whether this server schedules background maintenance (checkpoints and
-# reorganization folds) after writes; on by default. Set false on
-# write-serving nodes when a dedicated maintenance process owns ticks.
-#background_maintenance = true
+# Whether this server maintains the namespaces it touches by itself:
+# "automatic" (the default) registers the metadata, collection, and — when
+# the grep mode below maintains — index jobs, and lets the writer schedule
+# them; "manual" registers none of them and schedules nothing, leaving every
+# `loonfs admin` operation working exactly as before. Set "manual" on a
+# write-serving node when a dedicated maintenance process owns these
+# namespaces, and assign them to it with `loonfs admin run --namespace ...`.
+# This word and the grep mode are the only maintenance switches.
+#maintenance = "automatic"
 
 # Largest request body accepted for service-proxied upload content, in
 # bytes; the server buffers each upload in memory. Advertised to clients as

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -1,6 +1,6 @@
 //! The clap argument grammar for every `loonfs` command.
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::io::IsTerminal;
 
 /// `loonfs x.y.z (commit date)`: the string served by both `--version` and
@@ -606,6 +606,9 @@ pub(crate) enum AdminCommand {
     /// Advance the retention floor, surrendering replay history below the
     /// flushed manifest head. File revision history is never affected.
     RetentionAdvance(AdminNamespaceArgs),
+    /// Host maintenance for explicitly assigned namespaces: continuously
+    /// until a signal, or as one bounded catch-up with --drain.
+    Run(AdminRunArgs),
     /// Run one core maintenance step (WAL flush and metadata folds).
     Step(AdminStepArgs),
     /// Run a mark-and-sweep garbage-collection pass.
@@ -620,6 +623,46 @@ pub(crate) enum AdminCommand {
     IndexStatus(AdminNamespaceArgs),
     /// Collect the namespace's unreferenced gram-index objects.
     IndexGc(AdminIndexGcArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct AdminRunArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+    /// Namespace this host maintains. Repeat the flag to assign more; at
+    /// least one is required, because this command never discovers
+    /// namespaces.
+    #[arg(long = "namespace", required = true)]
+    pub namespaces: Vec<String>,
+    /// Maintenance job to host. Repeat the flag to select more; all three
+    /// when omitted. `core-gc` selects the runtime's collection job, which
+    /// logs and settles under its own name, `gc`.
+    #[arg(long = "job")]
+    pub jobs: Vec<MaintenanceJobArg>,
+    /// Catch every assigned namespace up and exit, instead of hosting until
+    /// a signal.
+    #[arg(long)]
+    pub drain: bool,
+    /// Give up after this many steps across the whole drain. Exits nonzero
+    /// and reports where every key got to. Requires --drain.
+    #[arg(long, requires = "drain")]
+    pub max_steps: Option<u64>,
+    /// Give up after this many milliseconds across the whole drain. Exits
+    /// nonzero and reports where every key got to. Requires --drain.
+    #[arg(long, requires = "drain")]
+    pub deadline_ms: Option<u64>,
+}
+
+/// The maintenance jobs `admin run` can host, as an operator names them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum MaintenanceJobArg {
+    /// Flush the WAL tail past its threshold and fold one reorganization
+    /// unit per step.
+    Metadata,
+    /// Run one bounded mark-and-sweep collection pass per step.
+    CoreGc,
+    /// Build and fold the gram content index.
+    GrepIndex,
 }
 
 #[derive(Debug, Args)]
@@ -771,6 +814,7 @@ pub(crate) enum CommandKind {
     AdminCheckpointRelease,
     AdminFlush,
     AdminRetentionAdvance,
+    AdminRun,
     AdminStep,
     AdminGc,
     AdminIndexEnable,
@@ -816,6 +860,7 @@ impl CommandKind {
             CommandKind::AdminCheckpointRelease => "admin_checkpoint_release",
             CommandKind::AdminFlush => "admin_flush",
             CommandKind::AdminRetentionAdvance => "admin_retention_advance",
+            CommandKind::AdminRun => "admin_run",
             CommandKind::AdminStep => "admin_step",
             CommandKind::AdminGc => "admin_gc",
             CommandKind::AdminIndexEnable => "admin_index_enable",
@@ -872,6 +917,7 @@ impl Cli {
                 AdminCommand::CheckpointRelease(_) => CommandKind::AdminCheckpointRelease,
                 AdminCommand::Flush(_) => CommandKind::AdminFlush,
                 AdminCommand::RetentionAdvance(_) => CommandKind::AdminRetentionAdvance,
+                AdminCommand::Run(_) => CommandKind::AdminRun,
                 AdminCommand::Step(_) => CommandKind::AdminStep,
                 AdminCommand::Gc(_) => CommandKind::AdminGc,
                 AdminCommand::IndexEnable(_) => CommandKind::AdminIndexEnable,

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -9,9 +9,9 @@ use crate::render::write_stderr_warning;
 use loonfs::{
     ByteStream, ChangesResponse, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    FsAdmin, FsReader, FsWriter, ListChangesOptions, MaintenanceJob, MaintenanceStepConclusion,
-    MaintenanceStepOptions, MoveOptions, PutFileOptions, RestoreRevisionOptions, RuntimeError,
-    SharedObjectStore, UndeleteOptions,
+    FsAdmin, FsReader, FsWriter, ListChangesOptions, MaintenanceHandle, MaintenanceJob,
+    MaintenanceJobId, MaintenanceStepConclusion, MaintenanceStepOptions, MoveOptions,
+    PutFileOptions, RestoreRevisionOptions, RuntimeError, SharedObjectStore, UndeleteOptions,
 };
 use loonfs_api::{
     v0::{
@@ -27,11 +27,12 @@ use loonfs_api::{
 use loonfs_client::{CommitOptions, NamespacePath};
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepIndexSnapshot,
-    GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
+    GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads, GREP_INDEX_JOB,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
+use std::sync::Arc;
 
-use super::{GrepWaitBudget, GrepWaitProgress};
+use super::{GrepWaitProgress, MaintenanceDrainProgress, MaintenanceKeyProgress, StepBudget};
 
 /// Purpose-specific handles over one shared store client: reads go through
 /// the reader, mutations through the writer, and maintenance through the
@@ -57,6 +58,10 @@ pub(crate) struct EmbeddedBackend {
 /// step it scheduled. One recovery is the normal case; the second covers a
 /// step that raced another writer's debt. Past that the error surfaces.
 const MAX_MAINTENANCE_RECOVERIES: usize = 2;
+
+/// One job `admin run` was asked to host, and the executor registered under
+/// it.
+type HostedJob = (MaintenanceJobId, Arc<dyn MaintenanceJob>);
 
 impl EmbeddedBackend {
     /// Waits out writer-scheduled maintenance so a one-shot command never
@@ -317,7 +322,7 @@ impl EmbeddedBackend {
         &self,
         namespace_id: &NamespaceId,
         target_seq: ChangeSeq,
-        budget: GrepWaitBudget,
+        budget: StepBudget,
     ) -> Result<GrepWaitProgress, BackendError> {
         let worker = self.grep_worker();
         let job = GrepMaintenanceJob::new(worker.clone(), GramIndexBuildPolicy::default());
@@ -356,6 +361,116 @@ impl EmbeddedBackend {
                 MaintenanceStepConclusion::Progressed | MaintenanceStepConclusion::Superseded
             );
         }
+    }
+
+    /// Registers the jobs this process composes itself, then resolves every
+    /// selected job's executor from the writer that owns it.
+    ///
+    /// The runtime's own jobs are registered by the writer; grep's is
+    /// registered here, over the same worker every other index command in
+    /// this process uses. After this, one lookup answers for all three.
+    fn hosted_jobs(&self, jobs: &[MaintenanceJobId]) -> Result<Vec<HostedJob>, BackendError> {
+        if jobs.contains(&GREP_INDEX_JOB) {
+            self.writer
+                .register_maintenance_job(Arc::new(GrepMaintenanceJob::new(
+                    self.grep_worker(),
+                    GramIndexBuildPolicy::default(),
+                )))
+                .map_err(map_runtime_error)?;
+        }
+        jobs.iter()
+            .map(|job| {
+                let executor = self.writer.maintenance_job(*job).ok_or_else(|| {
+                    BackendError::runtime_error(format!(
+                        "no maintenance job is registered under `{job}`"
+                    ))
+                })?;
+                Ok((*job, executor))
+            })
+            .collect()
+    }
+
+    /// Hosts `jobs` for `namespaces` until `shutdown` resolves.
+    ///
+    /// The runner does the work; this command's job is the assignment. It
+    /// nudges every key once at start-up and again on an interval, and the
+    /// runner decides when each step runs, how many run at once, and what
+    /// happens when one fails. The shutdown is the writer's own: maintenance
+    /// admission closes before publications drain, so nothing admitted is
+    /// left running behind a publisher that is already gone.
+    pub(super) async fn host_maintenance(
+        &self,
+        namespaces: &[NamespaceId],
+        jobs: &[MaintenanceJobId],
+        shutdown: impl std::future::Future<Output = ()>,
+    ) -> Result<(), BackendError> {
+        let hosted = self.hosted_jobs(jobs)?;
+        let maintenance = self.writer.maintenance();
+        assign(&maintenance, &hosted, namespaces);
+        let mut shutdown = std::pin::pin!(shutdown);
+        loop {
+            tokio::select! {
+                () = &mut shutdown => break,
+                () = rest_between_assignments() => assign(&maintenance, &hosted, namespaces),
+            }
+        }
+        self.writer
+            .shutdown_background()
+            .await
+            .map_err(map_runtime_error)
+    }
+
+    /// Runs every `{job, namespace}` key to a settled conclusion, or until
+    /// `budget` runs out.
+    ///
+    /// A drain hosts the steps itself rather than nudging the runner: it has
+    /// a budget to spend and per-key progress to report, and admission
+    /// offers neither. So it closes the runner down first — a second
+    /// scheduler over the same keys would race these steps and make the
+    /// counts below a lie — and then walks the assignment, carrying each
+    /// key's continuation from one step to the next exactly as the runner
+    /// would have.
+    pub(super) async fn drain_maintenance(
+        &self,
+        namespaces: &[NamespaceId],
+        jobs: &[MaintenanceJobId],
+        budget: StepBudget,
+    ) -> Result<MaintenanceDrainProgress, BackendError> {
+        let hosted = self.hosted_jobs(jobs)?;
+        self.writer
+            .shutdown_background()
+            .await
+            .map_err(map_runtime_error)?;
+        let timer = StdMonotonicTimer::default();
+        let started_ms = timer.monotonic_now_ms();
+        let mut steps = 0;
+        let mut keys = Vec::with_capacity(hosted.len() * namespaces.len());
+        for (job, executor) in &hosted {
+            for namespace_id in namespaces {
+                let mut key = MaintenanceKeyProgress {
+                    job: *job,
+                    namespace_id: namespace_id.clone(),
+                    steps: 0,
+                    conclusion: None,
+                };
+                let mut continuation = None;
+                while !budget.spent(steps, timer.monotonic_now_ms().saturating_sub(started_ms)) {
+                    let result = executor
+                        .step(namespace_id, continuation.as_deref())
+                        .await
+                        .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?;
+                    steps += 1;
+                    key.steps += 1;
+                    key.conclusion = Some(result.conclusion);
+                    continuation = result.continuation;
+                    if key.settled() {
+                        break;
+                    }
+                }
+                keys.push(key);
+            }
+        }
+        Ok(MaintenanceDrainProgress { keys, steps })
     }
 
     pub(super) async fn disable_grep_index(
@@ -656,6 +771,40 @@ impl EmbeddedBackend {
     }
 }
 
+/// How long an assignment rests before it is asserted again.
+///
+/// The runner forgets a key whose probe found it idle, which is right for a
+/// namespace this process merely touched and not enough for one an operator
+/// assigned: an assigned namespace must stay covered while it is quiet. So
+/// the host says so again on this interval, and the runner does the rest —
+/// one bounded step per key, which reads durable state, finds nothing, and
+/// concludes idle when there is nothing to do. It matches the runner's own
+/// reconciliation cadence: a shorter one would only ask the same question
+/// sooner, and a longer one would leave a cold namespace uncovered for
+/// longer than the runner's own sweep would.
+const ASSIGNMENT_INTERVAL_MS: u64 = 60_000;
+
+/// Tells the runner every assigned key may have work.
+///
+/// Nudges are hints and never block: what this asserts is the assignment,
+/// and every step that follows re-reads durable state to find out whether
+/// there was anything to it.
+fn assign(maintenance: &MaintenanceHandle, jobs: &[HostedJob], namespaces: &[NamespaceId]) {
+    for (job, _) in jobs {
+        for namespace_id in namespaces {
+            maintenance.nudge(*job, namespace_id);
+        }
+    }
+}
+
+/// The one timer a maintenance host owns: how long an assignment rests
+/// before it is asserted again. Nothing durable depends on it — it decides
+/// when to look, never what is true.
+#[allow(clippy::disallowed_methods)]
+async fn rest_between_assignments() {
+    tokio::time::sleep(std::time::Duration::from_millis(ASSIGNMENT_INTERVAL_MS)).await;
+}
+
 /// Grace windows are wall-clock policy, and this is where an embedded
 /// command enters wall time — the same boundary the server's HTTP handler
 /// is. Nothing durable replays through it.
@@ -681,13 +830,14 @@ fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendE
 #[cfg(test)]
 #[allow(clippy::panic)]
 mod tests {
-    use super::{map_runtime_error, resolve_cli_page_limit, GrepError};
+    use super::{map_runtime_error, resolve_cli_page_limit, GrepError, StepBudget, GREP_INDEX_JOB};
     use crate::backend_error::map_namespace_scoped_grep_error;
     use crate::config::StoreConfig;
     use crate::resolve::EmbeddedTarget;
     use loonfs::{
         BootstrapNamespaceError, CoreError, CreateNamespaceOptions, FsBackgroundWork, FsWriter,
-        PutFileOptions, RuntimeError, SharedObjectStore,
+        MaintenanceJobId, MaintenanceStepConclusion, PutFileOptions, RuntimeError,
+        SharedObjectStore,
     };
     use loonfs_api::{
         ChangeSeq, CreateCheckpointRequest, DestinationBehavior, ErrorCode, InodeId, NamespaceId,
@@ -699,6 +849,263 @@ mod tests {
 
     fn namespace_id(value: &str) -> NamespaceId {
         NamespaceId::parse(value).expect("valid namespace id")
+    }
+
+    /// The three jobs `admin run` hosts by default, in the order it drives
+    /// them.
+    fn every_job() -> [MaintenanceJobId; 3] {
+        [
+            MaintenanceJobId::METADATA,
+            MaintenanceJobId::GC,
+            GREP_INDEX_JOB,
+        ]
+    }
+
+    /// Leaves a namespace with a metadata backlog no scheduler will touch:
+    /// a `ManualOnly` writer publishes past the WAL-tail checkpoint
+    /// threshold, which is exactly the state a cold namespace is in when the
+    /// process that wrote it went away.
+    async fn seed_wal_backlog(store: &SharedObjectStore, namespace_id: &NamespaceId) {
+        const PUBLISHES_PAST_THE_CHECKPOINT_THRESHOLD: usize = 34;
+        let writer = FsWriter::builder_with_store(store.clone())
+            .writer_id(format!("{namespace_id}-backlog"))
+            .background_work(FsBackgroundWork::ManualOnly)
+            .min_publish_interval_ms(0)
+            .build()
+            .await
+            .expect("build backlog writer");
+        writer
+            .create_namespace(namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        for index in 0..PUBLISHES_PAST_THE_CHECKPOINT_THRESHOLD {
+            writer
+                .put_file_bytes(
+                    namespace_id,
+                    &format!("/notes/note-{index}.txt"),
+                    b"assigned needle\n",
+                    PutFileOptions::default(),
+                )
+                .await
+                .unwrap_or_else(|error| panic!("seed put {index} failed: {error}"));
+        }
+    }
+
+    fn local_store(temp_dir: &std::path::Path) -> (StoreConfig, SharedObjectStore) {
+        let config = StoreConfig::LocalFs {
+            root: temp_dir.display().to_string(),
+            key_prefix: None,
+        };
+        let store: SharedObjectStore =
+            Arc::new(config.configured_object_store().expect("configure store"));
+        (config, store)
+    }
+
+    /// A drain is the assigned host's catch-up: it walks every
+    /// `{job, namespace}` key it was given to a settled conclusion and does
+    /// the work it finds on the way. Two namespaces here, one with an index
+    /// to build and one with none at all.
+    #[tokio::test]
+    async fn a_drain_settles_every_assigned_key_and_does_the_work_it_finds() {
+        let temp_dir = tempdir().expect("create temp dir");
+        let (store_config, store) = local_store(temp_dir.path());
+        let indexed = namespace_id("alpha");
+        let unindexed = namespace_id("beta");
+        seed_wal_backlog(&store, &indexed).await;
+        seed_wal_backlog(&store, &unindexed).await;
+
+        let target = EmbeddedTarget::new(&store_config, None)
+            .await
+            .expect("build embedded target");
+        target
+            .backend
+            .enable_grep_index(&indexed)
+            .await
+            .expect("enable the index without driving it");
+        let head_seq = target
+            .backend
+            .namespace_status(&indexed)
+            .await
+            .expect("status before the drain")
+            .head_seq;
+
+        let progress = target
+            .backend
+            .drain_maintenance(
+                &[indexed.clone(), unindexed.clone()],
+                &every_job(),
+                StepBudget::default(),
+            )
+            .await
+            .expect("drain the assignment");
+
+        assert!(
+            !progress.budget_exhausted(),
+            "an unbudgeted drain settles every key: {:?}",
+            progress.keys
+        );
+        assert_eq!(progress.keys.len(), 6, "three jobs over two namespaces");
+        assert!(progress.steps >= 6, "every key took at least one step");
+        // A namespace with no grep root has nothing for that job to
+        // maintain, and saying so is a settled conclusion like any other.
+        let unindexed_grep = progress
+            .keys
+            .iter()
+            .find(|key| key.job == GREP_INDEX_JOB && key.namespace_id == unindexed)
+            .expect("the unindexed namespace's grep key");
+        assert_eq!(
+            unindexed_grep.conclusion,
+            Some(MaintenanceStepConclusion::NotEnabled)
+        );
+
+        // The work is durable, not a tally: both backlogs are flushed and
+        // the one index there was is at the namespace head.
+        for namespace_id in [&indexed, &unindexed] {
+            let status = target
+                .backend
+                .namespace_status(namespace_id)
+                .await
+                .expect("status after the drain");
+            assert!(
+                status.wal_tail_segments < 32,
+                "`{namespace_id}` kept a WAL tail of {} segments past the checkpoint threshold",
+                status.wal_tail_segments
+            );
+            assert!(status.current_manifest_id.is_some(), "{namespace_id}");
+        }
+        let indexed_status = target
+            .backend
+            .grep_index_status(&indexed)
+            .await
+            .expect("index status after the drain");
+        assert!(
+            indexed_status.state.is_built_through(head_seq),
+            "the assigned index must reach the head it was behind: {:?}",
+            indexed_status.state
+        );
+    }
+
+    /// A budget that runs out mid-assignment reports where every key got to
+    /// — including the ones it never reached — instead of claiming the
+    /// assignment is caught up.
+    #[tokio::test]
+    async fn a_spent_drain_budget_reports_the_keys_it_left_unsettled() {
+        let temp_dir = tempdir().expect("create temp dir");
+        let (store_config, store) = local_store(temp_dir.path());
+        let namespace = namespace_id("alpha");
+        seed_wal_backlog(&store, &namespace).await;
+        let target = EmbeddedTarget::new(&store_config, None)
+            .await
+            .expect("build embedded target");
+
+        let progress = target
+            .backend
+            .drain_maintenance(
+                std::slice::from_ref(&namespace),
+                &[MaintenanceJobId::METADATA, MaintenanceJobId::GC],
+                StepBudget {
+                    max_steps: Some(1),
+                    deadline_ms: None,
+                },
+            )
+            .await
+            .expect("drain within a budget");
+
+        assert!(progress.budget_exhausted());
+        assert_eq!(progress.steps, 1);
+        let metadata = &progress.keys[0];
+        assert_eq!(metadata.job, MaintenanceJobId::METADATA);
+        assert_eq!(metadata.steps, 1);
+        assert_eq!(
+            metadata.conclusion,
+            Some(MaintenanceStepConclusion::Progressed),
+            "one step of a real backlog moves durable state and leaves more behind"
+        );
+        assert!(!metadata.settled());
+        let collection = &progress.keys[1];
+        assert_eq!(collection.job, MaintenanceJobId::GC);
+        assert_eq!(collection.steps, 0);
+        assert_eq!(
+            collection.conclusion, None,
+            "a key the budget never reached reports no conclusion rather than a made-up one"
+        );
+        assert!(!collection.settled());
+    }
+
+    /// Hosting is the other half: the runner runs the steps, the assignment
+    /// is what admits them, and the signal is what stops it. Nothing here
+    /// discovered the namespace — the assignment did.
+    #[tokio::test]
+    async fn hosting_an_assignment_maintains_a_cold_namespace_until_the_signal() {
+        let temp_dir = tempdir().expect("create temp dir");
+        let (store_config, store) = local_store(temp_dir.path());
+        let namespace = namespace_id("alpha");
+        seed_wal_backlog(&store, &namespace).await;
+        let target = EmbeddedTarget::new(&store_config, None)
+            .await
+            .expect("build embedded target");
+        target
+            .backend
+            .enable_grep_index(&namespace)
+            .await
+            .expect("enable the index without driving it");
+        let head_seq = target
+            .backend
+            .namespace_status(&namespace)
+            .await
+            .expect("status before hosting")
+            .head_seq;
+
+        // The stop signal a test can drive: the host runs until the work it
+        // was assigned is observable in durable state, which is all an
+        // operator watching this process would have to go on either.
+        let stop = async {
+            wait_until(|| async {
+                target
+                    .backend
+                    .grep_index_status(&namespace)
+                    .await
+                    .expect("index status while hosting")
+                    .state
+                    .is_built_through(head_seq)
+            })
+            .await;
+        };
+        target
+            .backend
+            .host_maintenance(std::slice::from_ref(&namespace), &every_job(), stop)
+            .await
+            .expect("the host shuts down cleanly on its signal");
+
+        // The shutdown settled what it admitted, so this is the state the
+        // host left rather than a race with it.
+        let status = target
+            .backend
+            .namespace_status(&namespace)
+            .await
+            .expect("status after hosting");
+        assert!(
+            status.wal_tail_segments < 32,
+            "the hosted runner left a WAL tail of {} segments",
+            status.wal_tail_segments
+        );
+    }
+
+    /// Bounded observation of work the runner publishes durably and reports
+    /// nothing about in-process.
+    #[allow(clippy::disallowed_methods)]
+    async fn wait_until<F, Fut>(condition: F)
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = bool>,
+    {
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            while !condition().await {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the hosted runner never reached the state it was assigned");
     }
 
     #[test]

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -36,6 +36,7 @@ use loonfs_client::{
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 
 pub(crate) use embedded::EmbeddedBackend;
+use loonfs::{MaintenanceJobId, MaintenanceStepConclusion};
 
 /// How long a remote wait rests between status checks.
 ///
@@ -44,24 +45,88 @@ pub(crate) use embedded::EmbeddedBackend;
 /// budgets, not by how fast it polls.
 const REMOTE_STATUS_POLL_INTERVAL_MS: u64 = 250;
 
-/// What a caller will spend waiting for the index to reach a target.
+/// What a caller will spend driving bounded steps toward something.
 ///
-/// A step is one bounded index step where the profile is embedded and one
-/// status check where it is remote — the two arms do different work to
-/// advance the same wait.
+/// What one step is depends on what is being driven: one bounded index step
+/// where an embedded profile waits for the index, one status check where a
+/// remote one does, one bounded maintenance step where `admin run` drains an
+/// assignment. The accounting is the same in every case, and both bounds are
+/// optional — an unbudgeted caller runs until the work settles.
 #[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct GrepWaitBudget {
+pub(crate) struct StepBudget {
     pub max_steps: Option<u64>,
     pub deadline_ms: Option<u64>,
 }
 
-impl GrepWaitBudget {
+impl StepBudget {
     fn spent(&self, steps: u64, elapsed_ms: u64) -> bool {
         self.max_steps.is_some_and(|max_steps| steps >= max_steps)
             || self
                 .deadline_ms
                 .is_some_and(|deadline_ms| elapsed_ms >= deadline_ms)
     }
+}
+
+/// One assigned `{job, namespace}` key, as a drain left it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MaintenanceKeyProgress {
+    pub job: MaintenanceJobId,
+    pub namespace_id: NamespaceId,
+    /// Steps this drain ran for this key.
+    pub steps: u64,
+    /// What its last step concluded, absent when the budget ran out before
+    /// the key took one.
+    pub conclusion: Option<MaintenanceStepConclusion>,
+}
+
+impl MaintenanceKeyProgress {
+    /// Whether this key has nothing left for a drain to drive.
+    ///
+    /// Progress and a lost race both leave work behind, so a drain keeps
+    /// going. Everything else is where it stops — including `Blocked`, which
+    /// says there is work this step's policy cannot move: repeating it would
+    /// spin rather than finish.
+    pub(crate) fn settled(&self) -> bool {
+        match self.conclusion {
+            Some(
+                MaintenanceStepConclusion::Idle
+                | MaintenanceStepConclusion::Blocked
+                | MaintenanceStepConclusion::NotEnabled,
+            ) => true,
+            Some(MaintenanceStepConclusion::Progressed | MaintenanceStepConclusion::Superseded)
+            | None => false,
+        }
+    }
+}
+
+/// Where a drain stopped and what it cost.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MaintenanceDrainProgress {
+    /// Every assigned key, in the order the drain drove them.
+    pub keys: Vec<MaintenanceKeyProgress>,
+    /// Steps this drain ran across every key.
+    pub steps: u64,
+}
+
+impl MaintenanceDrainProgress {
+    /// Whether the budget stopped the drain before every key settled. A key
+    /// only goes unsettled that way: the loop that drives it ends at a
+    /// settled conclusion or at a spent budget, and at nothing else.
+    pub(crate) fn budget_exhausted(&self) -> bool {
+        !self.keys.iter().all(MaintenanceKeyProgress::settled)
+    }
+}
+
+/// Refuses a maintenance host to a profile that has no runtime to host it
+/// in. Remote profiles are served by a server that runs its own runner;
+/// stepping one from here would be a second scheduler over the same
+/// namespaces, and there is no remote step to drive anyway.
+fn maintenance_host_needs_an_embedded_profile() -> BackendError {
+    BackendError::new(
+        loonfs_api::ErrorCode::NotSupported.as_str(),
+        "`admin run` hosts maintenance in this process and needs an embedded profile; \
+         a remote profile's server runs its own maintenance",
+    )
 }
 
 /// Where a wait stopped and what it cost.
@@ -262,7 +327,7 @@ impl ResolvedTarget {
         &self,
         namespace_id: &NamespaceId,
         target_seq: ChangeSeq,
-        budget: GrepWaitBudget,
+        budget: StepBudget,
     ) -> Result<GrepWaitProgress, BackendError> {
         match self {
             Self::Embedded(target) => {
@@ -551,6 +616,50 @@ impl ResolvedTarget {
                 .client
                 .maintenance_step(namespace_id, &request)
                 .await?),
+        }
+    }
+
+    /// Hosts `jobs` for `namespaces` until `shutdown` resolves, then settles
+    /// what it admitted.
+    ///
+    /// This is the explicit half of the coverage contract: automatic
+    /// maintenance reaches the namespaces a process touches and the ones a
+    /// host is assigned, and this is where a namespace nobody is writing to
+    /// gets assigned. Only an embedded profile can host it — a remote
+    /// profile's server is already hosting its own.
+    pub(crate) async fn host_maintenance(
+        &self,
+        namespaces: &[NamespaceId],
+        jobs: &[MaintenanceJobId],
+        shutdown: impl std::future::Future<Output = ()>,
+    ) -> Result<(), BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .host_maintenance(namespaces, jobs, shutdown)
+                    .await
+            }
+            Self::Remote(_) => Err(maintenance_host_needs_an_embedded_profile()),
+        }
+    }
+
+    /// Runs every `{job, namespace}` key to a settled conclusion, or until
+    /// `budget` runs out, and reports where each one got to.
+    pub(crate) async fn drain_maintenance(
+        &self,
+        namespaces: &[NamespaceId],
+        jobs: &[MaintenanceJobId],
+        budget: StepBudget,
+    ) -> Result<MaintenanceDrainProgress, BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .drain_maintenance(namespaces, jobs, budget)
+                    .await
+            }
+            Self::Remote(_) => Err(maintenance_host_needs_an_embedded_profile()),
         }
     }
 

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -1,19 +1,24 @@
 //! `loonfs admin` commands: checkpoints, retention, GC, indexes, and the
 //! change feed.
 
-use super::context::resolve_command_context;
-use super::output::{CommandData, CommandFailure, CommandOutput};
+use super::context::{fail, fail_for, resolve_command_context};
+use super::output::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
 use crate::args::{
     AdminCheckpointArgs, AdminCheckpointReleaseArgs, AdminCommand, AdminGcArgs,
-    AdminIndexEnableArgs, AdminIndexGcArgs, AdminNamespaceArgs, AdminStepArgs, ChangesArgs,
-    CommandKind,
+    AdminIndexEnableArgs, AdminIndexGcArgs, AdminNamespaceArgs, AdminRunArgs, AdminStepArgs,
+    ChangesArgs, CommandKind, MaintenanceJobArg,
 };
-use crate::backend::GrepWaitBudget;
+use crate::backend::{MaintenanceKeyProgress, StepBudget};
+use crate::resolve::{parse_namespace_id, resolve_target_profile};
+use clap::ValueEnum;
+use loonfs::{MaintenanceJobId, NamespaceId};
 use loonfs_api::v0::{GrepGcRequest, GrepIndexLifecycle};
 use loonfs_api::{
     ChangeSeq, CheckpointId, CreateCheckpointRequest, ErrorCode, GcRequest, MaintenanceStepKind,
     MaintenanceStepRequest,
 };
+use loonfs_grep::GREP_INDEX_JOB;
+use std::collections::BTreeSet;
 
 // --- maintenance/admin plane ---
 
@@ -26,6 +31,7 @@ pub(crate) async fn run_admin_command(
         AdminCommand::CheckpointRelease(args) => run_admin_checkpoint_release(kind, args).await,
         AdminCommand::Flush(args) => run_admin_flush(kind, args).await,
         AdminCommand::RetentionAdvance(args) => run_admin_retention_advance(kind, args).await,
+        AdminCommand::Run(args) => run_admin_run(kind, args).await,
         AdminCommand::Step(args) => run_admin_step(kind, args).await,
         AdminCommand::Gc(args) => run_admin_gc(kind, args).await,
         AdminCommand::IndexEnable(args) => run_admin_index_enable(kind, args).await,
@@ -227,6 +233,129 @@ async fn run_admin_retention_advance(
     })
 }
 
+/// Hosts maintenance for the namespaces named on the command line.
+///
+/// Nothing here discovers a namespace, because LoonFS has no operation that
+/// enumerates them. The flags are the assignment, and the assignment is what
+/// brings a namespace no process is writing to under automatic maintenance:
+/// continuously until a signal, or as one bounded catch-up with `--drain`.
+async fn run_admin_run(
+    kind: CommandKind,
+    args: AdminRunArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let explicit_profile = args.profile.profile.as_deref();
+    let resolved = resolve_target_profile(explicit_profile, args.profile.no_retry)
+        .await
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    let namespaces = args
+        .namespaces
+        .iter()
+        .map(|namespace| parse_namespace_id(namespace))
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+    // Sorted and deduplicated, so the keys are driven in the order the
+    // runner itself keys them and two spellings of one assignment produce
+    // one report.
+    let namespaces: Vec<NamespaceId> = namespaces.into_iter().collect();
+    let jobs = selected_jobs(&args.jobs);
+    let fail_here = |error| fail_for(kind, &resolved.profile_name, &mode, error);
+
+    let (keys, steps, budget_exhausted) = if args.drain {
+        let budget = StepBudget {
+            max_steps: args.max_steps,
+            deadline_ms: args.deadline_ms,
+        };
+        let progress = resolved
+            .target
+            .drain_maintenance(&namespaces, &jobs, budget)
+            .await
+            .map_err(fail_here)?;
+        (
+            progress.keys.iter().map(key_report).collect(),
+            progress.steps,
+            progress.budget_exhausted(),
+        )
+    } else {
+        resolved
+            .target
+            .host_maintenance(&namespaces, &jobs, shutdown_signal())
+            .await
+            .map_err(fail_here)?;
+        // A hosted run reports no per-key outcome: the runner ran the steps,
+        // and where each namespace got to is durable state to read, not a
+        // tally this process kept.
+        (Vec::new(), 0, false)
+    };
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(resolved.profile_name),
+        mode: Some(mode),
+        data: CommandData::MaintenanceHosted {
+            namespaces,
+            jobs: jobs.iter().map(|job| job.as_str().to_owned()).collect(),
+            drained: args.drain,
+            keys,
+            steps,
+            budget_exhausted,
+        },
+    })
+}
+
+/// The jobs to host, in the order the runner keys them, with no repeats.
+/// An empty selection is every job this host knows how to run.
+fn selected_jobs(requested: &[MaintenanceJobArg]) -> Vec<MaintenanceJobId> {
+    MaintenanceJobArg::value_variants()
+        .iter()
+        .filter(|job| requested.is_empty() || requested.contains(job))
+        .map(|job| job_id(*job))
+        .collect()
+}
+
+fn job_id(job: MaintenanceJobArg) -> MaintenanceJobId {
+    match job {
+        MaintenanceJobArg::Metadata => MaintenanceJobId::METADATA,
+        MaintenanceJobArg::CoreGc => MaintenanceJobId::GC,
+        MaintenanceJobArg::GrepIndex => GREP_INDEX_JOB,
+    }
+}
+
+fn key_report(key: &MaintenanceKeyProgress) -> MaintenanceKeyReport {
+    MaintenanceKeyReport {
+        namespace_id: key.namespace_id.clone(),
+        job: key.job.as_str().to_owned(),
+        steps: key.steps,
+        conclusion: key
+            .conclusion
+            .map(|conclusion| conclusion.as_str().to_owned()),
+        settled: key.settled(),
+    }
+}
+
+/// Resolves on ctrl-c or, on unix, SIGTERM — the stop an orchestrator sends
+/// before a kill. The clean shutdown behind it is the writer's own.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("ctrl-c handler should install");
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("SIGTERM handler should install")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        () = ctrl_c => {}
+        _ = terminate => {}
+    }
+}
+
 pub(crate) async fn run_admin_changes(
     kind: CommandKind,
     args: ChangesArgs,
@@ -289,7 +418,7 @@ async fn run_admin_index_enable(
                 .wait_for_grep_index(
                     &context.namespace,
                     target_seq,
-                    GrepWaitBudget {
+                    StepBudget {
                         max_steps: args.max_steps,
                         deadline_ms: args.deadline_ms,
                     },

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -10,7 +10,7 @@ mod profile;
 mod profile_config;
 mod recursive;
 
-pub(crate) use self::output::{CommandData, CommandFailure, CommandOutput};
+pub(crate) use self::output::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
 
 use crate::args::{Cli, Command, RuntimeBehavior};
 

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -24,6 +24,22 @@ pub(crate) struct TreeTransferFailure {
     pub error: CliError,
 }
 
+/// One assigned `{job, namespace}` key, as a drain left it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct MaintenanceKeyReport {
+    pub namespace_id: NamespaceId,
+    /// The job as the runner names it in its own traces.
+    pub job: String,
+    /// Steps the drain ran for this key.
+    pub steps: u64,
+    /// What its last step concluded. Absent when the budget ran out before
+    /// this key took a step.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conclusion: Option<String>,
+    /// True when the key reached a conclusion with nothing left to drive.
+    pub settled: bool,
+}
+
 pub(crate) struct CommandOutput {
     pub kind: CommandKind,
     pub profile: Option<String>,
@@ -81,6 +97,22 @@ pub(crate) enum CommandData {
         /// status checks in remote mode.
         steps: u64,
         /// True when a budget stopped the wait before the target.
+        budget_exhausted: bool,
+    },
+    /// What an assigned-namespace maintenance host did.
+    MaintenanceHosted {
+        /// The assignment, sorted and deduplicated.
+        namespaces: Vec<NamespaceId>,
+        jobs: Vec<String>,
+        /// True when the host caught the assignment up and exited instead of
+        /// hosting until a signal.
+        drained: bool,
+        /// Where each key got to. Empty for a hosted run: the runner ran
+        /// those steps, and durable state is what reports them.
+        keys: Vec<MaintenanceKeyReport>,
+        /// Steps the drain ran across every key.
+        steps: u64,
+        /// True when a budget stopped the drain before every key settled.
         budget_exhausted: bool,
     },
     GrepIndexDisabled(DisableGrepIndexResponse),
@@ -172,6 +204,12 @@ impl CommandData {
             // — real data, not an error — and still exits nonzero, because
             // the caller asked for a target that was not reached.
             CommandData::GrepIndexEnabled {
+                budget_exhausted, ..
+            }
+            // Same for a drain that ran out of budget: the per-key progress
+            // it prints is real, and the assignment it was asked to catch
+            // up is not caught up.
+            | CommandData::MaintenanceHosted {
                 budget_exhausted, ..
             } => *budget_exhausted,
             _ => false,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -1,10 +1,10 @@
 //! Renders command outcomes as human-readable text or `--json`.
 
 use crate::args::CommandKind;
-use crate::commands::{CommandData, CommandFailure, CommandOutput};
+use crate::commands::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
 use crate::error::CliError;
 use loonfs_api::v0::GrepIndexLifecycle;
-use loonfs_api::{GcResponse, ReorganizeStepOutcome, WalFlushStepOutcome};
+use loonfs_api::{GcResponse, NamespaceId, ReorganizeStepOutcome, WalFlushStepOutcome};
 use serde::Serialize;
 use std::io::{self, Write};
 
@@ -36,6 +36,36 @@ fn grep_index_state_summary(state: &GrepIndexLifecycle) -> String {
                 )
             }
         }
+    }
+}
+
+/// One line for where a drain left one assigned key.
+fn maintenance_key_line(key: &MaintenanceKeyReport) -> String {
+    let Some(conclusion) = &key.conclusion else {
+        return format!(
+            "{}/{}: not started; the budget ran out first",
+            key.namespace_id, key.job
+        );
+    };
+    let spent = steps_phrase(key.steps);
+    if key.settled {
+        format!(
+            "{}/{}: {conclusion} after {spent}",
+            key.namespace_id, key.job
+        )
+    } else {
+        format!(
+            "{}/{}: {conclusion} after {spent}, still not settled",
+            key.namespace_id, key.job
+        )
+    }
+}
+
+fn steps_phrase(steps: u64) -> String {
+    if steps == 1 {
+        "1 step".to_owned()
+    } else {
+        format!("{steps} steps")
     }
 }
 
@@ -449,6 +479,43 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                 )
             } else {
                 format!("{opening}; {}", grep_index_state_summary(state))
+            }
+        }
+        CommandData::MaintenanceHosted {
+            namespaces,
+            jobs,
+            drained,
+            keys,
+            steps,
+            budget_exhausted,
+        } => {
+            let assignment = format!(
+                "{} for {}",
+                jobs.join(", "),
+                namespaces
+                    .iter()
+                    .map(NamespaceId::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            if !*drained {
+                format!("hosted {assignment}; stopped on signal")
+            } else {
+                let settled = keys.iter().filter(|key| key.settled).count();
+                let mut lines: Vec<String> = keys.iter().map(maintenance_key_line).collect();
+                lines.push(if *budget_exhausted {
+                    format!(
+                        "gave up on {assignment}: {settled} of {} keys settled after {}",
+                        keys.len(),
+                        steps_phrase(*steps)
+                    )
+                } else {
+                    format!(
+                        "drained {assignment}: {settled} keys settled after {}",
+                        steps_phrase(*steps)
+                    )
+                });
+                lines.join("\n")
             }
         }
         CommandData::GrepIndexDisabled(response) => {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -2375,6 +2375,182 @@ fn index_gc_loops_its_cursor_and_accumulates() {
     );
 }
 
+/// `admin run --drain` is the assigned host's catch-up: every
+/// `{job, namespace}` key it was given reaches a settled conclusion, it
+/// exits zero, and the work it did is in durable state rather than in its
+/// output.
+#[test]
+fn admin_run_drains_an_assignment_and_leaves_the_work_done() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    for namespace in ["alpha", "beta"] {
+        assert_success(&harness.run(&["namespace", "create", namespace]));
+        let payload = harness.temp_dir.path().join(format!("{namespace}.txt"));
+        fs::write(&payload, b"assigned needle\n").expect("write payload");
+        assert_success(&harness.run(&[
+            "put",
+            "--namespace",
+            namespace,
+            payload.to_str().expect("utf-8 path"),
+            "/note.txt",
+        ]));
+        // Enabled and deliberately left behind: catching it up is what the
+        // assignment is for.
+        assert_success(&harness.run(&[
+            "admin",
+            "index-enable",
+            "--namespace",
+            namespace,
+            "--no-wait",
+        ]));
+    }
+
+    let drained = harness.run(&[
+        "--json",
+        "admin",
+        "run",
+        "--namespace",
+        "alpha",
+        "--namespace",
+        "beta",
+        "--drain",
+    ]);
+    assert_success(&drained);
+    let data = json_data(&drained);
+    assert_eq!(data["drained"], true);
+    assert_eq!(data["budget_exhausted"], false);
+    let keys = data["keys"].as_array().expect("json array");
+    assert_eq!(keys.len(), 6, "three jobs over two namespaces: {data}");
+    assert!(
+        keys.iter().all(|key| key["settled"] == true),
+        "an unbudgeted drain settles every key: {data}"
+    );
+    assert_eq!(
+        data["jobs"],
+        serde_json::json!(["metadata", "gc", "grep-index"])
+    );
+
+    for namespace in ["alpha", "beta"] {
+        let status = harness.run(&["--json", "admin", "index-status", "--namespace", namespace]);
+        assert_success(&status);
+        assert_eq!(
+            json_data(&status)["state"]["built_through_seq"],
+            1,
+            "the assigned index must reach the head it was behind: {namespace}"
+        );
+    }
+}
+
+/// A drain that runs out of budget reports where every key got to — the one
+/// it stopped inside and the ones it never reached — and exits nonzero.
+#[test]
+fn admin_run_budgets_exit_nonzero_and_report_per_key_progress() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "alpha"]));
+
+    let unstarted = harness.run(&[
+        "--json",
+        "admin",
+        "run",
+        "--namespace",
+        "alpha",
+        "--drain",
+        "--max-steps",
+        "0",
+    ]);
+    assert_failure(&unstarted);
+    let data = json_data(&unstarted);
+    assert_eq!(data["budget_exhausted"], true);
+    assert_eq!(data["steps"], 0);
+    for key in data["keys"].as_array().expect("json array") {
+        assert_eq!(key["settled"], false, "{data}");
+        assert_eq!(key["steps"], 0, "{data}");
+        assert!(key.get("conclusion").is_none(), "{data}");
+    }
+
+    // One step is enough for the first key on a quiet namespace and reaches
+    // no other, which is exactly what the report has to say.
+    let partial = harness.run(&[
+        "admin",
+        "run",
+        "--namespace",
+        "alpha",
+        "--drain",
+        "--max-steps",
+        "1",
+    ]);
+    assert_failure(&partial);
+    let rendered = stdout_string(&partial);
+    assert!(
+        rendered.contains("alpha/metadata: idle after 1 step"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("alpha/gc: not started; the budget ran out first"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("gave up"), "{rendered}");
+}
+
+/// The assignment is explicit and the job names are a closed set: neither is
+/// something the command guesses at.
+#[test]
+fn admin_run_requires_an_assignment_and_names_the_jobs_it_hosts() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+
+    let unassigned = harness.run(&["admin", "run"]);
+    assert_failure(&unassigned);
+    assert!(
+        stderr_string(&unassigned).contains("--namespace"),
+        "{}",
+        stderr_string(&unassigned)
+    );
+
+    let unknown_job = harness.run(&["admin", "run", "--namespace", "alpha", "--job", "bogus"]);
+    assert_failure(&unknown_job);
+    let message = stderr_string(&unknown_job);
+    for job in ["metadata", "core-gc", "grep-index"] {
+        assert!(
+            message.contains(job),
+            "the valid set must be listed: {message}"
+        );
+    }
+}
+
+/// A remote profile's server hosts its own runner. Stepping one from here
+/// would be a second scheduler over the same namespaces, so the command
+/// refuses instead of pretending it can.
+#[test]
+fn admin_run_refuses_a_remote_profile() {
+    let harness = Harness::new();
+    assert_success(&harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "default",
+        "--mode",
+        "remote",
+        "--server-url",
+        "http://127.0.0.1:9",
+        "--auth-token",
+        "test-token",
+    ]));
+
+    let refused = harness.run(&["--json", "admin", "run", "--namespace", "demo", "--drain"]);
+    assert_failure(&refused);
+    let error = json_error(&refused);
+    assert_eq!(error["code"], "not_supported");
+    assert!(
+        error["message"]
+            .as_str()
+            .expect("message")
+            .contains("embedded profile"),
+        "{error}"
+    );
+}
+
 #[test]
 fn help_lists_the_context_commands() {
     let harness = Harness::new();
@@ -2431,6 +2607,7 @@ fn every_advertised_capability_maps_to_a_cli_command_path() {
                 &["admin", "checkpoint-release"],
                 &["admin", "flush"],
                 &["admin", "retention-advance"],
+                &["admin", "run"],
                 &["admin", "step"],
                 &["admin", "gc"],
                 &["admin", "index-enable"],

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -45,14 +45,10 @@ pub struct ServerConfig {
     /// queries and maintains the index.
     #[serde(default = "grep_absent")]
     pub grep: GrepConfig,
-    /// Whether the server writer runs a maintenance runner: metadata steps
-    /// after writes that cross the WAL-tail threshold, and collection
-    /// passes for the upload sessions it opened once their leases pass. It
-    /// never advances the retention floor. On by default; set `false` on
-    /// write-serving nodes when a dedicated maintenance process owns steps
-    /// for these namespaces.
-    #[serde(default = "default_background_maintenance")]
-    pub background_maintenance: bool,
+    /// Whether this server maintains the namespaces it touches by itself.
+    /// Automatic by default; see [`MaintenanceMode`].
+    #[serde(default)]
+    pub maintenance: MaintenanceMode,
     /// Minimum interval between publication starts per namespace, in
     /// milliseconds. A cold namespace publishes immediately; the interval
     /// paces follow-up batches so hot namespaces amortize into fewer,
@@ -103,10 +99,6 @@ pub struct ServerConfig {
     pub store: StoreConfig,
 }
 
-fn default_background_maintenance() -> bool {
-    true
-}
-
 fn default_min_publish_interval_ms() -> u64 {
     1_000
 }
@@ -151,6 +143,48 @@ pub struct RuntimeCacheConfigOverrides {
     pub max_cached_wal_tail_projection_rows: Option<usize>,
     pub max_cached_wal_tail_projection_decoded_bytes: Option<usize>,
     pub metadata_table_cache_max_decoded_bytes: Option<usize>,
+}
+
+/// Whether this server maintains the namespaces it touches.
+///
+/// One word decides it, and it is the only switch: `automatic` registers the
+/// runtime's own jobs — metadata upkeep and collection — and the grep index
+/// job when `[grep]`'s mode maintains, and lets the writer's runner schedule
+/// all of them; `manual` registers nothing automatic and schedules nothing.
+/// Explicit admin operations work identically either way, and the retention
+/// floor is never advanced automatically under either.
+///
+/// Set `manual` on a write-serving node when a dedicated maintenance
+/// process — `loonfs admin run --namespace ...`, or another server — owns
+/// upkeep for these namespaces. Automatic maintenance covers namespaces
+/// touched by the running process and namespaces explicitly assigned to a
+/// maintenance host, so a deployment that switches this off has to assign
+/// its namespaces somewhere.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaintenanceMode {
+    /// The writer schedules its own metadata and collection steps, and the
+    /// grep index job when the grep mode maintains.
+    #[default]
+    Automatic,
+    /// Nothing is scheduled and no automatic job is registered. Explicit
+    /// admin operations remain available.
+    Manual,
+}
+
+impl MaintenanceMode {
+    /// Whether this server registers automatic maintenance jobs at all.
+    pub fn registers_automatic_jobs(self) -> bool {
+        matches!(self, Self::Automatic)
+    }
+
+    /// The writer policy this mode selects.
+    pub fn background_work(self) -> loonfs::FsBackgroundWork {
+        match self {
+            Self::Automatic => loonfs::FsBackgroundWork::Enabled,
+            Self::Manual => loonfs::FsBackgroundWork::ManualOnly,
+        }
+    }
 }
 
 /// What this server does about grep: answer queries, keep the index built,
@@ -352,7 +386,7 @@ impl ServerConfig {
             return Err(ServerConfigError::InvalidField {
                 field: "max_concurrent_maintenance",
                 reason: "must be greater than zero; \
-                         set `background_maintenance = false` to disable scheduling"
+                         set `maintenance = \"manual\"` to disable scheduling"
                     .to_owned(),
             });
         }
@@ -440,7 +474,7 @@ mod tests {
         "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
     #[test]
-    fn background_maintenance_defaults_on_and_accepts_false() {
+    fn maintenance_defaults_to_automatic_and_accepts_manual() {
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"
@@ -453,11 +487,43 @@ root = "/tmp/loonfs-server"
 "#,
         );
         let config = load_server_config(&path).expect("valid config");
-        assert!(
-            config.background_maintenance,
-            "background maintenance defaults on"
+        assert_eq!(config.maintenance, super::MaintenanceMode::Automatic);
+        assert!(config.maintenance.registers_automatic_jobs());
+        assert_eq!(
+            config.maintenance.background_work(),
+            loonfs::FsBackgroundWork::Enabled
         );
 
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+maintenance = "manual"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let config = load_server_config(&path).expect("valid config");
+        assert_eq!(
+            config.maintenance,
+            super::MaintenanceMode::Manual,
+            "write-serving nodes can hand maintenance to a dedicated process"
+        );
+        assert!(!config.maintenance.registers_automatic_jobs());
+        assert_eq!(
+            config.maintenance.background_work(),
+            loonfs::FsBackgroundWork::ManualOnly
+        );
+    }
+
+    #[test]
+    fn the_retired_background_maintenance_key_is_no_longer_a_key() {
+        // One word decides automatic maintenance now, and `maintenance` is
+        // the word. The boolean it replaced fails through strict decoding
+        // like any other unknown key.
         let path = write_config(
             r#"
 bind = "127.0.0.1:9400"
@@ -470,11 +536,37 @@ kind = "local-fs"
 root = "/tmp/loonfs-server"
 "#,
         );
-        let config = load_server_config(&path).expect("valid config");
+
+        let error = load_server_config(&path).expect_err("retired key must not load");
         assert!(
-            !config.background_maintenance,
-            "write-serving nodes can hand maintenance to a dedicated process"
+            error.to_string().contains("background_maintenance"),
+            "{error}"
         );
+    }
+
+    #[test]
+    fn an_unknown_maintenance_word_is_rejected() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+maintenance = "sometimes"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let error = load_server_config(&path).expect_err("unknown mode must not load");
+        match error {
+            ServerConfigError::Decode(message) => {
+                assert!(message.contains("automatic"), "{message}");
+                assert!(message.contains("manual"), "{message}");
+            }
+            other => panic!("expected decode error naming the modes, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -8,8 +8,8 @@ use loonfs::metrics::{
 };
 use loonfs::publisher::PublisherRegistry;
 use loonfs::{
-    FsAdmin, FsBackgroundWork, FsReader, FsWriter, MaintenanceHandle, MaintenanceJob,
-    MaintenanceProbe, SharedObjectStore, TraceMode, TraceStoreKind,
+    FsAdmin, FsReader, FsWriter, MaintenanceHandle, MaintenanceJob, MaintenanceProbe,
+    SharedObjectStore, TraceMode, TraceStoreKind,
 };
 use loonfs_api::NamespaceId;
 use loonfs_grep::{GrepMaintenanceJob, GrepService, GrepWorker, GREP_INDEX_JOB};
@@ -41,8 +41,10 @@ pub(super) struct AppState {
     /// grep's own segments, held here because grep is a composed extension
     /// rather than part of the runtime the handles come from.
     pub(super) grep_service: Option<Arc<GrepService>>,
-    /// Present when this deployment maintains the index: how a request tells
-    /// the writer's runner a namespace may have indexing to do.
+    /// Present when this deployment maintains the index automatically: how a
+    /// request tells the writer's runner a namespace may have indexing to
+    /// do. Absent under `maintenance = "manual"`, where the mutating index
+    /// routes still work and nothing schedules itself behind them.
     pub(super) grep_maintenance: Option<GrepMaintenance>,
     /// Bounds concurrently buffered proxied-upload bodies; with the
     /// per-request body limit this makes worst-case upload memory
@@ -197,14 +199,15 @@ pub(super) async fn app_with_store_and_transfer_issuer(
     // through a slot this function fills the moment the writer is built,
     // before anything can publish through it.
     let maintenance_slot: Arc<OnceLock<MaintenanceHandle>> = Arc::new(OnceLock::new());
+    // Two switches decide automatic grep indexing and nothing else does:
+    // whether this server maintains anything automatically, and whether its
+    // grep mode maintains the index.
+    let maintains_grep_index =
+        config.maintenance.registers_automatic_jobs() && config.grep.mode.maintains_index();
     let (writer, reader, admin) = build_handles(
         &config,
         store.clone(),
-        config
-            .grep
-            .mode
-            .maintains_index()
-            .then(|| maintenance_slot.clone()),
+        maintains_grep_index.then(|| maintenance_slot.clone()),
     )
     .await?;
     // A deployment that maintains the index needs a worker whether or not it
@@ -216,7 +219,7 @@ pub(super) async fn app_with_store_and_transfer_issuer(
         .mode
         .serves_grep()
         .then(|| Arc::new(GrepService::new()));
-    let grep_maintenance = if config.grep.mode.maintains_index() {
+    let grep_maintenance = if maintains_grep_index {
         let policy = config
             .grep
             .worker_config()
@@ -310,11 +313,7 @@ async fn build_handles(
 
     let mut writer_builder = FsWriter::builder_with_store(store.clone())
         .writer_id(config.writer_id.clone())
-        .background_work(if config.background_maintenance {
-            FsBackgroundWork::Enabled
-        } else {
-            FsBackgroundWork::ManualOnly
-        })
+        .background_work(config.maintenance.background_work())
         .min_publish_interval_ms(config.min_publish_interval_ms)
         // The reader below shares this core, so the read cap covers every
         // proxied content read the server serves.

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1964,7 +1964,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         writer_id: writer_id.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         grep: crate::config::GrepConfig::default(),
-        background_maintenance: true,
+        maintenance: crate::config::MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,
         max_upload_bytes: 256 * 1024 * 1024,
         max_download_bytes: 256 * 1024 * 1024,

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -10,8 +10,8 @@ mod http;
 mod trace;
 
 pub use config::{
-    load_server_config, GrepConfig, GrepMode, RuntimeCacheConfigOverrides, ServerConfig,
-    ServerConfigError, StoreConfig,
+    load_server_config, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides,
+    ServerConfig, ServerConfigError, StoreConfig,
 };
 pub use http::{app, serve, serve_with_shutdown, ServeError, ServerLifecycle};
 #[cfg(feature = "openapi")]

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -3,7 +3,9 @@
 #![allow(dead_code)]
 
 use loonfs_client::{Client, ClientConfig};
-use loonfs_server::{app, GrepConfig, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig};
+use loonfs_server::{
+    app, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
+};
 use std::path::PathBuf;
 
 pub(crate) struct TestServer {
@@ -67,7 +69,7 @@ pub(crate) fn test_config(
         writer_id: writer_id.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
         grep: GrepConfig::default(),
-        background_maintenance: true,
+        maintenance: MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,
         max_upload_bytes: 256 * 1024 * 1024,
         max_download_bytes: 256 * 1024 * 1024,

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -21,8 +21,8 @@ use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepWorker};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::SharedObjectStore;
 use loonfs_server::{
-    app, GrepConfig, GrepMode, RuntimeCacheConfigOverrides, ServerConfig, ServerLifecycle,
-    StoreConfig,
+    app, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig,
+    ServerLifecycle, StoreConfig,
 };
 use serde::de::DeserializeOwned;
 use std::num::NonZeroUsize;
@@ -449,6 +449,65 @@ async fn maintain_only_keeps_the_index_built_without_serving_searches() {
     lifecycle.shutdown().await.expect("drain lifecycle");
 }
 
+/// `maintenance = "manual"` registers no automatic job — the grep index's
+/// included, whatever the grep mode says — and changes nothing an operator
+/// may ask for. Who schedules is the only difference.
+#[tokio::test]
+async fn manual_maintenance_registers_no_index_job_and_still_administers_one() {
+    let temp_dir = tempdir().expect("store tempdir");
+    let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "manual-maintenance").await;
+    let (router, lifecycle) = app(ServerConfig {
+        maintenance: MaintenanceMode::Manual,
+        ..test_config(temp_dir.path(), GrepMode::ServeAndMaintain)
+    })
+    .await
+    .expect("build app");
+    assert!(
+        !lifecycle.maintains_grep_index(),
+        "a manual deployment registers no automatic index job, whatever the grep mode maintains"
+    );
+
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/note.txt",
+            b"unscheduled needle\n",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("write file");
+    // Every index route still answers: manual maintenance withdraws the
+    // scheduler, not the operator's reach.
+    assert_eq!(enable_grep(&router, &namespace_id).await, StatusCode::OK);
+    assert!(
+        matches!(
+            index_status(&router, &namespace_id).await.state,
+            GrepIndexLifecycle::Backfilling { .. }
+        ),
+        "the enable published a backfill this deployment left for someone else"
+    );
+
+    settle(&lifecycle).await;
+    assert_eq!(
+        lifecycle_of(&store, &namespace_id).await.steady_watermark(),
+        None,
+        "nothing here schedules the backfill it published"
+    );
+
+    // And an assigned host — or an operator — carries it the rest of the way.
+    let worker = grep_worker(&store, "assigned-grep-host").await;
+    drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
+    assert_eq!(watermark(&store, &namespace_id).await, ChangeSeq(1));
+    assert_eq!(
+        grep(&router, &namespace_id, "unscheduled needle")
+            .await
+            .matches
+            .len(),
+        1
+    );
+    lifecycle.shutdown().await.expect("drain lifecycle");
+}
+
 async fn seed_namespace(root: &Path, name: &str) -> (SharedObjectStore, FsWriter, NamespaceId) {
     let store = Arc::new(LocalFsStore::new(root).expect("store")) as SharedObjectStore;
     let writer = FsWriter::builder_with_store(store.clone())
@@ -476,7 +535,7 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
             mode,
             ..GrepConfig::default()
         },
-        background_maintenance: true,
+        maintenance: MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,
         max_upload_bytes: 1024 * 1024,
         max_download_bytes: 1024 * 1024,

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -129,6 +129,20 @@ impl FsWriter {
         self.bits.maintenance.register(job)
     }
 
+    /// The executor registered under `job`, runtime-owned or extension-owned
+    /// alike, or `None` when nothing claims that id.
+    ///
+    /// For a host that drives bounded steps itself rather than through
+    /// admission: `loonfs admin run --drain` runs each key to a settled
+    /// conclusion under the operator's budget, and a caller with its own
+    /// budget needs the executor, not a nudge. What it gets is the same
+    /// bounded, compare-and-swap-published unit the runner admits — running
+    /// one here duplicates work at worst, because delivery is at-least-once
+    /// either way.
+    pub fn maintenance_job(&self, job: MaintenanceJobId) -> Option<Arc<dyn MaintenanceJob>> {
+        self.bits.maintenance.job(job)
+    }
+
     /// Waits until every writer-scheduled maintenance task has finished,
     /// without closing the handle. Panicked tasks surface as a runtime-task
     /// error.

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -153,8 +153,9 @@ pub enum MaintenanceStepConclusion {
 }
 
 impl MaintenanceStepConclusion {
-    /// The label traces use.
-    pub(crate) fn as_str(self) -> &'static str {
+    /// The label traces use, and the one a host reporting a step it drove
+    /// itself should use with it.
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Progressed => "progressed",
             Self::Idle => "idle",
@@ -461,6 +462,16 @@ impl MaintenanceRunner {
         MaintenanceHandle {
             inner: Arc::downgrade(&self.inner),
         }
+    }
+
+    /// The executor registered under `id`.
+    ///
+    /// For a host that drives bounded steps itself instead of through
+    /// admission — a catch-up command with a caller's budget on it. The
+    /// steps are the same bounded, compare-and-swap-published units this
+    /// runner admits; they simply have no scheduler in front of them.
+    pub(crate) fn job(&self, id: MaintenanceJobId) -> Option<Arc<dyn MaintenanceJob>> {
+        self.inner.job(id)
     }
 
     /// Registers an executor under its own id.

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -200,7 +200,20 @@ to have finished. Re-running enable on an already-enabled namespace is how
 an embedded operator advances a lagging index. Between enables, small write
 tails are served by the query-time exhaustive tail scan within its budget.
 
-Detached maintenance is explicitly assigned with repeatable
+Automatic maintenance covers the namespaces a process touches and the ones a
+host is explicitly assigned, and `loonfs admin run --namespace <id>` is how a
+namespace nobody is writing to gets assigned. It opens an embedded runtime,
+hosts that runtime's runner, registers this job beside the runtime's own, and
+tells the runner about every assigned key at start-up and again on an
+interval — the runner forgets a key its probe found idle, which is right for
+a namespace merely touched and not enough for one an operator named. Repeat
+`--job grep-index` to narrow the host to this job. `--drain` catches the
+assignment up and exits instead of hosting until a signal, bounded by
+`--max-steps` and `--deadline-ms`, and reports where every key stopped. A
+namespace with no grep root settles `not_enabled`, so assigning one costs a
+read and nothing else.
+
+Detached maintenance is also explicitly assigned with repeatable
 `loonfs-grep --namespace <id>` flags. `--once` catches up only those namespaces
 and exits. The long-running form runs the same job's probe for each assigned
 namespace at `poll_interval_ms` (default 1000, zero rejected) — the


### PR DESCRIPTION
This PR is part 5 of the unified-maintenance project: It adds the assigned-namespace maintenance host and reduces the maintenance configuration to one word.

**`loonfs admin run`.** The command hosts the runner for explicitly assigned namespaces, on embedded profiles only (a remote profile is refused; the server hosts its own runner):

```
loonfs admin run --namespace alpha --namespace beta [--job metadata --job core-gc --job grep-index] [--drain [--max-steps N] [--deadline-ms T]]
```

- Assignment is explicit. The command never discovers namespaces. This completes the coverage contract: touched namespaces get automatic maintenance from their own process, and cold namespaces get restart-stable coverage by assignment here.
- Without `--drain`, the host runs until ctrl-c or SIGTERM, then shuts down through the writer's ordered shutdown.
- With `--drain`, every assigned key runs until it settles, then the command exits 0. A spent budget prints per-key progress and exits nonzero.
- A namespace without an enabled grep index settles `NotEnabled` and the drain still succeeds.

One configuration authority: The server key `background_maintenance: bool` is replaced by `maintenance = "automatic" | "manual"`. The default stays automatic. Manual mode registers no automatic jobs and skips the server's grep-job registration; every explicit admin operation keeps working. The old key is rejected, with a test. There is no jobs list. The grep mode remains the only per-subsystem switch.

