### PR TITLE
feat(objectstore): store contract probe becomes a production surface

### DIFF
--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -28,7 +28,8 @@ pub use operations::{
     FlushWalOutcome, FlushWalResponse, ForkNamespaceRequest, GcRequest, GcResponse,
     ListFileRevisionsResponse, MaintenanceStepKind, MaintenanceStepRequest,
     MaintenanceStepResponse, NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse,
-    ReorganizeStepOutcome, WalFlushStepOutcome,
+    ReorganizeStepOutcome, StoreProbeCheckOutcome, StoreProbeCheckResult, StoreProbeRequest,
+    StoreProbeResponse, WalFlushStepOutcome,
 };
 pub use reads::{
     AuthoritativeFileBytes, AuthoritativePathEntry, ListPathEntriesResponse, ListTrashResponse,

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -675,6 +675,55 @@ pub struct MaintenanceStepResponse {
     pub gc: Option<GcResponse>,
 }
 
+/// Options for one store contract probe. Empty today; a body is still sent
+/// so later options do not change the shape of the request.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StoreProbeRequest {}
+
+/// What one store contract probe observed, check by check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StoreProbeResponse {
+    /// Label the server minted for this run. It scopes the objects the run
+    /// wrote, so it identifies the run in provider logs too.
+    pub run_id: String,
+    /// Every check the run performed, in the order it performed them. A
+    /// failed check lives here rather than in an error: the probe answered
+    /// the question, and the answer is that the store is wrong.
+    pub checks: Vec<StoreProbeCheckResult>,
+}
+
+/// One named contract check and what the store did with it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StoreProbeCheckResult {
+    /// Stable check name.
+    pub name: String,
+    /// What the store did.
+    pub outcome: StoreProbeCheckOutcome,
+    /// What was expected and what happened instead. Present only on
+    /// `failed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// What one contract check concluded about the store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum StoreProbeCheckOutcome {
+    /// The store behaved as the contract requires.
+    Passed,
+    /// The store declares it cannot do this at all. Only the optional
+    /// capabilities answer this way, and it is an answer rather than a
+    /// fault.
+    Unsupported,
+    /// The store did something the contract forbids, or the operation
+    /// failed outright.
+    Failed,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -194,6 +194,13 @@ Maintenance
     returns after one pass, and --grace-window-ms protects objects younger
     than the window
 
