### PR TITLE
feat(maintenance): passes self-schedule reclamation and jobs subscribe to publishes

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -509,6 +509,26 @@ pub struct GcResponse {
     /// is valid only against the same namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// The soonest instant still ahead of this pass at which something it
+    /// retained becomes reclaimable: an open session's lease plus the grace
+    /// window, an aborted session's grace, or a completed session's derived
+    /// content-reclamation grace. A scheduler reads this to decide when to
+    /// come back, so a namespace needs no other side channel to have its
+    /// reclamation happen.
+    ///
+    /// It reports what this pass saw and nothing more. A pass that stopped
+    /// on `next_cursor` examined only part of the keyspace, and candidates
+    /// that age out under a plain grace window on their object timestamps
+    /// carry no deadline here at all, so `None` is never a claim that
+    /// nothing is owed.
+    ///
+    /// Always serialized, `null` included, unlike `next_cursor` beside it:
+    /// a cursor's presence is what says the enumeration is unfinished,
+    /// while this is an answer every pass has — and one whose absence
+    /// otherwise makes the response's shape depend on what happened to be
+    /// in the namespace.
+    #[serde(default)]
+    pub next_reclamation_at_ms: Option<u64>,
 }
 
 impl GcResponse {
@@ -529,6 +549,7 @@ impl GcResponse {
             degraded_retention: false,
             content_reclamation_deferred: false,
             next_cursor: None,
+            next_reclamation_at_ms: None,
         }
     }
 }

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -319,7 +319,10 @@ async fn process_upload_session<S: ObjectStore + ?Sized>(
                 report.deleted_content_objects += 1;
             }
         }
-        UploadSessionSweep::Retain => report.retained_candidates += 1,
+        UploadSessionSweep::Retain { reclaimable_at_ms } => {
+            report.retained_candidates += 1;
+            note_reclamation_deadline(report, reclaimable_at_ms, context.now_ms);
+        }
         UploadSessionSweep::ContentReclamationDeferred => {
             // Retained for the same reason any undecidable session is,
             // plus a flag, so a caller can tell a pass that swept
@@ -330,6 +333,23 @@ async fn process_upload_session<S: ObjectStore + ?Sized>(
         }
     }
     Ok(())
