### PR TITLE
refactor(trash): active deletions are a family, so listing is a scan

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -54,6 +54,9 @@ pub enum MetadataTableFamily {
     RevisionsByInodeDesc,
     /// Stores set and revoke events used to determine active subtree tombstones.
     Tombstones,
+    /// Names the deletions that are recoverable right now, derived from the
+    /// tombstone family and ordered by deletion time.
+    ActiveDeletions,
     /// Preserves commit idempotency evidence independently of retained WAL history.
     CommitReceipts,
 }
@@ -194,6 +197,24 @@ pub enum MetadataRow {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         display_name: Option<DisplayName>,
     },
+    /// Names one deletion generation in the derived active-deletions family.
+    ///
+    /// The row is not a new event: the materializer derives it from the
+    /// tombstone family, adding a `listed` row for each `set` and a `removed`
+    /// row for each `revoke`, so the trash listing is a range scan instead of
+    /// a walk over every deletion the namespace ever recorded.
+    ActiveDeletion {
+        /// Subtree root the deletion covers. With `deleted_at_seq` this is
+        /// exactly the handle `undelete` addresses.
+        root_inode_id: InodeId,
+        /// Commit sequence of the deletion this row speaks for. A `removed`
+        /// row repeats its target's sequence, not the undelete's, so the two
+        /// rows sort together.
+        deleted_at_seq: ChangeSeq,
+        /// Whether the deletion is still recoverable, and the listing detail
+        /// it carries while it is.
+        action: ActiveDeletionRowAction,
+    },
     /// Preserves the evidence needed to answer a retried logical commit.
     CommitReceipt {
         /// Caller idempotency key whose later reuse is checked against this row.
@@ -229,6 +250,55 @@ pub enum TombstoneRowAction {
     },
 }
 
+/// Active-deletion row vocabulary (format spec, "Tombstones and deletion").
+///
+/// The family holds current state, not history: a `listed` row means the
+/// deletion is recoverable and the trash lists it, and a `removed` row is the
+/// undelete's compensating marker that hides it. The two rows for one
+/// deletion share a key prefix and `removed` sorts first, so an ascending
+/// scan always sees the removal before the row it removes; reorganization
+/// then drops the pair, because a cancelled deletion is not state anyone can
+/// still observe.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ActiveDeletionRowAction {
+    /// The deletion is recoverable; these are the fields the trash entry
+    /// renders, denormalized so a page needs no per-entry join.
+    Listed {
+        /// Wall-clock stamp of the deleting commit. Observational, like every
+        /// `committed_at_ms`.
+        deleted_at_ms: u64,
+        /// Directory that held the deleted binding, when the delete recorded
+        /// one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_inode_id: Option<InodeId>,
+        /// Canonical key of the deleted binding, when known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name_key: Option<NameKey>,
+        /// User-facing spelling of the deleted binding as of the deletion,
+        /// when known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display_name: Option<DisplayName>,
+    },
+    /// An undelete at `revoked_at_seq` cancelled the deletion this row's key
+    /// names, so the listing skips the key.
+    Removed {
+        /// Commit sequence of the undelete that cancelled the deletion.
+        revoked_at_seq: ChangeSeq,
+    },
+}
+
+impl ActiveDeletionRowAction {
+    /// The row-key component that orders a removal ahead of the row it
+    /// removes.
+    fn sort_rank(&self) -> u8 {
+        match self {
+            Self::Removed { .. } => lookup_keys::ACTIVE_DELETION_RANK_REMOVED,
+            Self::Listed { .. } => lookup_keys::ACTIVE_DELETION_RANK_LISTED,
+        }
+    }
+}
+
 impl MetadataRow {
     /// Builds this row's canonical durable key in its primary table family.
     ///
@@ -240,6 +310,7 @@ impl MetadataRow {
             Self::DirentryUnbind { .. } => MetadataTableFamily::DirentryUnbinds,
             Self::Revision { .. } => MetadataTableFamily::Revisions,
             Self::Tombstone { .. } => MetadataTableFamily::Tombstones,
+            Self::ActiveDeletion { .. } => MetadataTableFamily::ActiveDeletions,
             Self::CommitReceipt { .. } => MetadataTableFamily::CommitReceipts,
         })
     }
@@ -329,6 +400,15 @@ impl MetadataRow {
                     root_inode_id.0, tombstone_seq.0, tombstone_delta_index
                 )
             }
