### PR TITLE
feat(metrics): recorder trait with a served prometheus snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,15 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bit-vec"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +470,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "dialoguer"
@@ -1504,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -1801,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.8"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "pem",
  "ring",
@@ -2340,11 +2334,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2354,15 +2349,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.32"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3225,11 +3220,10 @@ checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yasna"
-version = "0.6.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "bit-vec",
  "time",
 ]
 

--- a/crates/loonfs-objectstore/src/attempts.rs
+++ b/crates/loonfs-objectstore/src/attempts.rs
@@ -1,0 +1,68 @@
+//! Counting the provider attempts one measured object-store call made.
+//!
+//! [`InstrumentedObjectStore`](crate::metrics::InstrumentedObjectStore)
+//! wraps above the bounded retry loops in
+//! [`provider_object_store`](crate::provider_object_store), so a sample's
+//! elapsed time already covers every retry while the count itself is
+//! invisible from up there — a slow call and a call that was retried nine
+//! times read the same. This task-local tally is the one channel between
+//! the two: the wrapper opens a tally around the call it is timing, the
+//! retry gate below counts each attempt it grants, and the wrapper reads
+//! the total back when it builds the sample.
+//!
+//! A retry gate outside a measured call finds no tally and counts nothing,
+//! so an uninstrumented store pays one failed task-local lookup per granted
+//! retry and nothing on any other path.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+tokio::task_local! {
+    /// Attempts made so far by the measured call running in this task.
+    static CALL_ATTEMPTS: Arc<AtomicU32>;
+}
+
+/// Runs `call` under a fresh tally and reports the attempts it made.
+///
+/// The count starts at the one attempt every call makes, so a sample's
+/// attempt count is never zero.
+pub(crate) async fn counting_attempts<F: Future>(call: F) -> (F::Output, u32) {
+    let attempts = Arc::new(AtomicU32::new(1));
+    let output = CALL_ATTEMPTS.scope(Arc::clone(&attempts), call).await;
+    (output, attempts.load(Ordering::Relaxed))
+}
+
+/// Counts one granted retry against the measured call it belongs to.
+pub(crate) fn count_retry_attempt() {
+    let _ = CALL_ATTEMPTS.try_with(|attempts| attempts.fetch_add(1, Ordering::Relaxed));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_call_that_never_retries_reports_one_attempt() {
+        let (output, attempts) = counting_attempts(async { 7 }).await;
+        assert_eq!(output, 7);
+        assert_eq!(attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn granted_retries_count_against_the_call_that_made_them() {
+        let (_, attempts) = counting_attempts(async {
+            count_retry_attempt();
+            count_retry_attempt();
+        })
+        .await;
+        assert_eq!(attempts, 3);
+    }
+
+    #[tokio::test]
+    async fn a_retry_outside_a_measured_call_counts_nothing() {
+        count_retry_attempt();
+        let (_, attempts) = counting_attempts(async {}).await;
+        assert_eq!(attempts, 1);
+    }
+}

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -12,6 +12,7 @@
 #![warn(missing_docs)]
 
 pub mod abs;
+mod attempts;
 mod configured;
 pub mod gcs;
 mod immutable_write;

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -1,6 +1,7 @@
 //! A metrics-recording wrapper around any object store: per-operation
 //! samples classified by object family.
 
+use crate::attempts::counting_attempts;
 use crate::layout::{parse_object_key, DurableObjectFamily};
 use crate::object_store::Result;
 use crate::{
@@ -29,6 +30,16 @@ pub struct ObjectStoreMetricSample {
     pub operation: ObjectStoreOperation,
     /// End-to-end operation latency in microseconds, including provider waits.
     pub elapsed_micros: u128,
+    /// Provider attempts this one call made, counting the first: `1` is a
+    /// call that never retried.
+    ///
+    /// Retries are what makes an otherwise unexplained `elapsed_micros`
+    /// readable. The count covers the bounded retry loops inside the store
+    /// this wrapper measures; a retry loop that sits *above* the wrapper —
+    /// [`crate::ObjectStore::put_immutable_verified`] is the one — surfaces
+    /// as one sample per attempt instead, because each of its attempts
+    /// really is a separate measured call.
+    pub attempts: u32,
     /// Cardinality-bounded success or failure classification.
     pub result: ObjectStoreResultClass,
     /// Request payload bytes for a put, including failed attempts; otherwise `None`.
@@ -75,6 +86,26 @@ pub enum ObjectStoreOperation {
     ListPrefixStream,
 }
 
+impl ObjectStoreOperation {
+    /// The label an aggregating recorder groups by. Identical to the serde
+    /// name: one operation has one spelling wherever it is reported.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Head => "head",
+            Self::GetWithMetadata => "get_with_metadata",
+            Self::Get => "get",
+            Self::Put => "put",
+            Self::PutStreamed => "put_streamed",
+            Self::Delete => "delete",
+            Self::CreateMultipartUpload => "create_multipart_upload",
+            Self::CompleteMultipartUpload => "complete_multipart_upload",
+            Self::AbortMultipartUpload => "abort_multipart_upload",
+            Self::ListPrefix => "list_prefix",
+            Self::ListPrefixStream => "list_prefix_stream",
+        }
+    }
+}
+
 /// Collapses object-store outcomes into a bounded metrics vocabulary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -99,6 +130,25 @@ pub enum ObjectStoreResultClass {
     Transport,
     /// Reserves a forward-compatible bucket for errors outside the current registry.
     OtherError,
+}
+
+impl ObjectStoreResultClass {
+    /// The label an aggregating recorder groups by. Identical to the serde
+    /// name: one outcome has one spelling wherever it is reported.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::NotFound => "not_found",
+            Self::InvalidKey => "invalid_key",
+            Self::InvalidContentRef => "invalid_content_ref",
+            Self::InvalidRange => "invalid_range",
+            Self::PreconditionFailed => "precondition_failed",
+            Self::PermissionDenied => "permission_denied",
+            Self::Unsupported => "unsupported",
+            Self::Transport => "transport",
+            Self::OtherError => "other_error",
+        }
+    }
 }
 
 /// Groups durable keys into low-cardinality operational families.
@@ -285,23 +335,35 @@ where
 {
     async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
         let start = sample_clock();
-        let result = self.inner.head(key).await;
-        self.record_head_like(ObjectStoreOperation::Head, key, start.elapsed(), &result);
+        let (result, attempts) = counting_attempts(self.inner.head(key)).await;
+        self.record_head_like(
+            ObjectStoreOperation::Head,
+            key,
+            start.elapsed(),
+            attempts,
+            &result,
+        );
         result
     }
 
     async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
         let start = sample_clock();
-        let result = self.inner.head_stored_checksum(key).await;
+        let (result, attempts) = counting_attempts(self.inner.head_stored_checksum(key)).await;
         // One provider metadata request, recorded as the head it is: the
         // point of this call is that it moves no payload.
-        self.record_head_like(ObjectStoreOperation::Head, key, start.elapsed(), &result);
+        self.record_head_like(
+            ObjectStoreOperation::Head,
+            key,
+            start.elapsed(),
+            attempts,
+            &result,
+        );
         result
     }
 
     async fn create_multipart_upload(&self, key: &str) -> Result<String> {
         let start = sample_clock();
-        let result = self.inner.create_multipart_upload(key).await;
+        let (result, attempts) = counting_attempts(self.inner.create_multipart_upload(key)).await;
         // The multipart control calls move no payload of their own: the
         // parts travel from the client straight to the provider. Timing them
         // is the only thing there is to record.
@@ -309,6 +371,7 @@ where
             ObjectStoreOperation::CreateMultipartUpload,
             key,
             start.elapsed(),
+            attempts,
             &result,
         );
         result
@@ -322,14 +385,18 @@ where
         full_object_checksum: &StorageChecksum,
     ) -> Result<MultipartCompletion> {
         let start = sample_clock();
-        let result = self
-            .inner
-            .complete_multipart_upload(key, provider_upload_id, parts, full_object_checksum)
-            .await;
+        let (result, attempts) = counting_attempts(self.inner.complete_multipart_upload(
+            key,
+            provider_upload_id,
+            parts,
+            full_object_checksum,
+        ))
+        .await;
         self.record_unit(
             ObjectStoreOperation::CompleteMultipartUpload,
             key,
             start.elapsed(),
+            attempts,
             &result,
         );
         result
@@ -337,14 +404,13 @@ where
 
     async fn abort_multipart_upload(&self, key: &str, provider_upload_id: &str) -> Result<()> {
         let start = sample_clock();
-        let result = self
-            .inner
-            .abort_multipart_upload(key, provider_upload_id)
-            .await;
+        let (result, attempts) =
+            counting_attempts(self.inner.abort_multipart_upload(key, provider_upload_id)).await;
         self.record_unit(
             ObjectStoreOperation::AbortMultipartUpload,
             key,
             start.elapsed(),
+            attempts,
             &result,
         );
         result
@@ -352,23 +418,23 @@ where
 
     async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
         let start = sample_clock();
-        let result = self.inner.get(key, range.clone()).await;
-        self.record_get(key, range.as_ref(), start.elapsed(), &result);
+        let (result, attempts) = counting_attempts(self.inner.get(key, range.clone())).await;
+        self.record_get(key, range.as_ref(), start.elapsed(), attempts, &result);
         result
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
         let start = sample_clock();
-        let result = self.inner.get_with_metadata(key).await;
-        self.record_get_with_metadata(key, start.elapsed(), &result);
+        let (result, attempts) = counting_attempts(self.inner.get_with_metadata(key)).await;
+        self.record_get_with_metadata(key, start.elapsed(), attempts, &result);
         result
     }
 
     async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         let start = sample_clock();
         let bytes_in = bytes.len() as u64;
-        let result = self.inner.put(key, bytes, mode.clone()).await;
-        self.record_put(key, bytes_in, &mode, start.elapsed(), &result);
+        let (result, attempts) = counting_attempts(self.inner.put(key, bytes, mode.clone())).await;
+        self.record_put(key, bytes_in, &mode, start.elapsed(), attempts, &result);
         result
     }
 
@@ -378,10 +444,12 @@ where
     /// its content is taking.
     async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
         let start = sample_clock();
-        let result = self.inner.put_streamed(key, body, mode.clone()).await;
+        let (result, attempts) =
+            counting_attempts(self.inner.put_streamed(key, body, mode.clone())).await;
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::PutStreamed,
             elapsed_micros: start.elapsed().as_micros(),
+            attempts,
             result: classify_result(&result),
             bytes_in: result.as_ref().ok().copied(),
             bytes_out: None,
@@ -396,8 +464,14 @@ where
 
     async fn delete(&self, key: &str) -> Result<()> {
         let start = sample_clock();
-        let result = self.inner.delete(key).await;
-        self.record_unit(ObjectStoreOperation::Delete, key, start.elapsed(), &result);
+        let (result, attempts) = counting_attempts(self.inner.delete(key)).await;
+        self.record_unit(
+            ObjectStoreOperation::Delete,
+            key,
+            start.elapsed(),
+            attempts,
+            &result,
+        );
         result
     }
 
@@ -419,16 +493,18 @@ where
 
     async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>> {
         let start = sample_clock();
-        let result: Result<Vec<_>> = self
-            .inner
-            .list_prefix_stream(prefix)
-            .try_collect()
-            .await
-            .map(|mut keys: Vec<String>| {
-                keys.sort();
-                keys
-            });
-        self.record_list(prefix, start.elapsed(), &result);
+        let (result, attempts): (Result<Vec<_>>, u32) = counting_attempts(async {
+            self.inner
+                .list_prefix_stream(prefix)
+                .try_collect()
+                .await
+                .map(|mut keys: Vec<String>| {
+                    keys.sort();
+                    keys
+                })
+        })
+        .await;
+        self.record_list(prefix, start.elapsed(), attempts, &result);
         result
     }
 }
