### PR TITLE
fix(publisher): retained tail projections share the read side's budget

### DIFF
--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -51,6 +51,12 @@ writer_id = "loonfs-server-local"
 # Clients gate on `core.uploads.direct_put` in the capability document.
 
 # Optional runtime cache overrides; omitted fields keep the runtime defaults.
+# `max_cached_namespaces` bounds every cache counted in entries: head anchors,
+# read-side WAL-tail projections, and the WAL-tail projections the writer's
+# namespace publishers retain. The two budgets under it bound those
+# projections' size, counted once for the read side and once for the publish
+# side. What a writer keeps per namespace it has mutated — the writer session
+# and its publisher, a few dozen bytes — is not bounded by any of them.
 #[runtime_cache]
 #max_cached_namespaces = 64
 #max_cached_wal_tail_projection_rows = 1000000

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -11,7 +11,9 @@ use crate::namespace::basis::MetadataBasis;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
 use crate::options::DeleteNamespaceOptions;
 use crate::path::write::{commit_fingerprint, CommitRequest, FilesystemOperation};
-use crate::protocol::{load_publish_metadata_view, PublishTailOptions, PublishTailProjection};
+use crate::protocol::{
+    load_publish_metadata_view, PublishTailOptions, PublishTailProjection, PublishTailWeight,
+};
 use crate::storage::content_admission::{ContentAdmission, ContentTokenError, PreparedContent};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
@@ -298,6 +300,18 @@ impl NamespaceCommitEngine {
         // re-checked against the head on every publish view load, and a
         // fenced session stays fenced.
         self.publish_tail_projection = None;
+    }
+
+    /// What the tail projection this engine retains weighs, or `None` when
+    /// it retains none.
+    ///
+    /// A runtime holding one engine per namespace bounds its total retention
+    /// with this; the per-projection ceiling in [`PublishTailOptions`] only
+    /// bounds one.
+    pub fn retained_tail_weight(&self) -> Option<PublishTailWeight> {
+        self.publish_tail_projection
+            .as_ref()
+            .map(PublishTailProjection::weight)
     }
 
     /// This session's writer epoch for the namespace, acquired on first use

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -149,7 +149,7 @@ pub mod publish {
         WalTailPolicy, WriterSessionState,
     };
     pub use crate::path::write::{CommitRequest, FilesystemOperation};
-    pub use crate::protocol::PublishTailOptions;
+    pub use crate::protocol::{PublishTailOptions, PublishTailWeight};
     pub use crate::storage::content_admission::PreparedContent;
 }
 

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -30,8 +30,8 @@ pub(crate) use self::batch::{
     publish_namespace_commits_batch_against_publish_view, PublishBatchAgainstViewResult,
 };
 pub(crate) use self::changes::list_changes_after;
-pub use self::publish_view::PublishTailOptions;
 pub(crate) use self::publish_view::{load_publish_metadata_view, PublishTailProjection};
+pub use self::publish_view::{PublishTailOptions, PublishTailWeight};
 pub use self::uploads::CompletedUpload;
 pub(crate) use self::uploads::{
     abort_upload, begin_direct_multipart_upload_target, begin_direct_put_upload_target,

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -64,6 +64,18 @@ impl Default for PublishTailOptions {
     }
 }
 
+/// What one retained publish-tail projection weighs, in the same two units
+/// [`PublishTailOptions`] bounds.
+///
+/// Runtimes that retain a projection per namespace bound the total with
+/// these, so the accounting reads the weight the reuse check already
+/// computed instead of walking the state again.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PublishTailWeight {
+    pub rows: usize,
+    pub decoded_bytes: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PublishTailProjection {
     pub(crate) namespace_id: NamespaceId,
@@ -97,9 +109,17 @@ impl PublishTailProjection {
             && self.manifest_payload_checksum == manifest_payload_checksum
     }
 
+    pub(crate) fn weight(&self) -> PublishTailWeight {
+        PublishTailWeight {
+            rows: self.tail_state.row_count(),
+            decoded_bytes: self.tail_state.decoded_bytes(),
+        }
+    }
+
     pub(crate) fn within_limits(&self, options: &PublishTailOptions) -> bool {
-        self.tail_state.row_count() <= options.max_tail_rows
-            && self.tail_state.decoded_bytes() <= options.max_tail_decoded_bytes
+        let weight = self.weight();
+        weight.rows <= options.max_tail_rows
+            && weight.decoded_bytes <= options.max_tail_decoded_bytes
     }
 }
 

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -5,7 +5,7 @@
 //! used; nothing here weakens read-after-write consistency.
 
 use crate::fs::{should_invalidate_after_result, ReadCore};
-use crate::{CommitResponse, CoreError, NamespaceId};
+use crate::{CommitResponse, CoreError, NamespaceId, RuntimeCacheConfig};
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
 use loonfs_core::cache::{MetadataTableCacheStats, WalTailProjectionCacheStats};