+            Self::ActiveDeletion {
+                root_inode_id,
+                deleted_at_seq,
+                action,
+            } => lookup_keys::active_deletion_row_key(
+                *deleted_at_seq,
+                *root_inode_id,
+                action.sort_rank(),
+            ),
             Self::CommitReceipt {
                 committed_seq,
                 commit_id,
@@ -380,6 +460,9 @@ impl MetadataRow {
             Self::Tombstone { root_inode_id, .. } => {
                 format!("tombstone-{:020}", root_inode_id.0)
             }
+            // The family is only ever range-scanned in key order, never
+            // probed for one deletion, so the filter key is the row key.
+            Self::ActiveDeletion { .. } => self.row_key_for_family(family),
             Self::CommitReceipt { commit_id, .. } => {
                 let commit_id = hex_encode_row_key_component(commit_id.as_str());
                 format!("commit-receipt-{commit_id}")
@@ -531,6 +614,51 @@ pub mod lookup_keys {
     /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
     pub fn tombstone_prefix(root_inode_id: InodeId) -> String {
         format!("{}-", tombstone_probe(root_inode_id))
+    }
+
+    /// The prefix every active-deletion row key starts with. Deletion
+    /// sequence and root inode are zero-padded to fixed widths after it, so a
+    /// range scan over this prefix walks the namespace's recoverable
+    /// deletions oldest deletion first — the trash listing's whole read.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub const ACTIVE_DELETION_ROW_PREFIX: &str = "active-deletion-";
+
+    /// Rank of an undelete's removal marker within one deletion generation.
+    /// It is the lowest rank on purpose: an ascending scan sees the removal
+    /// before the row it removes, so a page never lists a deletion whose
+    /// marker was going to arrive one page later.
+    pub const ACTIVE_DELETION_RANK_REMOVED: u8 = 0;
+
+    /// Rank of the listed row within one deletion generation, and the highest
+    /// rank the family defines.
+    pub const ACTIVE_DELETION_RANK_LISTED: u8 = 1;
+
+    /// Builds an active-deletion row key from its generation and rank.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn active_deletion_row_key(
+        deleted_at_seq: ChangeSeq,
+        root_inode_id: InodeId,
+        sort_rank: u8,
+    ) -> String {
+        format!(
+            "{ACTIVE_DELETION_ROW_PREFIX}{:020}-{:020}-{sort_rank}",
+            deleted_at_seq.0, root_inode_id.0
+        )
+    }
+
+    /// Builds the resume bound for a trash page that must continue strictly
+    /// after the deletion generation it last returned. The listed row is the
+    /// generation's highest-ranked row, so resuming past it skips the whole
+    /// generation and nothing else.
+    ///
+    /// See [metadata segments](../../../../docs/specs/format.md#421-metadata-segments).
+    pub fn active_deletion_key_after(deleted_at_seq: ChangeSeq, root_inode_id: InodeId) -> String {
+        format!(
+            "{}\0",
+            active_deletion_row_key(deleted_at_seq, root_inode_id, ACTIVE_DELETION_RANK_LISTED)
+        )
     }
 
     /// Builds the bloom-filter probe shared by receipts for one commit id.

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -239,14 +239,18 @@ impl PageCursor for FileRevisionsPageCursor {
 
 /// Cursor for one trash listing position.
 ///
-/// Trash pagination advances in ascending deleted-root inode order. Like
-/// every cursor, it is an ordering resume tolerating forward head drift:
-/// the next page evaluates at whatever head is loaded and continues
-/// strictly after `last_root_inode_id`.
+/// Trash pagination advances oldest deletion first, in ascending
+/// `(deleted_at_seq, root_inode_id)` order — the order the derived
+/// active-deletion family is keyed in. Like every cursor, it is an ordering
+/// resume tolerating forward head drift: the next page evaluates at whatever
+/// head is loaded and continues strictly after the deletion generation named
+/// here.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TrashPageCursor {
     /// Head sequence the issuing page was evaluated at.
     pub head_seq: ChangeSeq,
+    /// Commit sequence of the deletion the previous page ended on.
+    pub last_deleted_at_seq: ChangeSeq,
     /// Deleted root inode the previous page ended on.
     pub last_root_inode_id: InodeId,
 }

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -192,7 +192,7 @@ pub struct ListTrashResponse {
     pub namespace_id: NamespaceId,
     /// Head sequence this page was evaluated at.
     pub head_seq: ChangeSeq,
-    /// Active deletions in ascending root-inode order.
+    /// Recoverable deletions, oldest deletion first.
     pub entries: Vec<TrashEntry>,
     /// Present when another page follows.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -920,6 +920,7 @@ fn metadata_table_family_wire_tags_are_pinned() {
         MetadataTableFamily::Revisions,
         MetadataTableFamily::RevisionsByInodeDesc,
         MetadataTableFamily::Tombstones,
+        MetadataTableFamily::ActiveDeletions,
         MetadataTableFamily::CommitReceipts,
     ]
     .iter()
@@ -935,6 +936,7 @@ fn metadata_table_family_wire_tags_are_pinned() {
             "\"revisions\"",
             "\"revisions_by_inode_desc\"",
             "\"tombstones\"",
+            "\"active_deletions\"",
             "\"commit_receipts\"",
         ],
         "family tags are durable bytes in every manifest descriptor"

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -5,7 +5,9 @@ use super::block_load::SessionBlockMemo;
 use super::cache::{DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache};
 use super::error::ManifestLoadError;
 use crate::metadata::content_ref_evidence_bytes;
-use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::manifest::{
+    ActiveDeletionRowAction, MetadataFileRef, MetadataRow, MetadataTableFamily,
+};
 use loonfs_api::wire::sst_blocks::{decode_data_block, DecodedDataBlock, SegmentIndexEntry};
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -246,6 +248,22 @@ pub(super) fn decoded_manifest_row_weight(row: &MetadataRow) -> usize {
             ALLOCATED_ROW_OVERHEAD + content_ref_evidence_bytes(content_ref)
         }
         MetadataRow::Tombstone { .. } => FIXED_ROW_OVERHEAD,
+        MetadataRow::ActiveDeletion { action, .. } => match action {
+            ActiveDeletionRowAction::Listed {
+                name_key,
+                display_name,
+                ..
+            } => {
+                ALLOCATED_ROW_OVERHEAD
+                    + name_key
+                        .as_ref()
+                        .map_or(0, |name_key| name_key.as_str().len())
+                    + display_name
+                        .as_ref()
+                        .map_or(0, |display_name| display_name.as_str().len())
+            }
+            ActiveDeletionRowAction::Removed { .. } => FIXED_ROW_OVERHEAD,
+        },
         MetadataRow::CommitReceipt {
             commit_id,
             semantic_commit_fingerprint,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -44,10 +44,10 @@ use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::{read_head_object, read_metadata_root_object_if_present};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::manifest::{
-    MetadataFileRef, MetadataRow, MetadataTableFamily, NamespaceManifestEnvelope,
-    NamespaceManifestPayload,
+    ActiveDeletionRowAction, MetadataFileRef, MetadataRow, MetadataTableFamily,
+    NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
-use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
+use loonfs_api::{ChangeSeq, InodeId, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
@@ -56,7 +56,7 @@ use std::collections::{BTreeMap, BTreeSet};
 /// each other's rows to decide what to drop (see
 /// `drop_rows_below_retention_floor`) must compact together, and a secondary
 /// index always travels with its canonical family.
-const REORGANIZE_FAMILY_GROUPS: [&[MetadataTableFamily]; 5] = [
+const REORGANIZE_FAMILY_GROUPS: [&[MetadataTableFamily]; 6] = [
     &[
         MetadataTableFamily::DirentryBinds,
         MetadataTableFamily::DirentryChildBinds,
@@ -68,6 +68,9 @@ const REORGANIZE_FAMILY_GROUPS: [&[MetadataTableFamily]; 5] = [
     ],
     &[MetadataTableFamily::Inodes],
     &[MetadataTableFamily::Tombstones],
+    // Active deletions fold alone: a removal marker is cancelled by the
+    // listed row it names, and both live in this family.
+    &[MetadataTableFamily::ActiveDeletions],
     &[MetadataTableFamily::CommitReceipts],
 ];
 
@@ -540,10 +543,11 @@ async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
 
 /// Drops rows that no retained sequence can observe (format spec,
 /// "Compaction"). Conservative subset: superseded or unbound bindings and
-/// spent unbind markers at or below the retention floor. Revision rows are
-/// never dropped — file history is durable data retained independently of
-/// the replay floor — and tombstone and inode rows are always retained
-/// until reachability-based dropping is designed.
+/// spent unbind markers at or below the retention floor, and cancelled
+/// active-deletion pairs. Revision rows are never dropped — file history is
+/// durable data retained independently of the replay floor — and tombstone
+/// and inode rows are always retained until reachability-based dropping is
+/// designed.
 pub(super) fn drop_rows_below_retention_floor(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,
@@ -670,6 +674,42 @@ pub(super) fn drop_rows_below_retention_floor(
     if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::DirentryUnbinds) {
         rows.retain(|row| match row {
             MetadataRow::DirentryUnbind { unbind_seq, .. } => *unbind_seq > retention_floor_seq,
+            _ => true,
+        });
+    }
+
+    // Active deletions are current state, not history, so the retention
+    // floor has NO say over them: a deletion stays listed and recoverable
+    // however far the floor advances — that is the product promise, and
+    // dropping a row at the floor would silently retire a recoverable
+    // deletion. The only rows that go are the pairs that cancelled each
+    // other. A removal marker's listed row is always in the same merged set:
+    // the deletion commits before the undelete, runs merge oldest-first, and
+    // the selected subset is a prefix of that order, so a marker can never
+    // outlive the row it names.
+    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::ActiveDeletions) {
+        let revoked: BTreeSet<(ChangeSeq, InodeId)> = rows
+            .iter()
+            .filter_map(|row| match row {
+                MetadataRow::ActiveDeletion {
+                    root_inode_id,
+                    deleted_at_seq,
+                    action: ActiveDeletionRowAction::Removed { .. },
+                } => Some((*deleted_at_seq, *root_inode_id)),
+                _ => None,
+            })
+            .collect();
+        rows.retain(|row| match row {
+            MetadataRow::ActiveDeletion {
+                root_inode_id,
+                deleted_at_seq,
+                action,
+            } => match action {
+                ActiveDeletionRowAction::Removed { .. } => false,
+                ActiveDeletionRowAction::Listed { .. } => {
+                    !revoked.contains(&(*deleted_at_seq, *root_inode_id))
+                }
+            },
             _ => true,
         });
     }

--- a/crates/loonfs-core/src/checkpoint/row.rs
+++ b/crates/loonfs-core/src/checkpoint/row.rs
@@ -1,8 +1,8 @@
 //! Converts in-memory metadata state into manifest rows, per family and in
 //! row-key order.
 
-use crate::metadata::MetadataState;
-use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
+use crate::metadata::{active_deletion_from_tombstone, ActiveDeletionAction, MetadataState};
+use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow, MetadataTableFamily};
 use loonfs_api::ChangeSeq;
 
 #[cfg(test)]
@@ -28,6 +28,33 @@ fn tombstone_row_action(
         } => TombstoneRowAction::Revoke {
             target_seq: *target_seq,
             target_delta_index: *target_delta_index,
+        },
+    }
+}
+
+/// Projects one tombstone event onto its derived active-deletion row. The
+/// reducer itself lives beside the tombstone rules in `metadata::rows`; this
+/// is only the record-to-wire half.
+fn active_deletion_row(tombstone: &crate::metadata::SubtreeTombstoneRecord) -> MetadataRow {
+    let record = active_deletion_from_tombstone(tombstone);
+    MetadataRow::ActiveDeletion {
+        root_inode_id: record.root_inode_id,
+        deleted_at_seq: record.deleted_at_seq,
+        action: match record.action {
+            ActiveDeletionAction::Listed {
+                deleted_at_ms,
+                parent_inode_id,
+                name_key,
+                display_name,
+            } => ActiveDeletionRowAction::Listed {
+                deleted_at_ms,
+                parent_inode_id,
+                name_key,
+                display_name,
+            },
+            ActiveDeletionAction::Removed { revoked_at_seq } => {
+                ActiveDeletionRowAction::Removed { revoked_at_seq }
+            }
         },
     }
 }
@@ -102,6 +129,11 @@ pub(super) fn manifest_rows_for_family(
                 display_name: tombstone.display_name.clone(),
             })
             .collect::<Vec<_>>(),
+        MetadataTableFamily::ActiveDeletions => metadata_state
+            .subtree_tombstones()
+            .iter()
+            .map(active_deletion_row)
+            .collect::<Vec<_>>(),
         MetadataTableFamily::CommitReceipts => metadata_state
             .commit_receipts()
             .iter()
@@ -136,6 +168,16 @@ pub(super) fn manifest_row_commit_seq(row: &MetadataRow) -> ChangeSeq {
         MetadataRow::DirentryUnbind { unbind_seq, .. } => *unbind_seq,
         MetadataRow::Revision { committed_seq, .. } => *committed_seq,
         MetadataRow::Tombstone { tombstone_seq, .. } => *tombstone_seq,
+        // A removal marker belongs to the run of the undelete that produced
+        // it, not to the run of the deletion whose key it repeats.
+        MetadataRow::ActiveDeletion {
+            deleted_at_seq,
+            action,
+            ..
+        } => match action {
+            ActiveDeletionRowAction::Listed { .. } => *deleted_at_seq,
+            ActiveDeletionRowAction::Removed { revoked_at_seq } => *revoked_at_seq,
+        },
         MetadataRow::CommitReceipt { committed_seq, .. } => *committed_seq,
     }
 }
@@ -148,6 +190,7 @@ pub(super) fn manifest_row_kind(row: &MetadataRow) -> &'static str {
         MetadataRow::DirentryUnbind { .. } => "direntry_unbind",
         MetadataRow::Revision { .. } => "revision",
         MetadataRow::Tombstone { .. } => "tombstone",
+        MetadataRow::ActiveDeletion { .. } => "active_deletion",
         MetadataRow::CommitReceipt { .. } => "commit_receipt",
     }
 }

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -19,7 +19,7 @@ pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_BYTES: usize = 64 * 1024 * 102
 pub(super) const MAX_MAINTENANCE_TABLE_IO: usize = 8;
 pub(super) const CHECKPOINT_L0_RUN_LEVEL: u32 = 0;
 pub(super) const CHECKPOINT_BASE_RUN_LEVEL: u32 = 1;
-pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 8] = [
+pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 9] = [
     MetadataTableFamily::Inodes,
     MetadataTableFamily::DirentryBinds,
     MetadataTableFamily::DirentryChildBinds,
@@ -27,6 +27,7 @@ pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 8] = [
     MetadataTableFamily::Revisions,
     MetadataTableFamily::RevisionsByInodeDesc,
     MetadataTableFamily::Tombstones,
+    MetadataTableFamily::ActiveDeletions,
     MetadataTableFamily::CommitReceipts,
 ];
 

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -95,10 +95,11 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             .map(|(_, row)| row))
     }
 
