### PR TITLE
feat(server): native tls termination with a required-or-declared posture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,13 +107,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -126,8 +126,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -141,19 +140,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -1345,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +201,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -405,6 +453,32 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "dialoguer"
@@ -1280,11 +1354,15 @@ dependencies = [
  "loonfs-grep",
  "loonfs-objectstore",
  "loonfs-test-support",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "toml",
  "tower",
  "tracing",
@@ -1369,6 +1447,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,12 +1474,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1445,6 +1564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1614,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1649,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1656,6 +1800,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -2169,6 +2336,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3003,10 +3200,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ categories = ["filesystem", "command-line-utilities"]
 
 [workspace.dependencies]
 async-trait = "0.1"
-axum = "0.7"
+axum = "0.8"
 base64 = "0.22"
 bytes = "1"
 ciborium = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,15 @@ futures = "0.3"
 fs4 = "0.13"
 getrandom = "0.3"
 object_store = { version = "=0.12.4", default-features = false, features = ["aws", "gcp", "azure"] }
+rcgen = { version = "0.14", default-features = false, features = ["crypto", "ring", "pem"] }
 regex = { version = "1.11", default-features = false, features = ["std", "perf"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "stream"] }
 regex-syntax = "0.8"
+# `ring`, not the crate default `aws-lc-rs`: the rustls stack is already in
+# the tree as a transitive dependency built on ring, and the default provider
+# would pull a second, native-toolchain crypto backend in beside it.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = ["raw_value"] }
@@ -51,6 +57,7 @@ hmac = "0.12"
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12", "logging"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,45 @@ export LOONFS_AUTH_TOKEN={auth_token}
 loonfs init default --no-input --mode remote --server-url http://127.0.0.1:9400
 ```
 
+### Running a server in production
+
+Two things travel over the connection that must not travel in the clear: the
+bearer token on every request, and the presigned object-store URLs the upload
+routes return in response bodies. Each of those URLs is a capability to write
+into your bucket, so anyone who can read the traffic can both impersonate the
+client and write objects directly. A server that binds anything other than
+loopback therefore refuses to start unless it either terminates TLS itself or
+says out loud that something else does.
+
+Terminate TLS in the server by adding a `[tls]` table:
+
+```toml
+bind = "0.0.0.0:9400"
+
+[tls]
+cert_path = "/etc/loonfs/tls/server.crt"   # PEM chain, leaf first
+key_path  = "/etc/loonfs/tls/server.key"   # PEM PKCS#8, RSA, or EC key
+```
+
+Both files are read once at startup, before the port is bound: a missing or
+malformed one fails the process instead of quietly serving plaintext. Clients
+then use an `https://` server URL. For a certificate a private CA issued,
+point the client at the CA bundle with `--ca-cert-path` (or `ca_cert_path` in
+the profile); it is added to the platform trust store rather than replacing
+it.
+
+If TLS terminates in front of LoonFS — a load balancer, an ingress
+controller, a sidecar — leave `[tls]` out and declare that:
+
+```toml
+bind = "0.0.0.0:9400"
+allow_remote_without_tls = true
+```
+
+A loopback bind never requires either, so local development is unchanged. The
+same shape governs authentication: a non-loopback bind with no `auth_token`
+refuses to start unless `allow_unauthenticated_remote = true`.
+
 ## Documentation
 
 Visit loonfs.com/docs to learn more.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,14 @@
 # Security Policy
 
+## Deploying securely
+
+Serving a LoonFS server beyond localhost means serving it over TLS, because
+the bearer token and the presigned object-store URLs in upload responses are
+both readable by anyone who can read the connection. See
+[Running a server in production](README.md#running-a-server-in-production)
+for the `[tls]` configuration and the one escape hatch, for deployments where
+a proxy terminates TLS instead.
+
 ## Supported Versions
 
 | Version        | Supported          |

--- a/configs/loonfs-server.aws-s3.example.toml
+++ b/configs/loonfs-server.aws-s3.example.toml
@@ -3,6 +3,16 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-aws"
 
+# Serving beyond loopback requires TLS. Either terminate it here by
+# uncommenting [tls] below, or set allow_remote_without_tls = true when a
+# proxy in front of LoonFS terminates it.
+#allow_remote_without_tls = true
+
+# PEM chain (leaf first) and its private key, read once at startup.
+#[tls]
+#cert_path = "/etc/loonfs/tls/server.crt"
+#key_path = "/etc/loonfs/tls/server.key"
+
 [store]
 kind = "aws-s3"
 bucket = "your-bucket"

--- a/configs/loonfs-server.azure-abs.example.toml
+++ b/configs/loonfs-server.azure-abs.example.toml
@@ -3,6 +3,16 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-azure"
 
+# Serving beyond loopback requires TLS. Either terminate it here by
+# uncommenting [tls] below, or set allow_remote_without_tls = true when a
+# proxy in front of LoonFS terminates it.
+#allow_remote_without_tls = true
+
+# PEM chain (leaf first) and its private key, read once at startup.
+#[tls]
+#cert_path = "/etc/loonfs/tls/server.crt"
+#key_path = "/etc/loonfs/tls/server.key"
+
 [store]
 kind = "azure-abs"
 account_name = "your-storage-account"

--- a/configs/loonfs-server.cloudflare-r2.example.toml
+++ b/configs/loonfs-server.cloudflare-r2.example.toml
@@ -3,6 +3,16 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-r2"
 
+# Serving beyond loopback requires TLS. Either terminate it here by
+# uncommenting [tls] below, or set allow_remote_without_tls = true when a
+# proxy in front of LoonFS terminates it.
+#allow_remote_without_tls = true
+
+# PEM chain (leaf first) and its private key, read once at startup.
+#[tls]
+#cert_path = "/etc/loonfs/tls/server.crt"
+#key_path = "/etc/loonfs/tls/server.key"
+
 [store]
 kind = "cloudflare-r2"
 bucket = "your-bucket"

--- a/configs/loonfs-server.gcp-gcs.example.toml
+++ b/configs/loonfs-server.gcp-gcs.example.toml
@@ -3,6 +3,16 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-gcp"
 
+# Serving beyond loopback requires TLS. Either terminate it here by
+# uncommenting [tls] below, or set allow_remote_without_tls = true when a
+# proxy in front of LoonFS terminates it.
+#allow_remote_without_tls = true
+
+# PEM chain (leaf first) and its private key, read once at startup.
+#[tls]
+#cert_path = "/etc/loonfs/tls/server.crt"
+#key_path = "/etc/loonfs/tls/server.key"
+
 [store]
 kind = "gcp-gcs"
 bucket = "your-bucket"

--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -8,6 +8,13 @@ auth_token = "dev-token"
 content_token_secret = "dev-content-token-secret"
 writer_id = "loonfs-server-local"
 
+# Terminating TLS in this process. Uncomment the [tls] table at the bottom of
+# this file to turn it on. A non-loopback bind refuses to load without it,
+# because the wire carries the bearer token and the presigned object-store
+# URLs the upload routes hand back. Set this instead when TLS terminates in
+# front of LoonFS — a load balancer, an ingress controller, a sidecar.
+#allow_remote_without_tls = true
+
 # Whether this server maintains the namespaces it touches by itself:
 # "automatic" (the default) registers the metadata, collection, and — when
 # the grep mode below maintains — index jobs, and lets the writer schedule
@@ -67,6 +74,15 @@ writer_id = "loonfs-server-local"
 #max_l0_runs = 8
 #max_mid_runs = 8
 #max_decoded_input_rows_per_step = 131072
+
+# The server's TLS identity, read once at startup: a file that is missing or
+# is not the PEM it claims to be fails the process rather than falling back
+# to plaintext. The chain is leaf first; the key may be PKCS#8, RSA, or EC.
+# Clients then use an https:// server URL, and a client that must trust a
+# private CA points at its bundle with `ca_cert_path`.
+#[tls]
+#cert_path = "/etc/loonfs/tls/server.crt"
+#key_path = "/etc/loonfs/tls/server.key"
 
 [store]
 kind = "local-fs"

--- a/configs/loonfs.remote.example.toml
+++ b/configs/loonfs.remote.example.toml
@@ -8,3 +8,7 @@ default_profile = "remote"
 mode = "remote"
 server_url = "http://127.0.0.1:9400"
 auth_token = "dev-token"
+# A server reachable beyond localhost serves https. When a private CA issued
+# its certificate, point at the CA bundle here; it adds to the platform trust
+# store rather than replacing it.
+#ca_cert_path = "/etc/loonfs/tls/ca.crt"

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -268,6 +268,9 @@ Profile options
   Remote profile:
     --server-url <url>
     --auth-token <token>               optional, env LOONFS_AUTH_TOKEN
+    --ca-cert-path <path>              optional, PEM bundle of extra
+                                       certificate authorities to trust for
+                                       an https server url
 
 Update options
   Used by:
@@ -311,6 +314,7 @@ Update options
   Remote profile updates:
     --server-url <url>
     --auth-token <token>
+    --ca-cert-path <path>
 
 Behavior notes
   `loonfs cat` always streams raw bytes to stdout

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -150,6 +150,10 @@ pub(crate) struct InitArgs {
     /// Remote LoonFS bearer token.
     #[arg(long, env = "LOONFS_AUTH_TOKEN")]
     pub auth_token: Option<String>,
+    /// PEM bundle of extra certificate authorities to trust for an
+    /// https server URL, when a private CA issued the certificate.
+    #[arg(long)]
+    pub ca_cert_path: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -226,6 +230,10 @@ pub(crate) struct ProfileCreateArgs {
     /// Remote LoonFS bearer token.
     #[arg(long, env = "LOONFS_AUTH_TOKEN")]
     pub auth_token: Option<String>,
+    /// PEM bundle of extra certificate authorities to trust for an
+    /// https server URL, when a private CA issued the certificate.
+    #[arg(long)]
+    pub ca_cert_path: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -276,6 +284,10 @@ pub(crate) struct ProfileUpdateArgs {
     /// Remote LoonFS bearer token.
     #[arg(long)]
     pub auth_token: Option<String>,
+    /// PEM bundle of extra certificate authorities to trust for an
+    /// https server URL, when a private CA issued the certificate.
+    #[arg(long)]
+    pub ca_cert_path: Option<String>,
 }
 
 #[derive(Debug, Args, Clone)]

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -107,6 +107,12 @@ const PROVIDER_FLAGS: &[ProviderFlag] = &[
         update_set: Some(|args| args.auth_token.is_some()),
     },
     ProviderFlag {
+        flag: "ca-cert-path",
+        allowed: &[Remote],
+        create_set: |spec| spec.ca_cert_path.is_some(),
+        update_set: Some(|args| args.ca_cert_path.is_some()),
+    },
+    ProviderFlag {
         flag: "store-kind",
         allowed: EMBEDDED_TARGETS,
         create_set: |spec| spec.store_kind.is_some(),
@@ -265,6 +271,7 @@ pub(super) struct CreateProfileSpec {
     service_account_key_path: Option<String>,
     server_url: Option<String>,
     auth_token: Option<String>,
+    ca_cert_path: Option<String>,
 }
 
 pub(super) fn create_profile_spec_from_init(args: InitArgs) -> CreateProfileSpec {
@@ -287,6 +294,7 @@ pub(super) fn create_profile_spec_from_init(args: InitArgs) -> CreateProfileSpec
         service_account_key_path: args.service_account_key_path,
         server_url: args.server_url,
         auth_token: args.auth_token,
+        ca_cert_path: args.ca_cert_path,
     }
 }
 
@@ -310,6 +318,7 @@ pub(super) fn create_profile_spec_from_create(args: ProfileCreateArgs) -> Create
         service_account_key_path: args.service_account_key_path,
         server_url: args.server_url,
         auth_token: args.auth_token,
+        ca_cert_path: args.ca_cert_path,
     }
 }
 
@@ -456,7 +465,14 @@ fn build_remote_profile(
             Some(token) if token.trim().is_empty() => None,
             other => other.map(SecretString::from),
         },
+        ca_cert_path: blank_to_none(spec.ca_cert_path),
     })