+}
+
+/// Folds one retained candidate's deadline into the soonest the pass will
+/// report.
+///
+/// Only deadlines still ahead of this pass's own clock are kept. One
+/// already past is not an obligation this pass is leaving behind — it is
+/// something the pass just decided against for another reason — and
+/// reporting it would only ask a scheduler to come straight back.
+fn note_reclamation_deadline(report: &mut GcResponse, at_ms: Option<u64>, now_ms: u64) {
+    let Some(at_ms) = at_ms.filter(|at_ms| *at_ms > now_ms) else {
+        return;
+    };
+    report.next_reclamation_at_ms = Some(match report.next_reclamation_at_ms {
+        Some(soonest_ms) => soonest_ms.min(at_ms),
+        None => at_ms,
+    });
 }
 
 fn upload_id_of(key: &str) -> Option<UploadId> {

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -651,6 +651,122 @@ async fn upload_gc_aborts_an_expired_session_then_reaps_it() {
     assert_eq!(report.deleted_upload_sessions, 0);
 }
 
+/// A pass knows when the things it retained stop being retained, because
+/// it compared every one of them against its own clock to decide. Saying so
+/// is what lets a scheduler come back exactly once, for exactly that
+/// namespace, with nothing else having to remember.
+#[tokio::test]
+async fn a_pass_reports_the_soonest_deadline_it_retained() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (upload_id, ..) = stage_upload(&store, &namespace_id, &setup).await;
+    let expires_at_ms = setup.now_ms + UPLOAD_SESSION_LEASE_MS;
+
+    // One un-expired open session and nothing else: the lease plus the
+    // pass's own grace window is the whole answer.
+    let inside = context(setup.now_ms + 1);
+    let report = gc_namespace(&store, &namespace_id, &config(), &inside)
+        .await
+        .expect("gc pass inside the lease");
+    assert_eq!(report.retained_candidates, 1);
+    assert_eq!(
+        report.next_reclamation_at_ms,
+        Some(expires_at_ms + GRACE_MS),
+        "an open session's reclamation waits for its lease and then the grace window"
+    );
+
+    // Completing it moves the deadline to the derived content grace, which
+    // is the one the next pass is too early for.
+    let completed_at = context(setup.now_ms + 2);
+    complete_staged_upload(&store, &namespace_id, &upload_id, &completed_at).await;
+    let report = gc_namespace(&store, &namespace_id, &config(), &completed_at)
+        .await
+        .expect("gc pass over the completed session");
+    assert_eq!(
+        report.next_reclamation_at_ms,
+        Some(completed_at.now_ms + CONTENT_RECLAMATION_GRACE_MS),
+        "a completed session's content is protected by the derived grace, not the configured one"
+    );
+}
+
+/// The abort gap, closed at the source: nothing plants a deadline when a
+/// session is aborted, so the pass that observes the abort reports the one
+/// the abort created. A restart loses every in-memory deadline the same
+/// way, and is covered by the same sentence.
+#[tokio::test]
+async fn an_aborted_session_is_reclaimed_from_the_deadline_the_pass_reported() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    let (upload_id, ..) = stage_upload(&store, &namespace_id, &setup).await;
+    let session_key =
+        loonfs_objectstore::keys::upload_session(namespace_id.as_str(), upload_id.as_str());
+
+    // The pass that aborts the session is the only thing that knows the
+    // record now ages out a grace window from this instant.
+    let expired = context(setup.now_ms + UPLOAD_SESSION_LEASE_MS + GRACE_MS + 1);
+    let report = gc_namespace(&store, &namespace_id, &config(), &expired)
+        .await
+        .expect("gc pass past the lease");
+    assert_eq!(report.deleted_upload_sessions, 0);
+    let reclaim_at_ms = report
+        .next_reclamation_at_ms
+        .expect("the abort this pass performed is a deadline it created");
+    assert_eq!(reclaim_at_ms, expired.now_ms + GRACE_MS);
+
+    // Nothing between the two passes says anything about this namespace:
+    // the time the first pass reported is the whole trigger.
+    let reclaiming = context(reclaim_at_ms + 1);
+    let report = gc_namespace(&store, &namespace_id, &config(), &reclaiming)
+        .await
+        .expect("gc pass at the reported deadline");
+    assert_eq!(report.deleted_upload_sessions, 1);
+    assert!(store.head(&session_key).await.expect("head").is_none());
+    assert_eq!(
+        report.next_reclamation_at_ms, None,
+        "a pass that reclaimed everything it found owes no later visit"
+    );
+}
+
+/// Completes a staged session against the content it staged.
+async fn complete_staged_upload<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &UploadId,
+    context: &MutationContext,
+) {
+    let content_store_id =
+        crate::namespace::catalog::load_namespace_content_store_id(store, namespace_id)
+            .await
+            .expect("content store id");
+    let session = read_upload_session(store, namespace_id, upload_id)
+        .await
+        .expect("open session");
+    let content_ref = session
+        .staged_content_ref
+        .clone()
+        .expect("a staged session carries the reference it wrote");
+    crate::protocol::complete_upload(
+        store,
+        namespace_id,
+        &content_store_id,
+        upload_id,
+        &loonfs_api::v0::CompleteUploadRequest::for_content_ref(content_ref),
+        context,
+    )
+    .await
+    .expect("complete upload");
+}
+
 /// A session record written straight into the store, never touched by an
 /// upload, still ages out on nothing but its own recorded lease.
 #[tokio::test]

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -44,7 +44,16 @@ const REVISION_SCAN_WAVE_ROWS: usize = 1024;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum UploadSessionSweep {
     /// The session key survives this pass. It may have advanced a state.
-    Retain,
+    Retain {
+        /// When the wait this pass was too early for ends, for the three
+        /// retentions a clock decides: an open session's lease plus the
+        /// grace window, an aborted session's grace, a completed session's
+        /// derived content-reclamation grace. `None` for a retention no
+        /// clock resolves — a lost compare-and-swap, a reference set this
+        /// pass could not establish — where there is no time to come back
+        /// at, only a next pass to look again.
+        reclaimable_at_ms: Option<u64>,
+    },
     /// The session has nothing left to say and its key may be deleted.
     Delete {
         /// This sweep also removed the content object the session
@@ -83,7 +92,7 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
     // changes underneath the read is decided correctly anyway.
     let state = match read_upload_session_state(store, namespace_id, upload_id).await {
         Ok(state) => state,
-        Err(CoreError::UploadNotFound { .. }) => return Ok(UploadSessionSweep::Retain),
+        Err(CoreError::UploadNotFound { .. }) => return Ok(retain_undated()),
         Err(error) => return Err(error),
     };
 
@@ -102,7 +111,7 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
         }
         UploadSessionLifecycle::Aborted { aborted_at_ms } => {
             if context.now_ms.saturating_sub(aborted_at_ms) < grace_window_ms {
-                return Ok(UploadSessionSweep::Retain);
+                return Ok(retain_until(aborted_at_ms.saturating_add(grace_window_ms)));
             }
             // Repeating the abort's own cleanup is what makes a crash
             // between the abort swap and its provider work cost nothing.
@@ -124,13 +133,15 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
             content_ref,
         } => {
             if context.now_ms.saturating_sub(completed_at_ms) < CONTENT_RECLAMATION_GRACE_MS {
-                return Ok(UploadSessionSweep::Retain);
+                return Ok(retain_until(
+                    completed_at_ms.saturating_add(CONTENT_RECLAMATION_GRACE_MS),
+                ));
             }
             match references
                 .lookup(store, namespace_id, &content_ref.content_id, budget)
                 .await?
             {
-                ContentReference::Unknown => Ok(UploadSessionSweep::Retain),
+                ContentReference::Unknown => Ok(retain_undated()),
                 ContentReference::Deferred => Ok(UploadSessionSweep::ContentReclamationDeferred),
                 // Published content answers to metadata now, not to the
                 // session that uploaded it, so the record is all that goes.
@@ -153,6 +164,20 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
     }
 }
 
+/// A session held over for a wait that ends at `at_ms`.
+fn retain_until(at_ms: u64) -> UploadSessionSweep {
+    UploadSessionSweep::Retain {
+        reclaimable_at_ms: Some(at_ms),
+    }
+}
+
+/// A session held over for a reason no clock resolves.
+fn retain_undated() -> UploadSessionSweep {
+    UploadSessionSweep::Retain {
+        reclaimable_at_ms: None,
+    }
+}
+
 /// Aborts one session whose lease has passed, then deletes what it was
 /// writing.
 ///
@@ -169,7 +194,7 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> Result<UploadSessionSweep> {
     if context.now_ms.saturating_sub(expires_at_ms) < grace_window_ms {
-        return Ok(UploadSessionSweep::Retain);
+        return Ok(retain_until(expires_at_ms.saturating_add(grace_window_ms)));
     }
     let aborted = try_update_upload_session(
         store,
@@ -191,20 +216,22 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
     )
     .await;
     match aborted {
+        // The record this pass just aborted is retained under the aborted
+        // arm's own grace from here, and that is the next thing it owes.
         Ok(UploadSessionCas::Applied(Some(abandoned))) => {
             abandoned.release(store, content_store_id).await;
-            Ok(UploadSessionSweep::Retain)
+            Ok(retain_until(context.now_ms.saturating_add(grace_window_ms)))
         }
-        Ok(UploadSessionCas::Applied(None)) => Ok(UploadSessionSweep::Retain),
+        Ok(UploadSessionCas::Applied(None)) => Ok(retain_undated()),
         Ok(UploadSessionCas::Conflict) => {
             tracing::debug!(
                 namespace_id = %namespace_id,
                 upload_id = %upload_id,
                 "upload-session abort lost its inspected etag; retaining"
             );
-            Ok(UploadSessionSweep::Retain)
+            Ok(retain_undated())
         }
-        Err(CoreError::UploadNotFound { .. }) => Ok(UploadSessionSweep::Retain),
+        Err(CoreError::UploadNotFound { .. }) => Ok(retain_undated()),
         Err(error) => Err(error),
     }
 }

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -46,6 +46,14 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
         GREP_INDEX_JOB
     }
 
+    /// The index is a projection of the namespace's own history, so a
+    /// publication is its one real trigger and the cheapest possible hint.
+    /// Subscribing here is all it takes: no host wires anything to the
+    /// write path on grep's behalf.
+    fn nudged_by_publications(&self) -> bool {
+        true
+    }
+
     /// Builds one bounded unit, and folds one only when there is nothing
     /// left to build.
     ///

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -16,7 +16,7 @@ use loonfs_grep::{GrepMaintenanceJob, GrepService, GrepWorker, GREP_INDEX_JOB};
 use loonfs_objectstore::presign::ObjectTransferIssuer;
 use std::ffi::OsString;
 use std::net::SocketAddr;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Semaphore;
 