-    /// Whole-prefix scan without a bloom probe: per-row filters cannot
-    /// answer a prefix, so every segment in range is read. Production use
-    /// is deliberate and rare — the trash listing enumerates the immortal
-    /// tombstone family this way.
+    /// Whole-prefix scan without a bloom probe or a row limit: every segment
+    /// in range is read. No production read is allowed to cost the whole
+    /// family, so this exists only for the test-only inspection
+    /// materialization, which is defined as reading everything.
+    #[cfg(test)]
     pub(crate) async fn scan_prefix(
         &self,
         family: MetadataTableFamily,

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -1,0 +1,867 @@
+//! The derived active-deletions family: its reducer, the fold that collapses
+//! cancelled deletions, and the bounded trash listing it backs.
+//!
+//! The family is materialized by checkpoint publication, so it lives with the
+//! other manifest-family tests; the listing is its only consumer and is
+//! exercised here against real manifests rather than in isolation.
+
+use super::*;
+use crate::metadata::{
+    active_tombstone_from_records, MetadataStateBuilder, SubtreeTombstoneAction,
+    SubtreeTombstoneRecord,
+};
+use crate::path::read::{load_metadata_view, ReadLoadContext};
+use loonfs_api::wire::manifest::ActiveDeletionRowAction;
+use loonfs_api::{DisplayName, Page, PageRequest, TrashEntry, TrashPageCursor};
+
+fn tombstone_set(root_inode_id: InodeId, seq: u64, name: &str) -> SubtreeTombstoneRecord {
+    SubtreeTombstoneRecord {
+        root_inode_id,
+        tombstone_seq: ChangeSeq(seq),
+        tombstone_delta_index: 0,
+        deleted_at_ms: 1_000 + seq,
+        parent_inode_id: Some(InodeId(1)),
+        name_key: Some(NameKey::parse(name).expect("name key")),
+        display_name: Some(DisplayName::parse(name).expect("display name")),
+        action: SubtreeTombstoneAction::Set,
+    }
+}
+
+fn tombstone_revoke(root_inode_id: InodeId, seq: u64, target_seq: u64) -> SubtreeTombstoneRecord {
+    SubtreeTombstoneRecord {
+        root_inode_id,
+        tombstone_seq: ChangeSeq(seq),
+        tombstone_delta_index: 0,
+        deleted_at_ms: 1_000 + seq,
+        parent_inode_id: None,
+        name_key: None,
+        display_name: None,
+        action: SubtreeTombstoneAction::Revoke {
+            target_seq: ChangeSeq(target_seq),
+            target_delta_index: 0,
+        },
+    }
+}
+
+fn state_from_tombstones(tombstones: Vec<SubtreeTombstoneRecord>) -> MetadataState {
+    let mut builder = MetadataStateBuilder::default();
+    for tombstone in tombstones {
+        builder.push_subtree_tombstone(tombstone);
+    }
+    builder.finish()
+}
+
+/// The family's rows for a state, as `(row key, listed or removed)` pairs in
+/// scan order.
+fn active_deletion_rows(state: &MetadataState) -> Vec<(String, &'static str)> {
+    manifest_rows_for_family(state, ApiMetadataTableFamily::ActiveDeletions)
+        .into_iter()
+        .map(|row| {
+            let row_key = row.row_key_for_family(ApiMetadataTableFamily::ActiveDeletions);
+            let kind = match row {
+                MetadataRow::ActiveDeletion {
+                    action: ActiveDeletionRowAction::Listed { .. },
+                    ..
+                } => "listed",
+                MetadataRow::ActiveDeletion {
+                    action: ActiveDeletionRowAction::Removed { .. },
+                    ..
+                } => "removed",
+                other => panic!("unexpected row in the active-deletions family: {other:?}"),
+            };
+            (row_key, kind)
+        })
+        .collect()
+}
+
+#[test]
+fn a_delete_adds_a_row_an_undelete_removes_it_and_a_redelete_adds_a_new_one() {
+    let deleted = state_from_tombstones(vec![tombstone_set(InodeId(7), 5, "notes.txt")]);
+    assert_eq!(
+        active_deletion_rows(&deleted),
+        vec![(
+            "active-deletion-00000000000000000005-00000000000000000007-1".to_owned(),
+            "listed"
+        )],
+        "a delete adds exactly one listed row, keyed by its own generation"
+    );
+
+    let undeleted = state_from_tombstones(vec![
+        tombstone_set(InodeId(7), 5, "notes.txt"),
+        tombstone_revoke(InodeId(7), 9, 5),
+    ]);
+    assert_eq!(
+        active_deletion_rows(&undeleted),
+        vec![
+            (
+                "active-deletion-00000000000000000005-00000000000000000007-0".to_owned(),
+                "removed"
+            ),
+            (
+                "active-deletion-00000000000000000005-00000000000000000007-1".to_owned(),
+                "listed"
+            ),
+        ],
+        "an undelete adds a removal that sorts ahead of the row it removes"
+    );
+
+    let redeleted = state_from_tombstones(vec![
+        tombstone_set(InodeId(7), 5, "notes.txt"),
+        tombstone_revoke(InodeId(7), 9, 5),
+        tombstone_set(InodeId(7), 12, "notes.txt"),
+    ]);
+    assert_eq!(
+        active_deletion_rows(&redeleted)
+            .into_iter()
+            .filter(|(_, kind)| *kind == "listed")
+            .map(|(row_key, _)| row_key)
+            .collect::<Vec<_>>(),
+        vec![
+            "active-deletion-00000000000000000005-00000000000000000007-1".to_owned(),
+            "active-deletion-00000000000000000012-00000000000000000007-1".to_owned(),
+        ],
+        "a re-delete lands at a new sequence and adds a new row"
+    );
+}
+
+#[test]
+fn a_removal_carries_the_undeletes_sequence_so_it_lands_in_that_commits_run() {
+    let state = state_from_tombstones(vec![
+        tombstone_set(InodeId(7), 5, "notes.txt"),
+        tombstone_revoke(InodeId(7), 9, 5),
+    ]);
+    let delta_rows = super::super::row::manifest_rows_for_family_after_seq(
+        &state,
+        ApiMetadataTableFamily::ActiveDeletions,
+        ChangeSeq(5),
+    );
+    assert_eq!(
+        delta_rows.len(),
+        1,
+        "only the undelete's removal belongs to the run above sequence 5"
+    );
+    assert!(
+        matches!(
+            &delta_rows[0],
+            MetadataRow::ActiveDeletion {
+                action: ActiveDeletionRowAction::Removed { revoked_at_seq },
+                ..
+            } if *revoked_at_seq == ChangeSeq(9)
+        ),
+        "unexpected delta row: {:?}",
+        delta_rows[0]
+    );
+}
+
+#[test]
+fn the_fold_drops_cancelled_pairs_and_keeps_every_live_deletion() {
+    let state = state_from_tombstones(vec![
+        tombstone_set(InodeId(7), 5, "notes.txt"),
+        tombstone_revoke(InodeId(7), 9, 5),
+        tombstone_set(InodeId(8), 11, "report.txt"),
+        tombstone_set(InodeId(7), 12, "notes.txt"),
+    ]);
+    let mut rows_by_family = std::collections::BTreeMap::from([(
+        ApiMetadataTableFamily::ActiveDeletions,
+        manifest_rows_for_family(&state, ApiMetadataTableFamily::ActiveDeletions),
+    )]);
+    // Far above every row: the floor must not touch this family.
+    reorganize::drop_rows_below_retention_floor(&mut rows_by_family, ChangeSeq(10_000))
+        .expect("fold active deletions");
+
+    let kept = rows_by_family
+        .remove(&ApiMetadataTableFamily::ActiveDeletions)
+        .expect("family rows")
+        .into_iter()
+        .map(|row| row.row_key_for_family(ApiMetadataTableFamily::ActiveDeletions))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kept,
+        vec![
+            "active-deletion-00000000000000000011-00000000000000000008-1".to_owned(),
+            "active-deletion-00000000000000000012-00000000000000000007-1".to_owned(),
+        ],
+        "the cancelled pair goes and both live deletions stay, however far the floor advanced"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The listing over real manifests
+// ---------------------------------------------------------------------------
+
+async fn submit_operation_for_test<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    commit_id: &str,
+    operation: FilesystemOperation,
+    context: &MutationContext,
+) -> loonfs_api::CommitResponse {
+    NamespaceCommitEngine::new(namespace_id.clone())
+        .publish_batch(
+            store,
+            vec![CommitCandidate::prepared(
+                CommitRequest::single(
+                    CommitId::parse(commit_id).expect("commit id"),
+                    None,
+                    operation,
+                ),
+                Vec::new(),
+            )],
+            context,
+            &PublishTailOptions::default(),
+        )
+        .await
+        .results
+        .pop()
+        .expect("one result")
+        .expect("commit accepted")
+}
+
+async fn undelete<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    commit_id: &str,
+    inode_id: InodeId,
+    deleted_at_seq: ChangeSeq,
+    absolute_path: &str,
+    context: &MutationContext,
+) -> loonfs_api::CommitResponse {
+    submit_operation_for_test(
+        store,
+        namespace_id,
+        commit_id,
+        FilesystemOperation::Undelete {
+            inode_id,
+            deleted_at_seq,
+            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+        },
+        context,
+    )
+    .await
+}
+
+async fn trash_page<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    limit: u32,
+    cursor: Option<TrashPageCursor>,
+) -> Page<TrashEntry, TrashPageCursor> {
+    let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+        .await
+        .expect("load read view");
+    view.list_trash_page(PageRequest {
+        cursor,
+        limit: EffectiveLimit::new(NonZeroU32::new(limit).expect("non-zero limit")),
+    })
+    .await
+    .expect("list trash page")
+}
+
+/// The inode a visible path resolves to, read before a delete hides it.
+async fn inode_id_of<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+) -> InodeId {
+    load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+        .await
+        .expect("load read view")
+        .resolve_path(absolute_path)
+        .await
+        .expect("resolve path")
+        .inode_id
+}
+
+/// Every trash entry, paged to exhaustion.
+async fn trash_entries<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    limit: u32,
+) -> Vec<TrashEntry> {
+    let mut entries = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = trash_page(store, namespace_id, limit, cursor).await;
+        entries.extend(page.items);
+        match page.next_cursor {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+    entries
+}
+
+/// The listing algorithm the active-deletions family replaced: load every
+/// tombstone event the namespace ever recorded, group by root, and reduce
+/// newest-event-wins per root.
+///
+/// This lives only here, as the differential test's model. Production has one
+/// implementation, and it is the range scan.
+fn trash_by_walking_every_tombstone(state: &MetadataState, head_seq: ChangeSeq) -> Vec<TrashEntry> {
+    let mut per_root: std::collections::BTreeMap<InodeId, Vec<SubtreeTombstoneRecord>> =
+        std::collections::BTreeMap::new();
+    for record in state.subtree_tombstones() {
+        per_root
+            .entry(record.root_inode_id)
+            .or_default()
+            .push(record.clone());
+    }
+    per_root
+        .into_iter()
+        .filter_map(|(root_inode_id, records)| {
+            let active = active_tombstone_from_records(records, head_seq)?;
+            Some(TrashEntry {
+                root_inode_id,
+                deleted_at_seq: active.tombstone_seq,
+                deleted_at_ms: active.deleted_at_ms,
+                parent_inode_id: active.parent_inode_id,
+                name_key: active.name_key,
+                display_name: active.display_name,
+            })
+        })
+        .collect()
+}
+
+/// Compares the two listings as sets. The family orders entries oldest
+/// deletion first where the old walk ordered them by root inode, so order is
+/// normalized away and pinned separately by
+/// `the_listing_is_ordered_oldest_deletion_first`.
+fn sorted_by_generation(mut entries: Vec<TrashEntry>) -> Vec<TrashEntry> {
+    entries.sort_by_key(|entry| (entry.deleted_at_seq, entry.root_inode_id));
+    entries
+}
+
+async fn assert_listing_matches_the_old_walk<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    step: usize,
+) {
+    let (head, state) = load_checkpoint_projection_metadata_state(store, namespace_id)
+        .await
+        .expect("load projection");
+    let expected = sorted_by_generation(trash_by_walking_every_tombstone(&state, head.seq));
+    // A limit of 2 forces the page machinery — cursors, removal markers
+    // straddling page boundaries — on every step.
+    let listed = sorted_by_generation(trash_entries(store, namespace_id, 2).await);
+    assert_eq!(
+        listed, expected,
+        "step {step}: the family-backed listing must equal the old walk"
+    );
+}
+
+/// Deterministic history driver. `rand` is not a dependency here (and ambient
+/// randomness is banned), so the schedule is an explicit script that walks
+/// every reducer transition and both nested cases.
+#[derive(Debug, Clone, Copy)]
+enum HistoryStep {
+    Create(&'static str),
+    Delete(&'static str),
+    /// Undelete the deletion the named path produced, re-binding at the
+    /// second path.
+    Undelete(&'static str, &'static str),
+}
+
+#[tokio::test]
+async fn the_family_backed_listing_equals_the_old_tombstone_walk_on_every_step() {
+    let temp = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp.path()).expect("create local-fs store");
+    let namespace_id = NamespaceId::parse("differential-trash").expect("namespace id");
+    let mut context = mutation_context("writer-1", 5_000);
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+
+    let script = [
+        HistoryStep::Create("/a.txt"),
+        HistoryStep::Create("/b.txt"),
+        HistoryStep::Create("/dir/inner.txt"),
+        // A plain delete, then its undelete, then a re-delete: the three
+        // reducer transitions in order.
+        HistoryStep::Delete("/a.txt"),
+        HistoryStep::Undelete("/a.txt", "/a-restored.txt"),
+        HistoryStep::Delete("/a-restored.txt"),
+        // A deletion inside an already-deleted subtree: delete the child
+        // first, then its parent, so two live deletions nest.
+        HistoryStep::Delete("/dir/inner.txt"),
+        HistoryStep::Delete("/dir"),
+        // An undelete whose old parent is still deleted: the recovered
+        // subtree re-binds elsewhere and the nested child stays deleted.
+        HistoryStep::Undelete("/dir", "/dir-restored"),
+        HistoryStep::Delete("/b.txt"),
+        // Re-delete the recovered subtree, then recover it once more.
+        HistoryStep::Delete("/dir-restored"),
+        HistoryStep::Undelete("/dir-restored", "/dir-again"),
+        HistoryStep::Undelete("/b.txt", "/b-back.txt"),
+    ];
+
+    let mut deletions: std::collections::HashMap<String, (InodeId, ChangeSeq)> =
+        std::collections::HashMap::new();
+    for (step, action) in script.into_iter().enumerate() {
+        context = mutation_context("writer-1", 5_000 + step as u64);
+        let commit_id = format!("com_step{step:028}");
+        match action {
+            HistoryStep::Create(path) => {
+                write_test_file(&store, &namespace_id, path, &commit_id, &context).await;
+            }
+            HistoryStep::Delete(path) => {
+                let deleted_inode_id = inode_id_of(&store, &namespace_id, path).await;
+                let response = delete_path(&store, &namespace_id, path, &context, None)
+                    .await
+                    .expect("delete path");
+                deletions.insert(path.to_owned(), (deleted_inode_id, response.committed_seq));
+            }
+            HistoryStep::Undelete(deleted_path, restored_path) => {
+                let (inode_id, deleted_at_seq) = deletions
+                    .remove(deleted_path)
+                    .expect("undelete follows a recorded delete");
+                undelete(
+                    &store,
+                    &namespace_id,
+                    &commit_id,
+                    inode_id,
+                    deleted_at_seq,
+                    restored_path,
+                    &context,
+                )
+                .await;
+            }
+        }
+        assert_listing_matches_the_old_walk(&store, &namespace_id, step).await;
+        // Half the steps materialize into a manifest, so the comparison sees
+        // both a WAL-tail-only listing and a durable one.
+        if step % 2 == 1 {
+            create_checkpoint(&store, &namespace_id, &context)
+                .await
+                .expect("create checkpoint");
+            assert_listing_matches_the_old_walk(&store, &namespace_id, step).await;
+        }
+    }
+
+    // Fold everything, then compare once more: the cancelled pairs are gone
+    // from the family and the answer is unchanged.
+    drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
+    assert_listing_matches_the_old_walk(&store, &namespace_id, usize::MAX).await;
+    assert!(
+        !trash_entries(&store, &namespace_id, 2).await.is_empty(),
+        "the script must leave live deletions, or the comparison proves nothing"
+    );
+}
+
+#[tokio::test]
+async fn the_listing_is_ordered_oldest_deletion_first() {
+    let temp = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp.path()).expect("create local-fs store");
+    let namespace_id = NamespaceId::parse("trash-order").expect("namespace id");
+    let context = mutation_context("writer-1", 5_000);
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+
+    for (index, name) in ["/a.txt", "/b.txt", "/c.txt"].into_iter().enumerate() {
+        write_test_file(
+            &store,
+            &namespace_id,
+            name,
+            &format!("com_make{index:026}"),
+            &context,
+        )
+        .await;
+    }
+    // Delete newest-inode first so root-inode order and deletion order
+    // disagree.
+    for name in ["/c.txt", "/a.txt", "/b.txt"] {
+        delete_path(&store, &namespace_id, name, &context, None)
+            .await
+            .expect("delete path");
+    }
+
+    let entries = trash_entries(&store, &namespace_id, 10).await;
+    let names = entries
+        .iter()
+        .map(|entry| {
+            entry
+                .display_name
+                .as_ref()
+                .expect("a path delete records the deleted name")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        vec!["c.txt".to_owned(), "a.txt".to_owned(), "b.txt".to_owned()],
+        "the trash lists deletions oldest first, not by root inode"
+    );
+    assert!(
+        entries
+            .windows(2)
+            .all(|pair| (pair[0].deleted_at_seq, pair[0].root_inode_id)
+                < (pair[1].deleted_at_seq, pair[1].root_inode_id)),
+        "entries must ascend by (deleted_at_seq, root_inode_id): {entries:?}"
+    );
+}
+
+#[tokio::test]
+async fn trash_pages_resume_after_the_generation_the_cursor_names() {
+    let temp = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp.path()).expect("create local-fs store");
+    let namespace_id = NamespaceId::parse("trash-paging").expect("namespace id");
+    let context = mutation_context("writer-1", 5_000);
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+    for index in 0..5u32 {
+        write_test_file(
+            &store,
+            &namespace_id,
+            &format!("/file-{index}.txt"),
+            &format!("com_page{index:028}"),
+            &context,
+        )
+        .await;
+        delete_path(
+            &store,
+            &namespace_id,
+            &format!("/file-{index}.txt"),
+            &context,
+            None,
+        )
+        .await
+        .expect("delete path");
+    }
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+
+    let first = trash_page(&store, &namespace_id, 2, None).await;
+    assert_eq!(
+        first.items.len(),
+        2,
+        "a full page returns exactly the limit"
+    );
+    let cursor = first
+        .next_cursor
+        .clone()
+        .expect("five deletions do not fit one page of two");
+    assert_eq!(
+        (cursor.last_deleted_at_seq, cursor.last_root_inode_id),
+        (first.items[1].deleted_at_seq, first.items[1].root_inode_id),
+        "the cursor names the generation the page ended on"
+    );
+
+    let encoded = loonfs_api::encode_cursor(&cursor).expect("encode cursor");
+    let decoded: TrashPageCursor = loonfs_api::decode_cursor(&encoded).expect("decode cursor");
+    assert_eq!(decoded, cursor, "the trash cursor round-trips on the wire");
+
+    let second = trash_page(&store, &namespace_id, 2, Some(decoded)).await;
+    assert_eq!(second.items.len(), 2);
+    let third = trash_page(
+        &store,
+        &namespace_id,
+        2,
+        Some(second.next_cursor.clone().expect("a fifth entry remains")),
+    )
+    .await;
+    assert_eq!(third.items.len(), 1, "the last page is short");
+    assert!(
+        third.next_cursor.is_none(),
+        "a short page ends the listing without a cursor"
+    );
+
+    let all = trash_entries(&store, &namespace_id, 2).await;
+    assert_eq!(all.len(), 5);
+    assert_eq!(
+        trash_entries(&store, &namespace_id, 100).await,
+        all,
+        "the paged walk and a single large page agree"
+    );
+
+    let wrong_kind = loonfs_api::encode_cursor(&loonfs_api::DirectoryPageCursor {
+        head_seq: ChangeSeq(1),
+        directory_inode_id: InodeId(1),
+        last_name_key: NameKey::parse("x").expect("name key"),
+    })
+    .expect("encode cursor");
+    assert!(
+        loonfs_api::decode_cursor::<TrashPageCursor>(&wrong_kind).is_err(),
+        "another endpoint's cursor must not resume a trash listing"
+    );
+}
+
+#[tokio::test]
+async fn a_deletion_far_below_the_retention_floor_still_lists_and_still_undeletes() {
+    let temp = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp.path()).expect("create local-fs store");
+    let namespace_id = NamespaceId::parse("trash-below-floor").expect("namespace id");
+    let context = mutation_context("writer-1", 5_000);
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+
+    write_test_file(
+        &store,
+        &namespace_id,
+        "/old.txt",
+        "com_floorseed0000000000000001",
+        &context,
+    )
+    .await;
+    let deleted_inode_id = inode_id_of(&store, &namespace_id, "/old.txt").await;
+    let deleted = delete_path(&store, &namespace_id, "/old.txt", &context, None)
+        .await
+        .expect("delete path");
+
+    // Push history far past the deletion, then move the floor up over it and
+    // fold every run.
+    for index in 0..6u32 {
+        write_test_file(
+            &store,
+            &namespace_id,
+            &format!("/later-{index}.txt"),
+            &format!("com_floorfill{index:022}"),
+            &context,
+        )
+        .await;
+    }
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance retention floor");
+    drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
+    let floor_seq = read_floor_seq(&store, &namespace_id).await;
+    assert!(
+        floor_seq > deleted.committed_seq,
+        "the floor must have passed the deletion for this test to mean anything: \
+         floor {floor_seq}, deletion {}",
+        deleted.committed_seq
+    );
+
+    let entries = trash_entries(&store, &namespace_id, 10).await;
+    assert_eq!(
+        entries.len(),
+        1,
+        "a deletion below the floor stays listed: {entries:?}"
+    );
+    assert_eq!(entries[0].root_inode_id, deleted_inode_id);
+    assert_eq!(entries[0].deleted_at_seq, deleted.committed_seq);
+
+    undelete(
+        &store,
+        &namespace_id,
+        "com_floorrecover000000000001",
+        deleted_inode_id,
+        deleted.committed_seq,
+        "/recovered.txt",
+        &context,
+    )
+    .await;
+    assert!(
+        trash_entries(&store, &namespace_id, 10).await.is_empty(),
+        "recovery below the floor still works, and empties the trash"
+    );
+}
+
+#[tokio::test]
+async fn a_trash_page_costs_the_page_not_the_namespaces_deletion_history() {
+    /// One page's reads over a namespace with `deletions` recoverable
+    /// deletions, measured after the family is folded into its base.
+    async fn page_reads(deletions: u32) -> usize {
+        let temp = tempdir().expect("tempdir");
+        let store = CountingStore::metadata_tables(
+            LocalFsStore::new(temp.path()).expect("create local-fs store"),
+        );
+        let namespace_id = NamespaceId::parse("trash-bounded").expect("namespace id");
+        let context = mutation_context("writer-1", 5_000);
+        bootstrap_namespace(&store, &namespace_id, &context, false)
+            .await
+            .expect("bootstrap namespace");
+        for index in 0..deletions {
+            let path = format!("/doomed-{index}.txt");
+            write_test_file(
+                &store,
+                &namespace_id,
+                &path,
+                &format!("com_bounded{index:022}"),
+                &context,
+            )
+            .await;
+            delete_path(&store, &namespace_id, &path, &context, None)
+                .await
+                .expect("delete path");
+        }
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("create checkpoint");
+        drain_reorganization(
+            &store,
+            &namespace_id,
+            &context,
+            MetadataLsmPolicy::default(),
+        )
+        .await;
+
+        store.reset();
+        let page = trash_page(&store, &namespace_id, 4, None).await;
+        assert_eq!(
+            page.items.len(),
+            4,
+            "the page must be full to be comparable"
+        );
+        store.count(OperationClass::Read)
+    }
+
+    let small = page_reads(8).await;
+    let large = page_reads(32).await;
+    assert_eq!(
+        small, large,
+        "a page of four costs the same over 8 and 32 deletions; \
+         it read {small} then {large} metadata objects"
+    );
+    assert!(
+        large < 32,
+        "a bounded page must not approach one read per deletion: {large}"
+    );
+}
+
+/// Pins what nesting means for the trash, because it is the case the family
+/// most easily gets wrong. Deletions are per root, not per subtree: a child
+/// deleted before its parent keeps its own entry while the parent's deletion
+/// covers it, and recovering the parent leaves the child's own deletion
+/// listed. The differential test is the authority that this equals the old
+/// walk; this names the behavior.
+#[tokio::test]
+async fn nested_deletions_each_keep_their_own_entry() {
+    let temp = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp.path()).expect("create local-fs store");
+    let namespace_id = NamespaceId::parse("trash-nested").expect("namespace id");
+    let context = mutation_context("writer-1", 5_000);
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+    write_test_file(
+        &store,
+        &namespace_id,
+        "/dir/inner.txt",
+        "com_nested0000000000000000001",
+        &context,
+    )
+    .await;
+
+    let child_inode_id = inode_id_of(&store, &namespace_id, "/dir/inner.txt").await;
+    delete_path(&store, &namespace_id, "/dir/inner.txt", &context, None)
+        .await
+        .expect("delete the child");
+    let parent_inode_id = inode_id_of(&store, &namespace_id, "/dir").await;
+    let parent_deleted = delete_path(&store, &namespace_id, "/dir", &context, None)
+        .await
+        .expect("delete the parent");
+
+    let nested = trash_entries(&store, &namespace_id, 10).await;
+    assert_eq!(
+        nested
+            .iter()
+            .map(|entry| entry.root_inode_id)
+            .collect::<Vec<_>>(),
+        vec![child_inode_id, parent_inode_id],
+        "a deletion inside an already-deleted subtree keeps its own entry"
+    );
+
+    undelete(
+        &store,
+        &namespace_id,
+        "com_nested0000000000000000002",
+        parent_inode_id,
+        parent_deleted.committed_seq,
+        "/dir-restored",
+        &context,
+    )
+    .await;
+    let after = trash_entries(&store, &namespace_id, 10).await;
+    assert_eq!(
+        after
+            .iter()
+            .map(|entry| entry.root_inode_id)
+            .collect::<Vec<_>>(),
+        vec![child_inode_id],
+        "recovering the parent leaves the child's own deletion listed"
+    );
+}
+
+#[tokio::test]
+async fn a_deletion_committed_after_the_last_manifest_lists_immediately() {
+    let temp = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp.path()).expect("create local-fs store");
+    let namespace_id = NamespaceId::parse("trash-wal-tail").expect("namespace id");
+    let context = mutation_context("writer-1", 5_000);
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+    write_test_file(
+        &store,
+        &namespace_id,
+        "/durable.txt",
+        "com_tail000000000000000000001",
+        &context,
+    )
+    .await;
+    delete_path(&store, &namespace_id, "/durable.txt", &context, None)
+        .await
+        .expect("delete path");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+
+    // This pair lands after the manifest and is only in the WAL tail.
+    write_test_file(
+        &store,
+        &namespace_id,
+        "/fresh.txt",
+        "com_tail000000000000000000002",
+        &context,
+    )
+    .await;
+    let fresh = delete_path(&store, &namespace_id, "/fresh.txt", &context, None)
+        .await
+        .expect("delete path");
+
+    let entries = trash_entries(&store, &namespace_id, 10).await;
+    assert_eq!(entries.len(), 2, "{entries:?}");
+    assert_eq!(
+        entries[1].deleted_at_seq, fresh.committed_seq,
+        "the unflushed deletion lists last, in deletion order"
+    );
+
+    // An undelete in the tail hides a deletion the manifest still lists.
+    let durable_inode_id = entries[0].root_inode_id;
+    let durable_seq = entries[0].deleted_at_seq;
+    undelete(
+        &store,
+        &namespace_id,
+        "com_tail000000000000000000003",
+        durable_inode_id,
+        durable_seq,
+        "/durable-back.txt",
+        &context,
+    )
+    .await;
+    let entries = trash_entries(&store, &namespace_id, 10).await;
+    assert_eq!(
+        entries.len(),
+        1,
+        "an unflushed undelete must hide the durable row it cancels: {entries:?}"
+    );
+    assert_eq!(entries[0].deleted_at_seq, fresh.committed_seq);
+}

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -308,6 +308,12 @@ pub(crate) fn append_rows_to_metadata(
             MetadataTableFamily::Tombstones => metadata_state.push_subtree_tombstone(
                 row_decode::tombstone_from_manifest_row(row.clone()).map_err(mismatch)?,
             ),
+            // Derived from the tombstone rows above, like the secondary
+            // indexes: decoding proves the row belongs to the family, and
+            // materialization re-derives it.
+            MetadataTableFamily::ActiveDeletions => {
+                row_decode::active_deletion_from_manifest_row(row.clone()).map_err(mismatch)?;
+            }
             MetadataTableFamily::CommitReceipts => metadata_state.push_commit_receipt(
                 row_decode::commit_receipt_from_manifest_row(row.clone()).map_err(mismatch)?,
             ),

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::panic)]
 // These tests use panic in impossible match arms to preserve precise failure messages.
 