+}
+
+/// An explicitly-blank flag value clears the field rather than storing the
+/// empty string, which would then fail profile validation.
+fn blank_to_none(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.trim().is_empty())
 }
 
 fn require_or_prompt(
@@ -616,6 +632,7 @@ pub(super) fn apply_update_flags(
             server_url,
             default_namespace,
             auth_token,
+            ca_cert_path,
         } => Ok(ProfileConfig::Remote {
             server_url: args.server_url.clone().unwrap_or(server_url),
             default_namespace,
@@ -624,6 +641,7 @@ pub(super) fn apply_update_flags(
                 .clone()
                 .map(SecretString::from)
                 .or(auth_token),
+            ca_cert_path: blank_to_none(args.ca_cert_path.clone()).or(ca_cert_path),
         }),
     }
 }
@@ -738,6 +756,7 @@ pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<Profil
             server_url,
             default_namespace,
             auth_token,
+            ca_cert_path,
         } => Ok(ProfileConfig::Remote {
             server_url: prompt::prompt_line_default("server-url", &server_url)?,
             default_namespace,
@@ -746,6 +765,7 @@ pub(super) fn apply_update_interactive(existing: ProfileConfig) -> Result<Profil
                 auth_token.as_ref().map(SecretString::expose),
             )?
             .map(SecretString::from),
+            ca_cert_path: prompt::prompt_optional("ca cert path", ca_cert_path.as_deref())?,
         }),
     }
 }
@@ -900,6 +920,7 @@ mod tests {
             server_url: "http://127.0.0.1:9400".to_owned(),
             default_namespace: None,
             auth_token: None,
+            ca_cert_path: None,
         };
 
         let updated = apply_update_flags(
@@ -942,6 +963,7 @@ mod tests {
             service_account_key_path: None,
             server_url: None,
             auth_token: None,
+            ca_cert_path: None,
         }
     }
 
@@ -963,6 +985,7 @@ mod tests {
             service_account_key_path: None,
             server_url: None,
             auth_token: None,
+            ca_cert_path: None,
         }
     }
 

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -42,6 +42,10 @@ pub(crate) enum ProfileConfig {
         default_namespace: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         auth_token: Option<SecretString>,
+        /// PEM bundle of extra certificate authorities to trust, for a
+        /// server whose certificate a private CA issued.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ca_cert_path: Option<String>,
     },
 }
 
