### PR TITLE
refactor: one authority for dispatch, recency, the clock, and retry conflicts

### DIFF
--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -887,7 +887,6 @@ mod tests {
         RevisionNo,
     };
     use loonfs_client::NamespacePath;
-    use std::sync::Arc;
     use tempfile::tempdir;
 
     fn namespace_id(value: &str) -> NamespaceId {
@@ -939,8 +938,10 @@ mod tests {
             root: temp_dir.display().to_string(),
             key_prefix: None,
         };
-        let store: SharedObjectStore =
-            Arc::new(config.configured_object_store().expect("configure store"));
+        let store = config
+            .configured_object_store()
+            .expect("configure store")
+            .into_shared();
         (config, store)
     }
 
@@ -1342,11 +1343,10 @@ mod tests {
         // Accumulate WAL debt the way pre-fix builds did: a ManualOnly
         // writer publishes until the backpressure gate refuses the next
         // publish outright.
-        let store: SharedObjectStore = Arc::new(
-            store_config
-                .configured_object_store()
-                .expect("configure store"),
-        );
+        let store = store_config
+            .configured_object_store()
+            .expect("configure store")
+            .into_shared();
         let writer = FsWriter::builder_with_store(store)
             .writer_id("debt-builder")
             .background_work(FsBackgroundWork::ManualOnly)

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -10,7 +10,6 @@ use loonfs::{FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreK
 use loonfs_api::{ErrorCode, NamespaceId};
 use loonfs_client::{Client, ClientConfig};
 use loonfs_grep::GrepService;
-use std::sync::Arc;
 
 pub(crate) struct LoadedConfig {
     pub path: std::path::PathBuf,
@@ -142,11 +141,10 @@ impl EmbeddedTarget {
         let trace_store_kind = TraceStoreKind::from(store_config.kind());
         // One command drives all three handles from one runtime, so they
         // deliberately share one provider client.
-        let store: SharedObjectStore = Arc::new(
-            store_config
-                .configured_object_store()
-                .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}")))?,
-        );
+        let store: SharedObjectStore = store_config
+            .configured_object_store()
+            .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}")))?
+            .into_shared();
         let writer = FsWriter::builder_with_store(store.clone())
             .writer_id(writer_id.clone())
             // The server's policy: publishes past the WAL threshold schedule

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -27,7 +27,8 @@ use loonfs_api::{
         EnableGrepIndexResponse, FilesystemChange, GrepGcRequest, GrepGcResponse,
         GrepIndexStatusResponse, ObjectTransferAccess, SignUploadPartsRequest,
         SignUploadPartsResponse, SignedUploadPart, StoreProbeRequest, StoreProbeResponse,
-        UploadContentResponse, UploadMode, UploadPartChecksumClaim, ValidatedContentToken,
+        UploadContentResponse, UploadMode, UploadPartChecksumClaim, UploadStatusResponse,
+        ValidatedContentToken,
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId,
     ChecksumAlgorithm, CommitId, CommitRequest, ContentRef, Crc64Nvme, CreateCheckpointRequest,
@@ -111,6 +112,26 @@ fn digest_of(content_ref: &ContentRef, algorithm: ChecksumAlgorithm) -> Option<&
         ChecksumAlgorithm::Sha256 => content_ref.whole_file_sha256.as_deref(),
         _ => None,
     }
+}
+
+/// Whether the committed reference provably holds the bytes just uploaded.
+///
+/// The evidence is the trusted whole-file digest when the server has one,
+/// and otherwise the reference's own storage checksum — which for a
+/// provider-assembled multipart object is the only full-object evidence
+/// that exists. Only a digest this client can recompute, over bytes that
+/// agree, proves anything: a digest that disagrees and a digest this client
+/// cannot recompute are both unproven, and both leave the conflict
+/// standing.
+fn uploaded_matches_committed(uploaded: &UploadedContent<'_>, content_ref: &ContentRef) -> bool {
+    let evidence = match &content_ref.whole_file_sha256 {
+        Some(digest) => StorageChecksum {
+            algorithm: ChecksumAlgorithm::Sha256,
+            value: digest.clone(),
+        },
+        None => content_ref.storage_checksum.clone(),
+    };
+    uploaded.matches(&evidence) == Some(true)
 }
 
 /// Where a reuse conflict says the commit id already landed.
@@ -769,6 +790,26 @@ impl Client {
             .await
     }
 
+    /// Reads one upload session back.
+    ///
+    /// A completed session answers with the exact content reference it
+    /// settled on and a freshly minted validation token, so a caller that
+    /// lost its completion response — or the whole process — can commit
+    /// that content without re-uploading a byte. The upload id is the only
+    /// thing it has to have kept.
+    pub async fn read_upload_status(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+    ) -> Result<UploadStatusResponse> {
+        let url = format!(
+            "{}/v0/namespaces/{namespace_id}/uploads/{upload_id}",
+            self.base_url
+        );
+        self.request_json::<(), UploadStatusResponse>(self.get(&url), None)
+            .await
+    }
+
     pub async fn complete_upload(
         &self,
         namespace_id: &NamespaceId,
@@ -1385,9 +1426,10 @@ impl Client {
     ///
     /// The evidence is the committed content itself, read back from the
     /// change feed at the sequence the conflict reported, and compared
-    /// against the bytes that were just uploaded. Nothing weaker counts: a
-    /// comparison this build cannot make is reported as a conflict that
-    /// names why, never as agreement.
+    /// against the bytes that were just uploaded. Nothing weaker counts:
+    /// every way of failing to prove the two are the same — including a
+    /// comparison this client cannot make — leaves the original conflict
+    /// standing, never agreement.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,
@@ -1410,32 +1452,14 @@ impl Client {
         if content_ref.size_bytes != uploaded.size_bytes() {
             return Err(conflict);
         }
-
-        // The trusted whole-file digest when the server has one, and
-        // otherwise the reference's own storage checksum — which for a
-        // provider-assembled multipart object is the only full-object
-        // evidence that exists.
-        let evidence = match &content_ref.whole_file_sha256 {
-            Some(digest) => StorageChecksum {
-                algorithm: ChecksumAlgorithm::Sha256,
-                value: digest.clone(),
-            },
-            None => content_ref.storage_checksum.clone(),
-        };
-        match uploaded.matches(&evidence) {
-            Some(true) => Ok(ApiCommitResponse {
-                namespace_id: namespace_id.clone(),
-                commit_id: committed.commit_id,
-                committed_seq: committed.seq,
-            }),
-            Some(false) => Err(conflict),
-            None => Err(ClientError::Http(format!(
-                "commit `{commit_id}` already committed content checksummed with \
-                 `{}`, which this client cannot compare against what it just \
-                 uploaded, so it cannot tell whether this is the same upload retried",
-                evidence.algorithm
-            ))),
+        if !uploaded_matches_committed(&uploaded, content_ref) {
+            return Err(conflict);
         }
+        Ok(ApiCommitResponse {
+            namespace_id: namespace_id.clone(),
+            commit_id: committed.commit_id,
+            committed_seq: committed.seq,
+        })
     }
 
     /// Reads the one change a reuse conflict said the commit id landed at.
@@ -1705,6 +1729,52 @@ mod tests {
             size_bytes: content_ref.size_bytes,
             sha256: content_ref.storage_checksum.value,
         }
+    }
+
+    /// A reference whose only full-object evidence is a digest this client
+    /// has no implementation for. No server mints one today, which is
+    /// exactly why the reconciliation has to say what it does when one
+    /// arrives.
+    fn crc32c_content_ref(bytes: &[u8]) -> ContentRef {
+        ContentRef {
+            kind: loonfs_api::ContentRefKind::BlobV1,
+            content_id: ContentId::generate(),
+            size_bytes: bytes.len() as u64,
+            storage_checksum: StorageChecksum {
+                algorithm: ChecksumAlgorithm::Crc32c,
+                value: "0f5c0a1e".to_owned(),
+            },
+            whole_file_sha256: None,
+        }
+    }
+
+    #[test]
+    fn a_digest_this_client_cannot_compare_leaves_the_reuse_conflict_standing() {
+        let bytes = b"retried payload";
+        let committed = crc32c_content_ref(bytes);
+        let uploaded = UploadedContent::Bytes(bytes);
+
+        assert_eq!(
+            uploaded.matches(&committed.storage_checksum),
+            None,
+            "the fixture must reach the refusal, not a comparison"
+        );
+        assert!(!uploaded_matches_committed(&uploaded, &committed));
+    }
+
+    #[test]
+    fn a_whole_file_digest_over_the_same_bytes_proves_the_retry_did_this_work() {
+        let bytes = b"retried payload";
+        let committed = test_content_ref(bytes);
+
+        assert!(uploaded_matches_committed(
+            &UploadedContent::Bytes(bytes),
+            &committed
+        ));
+        assert!(!uploaded_matches_committed(
+            &UploadedContent::Bytes(b"some other payload"),
+            &committed
+        ));
     }
 
     /// `Client::new` runs the same validation as `ClientConfig::load`, so a

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -3,6 +3,7 @@
 
 use super::runs::MetadataRunManifest;
 use crate::metadata::MetadataState;
+use crate::recency::Recency;
 use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
@@ -125,14 +126,8 @@ pub struct MetadataTableCache {
 #[derive(Debug, Default)]
 struct MetadataTableCacheInner {
     entries: HashMap<MetadataTableCacheKey, CacheSlot>,
-    /// Recency queue with lazy deletion: a hit appends its key with a fresh
-    /// stamp in constant time and leaves its old position behind as a
-    /// ghost; eviction skips ghosts (stale stamps) as it pops. Nothing is
-    /// scheduled — the queue is compacted inline when ghosts outnumber live
-    /// entries, amortized constant like a vector reallocation.
-    order: VecDeque<(MetadataTableCacheKey, u64)>,
+    order: Recency<MetadataTableCacheKey>,
     decoded_byte_len: usize,
-    touch_counter: u64,
 }
 
 #[derive(Debug)]
@@ -269,21 +264,18 @@ impl MetadataTableCache {
         inner.decoded_byte_len = inner.decoded_byte_len.saturating_add(decoded_byte_len);
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
-        while inner.decoded_byte_len > self.config.max_decoded_bytes {
-            let Some((candidate, stamp)) = inner.order.pop_front() else {
+        let MetadataTableCacheInner {
+            entries,
+            order,
+            decoded_byte_len,
+        } = &mut *inner;
+        while *decoded_byte_len > self.config.max_decoded_bytes {
+            let Some(candidate) = order.pop_oldest(|key, stamp| slot_is_live(entries, key, stamp))
+            else {
                 break;
             };
-            let live = inner
-                .entries
-                .get(&candidate)
-                .is_some_and(|slot| slot.last_touch == stamp);
-            if !live {
-                continue;
-            }
-            if let Some(slot) = inner.entries.remove(&candidate) {
-                inner.decoded_byte_len = inner
-                    .decoded_byte_len
-                    .saturating_sub(slot.block.decoded_byte_len());
+            if let Some(slot) = entries.remove(&candidate) {
+                *decoded_byte_len = decoded_byte_len.saturating_sub(slot.block.decoded_byte_len());
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);
             }
         }
@@ -292,27 +284,27 @@ impl MetadataTableCache {
 
 impl MetadataTableCacheInner {
     fn touch(&mut self, key: &MetadataTableCacheKey) {
-        self.touch_counter += 1;
-        let stamp = self.touch_counter;
+        let stamp = self.order.touch(key);
         if let Some(slot) = self.entries.get_mut(key) {
             slot.last_touch = stamp;
         }
-        self.order.push_back((key.clone(), stamp));
-        if self.order.len() > (self.entries.len() * 2).max(16) {
-            self.compact_order();
-        }
-    }
-
-    /// Drops ghost queue positions. Runs inline when ghosts outnumber live
-    /// entries, so its cost is amortized over the touches that created them.
-    fn compact_order(&mut self) {
         let entries = &self.entries;
-        self.order.retain(|(key, stamp)| {
-            entries
-                .get(key)
-                .is_some_and(|slot| slot.last_touch == *stamp)
+        self.order.compact(entries.len(), |key, stamp| {
+            slot_is_live(entries, key, stamp)
         });
     }
+}
+
+/// Whether a queue position still names the entry's newest access. An entry
+/// that was replaced, evicted, or re-touched leaves stale positions behind.
+fn slot_is_live(
+    entries: &HashMap<MetadataTableCacheKey, CacheSlot>,
+    key: &MetadataTableCacheKey,
+    stamp: u64,
+) -> bool {
+    entries
+        .get(key)
+        .is_some_and(|slot| slot.last_touch == stamp)
 }
 
 /// Default bounds for WAL-tail projections, shared by the read-side
@@ -617,9 +609,9 @@ mod tests {
         let inner = cache.inner.lock().expect("cache lock");
         assert_eq!(inner.entries.len(), 8);
         assert!(
-            inner.order.len() <= (inner.entries.len() * 2).max(16),
+            inner.order.positions() <= (inner.entries.len() * 2).max(16),
             "hits must not grow the recency queue unboundedly, queue = {}",
-            inner.order.len()
+            inner.order.positions()
         );
     }
 

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -15,6 +15,7 @@ use crate::path::read::{
 };
 use crate::protocol::CompletedUpload;
 use crate::storage::content_admission::CompletedUploadReceipt;
+use crate::time::current_time_ms;
 use loonfs_api::v0::{
     AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, ChangesResponse, CommitResponse,
     CompleteUploadRequest, CompleteUploadResponse, DirectMultipartUploadOptions,
@@ -31,7 +32,6 @@ use loonfs_api::{
 };
 use loonfs_objectstore::{ByteStream, ObjectStore};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 /// The pinned inputs the runtime resolves once per read: the head anchored
@@ -789,17 +789,6 @@ pub enum NamespaceEngineBuildError {
     /// The writer id was empty or whitespace.
     #[error("writer identity must not be empty")]
     EmptyWriter,
-}
-
-#[allow(clippy::disallowed_methods)]
-fn current_time_ms() -> Result<u64> {
-    // Engine wrappers set request timestamps at this API boundary; core replay remains deterministic.
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_millis() as u64)
-        .map_err(|_| {
-            crate::error::CoreError::Internal("system time is before unix epoch".to_owned())
-        })
 }
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -105,6 +105,10 @@ pub mod metadata;
 /// Path parsing and current-state resolution. Consumed by `loonfs`'s write
 /// path (`ensure_mutation_path`, `parse_mutation_path`).
 pub mod path;
+/// The wall-clock boundary durable timestamps are stamped at. Consumed by
+/// `loonfs`, whose mutation contexts and maintenance clock stamp from the
+/// same boundary this crate's own commits do.
+pub mod time;
 
 /// Cache types and configuration for runtime read paths. Consumed by
 /// `loonfs`, which owns the runtime's cache configuration and stats.

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -84,6 +84,7 @@ mod gc;
 mod namespace;
 mod options;
 mod protocol;
+mod recency;
 mod storage;
 mod timing;
 mod wal;
@@ -111,8 +112,11 @@ pub mod path;
 pub mod time;
 
 /// Cache types and configuration for runtime read paths. Consumed by
-/// `loonfs`, which owns the runtime's cache configuration and stats.
+/// `loonfs`, which owns the runtime's cache configuration and stats, and
+/// which re-exports [`cache::Recency`] for the grep index's own block cache.
 pub mod cache {
+    pub use crate::recency::Recency;
+
     pub use crate::checkpoint::{
         ManifestLoadError, ManifestLoadFailureClass, MetadataTableCache, MetadataTableCacheConfig,
         MetadataTableCacheStats, WalTailProjectionCache, WalTailProjectionCacheConfig,

--- a/crates/loonfs-core/src/recency.rs
+++ b/crates/loonfs-core/src/recency.rs
@@ -1,0 +1,176 @@
+//! [`Recency`]: the least-recently-used order the runtime's stamped caches
+//! evict by.
+
+use std::collections::VecDeque;
+
+/// Shortest queue worth compacting, so a nearly empty cache does not compact
+/// on every touch.
+const MIN_COMPACTION_POSITIONS: usize = 16;
+
+/// A recency queue with lazy deletion.
+///
+/// A hit appends the key with a fresh stamp in constant time and leaves its
+/// old position behind as a ghost. The caller stores the returned stamp on
+/// its own entry and answers `is_live` from it, so this holds no second copy
+/// of the entry table and never duplicates whatever hangs off a key.
+/// Eviction skips ghosts as it pops them, and ghosts are dropped in bulk
+/// once they outnumber the live entries they shadow — amortized constant,
+/// like a vector reallocation. Nothing is scheduled.
+#[derive(Debug)]
+pub struct Recency<K> {
+    order: VecDeque<(K, u64)>,
+    counter: u64,
+}
+
+impl<K> Default for Recency<K> {
+    fn default() -> Self {
+        Self {
+            order: VecDeque::new(),
+            counter: 0,
+        }
+    }
+}
+
+impl<K: Clone> Recency<K> {
+    /// Records an access and returns the stamp the caller must store on its
+    /// entry before calling anything else here: until the entry carries it,
+    /// the position just appended reads as a ghost.
+    ///
+    /// Stamps start at 1, so an entry that has never been touched can carry
+    /// 0 and read as a ghost.
+    pub fn touch(&mut self, key: &K) -> u64 {
+        self.counter = self.counter.saturating_add(1);
+        self.order.push_back((key.clone(), self.counter));
+        self.counter
+    }
+
+    /// Removes and returns the least recently used live key.
+    ///
+    /// `None` means the queue holds no live position at all, so an eviction
+    /// loop must stop: popping again cannot make progress.
+    pub fn pop_oldest(&mut self, mut is_live: impl FnMut(&K, u64) -> bool) -> Option<K> {
+        while let Some((key, stamp)) = self.order.pop_front() {
+            if is_live(&key, stamp) {
+                return Some(key);
+            }
+        }
+        None
+    }
+
+    /// Drops ghost positions in place once they outnumber the `live_len`
+    /// entries they shadow. Cheap enough to call on every touch.
+    pub fn compact(&mut self, live_len: usize, mut is_live: impl FnMut(&K, u64) -> bool) {
+        let positions_before_compacting = live_len.saturating_mul(2).max(MIN_COMPACTION_POSITIONS);
+        if self.order.len() <= positions_before_compacting {
+            return;
+        }
+        self.order.retain(|(key, stamp)| is_live(key, *stamp));
+    }
+
+    /// Queue positions held, live and ghost alike.
+    pub fn positions(&self) -> usize {
+        self.order.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Recency;
+    use std::collections::HashMap;
+
+    /// A stand-in for a cache's entry table: keys mapped to the stamp the
+    /// queue last handed out for them.
+    #[derive(Default)]
+    struct Entries(HashMap<&'static str, u64>);
+
+    impl Entries {
+        fn is_live(&self, key: &&'static str, stamp: u64) -> bool {
+            self.0.get(key).is_some_and(|live| *live == stamp)
+        }
+    }
+
+    fn touch(recency: &mut Recency<&'static str>, entries: &mut Entries, key: &'static str) {
+        let stamp = recency.touch(&key);
+        entries.0.insert(key, stamp);
+        recency.compact(entries.0.len(), |key, stamp| entries.is_live(key, stamp));
+    }
+
+    #[test]
+    fn eviction_returns_keys_least_recently_touched_first() {
+        let mut recency = Recency::default();
+        let mut entries = Entries::default();
+        for key in ["a", "b", "c"] {
+            touch(&mut recency, &mut entries, key);
+        }
+        touch(&mut recency, &mut entries, "a");
+
+        let evicted = recency
+            .pop_oldest(|key, stamp| entries.is_live(key, stamp))
+            .expect("a live position");
+        assert_eq!(evicted, "b");
+    }
+
+    #[test]
+    fn eviction_skips_the_ghosts_a_re_touch_left_behind() {
+        let mut recency = Recency::default();
+        let mut entries = Entries::default();
+        touch(&mut recency, &mut entries, "a");
+        touch(&mut recency, &mut entries, "a");
+        touch(&mut recency, &mut entries, "b");
+
+        let evicted = recency
+            .pop_oldest(|key, stamp| entries.is_live(key, stamp))
+            .expect("a live position");
+        assert_eq!(evicted, "a", "the stale position for a must not evict b");
+    }
+
+    /// An eviction loop asks for a key it can drop; a queue holding only
+    /// ghosts has none, and saying so is what stops the loop spinning.
+    #[test]
+    fn eviction_reports_a_queue_of_ghosts_as_empty() {
+        let mut recency = Recency::default();
+        let mut entries = Entries::default();
+        touch(&mut recency, &mut entries, "a");
+        entries.0.clear();
+
+        assert!(recency
+            .pop_oldest(|key, stamp| entries.is_live(key, stamp))
+            .is_none());
+    }
+
+    #[test]
+    fn repeated_hits_on_one_key_keep_the_queue_bounded() {
+        let mut recency = Recency::default();
+        let mut entries = Entries::default();
+        for key in ["a", "b", "c"] {
+            touch(&mut recency, &mut entries, key);
+        }
+        for _ in 0..10_000 {
+            touch(&mut recency, &mut entries, "a");
+        }
+
+        assert_eq!(entries.0.len(), 3);
+        assert!(
+            recency.positions() <= (entries.0.len() * 2).max(16),
+            "compaction must bound the queue, positions = {}",
+            recency.positions()
+        );
+    }
+
+    #[test]
+    fn compaction_holds_off_until_ghosts_outnumber_live_entries() {
+        let mut recency = Recency::default();
+        let mut entries = Entries::default();
+        touch(&mut recency, &mut entries, "a");
+        assert_eq!(recency.positions(), 1);
+
+        // Under the floor nothing is dropped, so the ghosts stay visible.
+        for _ in 0..15 {
+            touch(&mut recency, &mut entries, "a");
+        }
+        assert_eq!(recency.positions(), 16);
+
+        touch(&mut recency, &mut entries, "a");
+        assert_eq!(recency.positions(), 1, "crossing the floor drops ghosts");
+    }
+}

--- a/crates/loonfs-core/src/time.rs
+++ b/crates/loonfs-core/src/time.rs
@@ -1,10 +1,16 @@
-//! The runtime's only wall-clock and monotonic-clock touchpoints.
+//! The one wall-clock boundary durable timestamps are stamped at.
 
-use crate::{CoreError, Result};
+use crate::error::{CoreError, Result};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub(crate) fn current_time_ms() -> Result<u64> {
-    unix_ms(wall_clock_now())
+/// Reads the wall clock as unix milliseconds.
+///
+/// Every timestamp that reaches durable state — commit, checkpoint, upload
+/// session, maintenance schedule — is stamped here and then carried as a
+/// value, so replay below this boundary stays deterministic.
+#[allow(clippy::disallowed_methods)]
+pub fn current_time_ms() -> Result<u64> {
+    unix_ms(SystemTime::now())
 }
 
 /// Converts a wall-clock instant to unix milliseconds, failing clearly on a
@@ -12,13 +18,7 @@ pub(crate) fn current_time_ms() -> Result<u64> {
 fn unix_ms(now: SystemTime) -> Result<u64> {
     now.duration_since(UNIX_EPOCH)
         .map(|elapsed| elapsed.as_millis() as u64)
-        .map_err(|_| CoreError::Internal("system time is before unix epoch".to_owned()).into())
-}
-
-#[allow(clippy::disallowed_methods)]
-pub(crate) fn wall_clock_now() -> SystemTime {
-    // Request timestamps are stamped at this runtime API boundary so core replay stays deterministic.
-    SystemTime::now()
+        .map_err(|_| CoreError::Internal("system time is before unix epoch".to_owned()))
 }
 
 #[cfg(test)]

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -2,8 +2,9 @@
 
 use crate::codec::IndexRow;
 use crate::root::GrepRootState;
+use loonfs::Recency;
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// Maximum decoded manifests and segment sections retained by one grep service or worker.
@@ -41,13 +42,14 @@ pub(crate) struct GrepBlockCache {
 #[derive(Debug, Default)]
 struct GrepBlockCacheInner {
     entries: HashMap<GrepBlockCacheKey, CacheSlot>,
-    order: VecDeque<(GrepBlockCacheKey, u64)>,
-    touch_counter: u64,
+    order: Recency<GrepBlockCacheKey>,
 }
 
 #[derive(Debug)]
 struct CacheSlot {
     block: DecodedGrepBlock,
+    /// Stamp of this entry's newest queue position; older positions for the
+    /// same key are ghosts.
     last_touch: u64,
 }
 
@@ -69,7 +71,6 @@ impl GrepBlockCache {
             .expect("grep block cache lock should not be poisoned");
         let block = inner.entries.get(key)?.block.clone();
         inner.touch(key);
-        inner.compact_if_needed(self.max_blocks);
         Some(block)
     }
 
@@ -81,61 +82,46 @@ impl GrepBlockCache {
             .inner
             .lock()
             .expect("grep block cache lock should not be poisoned");
-        let stamp = inner.next_stamp();
         inner.entries.insert(
             key.clone(),
             CacheSlot {
                 block,
-                last_touch: stamp,
+                last_touch: 0,
             },
         );
-        inner.order.push_back((key, stamp));
-        while inner.entries.len() > self.max_blocks {
-            inner.evict_oldest();
+        inner.touch(&key);
+        let GrepBlockCacheInner { entries, order } = &mut *inner;
+        while entries.len() > self.max_blocks {
+            let Some(evicted) = order.pop_oldest(|key, stamp| slot_is_live(entries, key, stamp))
+            else {
+                break;
+            };
+            entries.remove(&evicted);
         }
-        inner.compact_if_needed(self.max_blocks);
     }
 }
 
 impl GrepBlockCacheInner {
-    fn next_stamp(&mut self) -> u64 {
-        self.touch_counter = self.touch_counter.saturating_add(1);
-        self.touch_counter
-    }
-
     fn touch(&mut self, key: &GrepBlockCacheKey) {
-        let stamp = self.next_stamp();
-        let Some(slot) = self.entries.get_mut(key) else {
-            return;
-        };
-        slot.last_touch = stamp;
-        self.order.push_back((key.clone(), stamp));
-    }
-
-    fn evict_oldest(&mut self) {
-        while let Some((key, stamp)) = self.order.pop_front() {
-            if self
-                .entries
-                .get(&key)
-                .is_some_and(|slot| slot.last_touch == stamp)
-            {
-                self.entries.remove(&key);
-                return;
-            }
+        let stamp = self.order.touch(key);
+        if let Some(slot) = self.entries.get_mut(key) {
+            slot.last_touch = stamp;
         }
+        let entries = &self.entries;
+        self.order.compact(entries.len(), |key, stamp| {
+            slot_is_live(entries, key, stamp)
+        });
     }
+}
 
-    fn compact_if_needed(&mut self, max_blocks: usize) {
-        let queue_limit = max_blocks.saturating_mul(4);
-        if self.order.len() <= queue_limit {
-            return;
-        }
-        let mut live = self
-            .entries
-            .iter()
-            .map(|(key, slot)| (key.clone(), slot.last_touch))
-            .collect::<Vec<_>>();
-        live.sort_by_key(|(_, stamp)| *stamp);
-        self.order = live.into();
-    }
+/// Whether a queue position still names the entry's newest access. An entry
+/// that was replaced, evicted, or re-touched leaves stale positions behind.
+fn slot_is_live(
+    entries: &HashMap<GrepBlockCacheKey, CacheSlot>,
+    key: &GrepBlockCacheKey,
+    stamp: u64,
+) -> bool {
+    entries
+        .get(key)
+        .is_some_and(|slot| slot.last_touch == stamp)
 }

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -1,20 +1,12 @@
-//! [`ConfiguredObjectStore`]: one enum over every provider, built from
-//! configuration.
+//! [`ConfiguredObjectStore`]: one provider client built from configuration,
+//! paired with the direct-transfer issuer that provider supports.
 
-use super::{
-    ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
-    ObjectStore, PutMode, StoredObjectChecksum,
-};
 use crate::abs::{AzureAbsStore, AzureAbsStoreConfig};
 use crate::gcs::{GcpGcsStore, GcpGcsStoreConfig};
 use crate::local_fs_store::LocalFsStore;
-use crate::object_store::Result;
+use crate::object_store::{Result, SharedObjectStore};
 use crate::presign::{ObjectTransferIssuer, S3CompatiblePresigner, S3PresignerConfig};
 use crate::s3_compatible::{AwsS3StoreConfig, CloudflareR2StoreConfig, S3CompatibleStore};
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
-use loonfs_api::StorageChecksum;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -47,21 +39,16 @@ impl ConfiguredObjectStoreKind {
     }
 }
 
-/// Dispatches the common storage contract to one validated runtime provider.
+/// One validated runtime provider, plus the transfer issuer it supports.
+///
+/// Construction is the only thing this type adds: it holds the provider
+/// client as the same shared trait object every handle takes, so callers
+/// dispatch through the provider's own [`ObjectStore`](crate::ObjectStore)
+/// implementation rather than through a copy of it here.
 #[derive(Debug)]
 pub struct ConfiguredObjectStore {
-    kind: ConfiguredObjectStoreKind,
-    inner: ConfiguredObjectStoreInner,
+    inner: SharedObjectStore,
     transfer_issuer: Option<Arc<dyn ObjectTransferIssuer>>,
-}
-
-#[derive(Debug)]
-enum ConfiguredObjectStoreInner {
-    LocalFs(LocalFsStore),
-    AwsS3(S3CompatibleStore),
-    CloudflareR2(S3CompatibleStore),
-    GcpGcs(GcpGcsStore),
-    AzureAbs(AzureAbsStore),
 }
 
 impl ConfiguredObjectStore {
@@ -71,10 +58,7 @@ impl ConfiguredObjectStore {
     /// be created, or when `key_prefix` is invalid.
     pub fn local_fs(root: impl Into<PathBuf>, key_prefix: Option<&str>) -> Result<Self> {
         Ok(Self {
-            kind: ConfiguredObjectStoreKind::LocalFs,
-            inner: ConfiguredObjectStoreInner::LocalFs(LocalFsStore::with_key_prefix(
-                root, key_prefix,
-            )?),
+            inner: Arc::new(LocalFsStore::with_key_prefix(root, key_prefix)?),
             transfer_issuer: None,
         })
     }
@@ -95,8 +79,7 @@ impl ConfiguredObjectStore {
         })?) as Arc<dyn ObjectTransferIssuer>);
         let store = S3CompatibleStore::aws_s3(config)?;
         Ok(Self {
-            kind: ConfiguredObjectStoreKind::AwsS3,
-            inner: ConfiguredObjectStoreInner::AwsS3(store),
+            inner: Arc::new(store),
             transfer_issuer,
         })
     }
@@ -117,8 +100,7 @@ impl ConfiguredObjectStore {
         })?) as Arc<dyn ObjectTransferIssuer>);
         let store = S3CompatibleStore::cloudflare_r2(config)?;
         Ok(Self {
-            kind: ConfiguredObjectStoreKind::CloudflareR2,
-            inner: ConfiguredObjectStoreInner::CloudflareR2(store),
+            inner: Arc::new(store),
             transfer_issuer,
         })
     }
@@ -129,8 +111,7 @@ impl ConfiguredObjectStore {
     pub fn gcp_gcs(config: GcpGcsStoreConfig) -> Result<Self> {
         let store = GcpGcsStore::new(config)?;
         Ok(Self {
-            kind: ConfiguredObjectStoreKind::GcpGcs,
-            inner: ConfiguredObjectStoreInner::GcpGcs(store),
+            inner: Arc::new(store),
             transfer_issuer: None,
         })
     }
@@ -141,15 +122,9 @@ impl ConfiguredObjectStore {
     pub fn azure_abs(config: AzureAbsStoreConfig) -> Result<Self> {
         let store = AzureAbsStore::new(config)?;
         Ok(Self {
-            kind: ConfiguredObjectStoreKind::AzureAbs,
-            inner: ConfiguredObjectStoreInner::AzureAbs(store),
+            inner: Arc::new(store),
             transfer_issuer: None,
         })
-    }
-
-    /// Returns the provider selected when this store was constructed.
-    pub fn kind(&self) -> ConfiguredObjectStoreKind {
-        self.kind
     }
 
     /// Returns a direct-upload issuer for supported S3-compatible providers.
@@ -158,156 +133,19 @@ impl ConfiguredObjectStore {
     pub fn transfer_issuer(&self) -> Option<Arc<dyn ObjectTransferIssuer>> {
         self.transfer_issuer.clone()
     }
-}
 
-#[async_trait]
-impl ObjectStore for ConfiguredObjectStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => store.head(key).await,
-            ConfiguredObjectStoreInner::AwsS3(store) => store.head(key).await,
-            ConfiguredObjectStoreInner::CloudflareR2(store) => store.head(key).await,
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.head(key).await,
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.head(key).await,
-        }
-    }
-
-    async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => store.head_stored_checksum(key).await,
-            ConfiguredObjectStoreInner::AwsS3(store) => store.head_stored_checksum(key).await,
-            ConfiguredObjectStoreInner::CloudflareR2(store) => {
-                store.head_stored_checksum(key).await
-            }
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.head_stored_checksum(key).await,
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.head_stored_checksum(key).await,
-        }
-    }
-
-    async fn create_multipart_upload(&self, key: &str) -> Result<String> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => store.create_multipart_upload(key).await,
-            ConfiguredObjectStoreInner::AwsS3(store) => store.create_multipart_upload(key).await,
-            ConfiguredObjectStoreInner::CloudflareR2(store) => {
-                store.create_multipart_upload(key).await
-            }
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.create_multipart_upload(key).await,
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.create_multipart_upload(key).await,
-        }
-    }
-
-    async fn complete_multipart_upload(
-        &self,
-        key: &str,
-        provider_upload_id: &str,
-        parts: &[MultipartPart],
-        full_object_checksum: &StorageChecksum,
-    ) -> Result<MultipartCompletion> {
-        macro_rules! complete {
-            ($store:expr) => {
-                $store
-                    .complete_multipart_upload(key, provider_upload_id, parts, full_object_checksum)
-                    .await
-            };
-        }
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => complete!(store),
-            ConfiguredObjectStoreInner::AwsS3(store) => complete!(store),
-            ConfiguredObjectStoreInner::CloudflareR2(store) => complete!(store),
-            ConfiguredObjectStoreInner::GcpGcs(store) => complete!(store),
-            ConfiguredObjectStoreInner::AzureAbs(store) => complete!(store),
-        }
-    }
-
-    async fn abort_multipart_upload(&self, key: &str, provider_upload_id: &str) -> Result<()> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => {
-                store.abort_multipart_upload(key, provider_upload_id).await
-            }
-            ConfiguredObjectStoreInner::AwsS3(store) => {
-                store.abort_multipart_upload(key, provider_upload_id).await
-            }
-            ConfiguredObjectStoreInner::CloudflareR2(store) => {
-                store.abort_multipart_upload(key, provider_upload_id).await
-            }
-            ConfiguredObjectStoreInner::GcpGcs(store) => {
-                store.abort_multipart_upload(key, provider_upload_id).await
-            }
-            ConfiguredObjectStoreInner::AzureAbs(store) => {
-                store.abort_multipart_upload(key, provider_upload_id).await
-            }
-        }
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => store.get_with_metadata(key).await,
-            ConfiguredObjectStoreInner::AwsS3(store) => store.get_with_metadata(key).await,
-            ConfiguredObjectStoreInner::CloudflareR2(store) => store.get_with_metadata(key).await,
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.get_with_metadata(key).await,
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.get_with_metadata(key).await,
-        }
-    }
-
-    async fn get(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Bytes>> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => store.get(key, range).await,
-            ConfiguredObjectStoreInner::AwsS3(store) => store.get(key, range).await,
-            ConfiguredObjectStoreInner::CloudflareR2(store) => store.get(key, range).await,
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.get(key, range).await,
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.get(key, range).await,
-        }
-    }
-
-    async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => store.put(key, bytes, mode).await,
-            ConfiguredObjectStoreInner::AwsS3(store) => store.put(key, bytes, mode).await,
-            ConfiguredObjectStoreInner::CloudflareR2(store) => store.put(key, bytes, mode).await,
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.put(key, bytes, mode).await,
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.put(key, bytes, mode).await,
-        }
-    }
-
-    async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
-        macro_rules! put_streamed {
-            ($store:expr) => {
-                $store.put_streamed(key, body, mode).await
-            };
-        }
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => put_streamed!(store),
-            ConfiguredObjectStoreInner::AwsS3(store) => put_streamed!(store),
-            ConfiguredObjectStoreInner::CloudflareR2(store) => put_streamed!(store),
-            ConfiguredObjectStoreInner::GcpGcs(store) => put_streamed!(store),
-            ConfiguredObjectStoreInner::AzureAbs(store) => put_streamed!(store),
-        }
-    }
-
-    async fn delete(&self, key: &str) -> Result<()> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => store.delete(key).await,
-            ConfiguredObjectStoreInner::AwsS3(store) => store.delete(key).await,
-            ConfiguredObjectStoreInner::CloudflareR2(store) => store.delete(key).await,
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.delete(key).await,
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.delete(key).await,
-        }
-    }
-
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
-        match &self.inner {
-            ConfiguredObjectStoreInner::LocalFs(store) => store.list_prefix_stream(prefix),
-            ConfiguredObjectStoreInner::AwsS3(store) => store.list_prefix_stream(prefix),
-            ConfiguredObjectStoreInner::CloudflareR2(store) => store.list_prefix_stream(prefix),
-            ConfiguredObjectStoreInner::GcpGcs(store) => store.list_prefix_stream(prefix),
-            ConfiguredObjectStoreInner::AzureAbs(store) => store.list_prefix_stream(prefix),
-        }
+    /// Hands out the provider client every handle and helper reads through.
+    ///
+    /// Take [`transfer_issuer`](Self::transfer_issuer) first: this consumes
+    /// the configured store.
+    pub fn into_shared(self) -> SharedObjectStore {
+        self.inner
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
+    use super::ConfiguredObjectStore;
     use crate::abs::AzureAbsStoreConfig;
     use crate::gcs::GcpGcsStoreConfig;
     use crate::keys::wal_head;
@@ -331,7 +169,8 @@ mod tests {
     async fn configured_local_fs_scopes_optional_key_prefix() {
         let temp_dir = unique_temp_dir("configured-store-local");
         let store = ConfiguredObjectStore::local_fs(&temp_dir, Some("tenant-a"))
-            .expect("construct configured local fs store");
+            .expect("construct configured local fs store")
+            .into_shared();
         let head_key = wal_head("ns-1");
 
         store
@@ -354,11 +193,12 @@ mod tests {
         );
     }
 
+    /// Only the S3-compatible providers can presign, so only they carry a
+    /// direct-transfer issuer.
     #[test]
-    fn configured_object_store_builds_provider_variants() {
+    fn configured_object_store_issues_transfers_for_s3_compatible_providers_only() {
         let local = ConfiguredObjectStore::local_fs(unique_temp_dir("configured-store-kind"), None)
             .expect("construct local store");
-        assert_eq!(local.kind(), ConfiguredObjectStoreKind::LocalFs);
         assert!(local.transfer_issuer().is_none());
 
         let s3 = ConfiguredObjectStore::aws_s3(AwsS3StoreConfig {
@@ -372,7 +212,6 @@ mod tests {
             force_path_style: true,
         })
         .expect("construct s3 store");
-        assert_eq!(s3.kind(), ConfiguredObjectStoreKind::AwsS3);
         assert!(s3.transfer_issuer().is_some());
 
         let r2 = ConfiguredObjectStore::cloudflare_r2(CloudflareR2StoreConfig {
@@ -384,7 +223,6 @@ mod tests {
             key_prefix: Some("tenant-a".to_owned()),
         })
         .expect("construct r2 store");
-        assert_eq!(r2.kind(), ConfiguredObjectStoreKind::CloudflareR2);
         assert!(r2.transfer_issuer().is_some());
 
         let gcs_service_account_key_path =
@@ -395,7 +233,6 @@ mod tests {
             key_prefix: Some("tenant-a".to_owned()),
         })
         .expect("construct gcs store");
-        assert_eq!(gcs.kind(), ConfiguredObjectStoreKind::GcpGcs);
         assert!(gcs.transfer_issuer().is_none());
 
         let azure = ConfiguredObjectStore::azure_abs(AzureAbsStoreConfig {
@@ -406,7 +243,6 @@ mod tests {
             key_prefix: Some("tenant-a".to_owned()),
         })
         .expect("construct azure store");
-        assert_eq!(azure.kind(), ConfiguredObjectStoreKind::AzureAbs);
         assert!(azure.transfer_issuer().is_none());
     }
 
@@ -462,7 +298,8 @@ mod tests {
     async fn configured_local_fs_preserves_invalid_key_errors() {
         let temp_dir = unique_temp_dir("configured-store-invalid-key");
         let store = ConfiguredObjectStore::local_fs(&temp_dir, Some("tenant-a"))
-            .expect("construct configured local fs store");
+            .expect("construct configured local fs store")
+            .into_shared();
 
         let error = store
             .put_overwrite("../head.json", Bytes::from_static(br#"{"ok":true}"#))

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -323,8 +323,8 @@ impl<S> InstrumentedObjectStore<S> {
 
 #[allow(clippy::disallowed_methods)]
 fn sample_clock() -> Instant {
-    // Metrics sampling reads the wall clock at this recorder boundary so
-    // protocol replay stays deterministic.
+    // Durations only: sampling reads the monotonic clock at this recorder
+    // boundary, so no wall-clock reading reaches protocol code from here.
     Instant::now()
 }
 

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -188,7 +188,7 @@ pub async fn app(config: ServerConfig) -> Result<(Router, ServerLifecycle), Serv
         .direct_put_is_proven()
         .then(|| store.transfer_issuer())
         .flatten();
-    let store = Arc::new(store) as SharedObjectStore;
+    let store = store.into_shared();
     let (router, lifecycle, _state) =
         app_with_store_and_transfer_issuer(config, store, transfer_issuer).await?;
     Ok((router, lifecycle))

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -743,7 +743,8 @@ fn put_options(commit_id: &str) -> loonfs_client::PutFileOptions {
 async fn delete_everything_under_the_run_prefix(store_config: &StoreConfig) {
     let store = store_config
         .configured_object_store()
-        .expect("build a store for cleanup");
+        .expect("build a store for cleanup")
+        .into_shared();
     let keys = store.list_prefix("").await.expect("list the run prefix");
     for key in keys {
         store.delete(&key).await.expect("delete a run object");

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -427,7 +427,8 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
     post_checkpoint(&server_url, namespace.as_str()).expect("checkpoint");
 
     let store = ConfiguredObjectStore::local_fs(&store_root, store_key_prefix.as_deref())
-        .expect("construct store");
+        .expect("construct store")
+        .into_shared();
     let root = loonfs::control::load_namespace_metadata_root_control(&store, &namespace)
         .await
         .expect("metadata root");
@@ -510,7 +511,8 @@ async fn http_admin_store_probe_reports_every_check_against_the_configured_store
         harness.store_root.as_ref().expect("local-fs test store"),
         harness.store_key_prefix.as_deref(),
     )
-    .expect("open the test store");
+    .expect("open the test store")
+    .into_shared();
     assert!(store
         .list_prefix("probe-runs/")
         .await

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -319,6 +319,79 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     harness.server.abort();
 }
 
+/// Cross-process recovery through the Rust client alone: the upload id is
+/// the only thing that has to survive. Reading the session back names the
+/// exact content that landed and hands over a token that admits it, so the
+/// retry commits without re-uploading anything.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_reads_a_completed_upload_back_and_commits_what_it_names() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-client-upload-readback",
+    ))
+    .await;
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+
+    let file_bytes = b"read the session back";
+    let (upload_id, content_ref) = complete_upload_session(&harness, &namespace, file_bytes).await;
+
+    let status = harness
+        .client
+        .read_upload_status(&namespace, &upload_id)
+        .await
+        .expect("read the upload session back");
+    assert_eq!(status.namespace_id, namespace);
+    assert_eq!(status.upload_id, upload_id);
+    let UploadSessionStatus::Completed {
+        content_ref: reported_ref,
+        validated_content_token,
+        ..
+    } = status.status
+    else {
+        unreachable!("a completed session reports itself completed");
+    };
+    assert_eq!(reported_ref, content_ref);
+
+    let commit = harness
+        .client
+        .commit(
+            &namespace,
+            &CommitRequest {
+                commit_id: CommitId::parse("client-read-back-put").expect("valid commit id"),
+                message: None,
+                content_tokens: vec![loonfs_api::v0::ValidatedContentToken {
+                    content_ref: content_ref.clone(),
+                    token: validated_content_token.expect("a completed session re-mints"),
+                }],
+                operations: vec![FilesystemOperation::PutFile {
+                    path: AbsolutePath::parse("/read-back.txt").expect("path"),
+                    content_ref,
+                    behavior: DestinationBehavior::NoReplace,
+                    expected_revision_no: None,
+                }],
+            },
+        )
+        .await
+        .expect("the token the read handed back admits its content");
+    assert_eq!(commit.committed_seq, ChangeSeq(1));
+
+    let read_back = harness
+        .client
+        .get_file_bytes(&NamespacePath::parse("demo", "/read-back.txt").expect("path"))
+        .await
+        .expect("read the committed file");
+    assert_eq!(read_back, file_bytes);
+
+    harness.server.abort();
+}
+
 /// Stages content and hands back the session id, which the shared helper
 /// does not expose.
 async fn complete_upload_session(

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -7,7 +7,6 @@ use crate::config::{validate_writer_id, ReadConfig};
 use crate::maintenance_runner::MaintenanceRunner;
 use crate::metrics::RuntimeInstruments;
 use crate::publisher::PublishObserver;
-use crate::time::current_time_ms;
 use crate::{
     ChangeSeq, CoreError, ErrorCode, InodeId, ListFileRevisionsResponse, NamespaceId, ObjectStore,
     RuntimeCacheStats,
@@ -24,6 +23,7 @@ use loonfs_api::{
 use loonfs_core::cache::{
     MetadataTableCache, WalTailProjectionCache, WalTailProjectionCacheConfig,
 };
+use loonfs_core::time::current_time_ms;
 use loonfs_core::{MutationContext, NamespaceEngine};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, MutexGuard};

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -84,6 +84,25 @@ fn committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
     })
 }
 
+/// Whether the committed reference provably holds the bytes just staged.
+///
+/// The evidence is the trusted whole-file digest when one exists, and
+/// otherwise the reference's own storage checksum — which for a
+/// provider-assembled multipart object is the only full-object evidence
+/// there is. Only a digest this build can recompute, over bytes that agree,
+/// proves anything: a digest that disagrees and a digest this build cannot
+/// recompute are both unproven, and both leave the conflict standing.
+fn staged_matches_committed(staged: &StagedPayload<'_>, content_ref: &ContentRef) -> bool {
+    let evidence = match &content_ref.whole_file_sha256 {
+        Some(digest) => StorageChecksum {
+            algorithm: ChecksumAlgorithm::Sha256,
+            value: digest.clone(),
+        },
+        None => content_ref.storage_checksum.clone(),
+    };
+    staged.matches(&evidence) == Some(true)
+}
+
 impl FsWriter {
     /// A mutating engine under this writer's identity.
     pub(crate) fn engine(
@@ -239,8 +258,9 @@ impl FsWriter {
     ///
     /// The evidence is the committed content itself, read from the change
     /// feed at the sequence the conflict reported and compared against the
-    /// bytes just staged. Nothing weaker counts: a comparison this build
-    /// cannot make is reported as a conflict that names why, never as
+    /// bytes just staged. Nothing weaker counts: every way of failing to
+    /// prove the two are the same — including a comparison this build
+    /// cannot make — leaves the original conflict standing, never
     /// agreement.
     async fn reconcile_commit_id_reuse(
         &self,
@@ -264,31 +284,14 @@ impl FsWriter {
         if content_ref.size_bytes != staged.size_bytes() {
             return Err(conflict);
         }
-
-        // The trusted whole-file digest when one exists, and otherwise the
-        // reference's own storage checksum — which for a provider-assembled
-        // multipart object is the only full-object evidence there is.
-        let evidence = match &content_ref.whole_file_sha256 {
-            Some(digest) => StorageChecksum {
-                algorithm: ChecksumAlgorithm::Sha256,
-                value: digest.clone(),
-            },
-            None => content_ref.storage_checksum.clone(),
-        };
-        match staged.matches(&evidence) {
-            Some(true) => Ok(CommitResponse {
-                namespace_id: namespace_id.clone(),
-                commit_id: committed.commit_id,
-                committed_seq: committed.seq,
-            }),
-            Some(false) => Err(conflict),
-            None => Err(RuntimeError::Config(format!(
-                "commit `{commit_id}` already committed content checksummed with `{}`, \
-                 which this build cannot compare against what it just staged, so it \
-                 cannot tell whether this is the same upload retried",
-                evidence.algorithm
-            ))),
+        if !staged_matches_committed(&staged, content_ref) {
+            return Err(conflict);
         }
+        Ok(CommitResponse {
+            namespace_id: namespace_id.clone(),
+            commit_id: committed.commit_id,
+            committed_seq: committed.seq,
+        })
     }
 
     /// Reads the one change a reuse conflict said the commit id landed at.
@@ -869,4 +872,56 @@ fn maybe_auto_step_after_publish(
         .maintenance
         .handle()
         .nudge(MaintenanceJobId::METADATA, namespace_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{staged_matches_committed, StagedPayload};
+    use crate::{ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind};
+    use loonfs_api::StorageChecksum;
+
+    /// A reference whose only full-object evidence is a digest this build
+    /// has no implementation for. Nothing mints one today, which is exactly
+    /// why the reconciliation has to say what it does when one arrives.
+    fn crc32c_ref(bytes: &[u8]) -> ContentRef {
+        ContentRef {
+            kind: ContentRefKind::BlobV1,
+            content_id: ContentId::generate(),
+            size_bytes: bytes.len() as u64,
+            storage_checksum: StorageChecksum {
+                algorithm: ChecksumAlgorithm::Crc32c,
+                value: "0f5c0a1e".to_owned(),
+            },
+            whole_file_sha256: None,
+        }
+    }
+
+    #[test]
+    fn a_digest_this_build_cannot_compare_leaves_the_reuse_conflict_standing() {
+        let bytes = b"retried payload";
+        let committed = crc32c_ref(bytes);
+        let staged = StagedPayload::Bytes(bytes);
+
+        assert_eq!(
+            staged.matches(&committed.storage_checksum),
+            None,
+            "the fixture must reach the refusal, not a comparison"
+        );
+        assert!(!staged_matches_committed(&staged, &committed));
+    }
+
+    #[test]
+    fn a_whole_file_digest_over_the_same_bytes_proves_the_retry_did_this_work() {
+        let bytes = b"retried payload";
+        let committed = ContentRef::blob_v1(ContentId::generate(), bytes);
+
+        assert!(staged_matches_committed(
+            &StagedPayload::Bytes(bytes),
+            &committed
+        ));
+        assert!(!staged_matches_committed(
+            &StagedPayload::Bytes(b"some other payload"),
+            &committed
+        ));
+    }
 }

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -74,7 +74,7 @@ impl HandleBuilderCore {
                 let store = config.configured_object_store().map_err(|error| {
                     RuntimeError::Config(format!("invalid store config: {error}"))
                 })?;
-                (Arc::new(store) as SharedObjectStore, kind)
+                (store.into_shared(), kind)
             }
             StoreSource::Shared(store) => (store, TraceStoreKind::Unknown),
         };

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -65,7 +65,7 @@ pub use loonfs_api::{
     FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0,
     PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
-pub use loonfs_core::cache::MetadataTableCacheConfig;
+pub use loonfs_core::cache::{MetadataTableCacheConfig, Recency};
 pub use loonfs_core::limits::{DEFAULT_GC_MAX_OBJECTS, METADATA_PUBLICATION_BUDGET_MS};
 pub use loonfs_core::{
     BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -42,7 +42,6 @@ mod maintenance_runner;
 pub mod metrics;
 mod options;
 pub mod publisher;
-mod time;
 mod trace;
 
 use thiserror::Error;

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -319,7 +319,7 @@ impl MaintenanceClock for SystemMaintenanceClock {
         // A clock before the unix epoch reads as the epoch here rather than
         // failing: it can only make a scheduling decision early, and every
         // durable path already refuses such a clock outright.
-        crate::time::current_time_ms().unwrap_or(0)
+        loonfs_core::time::current_time_ms().unwrap_or(0)
     }
 
     fn jitter_below_ms(&self, span_ms: u64) -> u64 {


### PR DESCRIPTION
This PR makes four independent consolidations.

1. The configured store holds one shared provider client (net −162): `ConfiguredObjectStore` kept a 5-variant provider enum and a 144-line `impl ObjectStore` of 55 pure-forwarding match arms — two of which wrapped the same concrete type twice. The apparent exhaustiveness was backwards protection: adding a trait method with a default never broke the build, it silently skipped the forwarding (five methods were already in that state, harmless only because no provider overrides them). The store now holds `SharedObjectStore` and exposes `into_shared()`; the tested `Arc` blanket impl does the forwarding. Note: `ConfiguredObjectStore::kind()` is removed — it had zero production callers; `StoreConfig::kind()` is the authority everyone reads.

2. One recency primitive for the two stamped caches: The metadata table cache and the grep block cache each carried their own stamped/lazy-deletion LRU queue, and the copies had drifted. `loonfs_core::cache::Recency` (re-exported as `loonfs::Recency` for grep) settles all four: saturating stamp arithmetic (core's version debug-panicked on overflow), core's live-length-relative compaction trigger, in-place compaction, and a guarded pop — the last one fixes a real latent bug: grep's eviction loop assumed every pass removed an entry, so a queue holding only ghost positions would have spun forever. Core keeps its byte budget, single-flight, and stats; grep keeps its entry cap. Honest accounting: this part adds lines overall (+158, about a third production) because the primitive carries full docs and its own tests — (the duplication removed is behavioral)

3. One wall clock for durable timestamps: Two near-identical wall clocks fed durable state: the runtime's `time.rs`, whose doc claimed to be the only touchpoint, and a private duplicate inside core's engine that stamped every commit. The module now lives in `loonfs-core` beside the mutation context it feeds; the engine's copy is deleted; the pre-epoch error is spelled once at the durable boundary. The five non-durable clock reads (signing dates, token TTL, grep grace, temp names) stay where they are, as their own comments justify. Also fixes a metrics comment that said wall clock where the code reads the monotonic clock.

4. An uncomparable digest keeps the reuse conflict: In the put-retry reconciliation, five of six bail gates returned the original `commit_id_reuse_conflict`; the digest-not-comparable gate alone synthesized a different error (`invalid_request` embedded, a bare transport string on the client), reporting an idempotency ambiguity as a malformed request. All gates now behave the same: a failure to prove equality leaves the conflict standing, details intact. The arm is unreachable through today's mints (nothing produces a crc32c ref), so the new tests construct one directly — and each first asserts the comparison really answers "cannot compare", so the fixture fails loudly if that ever changes. 