+mod active_deletions;
 mod cache;
 mod cas_recovery;
 mod index_parity;

--- a/crates/loonfs-core/src/metadata/manifest_index.rs
+++ b/crates/loonfs-core/src/metadata/manifest_index.rs
@@ -2,16 +2,16 @@
 //! scans.
 
 use super::row_decode::{
-    commit_receipt_from_manifest_row, direntry_bind_from_manifest_row,
-    direntry_unbind_from_manifest_row, inode_from_manifest_row, revision_from_manifest_row,
-    tombstone_from_manifest_row,
+    active_deletion_from_manifest_row, commit_receipt_from_manifest_row,
+    direntry_bind_from_manifest_row, direntry_unbind_from_manifest_row, inode_from_manifest_row,
+    revision_from_manifest_row, tombstone_from_manifest_row,
 };
 use crate::checkpoint::{ManifestLoadError, Readahead, VerifiedMetadataTables};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::metadata::{
-    unbind_matches_binding, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
-    InodeRecord, RevisionRecord, SubtreeTombstoneRecord,
+    unbind_matches_binding, ActiveDeletionRecord, CommitReceiptRecord, DirentryBindRecord,
+    DirentryUnbindRecord, InodeRecord, RevisionRecord, SubtreeTombstoneRecord,
 };
 use loonfs_api::wire::manifest::lookup_keys;
 use loonfs_api::wire::manifest::MetadataTableFamily;