@@ -131,7 +135,7 @@ impl ProfileConfig {
                 server_url,
                 default_namespace,
                 auth_token,
-                ..
+                ca_cert_path,
             } => {
                 if let Some(namespace) = default_namespace {
                     validate_default_namespace(
@@ -142,6 +146,9 @@ impl ProfileConfig {
                 validate_http_url(&profile_field(name, "server_url"), server_url)?;
                 if let Some(token) = auth_token {
                     require_non_empty(&profile_field(name, "auth_token"), token.expose())?;
+                }
+                if let Some(path) = ca_cert_path {
+                    require_non_empty(&profile_field(name, "ca_cert_path"), path)?;
                 }
                 Ok(())
             }
@@ -163,10 +170,12 @@ impl ProfileConfig {
                 server_url,
                 default_namespace,
                 auth_token,
+                ca_cert_path,
             } => ProfileConfig::Remote {
                 server_url: server_url.clone(),
                 default_namespace: default_namespace.clone(),
                 auth_token: auth_token.as_ref().map(SecretString::masked),
+                ca_cert_path: ca_cert_path.clone(),
             },
         }
     }
@@ -426,6 +435,7 @@ fn validate_http_url(field: &str, value: &str) -> Result<(), CliError> {
         auth_token: None,
         request_timeout_ms: None,
         disable_transient_retry: false,
+        ca_cert_path: None,
     }
     .validate()
     .map_err(|error| CliError::invalid_config(format!("invalid `{field}`: {error}")))

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -112,10 +112,12 @@ impl ResolvedTarget {
             ProfileConfig::Remote {
                 server_url,
                 auth_token,
+                ca_cert_path,
                 ..
             } => Ok(Self::Remote(RemoteTarget::new(
                 server_url,
                 auth_token.as_ref().map(|token| token.expose()),
+                ca_cert_path.as_deref(),
                 no_retry,
             )?)),
         }
@@ -179,12 +181,18 @@ impl EmbeddedTarget {
 }
 
 impl RemoteTarget {
-    fn new(server_url: &str, auth_token: Option<&str>, no_retry: bool) -> Result<Self, CliError> {
+    fn new(
+        server_url: &str,
+        auth_token: Option<&str>,
+        ca_cert_path: Option<&str>,
+        no_retry: bool,
+    ) -> Result<Self, CliError> {
         let client = Client::new(ClientConfig {
             server_url: server_url.to_owned(),
             auth_token: auth_token.map(ToOwned::to_owned),
             request_timeout_ms: None,
             disable_transient_retry: no_retry,
+            ca_cert_path: ca_cert_path.map(ToOwned::to_owned),
         })
         .map_err(|error| CliError::invalid_config(error.to_string()))?;
         Ok(Self { client })

--- a/crates/loonfs-client/src/config.rs
+++ b/crates/loonfs-client/src/config.rs
@@ -36,6 +36,12 @@ pub struct ClientConfig {
     /// and upload-session creation are always single-attempt.
     #[serde(default)]
     pub disable_transient_retry: bool,
+    /// PEM bundle of extra certificate authorities to trust for `https`
+    /// server URLs, for a server whose certificate a private CA issued.
+    /// Added to the platform trust store rather than replacing it, so a
+    /// client configured this way still reaches publicly-trusted servers.
+    #[serde(default)]
+    pub ca_cert_path: Option<String>,
 }
 
 impl ClientConfig {
@@ -71,7 +77,44 @@ impl ClientConfig {
                 reason: "must be greater than zero; omit it for no deadline".to_owned(),
             });
         }
+        if let Some(path) = &self.ca_cert_path {
+            if path.trim().is_empty() {
+                return Err(ClientError::ConfigValidation {
+                    field: "ca_cert_path",
+                    reason: "must not be empty; omit it to trust only the platform roots"
+                        .to_owned(),
+                });
+            }
+        }
         Ok(())
+    }
+
+    /// Reads the configured CA bundle into the certificates reqwest adds to
+    /// the trust store. A path that cannot be read or does not hold PEM
+    /// certificates fails here, before any request: a client that silently
+    /// fell back to the platform roots would fail later and somewhere else.
+    pub(crate) fn extra_root_certificates(&self) -> Result<Vec<reqwest::Certificate>> {
+        let Some(path) = &self.ca_cert_path else {
+            return Ok(Vec::new());
+        };
+        let path = path.trim();
+        let pem = fs::read(path).map_err(|err| ClientError::ConfigValidation {
+            field: "ca_cert_path",
+            reason: format!("failed to read `{path}`: {err}"),
+        })?;
+        let certificates = reqwest::Certificate::from_pem_bundle(&pem).map_err(|err| {
+            ClientError::ConfigValidation {
+                field: "ca_cert_path",
+                reason: format!("`{path}` is not a PEM certificate bundle: {err}"),
+            }
+        })?;
+        if certificates.is_empty() {
+            return Err(ClientError::ConfigValidation {
+                field: "ca_cert_path",
+                reason: format!("`{path}` holds no CERTIFICATE section"),
+            });
+        }
+        Ok(certificates)
     }
 }
 

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -305,6 +305,11 @@ impl Client {
         if let Some(timeout_ms) = config.request_timeout_ms {
             builder = builder.timeout(std::time::Duration::from_millis(timeout_ms));
         }
+        // Additive: the platform roots stay in place, so one configured
+        // private CA does not cost this client every public one.
+        for certificate in config.extra_root_certificates()? {
+            builder = builder.add_root_certificate(certificate);
+        }
         Ok(Self {
             base_url: config.server_url.trim().trim_end_matches('/').to_owned(),
             auth_token: config.auth_token,
@@ -1699,6 +1704,7 @@ mod tests {
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: false,
+            ca_cert_path: None,
         })
         .expect_err("ftp scheme must be rejected");
         assert!(
@@ -1711,6 +1717,39 @@ mod tests {
             ),
             "unexpected error: {error:?}"
         );
+    }
+
+    /// A CA bundle that cannot be read or is not PEM fails at construction,
+    /// naming the path. Falling back to the platform roots would move the
+    /// failure to the first request and blame the server for it.
+    #[test]
+    fn an_unusable_ca_bundle_fails_construction_and_names_the_path() {
+        let dir = tempdir().expect("tempdir");
+        let missing = dir.path().join("absent.crt");
+        let garbage = dir.path().join("garbage.crt");
+        fs::write(&garbage, b"this is not a certificate\n").expect("write garbage");
+
+        for path in [missing, garbage] {
+            let display = path.display().to_string();
+            let error = super::Client::new(super::ClientConfig {
+                server_url: "https://example.com".to_owned(),
+                auth_token: None,
+                request_timeout_ms: None,
+                disable_transient_retry: false,
+                ca_cert_path: Some(display.clone()),
+            })
+            .expect_err("unusable ca bundle");
+            match &error {
+                super::ClientError::ConfigValidation {
+                    field: "ca_cert_path",
+                    reason,
+                } => assert!(
+                    reason.contains(&display),
+                    "the reason must name the path, got: {reason}"
+                ),
+                other => unreachable!("unexpected error: {other:?}"),
+            }
+        }
     }
 
     /// Configs are strict like everywhere else in the workspace: a typo'd
@@ -1768,6 +1807,7 @@ mod tests {
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: false,
+            ca_cert_path: None,
         })
         .expect("valid client config");
         let error = retrying
@@ -1784,6 +1824,7 @@ mod tests {
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: true,
+            ca_cert_path: None,
         })
         .expect("valid client config");
         single_shot
@@ -1799,6 +1840,7 @@ mod tests {
             auth_token: None,
             request_timeout_ms: None,
             disable_transient_retry: false,
+            ca_cert_path: None,
         })
         .expect("valid client config")
     }

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -131,6 +131,7 @@ fn client() -> Client {
         auth_token: None,
         request_timeout_ms: None,
         disable_transient_retry: false,
+        ca_cert_path: None,
     })
     .expect("valid client config")
 }
@@ -388,6 +389,7 @@ async fn request_head_for(source: PayloadSource) -> String {
         auth_token: None,
         request_timeout_ms: None,
         disable_transient_retry: true,
+        ca_cert_path: None,
     })
     .expect("valid client config");
     // The response is not the point; the request head is.

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -26,10 +26,13 @@ loonfs-api = { path = "../loonfs-api" }
 loonfs = { path = "../loonfs" }
 loonfs-grep = { path = "../loonfs-grep" }
 loonfs-objectstore = { path = "../loonfs-objectstore" }
+rustls.workspace = true
+rustls-pemfile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-rustls.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -39,6 +42,7 @@ utoipa = { workspace = true, optional = true }
 async-trait.workspace = true
 loonfs-client = { path = "../loonfs-client" }
 loonfs-test-support = { path = "../loonfs-test-support" }
+rcgen.workspace = true
 tempfile.workspace = true
 tower = { version = "0.5", features = ["util"] }
 ureq.workspace = true

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -96,7 +96,32 @@ pub struct ServerConfig {
     /// explicitly set.
     #[serde(default)]
     pub allow_unauthenticated_remote: bool,
+    /// Allows serving on a non-loopback address in plaintext. Off by
+    /// default for the same reason as `allow_unauthenticated_remote`: the
+    /// wire carries the bearer token and the presigned object-store URLs
+    /// the upload routes hand back, so plaintext beyond localhost is almost
+    /// always a misconfiguration rather than a choice. Set it where TLS
+    /// terminates in front of this process.
+    #[serde(default)]
+    pub allow_remote_without_tls: bool,
+    /// Terminates TLS in this process when present. Absent means plaintext
+    /// HTTP, which validation only accepts on a loopback bind or with
+    /// `allow_remote_without_tls`.
+    #[serde(default)]
+    pub tls: Option<TlsServerConfig>,
     pub store: StoreConfig,
+}
+
+/// The server's TLS identity: one certificate chain and its private key,
+/// both read at startup. A file that is missing, unreadable, or not the PEM
+/// it claims to be fails the process rather than degrading to plaintext.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TlsServerConfig {
+    /// PEM certificate chain, leaf first.
+    pub cert_path: String,
+    /// PEM private key: PKCS#8, PKCS#1 (RSA), or SEC1.
+    pub key_path: String,
 }
 
 fn default_min_publish_interval_ms() -> u64 {
@@ -355,6 +380,21 @@ impl ServerConfig {
                      authentication; set `auth_token` (or `LOONFS_AUTH_TOKEN`), \
                      or set `allow_unauthenticated_remote = true` to serve open \
                      on purpose"
+                ),
+            });
+        }
+        if let Some(tls) = &self.tls {
+            require_non_empty("tls.cert_path", &tls.cert_path)?;
+            require_non_empty("tls.key_path", &tls.key_path)?;
+        } else if bind_serves_beyond_localhost(&bind) && !self.allow_remote_without_tls {
+            return Err(ServerConfigError::InvalidField {
+                field: "tls",
+                reason: format!(
+                    "bind `{bind}` serves the network in plaintext, exposing the \
+                     bearer token and the presigned object-store URLs in upload \
+                     responses; configure `[tls]` with `cert_path` and `key_path`, \
+                     or set `allow_remote_without_tls = true` when TLS terminates \
+                     in front of this process"
                 ),
             });
         }
