### PR TITLE
chore(server): migrate to axum 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,13 +107,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -126,8 +126,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -141,19 +140,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -1345,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ categories = ["filesystem", "command-line-utilities"]
 
 [workspace.dependencies]
 async-trait = "0.1"
-axum = "0.7"
+axum = "0.8"
 base64 = "0.22"
 bytes = "1"
 ciborium = "0.2"

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -3,7 +3,6 @@
 use super::error::ApiResponseError;
 use super::serve::AppState;
 use crate::config::ServerConfig;
-use axum::async_trait;
 use axum::extract::rejection::PathRejection;
 use axum::extract::{FromRequest, FromRequestParts, Path as AxumPath, Query};
 use axum::http::request::Parts;
@@ -73,7 +72,7 @@ struct NamespaceSegment {
     namespace: String,
 }
 
-/// Extractor for the `:namespace` path segment of namespace-scoped routes.
+/// Extractor for the `{namespace}` path segment of namespace-scoped routes.
 ///
 /// The segment is parsed into a [`NamespaceId`] at extraction time, but the
 /// outcome is surfaced through [`NamespaceIdPath::into_id`] inside the
@@ -91,7 +90,6 @@ impl NamespaceIdPath {
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for NamespaceIdPath
 where
     S: Send + Sync,
@@ -126,7 +124,6 @@ impl<T> AppPath<T> {
     }
 }
 
-#[async_trait]
 impl<S, T> FromRequestParts<S> for AppPath<T>
 where
     S: Send + Sync,
@@ -154,7 +151,6 @@ impl<T> AppQuery<T> {
     }
 }
 
-#[async_trait]
 impl<S, T> FromRequestParts<S> for AppQuery<T>
 where
     S: Send + Sync,
@@ -203,7 +199,6 @@ where
     }
 }
 
-#[async_trait]
 impl<T> FromRequest<AppState> for AppJson<T>
 where
     T: serde::de::DeserializeOwned,
@@ -329,7 +324,6 @@ impl UploadStreamOutcome {
     }
 }
 
-#[async_trait]
 impl FromRequest<AppState> for UploadBodyStream {
     type Rejection = ApiResponseError;
 
@@ -395,7 +389,6 @@ pub(super) struct OptionalAppJson<T>(pub(super) Option<T>);
 
 const MAX_OPTIONAL_JSON_BODY_BYTES: usize = 1024 * 1024;
 
-#[async_trait]
 impl<T> FromRequest<AppState> for OptionalAppJson<T>
 where
     T: serde::de::DeserializeOwned,

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -122,48 +122,48 @@ fn router(state: AppState) -> Router {
         .route("/v0/capabilities", get(handlers_namespace::capabilities))
         .route("/v0/namespaces", post(create_namespace))
         .route(
-            "/v0/namespaces/:namespace",
+            "/v0/namespaces/{namespace}",
             get(namespace_status).delete(delete_namespace),
         )
-        .route("/v0/namespaces/:namespace/forks", post(fork_namespace))
+        .route("/v0/namespaces/{namespace}/forks", post(fork_namespace))
         .route(
-            "/v0/namespaces/:namespace/filesystem/list",
+            "/v0/namespaces/{namespace}/filesystem/list",
             get(list_path_entries),
         )
-        .route("/v0/namespaces/:namespace/filesystem/stat", get(stat_path))
+        .route("/v0/namespaces/{namespace}/filesystem/stat", get(stat_path))
         .route(
-            "/v0/namespaces/:namespace/filesystem/content",
+            "/v0/namespaces/{namespace}/filesystem/content",
             get(get_file_bytes),
         )
-        .route("/v0/namespaces/:namespace/query/grep", grep_route)
+        .route("/v0/namespaces/{namespace}/query/grep", grep_route)
         .route(
-            "/v0/admin/namespaces/:namespace/grep/index",
+            "/v0/admin/namespaces/{namespace}/grep/index",
             grep_status_route,
         )
         .route(
-            "/v0/admin/namespaces/:namespace/grep/index/enable",
+            "/v0/admin/namespaces/{namespace}/grep/index/enable",
             enable_grep_route,
         )
         .route(
-            "/v0/admin/namespaces/:namespace/grep/index/disable",
+            "/v0/admin/namespaces/{namespace}/grep/index/disable",
             disable_grep_route,
         )
         .route(
-            "/v0/admin/namespaces/:namespace/grep/index/gc",
+            "/v0/admin/namespaces/{namespace}/grep/index/gc",
             grep_gc_route,
         )
         .route(
-            "/v0/namespaces/:namespace/filesystem/revisions",
+            "/v0/namespaces/{namespace}/filesystem/revisions",
             get(list_file_revisions),
         )
         .route(
-            "/v0/namespaces/:namespace/filesystem/trash",
+            "/v0/namespaces/{namespace}/filesystem/trash",
             get(list_trash),
         )
-        .route("/v0/namespaces/:namespace/commits", post(apply_commit))
-        .route("/v0/namespaces/:namespace/uploads", post(begin_upload))
+        .route("/v0/namespaces/{namespace}/commits", post(apply_commit))
+        .route("/v0/namespaces/{namespace}/uploads", post(begin_upload))
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id/content",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
             // No body-limit layer: the upload route never buffers its
             // body, so a framework limit measured against a buffered read
             // would never fire. `UploadBodyStream` counts the bytes as it
@@ -171,32 +171,32 @@ fn router(state: AppState) -> Router {
             put(upload_content),
         )
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id/parts",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/parts",
             post(sign_upload_parts),
         )
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id/complete",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
             post(complete_upload),
         )
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id/abort",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/abort",
             post(abort_upload),
         )
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}",
             get(read_upload_status),
         )
-        .route("/v0/namespaces/:namespace/changes", get(list_changes))
+        .route("/v0/namespaces/{namespace}/changes", get(list_changes))
         .route(
-            "/v0/admin/namespaces/:namespace/checkpoints",
+            "/v0/admin/namespaces/{namespace}/checkpoints",
             post(create_checkpoint),
         )
         .route(
-            "/v0/admin/namespaces/:namespace/checkpoints/:checkpoint_id/release",
+            "/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release",
             post(release_checkpoint),
         )
         .route(
-            "/v0/admin/namespaces/:namespace/maintenance/step",
+            "/v0/admin/namespaces/{namespace}/maintenance/step",
             post(maintenance_step),
         )
         // Unmatched paths and wrong methods answer inside the error


### PR DESCRIPTION
This PR moves the server from axum 0.7 to axum 0.8. It is mechanical: same routes, same status codes, same error envelope, same graceful shutdown. It exists so the next PR can terminate TLS through axum 0.8's `Listener` trait.