@@ -114,8 +114,9 @@ impl ServerLifecycle {
     /// Maintenance admission closes first because draining publications is
     /// an await, and until it returns the runner is still live. Its timer
     /// promotes keys whose deadlines have arrived, each publication that
-    /// lands fires the publish observer that nudges the grep index, and a
-    /// finishing step hands its permit straight to the next queued key.
+    /// lands nudges the jobs subscribed to publications — the grep index
+    /// among them — and a finishing step hands its permit straight to the
+    /// next queued key.
     /// Everything admitted in that window is work this shutdown already
     /// decided to drop, and none of it is free: a metadata step advances
     /// the metadata root, a collection pass deletes provider objects, an
@@ -217,24 +218,17 @@ pub(super) async fn app_with_store_and_transfer_issuer(
         store,
         std::env::var_os(OBJECT_STORE_METRICS_JSONL_ENV),
     )?;
-    // Grep reads and checkpoints through the same handles the HTTP planes
-    // use, so it has to be composed after them — but the publish observer
-    // that nudges its indexing is set on the writer's builder, before the
-    // runner it nudges exists. The observer therefore resolves its handle
-    // through a slot this function fills the moment the writer is built,
-    // before anything can publish through it.
-    let maintenance_slot: Arc<OnceLock<MaintenanceHandle>> = Arc::new(OnceLock::new());
     // Two switches decide automatic grep indexing and nothing else does:
     // whether this server maintains anything automatically, and whether its
     // grep mode maintains the index.
     let maintains_grep_index =
         config.maintenance.registers_automatic_jobs() && config.grep.mode.maintains_index();
-    let (writer, reader, admin) = build_handles(
-        &config,
-        store.clone(),
-        maintains_grep_index.then(|| maintenance_slot.clone()),
-    )
-    .await?;
+    // Grep reads and checkpoints through the same handles the HTTP planes
+    // use, so it is composed after them. Nothing has to be wired back into
+    // the writer for its publications to reach the index: the job says on
+    // the trait that publications concern it, and registering it is what
+    // subscribes it.
+    let (writer, reader, admin) = build_handles(&config, store.clone()).await?;
     // A deployment that maintains the index needs a worker whether or not it
     // answers queries with one.
     let grep_worker = (config.grep.mode.serves_grep() || config.grep.mode.maintains_index())
@@ -266,9 +260,10 @@ pub(super) async fn app_with_store_and_transfer_issuer(
                 field: "grep",
                 reason: error.to_string(),
             })?;
-        let handle = writer.maintenance();
-        let _ = maintenance_slot.set(handle.clone());
-        Some(GrepMaintenance { handle, job })
+        Some(GrepMaintenance {
+            handle: writer.maintenance(),
+            job,
+        })
     } else {
         None
     };