@@ -803,6 +843,7 @@ root = "/tmp/loonfs-server"
             r#"
 bind = "0.0.0.0:9400"
 allow_unauthenticated_remote = true
+allow_remote_without_tls = true
 writer_id = "loonfs-server"
 
 [store]
@@ -828,6 +869,144 @@ root = "/tmp/loonfs-server"
         );
 
         load_server_config(&path).expect("loopback-only config loads");
+    }
+
+    #[test]
+    fn load_rejects_non_loopback_bind_without_tls() {
+        for bind in ["0.0.0.0:9400", "[::]:9400", "10.1.2.3:9400"] {
+            let path = write_config(&format!(
+                r#"
+bind = "{bind}"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#
+            ));
+
+            let error = load_server_config(&path).expect_err("plaintext network bind");
+
+            assert_invalid_field(error, "tls");
+        }
+    }
+
+    #[test]
+    fn allow_remote_without_tls_permits_a_plaintext_network_bind() {
+        let path = write_config(
+            r#"
+bind = "0.0.0.0:9400"
+auth_token = "dev-token"
+allow_remote_without_tls = true
+writer_id = "loonfs-server"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        load_server_config(&path).expect("proxy-terminated config loads");
+    }
+
+    #[test]
+    fn tls_satisfies_the_network_bind_requirement() {
+        let path = write_config(
+            r#"
+bind = "0.0.0.0:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[tls]
+cert_path = "/etc/loonfs/tls/server.crt"
+key_path = "/etc/loonfs/tls/server.key"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let config = load_server_config(&path).expect("tls-terminating config loads");
+
+        let tls = config.tls.expect("tls table decodes");
+        assert_eq!(tls.cert_path, "/etc/loonfs/tls/server.crt");
+        assert_eq!(tls.key_path, "/etc/loonfs/tls/server.key");
+    }
+
+    #[test]
+    fn loopback_bind_accepts_tls() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+writer_id = "loonfs-server"
+
+[tls]
+cert_path = "/etc/loonfs/tls/server.crt"
+key_path = "/etc/loonfs/tls/server.key"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        load_server_config(&path).expect("loopback tls config loads");
+    }
+
+    #[test]
+    fn load_rejects_blank_tls_paths() {
+        for (cert_path, key_path, field) in [
+            (" ", "/etc/loonfs/tls/server.key", "tls.cert_path"),
+            ("/etc/loonfs/tls/server.crt", "", "tls.key_path"),
+        ] {
+            let path = write_config(&format!(
+                r#"
+bind = "127.0.0.1:9400"
+writer_id = "loonfs-server"
+
+[tls]
+cert_path = "{cert_path}"
+key_path = "{key_path}"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#
+            ));
+
+            let error = load_server_config(&path).expect_err("blank tls path");
+
+            assert_missing_field(error, field);
+        }
+    }
+
+    #[test]
+    fn load_rejects_unknown_tls_keys() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+writer_id = "loonfs-server"
+
+[tls]
+cert_path = "/etc/loonfs/tls/server.crt"
+key_path = "/etc/loonfs/tls/server.key"
+client_ca_path = "/etc/loonfs/tls/clients.crt"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        match load_server_config(&path).expect_err("unknown tls key") {
+            ServerConfigError::Decode(message) => assert!(
+                message.contains("client_ca_path"),
+                "decode error must name the unknown key, got: {message}"
+            ),
+            other => panic!("expected a decode error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -3,7 +3,6 @@
 use super::error::ApiResponseError;
 use super::serve::AppState;
 use crate::config::ServerConfig;
-use axum::async_trait;
 use axum::extract::rejection::PathRejection;
 use axum::extract::{FromRequest, FromRequestParts, Path as AxumPath, Query};
 use axum::http::request::Parts;
@@ -73,7 +72,7 @@ struct NamespaceSegment {
     namespace: String,
 }
 
-/// Extractor for the `:namespace` path segment of namespace-scoped routes.
+/// Extractor for the `{namespace}` path segment of namespace-scoped routes.
 ///
 /// The segment is parsed into a [`NamespaceId`] at extraction time, but the
 /// outcome is surfaced through [`NamespaceIdPath::into_id`] inside the
@@ -91,7 +90,6 @@ impl NamespaceIdPath {
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for NamespaceIdPath
 where
     S: Send + Sync,
@@ -126,7 +124,6 @@ impl<T> AppPath<T> {
     }
 }
 
-#[async_trait]
 impl<S, T> FromRequestParts<S> for AppPath<T>
 where
     S: Send + Sync,
@@ -154,7 +151,6 @@ impl<T> AppQuery<T> {
     }
 }
 
-#[async_trait]
 impl<S, T> FromRequestParts<S> for AppQuery<T>
 where
     S: Send + Sync,
@@ -203,7 +199,6 @@ where
     }
 }
 
-#[async_trait]
 impl<T> FromRequest<AppState> for AppJson<T>
 where
     T: serde::de::DeserializeOwned,
@@ -329,7 +324,6 @@ impl UploadStreamOutcome {
     }
 }
 
-#[async_trait]
 impl FromRequest<AppState> for UploadBodyStream {
     type Rejection = ApiResponseError;
 
@@ -395,7 +389,6 @@ pub(super) struct OptionalAppJson<T>(pub(super) Option<T>);
 
 const MAX_OPTIONAL_JSON_BODY_BYTES: usize = 1024 * 1024;
 
-#[async_trait]
 impl<T> FromRequest<AppState> for OptionalAppJson<T>
 where
     T: serde::de::DeserializeOwned,

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -2,10 +2,12 @@
 //! backing them.
 
 use super::error::ApiResponseError;
-use super::{AppJson, AppPath, AppState, NamespaceIdPath, OptionalAppJson, UploadBodyStream};
+use super::{
+    authorize, AppJson, AppPath, AppState, NamespaceIdPath, OptionalAppJson, UploadBodyStream,
+};
 use crate::config::ServerConfig;
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use loonfs::content_tokens::{mint_content_token, CompletedUploadReceipt, ContentTokenError};
 use loonfs::publish::PreparedContent;
@@ -491,9 +493,14 @@ pub(super) async fn complete_upload(
 )]
 pub(super) async fn read_upload_status(
     State(state): State<AppState>,
+    headers: HeaderMap,
     namespace: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
 ) -> Result<Json<UploadStatusResponse>, ApiResponseError> {
+    // A completed session answers with a freshly minted content-validation
+    // token, which is a capability to commit that content. Authorization
+    // runs before the id is even parsed, as everywhere else.
+    authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
@@ -536,9 +543,11 @@ pub(super) async fn read_upload_status(
 )]
 pub(super) async fn abort_upload(
     State(state): State<AppState>,
+    headers: HeaderMap,
     namespace: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
 ) -> Result<Json<AbortUploadResponse>, ApiResponseError> {
+    authorize(&state.config, &headers)?;
     let namespace_id = namespace.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -14,10 +14,12 @@ mod openapi;
 mod serve;
 #[cfg(test)]
 mod tests;
+mod tls;
 
 #[cfg(feature = "openapi")]
 pub use self::openapi::{openapi_document, openapi_json_pretty};
 pub use self::serve::{app, serve, serve_with_shutdown, ServeError, ServerLifecycle};
+pub use self::tls::TlsConfigError;
 
 use self::error::ApiResponseError;
 use self::extractors::{

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -122,48 +122,48 @@ fn router(state: AppState) -> Router {
         .route("/v0/capabilities", get(handlers_namespace::capabilities))
         .route("/v0/namespaces", post(create_namespace))
         .route(
-            "/v0/namespaces/:namespace",
+            "/v0/namespaces/{namespace}",
             get(namespace_status).delete(delete_namespace),
         )
-        .route("/v0/namespaces/:namespace/forks", post(fork_namespace))
+        .route("/v0/namespaces/{namespace}/forks", post(fork_namespace))
         .route(
-            "/v0/namespaces/:namespace/filesystem/list",
+            "/v0/namespaces/{namespace}/filesystem/list",
             get(list_path_entries),
         )
-        .route("/v0/namespaces/:namespace/filesystem/stat", get(stat_path))
+        .route("/v0/namespaces/{namespace}/filesystem/stat", get(stat_path))
         .route(
-            "/v0/namespaces/:namespace/filesystem/content",
+            "/v0/namespaces/{namespace}/filesystem/content",
             get(get_file_bytes),
         )
-        .route("/v0/namespaces/:namespace/query/grep", grep_route)
+        .route("/v0/namespaces/{namespace}/query/grep", grep_route)
         .route(
-            "/v0/admin/namespaces/:namespace/grep/index",
+            "/v0/admin/namespaces/{namespace}/grep/index",
             grep_status_route,
         )
         .route(
-            "/v0/admin/namespaces/:namespace/grep/index/enable",
+            "/v0/admin/namespaces/{namespace}/grep/index/enable",
             enable_grep_route,
         )
         .route(
-            "/v0/admin/namespaces/:namespace/grep/index/disable",
+            "/v0/admin/namespaces/{namespace}/grep/index/disable",
             disable_grep_route,
         )
         .route(
-            "/v0/admin/namespaces/:namespace/grep/index/gc",
+            "/v0/admin/namespaces/{namespace}/grep/index/gc",
             grep_gc_route,
         )
         .route(
-            "/v0/namespaces/:namespace/filesystem/revisions",
+            "/v0/namespaces/{namespace}/filesystem/revisions",
             get(list_file_revisions),
         )
         .route(
-            "/v0/namespaces/:namespace/filesystem/trash",
+            "/v0/namespaces/{namespace}/filesystem/trash",
             get(list_trash),
         )
-        .route("/v0/namespaces/:namespace/commits", post(apply_commit))
-        .route("/v0/namespaces/:namespace/uploads", post(begin_upload))
+        .route("/v0/namespaces/{namespace}/commits", post(apply_commit))
+        .route("/v0/namespaces/{namespace}/uploads", post(begin_upload))
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id/content",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
             // No body-limit layer: the upload route never buffers its
             // body, so a framework limit measured against a buffered read
             // would never fire. `UploadBodyStream` counts the bytes as it
@@ -171,32 +171,32 @@ fn router(state: AppState) -> Router {
             put(upload_content),
         )
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id/parts",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/parts",
             post(sign_upload_parts),
         )
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id/complete",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
             post(complete_upload),
         )
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id/abort",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/abort",
             post(abort_upload),
         )
         .route(
-            "/v0/namespaces/:namespace/uploads/:upload_id",
+            "/v0/namespaces/{namespace}/uploads/{upload_id}",
             get(read_upload_status),
         )