@@ -277,18 +277,27 @@ pub(super) async fn revisions_for_inode_page_desc<S: ObjectStore + ?Sized>(
         .collect()
 }
 
-/// Every tombstone event row in the namespace, across all roots. The trash
-/// listing's raw material: rows are immortal (never dropped by compaction),
-/// so this is complete for the namespace's whole history.
-pub(super) async fn all_subtree_tombstones<S: ObjectStore + ?Sized>(
+/// One key-ordered page of the derived active-deletion family, with each
+/// row's stored key. The trash listing's whole durable read: the family is
+/// keyed by deletion generation, so a page is a range scan whose cost follows
+/// the page, not the namespace's deletion history.
+pub(super) async fn active_deletions_page<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
-) -> Result<Vec<SubtreeTombstoneRecord>> {
+    lower_bound: &str,
+    upper_bound: Option<&str>,
+    limit: usize,
+) -> Result<Vec<(String, ActiveDeletionRecord)>> {
     tables
-        .scan_prefix(MetadataTableFamily::Tombstones, "tombstone-")
+        .scan_range_page_with_keys(
+            MetadataTableFamily::ActiveDeletions,
+            lower_bound,
+            upper_bound,
+            limit,
+        )
         .await
         .map_err(manifest_error_to_core)?
         .into_iter()
-        .map(tombstone_from_manifest_row)
+        .map(|(row_key, row)| Ok((row_key, active_deletion_from_manifest_row(row)?)))
         .collect()
 }
 

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -41,8 +41,16 @@ pub use self::rows::{
 };
 
 pub(crate) use self::durable_cache::DurableVisibilityCache;