@@ -439,11 +515,13 @@ impl<S> InstrumentedObjectStore<S> {
         operation: ObjectStoreOperation,
         key: &str,
         elapsed: Duration,
+        attempts: u32,
         result: &Result<Option<T>>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation,
             elapsed_micros: elapsed.as_micros(),
+            attempts,
             result: classify_optional_result(result),
             bytes_in: None,
             bytes_out: None,
@@ -460,11 +538,13 @@ impl<S> InstrumentedObjectStore<S> {
         key: &str,
         range: Option<&ByteRange>,
         elapsed: Duration,
+        attempts: u32,
         result: &Result<Option<Bytes>>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::Get,
             elapsed_micros: elapsed.as_micros(),
+            attempts,
             result: classify_optional_result(result),
             bytes_in: None,
             bytes_out: result
@@ -483,11 +563,13 @@ impl<S> InstrumentedObjectStore<S> {
         &self,
         key: &str,
         elapsed: Duration,
+        attempts: u32,
         result: &Result<Option<ObjectBody>>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::GetWithMetadata,
             elapsed_micros: elapsed.as_micros(),
+            attempts,
             result: classify_optional_result(result),
             bytes_in: None,
             bytes_out: result
@@ -508,11 +590,13 @@ impl<S> InstrumentedObjectStore<S> {
         bytes_in: u64,
         mode: &PutMode,
         elapsed: Duration,
+        attempts: u32,
         result: &Result<ObjectMetadata>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::Put,
             elapsed_micros: elapsed.as_micros(),
+            attempts,
             result: classify_result(result),
             bytes_in: Some(bytes_in),
             bytes_out: None,
@@ -529,11 +613,13 @@ impl<S> InstrumentedObjectStore<S> {
         operation: ObjectStoreOperation,
         key: &str,
         elapsed: Duration,
+        attempts: u32,
         result: &Result<T>,
     ) {
         self.record(ObjectStoreMetricSample {
             operation,
             elapsed_micros: elapsed.as_micros(),
+            attempts,
             result: classify_result(result),
             bytes_in: None,
             bytes_out: None,
@@ -545,10 +631,17 @@ impl<S> InstrumentedObjectStore<S> {
         });
     }
 
-    fn record_list(&self, prefix: &str, elapsed: Duration, result: &Result<Vec<String>>) {
+    fn record_list(
+        &self,
+        prefix: &str,
+        elapsed: Duration,
+        attempts: u32,
+        result: &Result<Vec<String>>,
+    ) {
         self.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::ListPrefix,
             elapsed_micros: elapsed.as_micros(),
+            attempts,
             result: classify_result(result),
             bytes_in: None,
             bytes_out: None,
@@ -602,6 +695,11 @@ impl Drop for RecordedListStream {
         self.recorder.record(ObjectStoreMetricSample {
             operation: ObjectStoreOperation::ListPrefixStream,
             elapsed_micros: self.started.elapsed().as_micros(),
+            // A listing stream is polled by whoever holds it, across tasks a
+            // tally cannot follow, and no LoonFS-owned retry gate sits on
+            // the listing path: what retries a provider client does there
+            // are its own and were never countable from here.
+            attempts: 1,
             result: self.first_error.unwrap_or(ObjectStoreResultClass::Ok),
             bytes_in: None,
             bytes_out: None,

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -2,6 +2,7 @@
 //! delete and multipart stages, and multipart upload for large immutable
 //! payloads.
 
+use crate::attempts::count_retry_attempt;
 use crate::immutable_write::{readback, ImmutableReadback};
 use crate::keyspace::{
     normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
@@ -371,6 +372,10 @@ impl ProviderObjectStore {
             remaining = deadline_remaining;
         }
         *retries += 1;
+        // Every write retry this store grants passes through here, so this
+        // is the one place a measuring wrapper above needs counted for its
+        // sample's attempt count.
+        count_retry_attempt();
         let backoff = transport_retry_backoff(&self.transport_retry, *retries).min(remaining);
         tracing::info!(
             object_key = key,
@@ -1172,6 +1177,9 @@ fn mask_xml_element_text(message: &str, element: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metrics::{
+        InstrumentedObjectStore, ObjectStoreOperation, VecObjectStoreMetricsRecorder,
+    };
     use crate::test_support::SteppingTimer;
     use futures::StreamExt;
     use object_store::memory::InMemory;
@@ -2054,6 +2062,46 @@ mod tests {
             .expect("transient delete failure is retried");
         assert_eq!(flaky.deletes.load(Ordering::SeqCst), 4);
         assert!(store.head(transient_key).await.expect("head").is_none());
+    }
+
+    /// The metrics wrapper sits above this store's retry loops, so without
+    /// the attempt tally a retried call and a slow one make the same sample.
+    #[tokio::test]
+    async fn a_retried_call_reports_its_attempts_to_the_metrics_wrapper() {
+        let flaky = Arc::new(FlakyStore::default());
+        let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
+        let store =
+            InstrumentedObjectStore::new(retrying_store(Arc::clone(&flaky)), recorder.clone());
+        let key = "namespaces/demo/uploads/upl_8.json";
+
+        store
+            .put_overwrite(key, Bytes::from_static(b"payload"))
+            .await
+            .expect("seed object");
+        flaky
+            .delete_script
+            .lock()
+            .expect("delete script")
+            .push_back(WriteScript::FailWithoutLanding);
+        store.delete(key).await.expect("the delete converges");
+
+        let samples = recorder.samples();
+        let delete = samples
+            .iter()
+            .find(|sample| sample.operation == ObjectStoreOperation::Delete)
+            .expect("the delete is sampled");
+        assert_eq!(
+            delete.attempts, 2,
+            "one failed attempt, then the one that landed"
+        );
+        let seed = samples
+            .iter()
+            .find(|sample| sample.operation == ObjectStoreOperation::Put)
+            .expect("the seed write is sampled");
+        assert_eq!(
+            seed.attempts, 1,
+            "a call that never retried made one attempt"
+        );
     }
 
     #[test]

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -42,6 +42,7 @@ async fn records_put_success() {
     assert_eq!(sample.put_mode, Some(PutModeClass::CreateIfAbsent));
     assert_eq!(sample.key_class, KeyClass::NamespaceHead);
     assert_eq!(sample.store_kind.as_deref(), Some("local-fs"));
+    assert_eq!(sample.attempts, 1);
 }
 
 #[tokio::test]
@@ -283,6 +284,7 @@ async fn jsonl_recorder_writes_privacy_safe_samples() {
     let first: serde_json::Value = serde_json::from_str(lines[0]).expect("first sample");
     assert_eq!(first["operation"], "put");
     assert_eq!(first["result"], "ok");
+    assert_eq!(first["attempts"], 1);
     let second: serde_json::Value = serde_json::from_str(lines[1]).expect("second sample");
     assert_eq!(second["operation"], "get");
     assert_eq!(second["result"], "not_found");

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -336,7 +336,10 @@ impl FromRequest<AppState> for UploadBodyStream {
             .upload_permits
             .clone()
             .try_acquire_owned()
-            .map_err(|_| server_busy_error("proxied uploads"))?;
+            .map_err(|_| {
+                state.metrics.upload_rejected_as_busy();
+                server_busy_error("proxied uploads")
+            })?;
         let max_bytes = state.config.max_upload_bytes;
         // A declared length past the limit is refused before a byte moves.
         // The incremental count still runs: a chunked body declares nothing,

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -186,7 +186,10 @@ pub(super) async fn get_file_bytes(
         .download_permits
         .clone()
         .try_acquire_owned()
-        .map_err(|_| super::server_busy_error("proxied content reads"))?;
+        .map_err(|_| {
+            state.metrics.download_rejected_as_busy();
+            super::server_busy_error("proxied content reads")
+        })?;
     let path = query.path;
     let revision_no = query
         .revision_no

--- a/crates/loonfs-server/src/http/metrics.rs
+++ b/crates/loonfs-server/src/http/metrics.rs
@@ -1,0 +1,488 @@
+//! The server's own metrics: the instruments it reports as LoonFS's first
+//! embedder, and the Prometheus text its `/metrics` route serves.
+//!
+//! The runtime defines instruments and reports values; exporting them is the
+//! embedder's job (`loonfs::metrics`). This is that job, done once: the
+//! server installs a [`DefaultMetricsRecorder`] on its handles, adds the
+//! request-level instruments only an HTTP server can report, and renders the
+//! whole snapshot on demand.
+
+use axum::http::{Method, StatusCode};
+use loonfs::metrics::{
+    CounterHandle, DefaultMetricsRecorder, HistogramHandle, MetricEntry, MetricValue,
+    MetricsRecorder, MetricsSnapshot, LATENCY_SECONDS_BOUNDARIES,
+};
+use loonfs::RuntimeCacheStats;
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+/// The `route` label for a request that matched no route, and for one whose
+/// template arrived after the intern table filled.
+const UNMATCHED_ROUTE: &str = "unmatched";
+
+/// Most distinct route templates the intern table will hold.
+///
+/// The router's route list is fixed at build time and well under this, so
+/// the cap never binds in practice. It exists so the leak below is bounded
+/// by a mechanism rather than by a promise about what axum hands us.
+const MAX_ROUTE_LABELS: usize = 128;
+
+/// Everything the server reports and everything it renders.
+pub(super) struct ServerMetrics {
+    recorder: Arc<DefaultMetricsRecorder>,
+    routes: Mutex<RouteLabels>,
+    requests: Mutex<HashMap<&'static str, RequestInstruments>>,
+    busy_uploads: Arc<dyn CounterHandle>,
+    busy_downloads: Arc<dyn CounterHandle>,
+}
+
+/// One route's request instruments, and the per-method-and-status counters
+/// that route has served.
+struct RequestInstruments {
+    seconds: Arc<dyn HistogramHandle>,
+    served: HashMap<(&'static str, &'static str), Arc<dyn CounterHandle>>,
+}
+
+impl ServerMetrics {
+    /// Builds the server's recorder and registers what it can register up
+    /// front: the two admission-rejection counters, whose labels are the
+    /// closed pair of things this server refuses when it is full.
+    pub(super) fn new() -> Arc<Self> {
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let busy = |kind: &'static str| {
+            recorder.register_counter(
+                "loonfs.server.busy_rejections",
+                "Requests refused at a concurrency limit",
+                &[("kind", kind)],
+            )
+        };
+        Arc::new(Self {
+            busy_uploads: busy("upload"),
+            busy_downloads: busy("download"),
+            routes: Mutex::new(RouteLabels::default()),
+            requests: Mutex::new(HashMap::new()),
+            recorder,
+        })
+    }
+
+    /// The recorder the runtime handles report through.
+    pub(super) fn recorder(&self) -> Arc<dyn MetricsRecorder> {
+        Arc::clone(&self.recorder) as Arc<dyn MetricsRecorder>
+    }
+
+    /// Reports one served request.
+    ///
+    /// `matched_route` is the template axum matched, not the request's path:
+    /// the path carries namespace and upload ids, and one unbounded label is
+    /// how a metrics backend dies.
+    pub(super) fn request_served(
+        &self,
+        matched_route: Option<&str>,
+        method: &Method,
+        status: StatusCode,
+        elapsed_seconds: f64,
+    ) {
+        let route = self.route_label(matched_route);
+        let (seconds, served) = {
+            let mut requests = lock(&self.requests);
+            let instruments = requests
+                .entry(route)
+                .or_insert_with(|| RequestInstruments::register(self.recorder.as_ref(), route));
+            instruments.served(
+                self.recorder.as_ref(),
+                route,
+                method_label(method),
+                status_class_label(status),
+            )
+        };
+        served.increment(1);
+        seconds.record(elapsed_seconds);
+    }
+
+    /// Reports one proxied upload refused for want of a transfer slot.
+    pub(super) fn upload_rejected_as_busy(&self) {
+        self.busy_uploads.increment(1);
+    }
+
+    /// Reports one proxied content read refused for want of a transfer slot.
+    pub(super) fn download_rejected_as_busy(&self) {
+        self.busy_downloads.increment(1);
+    }
+
+    /// Renders everything this process has reported, plus the gauges that
+    /// are read at scrape time rather than accumulated.
+    pub(super) fn render(
+        &self,
+        cache: &RuntimeCacheStats,
+        upload_permits: usize,
+        download_permits: usize,
+    ) -> String {
+        let mut rendered = render_snapshot(&self.recorder.snapshot());
+        render_scrape_gauges(&mut rendered, cache, upload_permits, download_permits);
+        rendered
+    }
+
+    fn route_label(&self, matched_route: Option<&str>) -> &'static str {
+        match matched_route {
+            Some(route) => lock(&self.routes).intern(route),
+            None => UNMATCHED_ROUTE,
+        }
+    }
+}
+
+impl RequestInstruments {
+    fn register(recorder: &dyn MetricsRecorder, route: &'static str) -> Self {
+        Self {
+            seconds: recorder.register_histogram(
+                "loonfs.server.request_seconds",
+                "Time to serve one request, by matched route",
+                &[("route", route)],
+                LATENCY_SECONDS_BOUNDARIES,
+            ),
+            served: HashMap::new(),
+        }
+    }
+
+    fn served(
+        &mut self,
+        recorder: &dyn MetricsRecorder,
+        route: &'static str,
+        method: &'static str,
+        status_class: &'static str,
+    ) -> (Arc<dyn HistogramHandle>, Arc<dyn CounterHandle>) {
+        let counter = self
+            .served
+            .entry((method, status_class))
+            .or_insert_with(|| {
+                recorder.register_counter(
+                    "loonfs.server.requests",
+                    "Requests served, by matched route, method, and status class",
+                    &[
+                        ("route", route),
+                        ("method", method),
+                        ("status_class", status_class),
+                    ],
+                )
+            })
+            .clone();
+        (Arc::clone(&self.seconds), counter)
+    }
+}
+
+/// The `&'static str` route labels this process has seen.
+///
+/// Route templates arrive borrowed from the router, and a label has to be
+/// `'static` — that is the type-level cardinality rule the runtime's
+/// recorder enforces. Interning leaks each distinct template exactly once,
+/// which is bounded because the router's route list is fixed at build time
+/// and capped besides.
+#[derive(Default)]
+struct RouteLabels {
+    interned: HashMap<String, &'static str>,
+}
+
+impl RouteLabels {
+    fn intern(&mut self, route: &str) -> &'static str {
+        if let Some(label) = self.interned.get(route) {
+            return label;
+        }
+        if self.interned.len() >= MAX_ROUTE_LABELS {
+            return UNMATCHED_ROUTE;
+        }
+        let label: &'static str = Box::leak(route.to_owned().into_boxed_str());
+        self.interned.insert(route.to_owned(), label);
+        label
+    }
+}
+
+/// The `method` label for a served request.
+///
+/// `Method::as_str` borrows from the method, and a label must be `'static`,
+/// so the standard methods are mapped through this closed match instead —
+/// which also keeps an extension method from becoming a label of its own.
+fn method_label(method: &Method) -> &'static str {
+    match *method {
+        Method::GET => "GET",
+        Method::HEAD => "HEAD",
+        Method::POST => "POST",
+        Method::PUT => "PUT",
+        Method::DELETE => "DELETE",
+        Method::OPTIONS => "OPTIONS",
+        Method::PATCH => "PATCH",
+        _ => "other",
+    }
+}
+
+/// The `status_class` label for a served request: the status code's leading
+/// digit, which is the part an operator alerts on.
+fn status_class_label(status: StatusCode) -> &'static str {
+    match status.as_u16() / 100 {
+        1 => "1xx",
+        2 => "2xx",
+        3 => "3xx",
+        4 => "4xx",
+        5 => "5xx",
+        _ => "other",
+    }
+}
+
+/// Renders a snapshot as Prometheus text exposition format 0.0.4.
+///
+/// Dotted names become underscored ones, counters take the `_total` suffix
+/// the format expects, and histograms emit cumulative buckets with the
+/// `+Inf` bucket the format requires. Entries arrive ordered by name and
+/// then labels, so one `# HELP`/`# TYPE` pair per name is enough and the
+/// output is byte-identical for identical readings.
+fn render_snapshot(snapshot: &MetricsSnapshot) -> String {
+    let mut rendered = String::new();
+    let mut current_name = None;
+    for entry in snapshot.all() {
+        let name = prometheus_name(entry);
+        if current_name.as_deref() != Some(name.as_str()) {
+            write_metric_header(&mut rendered, &name, entry);
+            current_name = Some(name.clone());
+        }
+        write_entry(&mut rendered, &name, entry);
+    }
+    rendered
+}
+
+fn write_metric_header(rendered: &mut String, name: &str, entry: &MetricEntry) {
+    let kind = match entry.value {
+        MetricValue::Counter(_) => "counter",
+        MetricValue::Gauge(_) => "gauge",
+        MetricValue::Histogram { .. } => "histogram",
+    };
+    let _ = writeln!(rendered, "# HELP {name} {}", escape_help(entry.description));
+    let _ = writeln!(rendered, "# TYPE {name} {kind}");
+}
+
+fn write_entry(rendered: &mut String, name: &str, entry: &MetricEntry) {
+    match &entry.value {
+        MetricValue::Counter(value) => {
+            let _ = writeln!(rendered, "{name}{} {value}", labels(&entry.labels, None));
+        }
+        MetricValue::Gauge(value) => {
+            let _ = writeln!(rendered, "{name}{} {value}", labels(&entry.labels, None));
+        }
+        MetricValue::Histogram {
+            boundaries,
+            bucket_counts,
+            count,
+            sum,
+        } => {
+            let mut cumulative = 0u64;
+            for (boundary, filed) in boundaries.iter().zip(bucket_counts.iter()) {
+                cumulative += filed;
+                let _ = writeln!(
+                    rendered,
+                    "{name}_bucket{} {cumulative}",
+                    labels(&entry.labels, Some(&format_float(*boundary)))
+                );
+            }
+            let _ = writeln!(
+                rendered,
+                "{name}_bucket{} {count}",
+                labels(&entry.labels, Some("+Inf"))
+            );
+            let _ = writeln!(
+                rendered,
+                "{name}_sum{} {}",
+                labels(&entry.labels, None),
+                format_float(*sum)
+            );
+            let _ = writeln!(
+                rendered,
+                "{name}_count{} {count}",
+                labels(&entry.labels, None)
+            );
+        }
+    }
+}
+
+/// Appends the values that are read when a scrape asks rather than
+/// accumulated as work happens: the runtime's cache counters and the
+/// transfer slots this server has free.
+fn render_scrape_gauges(
+    rendered: &mut String,
+    cache: &RuntimeCacheStats,
+    upload_permits: usize,
+    download_permits: usize,
+) {
+    for (field, value) in cache_gauges(cache) {
+        let name = format!("loonfs_cache_{field}");
+        let _ = writeln!(rendered, "# HELP {name} Runtime cache counter `{field}`");
+        let _ = writeln!(rendered, "# TYPE {name} gauge");
+        let _ = writeln!(rendered, "{name} {value}");
+    }
+    for (name, description, value) in [
+        (
+            "loonfs_server_upload_permits_available",
+            "Proxied-upload slots free right now",
+            upload_permits,
+        ),
+        (
+            "loonfs_server_download_permits_available",
+            "Proxied-content-read slots free right now",
+            download_permits,
+        ),
+    ] {
+        let _ = writeln!(rendered, "# HELP {name} {description}");
+        let _ = writeln!(rendered, "# TYPE {name} gauge");
+        let _ = writeln!(rendered, "{name} {value}");
+    }
+}
+
+/// The runtime cache counters, named as their fields are.
+///
+/// Destructured without a rest pattern on purpose: a counter added to
+/// [`RuntimeCacheStats`] and not exported here fails to compile.
+fn cache_gauges(stats: &RuntimeCacheStats) -> [(&'static str, usize); 18] {
+    let RuntimeCacheStats {
+        latest_metadata_view_reads,
+        wal_tail_projection_cache_hits,
+        wal_tail_projection_cache_misses,
+        wal_tail_projection_cache_inserts,
+        wal_tail_projection_cache_evictions,
+        wal_tail_projection_cache_evicted_rows,
+        wal_tail_projection_cache_evicted_decoded_bytes,
+        wal_tail_projection_cache_uncacheable_count,
+        wal_tail_projection_cache_uncacheable_rows,
+        wal_tail_projection_cache_uncacheable_decoded_bytes,
+        wal_tail_projection_cache_cached_rows,
+        wal_tail_projection_cache_cached_decoded_bytes,
+        metadata_table_cache_hits,
+        metadata_table_cache_misses,
+        metadata_table_cache_inserts,
+        metadata_table_cache_evictions,
+        metadata_table_cache_filter_skips,
+        metadata_table_cache_filter_false_positives,
+    } = *stats;
+    [
+        ("latest_metadata_view_reads", latest_metadata_view_reads),
+        (
+            "wal_tail_projection_cache_hits",
+            wal_tail_projection_cache_hits,
+        ),
+        (
+            "wal_tail_projection_cache_misses",
+            wal_tail_projection_cache_misses,
+        ),
+        (
+            "wal_tail_projection_cache_inserts",
+            wal_tail_projection_cache_inserts,
+        ),
+        (
+            "wal_tail_projection_cache_evictions",
+            wal_tail_projection_cache_evictions,
+        ),
+        (
+            "wal_tail_projection_cache_evicted_rows",
+            wal_tail_projection_cache_evicted_rows,
+        ),
+        (
+            "wal_tail_projection_cache_evicted_decoded_bytes",
+            wal_tail_projection_cache_evicted_decoded_bytes,
+        ),
+        (
+            "wal_tail_projection_cache_uncacheable_count",
+            wal_tail_projection_cache_uncacheable_count,
+        ),
+        (
+            "wal_tail_projection_cache_uncacheable_rows",
+            wal_tail_projection_cache_uncacheable_rows,
+        ),
+        (
+            "wal_tail_projection_cache_uncacheable_decoded_bytes",
+            wal_tail_projection_cache_uncacheable_decoded_bytes,
+        ),
+        (
+            "wal_tail_projection_cache_cached_rows",
+            wal_tail_projection_cache_cached_rows,
+        ),
+        (
+            "wal_tail_projection_cache_cached_decoded_bytes",
+            wal_tail_projection_cache_cached_decoded_bytes,
+        ),
+        ("metadata_table_cache_hits", metadata_table_cache_hits),
+        ("metadata_table_cache_misses", metadata_table_cache_misses),
+        ("metadata_table_cache_inserts", metadata_table_cache_inserts),
+        (
+            "metadata_table_cache_evictions",
+            metadata_table_cache_evictions,
+        ),
+        (
+            "metadata_table_cache_filter_skips",
+            metadata_table_cache_filter_skips,
+        ),
+        (
+            "metadata_table_cache_filter_false_positives",
+            metadata_table_cache_filter_false_positives,
+        ),
+    ]
+}
+
+/// The exported name: dots become underscores, and a counter takes the
+/// `_total` suffix Prometheus expects of one.
+fn prometheus_name(entry: &MetricEntry) -> String {
+    let mut name = entry.name.replace('.', "_");
+    if matches!(entry.value, MetricValue::Counter(_)) {
+        name.push_str("_total");
+    }
+    name
+}
+
+fn labels(labels: &[(&'static str, &'static str)], le: Option<&str>) -> String {
+    if labels.is_empty() && le.is_none() {
+        return String::new();
+    }
+    let mut rendered = String::from("{");
+    for (index, (key, value)) in labels.iter().enumerate() {
+        if index > 0 {
+            rendered.push(',');
+        }
+        let _ = write!(rendered, "{key}=\"{}\"", escape_label(value));
+    }
+    if let Some(le) = le {
+        if !labels.is_empty() {
+            rendered.push(',');
+        }
+        let _ = write!(rendered, "le=\"{le}\"");
+    }
+    rendered.push('}');
+    rendered
+}
+
+/// Renders a float the way the exposition format wants it: an integral
+/// value keeps a trailing `.0` so a boundary and a bucket label never
+/// disagree between scrapes.
+fn format_float(value: f64) -> String {
+    if value.fract() == 0.0 && value.abs() < 1e15 {
+        format!("{value:.1}")
+    } else {
+        format!("{value}")
+    }
+}
+
+fn escape_label(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+fn escape_help(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('\n', "\\n")
+}
+
+// A poisoned instrument table is recovered rather than propagated:
+// reporting a metric must never be the thing that takes the server down.
+fn lock<T>(table: &Mutex<T>) -> MutexGuard<'_, T> {
+    table
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/loonfs-server/src/http/metrics/tests.rs
+++ b/crates/loonfs-server/src/http/metrics/tests.rs
@@ -1,0 +1,179 @@
+//! What the exposition format promises, held to the byte: one header pair
+//! per name, cumulative buckets, and an output that does not move between
+//! scrapes of the same readings.
+
+#![allow(clippy::panic)]
+// A wrong reading kind in a fixture is a bug in the test.
+
+use super::*;
+use loonfs::metrics::LATENCY_SECONDS_BOUNDARIES;
+
+#[test]
+fn a_counter_renders_with_the_total_suffix_and_its_labels() {
+    let recorder = DefaultMetricsRecorder::new();
+    recorder
+        .register_counter(
+            "loonfs.object_store.operations",
+            "Object-store calls by operation and outcome",
+            &[("operation", "put"), ("result", "ok")],
+        )
+        .increment(3);
+
+    assert_eq!(
+        render_snapshot(&recorder.snapshot()),
+        "# HELP loonfs_object_store_operations_total Object-store calls by operation and outcome\n\
+         # TYPE loonfs_object_store_operations_total counter\n\
+         loonfs_object_store_operations_total{operation=\"put\",result=\"ok\"} 3\n"
+    );
+}
+
+#[test]
+fn a_gauge_renders_without_a_suffix() {
+    let recorder = DefaultMetricsRecorder::new();
+    recorder
+        .register_gauge("loonfs.publisher.queue_depth", "Queued candidates", &[])
+        .set(7);
+
+    assert_eq!(
+        render_snapshot(&recorder.snapshot()),
+        "# HELP loonfs_publisher_queue_depth Queued candidates\n\
+         # TYPE loonfs_publisher_queue_depth gauge\n\
+         loonfs_publisher_queue_depth 7\n"
+    );
+}
+
+/// Prometheus buckets are cumulative and must end at `+Inf`; the runtime's
+/// are per-bucket, so this is where the running sum happens.
+#[test]
+fn a_histogram_renders_cumulative_buckets_ending_at_infinity() {
+    const BOUNDARIES: &[f64] = &[1.0, 2.0];
+    let recorder = DefaultMetricsRecorder::new();
+    let histogram = recorder.register_histogram(
+        "loonfs.server.request_seconds",
+        "Time to serve one request",
+        &[("route", "/health")],
+        BOUNDARIES,
+    );
+    histogram.record(0.5);
+    histogram.record(1.5);
+    histogram.record(9.0);
+
+    assert_eq!(
+        render_snapshot(&recorder.snapshot()),
+        "# HELP loonfs_server_request_seconds Time to serve one request\n\
+         # TYPE loonfs_server_request_seconds histogram\n\
+         loonfs_server_request_seconds_bucket{route=\"/health\",le=\"1.0\"} 1\n\
+         loonfs_server_request_seconds_bucket{route=\"/health\",le=\"2.0\"} 2\n\
+         loonfs_server_request_seconds_bucket{route=\"/health\",le=\"+Inf\"} 3\n\
+         loonfs_server_request_seconds_sum{route=\"/health\"} 11.0\n\
+         loonfs_server_request_seconds_count{route=\"/health\"} 3\n"
+    );
+}
+
+/// One name, one header pair, however many label sets it carries.
+#[test]
+fn label_sets_of_one_name_share_a_single_header_pair() {
+    let recorder = DefaultMetricsRecorder::new();
+    for kind in ["upload", "download"] {
+        recorder
+            .register_counter(
+                "loonfs.server.busy_rejections",
+                "Requests refused at a concurrency limit",
+                &[("kind", kind)],
+            )
+            .increment(1);
+    }
+
+    let rendered = render_snapshot(&recorder.snapshot());
+    assert_eq!(rendered.matches("# HELP").count(), 1);
+    assert_eq!(rendered.matches("# TYPE").count(), 1);
+    assert_eq!(
+        rendered
+            .lines()
+            .filter(|line| !line.starts_with('#'))
+            .count(),
+        2
+    );
+}
+
+/// A scrape that reads the same numbers twice must produce the same bytes,
+/// or a diffing operator sees changes that did not happen.
+#[test]
+fn rendering_the_same_readings_twice_produces_the_same_bytes() {
+    let recorder = DefaultMetricsRecorder::new();
+    for (name, labels) in [
+        ("loonfs.maintenance.steps", [("job", "gc")]),
+        ("loonfs.maintenance.steps", [("job", "metadata")]),
+        ("loonfs.gc.retained", [("category", "all")]),
+    ] {
+        recorder
+            .register_counter(name, "Steps", &labels)
+            .increment(1);
+    }
+    recorder
+        .register_histogram(
+            "loonfs.maintenance.step_seconds",
+            "Step duration",
+            &[("job", "gc")],
+            LATENCY_SECONDS_BOUNDARIES,
+        )
+        .record(0.02);
+
+    let first = render_snapshot(&recorder.snapshot());
+    assert_eq!(first, render_snapshot(&recorder.snapshot()));
+    // Names ascend, so a reader scanning the output finds a metric where it
+    // expects to.
+    let names: Vec<&str> = first
+        .lines()
+        .filter(|line| line.starts_with("# TYPE"))
+        .map(|line| line.split(' ').nth(2).expect("type line names its metric"))
+        .collect();
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    assert_eq!(names, sorted);
+}
+
+#[test]
+fn scrape_time_gauges_carry_every_runtime_cache_counter() {
+    let mut rendered = String::new();
+    let cache = RuntimeCacheStats {
+        metadata_table_cache_hits: 12,
+        ..RuntimeCacheStats::default()
+    };
+    render_scrape_gauges(&mut rendered, &cache, 4, 2);
+
+    assert!(rendered.contains("loonfs_cache_metadata_table_cache_hits 12\n"));
+    assert!(rendered.contains("loonfs_server_upload_permits_available 4\n"));
+    assert!(rendered.contains("loonfs_server_download_permits_available 2\n"));
+    assert_eq!(
+        rendered
+            .lines()
+            .filter(|line| line.starts_with("# TYPE"))
+            .count(),
+        20,
+        "eighteen cache counters and the two permit pools"
+    );
+}
+
+/// The whole reason the label is the matched template: a route seen twice is
+/// one label, and a path that matched nothing never becomes one.
+#[test]
+fn route_labels_intern_once_and_refuse_to_grow_without_bound() {
+    let mut routes = RouteLabels::default();
+    let first = routes.intern("/v0/namespaces/{namespace}/commits");
+    let again = routes.intern("/v0/namespaces/{namespace}/commits");
+    assert_eq!(first, again);
+    assert_eq!(first.as_ptr(), again.as_ptr());
+
+    for index in 0..MAX_ROUTE_LABELS {
+        routes.intern(&format!("/synthetic/{index}"));
+    }
+    assert_eq!(routes.intern("/one/too/many"), UNMATCHED_ROUTE);
+}
+
+#[test]
+fn status_classes_collapse_to_their_leading_digit() {
+    assert_eq!(status_class_label(StatusCode::OK), "2xx");
+    assert_eq!(status_class_label(StatusCode::UNAUTHORIZED), "4xx");
+    assert_eq!(status_class_label(StatusCode::SERVICE_UNAVAILABLE), "5xx");
+}

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -10,6 +10,7 @@ mod handlers_namespace;
 mod handlers_query;
 mod handlers_store;
 mod handlers_uploads;
+mod metrics;
 #[cfg(feature = "openapi")]
 mod openapi;
 mod serve;
@@ -50,10 +51,11 @@ use self::serve::{
     app_with_store, app_with_store_and_state, app_with_store_and_transfer_issuer,
     build_handles_with_metrics_jsonl_path, serve_on,
 };
-use axum::extract::{Request, State};
-use axum::http::{HeaderValue, StatusCode};
+use axum::extract::{MatchedPath, Request, State};
+use axum::http::header::CONTENT_TYPE;
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post, put};
 use axum::Router;
 use loonfs::ErrorCode;
@@ -83,6 +85,41 @@ async fn with_request_id(request: Request, next: Next) -> Response {
         response.headers_mut().insert(REQUEST_ID_HEADER, value);
     }
     response
+}
+
+/// Counts and times every request against the route axum matched it to.
+///
+/// The label is the route template, never the request's own path: a path
+/// carries namespace, upload, and checkpoint ids, and one unbounded label
+/// set is how a metrics backend dies. A request that matched no route — a
+/// 404 — reports as `unmatched`, which is one label rather than one per
+/// probe an internet-facing listener receives.
+async fn with_request_metrics(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|matched| matched.as_str().to_owned());
+    let method = request.method().clone();
+    let started = request_clock();
+    let response = next.run(request).await;
+    state.metrics.request_served(
+        route.as_deref(),
+        &method,
+        response.status(),
+        started.elapsed().as_secs_f64(),
+    );
+    response
+}
+
+#[allow(clippy::disallowed_methods)]
+fn request_clock() -> std::time::Instant {
+    // The measuring boundary the workspace lint points to: this reading
+    // becomes a histogram observation and reaches no protocol state.
+    std::time::Instant::now()
 }
 
 fn router(state: AppState) -> Router {
@@ -123,6 +160,7 @@ fn router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/readiness", get(readiness))
+        .route("/metrics", get(serve_metrics))
         .route("/v0/capabilities", get(handlers_namespace::capabilities))
         .route("/v0/namespaces", post(create_namespace))
         .route(
@@ -210,6 +248,12 @@ fn router(state: AppState) -> Router {
         // contract instead of axum's empty default bodies.
         .fallback(route_not_found)
         .method_not_allowed_fallback(method_not_allowed)
+        // Request timing runs inside the correlation id, so a slow request's
+        // trace and its measurement name the same id.
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            with_request_metrics,
+        ))
         .layer(middleware::from_fn(with_request_id))
         .with_state(state)
 }
@@ -285,4 +329,44 @@ async fn readiness(State(state): State<AppState>) -> Result<&'static str, ApiRes
         ));
     }
     Ok("ready")
+}
+
+/// Content type of the Prometheus text exposition format this server emits.
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
+
+/// Renders this process's metrics.
+///
+/// Authorized like every other route, unlike `/health` and `/readiness`:
+/// those report whether the process is up, while this reports what it has
+/// been doing, and a deployment's traffic shape is not public. Scrapers send
+/// the same bearer token clients do.
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/metrics",
+        tag = "health",
+        summary = "Scrape metrics",
+        description = "Returns this process's metrics in Prometheus text exposition format \
+                       0.0.4. Unlike `/health` and `/readiness`, the route requires the \
+                       deployment's bearer token.",
+        responses(
+            (status = 200, description = "Prometheus text exposition", body = String),
+            (status = 401, description = "Missing or invalid bearer token", body = loonfs_api::ApiError)
+        )
+    )
+)]
+async fn serve_metrics(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Response, ApiResponseError> {
+    authorize(&state.config, &headers)?;
+    // Read at scrape time rather than accumulated: these are levels, and a
+    // level is only true when it is asked for.
+    let rendered = state.metrics.render(
+        &state.writer.runtime_cache_stats(),
+        state.upload_permits.available_permits(),
+        state.download_permits.available_permits(),
+    );
+    Ok(([(CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)], rendered).into_response())
 }

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -39,6 +39,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
     paths(
         crate::http::health,
         crate::http::readiness,
+        crate::http::serve_metrics,
         crate::http::handlers_namespace::capabilities,
         crate::http::handlers_namespace::create_namespace,
         crate::http::handlers_namespace::namespace_status,

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -1,12 +1,11 @@
 //! HTTP application construction, listener service, and shutdown lifecycle.
 
+use super::metrics::ServerMetrics;
 use super::router;
 use super::tls::{self, TlsConfigError, TlsListener};
 use crate::config::{ServerConfig, ServerConfigError};
 use axum::Router;
-use loonfs::metrics::{
-    InstrumentedObjectStore, JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder,
-};
+use loonfs::metrics::{JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder};
 use loonfs::publisher::PublisherRegistry;
 use loonfs::{
     FsAdmin, FsReader, FsWriter, MaintenanceHandle, MaintenanceJob, MaintenanceProbe,
@@ -61,6 +60,12 @@ pub(super) struct AppState {
     /// worst-case download memory is
     /// `max_concurrent_downloads * max_download_bytes`.
     pub(super) download_permits: Arc<Semaphore>,
+    /// The recorder every handle in this process reports through, and the
+    /// request-level instruments only this server can report. `GET /metrics`
+    /// renders its snapshot. Always installed: a metrics surface a
+    /// deployment has to remember to switch on is a metrics surface nobody
+    /// has during the incident.
+    pub(super) metrics: Arc<ServerMetrics>,
 }
 
 /// Everything a request path tells the writer's maintenance runner about
@@ -216,14 +221,7 @@ pub(super) async fn app_with_store_and_transfer_issuer(
     store: SharedObjectStore,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
 ) -> Result<(Router, ServerLifecycle, AppState), ServerConfigError> {
-    // Instrumentation is installed once, here, so every LoonFS-owned request
-    // the process makes is measured — the handles' own traffic and the
-    // grep-owned traffic that used to run on a second, raw client.
-    let store = instrumented_store(
-        &config,
-        store,
-        std::env::var_os(OBJECT_STORE_METRICS_JSONL_ENV),
-    )?;
+    let metrics = ServerMetrics::new();
     // Two switches decide automatic grep indexing and nothing else does:
     // whether this server maintains anything automatically, and whether its
     // grep mode maintains the index.
@@ -234,12 +232,20 @@ pub(super) async fn app_with_store_and_transfer_issuer(
     // the writer for its publications to reach the index: the job says on
     // the trait that publications concern it, and registering it is what
     // subscribes it.
-    let (writer, reader, admin) = build_handles(&config, store.clone()).await?;
-    let probe_store = store.clone();
+    let (writer, reader, admin) = build_handles(
+        &config,
+        store,
+        &metrics,
+        std::env::var_os(OBJECT_STORE_METRICS_JSONL_ENV),
+    )
+    .await?;
+    let probe_store = writer.object_store();
     // A deployment that maintains the index needs a worker whether or not it
-    // answers queries with one.
+    // answers queries with one. It runs on the writer's own instrumented
+    // client, so the grep-owned traffic is measured like every other
+    // request instead of escaping on a second, raw client.
     let grep_worker = (config.grep.mode.serves_grep() || config.grep.mode.maintains_index())
-        .then(|| GrepWorker::new(store.clone(), reader.clone(), admin.clone()));
+        .then(|| GrepWorker::new(writer.object_store(), reader.clone(), admin.clone()));
     let grep_service = config
         .grep
         .mode
@@ -296,26 +302,9 @@ pub(super) async fn app_with_store_and_transfer_issuer(
         grep_worker,
         grep_service,
         grep_maintenance,
+        metrics,
     };
     Ok((router(state.clone()), lifecycle, state))
-}
-
-/// Wraps the store for object-store metrics when a recorder is configured.
-///
-/// One wrapper serves the whole process: the handles are built on it, and so
-/// is the grep worker, so no LoonFS-owned request escapes measurement.
-fn instrumented_store(
-    config: &ServerConfig,
-    store: SharedObjectStore,
-    metrics_jsonl_path: Option<OsString>,
-) -> Result<SharedObjectStore, ServerConfigError> {
-    let Some(recorder) = object_store_metrics_recorder(metrics_jsonl_path)? else {
-        return Ok(store);
-    };
-    Ok(Arc::new(
-        InstrumentedObjectStore::new(store, recorder)
-            .store_kind(TraceStoreKind::from(config.store.kind()).as_str()),
-    ) as SharedObjectStore)
 }
 
 #[cfg(test)]
@@ -324,21 +313,30 @@ pub(super) async fn build_handles_with_metrics_jsonl_path(
     store: SharedObjectStore,
     metrics_jsonl_path: Option<OsString>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
-    let store = instrumented_store(config, store, metrics_jsonl_path)?;
-    build_handles(config, store).await
+    build_handles(config, store, &ServerMetrics::new(), metrics_jsonl_path).await
 }
 
+/// Opens the process's handles on one store, with the metrics wiring every
+/// deployment gets.
+///
+/// Both handles report through the same recorder, so their instruments are
+/// one set of numbers rather than two. The optional JSONL path adds a second
+/// sink for the raw object-store samples; the handle fans one store wrapper
+/// out to both rather than stacking two.
 async fn build_handles(
     config: &ServerConfig,
     store: SharedObjectStore,
+    metrics: &ServerMetrics,
+    metrics_jsonl_path: Option<OsString>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
     let trace_store_kind = TraceStoreKind::from(config.store.kind());
+    let samples = object_store_metrics_recorder(metrics_jsonl_path)?;
     let runtime_error = |error: loonfs::RuntimeError| ServerConfigError::InvalidField {
         field: "runtime",
         reason: error.to_string(),
     };
 
-    let writer_builder = FsWriter::builder_with_store(store.clone())
+    let mut writer_builder = FsWriter::builder_with_store(store.clone())
         .writer_id(config.writer_id.clone())
         .background_work(config.maintenance.background_work())
         .min_publish_interval_ms(config.min_publish_interval_ms)
@@ -348,11 +346,15 @@ async fn build_handles(
         .max_concurrent_maintenance(config.max_concurrent_maintenance)
         .runtime_cache(config.runtime_cache_config())
         .trace_mode(TraceMode::Remote)
-        .trace_store_kind(trace_store_kind);
+        .trace_store_kind(trace_store_kind)
+        .metrics_recorder(metrics.recorder());
+    if let Some(samples) = &samples {
+        writer_builder = writer_builder.object_store_metrics_recorder(Arc::clone(samples));
+    }
     let writer = writer_builder.build().await.map_err(runtime_error)?;
     let reader = writer.reader();
 
-    let admin_builder = FsAdmin::builder_with_store(store)
+    let mut admin_builder = FsAdmin::builder_with_store(store)
         .actor_id(format!("{}-admin", config.writer_id))
         // The admin honors the configured cache sizing and shares the
         // writer's decoded-block cache instance, so explicit maintenance
@@ -361,7 +363,11 @@ async fn build_handles(
         .runtime_cache(config.runtime_cache_config())
         .shared_metadata_table_cache(&writer)
         .trace_mode(TraceMode::Remote)
-        .trace_store_kind(trace_store_kind);
+        .trace_store_kind(trace_store_kind)
+        .metrics_recorder(metrics.recorder());
+    if let Some(samples) = samples {
+        admin_builder = admin_builder.object_store_metrics_recorder(samples);
+    }
     let admin = admin_builder.build().await.map_err(runtime_error)?;
 
     Ok((writer, reader, admin))

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1703,6 +1703,12 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
         "server_busy",
         Some("the server is at its concurrency limit for proxied uploads; retry shortly"),
     );
+    // The refusal is countable: an operator sizing `max_concurrent_uploads`
+    // needs to know it is happening, not only that some clients saw 503.
+    assert!(state
+        .metrics
+        .render(&state.writer.runtime_cache_stats(), 0, 0)
+        .contains("loonfs_server_busy_rejections_total{kind=\"upload\"} 1\n"));
 
     drop(held);
     let client = Client::new(client_config).expect("valid client config");
@@ -1814,6 +1820,10 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
         "server_busy",
         Some("the server is at its concurrency limit for proxied content reads; retry shortly"),
     );
+    assert!(state
+        .metrics
+        .render(&state.writer.runtime_cache_stats(), 0, 0)
+        .contains("loonfs_server_busy_rejections_total{kind=\"download\"} 1\n"));
 
     drop(held);
     let client = Client::new(client_config).expect("valid client config");

--- a/crates/loonfs-server/tests/it/http_metrics.rs
+++ b/crates/loonfs-server/tests/it/http_metrics.rs
@@ -1,0 +1,212 @@
+//! What a scrape of a running server actually returns.
+
+use crate::common::http_split_support::*;
+use crate::common::start_server;
+use loonfs_client::NamespacePath;
+use loonfs_test_support::http::raw_agent;
+use loonfs_test_support::ids::namespace_id;
+use std::collections::BTreeMap;
+use std::io::Read as _;
+use tempfile::tempdir;
+
+/// The exposition lines of one scrape, keyed by everything left of the
+/// value. Comment lines are dropped; a value that does not parse as a number
+/// is a rendering bug and fails here.
+fn scrape(server_url: &str, token: Option<&str>) -> Result<BTreeMap<String, f64>, u16> {
+    let request = raw_agent().get(&format!("{server_url}/metrics"));
+    let request = match token {
+        Some(token) => request.set("authorization", &format!("Bearer {token}")),
+        None => request,
+    };
+    let response = match request.call() {
+        Ok(response) => response,
+        Err(ureq::Error::Status(status, _)) => return Err(status),
+        Err(error) => unreachable!("metrics scrape failed: {error}"),
+    };
+    assert_eq!(
+        response.header("content-type"),
+        Some("text/plain; version=0.0.4")
+    );
+    let mut body = String::new();
+    response
+        .into_reader()
+        .read_to_string(&mut body)
+        .expect("read scrape body");
+    Ok(body
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.is_empty())
+        .map(|line| {
+            let (series, value) = line
+                .rsplit_once(' ')
+                .unwrap_or_else(|| unreachable!("exposition line without a value: {line}"));
+            let value: f64 = value
+                .parse()
+                .unwrap_or_else(|_| unreachable!("unparsable value in `{line}`"));
+            (series.to_owned(), value)
+        })
+        .collect())
+}
+
+fn series(scrape: &BTreeMap<String, f64>, name: &str) -> f64 {
+    *scrape
+        .get(name)
+        .unwrap_or_else(|| unreachable!("no series `{name}` in the scrape"))
+}
+
+/// Object-store calls of every operation and outcome, summed.
+fn object_store_calls(scrape: &BTreeMap<String, f64>) -> f64 {
+    scrape
+        .iter()
+        .filter(|(series, _)| series.starts_with("loonfs_object_store_operations_total{"))
+        .map(|(_, calls)| calls)
+        .sum()
+}
+
+/// The route reports what the process is doing, not whether it is up, so it
+/// authorizes like every other route — unlike `/health` and `/readiness`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scraping_metrics_without_a_token_is_unauthorized() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-metrics-auth",
+    ))
+    .await;
+
+    assert_eq!(scrape(&harness.server_url, None).expect_err("401"), 401);
+    assert!(raw_agent()
+        .get(&format!("{}/health", harness.server_url))
+        .call()
+        .is_ok());
+
+    harness.server.abort();
+}
+
+/// One scrape has to show all three layers moving: the requests this server
+/// served, the object-store calls they made, and the runtime caches those
+/// reads warmed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_scrape_reports_requests_object_store_calls_and_cache_levels() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-metrics",
+    ))
+    .await;
+
+    let namespace = namespace_id("metered");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let target = NamespacePath::parse("metered", "/note.txt").expect("parse path");
+    harness
+        .client
+        .put_file_bytes(&target, b"body", &replace_file_options())
+        .await
+        .expect("write file");
+    harness
+        .client
+        .namespace_status(&namespace)
+        .await
+        .expect("read status");
+
+    let first = scrape(&harness.server_url, Some("test-token")).expect("scrape");
+
+    // Requests are labeled by the route template axum matched, never by the
+    // path — the namespace id in that path would be an unbounded label.
+    // Labels render in sorted order, so a scrape of the same readings is
+    // byte-stable however the instrument was registered.
+    let status_route = "loonfs_server_requests_total{method=\"GET\",\
+                        route=\"/v0/namespaces/{namespace}\",status_class=\"2xx\"}";
+    assert_eq!(series(&first, status_route), 1.0);
+    assert_eq!(
+        series(
+            &first,
+            "loonfs_server_requests_total{method=\"POST\",route=\"/v0/namespaces\",\
+             status_class=\"2xx\"}"
+        ),
+        1.0
+    );
+    assert!(first
+        .keys()
+        .all(|series| !series.contains("/v0/namespaces/metered")));
+    assert!(
+        series(
+            &first,
+            "loonfs_server_request_seconds_count{route=\"/v0/namespaces/{namespace}\"}"
+        ) >= 1.0
+    );
+
+    // The object-store bridge and the scrape-time cache gauges.
+    assert!(
+        series(
+            &first,
+            "loonfs_object_store_operations_total{operation=\"put\",result=\"ok\"}"
+        ) > 0.0
+    );
+    assert!(
+        series(
+            &first,
+            "loonfs_object_store_bytes_in_total{operation=\"put\"}"
+        ) > 0.0
+    );
+    assert!(first.contains_key("loonfs_cache_metadata_table_cache_hits"));
+    assert!(first.contains_key("loonfs_cache_latest_metadata_view_reads"));
+    assert_eq!(
+        series(&first, "loonfs_server_upload_permits_available"),
+        8.0,
+        "no transfer is in flight, so every configured slot is free"
+    );
+
+    // Counters are counters: a second status read moves that series and
+    // only that series.
+    harness
+        .client
+        .namespace_status(&namespace)
+        .await
+        .expect("read status again");
+    let second = scrape(&harness.server_url, Some("test-token")).expect("second scrape");
+    assert_eq!(series(&second, status_route), 2.0);
+    assert!(
+        object_store_calls(&second) > object_store_calls(&first),
+        "the second read made object-store calls of its own"
+    );
+
+    harness.server.abort();
+}
+
+/// A path outside the served surface must not become a label of its own, or
+/// one scanner turns the request metric into a cardinality bomb.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unmatched_paths_share_one_route_label() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-metrics-unmatched",
+    ))
+    .await;
+
+    for path in ["/wp-login.php", "/admin", "/v0/nope"] {
+        let _ = raw_agent()
+            .get(&format!("{}{path}", harness.server_url))
+            .call();
+    }
+
+    let scraped = scrape(&harness.server_url, Some("test-token")).expect("scrape");
+    assert_eq!(
+        series(
+            &scraped,
+            "loonfs_server_requests_total{method=\"GET\",route=\"unmatched\",\
+             status_class=\"4xx\"}"
+        ),
+        3.0
+    );
+    assert!(scraped.keys().all(|series| !series.contains("wp-login")));
+
+    harness.server.abort();
+}