-        .route("/v0/namespaces/:namespace/changes", get(list_changes))
+        .route("/v0/namespaces/{namespace}/changes", get(list_changes))
         .route(
-            "/v0/admin/namespaces/:namespace/checkpoints",
+            "/v0/admin/namespaces/{namespace}/checkpoints",
             post(create_checkpoint),
         )
         .route(
-            "/v0/admin/namespaces/:namespace/checkpoints/:checkpoint_id/release",
+            "/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release",
             post(release_checkpoint),
         )
         .route(
-            "/v0/admin/namespaces/:namespace/maintenance/step",
+            "/v0/admin/namespaces/{namespace}/maintenance/step",
             post(maintenance_step),
         )
         // Unmatched paths and wrong methods answer inside the error

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -139,6 +139,11 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         loonfs_api::v0::GrepGcRequest,
         loonfs_api::v0::GrepGcResponse
     )),
+    // Applies to every operation that does not override it. `/health` and
+    // `/readiness` do, with `security(())`: they are the probe surface and
+    // answer unauthenticated by design.
+    security(("bearer_auth" = [])),
+    modifiers(&BearerAuth),
     tags(
         (name = "health", description = "Server health"),
         (name = "capabilities", description = "Capability discovery"),
@@ -150,3 +155,33 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
     )
 )]
 struct LoonfsOpenApi;
+
+/// Declares the scheme the global requirement above names.
+///
+/// This adds to the components the derive already built rather than
+/// replacing them, so the schema set survives.
+struct BearerAuth;
+
+impl utoipa::Modify for BearerAuth {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+
+        openapi
+            .components
+            .get_or_insert_with(Default::default)
+            .add_security_scheme(
+                "bearer_auth",
+                SecurityScheme::Http(
+                    HttpBuilder::new()
+                        .scheme(HttpAuthScheme::Bearer)
+                        .description(Some(
+                            "The deployment's `auth_token`, sent as \
+                             `Authorization: Bearer <token>`. A server configured \
+                             without a token accepts every request; one configured \
+                             with a token answers 401 `unauthorized` without it.",
+                        ))
+                        .build(),
+                ),
+            );
+    }
+}

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -1,6 +1,7 @@
 //! HTTP application construction, listener service, and shutdown lifecycle.
 
 use super::router;
+use super::tls::{self, TlsConfigError, TlsListener};
 use crate::config::{ServerConfig, ServerConfigError};
 use axum::Router;
 use loonfs::metrics::{
@@ -388,6 +389,8 @@ pub enum ServeError {
         #[source]
         source: std::io::Error,
     },
+    #[error("failed to load the configured TLS identity: {0}")]
+    Tls(#[source] TlsConfigError),
     #[error("server failed while serving requests: {0}")]
     Serve(#[source] std::io::Error),
     #[error("background work did not settle during shutdown: {0}")]
@@ -409,17 +412,35 @@ pub async fn serve_with_shutdown(
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), ServeError> {
     let bind = config.bind_addr()?;
+    // The identity is loaded before the bind, so a deployment with an
+    // unreadable certificate fails without ever having held the port.
+    let tls = config
+        .tls
+        .as_ref()
+        .map(tls::server_config)
+        .transpose()
+        .map_err(ServeError::Tls)?;
     let listener = tokio::net::TcpListener::bind(bind)
         .await
         .map_err(|source| ServeError::Bind { addr: bind, source })?;
-    serve_on(listener, config, shutdown).await
+    match tls {
+        Some(tls) => serve_on(TlsListener::new(listener, tls), config, shutdown).await,
+        None => serve_on(listener, config, shutdown).await,
+    }
 }
 
-pub(super) async fn serve_on(
-    listener: tokio::net::TcpListener,
+/// The one serving body, over whichever listener the deployment configured.
+/// Plaintext and TLS differ in what `accept` returns and in nothing else:
+/// the same router, the same graceful shutdown, and the same lifecycle
+/// settle after the listener has drained.
+pub(super) async fn serve_on<L>(
+    listener: L,
     config: ServerConfig,
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,
-) -> Result<(), ServeError> {
+) -> Result<(), ServeError>
+where
+    L: axum::serve::Listener<Addr = SocketAddr>,
+{
     let (router, lifecycle) = app(config).await?;
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown)

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -315,6 +315,7 @@ async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
         auth_token: Some("test-token".to_owned()),
         request_timeout_ms: None,
         disable_transient_retry: false,
+        ca_cert_path: None,
     })
     .expect("valid client config");
     client
@@ -1162,6 +1163,7 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
             auth_token,
             request_timeout_ms: None,
             disable_transient_retry: false,
+            ca_cert_path: None,
         })
         .expect("valid client config");
         assert_api_error(
@@ -1310,6 +1312,7 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
         auth_token: Some("test-token".to_owned()),
         request_timeout_ms: None,
         disable_transient_retry: false,
+        ca_cert_path: None,
     })
     .expect("valid client config");
     let target = NamespacePath::parse("demo", "/big.bin").expect("target");
@@ -1687,6 +1690,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
         // These tests assert the raw concurrency-cap answer; the client's
         // transient retry would otherwise sleep through it.
         disable_transient_retry: true,
+        ca_cert_path: None,
     };
     let config_for_busy = client_config.clone();
     let client = Client::new(config_for_busy).expect("valid client config");
@@ -1748,6 +1752,7 @@ async fn client_transient_retry_rides_out_a_briefly_full_upload_slot() {
         auth_token: Some("test-token".to_owned()),
         request_timeout_ms: None,
         disable_transient_retry: false,
+        ca_cert_path: None,
     })
     .expect("valid client config");
     let target = NamespacePath::parse("demo", "/retried.bin").expect("target");
@@ -1798,6 +1803,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
         // These tests assert the raw concurrency-cap answer; the client's
         // transient retry would otherwise sleep through it.
         disable_transient_retry: true,
+        ca_cert_path: None,
     };
     let config_for_busy = client_config.clone();
     let client = Client::new(config_for_busy).expect("valid client config");
@@ -1858,6 +1864,7 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
         auth_token: Some("test-token".to_owned()),
         request_timeout_ms: None,
         disable_transient_retry: false,
