### PR TITLE
fix(server): stale commented keys in the example config

### DIFF
--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -28,12 +28,6 @@ writer_id = "loonfs-server-local"
 # as the `download.max_content_bytes` capability limit. Defaults to 256 MiB.
 #max_download_bytes = 268435456
 
-# Largest JSON body the commits endpoint accepts, in bytes. Commit bodies
-# are metadata only (file bytes ride uploads), so over-limit commits should
-# be split into smaller batches. Advertised to clients as the
-# `commit.max_body_bytes` capability limit. Defaults to 8 MiB.
-#max_commit_body_bytes = 8388608
-
 # How many proxied upload bodies / content reads the server will hold in
 # memory at once; requests past a cap answer 503 `server_busy`. Worst-case
 # transfer memory is the count cap times the matching byte cap.
@@ -72,7 +66,7 @@ writer_id = "loonfs-server-local"
 #max_rows_per_segment = 65536
 #max_l0_runs = 8
 #max_mid_runs = 8
-#max_fold_rows_per_step = 131072
+#max_decoded_input_rows_per_step = 131072
 
 [store]
 kind = "local-fs"


### PR DESCRIPTION
Two commented keys in the local-fs example config name fields that no longer exist. The config structs are `deny_unknown_fields`, so uncommenting either one fails to decode.