@@ -290,6 +290,12 @@ impl ReadCore {
 
     pub(crate) fn control_cache_enabled(&self) -> bool {
         self.inner.config.runtime_cache.max_cached_namespaces > 0
+    }
+
+    /// The budgets every runtime cache sizes itself from, including the
+    /// publish side's retained tail projections.
+    pub(crate) fn runtime_cache_config(&self) -> &RuntimeCacheConfig {
+        &self.inner.config.runtime_cache
     }
 
     pub(crate) fn runtime_read_context(

--- a/crates/loonfs/src/config.rs
+++ b/crates/loonfs/src/config.rs
@@ -51,17 +51,30 @@ pub(crate) struct ReadConfig {
 /// same way: a zero budget.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCacheConfig {
-    /// Maximum namespaces retained in runtime caches (control anchors,
-    /// catalogs, commit engines, and WAL-tail projection entries).
-    /// Setting this to zero disables those caches — a diagnostic mode that
-    /// trades speed for re-reads. Cache settings never change behavior:
-    /// maintenance scheduling is controlled only by
+    /// Maximum namespaces each entry-counted runtime cache retains: the
+    /// head anchors, the read-side WAL-tail projection entries, and the tail
+    /// projections a writer's namespace publishers hold. Setting this to
+    /// zero disables those caches — a diagnostic mode that trades speed for
+    /// re-reads. Cache settings never change behavior: maintenance
+    /// scheduling is controlled only by
     /// [`FsBackgroundWork`](crate::FsBackgroundWork).
+    ///
+    /// It does not bound what a writer keeps per namespace it has mutated.
+    /// One writer session — the epoch it acquired and its terminal fencing
+    /// record — and the empty publisher around it are retained for every
+    /// live namespace, at a few dozen bytes each. That is deliberate:
+    /// nothing in the store can rebuild "this session was fenced", so
+    /// evicting it would let a fenced writer reacquire the epoch (see
+    /// [`WriterSessionState`](loonfs_core::publish::WriterSessionState)).
     pub max_cached_namespaces: usize,
-    /// Maximum metadata rows retained across cached WAL-tail projections;
-    /// zero disables the projection cache.
+    /// Maximum metadata rows retained across WAL-tail projections. The read
+    /// cache and the publish side each hold their own total against it, so
+    /// this is the ceiling per side rather than for the process. Zero
+    /// disables the projection cache.
     pub max_cached_wal_tail_projection_rows: usize,
-    /// Approximate decoded-byte budget for cached WAL-tail projections.
+    /// Approximate decoded-byte budget for WAL-tail projections, per side
+    /// like the row budget. Both budgets also cap one projection: a publish
+    /// whose tail outgrows either keeps nothing.
     pub max_cached_wal_tail_projection_decoded_bytes: usize,
     /// Cache settings for decoded metadata tables.
     pub metadata_table_cache: MetadataTableCacheConfig,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -774,7 +774,9 @@ pub(crate) async fn publish_batch_with_engine(
         Ok(context) => context,
         Err(error) => return candidates.iter().map(|_| Err(error.clone())).collect(),
     };
-    let cache_config = &core.inner.config.runtime_cache;
+    let cache_config = core.runtime_cache_config();
+    // The per-projection ceiling. The publisher applies the same two knobs
+    // as an aggregate over every projection it retains.
     let tail_options = loonfs_core::publish::PublishTailOptions {
         max_tail_rows: cache_config.max_cached_wal_tail_projection_rows,
         max_tail_decoded_bytes: cache_config.max_cached_wal_tail_projection_decoded_bytes,

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -129,6 +129,22 @@ impl RuntimeInstruments {
             .set(i64::try_from(queue_depth).unwrap_or(i64::MAX));
     }
 
+    /// Reports the WAL-tail projections this writer retains across its
+    /// namespace publishers, after one publish or eviction settled them.
+    pub(crate) fn publisher_retained_projections(&self, projections: usize, decoded_bytes: usize) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed
+            .publisher
+            .retained_projections
+            .set(i64::try_from(projections).unwrap_or(i64::MAX));
+        installed
+            .publisher
+            .retained_projection_bytes
+            .set(i64::try_from(decoded_bytes).unwrap_or(i64::MAX));
+    }
+
     /// Reports one batch taken for publication.
     pub(crate) fn publisher_batch(&self, batch_size: usize) {
         let Some(installed) = &self.installed else {
@@ -396,6 +412,8 @@ struct PublisherInstruments {
     batches: Arc<dyn CounterHandle>,
     batch_size: Arc<dyn HistogramHandle>,
     queue_depth: Arc<dyn GaugeHandle>,
+    retained_projections: Arc<dyn GaugeHandle>,
+    retained_projection_bytes: Arc<dyn GaugeHandle>,
     published_ok: Arc<dyn CounterHandle>,
     published_error: Arc<dyn CounterHandle>,
 }
@@ -427,6 +445,18 @@ impl PublisherInstruments {
             queue_depth: recorder.register_gauge(
                 "loonfs.publisher.queue_depth",
                 "Candidates queued at the namespace publisher that last admitted or took work",
+                &[],
+            ),
+            // Totals, not samples: these are what the writer holds across
+            // every namespace it has published to.
+            retained_projections: recorder.register_gauge(
+                "loonfs.publisher.retained_projections",
+                "WAL-tail projections this writer's namespace publishers retain",
+                &[],
+            ),
+            retained_projection_bytes: recorder.register_gauge(
+                "loonfs.publisher.retained_projection_bytes",
+                "Decoded bytes held by the retained WAL-tail projections",
                 &[],
             ),
             published_ok: publishes("ok"),

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -22,6 +22,14 @@
 //! and the delete barrier run through one engine, under one session epoch,
 //! on one worker task draining one queue.
 //!
+//! That life is the namespace's, not a cache entry's, so what a publisher
+//! may hold is bounded rather than dropped: the session's epoch and fencing
+//! are a few dozen bytes nothing can rebuild, while the engine's WAL-tail
+//! projection is large and rebuildable from the store. The registry
+//! therefore keeps every publisher and bounds the projections across them,
+//! against the same budget the read-side projection cache spends
+//! (`max_cached_namespaces` and the two WAL-tail knobs beside it).
+//!
 //! Every writer owns one registry, and the direct
 //! [`FsWriter`](crate::FsWriter) mutation methods, the reference server,
 //! and any embedded host with many in-process writer agents all submit
@@ -54,14 +62,16 @@
 
 use crate::fs::{ReadCore, WriterBits};
 use crate::publish::{CommitCandidate, CommitRequest, PreparedContent};
-use crate::{CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeError};
+use crate::{
+    CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeCacheConfig, RuntimeError,
+};
 use futures::FutureExt;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::{CommitId, NamespaceId};
 use loonfs_core::commit::{CommitFingerprint, CommitHeadPublishError};
 // Publisher head-CAS races use the core-wide bounded contention retry limit.
 use loonfs_core::limits::CONTENTION_RETRY_LIMIT;
-use loonfs_core::publish::{NamespaceCommitEngine, SharedWriterSessionState};
+use loonfs_core::publish::{NamespaceCommitEngine, PublishTailWeight, SharedWriterSessionState};
 use std::collections::{HashMap, VecDeque};
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -128,6 +138,7 @@ struct RegistryShared {
 struct RegistryState {
     closed: bool,
     publishers: HashMap<NamespaceId, NamespacePublisher>,
+    projections: RetainedProjections,
 }
 
 impl RegistryShared {
@@ -141,8 +152,202 @@ impl RegistryShared {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    fn evict(&self, namespace_id: &NamespaceId) {
-        self.lock_state().publishers.remove(namespace_id);
+    fn evict(&self, namespace_id: &NamespaceId) -> RetainedProjectionTotals {
+        let mut state = self.lock_state();
+        state.publishers.remove(namespace_id);
+        state.projections.forget(namespace_id);
+        state.projections.totals()
+    }
+
+    /// Records what one namespace's publish left retained, then brings the
+    /// writer back under the shared projection budget.
+    ///
+    /// Victims are chosen least-recently-published first and lose their tail
+    /// projection only: never the publisher, never its engine identity,
+    /// never the writer session beside it. A victim whose engine is held —
+    /// a publication or delete is in flight — is skipped and stays
+    /// accounted, because that unit rebuilds and reports its own weight when
+    /// it finishes. Skipping therefore costs one sweep, not accounting
+    /// truth.
+    fn settle_projection(
+        &self,
+        namespace_id: &NamespaceId,
+        weight: Option<PublishTailWeight>,
+        budget: ProjectionBudget,
+    ) -> RetainedProjectionTotals {
+        let victims = {
+            let mut state = self.lock_state();
+            state.projections.record(namespace_id, weight);
+            let selected = state.projections.over_budget_victims(budget);
+            selected
+                .into_iter()
+                .map(|victim| {
+                    let publisher = state.publishers.get(&victim.namespace_id).cloned();
+                    (victim, publisher)
+                })
+                .collect::<Vec<_>>()
+        };
+        // Swept outside the registry lock: locks nest publisher-then-
+        // registry on the eviction path, never the other way around.
+        let dropped = victims
+            .into_iter()
+            .filter(|(_, publisher)| {
+                // No publisher means no engine, so nothing is retained under
+                // that namespace either way.
+                publisher
+                    .as_ref()
+                    .is_none_or(NamespacePublisher::invalidate_engine)
+            })
+            .map(|(victim, _)| victim)
+            .collect::<Vec<_>>();
+
+        let mut state = self.lock_state();
+        for victim in dropped {
+            state.projections.forget_recorded(&victim);
+        }
+        state.projections.totals()
+    }
+
+    /// Forgets one namespace's retained projection after something outside
+    /// the publish path dropped it.
+    fn forget_projection(&self, namespace_id: &NamespaceId) -> RetainedProjectionTotals {
+        let mut state = self.lock_state();
+        state.projections.forget(namespace_id);
+        state.projections.totals()
+    }
+}
+
+/// The aggregate ceiling on retained publish-tail projections: the same
+/// three knobs, read the same way, as the read-side projection cache.
+#[derive(Debug, Clone, Copy)]
+struct ProjectionBudget {
+    max_namespaces: usize,
+    max_rows: usize,
+    max_decoded_bytes: usize,
+}
+
+impl ProjectionBudget {
+    fn of(config: &RuntimeCacheConfig) -> Self {
+        Self {
+            max_namespaces: config.max_cached_namespaces,
+            max_rows: config.max_cached_wal_tail_projection_rows,
+            max_decoded_bytes: config.max_cached_wal_tail_projection_decoded_bytes,
+        }
+    }
+}
+
+/// The WAL-tail projections this writer's publishers retain, and what they
+/// weigh together.
+///
+/// The per-projection ceiling a publish already applies bounds one namespace;
+/// this bounds the writer, which is what a process publishing to thousands of
+/// namespaces actually holds.
+#[derive(Debug, Default)]
+struct RetainedProjections {
+    /// Least-recently-published first, one entry per namespace whose engine
+    /// retains a projection.
+    entries: VecDeque<RetainedProjection>,
+    rows: usize,
+    decoded_bytes: usize,
+    next_stamp: u64,
+}
+
+#[derive(Debug, Clone)]
+struct RetainedProjection {
+    namespace_id: NamespaceId,
+    weight: PublishTailWeight,
+    /// Distinguishes the projection a sweep selected from a newer one the
+    /// namespace published while that sweep ran outside the lock, so a
+    /// completed eviction never forgets a live projection.
+    stamp: u64,
+}
+
+/// What the writer retains right now, for the gauges and for tests.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct RetainedProjectionTotals {
+    projections: usize,
+    rows: usize,
+    decoded_bytes: usize,
+}
+
+impl RetainedProjections {
+    /// Records what one namespace retains after a publish; `None` is a
+    /// publish that kept nothing.
+    fn record(&mut self, namespace_id: &NamespaceId, weight: Option<PublishTailWeight>) {
+        self.forget(namespace_id);
+        let Some(weight) = weight else {
+            return;
+        };
+        self.next_stamp += 1;
+        self.rows = self.rows.saturating_add(weight.rows);
+        self.decoded_bytes = self.decoded_bytes.saturating_add(weight.decoded_bytes);
+        self.entries.push_back(RetainedProjection {
+            namespace_id: namespace_id.clone(),
+            weight,
+            stamp: self.next_stamp,
+        });
+    }
+
+    fn forget(&mut self, namespace_id: &NamespaceId) {
+        let index = self
+            .entries
+            .iter()
+            .position(|entry| entry.namespace_id == *namespace_id);
+        self.remove_entry(index);
+    }
+
+    /// Forgets exactly the projection an eviction dropped. A namespace that
+    /// published again while the sweep ran outside the lock carries a newer
+    /// stamp, so its live projection stays accounted.
+    fn forget_recorded(&mut self, recorded: &RetainedProjection) {
+        let index = self
+            .entries
+            .iter()
+            .position(|entry| entry.stamp == recorded.stamp);
+        self.remove_entry(index);
+    }
+
+    /// Drops one entry and its weight from the totals. At most one entry per
+    /// namespace exists, so callers locate it by whichever key they hold.
+    fn remove_entry(&mut self, index: Option<usize>) {
+        let Some(entry) = index.and_then(|index| self.entries.remove(index)) else {
+            return;
+        };
+        self.rows = self.rows.saturating_sub(entry.weight.rows);
+        self.decoded_bytes = self
+            .decoded_bytes
+            .saturating_sub(entry.weight.decoded_bytes);
+    }
+
+    /// The namespaces to drop, least-recently-published first, until what
+    /// remains fits the budget. Selection changes nothing: only an eviction
+    /// that actually took the engine does.
+    fn over_budget_victims(&self, budget: ProjectionBudget) -> Vec<RetainedProjection> {
+        let mut projections = self.entries.len();
+        let mut rows = self.rows;
+        let mut decoded_bytes = self.decoded_bytes;
+        let mut victims = Vec::new();
+        for entry in &self.entries {
+            if projections <= budget.max_namespaces
+                && rows <= budget.max_rows
+                && decoded_bytes <= budget.max_decoded_bytes
+            {
+                break;
+            }
+            projections = projections.saturating_sub(1);
+            rows = rows.saturating_sub(entry.weight.rows);
+            decoded_bytes = decoded_bytes.saturating_sub(entry.weight.decoded_bytes);
+            victims.push(entry.clone());
+        }
+        victims
+    }
+
+    fn totals(&self) -> RetainedProjectionTotals {
+        RetainedProjectionTotals {
+            projections: self.entries.len(),
+            rows: self.rows,
+            decoded_bytes: self.decoded_bytes,
+        }
     }
 }
 
@@ -163,6 +368,7 @@ impl PublisherRegistry {
                 state: Mutex::new(RegistryState {
                     closed: false,
                     publishers: HashMap::new(),
+                    projections: RetainedProjections::default(),
                 }),
                 panicked_units: AtomicUsize::new(0),
             }),
@@ -232,8 +438,14 @@ impl PublisherRegistry {
             .publishers
             .get(namespace_id)
             .cloned();
-        if let Some(publisher) = publisher {
-            publisher.invalidate_engine();
+        let Some(publisher) = publisher else {
+            return;
+        };
+        if publisher.invalidate_engine() {
+            let totals = self.shared.forget_projection(namespace_id);
+            self.read_core
+                .instruments()
+                .publisher_retained_projections(totals.projections, totals.decoded_bytes);
         }
     }
 
@@ -457,12 +669,42 @@ impl NamespacePublisher {
         self.lock_state().closed = true;
     }
 
-    fn invalidate_engine(&self) {
-        if let Ok(mut slot) = self.engine.try_lock() {
-            if let Some(engine) = slot.engine.as_mut() {
-                engine.invalidate();
-            }
+    /// Drops the engine's tail projection, reporting whether it took the
+    /// engine to do so. A `false` return means a publication or delete holds
+    /// the engine, and that unit's own settlement reports what it retains.
+    fn invalidate_engine(&self) -> bool {
+        let Ok(mut slot) = self.engine.try_lock() else {
+            return false;
+        };
+        if let Some(engine) = slot.engine.as_mut() {
+            engine.invalidate();
         }
+        true
+    }
+
+    /// Records what a publish left retained and sweeps the writer back under
+    /// the shared projection budget.
+    ///
+    /// Called while the publish still holds its engine, so the weight
+    /// recorded is the projection the engine actually kept: no concurrent
+    /// sweep can drop it in between and leave the ledger claiming one that
+    /// is gone. Taking the registry lock under a held engine is the one
+    /// place the nesting runs that way and it still cannot cycle, because a
+    /// sweep releases the registry lock before it reaches for an engine and
+    /// never waits for one.
+    fn settle_retained_projection(&self, weight: Option<PublishTailWeight>) {
+        let Some(shared) = self.shared.upgrade() else {
+            return;
+        };
+        let budget = ProjectionBudget::of(self.read_core.runtime_cache_config());
+        let totals = shared.settle_projection(&self.namespace_id, weight, budget);
+        self.report_retained_projections(totals);
+    }
+
+    fn report_retained_projections(&self, totals: RetainedProjectionTotals) {
+        self.read_core
+            .instruments()
+            .publisher_retained_projections(totals.projections, totals.decoded_bytes);
     }
 
     /// The path to `admit` is await-free: a submission future's first poll
@@ -775,17 +1017,19 @@ impl NamespacePublisher {
     ) -> Vec<CommitResult> {
         let mut slot = self.engine.lock().await;
         let engine = self.engine_for(&mut slot);
-        crate::fs::publish_batch_with_engine(
+        let results = crate::fs::publish_batch_with_engine(
             &self.read_core,
             writer,
             &self.namespace_id,
             engine,
             candidates,
         )
-        .await
-        .into_iter()
-        .map(|result| result.map_err(runtime_error_to_core))
-        .collect()
+        .await;
+        self.settle_retained_projection(engine.retained_tail_weight());
+        results
+            .into_iter()
+            .map(|result| result.map_err(runtime_error_to_core))
+            .collect()
     }
 
     /// The publisher's engine, built on first use. The namespace's
@@ -833,7 +1077,7 @@ impl NamespacePublisher {
                 // gets a fresh publisher whose publish fails on the durable
                 // tombstone.
                 if let Some(shared) = self.shared.upgrade() {
-                    shared.evict(&self.namespace_id);
+                    self.report_retained_projections(shared.evict(&self.namespace_id));
                 }
                 for waiter in waiters {
                     let _ = waiter.send(Ok(response.clone()));

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -8,7 +8,7 @@ use crate::config::ReadConfig;
 use crate::content_tokens::ContentTokenError;
 use crate::fs::WriterIdentity;
 use crate::maintenance_runner::MaintenanceRunner;
-use crate::metrics::RuntimeInstruments;
+use crate::metrics::{DefaultMetricsRecorder, MetricValue, RuntimeInstruments};
 use crate::publish::{ContentPreparationError, FilesystemOperation};
 use crate::{
     BeginUploadRequest, CreateNamespaceOptions, ErrorCode, RuntimeCacheConfig,
@@ -247,6 +247,77 @@ async fn test_writer_with_interval(
         .build()
         .await
         .expect("build writer")
+}
+
+async fn test_writer_with_cache(
+    store: SharedStore,
+    runtime_cache: RuntimeCacheConfig,
+    recorder: Arc<DefaultMetricsRecorder>,
+) -> crate::FsWriter {
+    crate::FsWriter::builder_with_store(store)
+        .writer_id("writer-a")
+        .min_publish_interval_ms(0)
+        .runtime_cache(runtime_cache)
+        .metrics_recorder(recorder)
+        .trace_mode(TraceMode::Remote)
+        .trace_store_kind(TraceStoreKind::LocalFs)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+fn gauge(recorder: &DefaultMetricsRecorder, name: &str) -> i64 {
+    let snapshot = recorder.snapshot();
+    let entry = snapshot
+        .by_name(name)
+        .next()
+        .unwrap_or_else(|| panic!("no `{name}` gauge registered"));
+    match entry.value {
+        MetricValue::Gauge(value) => value,
+        ref other => panic!("expected a gauge, found {other:?}"),
+    }
+}
+
+fn retained_projections(registry: &PublisherRegistry) -> RetainedProjectionTotals {
+    registry.shared.lock_state().projections.totals()
+}
+
+/// The namespaces whose projections the registry still holds, least
+/// recently published first.
+fn retained_namespaces(registry: &PublisherRegistry) -> Vec<NamespaceId> {
+    registry
+        .shared
+        .lock_state()
+        .projections
+        .entries
+        .iter()
+        .map(|entry| entry.namespace_id.clone())
+        .collect()
+}
+
+/// Bootstraps `namespaces` under `writer` and publishes one directory into
+/// each, in order, so the registry's retention order is the namespace order.
+async fn publish_once_into_each(writer: &crate::FsWriter, namespaces: &[NamespaceId]) {
+    let registry = writer.publisher();
+    for namespace_id in namespaces {
+        writer
+            .create_namespace(namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("bootstrap");
+        registry
+            .submit_commit(
+                namespace_id.clone(),
+                create_directory_request("seed", "docs"),
+            )
+            .await
+            .expect("commit");
+    }
+}
+
+fn test_namespaces(count: usize) -> Vec<NamespaceId> {
+    (0..count)
+        .map(|index| NamespaceId::parse(format!("ns-{index:02}")).expect("valid namespace id"))
+        .collect()
 }
 
 /// Bootstraps a namespace under the identity the standalone publisher will
@@ -1491,4 +1562,273 @@ async fn delete_queued_mid_publish_waits_behind_admitted_work() {
     assert_eq!(delete_response.head_seq, ChangeSeq(2));
     registry.close_admission();
     registry.drain().await.expect("drain settles both units");
+}
+
+/// Retained publish-tail projections are bounded across namespaces, not only
+/// one at a time: a writer that publishes to far more namespaces than the
+/// budget admits keeps a projection for the most recently published ones and
+/// nothing for the rest. The publishers stay — each one carries the writer
+/// session that nothing may evict — but they carry no tail.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retained_tail_projections_stay_within_the_namespace_count_cap() {
+    const NAMESPACES: usize = 12;
+    const RETAINED: usize = 3;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let writer = test_writer_with_cache(
+        store,
+        RuntimeCacheConfig {
+            max_cached_namespaces: RETAINED,
+            ..RuntimeCacheConfig::default()
+        },
+        recorder.clone(),
+    )
+    .await;
+    let registry = writer.publisher();
+    let namespaces = test_namespaces(NAMESPACES);
+
+    publish_once_into_each(&writer, &namespaces).await;
+
+    let totals = retained_projections(&registry);
+    assert_eq!(
+        totals.projections, RETAINED,
+        "the count cap bounds retained projections across namespaces"
+    );
+    assert!(
+        totals.rows > 0 && totals.decoded_bytes > 0,
+        "the surviving projections must be real ones: {totals:?}"
+    );
+    assert_eq!(
+        retained_namespaces(&registry),
+        namespaces[NAMESPACES - RETAINED..].to_vec(),
+        "eviction takes the least recently published namespaces first"
+    );
+    assert_eq!(
+        registry.shared.lock_state().publishers.len(),
+        NAMESPACES,
+        "bounding the projections must not evict a publisher or its session"
+    );
+
+    assert_eq!(
+        gauge(&recorder, "loonfs.publisher.retained_projections"),
+        i64::try_from(RETAINED).expect("small count"),
+        "the gauge reports what the registry retains"
+    );
+    assert_eq!(
+        gauge(&recorder, "loonfs.publisher.retained_projection_bytes"),
+        i64::try_from(totals.decoded_bytes).expect("small byte total"),
+    );
+
+    registry.close_admission();
+    registry
+        .drain()
+        .await
+        .expect("drain settles every publisher");
+}
+
+/// The row and decoded-byte budgets bound the publish side in aggregate, the
+/// same meaning the read-side projection cache gives them. A projection that
+/// fits the per-projection ceiling on its own is still evicted once the
+/// namespaces together outgrow the budget.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retained_tail_projections_stay_within_the_shared_byte_budget() {
+    const NAMESPACES: usize = 8;
+    const ADMITTED: usize = 2;
+
+    let budget_bytes = one_projection_decoded_bytes().await * ADMITTED;
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let writer = test_writer_with_cache(
+        store,
+        RuntimeCacheConfig {
+            max_cached_wal_tail_projection_decoded_bytes: budget_bytes,
+            ..RuntimeCacheConfig::default()
+        },
+        recorder.clone(),
+    )
+    .await;
+    let registry = writer.publisher();
+    let namespaces = test_namespaces(NAMESPACES);
+
+    publish_once_into_each(&writer, &namespaces).await;
+
+    let totals = retained_projections(&registry);
+    assert!(
+        totals.decoded_bytes <= budget_bytes,
+        "retained projections must fit the shared byte budget of {budget_bytes}: {totals:?}"
+    );
+    assert!(
+        (1..=ADMITTED).contains(&totals.projections),
+        "the budget admits {ADMITTED} projections of this size, no more: {totals:?}"
+    );
+    assert_eq!(
+        gauge(&recorder, "loonfs.publisher.retained_projection_bytes"),
+        i64::try_from(totals.decoded_bytes).expect("small byte total"),
+    );
+
+    registry.close_admission();
+    registry
+        .drain()
+        .await
+        .expect("drain settles every publisher");
+}
+
+/// What one namespace's tail projection weighs after a single publish, so a
+/// budget can be stated in whole projections instead of a guessed constant.
+async fn one_projection_decoded_bytes() -> usize {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let writer = test_writer(store).await;
+    publish_once_into_each(&writer, &test_namespaces(1)).await;
+    let totals = retained_projections(&writer.publisher());
+    assert_eq!(totals.projections, 1, "one publish retains one projection");
+    totals.decoded_bytes
+}
+
+/// Caches off is the one mode that keeps nothing: every publish drops its
+/// projection where it was built, so the registry has none to account for
+/// and none to evict.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disabled_runtime_caches_retain_no_tail_projections() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let writer =
+        test_writer_with_cache(store, RuntimeCacheConfig::disabled(), recorder.clone()).await;
+    let registry = writer.publisher();
+    let namespaces = test_namespaces(3);
+
+    publish_once_into_each(&writer, &namespaces).await;
+
+    assert_eq!(
+        retained_projections(&registry),
+        RetainedProjectionTotals::default(),
+        "a diagnostic run retains nothing to bound"
+    );
+    assert_eq!(gauge(&recorder, "loonfs.publisher.retained_projections"), 0);
+    assert_eq!(
+        registry.shared.lock_state().publishers.len(),
+        namespaces.len(),
+        "publishers and their sessions survive caches being off"
+    );
+
+    registry.close_admission();
+    registry
+        .drain()
+        .await
+        .expect("drain settles every publisher");
+}
+
+/// A landed delete takes its namespace's projection out of the accounting
+/// with the publisher itself: nothing stays charged to an id that can never
+/// rebind.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_landed_delete_forgets_the_namespace_projection() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let writer =
+        test_writer_with_cache(store, RuntimeCacheConfig::default(), recorder.clone()).await;
+    let registry = writer.publisher();
+    let namespaces = test_namespaces(2);
+
+    publish_once_into_each(&writer, &namespaces).await;
+    assert_eq!(retained_projections(&registry).projections, 2);
+
+    registry
+        .submit_delete(namespaces[0].clone(), DeleteNamespaceOptions::default())
+        .await
+        .expect("delete namespace");
+
+    assert_eq!(
+        retained_namespaces(&registry),
+        vec![namespaces[1].clone()],
+        "the deleted namespace leaves no accounting behind"
+    );
+    assert_eq!(gauge(&recorder, "loonfs.publisher.retained_projections"), 1);
+
+    registry.close_admission();
+    registry
+        .drain()
+        .await
+        .expect("drain settles every publisher");
+}
+
+/// A namespace that is publishing keeps its engine, so a sweep skips it —
+/// and must keep it accounted rather than record an eviction that never
+/// happened. The next publish sweeps again and the skipped namespace loses
+/// its projection then.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_skipped_eviction_leaves_the_namespace_accounted() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let writer = test_writer_with_cache(
+        store,
+        RuntimeCacheConfig {
+            max_cached_namespaces: 1,
+            ..RuntimeCacheConfig::default()
+        },
+        recorder.clone(),
+    )
+    .await;
+    let registry = writer.publisher();
+    let namespaces = test_namespaces(2);
+    let (busy, other) = (namespaces[0].clone(), namespaces[1].clone());
+
+    publish_once_into_each(&writer, &namespaces[..1]).await;
+    assert_eq!(retained_namespaces(&registry), vec![busy.clone()]);
+
+    // Standing in for a publication in flight: the engine is held, so the
+    // sweep the next publish runs cannot take it.
+    let busy_publisher = registry
+        .shared
+        .lock_state()
+        .publishers
+        .get(&busy)
+        .expect("the published namespace has a publisher")
+        .clone();
+    let held_engine = busy_publisher.engine.lock().await;
+
+    writer
+        .create_namespace(&other, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
+    registry
+        .submit_commit(other.clone(), create_directory_request("seed", "docs"))
+        .await
+        .expect("commit while the other engine is held");
+
+    let skipped = retained_projections(&registry);
+    assert_eq!(
+        retained_namespaces(&registry),
+        vec![busy.clone(), other.clone()],
+        "a skipped eviction must not be recorded as one"
+    );
+    assert_eq!(
+        gauge(&recorder, "loonfs.publisher.retained_projections"),
+        i64::try_from(skipped.projections).expect("small count"),
+        "the gauge reports the overshoot rather than hiding it"
+    );
+
+    drop(held_engine);
+    registry
+        .submit_commit(other.clone(), create_directory_request("second", "more"))
+        .await
+        .expect("commit once the engine is free");
+
+    assert_eq!(
+        retained_namespaces(&registry),
+        vec![other],
+        "the next sweep evicts what the previous one skipped"
+    );
+
+    registry.close_admission();
+    registry
+        .drain()
+        .await
+        .expect("drain settles every publisher");
 }

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -2,6 +2,7 @@
 //! instead of dropping them, and no cache lifecycle event — invalidation,
 //! LRU eviction, or running with caches disabled — erases writer fencing.
 
+use loonfs::metrics::{DefaultMetricsRecorder, MetricValue};
 use loonfs::{
     CreateNamespaceOptions, DeleteNamespaceOptions, FsWriter, NamespaceId, PutFileOptions,
     RuntimeCacheConfig, RuntimeError, SharedObjectStore, WriterFence,
@@ -28,6 +29,36 @@ async fn writer_with_cache(
         .build()
         .await
         .expect("build writer")
+}
+
+async fn writer_with_cache_and_metrics(
+    store: &SharedObjectStore,
+    writer_id: &str,
+    runtime_cache: RuntimeCacheConfig,
+    recorder: Arc<DefaultMetricsRecorder>,
+) -> FsWriter {
+    FsWriter::builder_with_store(store.clone())
+        .writer_id(writer_id)
+        .min_publish_interval_ms(0)
+        .runtime_cache(runtime_cache)
+        .metrics_recorder(recorder)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+/// The WAL-tail projections the writer's namespace publishers retain, read
+/// off the gauge that reports them.
+fn retained_projections(recorder: &DefaultMetricsRecorder) -> i64 {
+    let snapshot = recorder.snapshot();
+    let entry = snapshot
+        .by_name("loonfs.publisher.retained_projections")
+        .next()
+        .expect("the publisher registers its retention gauges");
+    match entry.value {
+        MetricValue::Gauge(value) => value,
+        ref other => unreachable!("retention is reported as a gauge, found {other:?}"),
+    }
 }
 
 /// Asserts a terminal fencing refusal and hands back the fence it carries.
@@ -166,14 +197,15 @@ async fn fenced_session_cannot_delete_namespace() {
         .expect("live writer keeps publishing after the refused delete");
 }
 
-/// Fencing must also survive LRU eviction of the namespace's cache entry:
-/// the namespace's publisher owns the session and its engine, and no cache
-/// holds either. Before this fix, capacity pressure from touching other
-/// namespaces evicted the fenced engine, and the fresh engine's first
-/// publish silently re-acquired the epoch — the fenced writer resumed
-/// publishing and fenced the legitimate writer back.
+/// Fencing must survive the eviction that bounds retained publish state.
+/// A writer's publishers hold one WAL-tail projection per namespace, and the
+/// projection budget drops the least recently published of them; only the
+/// projection goes. The epoch this session acquired belongs to the session,
+/// which nothing evicts — before that split, capacity pressure took the
+/// engine whole, and the rebuilt engine's first publish silently re-acquired
+/// the epoch, fencing the legitimate writer back.
 #[tokio::test]
-async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
+async fn fenced_writer_stays_fenced_after_its_tail_projection_is_evicted() {
     let temp_dir = tempdir().expect("tempdir");
     let ns_fence = NamespaceId::parse("fence").expect("valid namespace id");
     let ns_other = NamespaceId::parse("other").expect("valid namespace id");
@@ -183,11 +215,20 @@ async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
     ));
     let store: SharedObjectStore = counting.clone();
 
-    let single_entry_cache = RuntimeCacheConfig {
+    // Room for one projection: publishing to either namespace evicts the
+    // other's.
+    let single_projection_cache = RuntimeCacheConfig {
         max_cached_namespaces: 1,
         ..RuntimeCacheConfig::default()
     };
-    let writer_a = writer_with_cache(&store, "writer-a", single_entry_cache).await;
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let writer_a = writer_with_cache_and_metrics(
+        &store,
+        "writer-a",
+        single_projection_cache,
+        recorder.clone(),
+    )
+    .await;
     writer_a
         .create_namespace(&ns_fence, CreateNamespaceOptions::default())
         .await
@@ -201,25 +242,44 @@ async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
         .await
         .expect("writer a first put");
 
+    // Publishing to the other namespace pushes the first namespace's
+    // projection out of the budget. Its publisher, engine identity, and
+    // writer session stay behind.
+    writer_a
+        .put_file_bytes(&ns_other, "/spill.txt", b"s", PutFileOptions::default())
+        .await
+        .expect("writer a publishes to the other namespace");
+    assert_eq!(
+        retained_projections(&recorder),
+        1,
+        "the budget admits one namespace's projection at a time"
+    );
+
     let writer_b = writer(&store, "writer-b").await;
     writer_b
         .put_file_bytes(&ns_fence, "/b1.txt", b"b", PutFileOptions::default())
         .await
         .expect("writer b takes over the epoch");
 
-    expect_writer_fenced(
+    // The rebuilt projection publishes under the epoch the session still
+    // holds, so the takeover surfaces as fencing instead of a silent
+    // re-acquisition.
+    let fence = expect_writer_fenced(
         writer_a
             .put_file_bytes(&ns_fence, "/a2.txt", b"a", PutFileOptions::default())
             .await,
         "superseded writer surfaces fencing",
     );
+    let head_after_fencing = head_state(&store, &ns_fence).await;
+    assert_eq!(fence.active_epoch, head_after_fencing.writer_epoch);
+    assert_eq!(fence.active_writer.as_deref(), Some("writer-b"));
 
-    // Publishing to the other namespace evicts the fenced namespace's cache
-    // entry (capacity one), commit engine included.
+    // More budget pressure, now against a publisher whose session is fenced:
+    // fencing is session state, so no eviction can reach it.
     writer_a
-        .put_file_bytes(&ns_other, "/spill.txt", b"s", PutFileOptions::default())
+        .put_file_bytes(&ns_other, "/spill2.txt", b"s", PutFileOptions::default())
         .await
-        .expect("writer a publishes to the other namespace");
+        .expect("writer a keeps publishing to the other namespace");
 
     let head_cas_after_fencing = counting.count(OperationClass::CompareAndSwap);
     expect_writer_fenced(
@@ -233,6 +293,9 @@ async fn fenced_writer_stays_fenced_after_namespace_lru_eviction() {
         head_cas_after_fencing,
         "a fenced session must not touch the fenced namespace's head"
     );
+    let head = head_state(&store, &ns_fence).await;
+    assert_eq!(head.state, NamespaceState::Active);
+    assert_eq!(head.writer_epoch, head_after_fencing.writer_epoch);
     writer_b
         .put_file_bytes(&ns_fence, "/b2.txt", b"b", PutFileOptions::default())
         .await


### PR DESCRIPTION
This PR bounds the publish projection memory. 

The problem... A writer keeps one publisher per namespace it has mutated, forever. Each publisher's engine can keep a publish-tail projection for reuse. The two projection budget knobs mean "total" on the read side but meant "per projection" on the publish side, so a server writing to many namespaces had no aggregate ceiling: worst case N × 256 MiB, uncounted. 

The fix... The registry now keeps a small ledger of retained projections, ordered least-recently-published. After each publish, the publisher reports its projection's weight while it still holds the engine guard, and the registry evicts projections — oldest first — until the count is within `max_cached_namespaces` and the rows/bytes are within the same two knobs the read side uses as totals. Eviction reuses the existing safe primitive: it drops only the projection. The engine, the publisher, and the writer-session record (the acquired epoch and the terminal fencing flag) are never evicted — that retention is deliberate, because nothing in the store can rebuild "this session was fenced". 

Honesty under contention: Eviction try-locks a victim's engine and skips it when the publish path holds it. A skip leaves the entry accounted, so the gauge shows the overshoot instead of hiding it, and the next publish settles it. A stamp on each ledger entry keeps a late eviction from forgetting a projection that a newer publish just rebuilt. 