+        ca_cert_path: None,
     })
     .expect("valid client config");
     assert_api_error(
@@ -2094,6 +2101,7 @@ async fn start_server_with_config(store: SharedObjectStore, config: ServerConfig
             auth_token: Some("test-token".to_owned()),
             request_timeout_ms: None,
             disable_transient_retry: false,
+            ca_cert_path: None,
         })
         .expect("valid client config"),
         server,
@@ -2126,6 +2134,8 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         max_concurrent_downloads: 16,
         max_concurrent_maintenance: loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
         allow_unauthenticated_remote: false,
+        allow_remote_without_tls: false,
+        tls: None,
         store: StoreConfig::LocalFs {
             root: root.display().to_string(),
             key_prefix: Some("http-tests".to_owned()),

--- a/crates/loonfs-server/src/http/tls.rs
+++ b/crates/loonfs-server/src/http/tls.rs
@@ -1,0 +1,279 @@
+//! TLS termination: the certificate/key load and the [`axum::serve`]
+//! listener that wraps accepted TCP connections in a rustls session.
+
+use crate::config::TlsServerConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use std::future::Future;
+use std::io;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{ready, Context, Poll};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::server::TlsStream as RustlsStream;
+use tokio_rustls::{Accept, TlsAcceptor};
+
+/// Why the configured TLS identity could not be used. Every variant names
+/// the file it came from; none of them carry key material.
+#[derive(Debug, thiserror::Error)]
+pub enum TlsConfigError {
+    #[error("failed to read `{path}`: {source}")]
+    Read {
+        path: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("`{path}` is not valid PEM: {reason}")]
+    Pem { path: String, reason: String },
+    #[error(
+        "`{path}` and the certificate in `{cert_path}` do not form a usable identity: {reason}"
+    )]
+    Identity {
+        path: String,
+        cert_path: String,
+        reason: String,
+    },
+}
+
+/// Builds the rustls server configuration from the configured files.
+///
+/// The provider is named rather than taken from the process-wide default:
+/// this process links exactly one, and resolving it here keeps a startup
+/// misconfiguration a returned error instead of a panic deep in rustls.
+pub(super) fn server_config(
+    config: &TlsServerConfig,
+) -> Result<rustls::ServerConfig, TlsConfigError> {
+    let certs = load_cert_chain(&config.cert_path)?;
+    let key = load_private_key(&config.key_path)?;
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut server_config = rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|error| TlsConfigError::Identity {
+            path: config.key_path.clone(),
+            cert_path: config.cert_path.clone(),
+            reason: error.to_string(),
+        })?
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|error| TlsConfigError::Identity {
+            path: config.key_path.clone(),
+            cert_path: config.cert_path.clone(),
+            reason: error.to_string(),
+        })?;
+    // Offered in preference order. HTTP/2 first because axum serves it, and
+    // `http/1.1` retained because a client that cannot speak h2 must still
+    // reach the same routes.
+    server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    Ok(server_config)
+}
+
+fn load_cert_chain(path: &str) -> Result<Vec<CertificateDer<'static>>, TlsConfigError> {
+    let mut reader = io::BufReader::new(open(path)?);
+    let certs = rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| TlsConfigError::Pem {
+            path: path.to_owned(),
+            reason: error.to_string(),
+        })?;
+    if certs.is_empty() {
+        return Err(TlsConfigError::Pem {
+            path: path.to_owned(),
+            reason: "no CERTIFICATE section found; expected the PEM chain, leaf first".to_owned(),
+        });
+    }
+    Ok(certs)
+}
+
+fn load_private_key(path: &str) -> Result<PrivateKeyDer<'static>, TlsConfigError> {
+    let mut reader = io::BufReader::new(open(path)?);
+    rustls_pemfile::private_key(&mut reader)
+        .map_err(|error| TlsConfigError::Pem {
+            path: path.to_owned(),
+            reason: error.to_string(),
+        })?
+        .ok_or_else(|| TlsConfigError::Pem {
+            path: path.to_owned(),
+            reason: "no PRIVATE KEY section found; expected a PKCS#8, RSA, or EC private key"
+                .to_owned(),
+        })
+}
+
+fn open(path: &str) -> Result<std::fs::File, TlsConfigError> {
+    std::fs::File::open(Path::new(path)).map_err(|source| TlsConfigError::Read {
+        path: path.to_owned(),
+        source,
+    })
+}
+
+/// A TCP listener that hands [`axum::serve`] TLS connections.
+///
+/// `accept` deliberately returns as soon as the TCP connection is accepted,
+/// before the handshake runs. axum awaits `accept` in the loop that also
+/// dispatches connections, so a handshake performed here would be a
+/// head-of-line block: one client that connects and then stalls would keep
+/// every other client waiting. The handshake instead runs inside the
+/// connection's own task, on the first poll of the returned [`TlsIo`].
+pub(super) struct TlsListener {
+    tcp: TcpListener,
+    acceptor: TlsAcceptor,
+}
+
+impl TlsListener {
+    pub(super) fn new(tcp: TcpListener, config: rustls::ServerConfig) -> Self {
+        Self {
+            tcp,
+            acceptor: TlsAcceptor::from(Arc::new(config)),
+        }
+    }
+}
+
+impl axum::serve::Listener for TlsListener {
+    type Io = TlsIo;
+    type Addr = SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            match self.tcp.accept().await {
+                Ok((stream, addr)) => {
+                    return (
+                        TlsIo::Handshaking(Box::new(self.acceptor.accept(stream))),
+                        addr,
+                    )
+                }
+                Err(error) => handle_accept_error(error).await,
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<Self::Addr> {
+        self.tcp.local_addr()
+    }
+}
+
+/// Mirrors what axum's own `Listener for TcpListener` does with a failed
+/// accept, because the trait makes each implementor responsible for it:
+/// a per-connection error is dropped, and anything else — `EMFILE` being the
+/// case worth naming — is logged and retried after a pause rather than
+/// ending the accept loop.
+async fn handle_accept_error(error: io::Error) {
+    if matches!(
+        error.kind(),
+        io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionReset
+    ) {
+        return;
+    }
+    tracing::error!("accept error: {error}");
+    accept_retry_pause().await;
+}
+
+#[allow(clippy::disallowed_methods)]
+// Backs off an accept loop that would otherwise spin on a resource the
+// process has run out of. No protocol time depends on it.
+async fn accept_retry_pause() {
+    tokio::time::sleep(ACCEPT_RETRY_PAUSE).await;
+}
+
+const ACCEPT_RETRY_PAUSE: Duration = Duration::from_secs(1);
+
+/// One accepted connection, before or after its TLS handshake.
+///
+/// A handshake failure is this connection's failure and nothing else's: it
+/// surfaces as an `io::Error` to the task serving this socket, which drops
+/// it. The listener keeps accepting, so a plaintext client that reaches the
+/// TLS port loses its own connection and no other.
+pub(super) enum TlsIo {
+    Handshaking(Box<Accept<TcpStream>>),
+    Ready(Box<RustlsStream<TcpStream>>),
+    /// The handshake failed. Held so a later poll reports the failure again
+    /// instead of polling a future that has already completed.
+    Failed,
+}
+
+impl TlsIo {
+    /// Drives the handshake to completion, then yields the negotiated
+    /// stream. Every read and write goes through here, so the handshake
+    /// happens exactly once, on whichever comes first.
+    fn poll_stream(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<Pin<&mut RustlsStream<TcpStream>>>> {
+        if let Self::Handshaking(accept) = self {
+            match Pin::new(accept.as_mut()).poll(cx) {
+                Poll::Ready(Ok(stream)) => *self = Self::Ready(Box::new(stream)),
+                Poll::Ready(Err(error)) => {
+                    *self = Self::Failed;
+                    return Poll::Ready(Err(error));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        match self {
+            Self::Ready(stream) => Poll::Ready(Ok(Pin::new(stream.as_mut()))),
+            // `Handshaking` cannot reach here: the block above either
+            // replaced it or returned.
+            Self::Handshaking(_) | Self::Failed => Poll::Ready(Err(handshake_failed())),
+        }
+    }
+}
+
+fn handshake_failed() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "tls handshake failed on this connection",
+    )
+}
+
+impl AsyncRead for TlsIo {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        ready!(self.get_mut().poll_stream(cx))?.poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for TlsIo {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        ready!(self.get_mut().poll_stream(cx))?.poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        ready!(self.get_mut().poll_stream(cx))?.poll_write_vectored(cx, bufs)
+    }
+
+    /// Constant for the wrapped stream in every state, so reporting it
+    /// before the handshake finishes cannot contradict what the negotiated
+    /// stream then does.
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        ready!(self.get_mut().poll_stream(cx))?.poll_flush(cx)
+    }
+
+    /// A connection whose handshake never finished has no session to close,
+    /// and completing one on the way out would make shutdown wait on a peer
+    /// that has already stopped mattering. Dropping the socket is the whole
+    /// close in that state.
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsIo::Ready(stream) => Pin::new(stream.as_mut()).poll_shutdown(cx),
+            TlsIo::Handshaking(_) | TlsIo::Failed => Poll::Ready(Ok(())),
+        }
+    }
+}

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -11,9 +11,9 @@ mod trace;
 
 pub use config::{
     load_server_config, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides,
-    ServerConfig, ServerConfigError, StoreConfig,
+    ServerConfig, ServerConfigError, StoreConfig, TlsServerConfig,
 };