--- a/crates/loonfs-server/tests/it/main.rs
+++ b/crates/loonfs-server/tests/it/main.rs
@@ -9,6 +9,7 @@ mod http_admin;
 mod http_auth;
 mod http_commits;
 mod http_limits;
+mod http_metrics;
 mod http_pagination;
 mod http_paths;
 mod http_retry;

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -32,6 +32,7 @@ fn openapi_documents_current_server_paths() {
     for (path, method) in [
         ("/health", "get"),
         ("/readiness", "get"),
+        ("/metrics", "get"),
         ("/v0/capabilities", "get"),
         ("/v0/namespaces", "post"),
         ("/v0/namespaces/{namespace}", "get"),

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -5,6 +5,7 @@
 use crate::cache::{RuntimeCacheStatsInner, RuntimeControlCache};
 use crate::config::{validate_writer_id, ReadConfig};
 use crate::maintenance_runner::MaintenanceRunner;
+use crate::metrics::RuntimeInstruments;
 use crate::publisher::PublishObserver;
 use crate::time::current_time_ms;
 use crate::{
@@ -47,6 +48,10 @@ pub(crate) struct ReadCoreInner {
     pub(crate) metadata_table_cache: Arc<MetadataTableCache>,
     pub(crate) wal_tail_projection_cache: Arc<WalTailProjectionCache>,
     pub(crate) cache_stats: RuntimeCacheStatsInner,
+    /// Where this runtime's publication, maintenance, and collection
+    /// numbers go. Reports nothing unless the handle was built with a
+    /// metrics recorder.
+    pub(crate) instruments: Arc<RuntimeInstruments>,
 }
 
 /// The actor identity a write-capable handle publishes under: immutable
@@ -111,6 +116,7 @@ impl ReadCore {
         store: SharedObjectStore,
         config: ReadConfig,
         shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
+        instruments: Arc<RuntimeInstruments>,
     ) -> Self {
         let metadata_table_cache = shared_metadata_table_cache.unwrap_or_else(|| {
             Arc::new(MetadataTableCache::new(
@@ -133,8 +139,15 @@ impl ReadCore {
                 metadata_table_cache,
                 wal_tail_projection_cache,
                 cache_stats: RuntimeCacheStatsInner::default(),
+                instruments,
             }),
         }
+    }
+
+    /// This runtime's instrument set, for the publication, maintenance, and
+    /// collection paths that report through it.
+    pub(crate) fn instruments(&self) -> &Arc<RuntimeInstruments> {
+        &self.inner.instruments
     }
 
     /// This runtime's shared decoded-block cache handle, for builders

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -2,7 +2,7 @@
 
 use super::HandleBuilderCore;
 use crate::fs::{ReadCore, WriterIdentity};
-use crate::metrics::ObjectStoreMetricsRecorder;
+use crate::metrics::{MetricsRecorder, ObjectStoreMetricsRecorder};
 use crate::publisher::PublisherRegistry;
 use crate::{
     Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError, SharedObjectStore, StoreConfig,
@@ -127,8 +127,22 @@ impl FsAdminBuilder {
         self
     }
 
-    /// Installs object-store metrics collection for this handle.
-    pub fn metrics_recorder(mut self, recorder: Arc<dyn ObjectStoreMetricsRecorder>) -> Self {
+    /// Installs raw object-store sample collection for this handle.
+    ///
+    /// Combines with [`Self::metrics_recorder`]: one wrapper feeds both.
+    pub fn object_store_metrics_recorder(
+        mut self,
+        recorder: Arc<dyn ObjectStoreMetricsRecorder>,
+    ) -> Self {
+        self.core.object_store_metrics_recorder = Some(recorder);
+        self
+    }
+
+    /// Installs the metrics recorder this handle reports its instruments to
+    /// (see [`crate::metrics`]). An admin registers the object-store and
+    /// collection instruments; the explicit maintenance it drives reports
+    /// through the writer that scheduled it.
+    pub fn metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
         self.core.metrics_recorder = Some(recorder);
         self
     }

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -3,7 +3,9 @@
 
 use crate::config::ReadConfig;
 use crate::fs::ReadCore;
-use crate::metrics::ObjectStoreMetricsRecorder;
+use crate::metrics::{
+    fan_out_object_store_recorder, MetricsRecorder, ObjectStoreMetricsRecorder, RuntimeInstruments,
+};
 use crate::{
     Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
     TraceStoreKind,
@@ -32,7 +34,8 @@ pub(super) struct HandleBuilderCore {
     pub(super) shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
     pub(super) trace_mode: TraceMode,
     pub(super) trace_store_kind: Option<TraceStoreKind>,
-    pub(super) metrics_recorder: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
+    pub(super) object_store_metrics_recorder: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
+    pub(super) metrics_recorder: Option<Arc<dyn MetricsRecorder>>,
 }
 
 impl HandleBuilderCore {
@@ -52,6 +55,7 @@ impl HandleBuilderCore {
             shared_metadata_table_cache: None,
             trace_mode: TraceMode::Embedded,
             trace_store_kind: None,
+            object_store_metrics_recorder: None,
             metrics_recorder: None,
         }
     }
@@ -59,6 +63,10 @@ impl HandleBuilderCore {
     /// Resolves the object-store client, wraps it for metrics when the
     /// builder was given a recorder, and opens the read core every handle
     /// is built on.
+    ///
+    /// A builder given no recorder of either kind wraps nothing: the store
+    /// the core holds is the store it was handed, and the instrument set it
+    /// carries reports nowhere.
     pub(super) fn open_read_core(self) -> Result<ReadCore> {
         let (store, derived_kind) = match self.source {
             StoreSource::Config(config) => {
@@ -71,7 +79,12 @@ impl HandleBuilderCore {
             StoreSource::Shared(store) => (store, TraceStoreKind::Unknown),
         };
         let trace_store_kind = self.trace_store_kind.unwrap_or(derived_kind);
-        let store = match self.metrics_recorder {
+        let instruments = RuntimeInstruments::new(self.metrics_recorder);
+        let recorder = fan_out_object_store_recorder(
+            self.object_store_metrics_recorder,
+            instruments.object_store_recorder(),
+        );
+        let store = match recorder {
             Some(recorder) => Arc::new(
                 InstrumentedObjectStore::new(store, recorder).store_kind(trace_store_kind.as_str()),
             ) as SharedObjectStore,
@@ -86,6 +99,7 @@ impl HandleBuilderCore {
                 trace_store_kind,
             },
             self.shared_metadata_table_cache,
+            instruments,
         ))
     }
 }

--- a/crates/loonfs/src/handle/reader.rs
+++ b/crates/loonfs/src/handle/reader.rs
@@ -2,7 +2,7 @@
 
 use super::HandleBuilderCore;
 use crate::fs::ReadCore;
-use crate::metrics::ObjectStoreMetricsRecorder;
+use crate::metrics::{MetricsRecorder, ObjectStoreMetricsRecorder};
 use crate::{
     CapabilityDocument, Result, RuntimeCacheConfig, RuntimeCacheStats, SharedObjectStore,
     StoreConfig, TraceMode, TraceStoreKind,
@@ -100,8 +100,21 @@ impl FsReaderBuilder {
         self
     }
 
-    /// Installs object-store metrics collection for this handle.
-    pub fn metrics_recorder(mut self, recorder: Arc<dyn ObjectStoreMetricsRecorder>) -> Self {
+    /// Installs raw object-store sample collection for this handle.
+    ///
+    /// Combines with [`Self::metrics_recorder`]: one wrapper feeds both.
+    pub fn object_store_metrics_recorder(
+        mut self,
+        recorder: Arc<dyn ObjectStoreMetricsRecorder>,
+    ) -> Self {
+        self.core.object_store_metrics_recorder = Some(recorder);
+        self
+    }
+
+    /// Installs the metrics recorder this handle reports its instruments to
+    /// (see [`crate::metrics`]). A reader registers the object-store
+    /// instruments; it schedules nothing, so it reports nothing else.
+    pub fn metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
         self.core.metrics_recorder = Some(recorder);
         self
     }

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -3,7 +3,7 @@
 use super::{owning_runtime, FsReader, HandleBuilderCore};
 use crate::fs::{ReadCore, WriterBits, WriterIdentity};
 use crate::maintenance_runner::{register_core_jobs, MaintenanceRunner};
-use crate::metrics::ObjectStoreMetricsRecorder;
+use crate::metrics::{MetricsRecorder, ObjectStoreMetricsRecorder};
 use crate::publisher::{PublishObserver, PublisherRegistry};
 use crate::{
     CapabilityDocument, ChangeSeq, FsBackgroundWork, MaintenanceHandle, MaintenanceJob,
@@ -315,11 +315,26 @@ impl FsWriterBuilder {
         self
     }
 
-    /// Installs object-store metrics collection for this handle.
+    /// Installs raw object-store sample collection for this handle.
     ///
     /// The handle wraps its object store before opening; callers do not
-    /// need to construct an instrumented store manually.
-    pub fn metrics_recorder(mut self, recorder: Arc<dyn ObjectStoreMetricsRecorder>) -> Self {
+    /// need to construct an instrumented store manually. Combines with
+    /// [`Self::metrics_recorder`]: one wrapper feeds both.
+    pub fn object_store_metrics_recorder(
+        mut self,
+        recorder: Arc<dyn ObjectStoreMetricsRecorder>,
+    ) -> Self {
+        self.core.object_store_metrics_recorder = Some(recorder);
+        self
+    }
+
+    /// Installs the metrics recorder this handle reports its instruments to
+    /// (see [`crate::metrics`]).
+    ///
+    /// The handle registers its instrument set once, here, and reports into
+    /// it from then on: object-store calls, maintenance steps, publications,
+    /// and collection passes. A handle built without one registers nothing.
+    pub fn metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
         self.core.metrics_recorder = Some(recorder);
         self
     }
@@ -360,18 +375,23 @@ impl FsWriterBuilder {
                 )
             })?;
         let runtime = Some(owning_runtime()?);
+        let core = self.core.open_read_core()?;
+        let instruments = Arc::clone(core.instruments());
         let maintenance = match self.maintenance_clock {
             Some(clock) => MaintenanceRunner::with_clock(
                 self.background_work,
                 runtime,
                 max_concurrent_maintenance,
                 clock,
+                instruments,
             ),
-            None => {
-                MaintenanceRunner::new(self.background_work, runtime, max_concurrent_maintenance)
-            }
+            None => MaintenanceRunner::new(
+                self.background_work,
+                runtime,
+                max_concurrent_maintenance,
+                instruments,
+            ),
         };
-        let core = self.core.open_read_core()?;
         let bits = Arc::new(WriterBits {
             identity,
             maintenance,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -1,8 +1,8 @@
 //! Embedded LoonFS runtime.
 //!
 //! `loonfs` is the ergonomic runtime layer. It wraps `loonfs-core` with caching,
-//! upload helpers, maintenance hooks, and optional object-store metrics. Use it
-//! when you want LoonFS in-process, or when building the reference server.
+//! upload helpers, maintenance hooks, and an optional [`metrics`] surface. Use
+//! it when you want LoonFS in-process, or when building the reference server.
 //!
 //! The runtime is opened through purpose-specific handles, each built
 //! asynchronously inside the Tokio runtime that will own it:
@@ -39,6 +39,7 @@ mod config;
 mod fs;
 mod handle;
 mod maintenance_runner;
+pub mod metrics;
 mod options;
 pub mod publisher;
 mod time;
@@ -131,7 +132,6 @@ pub mod control {
     };
 }
 
-pub use loonfs_objectstore::metrics;
 pub use loonfs_objectstore::{
     ByteStream, ObjectStore, ObjectStoreError, SharedObjectStore, StoreConfig,
 };

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -42,6 +42,7 @@ mod jobs;
 #[cfg(test)]
 mod tests;
 
+use crate::metrics::RuntimeInstruments;
 use crate::{NamespaceId, Result, RuntimeError};
 use admission::{Admission, MaintenanceKey, StepOutcome};
 use std::collections::BTreeMap;
@@ -445,6 +446,11 @@ struct RunnerInner {
     state: Mutex<RunnerState>,
     wake: Arc<Notify>,
     counters: RunnerCounters,
+    /// Where settled steps report. The two [`RunnerCounters`] above stay
+    /// where they are: they answer "is this happening at all", which a
+    /// number on an existing trace answers for a reader with no metrics
+    /// pipeline at all.
+    instruments: Arc<RuntimeInstruments>,
 }
 
 struct RunnerState {
@@ -462,12 +468,14 @@ impl MaintenanceRunner {
         policy: FsBackgroundWork,
         runtime: Option<tokio::runtime::Handle>,
         max_concurrent: std::num::NonZeroUsize,
+        instruments: Arc<RuntimeInstruments>,
     ) -> Self {
         Self::with_clock(
             policy,
             runtime,
             max_concurrent,
             Arc::new(SystemMaintenanceClock::default()),
+            instruments,
         )
     }
 
@@ -476,6 +484,7 @@ impl MaintenanceRunner {
         runtime: Option<tokio::runtime::Handle>,
         max_concurrent: std::num::NonZeroUsize,
         clock: Arc<dyn MaintenanceClock>,
+        instruments: Arc<RuntimeInstruments>,
     ) -> Self {
         let next_reconcile_ms = clock.now_ms().saturating_add(RECONCILE_INTERVAL_MS);
         Self {
@@ -492,6 +501,7 @@ impl MaintenanceRunner {
                 clock,
                 wake: Arc::new(Notify::new()),
                 counters: RunnerCounters::default(),
+                instruments,
             }),
         }
     }
@@ -826,6 +836,10 @@ async fn run_step(inner: &Arc<RunnerInner>, key: &MaintenanceKey) -> StepOutcome
     let started = tokio::time::Instant::now();
     match job.step(&key.namespace_id, continuation.as_deref()).await {
         Ok(result) => {
+            let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+            inner
+                .instruments
+                .maintenance_step(key.job, result.conclusion, queued_ms, elapsed_ms);
             tracing::debug!(
                 job = %key.job,
                 namespace_id = %key.namespace_id,
@@ -836,12 +850,15 @@ async fn run_step(inner: &Arc<RunnerInner>, key: &MaintenanceKey) -> StepOutcome
                 // The two halves of what a step cost: how long it waited
                 // for a permit, and how long it then took.
                 queued_ms,
-                elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                elapsed_ms,
                 "maintenance step settled"
             );
             StepOutcome::Concluded(result)
         }
         Err(error) => {
+            inner
+                .instruments
+                .maintenance_step_failed(key.job, queued_ms);
             tracing::info!(
                 job = %key.job,
                 namespace_id = %key.namespace_id,

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -249,6 +249,10 @@ impl MaintenanceJob for GcJob {
                 MaintenanceStepConclusion::Idle,
             ));
         };
+        // The counts a pass produced survive here or nowhere: the runner
+        // reads a pass as one conclusion, and everything it reclaimed is
+        // dropped with the response a line below.
+        self.context.core.instruments().gc_pass(&gc);
         Ok(gc_step_result(gc, continuation))
     }
 

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -285,6 +285,7 @@ fn runner_with(
         Some(tokio::runtime::Handle::current()),
         nonzero_usize(1),
         clock,
+        RuntimeInstruments::new(None),
     );
     runner.register(job).expect("register the test job");
     runner

--- a/crates/loonfs/src/metrics.rs
+++ b/crates/loonfs/src/metrics.rs
@@ -1,0 +1,513 @@
+//! The runtime's metrics surface: a push-based recorder the embedder
+//! implements, and the instruments the runtime registers against it.
+//!
+//! LoonFS defines instruments and reports values. It does not export them,
+//! and it depends on no metrics crate to do so. An embedder that already
+//! has a metrics pipeline implements [`MetricsRecorder`] over its own
+//! registry and the runtime's numbers land there directly; an embedder that
+//! has none installs [`DefaultMetricsRecorder`], which aggregates in atomics
+//! and hands back a [`MetricsSnapshot`] to render however the host likes.
+//! Installing nothing costs nothing: with no recorder configured the runtime
+//! registers no instruments and no hot path touches this module at all.
+//!
+//! The reference server is LoonFS's own first embedder — it installs the
+//! default recorder and serves its snapshot as Prometheus text on
+//! `GET /metrics`.
+//!
+//! ## Names and labels
+//!
+//! Metric names are `loonfs.<subsystem>.<metric>` — `loonfs.gc.reclaimed`,
+//! `loonfs.maintenance.steps`. The subsystem is the part of the runtime that
+//! owns the number, and it is the same word the module that reports it is
+//! called.
+//!
+//! Every name, description, label key, and label value in this API is
+//! `&'static str`, and that is the whole cardinality policy expressed in the
+//! type system: a namespace id, a commit id, a path, or a request id cannot
+//! be borrowed for `'static`, so it cannot become a label. Label values come
+//! from closed enumerations' `as_str` methods and from nowhere else. There
+//! is no escape hatch, deliberately — a metrics backend does not survive one
+//! unbounded label, and "we will be careful" is not a mechanism.
+//!
+//! ## Object-store metrics
+//!
+//! This module also re-exports the object-store sampling vocabulary from
+//! [`loonfs_objectstore::metrics`]. The two surfaces compose rather than
+//! compete: a handle given a [`MetricsRecorder`] bridges every object-store
+//! sample into the instruments below, and a handle given an
+//! [`ObjectStoreMetricsRecorder`] as well receives the raw samples too.
+//!
+//! ## Deviations from the model this follows
+//!
+//! The design is SlateDB's (their RFC 0021), with two deliberate omissions:
+//!
+//! - **No up-down counter.** Nothing in the v1 instrument set needs one — a
+//!   quantity that falls is a gauge here. Adding the instrument later is
+//!   purely additive.
+//! - **No metric levels.** SlateDB filters instruments by verbosity because
+//!   it has enough of them for that to matter. This set is small enough to
+//!   read whole, and a level knob nobody turns is a knob that rots.
+
+mod instruments;
+
+pub use loonfs_objectstore::metrics::{
+    InstrumentedObjectStore, JsonlObjectStoreMetricsRecorder, KeyClass, ObjectStoreMetricSample,
+    ObjectStoreMetricsRecorder, ObjectStoreOperation, ObjectStoreResultClass, PutModeClass,
+    RangeClass, VecObjectStoreMetricsRecorder,
+};
+
+pub(crate) use instruments::{fan_out_object_store_recorder, RuntimeInstruments};
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Bucket upper bounds for a latency histogram, in seconds.
+///
+/// Twelve buckets from a millisecond to two minutes, stepping by roughly
+/// three: that spans a warm cache hit at one end and a provider call about
+/// to spend its whole operation deadline at the other, and no two adjacent
+/// buckets are so close that a shifted distribution hides between them.
+pub const LATENCY_SECONDS_BOUNDARIES: &[f64] = &[
+    0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 60.0, 120.0,
+];
+
+/// Bucket upper bounds for a histogram over small counts — how many
+/// candidates a publication batched, and the like.
+pub const SMALL_COUNT_BOUNDARIES: &[f64] = &[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0];
+
+/// Where the runtime reports its instruments.
+///
+/// An embedder implements this over whatever registry it already has. The
+/// runtime registers each instrument once, at handle construction, and then
+/// only ever calls the handle it was given — so an implementation may do
+/// real work in the `register_*` methods and must do as little as possible
+/// in the handles', which run on hot paths.
+///
+/// Registering the same `(name, labels)` pair twice returns a handle to the
+/// same underlying value. Two parts of the runtime reporting the same
+/// instrument are reporting one number, not two.
+///
+/// Everything here is `&'static str` on purpose: it makes a runtime id
+/// impossible to use as a name or a label value, which is the cardinality
+/// policy this crate enforces in the type system rather than by convention.
+pub trait MetricsRecorder: Send + Sync + 'static {
+    /// Registers a monotonically increasing count.
+    fn register_counter(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        labels: &[(&'static str, &'static str)],
+    ) -> Arc<dyn CounterHandle>;
+
+    /// Registers a value that rises and falls.
+    fn register_gauge(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        labels: &[(&'static str, &'static str)],
+    ) -> Arc<dyn GaugeHandle>;
+
+    /// Registers a distribution over `boundaries`, which are inclusive
+    /// bucket upper bounds in ascending order.
+    fn register_histogram(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        labels: &[(&'static str, &'static str)],
+        boundaries: &'static [f64],
+    ) -> Arc<dyn HistogramHandle>;
+}
+
+/// A registered counter.
+pub trait CounterHandle: Send + Sync {
+    /// Adds `value` to the count.
+    fn increment(&self, value: u64);
+}
+
+/// A registered gauge.
+pub trait GaugeHandle: Send + Sync {
+    /// Replaces the reported value.
+    fn set(&self, value: i64);
+}
+
+/// A registered histogram.
+pub trait HistogramHandle: Send + Sync {
+    /// Files one observation.
+    fn record(&self, value: f64);
+}
+
+/// The recorder that discards everything, and the runtime's default.
+///
+/// Its handles are shared singletons whose methods are empty, so a runtime
+/// built without a recorder pays one virtual call per report and allocates
+/// nothing.
+#[derive(Debug, Default)]
+pub struct NoopMetricsRecorder;
+
+impl MetricsRecorder for NoopMetricsRecorder {
+    fn register_counter(
+        &self,
+        _name: &'static str,
+        _description: &'static str,
+        _labels: &[(&'static str, &'static str)],
+    ) -> Arc<dyn CounterHandle> {
+        Arc::new(NoopInstrument)
+    }
+
+    fn register_gauge(
+        &self,
+        _name: &'static str,
+        _description: &'static str,
+        _labels: &[(&'static str, &'static str)],
+    ) -> Arc<dyn GaugeHandle> {
+        Arc::new(NoopInstrument)
+    }
+
+    fn register_histogram(
+        &self,
+        _name: &'static str,
+        _description: &'static str,
+        _labels: &[(&'static str, &'static str)],
+        _boundaries: &'static [f64],
+    ) -> Arc<dyn HistogramHandle> {
+        Arc::new(NoopInstrument)
+    }
+}
+
+struct NoopInstrument;
+
+impl CounterHandle for NoopInstrument {
+    fn increment(&self, _value: u64) {}
+}
+
+impl GaugeHandle for NoopInstrument {
+    fn set(&self, _value: i64) {}
+}
+
+impl HistogramHandle for NoopInstrument {
+    fn record(&self, _value: f64) {}
+}
+
+/// Identity of one registered instrument: its name and its label set.
+///
+/// Labels are sorted at registration, so two registrations that name the
+/// same labels in different orders are the same instrument.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct InstrumentKey {
+    name: &'static str,
+    labels: Vec<(&'static str, &'static str)>,
+}
+
+impl InstrumentKey {
+    fn new(name: &'static str, labels: &[(&'static str, &'static str)]) -> Self {
+        let mut labels = labels.to_vec();
+        labels.sort_unstable();
+        Self { name, labels }
+    }
+}
+
+/// The in-process recorder: every instrument is a few atomics, and
+/// [`Self::snapshot`] reads them all.
+///
+/// This is what an embedder installs when it has no metrics pipeline of its
+/// own and wants one anyway. Reporting is lock-free — registration takes a
+/// lock, the handles never do — so hot paths pay an atomic add and nothing
+/// else.
+#[derive(Debug, Default)]
+pub struct DefaultMetricsRecorder {
+    registry: Mutex<BTreeMap<InstrumentKey, RegisteredInstrument>>,
+}
+
+#[derive(Debug, Clone)]
+enum RegisteredInstrument {
+    Counter(Arc<CounterValue>),
+    Gauge(Arc<GaugeValue>),
+    Histogram(Arc<HistogramValue>),
+}
+
+impl DefaultMetricsRecorder {
+    /// Creates an empty recorder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reads every registered instrument's current value.
+    ///
+    /// The read is per instrument, not a stop-the-world barrier: two
+    /// instruments in one snapshot may have been read a few nanoseconds
+    /// apart. Nothing an operator asks of these numbers needs them to agree
+    /// to that resolution.
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        let registry = self.lock_registry();
+        MetricsSnapshot {
+            entries: registry
+                .iter()
+                .map(|(key, instrument)| MetricEntry {
+                    name: key.name,
+                    labels: key.labels.clone(),
+                    description: instrument.description(),
+                    value: instrument.value(),
+                })
+                .collect(),
+        }
+    }
+
+    // A poisoned registry is recovered rather than propagated: every
+    // critical section here inserts one map entry, and one panicked
+    // registration must not take the runtime's metrics down with it.
+    fn lock_registry(
+        &self,
+    ) -> std::sync::MutexGuard<'_, BTreeMap<InstrumentKey, RegisteredInstrument>> {
+        self.registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Returns the instrument registered under `key`, installing `build`'s
+    /// if there is none.
+    ///
+    /// A second registration of the same name and labels shares the first
+    /// one's value. A registration that reuses a name with a different
+    /// instrument kind keeps the first kind and hands back a detached
+    /// instrument, so a mistake costs the new instrument's readings rather
+    /// than corrupting the established one.
+    fn register(
+        &self,
+        key: InstrumentKey,
+        build: impl FnOnce() -> RegisteredInstrument,
+    ) -> RegisteredInstrument {
+        self.lock_registry()
+            .entry(key)
+            .or_insert_with(build)
+            .clone()
+    }
+}
+
+impl RegisteredInstrument {
+    fn description(&self) -> &'static str {
+        match self {
+            Self::Counter(counter) => counter.description,
+            Self::Gauge(gauge) => gauge.description,
+            Self::Histogram(histogram) => histogram.description,
+        }
+    }
+
+    fn value(&self) -> MetricValue {
+        match self {
+            Self::Counter(counter) => MetricValue::Counter(counter.value.load(Ordering::Relaxed)),
+            Self::Gauge(gauge) => MetricValue::Gauge(gauge.value.load(Ordering::Relaxed)),
+            Self::Histogram(histogram) => histogram.value(),
+        }
+    }
+}
+
+impl MetricsRecorder for DefaultMetricsRecorder {
+    fn register_counter(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        labels: &[(&'static str, &'static str)],
+    ) -> Arc<dyn CounterHandle> {
+        let fresh = Arc::new(CounterValue::new(description));
+        match self.register(InstrumentKey::new(name, labels), || {
+            RegisteredInstrument::Counter(Arc::clone(&fresh))
+        }) {
+            RegisteredInstrument::Counter(counter) => counter,
+            _ => fresh,
+        }
+    }
+
+    fn register_gauge(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        labels: &[(&'static str, &'static str)],
+    ) -> Arc<dyn GaugeHandle> {
+        let fresh = Arc::new(GaugeValue::new(description));
+        match self.register(InstrumentKey::new(name, labels), || {
+            RegisteredInstrument::Gauge(Arc::clone(&fresh))
+        }) {
+            RegisteredInstrument::Gauge(gauge) => gauge,
+            _ => fresh,
+        }
+    }
+
+    fn register_histogram(
+        &self,
+        name: &'static str,
+        description: &'static str,
+        labels: &[(&'static str, &'static str)],
+        boundaries: &'static [f64],
+    ) -> Arc<dyn HistogramHandle> {
+        let fresh = Arc::new(HistogramValue::new(description, boundaries));
+        match self.register(InstrumentKey::new(name, labels), || {
+            RegisteredInstrument::Histogram(Arc::clone(&fresh))
+        }) {
+            RegisteredInstrument::Histogram(histogram) => histogram,
+            _ => fresh,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CounterValue {
+    description: &'static str,
+    value: AtomicU64,
+}
+
+impl CounterValue {
+    fn new(description: &'static str) -> Self {
+        Self {
+            description,
+            value: AtomicU64::new(0),
+        }
+    }
+}
+
+impl CounterHandle for CounterValue {
+    fn increment(&self, value: u64) {
+        self.value.fetch_add(value, Ordering::Relaxed);
+    }
+}
+
+#[derive(Debug)]
+struct GaugeValue {
+    description: &'static str,
+    value: AtomicI64,
+}
+
+impl GaugeValue {
+    fn new(description: &'static str) -> Self {
+        Self {
+            description,
+            value: AtomicI64::new(0),
+        }
+    }
+}
+
+impl GaugeHandle for GaugeValue {
+    fn set(&self, value: i64) {
+        self.value.store(value, Ordering::Relaxed);
+    }
+}
+
+/// A fixed-boundary histogram over atomics.
+///
+/// The sum accumulates as a fixed-point integer stepping by one millionth
+/// rather than as a float: every value this runtime files is a duration in
+/// seconds or a small count, both of which that step holds exactly at the
+/// scales involved, and integer addition needs no compare-and-swap loop the
+/// way a float sum would. A negative observation cannot arise from any
+/// instrument here and contributes nothing to the sum if one ever does.
+#[derive(Debug)]
+struct HistogramValue {
+    description: &'static str,
+    boundaries: &'static [f64],
+    /// One counter per boundary plus one for the overflow bucket.
+    bucket_counts: Vec<AtomicU64>,
+    count: AtomicU64,
+    sum_millionths: AtomicU64,
+}
+
+impl HistogramValue {
+    fn new(description: &'static str, boundaries: &'static [f64]) -> Self {
+        Self {
+            description,
+            boundaries,
+            bucket_counts: (0..=boundaries.len()).map(|_| AtomicU64::new(0)).collect(),
+            count: AtomicU64::new(0),
+            sum_millionths: AtomicU64::new(0),
+        }
+    }
+
+    fn value(&self) -> MetricValue {
+        MetricValue::Histogram {
+            boundaries: self.boundaries,
+            bucket_counts: self
+                .bucket_counts
+                .iter()
+                .map(|bucket| bucket.load(Ordering::Relaxed))
+                .collect(),
+            count: self.count.load(Ordering::Relaxed),
+            sum: self.sum_millionths.load(Ordering::Relaxed) as f64 / 1_000_000.0,
+        }
+    }
+}
+
+impl HistogramHandle for HistogramValue {
+    fn record(&self, value: f64) {
+        let bucket = self
+            .boundaries
+            .iter()
+            .position(|boundary| value <= *boundary)
+            .unwrap_or(self.boundaries.len());
+        self.bucket_counts[bucket].fetch_add(1, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+        if value > 0.0 {
+            let millionths = (value * 1_000_000.0).round().min(u64::MAX as f64) as u64;
+            self.sum_millionths.fetch_add(millionths, Ordering::Relaxed);
+        }
+    }
+}
+
+/// One instrument's current reading.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetricValue {
+    /// A monotonically increasing count.
+    Counter(u64),
+    /// A value that rises and falls.
+    Gauge(i64),
+    /// A fixed-boundary distribution.
+    Histogram {
+        /// Inclusive bucket upper bounds, ascending.
+        boundaries: &'static [f64],
+        /// Observations per bucket, one longer than `boundaries`: the last
+        /// entry counts observations above the highest boundary.
+        bucket_counts: Vec<u64>,
+        /// Observations filed.
+        count: u64,
+        /// Sum of the observed values.
+        sum: f64,
+    },
+}
+
+/// One instrument in a snapshot.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricEntry {
+    /// The instrument's dotted name.
+    pub name: &'static str,
+    /// Its label set, sorted by key.
+    pub labels: Vec<(&'static str, &'static str)>,
+    /// What the instrument measures, as given at registration.
+    pub description: &'static str,
+    /// The reading.
+    pub value: MetricValue,
+}
+
+/// Every instrument a [`DefaultMetricsRecorder`] holds, read at one moment.
+///
+/// Entries are ordered by name and then by labels, so a host that renders a
+/// snapshot renders it deterministically without sorting again.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricsSnapshot {
+    entries: Vec<MetricEntry>,
+}
+
+impl MetricsSnapshot {
+    /// Every entry, ordered by name and then by labels.
+    pub fn all(&self) -> &[MetricEntry] {
+        &self.entries
+    }
+
+    /// The entries registered under `name`, one per label set.
+    pub fn by_name<'snapshot>(
+        &'snapshot self,
+        name: &'snapshot str,
+    ) -> impl Iterator<Item = &'snapshot MetricEntry> + 'snapshot {
+        self.entries.iter().filter(move |entry| entry.name == name)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -1,0 +1,796 @@
+//! The instruments the runtime reports, and the bridge that turns
+//! object-store samples into them.
+//!
+//! One [`RuntimeInstruments`] is built per handle and reaches the reporting
+//! sites through the read core. Without a configured recorder it holds
+//! nothing and every report returns on a null check, which is what makes
+//! "no recorder" cost nothing rather than cost a no-op registration for
+//! every instrument in the set.
+//!
+//! Instruments whose label value is only known when the first report
+//! arrives — the object-store operation that just finished, the id an
+//! extension registered its maintenance job under — are memoized here, so a
+//! recorder still sees exactly one registration per label set as
+//! [`MetricsRecorder`] promises. The memo costs one uncontended lock on
+//! paths whose unit of work is a provider round trip.
+
+use super::{
+    CounterHandle, GaugeHandle, HistogramHandle, MetricsRecorder, ObjectStoreMetricSample,
+    ObjectStoreMetricsRecorder, SMALL_COUNT_BOUNDARIES,
+};
+use crate::metrics::LATENCY_SECONDS_BOUNDARIES;
+use crate::{GcResponse, MaintenanceJobId, MaintenanceStepConclusion};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+/// One reclaimable family: its label, and the count a pass reports for it.
+type GcCategory = (&'static str, fn(&GcResponse) -> u64);
+
+/// Reclaimable object families one collection pass counts, named exactly as
+/// [`GcResponse`] names them.
+const GC_CATEGORIES: [GcCategory; 9] = [
+    ("deleted_wal_segments", |gc| gc.deleted_wal_segments),
+    ("deleted_metadata_tables", |gc| gc.deleted_metadata_tables),
+    ("deleted_manifests", |gc| gc.deleted_manifests),
+    ("deleted_checkpoint_records", |gc| {
+        gc.deleted_checkpoint_records
+    }),
+    ("released_fork_checkpoints", |gc| {
+        gc.released_fork_checkpoints
+    }),
+    ("released_expired_checkpoints", |gc| {
+        gc.released_expired_checkpoints
+    }),
+    ("deleted_upload_sessions", |gc| gc.deleted_upload_sessions),
+    ("deleted_content_objects", |gc| gc.deleted_content_objects),
+    ("released_missing_basis_checkpoints", |gc| {
+        gc.released_missing_basis_checkpoints
+    }),
+];
+
+/// Every instrument one runtime reports, or nothing at all.
+pub(crate) struct RuntimeInstruments {
+    installed: Option<Installed>,
+}
+
+struct Installed {
+    recorder: Arc<dyn MetricsRecorder>,
+    object_store: Mutex<HashMap<&'static str, ObjectStoreOperationInstruments>>,
+    maintenance: Mutex<HashMap<&'static str, MaintenanceJobInstruments>>,
+    publisher: PublisherInstruments,
+    gc: GcInstruments,
+}
+
+impl RuntimeInstruments {
+    /// Builds the instrument set a handle reports through, registering the
+    /// fully-labeled ones now and the rest as their labels first appear.
+    pub(crate) fn new(recorder: Option<Arc<dyn MetricsRecorder>>) -> Arc<Self> {
+        Arc::new(Self {
+            installed: recorder.map(|recorder| Installed {
+                publisher: PublisherInstruments::register(recorder.as_ref()),
+                gc: GcInstruments::register(recorder.as_ref()),
+                object_store: Mutex::new(HashMap::new()),
+                maintenance: Mutex::new(HashMap::new()),
+                recorder,
+            }),
+        })
+    }
+
+    /// An object-store recorder that bridges samples into these
+    /// instruments, or `None` when nothing is installed.
+    pub(crate) fn object_store_recorder(
+        self: &Arc<Self>,
+    ) -> Option<Arc<dyn ObjectStoreMetricsRecorder>> {
+        self.installed.as_ref()?;
+        Some(Arc::new(RecorderBridge {
+            instruments: Arc::clone(self),
+        }) as Arc<dyn ObjectStoreMetricsRecorder>)
+    }
+
+    /// Reports one settled maintenance step.
+    pub(crate) fn maintenance_step(
+        &self,
+        job: MaintenanceJobId,
+        conclusion: MaintenanceStepConclusion,
+        queued_ms: u64,
+        elapsed_ms: u64,
+    ) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        let instruments = installed.maintenance_job(job);
+        instruments.step(conclusion).increment(1);
+        instruments.step_seconds.record(seconds_from_ms(elapsed_ms));
+        instruments
+            .queue_wait_seconds
+            .record(seconds_from_ms(queued_ms));
+    }
+
+    /// Reports one maintenance step that failed before concluding.
+    pub(crate) fn maintenance_step_failed(&self, job: MaintenanceJobId, queued_ms: u64) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        let instruments = installed.maintenance_job(job);
+        instruments.failures.increment(1);
+        instruments
+            .queue_wait_seconds
+            .record(seconds_from_ms(queued_ms));
+    }
+
+    /// Reports the candidates a namespace has admitted but not yet taken.
+    pub(crate) fn publisher_queue_depth(&self, queue_depth: usize) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed
+            .publisher
+            .queue_depth
+            .set(i64::try_from(queue_depth).unwrap_or(i64::MAX));
+    }
+
+    /// Reports one batch taken for publication.
+    pub(crate) fn publisher_batch(&self, batch_size: usize) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed.publisher.batches.increment(1);
+        installed.publisher.batch_size.record(batch_size as f64);
+    }
+
+    /// Reports one publication result delivered to its caller.
+    pub(crate) fn publisher_publish(&self, result: &'static str) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed.publisher.publish(result).increment(1);
+    }
+
+    /// Reports what one collection pass reclaimed and retained.
+    ///
+    /// The automatic path reads a pass as one conclusion and drops its
+    /// counts; this is where they survive.
+    pub(crate) fn gc_pass(&self, gc: &GcResponse) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        for (category, count) in GC_CATEGORIES.iter().zip(installed.gc.reclaimed.iter()) {
+            let reclaimed = (category.1)(gc);
+            if reclaimed > 0 {
+                count.increment(reclaimed);
+            }
+        }
+        if gc.retained_candidates > 0 {
+            installed.gc.retained.increment(gc.retained_candidates);
+        }
+    }
+
+    fn object_store_sample(&self, sample: &ObjectStoreMetricSample) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        let operation = sample.operation.as_str();
+        let instruments = {
+            let mut registry = lock(&installed.object_store);
+            let instruments = registry.entry(operation).or_insert_with(|| {
+                ObjectStoreOperationInstruments::register(installed.recorder.as_ref(), operation)
+            });
+            instruments.reading(installed.recorder.as_ref(), sample.result.as_str())
+        };
+        instruments.outcome.increment(1);
+        instruments
+            .seconds
+            .record(sample.elapsed_micros as f64 / 1_000_000.0);
+        if let Some(bytes_in) = sample.bytes_in {
+            instruments.bytes_in.increment(bytes_in);
+        }
+        if let Some(bytes_out) = sample.bytes_out {
+            instruments.bytes_out.increment(bytes_out);
+        }
+        instruments
+            .retries
+            .increment(u64::from(sample.attempts.saturating_sub(1)));
+    }
+}
+
+impl Installed {
+    fn maintenance_job(&self, job: MaintenanceJobId) -> MaintenanceJobInstruments {
+        let mut registry = lock(&self.maintenance);
+        registry
+            .entry(job.as_str())
+            .or_insert_with(|| MaintenanceJobInstruments::register(self.recorder.as_ref(), job))
+            .clone()
+    }
+}
+
+/// Composes the object-store recorder a handle installs on its store.
+///
+/// A handle may be given a recorder for the raw samples, a general recorder
+/// the samples are bridged into, both, or neither. Both means one wrapper
+/// feeding two sinks rather than two wrappers double-counting the same call;
+/// neither means no wrapper at all, which is what keeps an uninstrumented
+/// handle exactly as fast as it was before this existed.
+pub(crate) fn fan_out_object_store_recorder(
+    samples: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
+    bridge: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
+) -> Option<Arc<dyn ObjectStoreMetricsRecorder>> {
+    match (samples, bridge) {
+        (None, None) => None,
+        (Some(only), None) | (None, Some(only)) => Some(only),
+        (Some(samples), Some(bridge)) => {
+            Some(Arc::new(FanOutRecorder { samples, bridge }) as Arc<dyn ObjectStoreMetricsRecorder>)
+        }
+    }
+}
+
+/// Turns object-store samples into the runtime's instruments.
+struct RecorderBridge {
+    instruments: Arc<RuntimeInstruments>,
+}
+
+impl ObjectStoreMetricsRecorder for RecorderBridge {
+    fn record(&self, sample: ObjectStoreMetricSample) {
+        self.instruments.object_store_sample(&sample);
+    }
+}
+
+/// Delivers one sample to both sinks, in the order they were configured.
+struct FanOutRecorder {
+    samples: Arc<dyn ObjectStoreMetricsRecorder>,
+    bridge: Arc<dyn ObjectStoreMetricsRecorder>,
+}
+
+impl ObjectStoreMetricsRecorder for FanOutRecorder {
+    fn record(&self, sample: ObjectStoreMetricSample) {
+        self.samples.record(sample.clone());
+        self.bridge.record(sample);
+    }
+}
+
+/// The instruments one object-store operation reports, plus the per-outcome
+/// counters that operation has seen.
+struct ObjectStoreOperationInstruments {
+    operation: &'static str,
+    seconds: Arc<dyn HistogramHandle>,
+    bytes_in: Arc<dyn CounterHandle>,
+    bytes_out: Arc<dyn CounterHandle>,
+    retries: Arc<dyn CounterHandle>,
+    outcomes: HashMap<&'static str, Arc<dyn CounterHandle>>,
+}
+
+/// One sample's worth of handles, cloned out from under the registry lock so
+/// a recorder's own reporting never runs while the runtime holds it.
+struct ObjectStoreReading {
+    outcome: Arc<dyn CounterHandle>,
+    seconds: Arc<dyn HistogramHandle>,
+    bytes_in: Arc<dyn CounterHandle>,
+    bytes_out: Arc<dyn CounterHandle>,
+    retries: Arc<dyn CounterHandle>,
+}
+
+impl ObjectStoreOperationInstruments {
+    fn register(recorder: &dyn MetricsRecorder, operation: &'static str) -> Self {
+        let labels = [("operation", operation)];
+        Self {
+            operation,
+            seconds: recorder.register_histogram(
+                "loonfs.object_store.operation_seconds",
+                "Object-store call latency in seconds, including provider retries",
+                &labels,
+                LATENCY_SECONDS_BOUNDARIES,
+            ),
+            bytes_in: recorder.register_counter(
+                "loonfs.object_store.bytes_in",
+                "Payload bytes sent to the object store",
+                &labels,
+            ),
+            bytes_out: recorder.register_counter(
+                "loonfs.object_store.bytes_out",
+                "Payload bytes read back from the object store",
+                &labels,
+            ),
+            retries: recorder.register_counter(
+                "loonfs.object_store.retries",
+                "Object-store attempts beyond the first",
+                &labels,
+            ),
+            outcomes: HashMap::new(),
+        }
+    }
+
+    fn reading(
+        &mut self,
+        recorder: &dyn MetricsRecorder,
+        result: &'static str,
+    ) -> ObjectStoreReading {
+        let operation = self.operation;
+        let outcome = self
+            .outcomes
+            .entry(result)
+            .or_insert_with(|| {
+                recorder.register_counter(
+                    "loonfs.object_store.operations",
+                    "Object-store calls by operation and outcome",
+                    &[("operation", operation), ("result", result)],
+                )
+            })
+            .clone();
+        ObjectStoreReading {
+            outcome,
+            seconds: Arc::clone(&self.seconds),
+            bytes_in: Arc::clone(&self.bytes_in),
+            bytes_out: Arc::clone(&self.bytes_out),
+            retries: Arc::clone(&self.retries),
+        }
+    }
+}
+
+/// The instruments one maintenance job reports.
+///
+/// Job ids are `&'static str` by construction — the runtime's own are
+/// associated constants and an extension names its own with
+/// [`MaintenanceJobId::new`] — so the label stays bounded by the jobs a
+/// build registers.
+#[derive(Clone)]
+struct MaintenanceJobInstruments {
+    progressed: Arc<dyn CounterHandle>,
+    idle: Arc<dyn CounterHandle>,
+    blocked: Arc<dyn CounterHandle>,
+    superseded: Arc<dyn CounterHandle>,
+    not_enabled: Arc<dyn CounterHandle>,
+    failures: Arc<dyn CounterHandle>,
+    step_seconds: Arc<dyn HistogramHandle>,
+    queue_wait_seconds: Arc<dyn HistogramHandle>,
+}
+
+impl MaintenanceJobInstruments {
+    fn register(recorder: &dyn MetricsRecorder, job: MaintenanceJobId) -> Self {
+        let job = job.as_str();
+        let steps = |conclusion: MaintenanceStepConclusion| {
+            recorder.register_counter(
+                "loonfs.maintenance.steps",
+                "Maintenance steps by job and conclusion",
+                &[("job", job), ("conclusion", conclusion.as_str())],
+            )
+        };
+        Self {
+            progressed: steps(MaintenanceStepConclusion::Progressed),
+            idle: steps(MaintenanceStepConclusion::Idle),
+            blocked: steps(MaintenanceStepConclusion::Blocked),
+            superseded: steps(MaintenanceStepConclusion::Superseded),
+            not_enabled: steps(MaintenanceStepConclusion::NotEnabled),
+            failures: recorder.register_counter(
+                "loonfs.maintenance.step_failures",
+                "Maintenance steps that failed before concluding",
+                &[("job", job)],
+            ),
+            step_seconds: recorder.register_histogram(
+                "loonfs.maintenance.step_seconds",
+                "Maintenance step duration in seconds",
+                &[("job", job)],
+                LATENCY_SECONDS_BOUNDARIES,
+            ),
+            queue_wait_seconds: recorder.register_histogram(
+                "loonfs.maintenance.queue_wait_seconds",
+                "Seconds a maintenance step waited for a permit",
+                &[("job", job)],
+                LATENCY_SECONDS_BOUNDARIES,
+            ),
+        }
+    }
+
+    fn step(&self, conclusion: MaintenanceStepConclusion) -> &Arc<dyn CounterHandle> {
+        match conclusion {
+            MaintenanceStepConclusion::Progressed => &self.progressed,
+            MaintenanceStepConclusion::Idle => &self.idle,
+            MaintenanceStepConclusion::Blocked => &self.blocked,
+            MaintenanceStepConclusion::Superseded => &self.superseded,
+            MaintenanceStepConclusion::NotEnabled => &self.not_enabled,
+        }
+    }
+}
+
+/// Publication instruments. Every label here is closed and known at
+/// construction, so all of them register once.
+struct PublisherInstruments {
+    batches: Arc<dyn CounterHandle>,
+    batch_size: Arc<dyn HistogramHandle>,
+    queue_depth: Arc<dyn GaugeHandle>,
+    published_ok: Arc<dyn CounterHandle>,
+    published_error: Arc<dyn CounterHandle>,
+}
+
+impl PublisherInstruments {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        let publishes = |result: &'static str| {
+            recorder.register_counter(
+                "loonfs.publisher.publishes",
+                "Publication results delivered to their callers",
+                &[("result", result)],
+            )
+        };
+        Self {
+            batches: recorder.register_counter(
+                "loonfs.publisher.batches",
+                "Mutation batches taken for publication",
+                &[],
+            ),
+            batch_size: recorder.register_histogram(
+                "loonfs.publisher.batch_size",
+                "Candidates in one published batch",
+                &[],
+                SMALL_COUNT_BOUNDARIES,
+            ),
+            // Sampled rather than totalled: one process serves many
+            // namespaces and each has its own queue, so this reads as the
+            // depth of whichever publisher last admitted or took work.
+            queue_depth: recorder.register_gauge(
+                "loonfs.publisher.queue_depth",
+                "Candidates queued at the namespace publisher that last admitted or took work",
+                &[],
+            ),
+            published_ok: publishes("ok"),
+            published_error: publishes("error"),
+        }
+    }
+
+    fn publish(&self, result: &'static str) -> &Arc<dyn CounterHandle> {
+        if result == "ok" {
+            &self.published_ok
+        } else {
+            &self.published_error
+        }
+    }
+}
+
+/// Collection instruments, one counter per reclaimable family.
+struct GcInstruments {
+    reclaimed: Vec<Arc<dyn CounterHandle>>,
+    retained: Arc<dyn CounterHandle>,
+}
+
+impl GcInstruments {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        Self {
+            reclaimed: GC_CATEGORIES
+                .iter()
+                .map(|(category, _)| {
+                    recorder.register_counter(
+                        "loonfs.gc.reclaimed",
+                        "Objects one collection pass reclaimed, by family",
+                        &[("category", *category)],
+                    )
+                })
+                .collect(),
+            retained: recorder.register_counter(
+                "loonfs.gc.retained",
+                "Candidates a collection pass retained rather than deleting",
+                &[],
+            ),
+        }
+    }
+}
+
+fn seconds_from_ms(milliseconds: u64) -> f64 {
+    milliseconds as f64 / 1_000.0
+}
+
+// A poisoned instrument registry is recovered rather than propagated:
+// reporting a metric must never be the thing that takes a runtime down.
+fn lock<T>(registry: &Mutex<T>) -> MutexGuard<'_, T> {
+    registry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic)]
+    // A reading of the wrong kind or an unregistered instrument is a bug in
+    // the test, not a case to handle.
+
+    use super::*;
+    use crate::metrics::{
+        DefaultMetricsRecorder, KeyClass, MetricValue, MetricsSnapshot, ObjectStoreOperation,
+        ObjectStoreResultClass, PutModeClass, VecObjectStoreMetricsRecorder,
+    };
+    use crate::{MaintenanceJobId, MaintenanceStepConclusion};
+
+    fn sample(
+        operation: ObjectStoreOperation,
+        result: ObjectStoreResultClass,
+        attempts: u32,
+    ) -> ObjectStoreMetricSample {
+        ObjectStoreMetricSample {
+            operation,
+            elapsed_micros: 250_000,
+            attempts,
+            result,
+            bytes_in: Some(64),
+            bytes_out: Some(16),
+            item_count: None,
+            key_class: KeyClass::Content,
+            range_class: None,
+            put_mode: Some(PutModeClass::Overwrite),
+            store_kind: None,
+        }
+    }
+
+    fn counter(snapshot: &MetricsSnapshot, name: &str, labels: &[(&str, &str)]) -> u64 {
+        let entry = snapshot
+            .by_name(name)
+            .find(|entry| entry.labels == labels)
+            .unwrap_or_else(|| panic!("no `{name}` registered with labels {labels:?}"));
+        match entry.value {
+            MetricValue::Counter(value) => value,
+            ref other => panic!("expected a counter, found {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_bridged_sample_moves_every_object_store_instrument() {
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let instruments = RuntimeInstruments::new(Some(recorder.clone()));
+        let bridge = instruments
+            .object_store_recorder()
+            .expect("an installed recorder bridges its samples");
+
+        bridge.record(sample(
+            ObjectStoreOperation::Put,
+            ObjectStoreResultClass::Ok,
+            3,
+        ));
+
+        let snapshot = recorder.snapshot();
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.object_store.operations",
+                &[("operation", "put"), ("result", "ok")],
+            ),
+            1
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.object_store.bytes_in",
+                &[("operation", "put")],
+            ),
+            64
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.object_store.bytes_out",
+                &[("operation", "put")],
+            ),
+            16
+        );
+        // Three attempts is two retries: the first attempt is the call.
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.object_store.retries",
+                &[("operation", "put")],
+            ),
+            2
+        );
+        let latency = snapshot
+            .by_name("loonfs.object_store.operation_seconds")
+            .next()
+            .expect("the latency histogram is registered");
+        match &latency.value {
+            MetricValue::Histogram { count, sum, .. } => {
+                assert_eq!(*count, 1);
+                assert!((sum - 0.25).abs() < 1e-9, "unexpected sum {sum}");
+            }
+            other => panic!("expected a histogram, found {other:?}"),
+        }
+    }
+
+    /// Outcomes share one operation's latency and byte instruments and get a
+    /// counter each, so a failing operation is visible without splitting its
+    /// timing in two.
+    #[test]
+    fn outcomes_of_one_operation_count_separately() {
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let instruments = RuntimeInstruments::new(Some(recorder.clone()));
+        let bridge = instruments.object_store_recorder().expect("bridge");
+
+        bridge.record(sample(
+            ObjectStoreOperation::Get,
+            ObjectStoreResultClass::Ok,
+            1,
+        ));
+        bridge.record(sample(
+            ObjectStoreOperation::Get,
+            ObjectStoreResultClass::NotFound,
+            1,
+        ));
+        bridge.record(sample(
+            ObjectStoreOperation::Get,
+            ObjectStoreResultClass::NotFound,
+            1,
+        ));
+
+        let snapshot = recorder.snapshot();
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.object_store.operations",
+                &[("operation", "get"), ("result", "ok")],
+            ),
+            1
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.object_store.operations",
+                &[("operation", "get"), ("result", "not_found")],
+            ),
+            2
+        );
+        assert_eq!(
+            snapshot
+                .by_name("loonfs.object_store.operation_seconds")
+                .count(),
+            1,
+            "one operation keeps one latency histogram whatever it returned"
+        );
+    }
+
+    #[test]
+    fn a_handle_with_both_recorders_delivers_each_sample_to_both() {
+        let samples = Arc::new(VecObjectStoreMetricsRecorder::default());
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let instruments = RuntimeInstruments::new(Some(recorder.clone()));
+        let composed = fan_out_object_store_recorder(
+            Some(samples.clone()),
+            instruments.object_store_recorder(),
+        )
+        .expect("a configured handle installs a recorder");
+
+        composed.record(sample(
+            ObjectStoreOperation::Delete,
+            ObjectStoreResultClass::Ok,
+            1,
+        ));
+
+        assert_eq!(samples.samples().len(), 1);
+        assert_eq!(
+            counter(
+                &recorder.snapshot(),
+                "loonfs.object_store.operations",
+                &[("operation", "delete"), ("result", "ok")],
+            ),
+            1
+        );
+    }
+
+    /// What the null check buys: a handle built without a recorder installs
+    /// no wrapper at all, and reporting through it is a returned call.
+    #[test]
+    fn a_handle_with_no_recorder_installs_nothing() {
+        let instruments = RuntimeInstruments::new(None);
+        assert!(instruments.object_store_recorder().is_none());
+        assert!(fan_out_object_store_recorder(None, instruments.object_store_recorder()).is_none());
+
+        instruments.publisher_batch(4);
+        instruments.publisher_publish("ok");
+        instruments.maintenance_step(MaintenanceJobId::GC, MaintenanceStepConclusion::Idle, 1, 2);
+    }
+
+    #[test]
+    fn a_settled_step_counts_against_its_job_and_conclusion() {
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let instruments = RuntimeInstruments::new(Some(recorder.clone()));
+
+        instruments.maintenance_step(
+            MaintenanceJobId::METADATA,
+            MaintenanceStepConclusion::Progressed,
+            5,
+            30,
+        );
+        instruments.maintenance_step(
+            MaintenanceJobId::METADATA,
+            MaintenanceStepConclusion::Idle,
+            0,
+            1,
+        );
+        instruments.maintenance_step_failed(MaintenanceJobId::GC, 7);
+
+        let snapshot = recorder.snapshot();
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.maintenance.steps",
+                &[("conclusion", "progressed"), ("job", "metadata")],
+            ),
+            1
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.maintenance.steps",
+                &[("conclusion", "idle"), ("job", "metadata")],
+            ),
+            1
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.maintenance.step_failures",
+                &[("job", "gc")],
+            ),
+            1
+        );
+        // A failed step has no duration to report, but it waited like any
+        // other, so its queue wait still counts. A job's whole instrument
+        // set registers the first time it reports anything, so `gc` has a
+        // step-duration histogram with nothing filed in it.
+        for (name, job, count) in [
+            ("loonfs.maintenance.step_seconds", "metadata", 2),
+            ("loonfs.maintenance.step_seconds", "gc", 0),
+            ("loonfs.maintenance.queue_wait_seconds", "metadata", 2),
+            ("loonfs.maintenance.queue_wait_seconds", "gc", 1),
+        ] {
+            let entry = snapshot
+                .by_name(name)
+                .find(|entry| entry.labels == [("job", job)])
+                .unwrap_or_else(|| panic!("no `{name}` for job `{job}`"));
+            match entry.value {
+                MetricValue::Histogram { count: filed, .. } => assert_eq!(filed, count),
+                ref other => panic!("expected a histogram, found {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_collection_pass_counts_what_it_reclaimed_and_retained() {
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let instruments = RuntimeInstruments::new(Some(recorder.clone()));
+        let mut gc = GcResponse {
+            namespace_id: loonfs_test_support::ids::namespace_id("demo"),
+            deleted_wal_segments: 3,
+            deleted_metadata_tables: 0,
+            deleted_manifests: 0,
+            deleted_checkpoint_records: 0,
+            released_fork_checkpoints: 0,
+            released_expired_checkpoints: 0,
+            deleted_upload_sessions: 0,
+            deleted_content_objects: 5,
+            released_missing_basis_checkpoints: 0,
+            retained_candidates: 2,
+            degraded_retention: false,
+            content_reclamation_deferred: false,
+            next_cursor: None,
+            next_reclamation_at_ms: None,
+        };
+
+        instruments.gc_pass(&gc);
+        gc.deleted_wal_segments = 1;
+        instruments.gc_pass(&gc);
+
+        let snapshot = recorder.snapshot();
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.gc.reclaimed",
+                &[("category", "deleted_wal_segments")],
+            ),
+            4
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.gc.reclaimed",
+                &[("category", "deleted_content_objects")],
+            ),
+            10
+        );
+        assert_eq!(counter(&snapshot, "loonfs.gc.retained", &[]), 4);
+        // Every family registers at construction, so a scrape names the
+        // whole reclaimable vocabulary rather than only what has happened.
+        assert_eq!(snapshot.by_name("loonfs.gc.reclaimed").count(), 9);
+    }
+}