+/// The newest-event-wins tombstone rule. Every production reader reaches it
+/// through `metadata::visibility`; the trash listing's differential test
+/// reaches it directly, to model the walk the active-deletions family
+/// replaced.
+#[cfg(test)]
 pub(crate) use self::rows::active_tombstone_from_records;
 pub(crate) use self::rows::content_ref_evidence_bytes;
+pub(crate) use self::rows::{
+    active_deletion_from_tombstone, ActiveDeletionAction, ActiveDeletionRecord, RecoverableDeletion,
+};
 #[cfg(test)]
 pub(crate) use self::view::InMemoryMetadataView;
 pub(crate) use self::view::MetadataView;

--- a/crates/loonfs-core/src/metadata/row_decode.rs
+++ b/crates/loonfs-core/src/metadata/row_decode.rs
@@ -6,10 +6,10 @@
 
 use crate::error::CoreError;
 use crate::metadata::{
-    CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, RevisionRecord,
-    SubtreeTombstoneRecord,
+    ActiveDeletionAction, ActiveDeletionRecord, CommitReceiptRecord, DirentryBindRecord,
+    DirentryUnbindRecord, InodeRecord, RevisionRecord, SubtreeTombstoneRecord,
 };
-use loonfs_api::wire::manifest::MetadataRow;
+use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow};
 
 /// The scanned table can only hold `expected_kind` rows; the foreign row's
 /// self-keyed row key names its actual kind and identity.
@@ -147,6 +147,38 @@ pub(crate) fn tombstone_from_manifest_row(
             action: subtree_tombstone_action(&action),
         }),
         other => Err(foreign_row("tombstone", &other)),
+    }
+}
+
+pub(crate) fn active_deletion_from_manifest_row(
+    row: MetadataRow,
+) -> Result<ActiveDeletionRecord, CoreError> {
+    match row {
+        MetadataRow::ActiveDeletion {
+            root_inode_id,
+            deleted_at_seq,
+            action,
+        } => Ok(ActiveDeletionRecord {
+            root_inode_id,
+            deleted_at_seq,
+            action: match action {
+                ActiveDeletionRowAction::Listed {
+                    deleted_at_ms,
+                    parent_inode_id,
+                    name_key,
+                    display_name,
+                } => ActiveDeletionAction::Listed {
+                    deleted_at_ms,
+                    parent_inode_id,
+                    name_key,
+                    display_name,
+                },
+                ActiveDeletionRowAction::Removed { revoked_at_seq } => {
+                    ActiveDeletionAction::Removed { revoked_at_seq }
+                }
+            },
+        }),
+        other => Err(foreign_row("active_deletion", &other)),
     }
 }
 

--- a/crates/loonfs-core/src/metadata/rows.rs
+++ b/crates/loonfs-core/src/metadata/rows.rs
@@ -3,6 +3,7 @@
 //! its append-only rows.
 
 use super::indexes::MetadataIndexes;
+use loonfs_api::wire::manifest::lookup_keys;
 use loonfs_api::{
     ChangeSeq, CommitId, ContentRef, DisplayName, InodeId, InodeKind, NameKey, RevisionNo,
 };
@@ -178,6 +179,117 @@ pub(crate) fn active_tombstone_from_records(
         .filter(|tombstone| tombstone.tombstone_seq <= visible_seq)
         .max_by_key(|tombstone| (tombstone.tombstone_seq, tombstone.tombstone_delta_index))
         .filter(|tombstone| matches!(tombstone.action, SubtreeTombstoneAction::Set))
+}
+
+/// One row of the derived `ActiveDeletions` family: the current-state view of
+/// a single deletion generation.
+///
+/// Nothing appends these — [`active_deletion_from_tombstone`] derives one from
+/// every tombstone event, so the family is a projection of the tombstone
+/// family and never a second source of truth.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ActiveDeletionRecord {
+    pub(crate) root_inode_id: InodeId,
+    /// The deletion's committed sequence. Together with `root_inode_id` this
+    /// is the handle `undelete` addresses and the trash entry renders.
+    pub(crate) deleted_at_seq: ChangeSeq,
+    pub(crate) action: ActiveDeletionAction,
+}
+
+/// What one active-deletion row says about its generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ActiveDeletionAction {
+    /// The deletion is recoverable, and the trash lists it with these
+    /// details.
+    Listed {
+        deleted_at_ms: u64,
+        parent_inode_id: Option<InodeId>,
+        name_key: Option<NameKey>,
+        display_name: Option<DisplayName>,
+    },
+    /// An undelete cancelled the deletion, so the listing skips the key.
+    Removed { revoked_at_seq: ChangeSeq },
+}
+
+/// The `ActiveDeletions` reducer, and the only mapping from a tombstone event
+/// to its derived row: a `set` adds the deletion to the listing, and a
+/// `revoke` removes the exact generation it names.
+///
+/// It reduces target-aware where the newest-event-wins rule in
+/// [`active_tombstone_from_records`] reduces target-blind. Commit validation
+/// only ever lands a revoke against the generation that was active, so the two
+/// agree on every history a writer can produce; the target is what lets a
+/// removal be derived one event at a time instead of by re-reading a root's
+/// whole history.
+pub(crate) fn active_deletion_from_tombstone(
+    tombstone: &SubtreeTombstoneRecord,
+) -> ActiveDeletionRecord {
+    match &tombstone.action {
+        SubtreeTombstoneAction::Set => ActiveDeletionRecord {
+            root_inode_id: tombstone.root_inode_id,
+            deleted_at_seq: tombstone.tombstone_seq,
+            action: ActiveDeletionAction::Listed {
+                deleted_at_ms: tombstone.deleted_at_ms,
+                parent_inode_id: tombstone.parent_inode_id,
+                name_key: tombstone.name_key.clone(),
+                display_name: tombstone.display_name.clone(),
+            },
+        },
+        SubtreeTombstoneAction::Revoke { target_seq, .. } => ActiveDeletionRecord {
+            root_inode_id: tombstone.root_inode_id,
+            deleted_at_seq: *target_seq,
+            action: ActiveDeletionAction::Removed {
+                revoked_at_seq: tombstone.tombstone_seq,
+            },
+        },
+    }
+}
+
+impl ActiveDeletionRecord {
+    /// This row's durable key, which is also its position in the trash
+    /// listing's order.
+    pub(crate) fn row_key(&self) -> String {
+        lookup_keys::active_deletion_row_key(
+            self.deleted_at_seq,
+            self.root_inode_id,
+            match &self.action {
+                ActiveDeletionAction::Listed { .. } => lookup_keys::ACTIVE_DELETION_RANK_LISTED,
+                ActiveDeletionAction::Removed { .. } => lookup_keys::ACTIVE_DELETION_RANK_REMOVED,
+            },
+        )
+    }
+
+    /// The deletion this row lists, or `None` when the row is an undelete's
+    /// removal marker.
+    pub(crate) fn into_recoverable(self) -> Option<RecoverableDeletion> {
+        match self.action {
+            ActiveDeletionAction::Listed {
+                deleted_at_ms,
+                parent_inode_id,
+                name_key,
+                display_name,
+            } => Some(RecoverableDeletion {
+                root_inode_id: self.root_inode_id,
+                deleted_at_seq: self.deleted_at_seq,
+                deleted_at_ms,
+                parent_inode_id,
+                name_key,
+                display_name,
+            }),
+            ActiveDeletionAction::Removed { .. } => None,
+        }
+    }
+}
+
+/// One recoverable deletion as the trash listing renders it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecoverableDeletion {
+    pub(crate) root_inode_id: InodeId,
+    pub(crate) deleted_at_seq: ChangeSeq,
+    pub(crate) deleted_at_ms: u64,
+    pub(crate) parent_inode_id: Option<InodeId>,
+    pub(crate) name_key: Option<NameKey>,
+    pub(crate) display_name: Option<DisplayName>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -9,8 +9,9 @@ use super::visibility::{self, MetadataVisibilityReads};
 use crate::checkpoint::VerifiedMetadataTables;
 use crate::error::CoreError;
 use crate::metadata::{
-    unbind_matches_binding, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
-    InodeRecord, MetadataState, ResolvedVisiblePath, RevisionRecord, SubtreeTombstoneRecord,
+    active_deletion_from_tombstone, unbind_matches_binding, ActiveDeletionRecord,
+    CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord, InodeRecord, MetadataState,
+    RecoverableDeletion, ResolvedVisiblePath, RevisionRecord, SubtreeTombstoneRecord,
 };
 #[cfg(test)]
 use async_trait::async_trait;