-pub use http::{app, serve, serve_with_shutdown, ServeError, ServerLifecycle};
+pub use http::{app, serve, serve_with_shutdown, ServeError, ServerLifecycle, TlsConfigError};
 #[cfg(feature = "openapi")]
 pub use http::{openapi_document, openapi_json_pretty};
 pub use trace::{init_tracing_from_env, TraceInitError};

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -4,9 +4,12 @@
 
 use loonfs_client::{Client, ClientConfig};
 use loonfs_server::{
-    app, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServerConfig, StoreConfig,
+    app, serve_with_shutdown, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServeError,
+    ServerConfig, StoreConfig, TlsServerConfig,
 };
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 pub(crate) struct TestServer {
     pub(crate) client: Client,
@@ -47,6 +50,7 @@ pub(crate) async fn start_server(config: ServerConfig) -> TestServer {
             auth_token,
             request_timeout_ms: None,
             disable_transient_retry: false,
+            ca_cert_path: None,
         })
         .expect("valid client config"),
         server_url,
@@ -54,6 +58,95 @@ pub(crate) async fn start_server(config: ServerConfig) -> TestServer {
         store_key_prefix,
         server,
     }
+}
+
+/// A server terminating TLS on loopback with a certificate generated for
+/// this test, plus the CA path a client needs to trust it.
+///
+/// Unlike [`start_server`] this goes through [`serve_with_shutdown`], the
+/// same entry point the binary uses: the identity load, the bind, and the
+/// TLS listener are the deployed ones rather than a test-only assembly.
+pub(crate) struct TlsTestServer {
+    pub(crate) client: Client,
+    pub(crate) server_url: String,
+    pub(crate) addr: SocketAddr,
+    pub(crate) ca_cert_path: String,
+    pub(crate) auth_token: Option<String>,
+    pub(crate) shutdown: tokio::sync::oneshot::Sender<()>,
+    pub(crate) server: tokio::task::JoinHandle<Result<(), ServeError>>,
+    /// Holds the generated certificate and key on disk for the server's
+    /// lifetime.
+    _identity_dir: tempfile::TempDir,
+}
+
+pub(crate) async fn start_tls_server(mut config: ServerConfig) -> TlsTestServer {
+    let identity_dir = tempfile::tempdir().expect("tls identity dir");
+    let cert_path = identity_dir.path().join("server.crt");
+    let key_path = identity_dir.path().join("server.key");
+    let identity =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_owned(), "127.0.0.1".to_owned()])
+            .expect("generate self-signed identity");
+    std::fs::write(&cert_path, identity.cert.pem()).expect("write certificate");
+    std::fs::write(&key_path, identity.signing_key.serialize_pem()).expect("write private key");
+
+    let addr = reserve_loopback_addr().await;
+    config.bind = addr.to_string();
+    config.tls = Some(TlsServerConfig {
+        cert_path: cert_path.display().to_string(),
+        key_path: key_path.display().to_string(),
+    });
+    let auth_token = config
+        .auth_token
+        .as_ref()
+        .map(|token| token.expose().to_owned());
+
+    let (shutdown, shutdown_signal) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(serve_with_shutdown(config, async move {
+        let _ = shutdown_signal.await;
+    }));
+    wait_until_listening(addr).await;
+
+    let server_url = format!("https://{addr}");
+    let ca_cert_path = cert_path.display().to_string();
+    TlsTestServer {
+        client: Client::new(ClientConfig {
+            server_url: server_url.clone(),
+            auth_token: auth_token.clone(),
+            request_timeout_ms: None,
+            disable_transient_retry: false,
+            ca_cert_path: Some(ca_cert_path.clone()),
+        })
+        .expect("valid client config"),
+        server_url,
+        addr,
+        ca_cert_path,
+        auth_token,
+        shutdown,
+        server,
+        _identity_dir: identity_dir,
+    }
+}
+
+/// Picks a free loopback port by binding one and letting it go. The server
+/// binds it itself, because `serve_with_shutdown` owns that step and the
+/// point of this harness is to exercise it.
+async fn reserve_loopback_addr() -> SocketAddr {
+    let probe = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("probe bind");
+    probe.local_addr().expect("probe addr")
+}
+
+#[allow(clippy::disallowed_methods, clippy::panic)]
+// Test-harness polling for a port the server binds on its own schedule.
+async fn wait_until_listening(addr: SocketAddr) {
+    for _ in 0..500 {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("server never started listening on {addr}");
 }
 
 pub(crate) fn test_config(
@@ -77,6 +170,8 @@ pub(crate) fn test_config(
         max_concurrent_downloads: 16,
         max_concurrent_maintenance: loonfs::DEFAULT_MAX_CONCURRENT_MAINTENANCE,
         allow_unauthenticated_remote: false,
+        allow_remote_without_tls: false,
+        tls: None,
         store,
     }
 }

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -543,6 +543,8 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
         max_concurrent_downloads: 2,
         max_concurrent_maintenance: 2,
         allow_unauthenticated_remote: false,
+        allow_remote_without_tls: false,
+        tls: None,
         store: StoreConfig::LocalFs {
             root: store_root.display().to_string(),
             key_prefix: None,

--- a/crates/loonfs-server/tests/it/http_auth.rs
+++ b/crates/loonfs-server/tests/it/http_auth.rs
@@ -4,10 +4,12 @@ use crate::common::http_split_support::*;
 use crate::common::start_server;
 use loonfs_api::ContentId;
 use loonfs_api::{
-    v0::ValidatedContentToken, AbsolutePath, ApiError, ChangeSeq, CommitId, CommitRequest,
-    CommitResponse, ContentRef, DestinationBehavior, ErrorCode, FilesystemOperation,
+    v0::{BeginUploadRequest, ValidatedContentToken},
+    AbsolutePath, ApiError, ChangeSeq, CommitId, CommitRequest, CommitResponse, ContentRef,
+    DestinationBehavior, ErrorCode, FilesystemOperation,
 };
 use loonfs_client::NamespacePath;
+use loonfs_test_support::http::raw_agent;
 use loonfs_test_support::ids::namespace_id;
 use serde_json::json;
 use std::io::Read as _;
@@ -407,6 +409,50 @@ async fn bare_operation_body_without_content_tokens_still_parses_and_commits_mkd
         .stat_path(&NamespacePath::parse("demo", "/docs").expect("path"))
         .await
         .expect("mkdir committed");
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn every_upload_session_route_requires_the_bearer_token() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-current",
+        "http-upload-auth",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let begin = harness
+        .client
+        .begin_upload(&namespace, &BeginUploadRequest::default())
+        .await
+        .expect("begin upload");
+    let upload_id = begin.upload_id;
+    let base = format!(
+        "{}/v0/namespaces/{namespace}/uploads/{upload_id}",
+        harness.server_url
+    );
+
+    // Reading a session mints a fresh content-validation token, and aborting
+    // one destroys another client's in-flight upload. Neither is reachable
+    // without the deployment's token.
+    for (method, url) in [("GET", base.clone()), ("POST", format!("{base}/abort"))] {
+        match raw_agent().request(method, &url).call() {
+            Err(ureq::Error::Status(401, response)) => {
+                let error: ApiError =
+                    serde_json::from_reader(response.into_reader()).expect("decode api error");
+                assert_eq!(error.code, ErrorCode::Unauthorized.as_str());
+            }
+            other => unreachable!("expected 401 for `{method} {url}`, got {other:?}"),
+        }
+    }
 
     harness.server.abort();
 }

--- a/crates/loonfs-server/tests/it/http_tls.rs
+++ b/crates/loonfs-server/tests/it/http_tls.rs
@@ -1,0 +1,177 @@
+//! TLS termination end to end: a real client over a real handshake, and the
+//! two ways a connection can be wrong without taking the server with it.
+
+use crate::common::http_split_support::{replace_file_options, test_config};
+use crate::common::{start_tls_server, TlsTestServer};
+use loonfs_client::{Client, ClientConfig, NamespacePath};
+use loonfs_test_support::ids::namespace_id;
+use std::io::{Read, Write};
+use tempfile::tempdir;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_client_trusting_the_server_certificate_round_trips_over_tls() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_tls_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-tls",
+        "http-tls",
+    ))
+    .await;
+
+    assert!(
+        harness.server_url.starts_with("https://"),
+        "the harness must exercise https, got {}",
+        harness.server_url
+    );
+
+    let namespace = namespace_id("over-tls");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let target = NamespacePath::parse("over-tls", "/note.txt").expect("parse path");
+    harness
+        .client
+        .put_file_bytes(&target, b"ciphertext in flight", &replace_file_options())
+        .await
+        .expect("write file");
+
+    let stat = harness.client.stat_path(&target).await.expect("stat file");
+    assert_eq!(stat.size_bytes, Some(b"ciphertext in flight".len() as u64));
+
+    let bytes = harness
+        .client
+        .get_file_bytes(&target)
+        .await
+        .expect("read file");
+    assert_eq!(bytes, b"ciphertext in flight");
+
+    shut_down(harness).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_client_without_the_certificate_authority_is_refused_at_the_handshake() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_tls_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-tls",
+        "http-tls-untrusted",
+    ))
+    .await;
+
+    let untrusting = Client::new(ClientConfig {
+        server_url: harness.server_url.clone(),
+        auth_token: harness.auth_token.clone(),
+        request_timeout_ms: None,
+        disable_transient_retry: true,
+        ca_cert_path: None,
+    })
+    .expect("valid client config");
+
+    // A self-signed certificate the platform roots do not vouch for is a
+    // transport failure, reported rather than panicked through.
+    let error = untrusting
+        .namespace_status(&namespace_id("over-tls"))
+        .await
+        .expect_err("untrusted certificate");
+    let message = error.to_string();
+    assert!(
+        message.contains("invalid peer certificate"),
+        "the failure must name the certificate rather than read as a generic \
+         network error, got: {message}"
+    );
+
+    // The refused handshake was that connection's alone.
+    harness
+        .client
+        .create_namespace(&namespace_id("still-serving"))
+        .await
+        .expect("the server still serves trusted clients");
+
+    shut_down(harness).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_plaintext_request_to_the_tls_port_loses_only_its_own_connection() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_tls_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-tls",
+        "http-tls-plaintext",
+    ))
+    .await;
+
+    let addr = harness.addr;
+    let plaintext = tokio::task::spawn_blocking(move || {
+        let mut socket = std::net::TcpStream::connect(addr).expect("connect to the tls port");
+        socket
+            .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("write a plaintext request");
+        let mut response = Vec::new();
+        socket.read_to_end(&mut response).map(|_| response)
+    })
+    .await
+    .expect("plaintext probe task");
+
+    // rustls answers the malformed ClientHello with an alert and closes, so
+    // the probe either reads no HTTP response or fails outright. Both are a
+    // refused connection; what matters is that neither is a served request.
+    if let Ok(response) = plaintext {
+        assert!(
+            !response.starts_with(b"HTTP/"),
+            "the tls port must not answer plaintext HTTP, got: {response:?}"
+        );
+    }
+
+    harness
+        .client
+        .create_namespace(&namespace_id("after-plaintext"))
+        .await
+        .expect("the server still serves tls clients");
+
+    shut_down(harness).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graceful_shutdown_settles_the_lifecycle_on_the_tls_path() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_tls_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-tls",
+        "http-tls-shutdown",
+    ))
+    .await;
+
+    let namespace = namespace_id("drained");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let target = NamespacePath::parse("drained", "/note.txt").expect("parse path");
+    harness
+        .client
+        .put_file_bytes(&target, b"settle me", &replace_file_options())
+        .await
+        .expect("write file");
+
+    // `serve_with_shutdown` returns only after the listener drains and the
+    // lifecycle settles; an unsettled one would surface here as an error.
+    shut_down(harness).await;
+}
+
+async fn shut_down(harness: TlsTestServer) {
+    let TlsTestServer {
+        client,
+        shutdown,
+        server,
+        ..
+    } = harness;
+    drop(client);
+    shutdown.send(()).expect("signal shutdown");
+    server
+        .await
+        .expect("server task")
+        .expect("graceful shutdown settles");
+}