--- a/crates/loonfs/src/metrics/tests.rs
+++ b/crates/loonfs/src/metrics/tests.rs
@@ -1,0 +1,188 @@
+//! Unit coverage for the recorder surface: registration identity, the
+//! atomic-backed values, and histogram bucket arithmetic.
+
+#![allow(clippy::panic)]
+// A reading of the wrong kind is a bug in the test, not a case to handle.
+
+use super::*;
+
+fn counter_value(snapshot: &MetricsSnapshot, name: &str) -> u64 {
+    match snapshot
+        .by_name(name)
+        .next()
+        .expect("registered counter")
+        .value
+    {
+        MetricValue::Counter(value) => value,
+        ref other => panic!("expected a counter, found {other:?}"),
+    }
+}
+
+#[test]
+fn a_counter_reports_what_was_added_to_it() {
+    let recorder = DefaultMetricsRecorder::new();
+    let counter = recorder.register_counter("loonfs.test.calls", "Calls", &[("kind", "read")]);
+
+    counter.increment(2);
+    counter.increment(3);
+
+    let snapshot = recorder.snapshot();
+    let entry = snapshot.by_name("loonfs.test.calls").next().expect("entry");
+    assert_eq!(entry.labels, vec![("kind", "read")]);
+    assert_eq!(entry.description, "Calls");
+    assert_eq!(entry.value, MetricValue::Counter(5));
+}
+
+#[test]
+fn a_gauge_reports_only_its_latest_value() {
+    let recorder = DefaultMetricsRecorder::new();
+    let gauge = recorder.register_gauge("loonfs.test.depth", "Depth", &[]);
+
+    gauge.set(9);
+    gauge.set(4);
+
+    assert_eq!(
+        recorder
+            .snapshot()
+            .by_name("loonfs.test.depth")
+            .next()
+            .expect("entry")
+            .value,
+        MetricValue::Gauge(4)
+    );
+}
+
+/// Boundaries are inclusive upper bounds, and the bucket past the last one
+/// catches everything above it.
+#[test]
+fn histogram_observations_land_in_the_bucket_their_boundary_names() {
+    const BOUNDARIES: &[f64] = &[1.0, 2.0, 4.0];
+    let recorder = DefaultMetricsRecorder::new();
+    let histogram = recorder.register_histogram("loonfs.test.seconds", "Seconds", &[], BOUNDARIES);
+
+    for observation in [0.5, 1.0, 1.5, 2.0, 4.0, 4.5, 100.0] {
+        histogram.record(observation);
+    }
+
+    let snapshot = recorder.snapshot();
+    let entry = snapshot
+        .by_name("loonfs.test.seconds")
+        .next()
+        .expect("entry");
+    match &entry.value {
+        MetricValue::Histogram {
+            boundaries,
+            bucket_counts,
+            count,
+            sum,
+        } => {
+            assert_eq!(*boundaries, BOUNDARIES);
+            // 0.5 and 1.0 in `<= 1`, 1.5 and 2.0 in `<= 2`, 4.0 in `<= 4`,
+            // 4.5 and 100.0 above every boundary.
+            assert_eq!(bucket_counts, &[2, 2, 1, 2]);
+            assert_eq!(*count, 7);
+            assert!((sum - 113.5).abs() < 1e-9, "unexpected sum {sum}");
+        }
+        other => panic!("expected a histogram, found {other:?}"),
+    }
+}
+
+#[test]
+fn registering_one_name_and_label_set_twice_shares_one_value() {
+    let recorder = DefaultMetricsRecorder::new();
+    let first = recorder.register_counter("loonfs.test.calls", "Calls", &[("kind", "read")]);
+    let second = recorder.register_counter("loonfs.test.calls", "Calls", &[("kind", "read")]);
+
+    first.increment(1);
+    second.increment(1);
+
+    let snapshot = recorder.snapshot();
+    assert_eq!(snapshot.by_name("loonfs.test.calls").count(), 1);
+    assert_eq!(counter_value(&snapshot, "loonfs.test.calls"), 2);
+}
+
+/// The label set is the identity, not the order it was written in.
+#[test]
+fn label_order_does_not_split_an_instrument_in_two() {
+    let recorder = DefaultMetricsRecorder::new();
+    recorder
+        .register_counter(
+            "loonfs.test.calls",
+            "Calls",
+            &[("kind", "read"), ("result", "ok")],
+        )
+        .increment(1);
+    recorder
+        .register_counter(
+            "loonfs.test.calls",
+            "Calls",
+            &[("result", "ok"), ("kind", "read")],
+        )
+        .increment(1);
+
+    let snapshot = recorder.snapshot();
+    assert_eq!(snapshot.by_name("loonfs.test.calls").count(), 1);
+    assert_eq!(counter_value(&snapshot, "loonfs.test.calls"), 2);
+}
+
+#[test]
+fn distinct_label_sets_are_distinct_instruments() {
+    let recorder = DefaultMetricsRecorder::new();
+    recorder
+        .register_counter("loonfs.test.calls", "Calls", &[("kind", "read")])
+        .increment(1);
+    recorder
+        .register_counter("loonfs.test.calls", "Calls", &[("kind", "write")])
+        .increment(4);
+
+    let snapshot = recorder.snapshot();
+    let entries: Vec<_> = snapshot.by_name("loonfs.test.calls").collect();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].labels, vec![("kind", "read")]);
+    assert_eq!(entries[0].value, MetricValue::Counter(1));
+    assert_eq!(entries[1].labels, vec![("kind", "write")]);
+    assert_eq!(entries[1].value, MetricValue::Counter(4));
+}
+
+/// A snapshot renders in a fixed order so a host does not have to sort it.
+#[test]
+fn a_snapshot_orders_entries_by_name_then_labels() {
+    let recorder = DefaultMetricsRecorder::new();
+    recorder.register_counter("loonfs.test.zebra", "Z", &[]);
+    recorder.register_counter("loonfs.test.alpha", "A", &[("kind", "write")]);
+    recorder.register_counter("loonfs.test.alpha", "A", &[("kind", "read")]);
+
+    let snapshot = recorder.snapshot();
+    let ordered: Vec<_> = snapshot
+        .all()
+        .iter()
+        .map(|entry| (entry.name, entry.labels.clone()))
+        .collect();
+    assert_eq!(
+        ordered,
+        vec![
+            ("loonfs.test.alpha", vec![("kind", "read")]),
+            ("loonfs.test.alpha", vec![("kind", "write")]),
+            ("loonfs.test.zebra", vec![]),
+        ]
+    );
+}
+
+#[test]
+fn the_noop_recorder_keeps_nothing() {
+    let recorder = NoopMetricsRecorder;
+    recorder
+        .register_counter("loonfs.test.calls", "Calls", &[])
+        .increment(1);
+    recorder
+        .register_gauge("loonfs.test.depth", "Depth", &[])
+        .set(1);
+    recorder
+        .register_histogram(
+            "loonfs.test.seconds",
+            "Seconds",
+            &[],
+            LATENCY_SECONDS_BOUNDARIES,
+        )
+        .record(1.0);
+}

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -623,6 +623,9 @@ impl NamespacePublisher {
 
             match item {
                 WorkItem::Batch(batch) => {
+                    self.read_core
+                        .instruments()
+                        .publisher_batch(batch.candidates.len());
                     tracing::info!(
                         phase = "batch_collect",
                         mode = self.trace_mode,
@@ -659,6 +662,11 @@ impl NamespacePublisher {
         }
         let item = state.queue.pop_front();
         state.next_allowed_cas_at = Some(Instant::now() + self.min_publish_interval);
+        let queue_depth = queued_candidates(&state);
+        drop(state);
+        self.read_core
+            .instruments()
+            .publisher_queue_depth(queue_depth);
         item
     }
 
@@ -956,6 +964,7 @@ impl NamespacePublisher {
         }
 
         for (result, wait_ms) in wait_traces {
+            self.read_core.instruments().publisher_publish(result);
             tracing::info!(
                 phase = "wait_for_result",
                 mode = self.trace_mode,
@@ -972,6 +981,9 @@ impl NamespacePublisher {
     }
 
     fn trace_enqueue(&self, queue_depth: usize, reason: &'static str) {
+        self.read_core
+            .instruments()
+            .publisher_queue_depth(queue_depth);
         tracing::info!(
             phase = "enqueue",
             mode = self.trace_mode,

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -8,6 +8,7 @@ use crate::config::ReadConfig;
 use crate::content_tokens::ContentTokenError;
 use crate::fs::WriterIdentity;
 use crate::maintenance_runner::MaintenanceRunner;
+use crate::metrics::RuntimeInstruments;
 use crate::publish::{ContentPreparationError, FilesystemOperation};
 use crate::{
     BeginUploadRequest, CreateNamespaceOptions, ErrorCode, RuntimeCacheConfig,
@@ -199,6 +200,7 @@ fn test_read_core(store: SharedStore) -> ReadCore {
             trace_store_kind: TraceStoreKind::LocalFs,
         },
         None,
+        RuntimeInstruments::new(None),
     )
 }
 
@@ -209,6 +211,7 @@ fn test_writer_bits() -> Arc<WriterBits> {
             crate::FsBackgroundWork::ManualOnly,
             None,
             std::num::NonZeroUsize::new(1).expect("nonzero"),
+            RuntimeInstruments::new(None),
         ),
         publish_observer: None,
     })

--- a/crates/loonfs/tests/it/main.rs
+++ b/crates/loonfs/tests/it/main.rs
@@ -17,6 +17,7 @@ mod handles;
 mod immutable_view_inputs;
 mod invalidation;
 mod maintenance;
+mod metrics_instruments;
 mod pagination;
 mod publication;
 mod publish_observer;

--- a/crates/loonfs/tests/it/metrics_instruments.rs
+++ b/crates/loonfs/tests/it/metrics_instruments.rs
@@ -1,0 +1,210 @@
+//! What a writer built with a metrics recorder actually reports: the
+//! object-store bridge, the publication instruments, and a maintenance step
+//! that settled through the runner.
+
+#![allow(clippy::panic)]
+// A missing instrument is a wiring bug, and naming it beats an option.
+
+use crate::common::*;
+use loonfs::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};
+use loonfs::{
+    CreateNamespaceOptions, FsBackgroundWork, MaintenanceJobId, MaintenanceStepConclusion,
+    MaintenanceStepOptions, PutFileOptions,
+};
+use loonfs_test_support::block_on::block_on;
+use loonfs_test_support::ids::namespace_id;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+fn counter(snapshot: &MetricsSnapshot, name: &str, labels: &[(&str, &str)]) -> u64 {
+    let entry = snapshot
+        .by_name(name)
+        .find(|entry| entry.labels == labels)
+        .unwrap_or_else(|| panic!("no `{name}` registered with labels {labels:?}"));
+    match entry.value {
+        MetricValue::Counter(value) => value,
+        ref other => panic!("expected a counter, found {other:?}"),
+    }
+}
+
+fn histogram_count(snapshot: &MetricsSnapshot, name: &str) -> u64 {
+    snapshot
+        .by_name(name)
+        .map(|entry| match entry.value {
+            MetricValue::Histogram { count, .. } => count,
+            ref other => panic!("expected a histogram, found {other:?}"),
+        })
+        .sum()
+}
+
+/// One writer's ordinary work has to reach the recorder through three
+/// separate paths: the store wrapper the builder installed, the publisher,
+/// and the maintenance runner.
+#[test]
+fn a_writer_with_a_recorder_reports_stores_publications_and_steps() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let namespace_id = namespace_id("demo");
+    // Enough writes to push the WAL tail past its threshold, which is what
+    // nudges the metadata job and gives the runner a step to settle.
+    let writes = MaintenanceStepOptions::default().max_wal_tail_segments + 1;
+    // One runtime for the whole test: the writer's background work is
+    // spawned on the runtime that opened it, so a second `block_on` would
+    // be waiting on tasks that went away with the first.
+    let snapshot = block_on(async {
+        let fs = open_runtime_with_async(store(temp_dir.path()), "metrics-writer", |builder| {
+            builder
+                .background_work(FsBackgroundWork::Enabled)
+                .metrics_recorder(recorder.clone())
+        })
+        .await;
+        fs.writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        for file in 0..writes {
+            fs.writer
+                .put_file_bytes(
+                    &namespace_id,
+                    &format!("/docs/file-{file}.txt"),
+                    b"body",
+                    PutFileOptions::default(),
+                )
+                .await
+                .expect("put file");
+        }
+        fs.writer
+            .wait_for_background_work()
+            .await
+            .expect("background steps settle");
+        recorder.snapshot()
+    });
+
+    // The bridge: writes went out and their latency was filed.
+    assert!(
+        counter(
+            &snapshot,
+            "loonfs.object_store.operations",
+            &[("operation", "put"), ("result", "ok")],
+        ) > 0
+    );
+    assert!(
+        counter(
+            &snapshot,
+            "loonfs.object_store.bytes_in",
+            &[("operation", "put")],
+        ) > 0
+    );
+    assert!(histogram_count(&snapshot, "loonfs.object_store.operation_seconds") > 0);
+    // Nothing here retried, so the instrument exists and reads zero.
+    assert_eq!(
+        counter(
+            &snapshot,
+            "loonfs.object_store.retries",
+            &[("operation", "put")],
+        ),
+        0
+    );
+
+    // The publisher: creating a namespace installs a head rather than
+    // publishing, so every batch here is one of the puts.
+    assert_eq!(
+        counter(&snapshot, "loonfs.publisher.publishes", &[("result", "ok")]),
+        writes
+    );
+    assert_eq!(
+        histogram_count(&snapshot, "loonfs.publisher.batch_size"),
+        counter(&snapshot, "loonfs.publisher.batches", &[]),
+        "every batch taken files its size"
+    );
+
+    // The runner: a write nudges the metadata job, and whatever it
+    // concluded, the step settled under its own job label.
+    let metadata_steps: u64 = MetadataConclusions::all()
+        .map(|conclusion| {
+            counter(
+                &snapshot,
+                "loonfs.maintenance.steps",
+                &[("conclusion", conclusion), ("job", "metadata")],
+            )
+        })
+        .sum();
+    assert!(
+        metadata_steps > 0,
+        "a write should have settled at least one metadata step"
+    );
+    assert!(histogram_count(&snapshot, "loonfs.maintenance.step_seconds") > 0);
+    assert!(histogram_count(&snapshot, "loonfs.maintenance.queue_wait_seconds") > 0);
+}
+
+/// The automatic collection path reads a pass as one conclusion; these are
+/// the counts that would otherwise be dropped with the response.
+#[test]
+fn a_collection_step_reports_what_the_pass_retained() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let namespace_id = namespace_id("demo");
+    let snapshot = block_on(async {
+        let fs = open_runtime_with_async(store(temp_dir.path()), "metrics-gc-writer", |builder| {
+            builder.metrics_recorder(recorder.clone())
+        })
+        .await;
+        fs.writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        let job = fs
+            .writer
+            .maintenance_job(MaintenanceJobId::GC)
+            .expect("the runtime registers its collection job");
+        job.step(&namespace_id, None)
+            .await
+            .expect("run one collection pass");
+        recorder.snapshot()
+    });
+    assert_eq!(
+        snapshot.by_name("loonfs.gc.reclaimed").count(),
+        9,
+        "one pass registers the whole reclaimable vocabulary"
+    );
+    assert_eq!(
+        counter(
+            &snapshot,
+            "loonfs.gc.reclaimed",
+            &[("category", "deleted_wal_segments")],
+        ),
+        0,
+        "a fresh namespace has nothing to reclaim yet"
+    );
+}
+
+/// A handle built without a recorder must be exactly the handle it was
+/// before: no wrapper on its store, and nothing registered anywhere.
+#[test]
+fn a_writer_without_a_recorder_registers_nothing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let fs = runtime(temp_dir.path(), "unmetered-writer");
+
+    fs.create_namespace_blocking(&namespace_id("demo"), CreateNamespaceOptions::default())
+        .expect("create namespace");
+
+    assert!(recorder.snapshot().all().is_empty());
+}
+
+/// The five conclusions a metadata step can settle on, as label values.
+struct MetadataConclusions;
+
+impl MetadataConclusions {
+    fn all() -> impl Iterator<Item = &'static str> {
+        [
+            MaintenanceStepConclusion::Progressed,
+            MaintenanceStepConclusion::Idle,
+            MaintenanceStepConclusion::Blocked,
+            MaintenanceStepConclusion::Superseded,
+            MaintenanceStepConclusion::NotEnabled,
+        ]
+        .into_iter()
+        .map(MaintenanceStepConclusion::as_str)
+    }
+}