@@ -322,13 +317,12 @@ pub(super) async fn build_handles_with_metrics_jsonl_path(
     metrics_jsonl_path: Option<OsString>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
     let store = instrumented_store(config, store, metrics_jsonl_path)?;
-    build_handles(config, store, None).await
+    build_handles(config, store).await
 }
 
 async fn build_handles(
     config: &ServerConfig,
     store: SharedObjectStore,
-    grep_maintenance: Option<Arc<OnceLock<MaintenanceHandle>>>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
     let trace_store_kind = TraceStoreKind::from(config.store.kind());
     let runtime_error = |error: loonfs::RuntimeError| ServerConfigError::InvalidField {
@@ -336,7 +330,7 @@ async fn build_handles(
         reason: error.to_string(),
     };
 
-    let mut writer_builder = FsWriter::builder_with_store(store.clone())
+    let writer_builder = FsWriter::builder_with_store(store.clone())
         .writer_id(config.writer_id.clone())
         .background_work(config.maintenance.background_work())
         .min_publish_interval_ms(config.min_publish_interval_ms)
@@ -347,17 +341,6 @@ async fn build_handles(
         .runtime_cache(config.runtime_cache_config())
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind);
-    if let Some(maintenance) = grep_maintenance {
-        // A publish is the index's one real trigger, and the cheapest
-        // possible hint: no blocking, no permit, nothing owed. The runner
-        // decides when the step runs, and the step re-reads what this
-        // publish committed rather than trusting it.
-        writer_builder = writer_builder.publish_observer(move |namespace_id, _committed_seq| {
-            if let Some(maintenance) = maintenance.get() {
-                maintenance.nudge(GREP_INDEX_JOB, namespace_id);
-            }
-        });
-    }
     let writer = writer_builder.build().await.map_err(runtime_error)?;
     let reader = writer.reader();
 

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -819,25 +819,34 @@ pub(crate) async fn publish_batch_with_engine(
         .into_iter()
         .map(|result| result.map_err(RuntimeError::Core))
         .collect::<Vec<_>>();
-    notify_publish_observer(writer, namespace_id, &results);
+    // One reading of what landed serves both the host's observer and the
+    // jobs that asked to hear about publications.
+    if let Some(committed_seq) = landed_commit_seq(&results) {
+        notify_publish_observer(writer, namespace_id, committed_seq);
+        writer
+            .maintenance
+            .nudge_publication_subscribers(namespace_id);
+    }
     maybe_auto_step_after_publish(writer, namespace_id, wal_tail_segments);
     results
+}
+
+/// The furthest sequence this batch actually committed, or `None` when
+/// nothing in it landed.
+fn landed_commit_seq(results: &[Result<CommitResponse>]) -> Option<ChangeSeq> {
+    results
+        .iter()
+        .filter_map(|result| result.as_ref().ok())
+        .map(|response| response.committed_seq)
+        .max()
 }
 
 fn notify_publish_observer(
     writer: &WriterBits,
     namespace_id: &NamespaceId,
-    results: &[Result<CommitResponse>],
+    committed_seq: ChangeSeq,
 ) {
-    let Some(observer) = &writer.publish_observer else {
-        return;
-    };
-    if let Some(committed_seq) = results
-        .iter()
-        .filter_map(|result| result.as_ref().ok())
-        .map(|response| response.committed_seq)
-        .max()
-    {
+    if let Some(observer) = &writer.publish_observer {
         observer(namespace_id, committed_seq);
     }
 }

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -186,18 +186,21 @@ impl FsWriter {
     /// server does. Dropping the handle without calling this is best-effort
     /// cleanup, not the documented graceful shutdown path.
     pub async fn shutdown_background(&self) -> Result<()> {
-        // Closing maintenance admission has to come first, and has to happen
-        // before this future's first await. A maintenance step parked in its
-        // own publication only finishes once the drain below settles it, and
-        // a step that finishes while the queue is still open hands its slot
-        // straight to a queued namespace — spawning the exact work the
-        // shutdown decided to drop. Closing first makes that transfer
-        // impossible for the whole drain.
+        // Closing maintenance admission has to come first, and before this
+        // future's first await. The drain below is that await: while it is
+        // pending the runtime keeps polling the runner, so a nudge landing
+        // in the window is admitted and its step does real durable work
+        // after the shutdown began — and a finishing step hands its slot
+        // straight to the next queued key rather than releasing it. Closing
+        // first leaves that window empty.
         self.bits.maintenance.shut_down();
-        // Publications second: an in-flight step still has one to settle, and
-        // settling it is what lets that step's task end. Draining without
-        // closing admission keeps the handle usable; a caller that keeps
-        // submitting concurrently just keeps the drain waiting.
+        // Publications second, and this order cannot wedge: no maintenance
+        // step submits to the publication service at all — every job
+        // compare-and-swaps the namespace head through `FsAdmin` — so the
+        // drain waits only on client work and its pending set can only
+        // shrink. Draining without closing admission keeps the handle
+        // usable; a caller that keeps submitting concurrently just keeps
+        // the drain waiting.
         self.publisher.drain().await?;
         self.bits.maintenance.drain().await
     }
@@ -404,12 +407,12 @@ mod tests {
     use tempfile::tempdir;
 
     /// Maintenance admission must close on the shutdown's first poll, before
-    /// it starts draining publications. A step parked in its own publication
-    /// only finishes once that drain settles it, so a queue still open here
-    /// lets the finishing step hand its slot on and spawn work the shutdown
-    /// already decided to drop. Asserting on the first poll pins the order
-    /// on every machine; the integration coverage in `tests/it/handles.rs`
-    /// only loses the race on some.
+    /// it starts draining publications. The drain is a wait, and the runner
+    /// stays live across it: a queue still open here lets a nudge landing in
+    /// that window be admitted, and lets a finishing step hand its slot on
+    /// and spawn work the shutdown already decided to drop. Asserting on the
+    /// first poll pins the order on every machine; the integration coverage
+    /// in `tests/it/handles.rs` only loses the race on some.
     #[tokio::test]
     async fn shutdown_closes_maintenance_admission_before_draining_publications() {
         let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -248,6 +248,22 @@ pub trait MaintenanceJob: Send + Sync + 'static {
     /// Answers whether `namespace_id` has work waiting, as cheaply as this
     /// job can. Called only by reconciliation, never on the hot path.
     async fn probe(&self, namespace_id: &NamespaceId) -> Result<MaintenanceProbe>;
+
+    /// Whether a landed publication is a reason to look at this job's work
+    /// for the namespace that published it.
+    ///
+    /// A job that derives something from the namespace's own history — an
+    /// index, a projection — says `true` and is nudged after every
+    /// publication the writer commits, so it needs no hook of its own on
+    /// the write path. The nudge is a hint like any other: it is dropped
+    /// when admission is closed, and the step it suggests re-reads what the
+    /// publication committed rather than trusting it.
+    ///
+    /// Jobs that answer to durable deadlines rather than to writes leave
+    /// this `false`, which is why it is the default.
+    fn nudged_by_publications(&self) -> bool {
+        false
+    }
 }
 
 /// Wall-clock milliseconds the runner schedules against.
@@ -392,6 +408,28 @@ pub(crate) struct MaintenanceRunner {
     inner: Arc<RunnerInner>,
 }
 
+/// Running totals a trace reports beside the event that moved them.
+///
+/// Counters rather than a metrics framework, and process-wide rather than
+/// per key: what an operator asks of them is whether backoffs and timed
+/// wakes are happening at all and roughly how often, which a monotonic
+/// number on an existing event answers without any new cardinality.
+#[derive(Debug, Default)]
+struct RunnerCounters {
+    /// Steps that failed and were scheduled for a backoff retry.
+    backoff_scheduled: std::sync::atomic::AtomicU64,
+    /// Timer wakes that found at least one not-before deadline arrived.
+    not_before_wakes: std::sync::atomic::AtomicU64,
+}
+
+impl RunnerCounters {
+    fn bump(counter: &std::sync::atomic::AtomicU64) -> u64 {
+        counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .saturating_add(1)
+    }
+}
+
 struct RunnerInner {
     policy: FsBackgroundWork,
     /// Runtime that owns spawned work. Handle builders pin the runtime they
@@ -406,6 +444,7 @@ struct RunnerInner {
     /// a spawn into running unobserved.
     state: Mutex<RunnerState>,
     wake: Arc<Notify>,
+    counters: RunnerCounters,
 }
 
 struct RunnerState {
@@ -452,6 +491,7 @@ impl MaintenanceRunner {
                 }),
                 clock,
                 wake: Arc::new(Notify::new()),
+                counters: RunnerCounters::default(),
             }),
         }
     }
@@ -542,6 +582,31 @@ impl MaintenanceRunner {
             )));
         }
         Ok(())
+    }
+
+    /// Tells every job that subscribes to publications that `namespace_id`
+    /// just committed one.
+    ///
+    /// The write path calls this instead of knowing which jobs care, so a
+    /// job that wants publication nudges gets them by saying so on the
+    /// trait rather than by a host wiring an observer to it. Each nudge is
+    /// an ordinary one: non-blocking, coalescing, and dropped once
+    /// admission is closed or the policy is
+    /// [`FsBackgroundWork::ManualOnly`].
+    pub(crate) fn nudge_publication_subscribers(&self, namespace_id: &NamespaceId) {
+        // The subscriber list is read out from under the job lock before
+        // any nudge takes the scheduling lock: the two are never held
+        // together anywhere, and this is the one place that would.
+        let subscribers: Vec<MaintenanceJobId> = self
+            .inner
+            .lock_jobs()
+            .iter()
+            .filter(|(_, job)| job.nudged_by_publications())
+            .map(|(id, _)| *id)
+            .collect();
+        for job in subscribers {
+            nudge_at(&self.inner, job, namespace_id, None);
+        }
     }
 
     /// Whether the key is admitted with work still owed to it. Test and