+  loonfs admin probe-store
+    Prove the profile's object store honours the contract LoonFS depends on
+    (create-if-absent, compare-and-swap, visibility, listing, ranged reads)
+    and print one line per check; the run writes and deletes objects under a
+    scratch prefix it empties afterwards, and exits nonzero when any check
+    failed
+
   loonfs admin checkpoint --name <label> [--ttl-ms <ms>]
     Pin the namespace's current state under a named checkpoint; --ttl-ms
     expires the pin, and an omitted TTL holds it until release

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -613,6 +613,9 @@ pub(crate) enum AdminCommand {
     Step(AdminStepArgs),
     /// Run a mark-and-sweep garbage-collection pass.
     Gc(AdminGcArgs),
+    /// Prove the profile's object store honours the contract LoonFS
+    /// depends on, and report what it found check by check.
+    ProbeStore(AdminProbeStoreArgs),
     /// Enable the gram content index and wait for its backfill to reach the
     /// sequence the namespace was at when this command started.
     IndexEnable(AdminIndexEnableArgs),
@@ -762,6 +765,12 @@ pub(crate) struct AdminGcArgs {
     pub max_objects: Option<u64>,
 }
 
+#[derive(Debug, Args)]
+pub(crate) struct AdminProbeStoreArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+}
+
 #[derive(Debug, Subcommand)]
 pub(crate) enum ConfigCommand {
     /// Print the config file path.
@@ -827,6 +836,7 @@ pub(crate) enum CommandKind {
     AdminRun,
     AdminStep,
     AdminGc,
+    AdminProbeStore,
     AdminIndexEnable,
     AdminIndexDisable,
     AdminIndexStatus,
@@ -873,6 +883,7 @@ impl CommandKind {
             CommandKind::AdminRun => "admin_run",
             CommandKind::AdminStep => "admin_step",
             CommandKind::AdminGc => "admin_gc",
+            CommandKind::AdminProbeStore => "admin_probe_store",
             CommandKind::AdminIndexEnable => "admin_index_enable",
             CommandKind::AdminIndexDisable => "admin_index_disable",
             CommandKind::AdminIndexStatus => "admin_index_status",
@@ -930,6 +941,7 @@ impl Cli {
                 AdminCommand::Run(_) => CommandKind::AdminRun,
                 AdminCommand::Step(_) => CommandKind::AdminStep,
                 AdminCommand::Gc(_) => CommandKind::AdminGc,
+                AdminCommand::ProbeStore(_) => CommandKind::AdminProbeStore,
                 AdminCommand::IndexEnable(_) => CommandKind::AdminIndexEnable,
                 AdminCommand::IndexDisable(_) => CommandKind::AdminIndexDisable,
                 AdminCommand::IndexStatus(_) => CommandKind::AdminIndexStatus,

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -16,7 +16,8 @@ use loonfs::{
 use loonfs_api::{
     v0::{
         DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest, GrepGcResponse,
-        GrepIndexLifecycle, GrepIndexStatusResponse,
+        GrepIndexLifecycle, GrepIndexStatusResponse, StoreProbeCheckOutcome, StoreProbeCheckResult,
+        StoreProbeResponse,
     },
     AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
     CreateCheckpointResponse, DestinationBehavior, EffectiveLimit, ErrorCode, GrepRequest,
@@ -29,6 +30,7 @@ use loonfs_grep::{
     GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepIndexSnapshot,
     GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads, GREP_INDEX_JOB,
 };
+use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, StoreProbeReport};
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::sync::Arc;
 
@@ -758,6 +760,15 @@ impl EmbeddedBackend {
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
+    /// Proves this profile's object store honours the contract LoonFS
+    /// depends on. Store-scoped: it names no namespace and reads none, so
+    /// no namespace error scoping applies.
+    pub(super) async fn probe_store(&self) -> StoreProbeResponse {
+        let run_id = loonfs_api::generated_id("probe");
+        let report = run_store_contract_probe(self.writer.object_store().as_ref(), &run_id).await;
+        store_probe_response(report)
+    }
+
     pub(super) async fn list_changes(
         &self,
         namespace_id: &NamespaceId,
@@ -831,6 +842,32 @@ fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendE
     PaginationPolicy::default()
         .resolve_limit(limit)
         .map_err(|error| BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
+}
+
+/// Renders a probe report as the wire shape both backends answer with, so
+/// an embedded run and a remote one print the same thing.
+fn store_probe_response(report: StoreProbeReport) -> StoreProbeResponse {
+    StoreProbeResponse {
+        run_id: report.run_id,
+        checks: report
+            .checks
+            .into_iter()
+            .map(|check| {
+                let (outcome, message) = match check.outcome {
+                    StoreProbeOutcome::Passed => (StoreProbeCheckOutcome::Passed, None),
+                    StoreProbeOutcome::Unsupported => (StoreProbeCheckOutcome::Unsupported, None),
+                    StoreProbeOutcome::Failed { message } => {
+                        (StoreProbeCheckOutcome::Failed, Some(message))
+                    }
+                };
+                StoreProbeCheckResult {
+                    name: check.name.to_owned(),
+                    outcome,
+                    message,
+                }
+            })
+            .collect(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -22,7 +22,8 @@ use crate::resolve::ResolvedTarget;
 use loonfs_api::{
     v0::{
         ChangesResponse, DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest,
-        GrepGcResponse, GrepIndexLifecycle, GrepIndexStatusResponse,
+        GrepGcResponse, GrepIndexLifecycle, GrepIndexStatusResponse, StoreProbeRequest,
+        StoreProbeResponse,
     },
     AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
     CreateCheckpointResponse, DeleteNamespaceResponse, DestinationBehavior, GrepRequest,
@@ -616,6 +617,20 @@ impl ResolvedTarget {
                 .client
                 .maintenance_step(namespace_id, &request)
                 .await?),
+        }
+    }
+
+    /// Proves the profile's object store honours the object-store contract
+    /// LoonFS depends on, and reports what it found check by check.
+    ///
+    /// Store-scoped: it names no namespace. An embedded profile probes the
+    /// store it is configured with; a remote profile asks its server to
+    /// probe the store that server is configured with, which is the store
+    /// the answer is about either way.
+    pub(crate) async fn probe_store(&self) -> Result<StoreProbeResponse, BackendError> {
+        match self {
+            Self::Embedded(target) => Ok(target.backend.probe_store().await),
+            Self::Remote(target) => Ok(target.client.probe_store(&StoreProbeRequest {}).await?),
         }
     }
 

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -5,8 +5,8 @@ use super::context::{fail, fail_for, resolve_command_context};
 use super::output::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
 use crate::args::{
     AdminCheckpointArgs, AdminCheckpointReleaseArgs, AdminCommand, AdminGcArgs,
-    AdminIndexEnableArgs, AdminIndexGcArgs, AdminNamespaceArgs, AdminRunArgs, AdminStepArgs,
-    ChangesArgs, CommandKind, MaintenanceJobArg,
+    AdminIndexEnableArgs, AdminIndexGcArgs, AdminNamespaceArgs, AdminProbeStoreArgs, AdminRunArgs,
+    AdminStepArgs, ChangesArgs, CommandKind, MaintenanceJobArg,
 };
 use crate::backend::{MaintenanceKeyProgress, StepBudget};
 use crate::resolve::{parse_namespace_id, resolve_target_profile};
@@ -34,6 +34,7 @@ pub(crate) async fn run_admin_command(
         AdminCommand::Run(args) => run_admin_run(kind, args).await,
         AdminCommand::Step(args) => run_admin_step(kind, args).await,
         AdminCommand::Gc(args) => run_admin_gc(kind, args).await,
+        AdminCommand::ProbeStore(args) => run_admin_probe_store(kind, args).await,
         AdminCommand::IndexEnable(args) => run_admin_index_enable(kind, args).await,
         AdminCommand::IndexDisable(args) => run_admin_index_disable(kind, args).await,
         AdminCommand::IndexStatus(args) => run_admin_index_status(kind, args).await,
@@ -300,6 +301,32 @@ async fn run_admin_run(
             steps,
             budget_exhausted,
         },
+    })
+}
+
+/// Proves the profile's object store honours the contract LoonFS depends
+/// on. Store-scoped like `admin run`: it names no namespace, because the
+/// store is the subject.
+async fn run_admin_probe_store(
+    kind: CommandKind,
+    args: AdminProbeStoreArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let explicit_profile = args.profile.profile.as_deref();
+    let resolved = resolve_target_profile(explicit_profile, args.profile.no_retry)
+        .await
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    let response = resolved
+        .target
+        .probe_store()
+        .await
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(resolved.profile_name),
+        mode: Some(mode),
+        data: CommandData::StoreProbed(response),
     })
 }
 

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -6,7 +6,7 @@ use crate::error::CliError;
 use crate::profiles::ProfileSummary;
 use loonfs_api::v0::{
     ChangesResponse, DisableGrepIndexResponse, GrepGcResponse, GrepIndexLifecycle,
-    GrepIndexStatusResponse,
+    GrepIndexStatusResponse, StoreProbeCheckOutcome, StoreProbeResponse,
 };
 use loonfs_api::{
     AuthoritativePathEntry, ChangeSeq, CommitId, CreateCheckpointResponse, DeleteNamespaceResponse,
@@ -115,6 +115,9 @@ pub(crate) enum CommandData {
         /// True when a budget stopped the drain before every key settled.
         budget_exhausted: bool,
     },
+    /// What one store contract probe found. Failed checks are data, not an
+    /// error: the probe ran and the store is what it is.
+    StoreProbed(StoreProbeResponse),
     GrepIndexDisabled(DisableGrepIndexResponse),
     GrepIndexStatus(GrepIndexStatusResponse),
     GrepIndexCollected(GrepGcResponse),
@@ -212,6 +215,13 @@ impl CommandData {
             | CommandData::MaintenanceHosted {
                 budget_exhausted, ..
             } => *budget_exhausted,
+            // A probe that found a broken store prints every check's verdict
+            // and still exits nonzero, because the store it was asked about
+            // cannot be trusted.
+            CommandData::StoreProbed(response) => response
+                .checks
+                .iter()
+                .any(|check| check.outcome == StoreProbeCheckOutcome::Failed),
             _ => false,
         }
     }

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -3,10 +3,23 @@
 use crate::args::CommandKind;
 use crate::commands::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
 use crate::error::CliError;
-use loonfs_api::v0::GrepIndexLifecycle;
+use loonfs_api::v0::{GrepIndexLifecycle, StoreProbeCheckOutcome, StoreProbeCheckResult};
 use loonfs_api::{GcResponse, NamespaceId, ReorganizeStepOutcome, WalFlushStepOutcome};
 use serde::Serialize;
 use std::io::{self, Write};
+
+/// One line per contract check: its verdict, and what went wrong when the
+/// verdict is that something did.
+fn store_probe_check_line(check: &StoreProbeCheckResult) -> String {
+    match check.outcome {
+        StoreProbeCheckOutcome::Passed => format!("{}: passed", check.name),
+        StoreProbeCheckOutcome::Unsupported => format!("{}: unsupported", check.name),
+        StoreProbeCheckOutcome::Failed => match &check.message {
+            Some(message) => format!("{}: failed: {message}", check.name),
+            None => format!("{}: failed", check.name),
+        },
+    }
+}
 
 /// One phrase for where the index is, in the terms that phase actually has.
 fn grep_index_state_summary(state: &GrepIndexLifecycle) -> String {
@@ -517,6 +530,29 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                 });
                 lines.join("\n")
             }
+        }
+        CommandData::StoreProbed(response) => {
+            let failed = response
+                .checks
+                .iter()
+                .filter(|check| check.outcome == StoreProbeCheckOutcome::Failed)
+                .count();
+            let mut lines: Vec<String> =
+                response.checks.iter().map(store_probe_check_line).collect();
+            lines.push(if failed == 0 {
+                format!(
+                    "store probe {}: {} checks passed",
+                    response.run_id,
+                    response.checks.len()
+                )
+            } else {
+                format!(
+                    "store probe {}: {failed} of {} checks failed",
+                    response.run_id,
+                    response.checks.len()
+                )
+            });
+            lines.join("\n")
         }
         CommandData::GrepIndexDisabled(response) => {
             if response.was_enabled {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -2581,6 +2581,52 @@ fn admin_run_takes_a_poll_interval_with_a_floor_that_a_drain_ignores() {
     );
 }
 
+/// The store probe is store-scoped: it needs no namespace, prints one line
+/// per check, and exits zero only because every check passed.
+#[test]
+fn admin_probe_store_reports_every_check_against_the_profile_store() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+
+    let probe = harness.run(&["admin", "probe-store"]);
+    assert_success(&probe);
+    let text = stdout_string(&probe);
+    for check in [
+        "create_if_absent_enforced",
+        "compare_and_swap_rejects_stale",
+        "compare_and_swap_missing_object_rejected",
+        "overwrite_updates_head_and_body",
+        "get_with_metadata_round_trip",
+        "visibility_after_write",
+        "visibility_after_delete",
+        "delete_missing_idempotent",
+        "sorted_listing",
+        "range_reads",
+        "multipart_round_trip",
+        "stored_checksum_readback",
+        "cleanup_leaves_prefix_empty",
+    ] {
+        assert!(text.contains(check), "missing `{check}` in: {text}");
+    }
+    assert!(text.contains("13 checks passed"), "{text}");
+
+    let json = harness.run(&["--json", "admin", "probe-store"]);
+    assert_success(&json);
+    let data = json_data(&json);
+    assert_eq!(data["kind"], "store_probed");
+    assert_eq!(data["checks"].as_array().expect("checks array").len(), 13);
+    assert_eq!(data["checks"][0]["name"], "create_if_absent_enforced");
+    assert_eq!(data["checks"][0]["outcome"], "passed");
+
+    // The probe cleans up after itself, so the store carries no probe keys.
+    let probe_runs = harness.store_root("default").join("probe-runs");
+    assert!(
+        !probe_runs.exists() || fs::read_dir(&probe_runs).is_ok_and(|mut dir| dir.next().is_none()),
+        "the probe left objects behind at {}",
+        probe_runs.display()
+    );
+}
+
 /// A remote profile's server hosts its own runner. Stepping one from here
 /// would be a second scheduler over the same namespaces, so the command
 /// refuses instead of pretending it can.
@@ -2672,6 +2718,7 @@ fn every_advertised_capability_maps_to_a_cli_command_path() {
                 &["admin", "run"],
                 &["admin", "step"],
                 &["admin", "gc"],
+                &["admin", "probe-store"],
                 &["admin", "index-enable"],
                 &["admin", "index-disable"],
                 &["admin", "index-status"],
@@ -2942,12 +2989,25 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
             "namespace `missing` does not exist"
         );
 
+        // The store probe is store-scoped, so it is the one admin command
+        // that names no namespace in either mode; both modes still answer
+        // with the same report shape.
+        let probe = harness.run(&["--json", "admin", "probe-store", "--profile", profile]);
+        assert_success(&probe);
+        let probe_data = json_data(&probe);
+        assert_eq!(probe_data["kind"], "store_probed");
+        assert_eq!(
+            probe_data["checks"].as_array().expect("checks array").len(),
+            13
+        );
+
         shapes_by_mode.push((
             sorted_object_keys(&changes_data),
             sorted_object_keys(&checkpoint_data),
             sorted_object_keys(&retention_data),
             sorted_object_keys(&step_data),
             sorted_object_keys(&gc_data),
+            sorted_object_keys(&probe_data),
         ));
     }
 

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -26,8 +26,8 @@ use loonfs_api::{
         DirectMultipartUploadOptions, DirectPutContentClaim, DisableGrepIndexResponse,
         EnableGrepIndexResponse, FilesystemChange, GrepGcRequest, GrepGcResponse,
         GrepIndexStatusResponse, ObjectTransferAccess, SignUploadPartsRequest,
-        SignUploadPartsResponse, SignedUploadPart, UploadContentResponse, UploadMode,
-        UploadPartChecksumClaim, ValidatedContentToken,
+        SignUploadPartsResponse, SignedUploadPart, StoreProbeRequest, StoreProbeResponse,
+        UploadContentResponse, UploadMode, UploadPartChecksumClaim, ValidatedContentToken,
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId,
     ChecksumAlgorithm, CommitId, CommitRequest, ContentRef, Crc64Nvme, CreateCheckpointRequest,
@@ -839,6 +839,18 @@ impl Client {
             "{}/v0/admin/namespaces/{namespace_id}/maintenance/step",
             self.base_url
         );
+        self.request_json(self.post(&url), Some(request)).await
+    }
+
+    /// Proves the server's backing store honours the object-store contract
+    /// LoonFS depends on (admin plane).
+    ///
+    /// The probe writes and deletes objects under a scratch prefix, so it
+    /// runs only when asked. A store that fails a check answers with that
+    /// check reported failed rather than with an error: the probe ran, and
+    /// the answer is that the store is wrong.
+    pub async fn probe_store(&self, request: &StoreProbeRequest) -> Result<StoreProbeResponse> {
+        let url = format!("{}/v0/admin/store/probe", self.base_url);
         self.request_json(self.post(&url), Some(request)).await
     }
 

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -5,8 +5,9 @@
 //! listing — and this crate owns that boundary: the [`ObjectStore`] trait,
 //! provider adapters for S3, Cloudflare R2, Google Cloud Storage, Azure Blob
 //! Storage, and the local filesystem, the durable key layout in [`keys`] and
-//! [`layout`], and the conformance suite that keeps provider assumptions
-//! honest.
+//! [`layout`], and the contract probe in [`probe`] that proves a configured
+//! store honours that contract — the same checks the conformance suite runs
+//! against real providers.
 
 #![warn(missing_docs)]
 
@@ -21,6 +22,7 @@ pub mod local_fs_store;
 pub mod metrics;
 pub mod object_store;
 pub mod presign;
+pub mod probe;
 mod provider_object_store;
 mod retry;
 pub mod s3_compatible;
@@ -39,6 +41,7 @@ pub use object_store::{
     ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
     ObjectStore, ObjectStoreError, PutMode, Result, SharedObjectStore, StoredObjectChecksum,
 };
+pub use probe::{run_store_contract_probe, StoreProbeCheck, StoreProbeOutcome, StoreProbeReport};
 pub use provider_object_store::{
     ProviderObjectStore, ProviderObjectStoreConfig, PROVIDER_ATTEMPT_TIMEOUT,
     PROVIDER_CONNECT_TIMEOUT, PROVIDER_MULTIPART_PART_BYTES, PROVIDER_MULTIPART_PART_WINDOW,

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -1,0 +1,963 @@
+//! On-demand proof that a configured store honours the object-store
+//! contract LoonFS depends on.
+//!
+//! Fencing, publication, and upload completion are all decided by provider
+//! preconditions: a gateway that accepts a create-if-absent write over an
+//! existing object, or a compare-and-swap against a stale token, corrupts
+//! data rather than failing. Nothing about a store's configuration proves
+//! it honours those preconditions, so an operator asks — and this module is
+//! the question. It is never asked implicitly: a probe writes and deletes
+//! objects, so only an explicit operator decision runs one.
+//!
+//! Every check reports its own outcome and no check can end the run, so one
+//! probe answers the whole question rather than the first thing that went
+//! wrong. A check that fails names what it expected; a store that lacks an
+//! optional capability answers [`StoreProbeOutcome::Unsupported`], which is
+//! an answer and not a failure.
+//!
+//! Every object a probe writes lives under `probe-runs/{run_id}/`, which is
+//! not a durable object family: garbage collection enumerates the durable
+//! families by name and never sees this prefix, and nothing else reads it.
+//! The final check deletes the run's objects and proves the prefix empty, so
+//! a probe that completes leaves nothing behind. A probe that dies partway
+//! leaves orphans under a prefix nothing consults — harmless, and removable
+//! by prefix.
+//!
+//! This module does not decide whether a store may serve presigned direct
+//! uploads. That trust comes from [`crate::StoreConfig::direct_put_is_proven`],
+//! because a probe exercises the store's own request path and never a
+//! presigned capability handed to a client.
+
+use crate::object_store::Result as StoreResult;
+use crate::{
+    ByteRange, ObjectStore, ObjectStoreError, PROVIDER_MULTIPART_PART_BYTES,
+    PROVIDER_MULTIPART_THRESHOLD_BYTES,
+};
+use bytes::Bytes;
+use futures::StreamExt;
+use loonfs_api::{ChecksumAlgorithm, StorageChecksum};
+
+/// Prefix owning every object a probe run writes.
+const PROBE_RUN_PREFIX: &str = "probe-runs";
+
+/// What one probe run observed, check by check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoreProbeReport {
+    /// Caller-minted label scoping this run's objects and naming it in logs.
+    pub run_id: String,
+    /// Every check the run performed, in the order it performed them.
+    pub checks: Vec<StoreProbeCheck>,
+}
+
+impl StoreProbeReport {
+    /// Whether the store answered every check acceptably.
+    ///
+    /// An [`StoreProbeOutcome::Unsupported`] answer counts as acceptable:
+    /// the optional capabilities are declared missing rather than found
+    /// broken, and a deployment that does not need them is unaffected.
+    pub fn all_passed(&self) -> bool {
+        self.checks.iter().all(|check| {
+            matches!(
+                check.outcome,
+                StoreProbeOutcome::Passed | StoreProbeOutcome::Unsupported
+            )
+        })
+    }
+}
+
+/// One named contract check and what the store did with it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoreProbeCheck {
+    /// Stable check name. Names are part of the report's contract: callers
+    /// and operators match on them, so they are renamed deliberately.
+    pub name: &'static str,
+    /// What the store did.
+    pub outcome: StoreProbeOutcome,
+}
+
+/// What one check concluded about the store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreProbeOutcome {
+    /// The store behaved as the contract requires.
+    Passed,
+    /// The store declares it cannot do this at all. Only the optional
+    /// capabilities — client-driven multipart and stored-checksum readback
+    /// — can answer this way, and a deployment that offers neither
+    /// `direct_put` nor multipart uploads is unaffected by it.
+    Unsupported,
+    /// The store did something the contract forbids, or the operation
+    /// failed outright. Either way the store is not trustworthy for the
+    /// behaviour this check names.
+    Failed {
+        /// What was expected and what happened instead. Provider text
+        /// arrives already sanitized, so no credential material reaches
+        /// this message.
+        message: String,
+    },
+}
+
+/// Runs every contract check against `store`, scoping the run's objects
+/// under `run_id`.
+///
+/// This never fails as a whole: a check that cannot complete records its
+/// own failure and the remaining checks still run, because an operator
+/// asking "is this store trustworthy?" is owed the full answer rather than
+/// the first symptom. `run_id` scopes the run's keys, so concurrent probes
+/// against one store do not collide; callers mint it.
+pub async fn run_store_contract_probe(store: &dyn ObjectStore, run_id: &str) -> StoreProbeReport {
+    let run = ProbeRun {
+        prefix: format!("{PROBE_RUN_PREFIX}/{run_id}"),
+    };
+    let checks = vec![
+        check(
+            "create_if_absent_enforced",
+            create_if_absent_enforced(store, &run).await,
+        ),
+        check(
+            "compare_and_swap_rejects_stale",
+            compare_and_swap_rejects_stale(store, &run).await,
+        ),
+        check(
+            "compare_and_swap_missing_object_rejected",
+            compare_and_swap_missing_object_rejected(store, &run).await,
+        ),
+        check(
+            "overwrite_updates_head_and_body",
+            overwrite_updates_head_and_body(store, &run).await,
+        ),
+        check(
+            "get_with_metadata_round_trip",
+            get_with_metadata_round_trip(store, &run).await,
+        ),
+        check(
+            "visibility_after_write",
+            visibility_after_write(store, &run).await,
+        ),
+        check(
+            "visibility_after_delete",
+            visibility_after_delete(store, &run).await,
+        ),
+        check(
+            "delete_missing_idempotent",
+            delete_missing_idempotent(store, &run).await,
+        ),
+        check("sorted_listing", sorted_listing(store, &run).await),
+        check("range_reads", range_reads(store, &run).await),
+        check(
+            "multipart_round_trip",
+            multipart_round_trip(store, &run).await,
+        ),
+        check(
+            "stored_checksum_readback",
+            stored_checksum_readback(store, &run).await,
+        ),
+        // Last, and last for a reason: it deletes what every check above
+        // wrote and then proves the prefix empty, so cleanup is itself
+        // under test rather than a hope.
+        check(
+            "cleanup_leaves_prefix_empty",
+            cleanup_leaves_prefix_empty(store, &run).await,
+        ),
+    ];
+
+    StoreProbeReport {
+        run_id: run_id.to_owned(),
+        checks,
+    }
+}
+
+/// One run's key scope.
+struct ProbeRun {
+    prefix: String,
+}
+
+impl ProbeRun {
+    /// A key inside this run's scope.
+    fn key(&self, name: &str) -> String {
+        format!("{}/{name}", self.prefix)
+    }
+
+    /// A listing prefix inside this run's scope.
+    fn listing(&self, name: &str) -> String {
+        format!("{}/{name}/", self.prefix)
+    }
+}
+
+/// What a check concluded, before it becomes a reportable outcome.
+enum CheckFailure {
+    /// The store declares the capability absent.
+    Unsupported,
+    /// The store is wrong, or the operation could not complete.
+    Failed(String),
+}
+
+type CheckResult = std::result::Result<(), CheckFailure>;
+
+fn check(name: &'static str, result: CheckResult) -> StoreProbeCheck {
+    let outcome = match result {
+        Ok(()) => StoreProbeOutcome::Passed,
+        Err(CheckFailure::Unsupported) => StoreProbeOutcome::Unsupported,
+        Err(CheckFailure::Failed(message)) => StoreProbeOutcome::Failed { message },
+    };
+    StoreProbeCheck { name, outcome }
+}
+
+/// Turns a store failure into a reportable one, naming the operation that
+/// failed and the object it was about.
+fn failed(operation: &str, error: &ObjectStoreError) -> CheckFailure {
+    match error.object_key() {
+        Some(object_key) => CheckFailure::Failed(format!(
+            "{operation} failed for `{object_key}`: {}",
+            error.message()
+        )),
+        None => CheckFailure::Failed(format!("{operation} failed: {}", error.message())),
+    }
+}
+
+/// Reports what the store did instead of what the contract requires.
+fn wrong(message: impl Into<String>) -> CheckFailure {
+    CheckFailure::Failed(message.into())
+}
+
+/// Unwraps a store call, attributing any failure to `operation`.
+fn ok<T>(operation: &str, result: StoreResult<T>) -> std::result::Result<T, CheckFailure> {
+    result.map_err(|error| failed(operation, &error))
+}
+
+/// Unwraps a store call for an optional capability: a store that declares
+/// the capability absent ends the check as [`StoreProbeOutcome::Unsupported`]
+/// rather than failing it.
+fn ok_optional<T>(operation: &str, result: StoreResult<T>) -> std::result::Result<T, CheckFailure> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(ObjectStoreError::Unsupported(_)) => Err(CheckFailure::Unsupported),
+        Err(error) => Err(failed(operation, &error)),
+    }
+}
+
+/// Requires a present object, so an absent one reads as the contract
+/// violation it is rather than a `None` the check silently tolerates.
+fn present<T>(what: &str, value: Option<T>) -> std::result::Result<T, CheckFailure> {
+    value.ok_or_else(|| wrong(format!("{what} read back as absent")))
+}
+
+/// Requires the store to have refused a write whose precondition did not
+/// hold. Anything else — acceptance, or a different failure — means the
+/// precondition is not being enforced as fencing assumes.
+fn refused<T>(what: &str, result: StoreResult<T>) -> CheckResult {
+    match result {
+        Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(()),
+        Err(error) => Err(wrong(format!(
+            "{what} should have been refused as a failed precondition, but failed differently: {}",
+            error.message()
+        ))),
+        Ok(_) => Err(wrong(format!(
+            "{what} was accepted; the store does not enforce this precondition"
+        ))),
+    }
+}
+
+/// Create-if-absent is how a namespace's first writer claims a mutable key
+/// nobody else may claim. A store that lets the second create through hands
+/// two writers the same claim.
+async fn create_if_absent_enforced(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("create-if-absent");
+
+    ok(
+        "create-if-absent write",
+        store
+            .put_if_absent(&key, Bytes::from_static(br#"{"seq":41}"#))
+            .await,
+    )?;
+    refused(
+        "a create-if-absent write over an existing object",
+        store
+            .put_if_absent(&key, Bytes::from_static(br#"{"seq":42}"#))
+            .await,
+    )?;
+
+    let body = present(
+        "the created object",
+        ok("read", store.get(&key, None).await)?,
+    )?;
+    if body.as_ref() != br#"{"seq":41}"# {
+        return Err(wrong(
+            "a refused create-if-absent write still changed the stored bytes",
+        ));
+    }
+    Ok(())
+}
+
+/// Compare-and-swap is the fence itself: an evicted writer's stale token
+/// must be refused, or two writers publish over each other.
+async fn compare_and_swap_rejects_stale(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("compare-and-swap");
+
+    ok(
+        "seed write",
+        store
+            .put_if_absent(&key, Bytes::from_static(br#"{"seq":41,"writer_epoch":8}"#))
+            .await,
+    )?;
+    let first_token = present(
+        "the seeded object's metadata",
+        ok("head", store.head(&key).await)?,
+    )?
+    .etag
+    .ok_or_else(|| {
+        wrong("the store reports no compare token, so compare-and-swap cannot fence anything")
+    })?;
+
+    ok(
+        "compare-and-swap on a current token",
+        store
+            .compare_and_swap(
+                &key,
+                &first_token,
+                Bytes::from_static(br#"{"seq":42,"writer_epoch":8}"#),
+            )
+            .await,
+    )?;
+    refused(
+        "a compare-and-swap on a stale token",
+        store
+            .compare_and_swap(
+                &key,
+                &first_token,
+                Bytes::from_static(br#"{"seq":43,"writer_epoch":9}"#),
+            )
+            .await,
+    )?;
+
+    let body = present(
+        "the compare-and-swap object",
+        ok("read", store.get(&key, None).await)?,
+    )?;
+    if body.as_ref() != br#"{"seq":42,"writer_epoch":8}"# {
+        return Err(wrong(
+            "a refused compare-and-swap still changed the stored bytes",
+        ));
+    }
+    Ok(())
+}
+
+/// A compare-and-swap against a key that does not exist has no version to
+/// match, so it is a failed precondition — not a create.
+async fn compare_and_swap_missing_object_rejected(
+    store: &dyn ObjectStore,
+    run: &ProbeRun,
+) -> CheckResult {
+    let key = run.key("compare-and-swap-missing");
+    refused(
+        "a compare-and-swap against a missing object",
+        store
+            .compare_and_swap(&key, "missing-etag", Bytes::from_static(br#"{"seq":1}"#))
+            .await,
+    )
+}
+
+/// An overwrite must be immediately authoritative in both what the object
+/// says and what its metadata says, because readers decide from the head
+/// and writers decide from the body.
+async fn overwrite_updates_head_and_body(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("overwrite");
+
+    let first = ok(
+        "first overwrite",
+        store
+            .put_overwrite(&key, Bytes::from_static(br#"{"seq":41}"#))
+            .await,
+    )?;
+    let second = ok(
+        "second overwrite",
+        store
+            .put_overwrite(&key, Bytes::from_static(br#"{"seq":42}"#))
+            .await,
+    )?;
+
+    let body = present(
+        "the overwritten object",
+        ok("read", store.get(&key, None).await)?,
+    )?;
+    if body.as_ref() != br#"{"seq":42}"# {
+        return Err(wrong("a read after overwrite returned the previous bytes"));
+    }
+    let head = present(
+        "the overwritten object's metadata",
+        ok("head", store.head(&key).await)?,
+    )?;
+    if head.etag != second.etag || head.size_bytes != second.size_bytes {
+        return Err(wrong(
+            "the object's metadata disagrees with the overwrite that just wrote it",
+        ));
+    }
+    if first == second {
+        return Err(wrong(
+            "an overwrite left the object's visible metadata unchanged",
+        ));
+    }
+
+    ok("delete", store.delete(&key).await)?;
+    if ok("head after delete", store.head(&key).await)?.is_some() {
+        return Err(wrong("a deleted object is still visible to head"));
+    }
+    Ok(())
+}
+
+/// Reading bytes and identity from one observation is what lets a caller
+/// trust that the metadata describes the bytes it just read, rather than a
+/// version that replaced them between two requests.
+async fn get_with_metadata_round_trip(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("get-with-metadata");
+    let bytes = br#"{"seq":41,"source":"get-with-metadata"}"#;
+
+    let written = ok(
+        "write",
+        store
+            .put_overwrite(&key, Bytes::copy_from_slice(bytes))
+            .await,
+    )?;
+    let loaded = present(
+        "the written object",
+        ok("full-object read", store.get_with_metadata(&key).await)?,
+    )?;
+
+    if loaded.bytes != bytes {
+        return Err(wrong("a full-object read returned unexpected bytes"));
+    }
+    if loaded.metadata.size_bytes != bytes.len() as u64 {
+        return Err(wrong(
+            "a full-object read reports a size that disagrees with its own bytes",
+        ));
+    }
+    if loaded.metadata.etag != written.etag {
+        return Err(wrong(
+            "a full-object read reports an identity that disagrees with the write that produced it",
+        ));
+    }
+    Ok(())
+}
+
+/// A write must be listable immediately. Recovery and garbage collection
+/// both enumerate prefixes to find what exists, so a listing that lags a
+/// write hides objects from the code that owns them.
+async fn visibility_after_write(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let prefix = run.listing("visibility-after-write");
+    let key = format!("{prefix}object");
+
+    ok(
+        "write",
+        store
+            .put_if_absent(&key, Bytes::from_static(br#"{"created":true}"#))
+            .await,
+    )?;
+    let listed = ok("list", store.list_prefix(&prefix).await)?;
+    if listed != vec![key.clone()] {
+        return Err(wrong(format!(
+            "listing a prefix straight after a write into it answered {listed:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// A delete must be listable-absent immediately, for the same reason: a
+/// listing that still reports a deleted object makes reclamation re-read
+/// objects that are already gone.
+async fn visibility_after_delete(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let prefix = run.listing("visibility-after-delete");
+    let key = format!("{prefix}object");
+
+    ok(
+        "write",
+        store
+            .put_if_absent(&key, Bytes::from_static(br#"{"created":true}"#))
+            .await,
+    )?;
+    ok("delete", store.delete(&key).await)?;
+    let listed = ok("list", store.list_prefix(&prefix).await)?;
+    if !listed.is_empty() {
+        return Err(wrong(format!(
+            "listing a prefix straight after deleting its only object answered {listed:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Deleting what is not there succeeds. Every cleanup path deletes without
+/// first proving what it is cleaning up, so a store that errors here turns
+/// ordinary cleanup into a failure.
+async fn delete_missing_idempotent(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("delete-missing");
+    ok("delete of a missing object", store.delete(&key).await)?;
+    if ok("head", store.head(&key).await)?.is_some() {
+        return Err(wrong("an object that was never written reads as present"));
+    }
+    Ok(())
+}
+
+/// A prefix listing must answer with exactly the objects under it, in
+/// ascending key order.
+async fn sorted_listing(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let prefix = run.listing("sorted");
+    let keys = vec![
+        format!("{prefix}a"),
+        format!("{prefix}b"),
+        format!("{prefix}c"),
+    ];
+
+    // Written out of order, so a store that echoes write order rather than
+    // key order is caught.
+    for index in [1usize, 2, 0] {
+        ok(
+            "write",
+            store
+                .put_if_absent(&keys[index], Bytes::from_static(br#"{"seq":1}"#))
+                .await,
+        )?;
+    }
+
+    // The streamed keys are the provider's own answer; `list_prefix` sorts
+    // client-side, so it is the documented convenience rather than evidence
+    // about the provider.
+    let mut streamed = Vec::new();
+    let mut stream = store.list_prefix_stream(&prefix);
+    while let Some(item) = stream.next().await {
+        streamed.push(ok("list", item)?);
+    }
+    streamed.sort();
+    let listed = ok("list", store.list_prefix(&prefix).await)?;
+    if streamed != keys {
+        return Err(wrong(format!(
+            "streaming a prefix answered {streamed:?}, not the {} objects written under it",
+            keys.len()
+        )));
+    }
+    if listed != keys {
+        return Err(wrong(format!(
+            "listing a prefix answered {listed:?}, not the {} objects written under it in key order",
+            keys.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Bounded reads are how metadata tables are read at all: a wrong range
+/// answer is a wrong block, which decodes as corruption rather than as an
+/// error.
+async fn range_reads(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("range");
+    ok(
+        "write",
+        store
+            .put_if_absent(&key, Bytes::from_static(b"abcdef"))
+            .await,
+    )?;
+
+    let bounded = |start_inclusive, end_exclusive| {
+        Some(ByteRange {
+            start_inclusive,
+            end_exclusive,
+        })
+    };
+
+    let read = ok("bounded read", store.get(&key, bounded(1, 4)).await)?;
+    if read != Some(Bytes::from_static(b"bcd")) {
+        return Err(wrong(format!(
+            "a bounded read of bytes 1..4 answered {read:?}"
+        )));
+    }
+    // The bounded-read contract, uniform across providers: an end past the
+    // object clamps, reading at the exact end is empty, and a start past
+    // the end is an invalid range.
+    let clamped = ok("clamped read", store.get(&key, bounded(4, 99)).await)?;
+    if clamped != Some(Bytes::from_static(b"ef")) {
+        return Err(wrong(format!(
+            "a read whose end runs past the object should clamp, but answered {clamped:?}"
+        )));
+    }
+    let at_end = ok(
+        "read at the exact end",
+        store.get(&key, bounded(6, 8)).await,
+    )?;
+    if at_end != Some(Bytes::new()) {
+        return Err(wrong(format!(
+            "a read starting at the object's exact end should be empty, but answered {at_end:?}"
+        )));
+    }
+    match store.get(&key, bounded(7, 8)).await {
+        Err(ObjectStoreError::InvalidRange { .. }) => {}
+        Err(error) => {
+            return Err(wrong(format!(
+                "a read starting past the object's end should be an invalid range, but failed differently: {}",
+                error.message()
+            )))
+        }
+        Ok(answer) => {
+            return Err(wrong(format!(
+                "a read starting past the object's end should be an invalid range, but answered {answer:?}"
+            )))
+        }
+    }
+
+    ok("delete", store.delete(&key).await)?;
+    let missing = ok(
+        "bounded read of a missing object",
+        store.get(&key, bounded(0, 4)).await,
+    )?;
+    if missing.is_some() {
+        return Err(wrong(
+            "a bounded read of a deleted object answered bytes instead of absence",
+        ));
+    }
+    Ok(())
+}
+
+/// A write past the multipart threshold goes through the provider's own
+/// multipart rules — non-final part sizes, completion, assembly — and must
+/// read back byte-identical. Cloudflare R2's fixed non-final part size is
+/// the rule this geometry exists to satisfy.
+async fn multipart_round_trip(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("multipart");
+
+    // The smallest payload with a middle part, which is where a provider's
+    // own rules about non-final part sizes bite.
+    let payload_len =
+        PROVIDER_MULTIPART_THRESHOLD_BYTES as usize + PROVIDER_MULTIPART_PART_BYTES as usize + 4096;
+    let payload: Vec<u8> = (0..payload_len).map(|index| (index % 251) as u8).collect();
+
+    let metadata = ok_optional(
+        "multipart overwrite",
+        store
+            .put_overwrite(&key, Bytes::from(payload.clone()))
+            .await,
+    )?;
+    if metadata.size_bytes != payload_len as u64 {
+        return Err(wrong(format!(
+            "a multipart write of {payload_len} bytes reports {} stored",
+            metadata.size_bytes
+        )));
+    }
+
+    let read_back = present(
+        "the assembled object",
+        ok_optional("read", store.get(&key, None).await)?,
+    )?;
+    if read_back.as_ref() != payload.as_slice() {
+        return Err(wrong(
+            "an object assembled from parts does not read back as the bytes written",
+        ));
+    }
+    Ok(())
+}
+
+/// Direct-put completion decides whether to publish an object from one
+/// checksum-bearing metadata request, so a store that reports a checksum
+/// must report an honest one.
+///
+/// Which algorithm comes back is the provider's business, and the providers
+/// disagree: AWS S3 reports the SHA-256 this adapter attaches to uploads,
+/// while Cloudflare R2 reports a CRC-64/NVME of its own. So this pins what
+/// must be true everywhere — the size, the algorithm's own encoding rules,
+/// and a SHA-256 that actually matches when SHA-256 is what is reported.
+async fn stored_checksum_readback(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("stored-checksum");
+    let payload = Bytes::from_static(b"stored checksum readback payload");
+
+    // A store that cannot ask the question at all says so plainly. Those
+    // are exactly the providers that cannot offer `direct_put`, so no
+    // completion path depends on them.
+    let absent = ok_optional(
+        "stored-checksum read of a missing object",
+        store.head_stored_checksum(&key).await,
+    )?;
+    if absent.is_some() {
+        return Err(wrong("an object that does not exist reports a checksum"));
+    }
+
+    ok("write", store.put_if_absent(&key, payload.clone()).await)?;
+    let stored = match store.head_stored_checksum(&key).await {
+        Ok(stored) => present("a present object's checksum", stored)?,
+        // A provider that stores no checksum for this object must say so
+        // rather than invent an answer.
+        Err(error) => {
+            let message = error.message();
+            return if message.contains("no full-object checksum") {
+                Ok(())
+            } else {
+                Err(failed("stored-checksum read", &error))
+            };
+        }
+    };
+
+    if stored.size_bytes != payload.len() as u64 {
+        return Err(wrong(format!(
+            "a stored-checksum read of a {}-byte object reports {} bytes",
+            payload.len(),
+            stored.size_bytes
+        )));
+    }
+    let checksum = stored.storage_checksum;
+    if checksum.value.len() != checksum.algorithm.value_bytes() * 2 {
+        return Err(wrong(format!(
+            "a checksum value must be its algorithm's width in hex: {checksum:?}"
+        )));
+    }
+    if !checksum
+        .value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(wrong(format!(
+            "a checksum value must be lowercase hex: {checksum:?}"
+        )));
+    }
+    if checksum.algorithm == ChecksumAlgorithm::Sha256
+        && checksum != StorageChecksum::sha256(&payload)
+    {
+        return Err(wrong(
+            "a reported sha256 does not describe the bytes actually stored",
+        ));
+    }
+    Ok(())
+}
+
+/// The run's own cleanup, and a check in its own right: after deleting
+/// everything the run wrote, listing the run's prefix must answer empty.
+async fn cleanup_leaves_prefix_empty(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let prefix = format!("{}/", run.prefix);
+    for key in ok("list", store.list_prefix(&prefix).await)? {
+        ok("cleanup delete", store.delete(&key).await)?;
+    }
+    let remaining = ok("list after cleanup", store.list_prefix(&prefix).await)?;
+    if !remaining.is_empty() {
+        return Err(wrong(format!(
+            "the probe's own prefix still holds {remaining:?} after cleanup"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::local_fs_store::LocalFsStore;
+    use crate::{ObjectBody, ObjectMetadata, PutMode};
+    use async_trait::async_trait;
+    use futures::stream::BoxStream;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn outcome<'a>(report: &'a StoreProbeReport, name: &str) -> &'a StoreProbeOutcome {
+        &report
+            .checks
+            .iter()
+            .find(|check| check.name == name)
+            .expect("report should carry the named check")
+            .outcome
+    }
+
+    #[tokio::test]
+    async fn a_conforming_store_passes_every_check() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
+
+        let report = run_store_contract_probe(&store, "probe_test_conforming").await;
+
+        assert_eq!(report.run_id, "probe_test_conforming");
+        let failures: Vec<_> = report
+            .checks
+            .iter()
+            .filter(|check| matches!(check.outcome, StoreProbeOutcome::Failed { .. }))
+            .collect();
+        assert!(failures.is_empty(), "unexpected failures: {failures:?}");
+        assert!(report.all_passed());
+    }
+
+    #[tokio::test]
+    async fn the_report_names_every_check_once_and_in_run_order() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
+
+        let report = run_store_contract_probe(&store, "probe_test_shape").await;
+
+        let names: Vec<_> = report.checks.iter().map(|check| check.name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "create_if_absent_enforced",
+                "compare_and_swap_rejects_stale",
+                "compare_and_swap_missing_object_rejected",
+                "overwrite_updates_head_and_body",
+                "get_with_metadata_round_trip",
+                "visibility_after_write",
+                "visibility_after_delete",
+                "delete_missing_idempotent",
+                "sorted_listing",
+                "range_reads",
+                "multipart_round_trip",
+                "stored_checksum_readback",
+                "cleanup_leaves_prefix_empty",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_probe_run_leaves_its_prefix_empty() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
+
+        let report = run_store_contract_probe(&store, "probe_test_cleanup").await;
+
+        assert_eq!(
+            outcome(&report, "cleanup_leaves_prefix_empty"),
+            &StoreProbeOutcome::Passed
+        );
+        assert!(store
+            .list_prefix("probe-runs/")
+            .await
+            .expect("list the probe prefix")
+            .is_empty());
+    }
+
+    /// A store whose local filesystem honours everything except
+    /// compare-and-swap: the one shape a preconditions-ignoring S3 gateway
+    /// presents, and the one that silently corrupts fenced writes.
+    #[derive(Debug)]
+    struct StaleCompareAndSwapAcceptingStore {
+        inner: LocalFsStore,
+        accepted_a_stale_swap: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl ObjectStore for StaleCompareAndSwapAcceptingStore {
+        async fn head(&self, key: &str) -> StoreResult<Option<ObjectMetadata>> {
+            self.inner.head(key).await
+        }
+
+        async fn get_with_metadata(&self, key: &str) -> StoreResult<Option<ObjectBody>> {
+            self.inner.get_with_metadata(key).await
+        }
+
+        async fn get(&self, key: &str, range: Option<ByteRange>) -> StoreResult<Option<Bytes>> {
+            self.inner.get(key, range).await
+        }
+
+        async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> StoreResult<ObjectMetadata> {
+            let mode = match mode {
+                PutMode::CompareAndSwap { .. } => {
+                    self.accepted_a_stale_swap.store(true, Ordering::SeqCst);
+                    PutMode::Overwrite
+                }
+                mode => mode,
+            };
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn delete(&self, key: &str) -> StoreResult<()> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
+            self.inner.list_prefix_stream(prefix)
+        }
+    }
+
+    #[tokio::test]
+    async fn a_store_that_ignores_compare_and_swap_fails_only_the_checks_about_it() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let accepted_a_stale_swap = Arc::new(AtomicBool::new(false));
+        let store = StaleCompareAndSwapAcceptingStore {
+            inner: LocalFsStore::new(temp_dir.path()).expect("create local object store"),
+            accepted_a_stale_swap: Arc::clone(&accepted_a_stale_swap),
+        };
+
+        let report = run_store_contract_probe(&store, "probe_test_broken_cas").await;
+
+        assert!(accepted_a_stale_swap.load(Ordering::SeqCst));
+        assert!(!report.all_passed());
+        assert!(matches!(
+            outcome(&report, "compare_and_swap_rejects_stale"),
+            StoreProbeOutcome::Failed { message } if message.contains("does not enforce")
+        ));
+        assert!(matches!(
+            outcome(&report, "compare_and_swap_missing_object_rejected"),
+            StoreProbeOutcome::Failed { .. }
+        ));
+        // A failed check ends that check, not the run: everything after it
+        // still reports, and the run still cleans up after itself.
+        assert_eq!(
+            outcome(&report, "create_if_absent_enforced"),
+            &StoreProbeOutcome::Passed
+        );
+        assert_eq!(outcome(&report, "range_reads"), &StoreProbeOutcome::Passed);
+        assert_eq!(
+            outcome(&report, "cleanup_leaves_prefix_empty"),
+            &StoreProbeOutcome::Passed
+        );
+        assert!(store
+            .list_prefix("probe-runs/")
+            .await
+            .expect("list the probe prefix")
+            .is_empty());
+    }
+
+    /// A store that cannot report stored checksums — GCS and Azure Blob
+    /// Storage are both this case, and it is an answer rather than a fault.
+    #[derive(Debug)]
+    struct NoStoredChecksumStore {
+        inner: LocalFsStore,
+    }
+
+    #[async_trait]
+    impl ObjectStore for NoStoredChecksumStore {
+        async fn head(&self, key: &str) -> StoreResult<Option<ObjectMetadata>> {
+            self.inner.head(key).await
+        }
+
+        async fn head_stored_checksum(
+            &self,
+            _key: &str,
+        ) -> StoreResult<Option<crate::StoredObjectChecksum>> {
+            Err(ObjectStoreError::Unsupported(
+                "stored full-object checksum readback",
+            ))
+        }
+
+        async fn get_with_metadata(&self, key: &str) -> StoreResult<Option<ObjectBody>> {
+            self.inner.get_with_metadata(key).await
+        }
+
+        async fn get(&self, key: &str, range: Option<ByteRange>) -> StoreResult<Option<Bytes>> {
+            self.inner.get(key, range).await
+        }
+
+        async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> StoreResult<ObjectMetadata> {
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn delete(&self, key: &str) -> StoreResult<()> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
+            self.inner.list_prefix_stream(prefix)
+        }
+    }
+
+    #[tokio::test]
+    async fn a_missing_optional_capability_is_an_answer_not_a_failure() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let store = NoStoredChecksumStore {
+            inner: LocalFsStore::new(temp_dir.path()).expect("create local object store"),
+        };
+
+        let report = run_store_contract_probe(&store, "probe_test_unsupported").await;
+
+        assert_eq!(
+            outcome(&report, "stored_checksum_readback"),
+            &StoreProbeOutcome::Unsupported
+        );
+        assert!(report.all_passed());
+    }
+}

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -7,18 +7,19 @@ use crate::provider_env::{
 };
 use bytes::Bytes;
 use futures::StreamExt;
-use loonfs_api::{ChecksumAlgorithm, ContentId, ManifestObjectId, StorageChecksum};
+use loonfs_api::{ContentId, ManifestObjectId, StorageChecksum};
 use loonfs_objectstore::abs::{AzureAbsStore, AzureAbsStoreConfig};
 use loonfs_objectstore::gcs::{GcpGcsStore, GcpGcsStoreConfig};
 use loonfs_objectstore::keys::{
-    content_blob, metadata_manifest_object, metadata_table, upload_session, wal_head, wal_segment,
+    content_blob, metadata_manifest_object, metadata_table, wal_head, wal_segment,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, StoreProbeReport};
 use loonfs_objectstore::s3_compatible::{
     AwsS3StoreConfig, CloudflareR2StoreConfig, S3CompatibleStore,
 };
+use loonfs_objectstore::ObjectStore;
 use loonfs_objectstore::ObjectStoreError;
-use loonfs_objectstore::{ByteRange, ObjectStore};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -80,41 +81,10 @@ fn provider_env_example_covers_real_provider_contract() {
 }
 
 #[tokio::test]
-async fn local_fs_create_if_absent_is_enforced() {
-    let temp_dir = TestDir::new("create-if-absent");
+async fn local_fs_passes_the_store_contract_probe() {
+    let temp_dir = TestDir::new("contract-probe");
     let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
-    assert_create_if_absent_is_enforced(&store).await;
-}
-
-#[tokio::test]
-async fn local_fs_compare_and_swap_rejects_stale_writer() {
-    let temp_dir = TestDir::new("cas");
-    let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
-    assert_compare_and_swap_rejects_stale_writer(&store).await;
-}
-
-#[tokio::test]
-async fn local_fs_overwrite_visibility_and_delete_idempotence() {
-    let temp_dir = TestDir::new("overwrite-delete");
-    let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
-    assert_overwrite_updates_head_and_body(&store).await;
-    assert_get_with_metadata_returns_body_and_identity(&store).await;
-    assert_delete_missing_is_idempotent(&store).await;
-}
-
-#[tokio::test]
-async fn local_fs_lists_immediately_after_write_and_delete() {
-    let temp_dir = TestDir::new("listing");
-    let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
-    assert_lists_immediately_after_write_and_delete(&store).await;
-    assert_sorted_list_prefix(&store).await;
-}
-
-#[tokio::test]
-async fn local_fs_supports_range_reads() {
-    let temp_dir = TestDir::new("ranges");
-    let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
-    assert_supports_range_reads(&store).await;
+    assert_store_contract_probe_passes(&store).await;
 }
 
 #[tokio::test]
@@ -122,13 +92,6 @@ async fn local_fs_rejects_path_traversal_keys() {
     let temp_dir = TestDir::new("invalid-key");
     let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
     assert_rejects_invalid_keys_consistently(&store).await;
-}
-
-#[tokio::test]
-async fn local_fs_compare_and_swap_missing_object_rejects_writer() {
-    let temp_dir = TestDir::new("cas-missing");
-    let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
-    assert_compare_and_swap_missing_object_rejects_writer(&store).await;
 }
 
 #[tokio::test]
@@ -307,308 +270,56 @@ async fn azure_abs_real_provider_conformance() {
     assert_provider_conformance(&store).await;
 }
 
-async fn assert_provider_conformance<S: ObjectStore>(store: &S) {
-    assert_create_if_absent_is_enforced(store).await;
-    assert_compare_and_swap_rejects_stale_writer(store).await;
-    assert_compare_and_swap_missing_object_rejects_writer(store).await;
-    assert_overwrite_updates_head_and_body(store).await;
-    assert_get_with_metadata_returns_body_and_identity(store).await;
-    assert_delete_missing_is_idempotent(store).await;
-    assert_lists_immediately_after_write_and_delete(store).await;
-    assert_sorted_list_prefix(store).await;
-    assert_supports_range_reads(store).await;
-    assert_multipart_overwrite_round_trips(store).await;
-    assert_stored_checksum_readback_is_honest(store).await;
+/// The live provider sweep: the store contract probe, plus the key
+/// rejection the probe deliberately leaves to tests.
+///
+/// The probe is the production surface an operator runs, and running it
+/// here is what stops the two from drifting: a contract check changes for
+/// production and for this sweep in one edit, or not at all.
+async fn assert_provider_conformance(store: &dyn ObjectStore) {
+    assert_store_contract_probe_passes(store).await;
     assert_rejects_invalid_keys_consistently(store).await;
 }
 
-/// Direct-put completion decides whether to publish an object from one
-/// checksum-bearing metadata request, so a wrong header name, a mis-decoded
-/// base64 value, or a mis-scoped key would silently break publication.
+/// Requires every probe check to pass, and prints the whole report when one
+/// does not.
 ///
-/// Which algorithm comes back is the provider's business, and the providers
-/// disagree: AWS S3 reports the SHA-256 this adapter attaches to uploads,
-/// while Cloudflare R2 reports a CRC-64/NVME of its own even though this
-/// adapter attaches nothing to proxied writes. So the check pins what must
-/// be true everywhere — the size, the algorithm's own encoding rules, and a
-/// SHA-256 that actually matches when SHA-256 is what is reported — rather
-/// than a single expected algorithm.
+/// The report is the point of a live run. Cloudflare R2's 501 answer to
+/// `GetObjectAttributes` was read off exactly this output, so a failure
+/// shows every check's verdict rather than the first one that broke.
 ///
-/// Presigned direct-put writes carry a signed SHA-256 on both providers,
-/// which is the path completion actually verifies; the end-to-end proof of
-/// that lives in `loonfs-server`'s real-provider direct-put tests.
-async fn assert_stored_checksum_readback_is_honest<S: ObjectStore>(store: &S) {
-    let key = wal_segment("ns-1", "seg_00000000000000000000000000000778");
-    let _ = store.delete(&key).await;
-    let payload = Bytes::from_static(b"stored checksum readback payload");
-
-    let absent = match store.head_stored_checksum(&key).await {
-        // A store that cannot ask the question at all says so plainly, and
-        // there is nothing further to check: those are exactly the providers
-        // that do not offer direct_put, so no completion path depends on
-        // them. GCS and Azure Blob Storage are both this case.
-        Err(ObjectStoreError::Unsupported(_)) => return,
-        answer => answer.expect("absent object answers without a checksum"),
-    };
+/// `stored_checksum_readback` may answer `unsupported`: that is the
+/// capability line for presigned direct uploads, and GCS and Azure Blob
+/// Storage both sit on the far side of it. Every other check must pass
+/// outright on every provider this suite covers, multipart included.
+async fn assert_store_contract_probe_passes(store: &dyn ObjectStore) {
+    let run_id = loonfs_api::generated_id("probe");
+    let report = run_store_contract_probe(store, &run_id).await;
+    let acceptable = report.checks.iter().all(|check| match check.outcome {
+        StoreProbeOutcome::Passed => true,
+        StoreProbeOutcome::Unsupported => check.name == "stored_checksum_readback",
+        StoreProbeOutcome::Failed { .. } => false,
+    });
     assert!(
-        absent.is_none(),
-        "an absent object must not report a checksum"
+        acceptable,
+        "store contract probe {run_id} did not pass:\n{}",
+        probe_report_lines(&report)
     );
+}
 
-    store
-        .put_if_absent(&key, payload.clone())
-        .await
-        .expect("write checksum probe object");
-    match store.head_stored_checksum(&key).await {
-        Ok(stored) => {
-            let stored = stored.expect("a present object must not read back as absent");
-            assert_eq!(stored.size_bytes, payload.len() as u64);
-            let checksum = stored.storage_checksum;
-            assert_eq!(
-                checksum.value.len(),
-                checksum.algorithm.value_bytes() * 2,
-                "a checksum value must be its algorithm's width in hex: {checksum:?}"
-            );
-            assert!(
-                checksum
-                    .value
-                    .bytes()
-                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-                "a checksum value must be lowercase hex: {checksum:?}"
-            );
-            if checksum.algorithm == ChecksumAlgorithm::Sha256 {
-                assert_eq!(
-                    checksum,
-                    StorageChecksum::sha256(&payload),
-                    "a reported sha256 must describe the bytes actually stored"
-                );
+fn probe_report_lines(report: &StoreProbeReport) -> String {
+    report
+        .checks
+        .iter()
+        .map(|check| match &check.outcome {
+            StoreProbeOutcome::Passed => format!("  {}: passed", check.name),
+            StoreProbeOutcome::Unsupported => format!("  {}: unsupported", check.name),
+            StoreProbeOutcome::Failed { message } => {
+                format!("  {}: failed: {message}", check.name)
             }
-        }
-        // A provider that stores no checksum for this object must say so
-        // rather than invent an answer.
-        Err(error) => {
-            let message = error.to_string();
-            assert!(
-                message.contains("no full-object checksum"),
-                "a provider that stores no checksum must say so: {message}"
-            );
-        }
-    }
-
-    store.delete(&key).await.expect("delete checksum probe");
-}
-
-/// The one live exercise of the native multipart path: an overwrite past
-/// the threshold uploads in parts (at least two) and must read back
-/// byte-identical. R2's fixed-part-size rule and each provider's completion
-/// semantics only show up against the real service.
-async fn assert_multipart_overwrite_round_trips<S: ObjectStore>(store: &S) {
-    let key = wal_segment("ns-1", "seg_00000000000000000000000000000777");
-    let _ = store.delete(&key).await;
-
-    let payload_len = loonfs_objectstore::PROVIDER_MULTIPART_THRESHOLD_BYTES as usize
-        + loonfs_objectstore::PROVIDER_MULTIPART_PART_BYTES as usize
-        + 4096;
-    let payload: Vec<u8> = (0..payload_len).map(|index| (index % 251) as u8).collect();
-
-    let metadata = store
-        .put_overwrite(&key, Bytes::from(payload.clone()))
-        .await
-        .expect("multipart overwrite");
-    assert_eq!(metadata.size_bytes, payload_len as u64);
-
-    let read_back = store
-        .get(&key, None)
-        .await
-        .expect("read back")
-        .expect("object exists");
-    assert_eq!(read_back.len(), payload_len);
-    assert_eq!(read_back.as_ref(), payload.as_slice());
-
-    store.delete(&key).await.expect("cleanup multipart object");
-}
-
-async fn assert_get_with_metadata_returns_body_and_identity<S: ObjectStore>(store: &S) {
-    let key = wal_head("ns-1");
-    let _ = store.delete(&key).await;
-
-    let written = store
-        .put_overwrite(
-            &key,
-            Bytes::from_static(br#"{"seq":41,"source":"get-with-metadata"}"#),
-        )
-        .await
-        .expect("write object for get_with_metadata");
-    let loaded = store
-        .get_with_metadata(&key)
-        .await
-        .expect("get_with_metadata")
-        .expect("object should exist");
-
-    assert_eq!(loaded.bytes, br#"{"seq":41,"source":"get-with-metadata"}"#);
-    assert_eq!(loaded.metadata.size_bytes, loaded.bytes.len() as u64);
-    assert_eq!(loaded.metadata.etag, written.etag);
-
-    store
-        .delete(&key)
-        .await
-        .expect("cleanup get_with_metadata object");
-}
-
-async fn assert_create_if_absent_is_enforced<S: ObjectStore>(store: &S) {
-    let key = wal_head("ns-1");
-    let _ = store.delete(&key).await;
-
-    store
-        .put_if_absent(&key, Bytes::from_static(br#"{"seq":41}"#))
-        .await
-        .expect("initial create should succeed");
-
-    let second = store
-        .put_if_absent(&key, Bytes::from_static(br#"{"seq":42}"#))
-        .await;
-    assert_precondition_failed(second);
-
-    assert_eq!(
-        store
-            .get(&key, None)
-            .await
-            .expect("read body")
-            .expect("body exists"),
-        Bytes::from_static(br#"{"seq":41}"#)
-    );
-
-    store
-        .delete(&key)
-        .await
-        .expect("cleanup create-if-absent object");
-}
-
-async fn assert_compare_and_swap_rejects_stale_writer<S: ObjectStore>(store: &S) {
-    let key = wal_head("ns-1");
-    let _ = store.delete(&key).await;
-
-    store
-        .put_if_absent(&key, Bytes::from_static(br#"{"seq":41,"writer_epoch":8}"#))
-        .await
-        .expect("seed initial head");
-    let first_read = store
-        .head(&key)
-        .await
-        .expect("head read")
-        .expect("head should exist")
-        .etag
-        .expect("etag should exist");
-
-    store
-        .compare_and_swap(
-            &key,
-            &first_read,
-            Bytes::from_static(br#"{"seq":42,"writer_epoch":8}"#),
-        )
-        .await
-        .expect("first CAS should succeed");
-
-    let stale = store
-        .compare_and_swap(
-            &key,
-            &first_read,
-            Bytes::from_static(br#"{"seq":42,"writer_epoch":9}"#),
-        )
-        .await;
-    assert_precondition_failed(stale);
-
-    assert_eq!(
-        store
-            .get(&key, None)
-            .await
-            .expect("read body")
-            .expect("body exists"),
-        Bytes::from_static(br#"{"seq":42,"writer_epoch":8}"#)
-    );
-
-    store.delete(&key).await.expect("cleanup CAS object");
-}
-
-async fn assert_compare_and_swap_missing_object_rejects_writer<S: ObjectStore>(store: &S) {
-    let key = wal_head("ns-cas-missing");
-    let _ = store.delete(&key).await;
-    assert_precondition_failed(
-        store
-            .compare_and_swap(&key, "missing-etag", Bytes::from_static(br#"{"seq":1}"#))
-            .await,
-    );
-}
-
-async fn assert_overwrite_updates_head_and_body<S: ObjectStore>(store: &S) {
-    let key = wal_head("ns-overwrite");
-    let _ = store.delete(&key).await;
-
-    let first = store
-        .put_overwrite(&key, Bytes::from_static(br#"{"seq":41}"#))
-        .await
-        .expect("initial overwrite should succeed");
-    let second = store
-        .put_overwrite(&key, Bytes::from_static(br#"{"seq":42}"#))
-        .await
-        .expect("second overwrite should succeed");
-
-    assert_eq!(
-        store
-            .get(&key, None)
-            .await
-            .expect("read overwritten body")
-            .expect("overwritten body exists"),
-        Bytes::from_static(br#"{"seq":42}"#)
-    );
-    let head = store
-        .head(&key)
-        .await
-        .expect("head after overwrite")
-        .expect("overwritten object exists");
-    assert_eq!(head.etag, second.etag);
-    assert_eq!(head.size_bytes, second.size_bytes);
-    assert_ne!(first, second, "overwrite should refresh visible metadata");
-
-    store
-        .delete(&key)
-        .await
-        .expect("cleanup overwritten object");
-    assert_eq!(store.head(&key).await.expect("head after delete"), None);
-}
-
-async fn assert_delete_missing_is_idempotent<S: ObjectStore>(store: &S) {
-    let key = wal_head("ns-delete-missing");
-    let _ = store.delete(&key).await;
-    store
-        .delete(&key)
-        .await
-        .expect("delete missing object should succeed");
-    assert_eq!(store.head(&key).await.expect("head missing object"), None);
-}
-
-async fn assert_lists_immediately_after_write_and_delete<S: ObjectStore>(store: &S) {
-    let key = upload_session("ns-1", "upl_00000000000000000000000000000001");
-    let _ = store.delete(&key).await;
-
-    store
-        .put_if_absent(&key, Bytes::from_static(br#"{"created":true}"#))
-        .await
-        .expect("create upload object");
-    assert_eq!(
-        store
-            .list_prefix("namespaces/ns-1/uploads/")
-            .await
-            .expect("list after write"),
-        vec![key.clone()]
-    );
-
-    store.delete(&key).await.expect("delete upload object");
-    assert!(store
-        .list_prefix("namespaces/ns-1/uploads/")
-        .await
-        .expect("list after delete")
-        .is_empty());
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// The content key a streamed-write exercise writes to and cleans up.
@@ -677,112 +388,7 @@ async fn assert_streamed_write_round_trips<S: ObjectStore>(store: &S) {
     );
 }
 
-async fn assert_sorted_list_prefix<S: ObjectStore>(store: &S) {
-    let manifest_object_id = ManifestObjectId::parse("00000000000000000001-0123456789abcdef")
-        .expect("valid manifest object id");
-    let keys = vec![
-        wal_head("ns-sort"),
-        metadata_manifest_object("ns-sort", &manifest_object_id),
-        upload_session("ns-sort", "upl_00000000000000000000000000000001"),
-    ];
-    for key in &keys {
-        let _ = store.delete(key).await;
-    }
-
-    store
-        .put_if_absent(&keys[1], Bytes::from_static(br#"{"seq":1}"#))
-        .await
-        .expect("seed second sort key");
-    store
-        .put_if_absent(&keys[2], Bytes::from_static(br#"{"lease":1}"#))
-        .await
-        .expect("seed third sort key");
-    store
-        .put_if_absent(&keys[0], Bytes::from_static(br#"{"through_seq":1}"#))
-        .await
-        .expect("seed first sort key");
-
-    // Assert on the raw provider stream, not `list_prefix` — the trait
-    // default sorts client-side, so asserting on it can never fail. No
-    // protocol depends on listing order; this pins the documented
-    // convenience that `list_prefix` answers sorted regardless.
-    let mut streamed = Vec::new();
-    let mut stream = store.list_prefix_stream("namespaces/ns-sort/");
-    while let Some(key) = stream.next().await {
-        streamed.push(key.expect("stream sorted keys"));
-    }
-    streamed.sort();
-    let listed = store
-        .list_prefix("namespaces/ns-sort/")
-        .await
-        .expect("list sorted keys");
-    let mut expected = keys.clone();
-    expected.sort();
-    assert_eq!(streamed, expected);
-    assert_eq!(listed, expected);
-
-    for key in &keys {
-        store.delete(key).await.expect("cleanup sort key");
-    }
-}
-
-async fn assert_supports_range_reads<S: ObjectStore>(store: &S) {
-    let key = wal_segment("ns-1", "seg_00000000000000000000000000000001");
-    let _ = store.delete(&key).await;
-
-    store
-        .put_if_absent(&key, Bytes::from_static(b"abcdef"))
-        .await
-        .expect("create wal object");
-
-    let bounded = |start_inclusive, end_exclusive| {
-        Some(ByteRange {
-            start_inclusive,
-            end_exclusive,
-        })
-    };
-
-    let range = store
-        .get(&key, bounded(1, 4))
-        .await
-        .expect("range read")
-        .expect("range body should exist");
-    assert_eq!(range, Bytes::from_static(b"bcd"));
-
-    // The bounded-read contract, uniform across providers: an end past the
-    // object clamps, reading at the exact end is empty, a start past the
-    // end is an invalid range, and a missing object answers `None` however
-    // the request was shaped.
-    assert_eq!(
-        store
-            .get(&key, bounded(4, 99))
-            .await
-            .expect("clamped range read"),
-        Some(Bytes::from_static(b"ef"))
-    );
-    assert_eq!(
-        store
-            .get(&key, bounded(6, 8))
-            .await
-            .expect("range at the exact end"),
-        Some(Bytes::new())
-    );
-    assert!(matches!(
-        store.get(&key, bounded(7, 8)).await,
-        Err(ObjectStoreError::InvalidRange { .. })
-    ));
-
-    store.delete(&key).await.expect("cleanup range object");
-    assert_eq!(
-        store
-            .get(&key, bounded(0, 4))
-            .await
-            .expect("ranged read of a missing object"),
-        None
-    );
-}
-
-async fn assert_rejects_invalid_keys_consistently<S: ObjectStore>(store: &S) {
+async fn assert_rejects_invalid_keys_consistently(store: &dyn ObjectStore) {
     fn assert_invalid_key<T: std::fmt::Debug>(key: &str, result: Result<T, ObjectStoreError>) {
         let carries_rejected_key = matches!(
             &result,
@@ -814,13 +420,6 @@ async fn assert_rejects_invalid_keys_consistently<S: ObjectStore>(store: &S) {
         assert_invalid_key(key, store.delete(key).await);
         assert_invalid_key(key, store.list_prefix(key).await);
     }
-}
-
-fn assert_precondition_failed<T>(result: Result<T, ObjectStoreError>) {
-    assert!(matches!(
-        result,
-        Err(ObjectStoreError::PreconditionFailed { .. })
-    ));
 }
 
 #[derive(Debug)]

--- a/crates/loonfs-server/src/http/handlers_store.rs
+++ b/crates/loonfs-server/src/http/handlers_store.rs
@@ -1,0 +1,61 @@
+//! The `admin/v0` routes whose subject is the backing store itself rather
+//! than one namespace.
+
+use super::{AppState, OptionalAppJson};
+use crate::http::error::ApiResponseError;
+use axum::extract::State;
+use axum::Json;
+use loonfs_api::v0::{
+    StoreProbeCheckOutcome, StoreProbeCheckResult, StoreProbeRequest, StoreProbeResponse,
+};
+#[cfg(feature = "openapi")]
+use loonfs_api::ApiError;
+use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome};
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/admin/store/probe",
+        tag = "admin",
+        summary = "Probe the store contract",
+        description = "Proves the configured object store honours the create-if-absent, compare-and-swap, visibility, listing, and ranged-read semantics LoonFS depends on, and reports what it found check by check. Nothing runs this implicitly: a probe writes and deletes objects, all of them under a scratch prefix that is not a durable object family, and its last check deletes them and proves the prefix empty. A store that fails a check answers 200 with that check reported `failed` — the probe ran, and the answer is that the store is wrong. Optional capabilities a store declares it lacks answer `unsupported`, which is an answer rather than a fault. This route does not decide whether the deployment may serve presigned direct uploads: that trust comes from the endpoint allowlist, because a probe exercises the server's own request path and never a presigned capability handed to a client.",
+        request_body(content = StoreProbeRequest, description = "Probe options; send `{}` for defaults"),
+        responses(
+            (status = 200, description = "Probe completed; per-check outcomes are in the body", body = StoreProbeResponse),
+            (status = 400, description = "Malformed request body", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError)
+        )
+    )
+)]
+pub(super) async fn probe_store(
+    State(state): State<AppState>,
+    OptionalAppJson(request): OptionalAppJson<StoreProbeRequest>,
+) -> Result<Json<StoreProbeResponse>, ApiResponseError> {
+    let StoreProbeRequest {} = request.unwrap_or_default();
+    // The run id scopes the objects this run writes, so two probes against
+    // one store never collide, and a provider's own log names the run.
+    let run_id = loonfs_api::generated_id("probe");
+    let report = run_store_contract_probe(state.probe_store.as_ref(), &run_id).await;
+    Ok(Json(StoreProbeResponse {
+        run_id: report.run_id,
+        checks: report
+            .checks
+            .into_iter()
+            .map(|check| {
+                let (outcome, message) = match check.outcome {
+                    StoreProbeOutcome::Passed => (StoreProbeCheckOutcome::Passed, None),
+                    StoreProbeOutcome::Unsupported => (StoreProbeCheckOutcome::Unsupported, None),
+                    StoreProbeOutcome::Failed { message } => {
+                        (StoreProbeCheckOutcome::Failed, Some(message))
+                    }
+                };
+                StoreProbeCheckResult {
+                    name: check.name.to_owned(),
+                    outcome,
+                    message,
+                }
+            })
+            .collect(),
+    }))
+}

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -8,6 +8,7 @@ mod extractors;
 mod handlers_filesystem;
 mod handlers_namespace;
 mod handlers_query;
+mod handlers_store;
 mod handlers_uploads;
 #[cfg(feature = "openapi")]
 mod openapi;
@@ -36,6 +37,7 @@ use self::handlers_query::{
     disable_grep_index, enable_grep_index, gc_grep_index, grep, grep_index_not_maintained,
     grep_index_status, grep_queries_not_served,
 };
+use self::handlers_store::probe_store;
 use self::handlers_uploads::{
     abort_upload, begin_upload, complete_upload, read_upload_status, sign_upload_parts,
     upload_content,
@@ -199,6 +201,9 @@ fn router(state: AppState) -> Router {
             "/v0/admin/namespaces/:namespace/maintenance/step",
             post(maintenance_step),
         )
+        // The one admin route whose subject is the store rather than a
+        // namespace, so it sits beside them rather than under one.
+        .route("/v0/admin/store/probe", post(probe_store))
         // Unmatched paths and wrong methods answer inside the error
         // contract instead of axum's empty default bodies.
         .fallback(route_not_found)

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -64,7 +64,8 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         crate::http::handlers_query::grep_index_status,
         crate::http::handlers_query::enable_grep_index,
         crate::http::handlers_query::disable_grep_index,
-        crate::http::handlers_query::gc_grep_index
+        crate::http::handlers_query::gc_grep_index,
+        crate::http::handlers_store::probe_store
     ),
     components(schemas(
         loonfs_api::CapabilityDocument,
@@ -137,7 +138,11 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         loonfs_api::v0::EnableGrepIndexResponse,
         loonfs_api::v0::DisableGrepIndexResponse,
         loonfs_api::v0::GrepGcRequest,
-        loonfs_api::v0::GrepGcResponse
+        loonfs_api::v0::GrepGcResponse,
+        loonfs_api::v0::StoreProbeRequest,
+        loonfs_api::v0::StoreProbeCheckOutcome,
+        loonfs_api::v0::StoreProbeCheckResult,
+        loonfs_api::v0::StoreProbeResponse
     )),
     tags(
         (name = "health", description = "Server health"),

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -35,6 +35,11 @@ pub(super) struct AppState {
     pub(super) writer: FsWriter,
     pub(super) reader: FsReader,
     pub(super) admin: FsAdmin,
+    /// The store itself, for the one endpoint whose subject is the store
+    /// rather than a namespace: the contract probe. It is the same
+    /// instrumented client the handles were built on, so a probe measures
+    /// what production traffic measures.
+    pub(super) probe_store: SharedObjectStore,
     pub(super) transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
     pub(super) grep_worker: Option<GrepWorker<SharedObjectStore>>,
     /// The grep query service: one process-wide decoded-block cache for
@@ -229,6 +234,7 @@ pub(super) async fn app_with_store_and_transfer_issuer(
     // the trait that publications concern it, and registering it is what
     // subscribes it.
     let (writer, reader, admin) = build_handles(&config, store.clone()).await?;
+    let probe_store = store.clone();
     // A deployment that maintains the index needs a worker whether or not it
     // answers queries with one.
     let grep_worker = (config.grep.mode.serves_grep() || config.grep.mode.maintains_index())
@@ -284,6 +290,7 @@ pub(super) async fn app_with_store_and_transfer_issuer(
         writer,
         reader,
         admin,
+        probe_store,
         transfer_issuer,
         grep_worker,
         grep_service,

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -453,3 +453,96 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
     harness.server.abort();
     cold.server.abort();
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_admin_store_probe_reports_every_check_against_the_configured_store() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-probe",
+        "http-admin-probe",
+    ))
+    .await;
+
+    let probe: loonfs_api::v0::StoreProbeResponse = post_admin_json_body(
+        &format!("{}/v0/admin/store/probe", harness.server_url),
+        "test-token",
+        serde_json::json!({}),
+    )
+    .expect("probe the configured store");
+
+    assert!(probe.run_id.starts_with("probe_"));
+    let names: Vec<&str> = probe
+        .checks
+        .iter()
+        .map(|check| check.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "create_if_absent_enforced",
+            "compare_and_swap_rejects_stale",
+            "compare_and_swap_missing_object_rejected",
+            "overwrite_updates_head_and_body",
+            "get_with_metadata_round_trip",
+            "visibility_after_write",
+            "visibility_after_delete",
+            "delete_missing_idempotent",
+            "sorted_listing",
+            "range_reads",
+            "multipart_round_trip",
+            "stored_checksum_readback",
+            "cleanup_leaves_prefix_empty",
+        ]
+    );
+    for check in &probe.checks {
+        assert_ne!(
+            check.outcome,
+            loonfs_api::v0::StoreProbeCheckOutcome::Failed,
+            "the local filesystem store should honour every contract check: {check:?}"
+        );
+        assert_eq!(check.message, None);
+    }
+
+    // A probe leaves the store as it found it: emptying the run's scratch
+    // prefix is its own last check, and nothing else here wrote there.
+    let store = ConfiguredObjectStore::local_fs(
+        harness.store_root.as_ref().expect("local-fs test store"),
+        harness.store_key_prefix.as_deref(),
+    )
+    .expect("open the test store");
+    assert!(store
+        .list_prefix("probe-runs/")
+        .await
+        .expect("list the probe prefix")
+        .is_empty());
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_admin_store_probe_requires_a_token_and_accepts_a_bodyless_request() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-probe-auth",
+        "http-admin-probe-auth",
+    ))
+    .await;
+    let url = format!("{}/v0/admin/store/probe", harness.server_url);
+
+    let unauthorized: Result<loonfs_api::v0::StoreProbeResponse, ApiError> =
+        post_admin_json_body(&url, "wrong-token", serde_json::json!({}));
+    assert_eq!(
+        unauthorized.expect_err("a wrong token is refused").code,
+        "unauthorized"
+    );
+
+    // Body handling matches the maintenance-step route: an absent body is
+    // the same request as `{}`.
+    let bodyless: loonfs_api::v0::StoreProbeResponse =
+        post_admin_json(&url, "test-token").expect("probe with no body");
+    assert_eq!(bodyless.checks.len(), 13);
+
+    harness.server.abort();
+}

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -60,6 +60,7 @@ fn openapi_documents_current_server_paths() {
             "post",
         ),
         ("/v0/admin/namespaces/{namespace}/grep/index/gc", "post"),
+        ("/v0/admin/store/probe", "post"),
     ] {
         assert_path_method(paths, path, method);
     }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -545,6 +545,7 @@ A representative v0 binding is shown below.
 | Enable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/enable` (CAS-publishes the independent grep root into checkpointed backfill and nudges the deployment's maintenance runner; requires a deployment that maintains the index; idempotent) |
 | Disable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/disable` (CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
 | Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (one explicit pass over only that namespace's grep extension; `max_objects` bounds the reads it spends and returns a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
+| Probe the store contract | `POST /v0/admin/store/probe` (the one admin route whose subject is the store rather than a namespace; body carries no options today and `{}` is the request; see below) |
 
 The status route and the enable response both report the index's lifecycle
 as a tagged `state`, and the phases never share a field:
@@ -606,6 +607,42 @@ runs the two opted-in sub-steps after flush and reorganization.
 The retention floor bounds incremental replay only. File revision history
 is never pruned: a revisions listing is always complete, however far the
 floor has advanced.
+
+#### Store contract probe
+
+The store probe proves the configured object store honours the provider
+contract this format depends on — create-if-absent, compare-and-swap,
+read-after-write visibility, prefix listing, ranged reads — and reports what
+it found check by check. It runs only when an operator asks: a probe writes
+and deletes objects, so nothing runs one at startup or on a schedule.
+
+Every object a run writes lives under `probe-runs/{run_id}/`, which is not a
+durable object family, so garbage collection never enumerates it and no
+namespace state can be reached from it. The run's last check deletes those
+objects and proves the prefix empty, so a probe that completes leaves
+nothing behind; one that dies partway leaves orphans under a prefix nothing
+consults.
+
+The response carries the `run_id` the server minted and one entry per check,
+in the order the checks ran. Each entry names the check and its `outcome`:
+
+| `outcome` | Means |
+| --- | --- |
+| `passed` | The store behaved as the contract requires. |
+| `unsupported` | The store declares it cannot do this at all. Only the optional capabilities answer this way, and a deployment that needs neither is unaffected. |
+| `failed` | The store did something the contract forbids, or the operation failed outright. The entry's `message` says what was expected and what happened instead. |
+
+A failed check is reported in the body, not as an error: a probe that ran to
+completion answers 200 whatever it found, because the operator asked a
+question and the answer is that the store is wrong. Only an unauthorized
+request or a malformed body answers in the error envelope. One check ending
+does not end the run, so one probe answers the whole question rather than
+the first thing that went wrong.
+
+A probe never decides whether a deployment may serve presigned direct
+uploads. That trust comes from the endpoint allowlist behind the
+`uploads.direct_put` capability, because a probe exercises the server's own
+request path and never a presigned capability handed to a client.
 
 Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -672,6 +672,59 @@
         }
       }
     },
+    "/v0/admin/store/probe": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Probe the store contract",
+        "description": "Proves the configured object store honours the create-if-absent, compare-and-swap, visibility, listing, and ranged-read semantics LoonFS depends on, and reports what it found check by check. Nothing runs this implicitly: a probe writes and deletes objects, all of them under a scratch prefix that is not a durable object family, and its last check deletes them and proves the prefix empty. A store that fails a check answers 200 with that check reported `failed` — the probe ran, and the answer is that the store is wrong. Optional capabilities a store declares it lacks answer `unsupported`, which is an answer rather than a fault. This route does not decide whether the deployment may serve presigned direct uploads: that trust comes from the endpoint allowlist, because a probe exercises the server's own request path and never a presigned capability handed to a client.",
+        "operationId": "probe_store",
+        "requestBody": {
+          "description": "Probe options; send `{}` for defaults",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StoreProbeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Probe completed; per-check outcomes are in the body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoreProbeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v0/capabilities": {
       "get": {
         "tags": [
@@ -4897,6 +4950,65 @@
           }
         },
         "additionalProperties": false
+      },
+      "StoreProbeCheckOutcome": {
+        "type": "string",
+        "description": "What one contract check concluded about the store.",
+        "enum": [
+          "passed",
+          "unsupported",
+          "failed"
+        ]
+      },
+      "StoreProbeCheckResult": {
+        "type": "object",
+        "description": "One named contract check and what the store did with it.",
+        "required": [
+          "name",
+          "outcome"
+        ],
+        "properties": {
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "What was expected and what happened instead. Present only on\n`failed`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Stable check name."
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/StoreProbeCheckOutcome",
+            "description": "What the store did."
+          }
+        }
+      },
+      "StoreProbeRequest": {
+        "type": "object",
+        "description": "Options for one store contract probe. Empty today; a body is still sent\nso later options do not change the shape of the request."
+      },
+      "StoreProbeResponse": {
+        "type": "object",
+        "description": "What one store contract probe observed, check by check.",
+        "required": [
+          "run_id",
+          "checks"
+        ],
+        "properties": {
+          "checks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StoreProbeCheckResult"
+            },
+            "description": "Every check the run performed, in the order it performed them. A\nfailed check lives here rather than in an error: the probe answered\nthe question, and the answer is that the store is wrong."
+          },
+          "run_id": {
+            "type": "string",
+            "description": "Label the server minted for this run. It scopes the objects the run\nwrote, so it identifies the run in provider logs too."
+          }
+        }
       },
       "TrashEntry": {
         "type": "object",


### PR DESCRIPTION
This PR makes the store contract probe a production surface. Before this, the only proof of a provider's semantics was the live conformance suite. That suite is ignored by default and no deployment runs it. A server with bad credentials, a missing bucket, or a gateway that ignores preconditions starts cleanly and fails on the first client request. Fencing depends on those preconditions, so a gateway that ignores them corrupts data instead of failing.

The probe module: `loonfs_objectstore::probe::run_store_contract_probe(store, run_id)` runs 13 named checks: create-if-absent enforced, CAS rejects a stale etag, CAS on a missing object rejected, overwrite updates head and body, get-with-metadata round trip, visibility after write, visibility after delete, delete-missing idempotent, sorted listing, range reads, multipart round trip, stored-checksum readback, and cleanup-leaves-prefix-empty. Each check reports `passed`, `unsupported`, or `failed` with a message. A failure in one check does not stop the run: the operator gets the full answer. Optional capabilities a store does not have report `unsupported`, which is an answer, not a fault. Every object a run writes lives under `probe-runs/{run_id}/`. That prefix is not a durable object family. The last check deletes everything and proves the prefix lists empty. Objects left by a crashed probe are harmless orphans.

One implementation for test and production: The live conformance suite now calls the probe module and asserts on its report. The module is the suite's core, so the two cannot drift. The LocalFs tests run the same module in CI.

where: `POST /v0/admin/store/probe` is the first store-scoped admin route. It requires the bearer token. It probes the same instrumented store that serves production traffic. It returns 200 with the report when the probe ran: failed checks live in the report, not in the HTTP status. The request body is optional, the same as the maintenance-step route. `loonfs admin probe-store` works on embedded and remote profiles, prints one line per check, and exits nonzero when a check failed.

What stays the same... `direct_put_is_proven` (the endpoint allowlist for presigned direct uploads) stays authoritative. The probe exercises the server's own request path, never a presigned capability. No probe runs implicitly, at boot or anywhere else — a probe writes and deletes objects, so only an explicit operator decision starts one.