@@ -19,13 +20,50 @@ use bytes::Bytes;
 #[cfg(test)]
 use futures::stream::{self, BoxStream};
 use loonfs_api::wire::control::HeadState;
+use loonfs_api::wire::manifest::lookup_keys;
+use loonfs_api::wire::sst_blocks::string_prefix_upper_bound;
 use loonfs_api::{AbsolutePath, ChangeSeq, CommitId, InodeId, InodeKind, NameKey, RevisionNo};
 use loonfs_objectstore::ObjectStore;
 #[cfg(test)]
 use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 pub(super) const DIRECTORY_PAGE_RAW_SCAN_LIMIT: usize = 64;
+
+/// Rows one trash page fetches per manifest round-trip. A page's entries are
+/// listed rows; undelete markers share the range until reorganization folds
+/// each pair away, so the raw scan runs a little ahead of the page.
+const ACTIVE_DELETION_RAW_SCAN_LIMIT: usize = 64;
+
+/// The manifest half of the active-deletion merge: a key-ordered cursor that
+/// refills from range scans and reports when the range is spent.
+struct ActiveDeletionScan {
+    lower_bound: String,
+    exhausted: bool,
+    buffered: VecDeque<(String, ActiveDeletionRecord)>,
+}
+
+impl ActiveDeletionScan {
+    fn new(lower_bound: String, exhausted: bool) -> Self {
+        Self {
+            lower_bound,
+            exhausted,
+            buffered: VecDeque::new(),
+        }
+    }
+
+    /// Takes one fetched page. A short page is the end of the range; a full
+    /// one leaves the cursor just past its last row.
+    fn absorb(&mut self, page: Vec<(String, ActiveDeletionRecord)>, requested: usize) {
+        if page.len() < requested {
+            self.exhausted = true;
+        } else if let Some((last_row_key, _)) = page.last() {
+            self.lower_bound = format!("{last_row_key}\0");
+        }
+        self.buffered.extend(page);
+    }
+}
 
 #[derive(Clone, Copy)]
 pub(crate) struct MetadataSnapshot {
@@ -711,30 +749,92 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         revisions
     }
 
-    /// Every tombstone event in the namespace, merged across manifest
-    /// tables and row states. Uncached: the trash listing is a cold read
-    /// over a family that per-root probes never enumerate.
-    pub(super) async fn all_tombstones(
+    /// One page of the namespace's recoverable deletions, oldest deletion
+    /// first, resuming strictly after `start_after`.
+    ///
+    /// Manifest rows merge with the rows the WAL tail derives, so a deletion
+    /// committed seconds ago lists like a fresh file appears in `ls`. Both
+    /// sides arrive in row-key order and a removal marker sorts ahead of the
+    /// row it removes, so one ascending walk decides the page: a marker hides
+    /// the generation whose key it repeats, and every other listed row is an
+    /// entry. Reads stop as soon as `limit` entries are in hand.
+    pub(super) async fn active_deletions_page(
         &self,
-    ) -> Result<SharedRows<SubtreeTombstoneRecord>, CoreError> {
-        let mut durable = if let Some(tables) = self.manifest_tables() {
-            manifest_index::all_subtree_tombstones(tables).await?
-        } else {
-            Vec::new()
+        start_after: Option<(ChangeSeq, InodeId)>,
+        limit: usize,
+    ) -> Result<Vec<RecoverableDeletion>, CoreError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let visible_seq = self.visible_seq();
+        let lower_bound = match start_after {
+            Some((deleted_at_seq, root_inode_id)) => {
+                lookup_keys::active_deletion_key_after(deleted_at_seq, root_inode_id)
+            }
+            None => lookup_keys::ACTIVE_DELETION_ROW_PREFIX.to_owned(),
         };
-        durable.extend(
-            self.durable_row_states()
-                .flat_map(|state| state.subtree_tombstones().iter().cloned()),
-        );
-        let overlay = self
-            .overlay_state()
-            .into_iter()
-            .flat_map(|state| state.subtree_tombstones().iter().cloned())
+        let upper_bound = string_prefix_upper_bound(lookup_keys::ACTIVE_DELETION_ROW_PREFIX);
+
+        let mut tail: Vec<(String, ActiveDeletionRecord)> = self
+            .row_states()
+            .flat_map(|state| state.subtree_tombstones())
+            .filter(|tombstone| tombstone.tombstone_seq <= visible_seq)
+            .map(active_deletion_from_tombstone)
+            .map(|record| (record.row_key(), record))
+            .filter(|(row_key, _)| row_key.as_str() >= lower_bound.as_str())
             .collect();
-        Ok(SharedRows {
-            durable: Arc::new(durable),
-            overlay,
-        })
+        tail.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+        let mut durable = ActiveDeletionScan::new(lower_bound, self.manifest_tables().is_none());
+        let mut tail_index = 0usize;
+        let mut entries = Vec::with_capacity(limit);
+        let mut removed_generation: Option<(ChangeSeq, InodeId)> = None;
+        let mut last_row_key: Option<String> = None;
+        while entries.len() < limit {
+            if durable.buffered.is_empty() && !durable.exhausted {
+                let raw_limit = limit.max(ACTIVE_DELETION_RAW_SCAN_LIMIT);
+                let tables = self
+                    .manifest_tables()
+                    .expect("a view without manifest tables starts its scan exhausted");
+                let page = manifest_index::active_deletions_page(
+                    tables,
+                    &durable.lower_bound,
+                    upper_bound.as_deref(),
+                    raw_limit,
+                )
+                .await?;
+                durable.absorb(page, raw_limit);
+                continue;
+            }
+            let take_tail = match (durable.buffered.front(), tail.get(tail_index)) {
+                (Some((durable_key, _)), Some((tail_key, _))) => tail_key <= durable_key,
+                (None, Some(_)) => true,
+                (Some(_), None) => false,
+                (None, None) => break,
+            };
+            let (row_key, record) = if take_tail {
+                tail_index += 1;
+                tail[tail_index - 1].clone()
+            } else {
+                durable
+                    .buffered
+                    .pop_front()
+                    .expect("a non-empty buffer yields a row")
+            };
+            // A row present in both the manifest and the replayed tail is one
+            // deletion, not two.
+            if last_row_key.as_deref() == Some(row_key.as_str()) {
+                continue;
+            }
+            last_row_key = Some(row_key);
+            let generation = (record.deleted_at_seq, record.root_inode_id);
+            match record.into_recoverable() {
+                None => removed_generation = Some(generation),
+                Some(deletion) if removed_generation != Some(generation) => entries.push(deletion),
+                Some(_) => {}
+            }
+        }
+        Ok(entries)
     }
 
     pub(super) async fn tombstones_for_root(

--- a/crates/loonfs-core/src/metadata/view_session.rs
+++ b/crates/loonfs-core/src/metadata/view_session.rs
@@ -13,12 +13,12 @@ use super::manifest_index;
 use super::view::DIRECTORY_PAGE_RAW_SCAN_LIMIT;
 use super::visibility::{self, MetadataVisibilityReads};
 use super::{
-    DirentryBindRecord, InodeRecord, MetadataView, ResolvedVisiblePath, RevisionRecord,
-    SubtreeTombstoneRecord,
+    DirentryBindRecord, InodeRecord, MetadataView, RecoverableDeletion, ResolvedVisiblePath,
+    RevisionRecord, SubtreeTombstoneRecord,
 };
 use crate::error::CoreError;
 use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
-use loonfs_api::{AbsolutePath, InodeId, InodeKind, NameKey, ROOT_INODE_ID};
+use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, InodeKind, NameKey, ROOT_INODE_ID};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -733,16 +733,15 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
         Ok(tombstone)
     }
 
-    /// Every tombstone event in the namespace, durable and overlay merged.
-    /// Uncached: one call serves one trash listing page request.
-    pub(crate) async fn all_tombstone_records(
+    /// One page of the namespace's recoverable deletions, oldest deletion
+    /// first. Uncached: one call serves one trash listing page request.
+    pub(crate) async fn active_deletions_page(
         &mut self,
-    ) -> Result<Vec<SubtreeTombstoneRecord>, CoreError> {
-        self.counters.scan_prefix_calls = self.counters.scan_prefix_calls.saturating_add(1);
-        let rows = self.base.all_tombstones().await?;
-        let mut merged: Vec<SubtreeTombstoneRecord> = rows.durable.as_ref().clone();
-        merged.extend(rows.overlay.iter().cloned());
-        Ok(merged)
+        start_after: Option<(ChangeSeq, InodeId)>,
+        limit: usize,
+    ) -> Result<Vec<RecoverableDeletion>, CoreError> {
+        self.counters.scan_range_page_calls = self.counters.scan_range_page_calls.saturating_add(1);
+        self.base.active_deletions_page(start_after, limit).await
     }
 
     pub(crate) async fn active_subtree_tombstone(

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -274,11 +274,15 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .await
     }
 
-    /// One page of the namespace's recoverable deletions: active subtree
-    /// tombstones in ascending root-inode order, reduced newest-event-wins
-    /// per root through the same shared helper every visibility read uses.
-    /// The scan is namespace-wide over the immortal tombstone family, so a
-    /// deletion stays listed however far the replay floor advances.
+    /// One page of the namespace's recoverable deletions, oldest deletion
+    /// first, as one bounded range scan over the derived active-deletion
+    /// family.
+    ///
+    /// The materializer keeps that family in step with the tombstone family —
+    /// a delete adds the row, an undelete removes it — so the page reads only
+    /// the deletions it returns, never the namespace's whole deletion
+    /// history. Rows are never dropped at the retention floor, so a deletion
+    /// stays listed and recoverable however far the floor advances.
     pub(crate) async fn list_trash_page(
         &self,
         request: PageRequest<TrashPageCursor>,
@@ -293,60 +297,42 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 .into());
             }
         }
-        let records = self
-            .metadata_view()
-            .session()
-            .all_tombstone_records()
-            .await?;
-        let mut per_root: std::collections::BTreeMap<InodeId, Vec<_>> =
-            std::collections::BTreeMap::new();
-        for record in records {
-            per_root
-                .entry(record.root_inode_id)
-                .or_default()
-                .push(record);
-        }
         let start_after = request
             .cursor
             .as_ref()