@@ -669,13 +734,29 @@ fn nudge_at(
 
 /// Claims every permit the ready keys can fill and spawns a chain for each.
 fn dispatch_ready(inner: &Arc<RunnerInner>) {
+    let mut dispatched = 0usize;
     loop {
         let now_ms = inner.clock.now_ms();
-        let dispatched = inner.lock_state().admission.try_dispatch(now_ms);
-        let Some(key) = dispatched else {
+        let claimed = inner.lock_state().admission.try_dispatch(now_ms);
+        let Some(key) = claimed else {
             break;
         };
+        dispatched += 1;
         spawn_chain(inner, key);
+    }
+    if dispatched > 0 {
+        // What is left behind is the useful half: a queue that keeps
+        // growing, or an oldest wait that keeps climbing, is the permit
+        // pool being too small for what this process admits. Queue-wide
+        // numbers, so no key names appear.
+        let now_ms = inner.clock.now_ms();
+        let state = inner.lock_state();
+        tracing::debug!(
+            dispatched,
+            ready_queued = state.admission.ready_queued(),
+            oldest_queued_ms = state.admission.oldest_queued_ms(now_ms),
+            "maintenance keys dispatched"
+        );
     }
 }
 
@@ -735,7 +816,13 @@ async fn run_step(inner: &Arc<RunnerInner>, key: &MaintenanceKey) -> StepOutcome
     // Read under the same lock every scheduling decision takes, and only
     // this key's own: a step that resumes is resuming from what this
     // runner stored for it when its last step ended.
-    let continuation = inner.lock_state().admission.continuation(key);
+    let (continuation, queued_ms) = {
+        let state = inner.lock_state();
+        (
+            state.admission.continuation(key),
+            state.admission.queue_wait_ms(key),
+        )
+    };
     let started = tokio::time::Instant::now();
     match job.step(&key.namespace_id, continuation.as_deref()).await {
         Ok(result) => {
@@ -746,6 +833,9 @@ async fn run_step(inner: &Arc<RunnerInner>, key: &MaintenanceKey) -> StepOutcome
                 resumed = continuation.is_some(),
                 continues = result.continuation.is_some(),
                 not_before_ms = ?result.not_before_ms,
+                // The two halves of what a step cost: how long it waited
+                // for a permit, and how long it then took.
+                queued_ms,
                 elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
                 "maintenance step settled"
             );
@@ -757,6 +847,8 @@ async fn run_step(inner: &Arc<RunnerInner>, key: &MaintenanceKey) -> StepOutcome
                 namespace_id = %key.namespace_id,
                 result = "error",
                 error = %error,
+                queued_ms,
+                backoff_scheduled = RunnerCounters::bump(&inner.counters.backoff_scheduled),
                 "maintenance step failed; backing off"
             );
             StepOutcome::Failed
@@ -803,7 +895,16 @@ async fn scheduler_loop(inner: Weak<RunnerInner>, wake: Arc<Notify>) {
             break;
         }
         let now_ms = inner.clock.now_ms();
-        inner.lock_state().admission.promote_due(now_ms);
+        let promoted = inner.lock_state().admission.promote_due(now_ms);
+        if promoted > 0 {
+            // Distinguishes a wake a durable deadline caused from the far
+            // more common one a nudge or the reconciliation interval did.
+            tracing::debug!(
+                promoted,
+                not_before_wakes = RunnerCounters::bump(&inner.counters.not_before_wakes),
+                "maintenance deadlines arrived"
+            );
+        }
         if take_reconcile_turn(&inner, now_ms) {
             reconcile(&inner).await;
         }
@@ -866,13 +967,17 @@ async fn reconcile(inner: &Arc<RunnerInner>) {
         .lock_state()
         .admission
         .reconcile_batch(MAX_RECONCILE_PROBES_PER_SWEEP);
+    let mut probes = 0usize;
+    let mut re_admitted = 0usize;
     for key in batch {
         let Some(job) = inner.job(key.job) else {
             inner.lock_state().admission.forget(&key);
             continue;
         };
+        probes += 1;
         match job.probe(&key.namespace_id).await {
             Ok(MaintenanceProbe::Due) => {
+                re_admitted += 1;
                 tracing::debug!(
                     job = %key.job,
                     namespace_id = %key.namespace_id,
@@ -897,4 +1002,13 @@ async fn reconcile(inner: &Arc<RunnerInner>) {
             ),
         }
     }
+    // What one sweep cost, against the probe budget above: a sweep that
+    // keeps hitting the cap is an admitted set larger than one interval can
+    // walk.
+    tracing::debug!(
+        probes,
+        re_admitted,
+        probe_budget = MAX_RECONCILE_PROBES_PER_SWEEP,
+        "maintenance reconciliation swept"
+    );
 }

--- a/crates/loonfs/src/maintenance_runner/admission.rs
+++ b/crates/loonfs/src/maintenance_runner/admission.rs
@@ -68,6 +68,13 @@ struct KeyState {
     /// Ticket order is the fairness rule: among eligible keys the one that
     /// has waited longest takes the next free slot.
     ready_ticket: Option<u64>,
+    /// When the ticket above was taken. Observability only — the ticket is
+    /// what orders the queue — and it is what lets a trace say how long a
+    /// key has been waiting rather than only that it is.
+    ready_at_ms: Option<u64>,
+    /// How long the last dispatch of this key waited between taking its
+    /// ticket and holding a permit. Read by the step's own trace.
+    queue_wait_ms: u64,
     /// Wall-clock millisecond the next planted obligation comes due. Not a
     /// gate on a key some other trigger already made ready — a scheduled
     /// future readiness of its own, so an unrelated run never cancels a
@@ -108,6 +115,7 @@ impl KeyState {
 
     fn clear_schedule(&mut self) {
         self.ready_ticket = None;
+        self.ready_at_ms = None;
         self.not_before_ms = None;
         self.obligation_until_ms = None;
         self.retry_at_ms = None;
@@ -115,6 +123,16 @@ impl KeyState {
 
     fn owes_an_obligation(&self) -> bool {
         self.not_before_ms.is_some() || self.obligation_until_ms.is_some()
+    }
+
+    /// Takes a queue ticket unless the key already holds one, so repeated
+    /// requests coalesce into the one run the first ticket bought.
+    fn queue(&mut self, ticket: u64, now_ms: u64) {
+        if self.ready_ticket.is_some() {
+            return;
+        }
+        self.ready_ticket = Some(ticket);
+        self.ready_at_ms = Some(now_ms);
     }
 }
 
@@ -140,9 +158,11 @@ pub(crate) struct Admission {
     /// Where the next reconciliation sweep resumes, so a probe budget
     /// cannot starve the tail of a large admitted set.
     reconcile_cursor: Option<MaintenanceKey>,
-    /// Here for one thing: the draw the error backoff jitters with. Every
-    /// `now_ms` a decision needs is still passed in, so the tests below can
-    /// move time by hand and name the delay they expect.
+    /// Here for the draw the error backoff jitters with, and for the queue
+    /// timestamp [`Self::nudge`] stamps — an observability field, not an
+    /// input to anything. Every `now_ms` a decision needs is still passed
+    /// in, so the tests below can move time by hand and name the delay they
+    /// expect.
     clock: Arc<dyn MaintenanceClock>,
 }
 
@@ -189,6 +209,31 @@ impl Admission {
             .and_then(|state| state.continuation.clone())
     }
 
+    /// How long the step about to run waited for its permit.
+    pub(crate) fn queue_wait_ms(&self, key: &MaintenanceKey) -> u64 {
+        self.keys.get(key).map_or(0, |state| state.queue_wait_ms)
+    }
+
+    /// Keys holding a ticket: work admitted, eligible, and waiting for a
+    /// permit.
+    pub(crate) fn ready_queued(&self) -> usize {
+        self.keys
+            .values()
+            .filter(|state| state.ready_ticket.is_some())
+            .count()
+    }
+
+    /// How long the longest-waiting queued key has been waiting, or `0`
+    /// when nothing is queued.
+    pub(crate) fn oldest_queued_ms(&self, now_ms: u64) -> u64 {
+        self.keys
+            .values()
+            .filter(|state| state.ready_ticket.is_some())
+            .filter_map(|state| state.ready_at_ms)
+            .min()
+            .map_or(0, |ready_at_ms| now_ms.saturating_sub(ready_at_ms))
+    }
+
     fn take_ticket(&mut self) -> u64 {
         let ticket = self.next_ticket;
         self.next_ticket = self.next_ticket.saturating_add(1);
@@ -205,10 +250,11 @@ impl Admission {
             return;
         }
         let ticket = self.take_ticket();
-        let state = self.keys.entry(key).or_default();
-        if state.ready_ticket.is_none() {
-            state.ready_ticket = Some(ticket);
-        }
+        // The only decision-free clock reading here: the queue timestamp a
+        // trace reports. Every scheduling decision still takes its `now_ms`
+        // as an argument.
+        let now_ms = self.clock.now_ms();
+        self.keys.entry(key).or_default().queue(ticket, now_ms);
     }
 
     /// Plants a timed obligation on the key: it becomes eligible on its own
@@ -238,15 +284,20 @@ impl Admission {
 
     /// Turns arrived obligations into ready keys, and re-arms a key whose
     /// latest planted deadline is still ahead of the one that just fired.
-    pub(crate) fn promote_due(&mut self, now_ms: u64) {
+    ///
+    /// Reports how many keys arrived, which is what tells a timer wake a
+    /// deadline caused it from one an ordinary notify did.
+    pub(crate) fn promote_due(&mut self, now_ms: u64) -> usize {
         if self.closed {
-            return;
+            return 0;
         }
         let mut ticket = self.next_ticket;
+        let mut promoted = 0usize;
         for state in self.keys.values_mut() {
             if state.not_before_ms.is_none_or(|at_ms| at_ms > now_ms) {
                 continue;
             }
+            promoted += 1;
             state.not_before_ms = state
                 .obligation_until_ms
                 .filter(|until_ms| *until_ms > now_ms);
@@ -254,11 +305,12 @@ impl Admission {
                 state.obligation_until_ms = None;
             }
             if state.ready_ticket.is_none() {
-                state.ready_ticket = Some(ticket);
+                state.queue(ticket, now_ms);
                 ticket = ticket.saturating_add(1);
             }
         }
         self.next_ticket = ticket;
+        promoted
     }
 
     /// Claims a permit for the fairest eligible key, if there is one and the
@@ -269,7 +321,7 @@ impl Admission {
             return None;
         }
         let key = self.pick_eligible(now_ms)?;
-        self.hold(&key);
+        self.hold(&key, now_ms);
         self.running = self.running.saturating_add(1);
         Some(key)
     }
@@ -303,12 +355,12 @@ impl Admission {
             return None;
         }
         if renudged && self.is_eligible(key, now_ms) {
-            self.hold(key);
+            self.hold(key, now_ms);
             return Some(key.clone());
         }
         match self.pick_eligible(now_ms) {
             Some(next) => {
-                self.hold(&next);
+                self.hold(&next, now_ms);
                 Some(next)
             }
             None => {
@@ -426,9 +478,7 @@ impl Admission {
                 // waiting, resuming from wherever this step stopped.
                 MaintenanceStepConclusion::Progressed | MaintenanceStepConclusion::Superseded => {
                     state.continuation = result.continuation;
-                    if state.ready_ticket.is_none() {
-                        state.ready_ticket = Some(ticket);
-                    }
+                    state.queue(ticket, now_ms);
                 }
                 // Work is left and this step's policy could not move it.
                 // Parks like `Idle` — requeueing zero-progress work would
@@ -468,9 +518,7 @@ impl Admission {
         };
         state.consecutive_failures = failures;
         state.retry_at_ms = Some(now_ms.saturating_add(delay_ms));
-        if state.ready_ticket.is_none() {
-            state.ready_ticket = Some(ticket);
-        }
+        state.queue(ticket, now_ms);
     }
 
     fn is_eligible(&self, key: &MaintenanceKey, now_ms: u64) -> bool {
@@ -499,9 +547,13 @@ impl Admission {
 
     /// Marks a key as the one this permit is running; the permit count is
     /// the caller's business, because a handoff keeps it.
-    fn hold(&mut self, key: &MaintenanceKey) {
+    fn hold(&mut self, key: &MaintenanceKey, now_ms: u64) {
         if let Some(state) = self.keys.get_mut(key) {
+            state.queue_wait_ms = state
+                .ready_at_ms
+                .map_or(0, |ready_at_ms| now_ms.saturating_sub(ready_at_ms));
             state.ready_ticket = None;
+            state.ready_at_ms = None;
             state.inflight = true;
         }
     }

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -318,12 +318,14 @@ fn gc_step_result(gc: GcResponse, submitted_cursor: Option<&str>) -> Maintenance
     MaintenanceStepResult {
         conclusion: gc_conclusion(&gc, submitted_cursor),
         continuation: gc.next_cursor,
-        // A pass reports what it retained, never when that retention
-        // lapses: the lease and grace deadlines it compares against live
-        // inside the sweep and are not in `GcResponse`. Surfacing them
-        // would be new core plumbing, and this job does not need it — the
-        // upload paths plant the deadlines they create as they create them.
-        not_before_ms: None,
+        // The pass itself is the source of truth for when it should be run
+        // again: it compared every retained candidate against its own
+        // clock, so it knows the soonest of those waits without being told.
+        // Handing it back here is what makes a pass self-scheduling —
+        // reclamation an upload path never planted a deadline for, and the
+        // deadlines a restart forgot, both come back through the next pass
+        // over the namespace rather than through a side channel.
+        not_before_ms: gc.next_reclamation_at_ms,
     }
 }
 
@@ -543,7 +545,7 @@ mod tests {
         );
         assert_eq!(
             first.not_before_ms, None,
-            "a pass reports no deadline of its own; the upload paths plant those"
+            "a pass that retained nothing on a clock has no deadline to report"
         );
 
         // The resumed step is handed that cursor back. One that cannot get
@@ -560,6 +562,27 @@ mod tests {
         assert_eq!(
             cleared.continuation, None,
             "a pass that reached the end of the keyspace carries nothing forward"
+        );
+    }
+
+    /// The deadline a pass reports for what it retained becomes the key's
+    /// own, which is what makes a pass schedule its own successor.
+    #[test]
+    fn a_collection_pass_hands_its_soonest_retained_deadline_to_the_runner() {
+        let mut retained = GcResponse::empty(namespace_id("demo"));
+        retained.retained_candidates = 2;
+        retained.next_reclamation_at_ms = Some(1_700_000_600_000);
+
+        let result = gc_step_result(retained, None);
+        assert_eq!(
+            result.conclusion,
+            MaintenanceStepConclusion::Idle,
+            "a candidate inside its grace window is still not work to redo now"
+        );
+        assert_eq!(
+            result.not_before_ms,
+            Some(1_700_000_600_000),
+            "the runner parks the key on the pass's own soonest retention"
         );
     }
 

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -55,6 +55,10 @@ enum StepAnswer {
     Conclude(MaintenanceStepConclusion),
     /// Conclude, and tell the runner where this step stopped.
     Continue(MaintenanceStepConclusion, Option<String>),
+    /// Conclude, and tell the runner when what this step left behind
+    /// becomes eligible — what a collection pass reports for what it
+    /// retained.
+    Due(MaintenanceStepConclusion, u64),
     Fail,
     Panic,
 }
@@ -211,6 +215,11 @@ impl MaintenanceJob for TestJob {
                 continuation,
                 not_before_ms: None,
             }),
+            StepAnswer::Due(conclusion, not_before_ms) => Ok(MaintenanceStepResult {
+                conclusion,
+                continuation: None,
+                not_before_ms: Some(not_before_ms),
+            }),
             StepAnswer::Fail => Err(RuntimeError::Config("scripted step failure".to_owned())),
             StepAnswer::Panic => panic!("injected maintenance step panic"),
         }
@@ -222,6 +231,47 @@ impl MaintenanceJob for TestJob {
             .expect("probes")
             .push(namespace_id.clone());
         Ok(*self.probe_answer.lock().expect("probe answer"))
+    }
+}
+
+const SUBSCRIBING_JOB: MaintenanceJobId = MaintenanceJobId::new("subscribing");
+
+/// A job that says publications concern it, and records which namespaces
+/// it was told about.
+#[derive(Default)]
+struct SubscribingJob {
+    steps: StdMutex<Vec<NamespaceId>>,
+}
+
+impl SubscribingJob {
+    fn stepped(&self) -> Vec<String> {
+        names(&self.steps)
+    }
+}
+
+#[async_trait::async_trait]
+impl MaintenanceJob for SubscribingJob {
+    fn id(&self) -> MaintenanceJobId {
+        SUBSCRIBING_JOB
+    }
+
+    fn nudged_by_publications(&self) -> bool {
+        true
+    }
+
+    async fn step(
+        &self,
+        namespace_id: &NamespaceId,
+        _continuation: Option<&str>,
+    ) -> Result<MaintenanceStepResult> {
+        self.steps.lock().expect("steps").push(namespace_id.clone());
+        Ok(MaintenanceStepResult::concluded(
+            MaintenanceStepConclusion::Idle,
+        ))
+    }
+
+    async fn probe(&self, _namespace_id: &NamespaceId) -> Result<MaintenanceProbe> {
+        Ok(MaintenanceProbe::Idle)
     }
 }
 
@@ -509,6 +559,66 @@ async fn a_key_planted_in_the_future_does_not_fire_early() {
         job.stepped(),
         vec!["leased".to_owned()],
         "the key fires once its time arrives"
+    );
+}
+
+/// The other end of the same mechanism: a step that reports a deadline
+/// arms its own key with it. This is what makes a pass self-scheduling —
+/// reclamation nothing planted a deadline for, and deadlines a restart
+/// forgot, both come back through the next pass over the namespace.
+#[tokio::test]
+async fn a_step_that_reports_a_deadline_re_arms_its_own_key() {
+    let clock = ManualClock::at(1_000_000);
+    let job = TestJob::scripted(
+        [StepAnswer::Due(MaintenanceStepConclusion::Idle, 1_060_000)],
+        StepAnswer::Conclude(MaintenanceStepConclusion::Idle),
+    );
+    let runner = runner_with(FsBackgroundWork::Enabled, clock.clone(), job.clone());
+    let namespace_id = namespace_id("retained");
+
+    runner.handle().nudge(TEST_JOB, &namespace_id);
+    runner.drain().await.expect("the first pass settles");
+    assert_eq!(job.stepped().len(), 1);
+    assert_eq!(
+        runner.not_before_ms(TEST_JOB, &namespace_id),
+        Some(1_060_000),
+        "an idle conclusion still parks on the deadline the step reported"
+    );
+
+    clock.advance_to(1_060_000);
+    runner.tick_now();
+    runner.drain().await.expect("the re-armed pass settles");
+    assert_eq!(
+        job.stepped().len(),
+        2,
+        "the deadline the step reported is what brought the key back, with nothing else asking"
+    );
+    assert_eq!(
+        runner.not_before_ms(TEST_JOB, &namespace_id),
+        None,
+        "the second pass reported nothing left to wait for"
+    );
+}
+
+/// Publications reach the jobs that asked for them and no others, so a
+/// host wires nothing into the write path on any job's behalf.
+#[tokio::test]
+async fn a_publication_nudges_only_the_jobs_that_subscribe_to_it() {
+    let quiet = TestJob::idle();
+    let subscriber = Arc::new(SubscribingJob::default());
+    let runner = enabled_runner(quiet.clone());
+    runner
+        .register(subscriber.clone())
+        .expect("register the subscribing job");
+    let namespace_id = namespace_id("published");
+
+    runner.nudge_publication_subscribers(&namespace_id);
+    runner.drain().await.expect("the subscriber's step settles");
+
+    assert_eq!(subscriber.stepped(), vec!["published".to_owned()]);
+    assert!(
+        quiet.stepped().is_empty(),
+        "a job that did not subscribe hears nothing from a publication"
     );
 }
 

--- a/crates/loonfs/tests/tracing_capture.rs
+++ b/crates/loonfs/tests/tracing_capture.rs
@@ -119,11 +119,23 @@ fn background_step_conclusions_emit_debug_events() {
         assert!(step.contains(field), "missing `{field}` in: {step}");
     }
     let admission = find_event(&log, "maintenance step settled");
-    for field in ["job=", "namespace_id=", "conclusion=", "elapsed_ms="] {
+    // What the step cost, in both halves: waiting for a permit, then running.
+    for field in [
+        "job=",
+        "namespace_id=",
+        "conclusion=",
+        "queued_ms=",
+        "elapsed_ms=",
+    ] {
         assert!(
             admission.contains(field),
             "missing `{field}` in: {admission}"
         );
+    }
+    // What the queue looked like when the runner claimed permits.
+    let dispatch = find_event(&log, "maintenance keys dispatched");
+    for field in ["dispatched=", "ready_queued=", "oldest_queued_ms="] {
+        assert!(dispatch.contains(field), "missing `{field}` in: {dispatch}");
     }
     // The spans this work runs under say maintenance, which is what it is.
     for span in ["loonfs.maintenance.step", "loonfs.maintenance.wal_flush"] {

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -177,10 +177,12 @@ read the grep root, and — only for a steady root sitting at a commit
 boundary — ask the change feed for one commit after its watermark. Two small
 reads answer whether the index trails its namespace.
 
-A server that maintains the index registers that job on its writer. Enable
-nudges the namespace so the backfill starts at once; every successful
-runtime publication nudges it through the writer's publish observer; and a
-grep query nudges a namespace whose probe says it is behind, which is what
+A server that maintains the index registers that job on its writer, and
+registering it is all the wiring there is: the job says on the maintenance
+trait that publications concern it, so the runtime nudges it after every
+publication the writer commits without the host connecting anything to the
+write path. Enable nudges the namespace so the backfill starts at once, and
+a grep query nudges a namespace whose probe says it is behind, which is what
 resumes durable work after a restart without a scan. Disable is one durable
 compare-and-swap and nothing else: a step already running loses its own root
 publication to it, retries, reads a disabled root, and the runner forgets the

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -602,6 +602,16 @@ Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to
 `core/v0`.
 
+Every GC response carries `next_reclamation_at_ms`, which is the soonest
+time still ahead of the pass at which something it retained becomes
+reclaimable: an open upload session's lease plus the grace window, an
+aborted session's grace, or a completed session's derived
+content-reclamation grace. A scheduler reads it to decide when to run the
+namespace again rather than tracking upload deadlines itself. It describes
+only what this pass examined — a pass that stopped on `next_cursor` saw part
+of the keyspace, and candidates that age out on their object timestamps
+carry no time here — so `null` is not a claim that nothing is owed.
+
 GC responses carry `next_cursor` only when more candidate enumeration remains.
 The token is opaque, tolerant of additive fields when decoded, and valid only
 against the namespace that issued it. It encodes the last examined key and

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4028,6 +4028,15 @@
             ],
             "description": "Opaque resume token when more candidates remain. Resuming rebuilds\nevery safety proof; the token carries enumeration position only and\nis valid only against the same namespace."
           },
+          "next_reclamation_at_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "The soonest instant still ahead of this pass at which something it\nretained becomes reclaimable: an open session's lease plus the grace\nwindow, an aborted session's grace, or a completed session's derived\ncontent-reclamation grace. A scheduler reads this to decide when to\ncome back, so a namespace needs no other side channel to have its\nreclamation happen.\n\nIt reports what this pass saw and nothing more. A pass that stopped\non `next_cursor` examined only part of the keyspace, and candidates\nthat age out under a plain grace window on their object timestamps\ncarry no deadline here at all, so `None` is never a claim that\nnothing is owed.\n\nAlways serialized, `null` included, unlike `next_cursor` beside it:\na cursor's presence is what says the enumeration is unfinished,\nwhile this is an answer every pass has — and one whose absence\notherwise makes the response's shape depend on what happened to be\nin the namespace.",
+            "minimum": 0
+          },
           "released_expired_checkpoints": {
             "type": "integer",
             "format": "int64",


### PR DESCRIPTION
GC passes self-schedule reclamation: `GcResponse.next_reclamation_at_ms` reports the soonest future deadline among candidates the pass retained. Five retain decisions report one, all from values the sweep already computed — no new reads. The abort case reports `now + grace` in the same pass that applied the abort, which closes the abort-nudge gap. The runner's GC job returns the deadline as its `not_before_ms`, so any pass over a namespace re-arms the next one; process restarts recover the schedule from the first pass instead of from lost in-memory state.

Jobs subscribe to publications: `MaintenanceJob` gains `nudged_by_publications()` (default false; the grep job says true). The writer nudges subscribing jobs where the publish observer fires, gated on a landed commit. The server deletes its `OnceLock` handle slot, the observer closure, and the extra constructor parameter. The observer test passes unchanged through the new mechanism.

Runner observability: The settled event gains `queued_ms`; three new low-cardinality debug events report dispatch rounds (ready-queue length, oldest queued age), deadline wakes, and reconcile sweeps. No per-key fields beyond job and namespace.