--- a/crates/loonfs/tests/it/runtime_config.rs
+++ b/crates/loonfs/tests/it/runtime_config.rs
@@ -45,13 +45,13 @@ fn open_validates_runtime_config() {
 }
 
 #[test]
-fn builder_metrics_recorder_instruments_object_store() {
+fn builder_object_store_metrics_recorder_instruments_object_store() {
     let temp_dir = tempdir().expect("tempdir");
     let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
     let fs = open_runtime_with(store(temp_dir.path()), "metrics-test", |builder| {
         builder
             .trace_store_kind(TraceStoreKind::LocalFs)
-            .metrics_recorder(recorder.clone())
+            .object_store_metrics_recorder(recorder.clone())
     });
 
     fs.create_namespace_blocking(&namespace_id("demo"), CreateNamespaceOptions::default())

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -571,6 +571,7 @@ A representative v0 binding is shown below.
 | Disable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/disable` (CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
 | Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (one explicit pass over only that namespace's grep extension; `max_objects` bounds the reads it spends and returns a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
 | Probe the store contract | `POST /v0/admin/store/probe` (the one admin route whose subject is the store rather than a namespace; body carries no options today and `{}` is the request; see below) |
+| Scrape metrics | `GET /metrics` (Prometheus text exposition; authorized, unlike the liveness routes — see below) |
 
 The status route and the enable response both report the index's lifecycle
 as a tagged `state`, and the phases never share a field:
@@ -1683,6 +1684,35 @@ scope resolves to an inode under the namespace's name policy and filters by
 ancestry, so it requires the same canonical spelling and validation as every
 other path read. A missing data half answers `not_supported` with the
 `feature` field naming `grep.index`.
+
+### 6.13 `GET /metrics`
+
+An operational route, alongside the two liveness routes: `GET /health`
+answers `ok` while the process is up, `GET /readiness` answers `ready`
+while it still admits work, and this one reports what the process has been
+doing. It answers Prometheus text exposition format 0.0.4 with
+`Content-Type: text/plain; version=0.0.4`.
+
+Unlike `/health` and `/readiness`, it requires the deployment's bearer
+token. Those two say only whether the process is alive, which a load
+balancer needs and nobody can misuse; this one describes a deployment's
+traffic, its namespaces' shape of work, and its failure rates, which is
+not public. A scrape sends the same `Authorization: Bearer` header a
+client does, and an unauthorized one answers `401 unauthorized` inside the
+standard error envelope.
+
+Metric names are `loonfs_<subsystem>_<metric>`, covering the object-store
+calls the process made, the maintenance steps it settled, the publications
+it batched, what garbage collection reclaimed, and the requests this
+server served. Label values come from closed vocabularies only: a request
+is labeled by the route template it matched (`/v0/namespaces/{namespace}`),
+never by its own path, so no namespace, upload, commit, or checkpoint id
+ever appears in a label. Values are per process and reset when it
+restarts, which is the ordinary contract for a counter a scraper reads.
+
+The metric set is not part of the v0 wire contract: names may be added or
+adjusted as the runtime's instrumentation grows, and clients must not
+depend on any particular series existing.
 
 ## 7. Conformance requirements
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -35,6 +35,38 @@
         ]
       }
     },
+    "/metrics": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Scrape metrics",
+        "description": "Returns this process's metrics in Prometheus text exposition format 0.0.4. Unlike `/health` and `/readiness`, the route requires the deployment's bearer token.",
+        "operationId": "serve_metrics",
+        "responses": {
+          "200": {
+            "description": "Prometheus text exposition",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/readiness": {
       "get": {
         "tags": [


### PR DESCRIPTION
This PR gives LoonFS a metrics surface. The library defines a push-based recorder trait and ships an atomic default plus a no-op. The server is LoonFS's own first embedder, so it installs the default recorder and serves the snapshot as Prometheus text on `GET /metrics`. 

**The trait.** `loonfs::metrics::MetricsRecorder` registers counters, gauges, and histograms under dotted names (`loonfs.<subsystem>.<metric>`). Names and label values are `&'static str` throughout. That is the whole cardinality policy expressed in the type system: a runtime id cannot become a label. Label values come only from closed enums. 

**The instruments.** Object store: operations, latency, bytes in/out, and retries, by operation and result. Maintenance: steps by `{job, conclusion}`, failures, step and queue-wait latency. Publisher: batches, batch size, queue depth, publish outcomes. GC: reclaimed objects by category and retained candidates — the counts the automatic runner used to discard. Server: requests by `{route, method, status_class}` (route is the matched template, never the raw path), request latency, busy rejections. At scrape time the endpoint also renders the 18 runtime-cache counters and the free upload/download permits.

**Retries were invisible; now they are counted.** `ObjectStoreMetricSample` gains a required `attempts` field. The instrumenting wrapper sits above the retry loops, so the count travels through a task-local tally: the wrapper opens a tally around the call it times, the retry gate below counts each attempt it grants. An uninstrumented store pays one failed task-local lookup per granted retry and nothing else. The field is a breaking change for direct sample constructors and old JSONL lines, which is correct pre-release.

**What stayed.** The object-store sample layer is untouched in role: the JSONL recorder, the sample vocabulary, and the wrapper all remain, and the new general recorder consumes samples through a bridge. The handle builder method `metrics_recorder` (object-store samples) is renamed `object_store_metrics_recorder`; the general recorder takes the `metrics_recorder` name on all three builders. `loonfs::metrics` is now a real module and re-exports every previously reachable path, so no import breaks. The maintenance runner's two inline trace counters stay exactly as they are, per their own documentation.

**The endpoint.** `GET /metrics` requires the bearer token, unlike `/health` and `/readiness`. Failed checks of the render never exist: the handler snapshots atomics and formats text. Dotted names become underscored, counters take `_total`, histograms emit cumulative buckets with `+Inf`, sum, and count. Output order is deterministic.

**Notes.**

- When no recorder is configured, nothing is installed: the store is not wrapped and every report site returns on a null check. Tests pin this. Embedded defaults and the CLI are unchanged.