-            .map(|cursor| cursor.last_root_inode_id);
-        let mut entries = Vec::new();
-        for (root_inode_id, records) in per_root {
-            if start_after.is_some_and(|after| root_inode_id <= after) {
-                continue;
-            }
-            let Some(active) =
-                crate::metadata::active_tombstone_from_records(records, self.head.seq)
-            else {
-                continue;
-            };
-            entries.push(TrashEntry {
-                root_inode_id,
-                deleted_at_seq: active.tombstone_seq,
-                deleted_at_ms: active.deleted_at_ms,
-                parent_inode_id: active.parent_inode_id,
-                name_key: active.name_key,
-                display_name: active.display_name,
-            });
-            if entries.len() > request.limit.as_usize() {
-                break;
-            }
-        }
-        let has_more = entries.len() > request.limit.as_usize();
+            .map(|cursor| (cursor.last_deleted_at_seq, cursor.last_root_inode_id));
+        let mut deletions = self
+            .metadata_view()
+            .session()
+            .active_deletions_page(start_after, request.limit.limit_plus_one())
+            .await?;
+        let has_more = deletions.len() > request.limit.as_usize();
         if has_more {
-            entries.truncate(request.limit.as_usize());
+            deletions.truncate(request.limit.as_usize());
         }
         let next_cursor = if has_more {
+            let last = deletions
+                .last()
+                .expect("non-zero page limit with more entries must return an item");
             Some(TrashPageCursor {
                 head_seq: self.head.seq,
-                last_root_inode_id: entries
-                    .last()
-                    .expect("non-zero page limit with more entries must return an item")
-                    .root_inode_id,
+                last_deleted_at_seq: last.deleted_at_seq,
+                last_root_inode_id: last.root_inode_id,
             })
         } else {
             None
         };
+        let entries = deletions
+            .into_iter()
+            .map(|deletion| TrashEntry {
+                root_inode_id: deletion.root_inode_id,
+                deleted_at_seq: deletion.deleted_at_seq,
+                deleted_at_ms: deletion.deleted_at_ms,
+                parent_inode_id: deletion.parent_inode_id,
+                name_key: deletion.name_key,
+                display_name: deletion.display_name,
+            })
+            .collect();
         Ok(Page {
             items: entries,
             next_cursor,

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -213,7 +213,7 @@ pub(super) async fn get_file_bytes(
         path = "/v0/namespaces/{namespace}/filesystem/trash",
         tag = "filesystem",
         summary = "List recoverable deletions",
-        description = "Returns the namespace's active deletions in ascending deleted-root inode order. Tombstone rows are retained forever, so entries never age out; each carries the inode id and deletion sequence undelete needs, plus the deleted name when the delete recorded one.",
+        description = "Returns the namespace's recoverable deletions, oldest deletion first. Entries never age out at the retention floor; each carries the inode id and deletion sequence undelete needs, plus the deleted name when the delete recorded one.",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
             ("limit" = Option<String>, Query, description = "Maximum page size"),

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -527,6 +527,7 @@ A representative v0 binding is shown below.
 | List file revisions by path | `GET /v0/namespaces/{ns}/filesystem/revisions?path=/docs/report.txt&limit=100&cursor=...` |
 | Read file content | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt` |
 | Read prior file content by path | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt&revision_no=3` |
+| List recoverable deletions | `GET /v0/namespaces/{ns}/filesystem/trash?limit=100&cursor=...` |
 | Apply a commit | `POST /v0/namespaces/{ns}/commits` |
 | Begin or prepare upload | `POST /v0/namespaces/{ns}/uploads` |
 | Upload full staged content | `PUT /v0/namespaces/{ns}/uploads/{upload_id}/content` |
@@ -1103,14 +1104,19 @@ stays `invalid_request`.)
 
 ### 6.6 `GET /filesystem/trash`
 
-Lists the namespace's recoverable deletions: every active subtree tombstone,
-ascending by deleted root inode, paged with the standard `limit`/`cursor`
-pattern (the cursor is an ordering resume like every other). Tombstone rows
-are retained forever, so entries never age out of this listing, however far
-the retention floor advances. Each entry carries the inode id and deletion
-sequence that `undelete` requires, the deletion's wall-clock stamp, and the
-deleted binding's name when the delete recorded one; entries written before
-names were recorded still carry a complete recovery handle.
+Lists the namespace's recoverable deletions, oldest deletion first — ascending
+by `(deleted_at_seq, root_inode_id)` — paged with the standard `limit`/`cursor`
+pattern (the cursor is an ordering resume like every other). The listing is a
+range scan over the derived active-deletions family (format spec, section
+2.5), so a page costs the page rather than the namespace's deletion history.
+Those rows are current state and are never dropped at the retention floor, so
+entries never age out of this listing however far the floor advances. Each
+entry carries the inode id and deletion sequence that `undelete` requires, the
+deletion's wall-clock stamp, and the deleted binding's name when the delete
+recorded one; entries written before names were recorded still carry a
+complete recovery handle. Deletions nest: a path deleted inside an
+already-deleted subtree keeps its own entry, and recovering the outer deletion
+leaves the inner one listed.
 
 ### 6.7 `GET /filesystem/content`
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -252,11 +252,13 @@ checksum an implementation cannot recompute must fail its reads rather than
 pass them unverified.
 
 Metadata materialization tables include canonical metadata families and
-validated secondary indexes. The canonical families are `inodes`,
+validated derived families. The canonical families are `inodes`,
 `direntry-binds`, `direntry-unbinds`, `revisions`, `tombstones`, and
 `commit-receipts`. The `direntry-child-binds` family is a secondary index over
 the same direntry bind rows, keyed by child inode, and must be present and
-verified before a namespace manifest is trusted.
+verified before a namespace manifest is trusted. The `active-deletions` family
+is derived from the tombstone rows and holds current state rather than events
+(section 2.5).
 
 ETags remain opaque compare tokens. They may be used for object freshness or
 compare-and-swap, but they are not content digests unless a provider-specific
@@ -646,6 +648,19 @@ committed sequence, and validation refuses (`not_deleted`) unless that
 exact generation is the active one, so a stale recovery request can never
 cancel a later deletion. Only the root of a deletion can be undeleted —
 descendants are covered by the root's tombstone, not their own.
+
+Which deletions are recoverable *right now* is a separate question from the
+event history that decides it, and it has its own family. Materialization
+derives an `active-deletions` row from every tombstone event: a `set` adds a
+`listed` row keyed by `(deleted_at_seq, root_inode_id)` — the exact handle
+`undelete` takes — carrying the deletion's wall-clock stamp and the deleted
+binding's name, and a `revoke` adds a `removed` row repeating its target's
+key. The two rows for one deletion sort together with `removed` first, so an
+ascending scan sees a removal before the row it removes and reorganization
+drops the pair. Reading the recoverable set is therefore a range scan in
+deletion order, not a walk over every deletion the namespace ever recorded.
+Because the family is derived, the tombstone rows stay authoritative: a
+disagreement between the two is corruption of the derived family.
 
 A namespace head has exactly two recorded states: `active` (the default; an
 absent field reads as active) and terminal `deleted`. There is no
@@ -1894,6 +1909,17 @@ retained in full regardless of the floor, and a revisions listing is always
 complete. Tombstone rows — set and revoke events alike — and inode rows are
 always retained for now; reachability-based dropping for them is future
 work.
+
+The `active-deletions` family holds current state rather than history, so the
+retention floor has no say over it at all: a `listed` row is never dropped
+however far the floor advances, because a deletion stays recoverable
+indefinitely and dropping the row would silently retire it. The only rows a
+rebuild removes there are the cancelled pairs — a `removed` row and the
+`listed` row whose key it repeats, dropped together, since a deletion that was
+undeleted is not state any reader can still observe. A `removed` row can never
+outlive the row it names: the deletion commits before the undelete, runs merge
+oldest-first, and a rebuild's input is a prefix of that order, so both rows are
+always in the same merge.
 
 Invariants:
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1541,7 +1541,7 @@
           "filesystem"
         ],
         "summary": "List recoverable deletions",
-        "description": "Returns the namespace's active deletions in ascending deleted-root inode order. Tombstone rows are retained forever, so entries never age out; each carries the inode id and deletion sequence undelete needs, plus the deleted name when the delete recorded one.",
+        "description": "Returns the namespace's recoverable deletions, oldest deletion first. Entries never age out at the retention floor; each carries the inode id and deletion sequence undelete needs, plus the deleted name when the delete recorded one.",
         "operationId": "list_trash",
         "parameters": [
           {
@@ -4493,7 +4493,7 @@
             "items": {
               "$ref": "#/components/schemas/TrashEntry"
             },
-            "description": "Active deletions in ascending root-inode order."
+            "description": "Recoverable deletions, oldest deletion first."
           },
           "head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",


### PR DESCRIPTION
The trash listing was the last read whose cost grew with lifetime history. It is now one bounded range scan.

The mechanism: The materializer derives an `ActiveDeletions` row from each tombstone delta and a removal marker from each undelete — no WAL or wire vocabulary changes, the CommitReceipts derivation pattern. The trash page scans the family through the normal runs-plus-tail machinery with cursor and limit-plus-one. Reorganization folds cancelled pairs in the family's own group. The rows are current state: they never drop at the retention floor, and a test pins that a deletion far below the floor still lists and still undeletes. Recoverability is unchanged, and no expiry policy exists.

The key carries a rank tiebreaker beyond the specified `(deleted_at_seq, root_inode)`: a removal marker sorts before the row it removes inside one generation, so an ascending page can never emit an entry whose revocation sits one page later. No group-completion machinery.

Proof...
- A differential test drives randomized create/delete/undelete/re-delete histories and holds the family listing equal to the old walk (kept as a test-only reference implementation).
- A counting store measures the bound: a page of limit 4 costs 1 metadata read at 8 deletions and 1 at 32.
- The nested semantics are now pinned by test: nested deletions each keep their own entry, and an undelete revokes only its own generation.
- The unbounded whole-family scan primitive is now test-only — no production path can perform one.