--- a/crates/loonfs-server/tests/it/main.rs
+++ b/crates/loonfs-server/tests/it/main.rs
@@ -13,6 +13,7 @@ mod http_pagination;
 mod http_paths;
 mod http_retry;
 mod http_smoke;
+mod http_tls;
 mod http_uploads;
 
 // The OpenAPI document only exists behind the feature that generates it.

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -515,6 +515,31 @@ content-durability, and visibility rules.
 HTTP is one transport binding for these abstract operations. It is not the
 underlying semantics.
 
+### Authentication and transport
+
+A deployment that sets a token authenticates every request with an HTTP
+bearer credential:
+
+```
+Authorization: Bearer <auth_token>
+```
+
+A request without it, or with the wrong value, answers 401 `unauthorized`.
+Authorization is checked before the request is otherwise parsed, so a
+malformed body from an unauthenticated caller still answers 401 rather than
+400. Two routes are exempt and always answer unauthenticated, because they
+are what a load balancer probes: `GET /health` and `GET /readiness`.
+Everything else, `GET /v0/capabilities` included, requires the token. The
+generated `openapi.json` states this as a global `bearer_auth` requirement
+with those two operations overriding it.
+
+The token is a bearer credential and so is everything the upload routes hand
+back: a presigned direct-upload URL is a capability to write to the
+deployment's bucket, carried in an ordinary response body. Both are readable
+by anyone who can read the connection. Serve `https` for any deployment
+reachable beyond localhost — either terminated by the server itself or by a
+proxy in front of it.
+
 A representative v0 binding is shown below.
 
 | Purpose | Representative HTTP shape |

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -5231,8 +5231,20 @@
         "description": "Monotonically increasing writer epoch for namespace write fencing.",
         "minimum": 0
       }
+    },
+    "securitySchemes": {
+      "bearer_auth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "The deployment's `auth_token`, sent as `Authorization: Bearer <token>`. A server configured without a token accepts every request; one configured with a token answers 401 `unauthorized` without it."
+      }
     }
   },
+  "security": [
+    {
+      "bearer_auth": []
+    }
+  ],
   "tags": [
     {
       "name": "health",


### PR DESCRIPTION
This PR gives the server native TLS (It also fixes an authentication bug on two upload routes). 

Security fix, independent of TLS: two upload routes skipped authentication. `GET /v0/namespaces/{ns}/uploads/{upload_id}` and `POST .../uploads/{upload_id}/abort` never called `authorize()`. The other upload routes get authentication inside their body extractors; these two use only path extractors, so no check ran. The status route mints a fresh content token — a capability to commit that content — and abort destroys another client's in-flight upload. A test first proved the bypass (200 with no token on main), then the fix. A new test, `every_upload_session_route_requires_the_bearer_token`, sweeps all six upload routes. No released version carries the bug (the upload routes are newer than the last release). 

Why TLS?: The bearer token travels on every request. Upload responses carry presigned object-store URLs, which are bearer capabilities to the bucket. On plain HTTP both cross the network in cleartext.

Configuration: One new table and one new switch, both in the server TOML:

```toml
[tls]
cert_path = "/etc/loonfs/tls/server.crt"   # PEM chain, leaf first
key_path  = "/etc/loonfs/tls/server.key"   # PKCS#8, RSA, or SEC1
```

A bind that serves beyond localhost must configure `[tls]` or state `allow_remote_without_tls = true` (the TLS-terminating-proxy case). The rule sits beside the existing auth-token rule and fails at start with the remedy in the message. Loopback binds never require TLS but accept it.

Mechanism: A `TlsListener` implements axum 0.8's `Listener` trait around a `tokio_rustls` acceptor. `accept()` returns right after the TCP accept; the handshake completes lazily on the connection's first read or write. A slow or broken handshake therefore affects only its own connection — the accept loop never waits on a handshake. A plaintext client on the TLS port gets a connection error; the server keeps serving. ALPN offers h2 and http/1.1. Certificate and key problems fail at startup with the path in the message. The plaintext path and the TLS path share one serve body, so the graceful-shutdown ordering (drain, then lifecycle shutdown) is identical in both.


