### PR TITLE
refactor(api): one pre-planning operation language

### DIFF
--- a/crates/loonfs-api/src/options.rs
+++ b/crates/loonfs-api/src/options.rs
@@ -6,6 +6,10 @@
 //! Keeping one definition is what stops the two surfaces from drifting a
 //! field apart.
 //!
+//! There is one type per operation, even where two of them currently hold the
+//! same fields: options follow the operation they parameterize, so a guard
+//! added to one is not silently offered on the others.
+//!
 //! These are plain in-process argument structs, not wire shapes: nothing here
 //! serializes. The request bodies that do cross the wire live in
 //! [`crate::v0`], and each surface resolves these options into one.
@@ -77,4 +81,44 @@ impl Default for DeleteOptions {
             expected_inode_id: None,
         }
     }
+}
+
+/// Options for moving a path.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MoveOptions {
+    /// Create-only or replace-existing behavior for the destination.
+    pub behavior: DestinationBehavior,
+    /// Optional idempotency key.
+    pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
+}
+
+/// Options for copying a file path.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CopyOptions {
+    /// Create-only or replace-existing behavior for the destination.
+    pub behavior: DestinationBehavior,
+    /// Optional idempotency key.
+    pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
+}
+
+/// Options for restoring a file revision by path.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RestoreRevisionOptions {
+    /// Optional idempotency key.
+    pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
+}
+
+/// Options for recovering a deleted file or subtree.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct UndeleteOptions {
+    /// Optional idempotency key.
+    pub commit_id: Option<CommitId>,
+    /// Annotation recorded on the commit; part of the commit's identity.
+    pub message: Option<String>,
 }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -20,12 +20,12 @@ use loonfs_api::{
         StoreProbeResponse,
     },
     AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
-    CreateCheckpointResponse, DestinationBehavior, EffectiveLimit, ErrorCode, GrepRequest,
-    GrepResponse, InodeId, ListFileRevisionsResponse, ListTrashResponse, MaintenanceStepRequest,
-    MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
-    PaginationPolicy, ReleaseCheckpointResponse, RevisionNo,
+    CreateCheckpointResponse, EffectiveLimit, ErrorCode, GrepRequest, GrepResponse, InodeId,
+    ListFileRevisionsResponse, ListTrashResponse, MaintenanceStepRequest, MaintenanceStepResponse,
+    NamespaceId, NamespaceStatusResponse, NamespaceSummary, PaginationPolicy,
+    ReleaseCheckpointResponse, RevisionNo,
 };
-use loonfs_client::{CommitOptions, NamespacePath};
+use loonfs_client::NamespacePath;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepIndexSnapshot,
     GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads, GREP_INDEX_JOB,
@@ -639,19 +639,14 @@ impl EmbeddedBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-        behavior: DestinationBehavior,
-        options: &CommitOptions,
+        options: &MoveOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(from.namespace(), || {
             self.writer.move_path(
                 from.namespace(),
                 from.absolute_path().as_str(),
                 to.absolute_path().as_str(),
-                MoveOptions {
-                    behavior,
-                    commit_id: options.commit_id.clone(),
-                    message: options.message.clone(),
-                },
+                options.clone(),
             )
         })
         .await
@@ -661,19 +656,14 @@ impl EmbeddedBackend {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-        behavior: DestinationBehavior,
-        options: &CommitOptions,
+        options: &CopyOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(from.namespace(), || {
             self.writer.copy_path(
                 from.namespace(),
                 from.absolute_path().as_str(),
                 to.absolute_path().as_str(),
-                CopyOptions {
-                    behavior,
-                    commit_id: options.commit_id.clone(),
-                    message: options.message.clone(),
-                },
+                options.clone(),
             )
         })
         .await
@@ -683,17 +673,14 @@ impl EmbeddedBackend {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-        options: &CommitOptions,
+        options: &RestoreRevisionOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.restore_file_revision(
                 spec.namespace(),
                 spec.absolute_path().as_str(),
                 source_revision_no,
-                RestoreRevisionOptions {
-                    commit_id: options.commit_id.clone(),
-                    message: options.message.clone(),
-                },
+                options.clone(),
             )
         })
         .await
@@ -704,7 +691,7 @@ impl EmbeddedBackend {
         spec: &NamespacePath,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
-        options: &CommitOptions,
+        options: &UndeleteOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(spec.namespace(), || {
             self.writer.undelete(
@@ -712,10 +699,7 @@ impl EmbeddedBackend {
                 inode_id,
                 deleted_at_seq,
                 spec.absolute_path().as_str(),
-                UndeleteOptions {
-                    commit_id: options.commit_id.clone(),
-                    message: options.message.clone(),
-                },
+                options.clone(),
             )
         })
         .await

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -26,13 +26,13 @@ use loonfs_api::{
         StoreProbeResponse,
     },
     AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
-    CreateCheckpointResponse, DeleteNamespaceResponse, DestinationBehavior, GrepRequest,
-    GrepResponse, InodeId, ListFileRevisionsResponse, ListTrashResponse, MaintenanceStepRequest,
-    MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
-    ReleaseCheckpointResponse, RevisionNo,
+    CreateCheckpointResponse, DeleteNamespaceResponse, GrepRequest, GrepResponse, InodeId,
+    ListFileRevisionsResponse, ListTrashResponse, MaintenanceStepRequest, MaintenanceStepResponse,
+    NamespaceId, NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RevisionNo,
 };
 use loonfs_client::{
-    CommitOptions, CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions,
+    CopyOptions, CreateDirectoryOptions, DeleteOptions, MoveOptions, NamespacePath, PutFileOptions,
+    RestoreRevisionOptions, UndeleteOptions,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 
@@ -480,37 +480,29 @@ impl ResolvedTarget {
         }
     }
 
-    /// Moves a path within a namespace; `behavior` selects create-only or
-    /// replace semantics for the destination.
+    /// Moves a path within a namespace.
     pub(crate) async fn move_path(
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-        behavior: DestinationBehavior,
-        options: &CommitOptions,
+        options: &MoveOptions,
     ) -> Result<CommitResponse, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.move_path(from, to, behavior, options).await,
-            Self::Remote(target) => {
-                Ok(target.client.move_path(from, to, behavior, options).await?)
-            }
+            Self::Embedded(target) => target.backend.move_path(from, to, options).await,
+            Self::Remote(target) => Ok(target.client.move_path(from, to, options).await?),
         }
     }
 
-    /// Copies a file within a namespace; `behavior` selects create-only or
-    /// replace semantics for the destination.
+    /// Copies a file within a namespace.
     pub(crate) async fn copy_path(
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-        behavior: DestinationBehavior,
-        options: &CommitOptions,
+        options: &CopyOptions,
     ) -> Result<CommitResponse, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.copy_path(from, to, behavior, options).await,
-            Self::Remote(target) => {
-                Ok(target.client.copy_path(from, to, behavior, options).await?)
-            }
+            Self::Embedded(target) => target.backend.copy_path(from, to, options).await,
+            Self::Remote(target) => Ok(target.client.copy_path(from, to, options).await?),
         }
     }
 
@@ -519,7 +511,7 @@ impl ResolvedTarget {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-        options: &CommitOptions,
+        options: &RestoreRevisionOptions,
     ) -> Result<CommitResponse, BackendError> {
         match self {
             Self::Embedded(target) => {
@@ -543,7 +535,7 @@ impl ResolvedTarget {
         spec: &NamespacePath,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
-        options: &CommitOptions,
+        options: &UndeleteOptions,
     ) -> Result<CommitResponse, BackendError> {
         match self {
             Self::Embedded(target) => {

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -591,7 +591,7 @@ pub(crate) async fn run_filesystem_restore(
         .restore_file_revision(
             &spec,
             RevisionNo(args.revision),
-            &loonfs_client::CommitOptions {
+            &loonfs_client::RestoreRevisionOptions {
                 commit_id,
                 message: args.message.clone(),
             },
@@ -628,7 +628,7 @@ pub(crate) async fn run_filesystem_undelete(
             &spec,
             loonfs_api::InodeId(args.inode),
             loonfs_api::ChangeSeq(args.deleted_at),
-            &loonfs_client::CommitOptions {
+            &loonfs_client::UndeleteOptions {
                 commit_id,
                 message: args.message.clone(),
             },
@@ -791,8 +791,8 @@ async fn run_filesystem_transfer(
             .copy_path(
                 &from,
                 &to,
-                behavior,
-                &loonfs_client::CommitOptions {
+                &loonfs_client::CopyOptions {
+                    behavior,
                     commit_id,
                     message: args.message.clone(),
                 },
@@ -809,8 +809,8 @@ async fn run_filesystem_transfer(
             .move_path(
                 &from,
                 &to,
-                behavior,
-                &loonfs_client::CommitOptions {
+                &loonfs_client::MoveOptions {
+                    behavior,
                     commit_id,
                     message: args.message.clone(),
                 },

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -348,8 +348,8 @@ pub(crate) async fn run_copy_tree(
                 .copy_path(
                     &from,
                     &to,
-                    behavior,
-                    &loonfs_client::CommitOptions {
+                    &loonfs_client::CopyOptions {
+                        behavior,
                         commit_id: None,
                         message: message.clone(),
                     },

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -31,8 +31,8 @@ use loonfs_api::{
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId,
     ChecksumAlgorithm, CommitId, CommitRequest, ContentRef, Crc64Nvme, CreateCheckpointRequest,
-    CreateCheckpointResponse, CreateNamespaceRequest, DeleteNamespaceResponse, DestinationBehavior,
-    ErrorCode, FilesystemOperation, ForkNamespaceRequest, GrepRequest, GrepResponse, InodeId,
+    CreateCheckpointResponse, CreateNamespaceRequest, DeleteNamespaceResponse, ErrorCode,
+    FilesystemOperation, ForkNamespaceRequest, GrepRequest, GrepResponse, InodeId,
     ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest,
     MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
     ReleaseCheckpointResponse, RevisionNo, StorageChecksum, UploadId,
@@ -143,7 +143,10 @@ pub use ClientError as Error;
 
 /// Per-operation options, defined once in `loonfs-api` and shared with the
 /// embedded `loonfs` runtime so the two surfaces cannot drift a field apart.
-pub use loonfs_api::options::{CreateDirectoryOptions, DeleteOptions, PutFileOptions};
+pub use loonfs_api::options::{
+    CopyOptions, CreateDirectoryOptions, DeleteOptions, MoveOptions, PutFileOptions,
+    RestoreRevisionOptions, UndeleteOptions,
+};
 
 /// Result type returned by the client.
 pub type Result<T> = std::result::Result<T, ClientError>;
@@ -270,25 +273,6 @@ fn signed_access(signed: &[SignedUploadPart], part_number: u32) -> Result<Object
 pub struct NamespacePath {
     namespace: NamespaceId,
     absolute_path: AbsolutePath,
-}
-
-/// Options for client commits whose only optional input is a commit id.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct CommitOptions {
-    /// Idempotency key for the commit; retrying with the same id replays
-    /// the landed commit instead of double-committing. A fresh id is
-    /// generated when absent.
-    pub commit_id: Option<CommitId>,
-    /// Annotation recorded on the commit and reported by the change feed.
-    /// Part of the commit's identity: the same `commit_id` with a different
-    /// message is a `commit_id_reuse_conflict`.
-    pub message: Option<String>,
-}
-
-impl CommitOptions {
-    fn resolve_commit_id(&self) -> CommitId {
-        self.commit_id.clone().unwrap_or_else(CommitId::generate)
-    }
 }
 
 impl Client {
@@ -1517,8 +1501,7 @@ impl Client {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-        behavior: DestinationBehavior,
-        options: &CommitOptions,
+        options: &MoveOptions,
     ) -> Result<ApiCommitResponse> {
         if from.namespace() != to.namespace() {
             return Err(ClientError::InvalidNamespacePath(format!(
@@ -1527,7 +1510,7 @@ impl Client {
                 to.namespace()
             )));
         }
-        let commit_id = options.resolve_commit_id();
+        let commit_id = options.commit_id.clone().unwrap_or_else(CommitId::generate);
         let response = self
             .commit(
                 from.namespace(),
@@ -1537,7 +1520,7 @@ impl Client {
                     FilesystemOperation::MovePath {
                         from_path: from.absolute_path().clone(),
                         to_path: to.absolute_path().clone(),
-                        behavior,
+                        behavior: options.behavior,
                     },
                 ),
             )
@@ -1549,8 +1532,7 @@ impl Client {
         &self,
         from: &NamespacePath,
         to: &NamespacePath,
-        behavior: DestinationBehavior,
-        options: &CommitOptions,
+        options: &CopyOptions,
     ) -> Result<ApiCommitResponse> {
         if from.namespace() != to.namespace() {
             return Err(ClientError::InvalidNamespacePath(format!(
@@ -1559,7 +1541,7 @@ impl Client {
                 to.namespace()
             )));
         }
-        let commit_id = options.resolve_commit_id();
+        let commit_id = options.commit_id.clone().unwrap_or_else(CommitId::generate);
         let response = self
             .commit(
                 from.namespace(),
@@ -1569,7 +1551,7 @@ impl Client {
                     FilesystemOperation::CopyPath {
                         from_path: from.absolute_path().clone(),
                         to_path: to.absolute_path().clone(),
-                        behavior,
+                        behavior: options.behavior,
                     },
                 ),
             )
@@ -1585,9 +1567,9 @@ impl Client {
         spec: &NamespacePath,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
-        options: &CommitOptions,
+        options: &UndeleteOptions,
     ) -> Result<ApiCommitResponse> {
-        let commit_id = options.resolve_commit_id();
+        let commit_id = options.commit_id.clone().unwrap_or_else(CommitId::generate);
         let response = self
             .commit(
                 spec.namespace(),
@@ -1609,9 +1591,9 @@ impl Client {
         &self,
         spec: &NamespacePath,
         source_revision_no: RevisionNo,
-        options: &CommitOptions,
+        options: &RestoreRevisionOptions,
     ) -> Result<ApiCommitResponse> {
-        let commit_id = options.resolve_commit_id();
+        let commit_id = options.commit_id.clone().unwrap_or_else(CommitId::generate);
         let response = self
             .commit(
                 spec.namespace(),

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -233,7 +233,7 @@ async fn undelete<S: ObjectStore + ?Sized>(
         FilesystemOperation::Undelete {
             inode_id,
             deleted_at_seq,
-            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+            path: AbsolutePath::parse(absolute_path).expect("path"),
         },
         context,
     )

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -131,7 +131,7 @@ pub(crate) async fn write_test_file<S: ObjectStore>(
                     CommitId::parse(commit_id).expect("commit id"),
                     None,
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse(path).expect("path"),
+                        path: AbsolutePath::parse(path).expect("path"),
                         content_ref,
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -561,9 +561,8 @@ mod tests {
         CommitRequest::single(
             CommitId::parse(commit_id).expect("valid commit id"),
             None,
-            FilesystemOperation::CreateDir {
-                absolute_path: loonfs_api::AbsolutePath::parse(format!("/{name}"))
-                    .expect("valid path"),
+            FilesystemOperation::CreateDirectory {
+                path: loonfs_api::AbsolutePath::parse(format!("/{name}")).expect("valid path"),
                 parents: false,
             },
         )
@@ -592,8 +591,8 @@ mod tests {
             commit_id: CommitId::parse("too-many-ops").expect("valid commit id"),
             message: None,
             operations: (0..=crate::limits::MAX_COMMIT_OPERATIONS)
-                .map(|index| FilesystemOperation::CreateDir {
-                    absolute_path: loonfs_api::AbsolutePath::parse(format!("/dir-{index}"))
+                .map(|index| FilesystemOperation::CreateDirectory {
+                    path: loonfs_api::AbsolutePath::parse(format!("/dir-{index}"))
                         .expect("valid path"),
                     parents: false,
                 })
@@ -620,8 +619,8 @@ mod tests {
         let oversized_message = CommitCandidate::new(CommitRequest {
             commit_id: CommitId::parse("too-long-message").expect("valid commit id"),
             message: Some("m".repeat(crate::limits::MAX_COMMIT_MESSAGE_BYTES + 1)),
-            operations: vec![FilesystemOperation::CreateDir {
-                absolute_path: loonfs_api::AbsolutePath::parse("/docs").expect("valid path"),
+            operations: vec![FilesystemOperation::CreateDirectory {
+                path: loonfs_api::AbsolutePath::parse("/docs").expect("valid path"),
                 parents: false,
             }],
         });
@@ -638,8 +637,8 @@ mod tests {
             commit_id: CommitId::parse("oversized-batch").expect("valid commit id"),
             message: None,
             operations: (0..=crate::limits::MAX_COMMIT_OPERATIONS)
-                .map(|index| FilesystemOperation::CreateDir {
-                    absolute_path: loonfs_api::AbsolutePath::parse(format!("/dir-{index}"))
+                .map(|index| FilesystemOperation::CreateDirectory {
+                    path: loonfs_api::AbsolutePath::parse(format!("/dir-{index}"))
                         .expect("valid path"),
                     parents: false,
                 })
@@ -655,8 +654,8 @@ mod tests {
             commit_id: CommitId::parse("largest-batch").expect("valid commit id"),
             message: None,
             operations: (0..crate::limits::MAX_COMMIT_OPERATIONS)
-                .map(|index| FilesystemOperation::CreateDir {
-                    absolute_path: loonfs_api::AbsolutePath::parse(format!("/dir-{index}"))
+                .map(|index| FilesystemOperation::CreateDirectory {
+                    path: loonfs_api::AbsolutePath::parse(format!("/dir-{index}"))
                         .expect("valid path"),
                     parents: false,
                 })
@@ -671,8 +670,8 @@ mod tests {
     /// durable record or the fingerprint path.
     #[test]
     fn a_message_past_the_byte_ceiling_is_rejected() {
-        let operations = vec![FilesystemOperation::CreateDir {
-            absolute_path: loonfs_api::AbsolutePath::parse("/docs").expect("valid path"),
+        let operations = vec![FilesystemOperation::CreateDirectory {
+            path: loonfs_api::AbsolutePath::parse("/docs").expect("valid path"),
             parents: false,
         }];
 

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -951,7 +951,7 @@ async fn publish_completed_content<S: ObjectStore>(
                     loonfs_api::CommitId::parse("publish-completed-content").expect("commit id"),
                     None,
                     FilesystemOperation::PutFile {
-                        absolute_path: loonfs_api::AbsolutePath::parse(path).expect("path"),
+                        path: loonfs_api::AbsolutePath::parse(path).expect("path"),
                         content_ref,
                         behavior: loonfs_api::DestinationBehavior::NoReplace,
                         expected_revision_no: None,

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -45,8 +45,8 @@
 //!     vec![CommitCandidate::new(CommitRequest::single(
 //!         CommitId::generate(),
 //!         None,
-//!         FilesystemOperation::CreateDir {
-//!             absolute_path: AbsolutePath::parse("/plans").expect("path"),
+//!         FilesystemOperation::CreateDirectory {
+//!             path: AbsolutePath::parse("/plans").expect("path"),
 //!             parents: false,
 //!         },
 //!     ))],

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -371,8 +371,8 @@ mod tests {
         crate::path::write::CommitRequest::single(
             CommitId::parse(commit_id).expect("valid commit id"),
             None,
-            crate::path::write::FilesystemOperation::CreateDir {
-                absolute_path: loonfs_api::AbsolutePath::parse(format!("/{display_name}"))
+            crate::path::write::FilesystemOperation::CreateDirectory {
+                path: loonfs_api::AbsolutePath::parse(format!("/{display_name}"))
                     .expect("valid path"),
                 parents: false,
             },

--- a/crates/loonfs-core/src/path/write/intent.rs
+++ b/crates/loonfs-core/src/path/write/intent.rs
@@ -1,9 +1,17 @@
 //! [`CommitRequest`]: the one filesystem commit language, before planning.
 
-use loonfs_api::{
-    AbsolutePath, ChangeSeq, CommitId, ContentRef, DeleteDirectoryBehavior, DestinationBehavior,
-    InodeId, RevisionNo,
-};
+use loonfs_api::CommitId;
+
+/// The operation language a commit is written in, owned by `loonfs-api` and
+/// used here unchanged.
+///
+/// There is one spelling of a pre-planning operation across the workspace:
+/// what a client sends is what the planner matches on, so no surface
+/// translates between two versions of the same language. The durable
+/// fingerprint preimage is a separate, frozen spelling, and the planner's
+/// `operation_fingerprint_input` is the only place this one is renamed
+/// into it.
+pub use loonfs_api::FilesystemOperation;
 
 /// One logical filesystem commit: an idempotency key, an optional caller
 /// annotation, and an ordered, non-empty list of operations.
@@ -12,6 +20,10 @@ use loonfs_api::{
 /// the effects of the ones before it, and either all of them commit or none
 /// of them do. A convenience one-operation request is this same type with a
 /// single-element list, so it plans, fingerprints, and replays identically.
+///
+/// This is the wire [`CommitRequest`](loonfs_api::CommitRequest) minus the
+/// content tokens: proofs are checked at the surface that accepts them, and
+/// what reaches the planner is the commit itself.
 ///
 /// Paths are parsed once at the surface that accepts the raw string
 /// ([`parse_mutation_path`]); a request always carries validated, normalized
@@ -42,57 +54,4 @@ impl CommitRequest {
             operations: vec![operation],
         }
     }
-}
-
-/// One path-oriented operation inside a [`CommitRequest`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FilesystemOperation {
-    /// Create one directory.
-    CreateDir {
-        absolute_path: AbsolutePath,
-        /// Also create missing ancestor directories, like `PutFile` does.
-        parents: bool,
-    },
-    /// Put one file at a path.
-    PutFile {
-        absolute_path: AbsolutePath,
-        content_ref: ContentRef,
-        behavior: DestinationBehavior,
-        /// When set, replacing applies only while the file's current
-        /// revision is still this one; a raced write fails the plan
-        /// instead of stacking a revision on state the caller never saw.
-        expected_revision_no: Option<RevisionNo>,
-    },
-    /// Delete one path.
-    DeletePath {
-        absolute_path: AbsolutePath,
-        behavior: DeleteDirectoryBehavior,
-        /// When set, the delete applies only while the path still resolves
-        /// to this inode; a raced rebinding fails the plan instead of
-        /// deleting the wrong inode.
-        expected_inode_id: Option<InodeId>,
-    },
-    /// Move one path to another path.
-    MovePath {
-        from_path: AbsolutePath,
-        to_path: AbsolutePath,
-        behavior: DestinationBehavior,
-    },
-    /// Copy one file path to another path.
-    CopyFilePath {
-        from_path: AbsolutePath,
-        to_path: AbsolutePath,
-        behavior: DestinationBehavior,
-    },
-    /// Restore a file revision at a path.
-    RestoreRevision {
-        absolute_path: AbsolutePath,
-        source_revision_no: RevisionNo,
-    },
-    /// Recover a deleted subtree to a destination path.
-    Undelete {
-        inode_id: InodeId,
-        deleted_at_seq: ChangeSeq,
-        absolute_path: AbsolutePath,
-    },
 }

--- a/crates/loonfs-core/src/path/write/ops.rs
+++ b/crates/loonfs-core/src/path/write/ops.rs
@@ -107,7 +107,7 @@ async fn put_prepared_file_content<S: ObjectStore + ?Sized>(
         namespace_id,
         normalized_commit_id(commit_id),
         FilesystemOperation::PutFile {
-            absolute_path: parse_mutation_path(absolute_path)?,
+            path: parse_mutation_path(absolute_path)?,
             content_ref,
             behavior,
             expected_revision_no: None,
@@ -150,7 +150,7 @@ async fn delete_path_with_behavior<S: ObjectStore + ?Sized>(
         namespace_id,
         commit_id,
         FilesystemOperation::DeletePath {
-            absolute_path: parse_mutation_path(absolute_path)?,
+            path: parse_mutation_path(absolute_path)?,
             behavior,
             expected_inode_id: None,
         },
@@ -198,7 +198,7 @@ pub(crate) async fn restore_file_revision<S: ObjectStore + ?Sized>(
         namespace_id,
         commit_id,
         FilesystemOperation::RestoreRevision {
-            absolute_path: parse_mutation_path(absolute_path)?,
+            path: parse_mutation_path(absolute_path)?,
             source_revision_no,
         },
         Vec::new(),

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -39,6 +39,17 @@ pub(crate) struct PlannedCommit {
 /// identity fingerprints"): the same normalized request must fingerprint
 /// identically across releases. A pinned-value test below fails if the
 /// encoding drifts.
+///
+/// The variant names, the field names, and the field order below are all part
+/// of that preimage under the [`COMMIT_FINGERPRINT_DOMAIN`] tag, and none of
+/// them tracks the wire enum. They deliberately differ from it — `CreateDir`
+/// against the wire's `CreateDirectory`, `absolute_path` against its `path`,
+/// `behavior` ahead of `content_ref` in the put — because renaming a wire
+/// field must not silently restate every already-published commit's identity.
+/// [`operation_fingerprint_input`] is the one place the wire spelling is
+/// translated into this one; nothing else may name these variants. Change any
+/// of it and every stored fingerprint disagrees with its recomputed value,
+/// which the pinned tests below exist to catch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum OperationFingerprintInput<'a> {
@@ -112,32 +123,36 @@ fn content_ref_fingerprint_input(content_ref: &ContentRef) -> ContentRefFingerpr
     }
 }
 
+/// Renames one wire operation into its durable preimage.
+///
+/// This is the whole of the wire-to-fingerprint translation. The left side
+/// follows [`FilesystemOperation`] and may be renamed with it; the right side
+/// is frozen (see [`OperationFingerprintInput`]).
 fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFingerprintInput<'_> {
     match operation {
-        FilesystemOperation::CreateDir {
-            absolute_path,
-            parents,
-        } => OperationFingerprintInput::CreateDir {
-            absolute_path: absolute_path.as_str(),
-            parents: *parents,
-        },
+        FilesystemOperation::CreateDirectory { path, parents } => {
+            OperationFingerprintInput::CreateDir {
+                absolute_path: path.as_str(),
+                parents: *parents,
+            }
+        }
         FilesystemOperation::PutFile {
-            absolute_path,
+            path,
             content_ref,
             behavior,
             expected_revision_no,
         } => OperationFingerprintInput::PutFile {
-            absolute_path: absolute_path.as_str(),
+            absolute_path: path.as_str(),
             behavior: *behavior,
             content_ref: content_ref_fingerprint_input(content_ref),
             expected_revision_no: *expected_revision_no,
         },
         FilesystemOperation::DeletePath {
-            absolute_path,
+            path,
             behavior,
             expected_inode_id,
         } => OperationFingerprintInput::DeletePath {
-            absolute_path: absolute_path.as_str(),
+            absolute_path: path.as_str(),
             behavior: *behavior,
             expected_inode_id: *expected_inode_id,
         },
@@ -150,7 +165,7 @@ fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFing
             to_path: to_path.as_str(),
             behavior: *behavior,
         },
-        FilesystemOperation::CopyFilePath {
+        FilesystemOperation::CopyPath {
             from_path,
             to_path,
             behavior,
@@ -160,20 +175,20 @@ fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFing
             behavior: *behavior,
         },
         FilesystemOperation::RestoreRevision {
-            absolute_path,
+            path,
             source_revision_no,
         } => OperationFingerprintInput::RestoreRevision {
-            absolute_path: absolute_path.as_str(),
+            absolute_path: path.as_str(),
             source_revision_no: *source_revision_no,
         },
         FilesystemOperation::Undelete {
             inode_id,
             deleted_at_seq,
-            absolute_path,
+            path,
         } => OperationFingerprintInput::Undelete {
             inode_id: *inode_id,
             deleted_at_seq: *deleted_at_seq,
-            absolute_path: absolute_path.as_str(),
+            absolute_path: path.as_str(),
         },
     }
 }
@@ -287,18 +302,17 @@ async fn plan_operation<S: ObjectStore + ?Sized>(
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<PlannedOperation> {
     match operation {
-        FilesystemOperation::CreateDir {
-            absolute_path,
-            parents,
-        } => plan_publish_create_directory(absolute_path, *parents, view).await,
+        FilesystemOperation::CreateDirectory { path, parents } => {
+            plan_publish_create_directory(path, *parents, view).await
+        }
         FilesystemOperation::PutFile {
-            absolute_path,
+            path,
             content_ref,
             behavior,
             expected_revision_no,
         } => {
             plan_publish_put_file_content_ref(
-                absolute_path,
+                path,
                 content_ref.clone(),
                 *behavior,
                 *expected_revision_no,
@@ -307,29 +321,29 @@ async fn plan_operation<S: ObjectStore + ?Sized>(
             .await
         }
         FilesystemOperation::DeletePath {
-            absolute_path,
+            path,
             behavior,
             expected_inode_id,
-        } => plan_publish_delete_path(absolute_path, *behavior, *expected_inode_id, view).await,
+        } => plan_publish_delete_path(path, *behavior, *expected_inode_id, view).await,
         FilesystemOperation::MovePath {
             from_path,
             to_path,
             behavior,
         } => plan_publish_move_path(from_path, to_path, *behavior, view).await,
-        FilesystemOperation::CopyFilePath {
+        FilesystemOperation::CopyPath {
             from_path,
             to_path,
             behavior,
         } => plan_publish_copy_file_path(from_path, to_path, *behavior, view).await,
         FilesystemOperation::RestoreRevision {
-            absolute_path,
+            path,
             source_revision_no,
-        } => plan_publish_restore_revision(absolute_path, *source_revision_no, view).await,
+        } => plan_publish_restore_revision(path, *source_revision_no, view).await,
         FilesystemOperation::Undelete {
             inode_id,
             deleted_at_seq,
-            absolute_path,
-        } => plan_publish_undelete(*inode_id, *deleted_at_seq, absolute_path, view).await,
+            path,
+        } => plan_publish_undelete(*inode_id, *deleted_at_seq, path, view).await,
     }
 }
 
@@ -425,8 +439,8 @@ mod tests {
     }
 
     fn create_dir(path: &str) -> FilesystemOperation {
-        FilesystemOperation::CreateDir {
-            absolute_path: AbsolutePath::parse(path).expect("path"),
+        FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse(path).expect("path"),
             parents: false,
         }
     }
@@ -456,7 +470,7 @@ mod tests {
     fn guarded_delete_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let mut fixed = request(FilesystemOperation::DeletePath {
-            absolute_path: AbsolutePath::parse("/docs").expect("path"),
+            path: AbsolutePath::parse("/docs").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: Some(InodeId(42)),
         });
@@ -481,7 +495,7 @@ mod tests {
     fn put_file_fingerprint_value_is_pinned() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let mut fixed = request(FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/docs/report.txt").expect("path"),
+            path: AbsolutePath::parse("/docs/report.txt").expect("path"),
             content_ref: ContentRef::blob_v1(
                 loonfs_api::ContentId::parse("con_0123456789abcdef0123456789abcdef")
                     .expect("content id"),
@@ -517,7 +531,7 @@ mod tests {
         };
         let build = |content_ref| {
             request(FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/docs/report.txt").expect("path"),
+                path: AbsolutePath::parse("/docs/report.txt").expect("path"),
                 content_ref,
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
@@ -537,7 +551,7 @@ mod tests {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
         let build = |content_ref| {
             request(FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/docs/report.txt").expect("path"),
+                path: AbsolutePath::parse("/docs/report.txt").expect("path"),
                 content_ref,
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
@@ -738,7 +752,7 @@ mod tests {
             &store,
             &namespace_id,
             &request(FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/docs/nested/a.txt").expect("path"),
+                path: AbsolutePath::parse("/docs/nested/a.txt").expect("path"),
                 content_ref: staged.content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
@@ -837,7 +851,7 @@ mod tests {
         let planned = plan_against_current_state(
             &store,
             &namespace_id,
-            &request(FilesystemOperation::CopyFilePath {
+            &request(FilesystemOperation::CopyPath {
                 from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 to_path: AbsolutePath::parse("/docs/copy.txt").expect("path"),
                 behavior: DestinationBehavior::NoReplace,
@@ -945,7 +959,7 @@ mod tests {
             &store,
             &namespace_id,
             &request(FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/dead/new.txt").expect("path"),
+                path: AbsolutePath::parse("/dead/new.txt").expect("path"),
                 content_ref: staged.content_ref,
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
@@ -973,7 +987,7 @@ mod tests {
                 operations: vec![
                     create_dir("/reports"),
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/reports/a.txt").expect("path"),
+                        path: AbsolutePath::parse("/reports/a.txt").expect("path"),
                         content_ref: staged.content_ref.clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -1025,12 +1039,12 @@ mod tests {
                 message: None,
                 operations: vec![
                     FilesystemOperation::DeletePath {
-                        absolute_path: AbsolutePath::parse("/docs/tmp.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/tmp.txt").expect("path"),
                         behavior: DeleteDirectoryBehavior::NonRecursive,
                         expected_inode_id: None,
                     },
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/docs/tmp.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/tmp.txt").expect("path"),
                         content_ref: staged.content_ref.clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -1063,7 +1077,7 @@ mod tests {
                 operations: vec![
                     create_dir("/first"),
                     FilesystemOperation::DeletePath {
-                        absolute_path: AbsolutePath::parse("/missing").expect("path"),
+                        path: AbsolutePath::parse("/missing").expect("path"),
                         behavior: DeleteDirectoryBehavior::NonRecursive,
                         expected_inode_id: None,
                     },

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -130,7 +130,7 @@ mod tests {
                 CommitId::parse(commit_id).expect("valid commit id"),
                 None,
                 FilesystemOperation::PutFile {
-                    absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+                    path: AbsolutePath::parse(absolute_path).expect("path"),
                     content_ref: content_ref.clone(),
                     behavior: DestinationBehavior::NoReplace,
                     expected_revision_no: None,
@@ -181,7 +181,7 @@ mod tests {
             CommitId::parse("plan-a").expect("valid commit id"),
             None,
             FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                 content_ref: staged.content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
@@ -197,7 +197,7 @@ mod tests {
             CommitId::parse("plan-b").expect("valid commit id"),
             None,
             FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
+                path: AbsolutePath::parse("/docs/b.txt").expect("path"),
                 content_ref: staged.content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
@@ -221,7 +221,7 @@ mod tests {
 
     /// The first candidate implicitly creates `/wide`; the second must plan
     /// against the session state that already contains it, or its own
-    /// duplicate `CreateDir` would fail child-name-absent validation.
+    /// duplicate `CreateDirectory` would fail child-name-absent validation.
     #[tokio::test]
     async fn batch_creates_under_one_new_parent_share_session_state() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
@@ -323,7 +323,7 @@ mod tests {
                     CommitId::parse("delete-doomed").expect("valid commit id"),
                     None,
                     FilesystemOperation::DeletePath {
-                        absolute_path: AbsolutePath::parse("/docs/doomed.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/doomed.txt").expect("path"),
                         behavior: DeleteDirectoryBehavior::NonRecursive,
                         expected_inode_id: None,
                     },

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -46,7 +46,7 @@ async fn delete_path_non_recursive_expecting<S: ObjectStore + ?Sized>(
         namespace_id,
         CommitId::parse(commit_id).expect("valid test commit id"),
         FilesystemOperation::DeletePath {
-            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+            path: AbsolutePath::parse(absolute_path).expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id,
         },
@@ -377,7 +377,7 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
             CommitCandidate::new(commit_request(
                 "delete-cycled",
                 FilesystemOperation::DeletePath {
-                    absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
+                    path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
                     behavior: DeleteDirectoryBehavior::NonRecursive,
                     expected_inode_id: None,
                 },
@@ -388,7 +388,7 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
                 commit_request(
                     "recreate-cycled",
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
                         content_ref: staged.content_ref,
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -427,15 +427,15 @@ async fn batch_commit_writes_one_segment_and_expands_change_feed() {
         vec![
             commit_request(
                 "req-batch-a",
-                FilesystemOperation::CreateDir {
-                    absolute_path: AbsolutePath::parse("/alpha").expect("path"),
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/alpha").expect("path"),
                     parents: false,
                 },
             ),
             commit_request(
                 "req-batch-b",
-                FilesystemOperation::CreateDir {
-                    absolute_path: AbsolutePath::parse("/beta").expect("path"),
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/beta").expect("path"),
                     parents: false,
                 },
             ),
@@ -561,7 +561,7 @@ async fn ack_lost_head_cas_reports_unknown_outcome_and_replays_idempotently() {
         commit_request(
             "ack-lost-put",
             FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/ack.txt").expect("path"),
+                path: AbsolutePath::parse("/ack.txt").expect("path"),
                 content_ref: content.content_ref.clone(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
@@ -605,7 +605,7 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
     let put = commit_request(
         "retry-after-orphan",
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/retry.txt").expect("path"),
+            path: AbsolutePath::parse("/retry.txt").expect("path"),
             content_ref: content.content_ref,
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
@@ -703,7 +703,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
             CommitCandidate::new(commit_request(
                 "reject-materialization",
                 FilesystemOperation::DeletePath {
-                    absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
+                    path: AbsolutePath::parse("/missing.txt").expect("path"),
                     behavior: DeleteDirectoryBehavior::NonRecursive,
                     expected_inode_id: None,
                 },
@@ -715,7 +715,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                 commit_request(
                     "accept-a",
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                         content_ref: content.content_ref.clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -731,7 +731,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                 commit_request(
                     "reject-speculative",
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                         content_ref: content.content_ref.clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -743,7 +743,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
             CommitCandidate::new(commit_request(
                 "reject-materialization",
                 FilesystemOperation::DeletePath {
-                    absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
+                    path: AbsolutePath::parse("/missing.txt").expect("path"),
                     behavior: DeleteDirectoryBehavior::NonRecursive,
                     expected_inode_id: None,
                 },
@@ -819,7 +819,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
             CommitCandidate::new(commit_request(
                 "reject-materialization",
                 FilesystemOperation::DeletePath {
-                    absolute_path: AbsolutePath::parse("/missing.txt").expect("path"),
+                    path: AbsolutePath::parse("/missing.txt").expect("path"),
                     behavior: DeleteDirectoryBehavior::NonRecursive,
                     expected_inode_id: None,
                 },
@@ -830,7 +830,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                 commit_request(
                     "accept-a",
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                         content_ref: content.content_ref.clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -844,7 +844,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                 commit_request(
                     "reject-speculative",
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                         content_ref: content.content_ref.clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -960,8 +960,8 @@ async fn retry_succeeds_after_stale_head_get_during_publish_view_load() {
     let publish = async |engine: &mut NamespaceCommitEngine, path: &str, commit_id: &str| {
         let mkdir = commit_request(
             commit_id,
-            FilesystemOperation::CreateDir {
-                absolute_path: AbsolutePath::parse(path).expect("path"),
+            FilesystemOperation::CreateDirectory {
+                path: AbsolutePath::parse(path).expect("path"),
                 parents: false,
             },
         );
@@ -1023,8 +1023,8 @@ async fn batch_commit_aliases_duplicate_commit_id_with_same_fingerprint() {
 
     let duplicated = commit_request(
         "req-duplicate",
-        FilesystemOperation::CreateDir {
-            absolute_path: AbsolutePath::parse("/alpha").expect("path"),
+        FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse("/alpha").expect("path"),
             parents: false,
         },
     );
@@ -1084,7 +1084,7 @@ async fn oversized_prepared_proof_candidate_replays_receipt_but_new_request_is_r
     let put = commit_request(
         "over-proof-replay",
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/proof-replay.txt").expect("path"),
+            path: AbsolutePath::parse("/proof-replay.txt").expect("path"),
             content_ref: stored.content_ref,
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
@@ -1154,7 +1154,7 @@ async fn same_batch_over_limit_proof_duplicate_joins_its_primary() {
     let put = commit_request(
         "over-proof-duplicate",
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/batch-proof.txt").expect("path"),
+            path: AbsolutePath::parse("/batch-proof.txt").expect("path"),
             content_ref: stored.content_ref,
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
@@ -1195,9 +1195,8 @@ async fn new_candidate_with_4097_operations_is_rejected_after_identity_computati
         commit_id: CommitId::parse("over-operation-new").expect("valid commit id"),
         message: None,
         operations: (0..=loonfs_core::limits::MAX_COMMIT_OPERATIONS)
-            .map(|index| FilesystemOperation::CreateDir {
-                absolute_path: AbsolutePath::parse(format!("/over-operation-{index}"))
-                    .expect("path"),
+            .map(|index| FilesystemOperation::CreateDirectory {
+                path: AbsolutePath::parse(format!("/over-operation-{index}")).expect("path"),
                 parents: false,
             })
             .collect(),
@@ -1227,8 +1226,8 @@ async fn visible_commit_id_retry_aliases_across_writer_takeover() {
 
     let mkdir = commit_request(
         "retry-across-writer",
-        FilesystemOperation::CreateDir {
-            absolute_path: AbsolutePath::parse("/alpha").expect("path"),
+        FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse("/alpha").expect("path"),
             parents: false,
         },
     );
@@ -1264,15 +1263,15 @@ async fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
         vec![
             commit_request(
                 "req-conflict",
-                FilesystemOperation::CreateDir {
-                    absolute_path: AbsolutePath::parse("/alpha").expect("path"),
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/alpha").expect("path"),
                     parents: false,
                 },
             ),
             commit_request(
                 "req-conflict",
-                FilesystemOperation::CreateDir {
-                    absolute_path: AbsolutePath::parse("/beta").expect("path"),
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/beta").expect("path"),
                     parents: false,
                 },
             ),
@@ -1330,7 +1329,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
     let put = commit_request(
         "same-path-request",
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
+            path: AbsolutePath::parse("/same/path.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
@@ -1350,7 +1349,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
         commit_request(
             "same-path-request",
             FilesystemOperation::DeletePath {
-                absolute_path: AbsolutePath::parse("/same/path.txt").expect("path"),
+                path: AbsolutePath::parse("/same/path.txt").expect("path"),
                 behavior: DeleteDirectoryBehavior::NonRecursive,
                 expected_inode_id: None,
             },
@@ -1600,7 +1599,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
                     commit_id.clone(),
                     None,
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
                         content_ref: content.content_ref.clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -1631,7 +1630,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
             commit_id,
             None,
             FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
+                path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
                 content_ref: content.content_ref,
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -116,7 +116,7 @@ impl ObjectStore for ContentStoreAccessLimitStore {
 
 fn put_file(absolute_path: &str, content_ref: loonfs_api::ContentRef) -> FilesystemOperation {
     FilesystemOperation::PutFile {
-        absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+        path: AbsolutePath::parse(absolute_path).expect("path"),
         content_ref,
         behavior: DestinationBehavior::NoReplace,
         expected_revision_no: None,
@@ -124,15 +124,15 @@ fn put_file(absolute_path: &str, content_ref: loonfs_api::ContentRef) -> Filesys
 }
 
 fn create_dir(absolute_path: &str) -> FilesystemOperation {
-    FilesystemOperation::CreateDir {
-        absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+    FilesystemOperation::CreateDirectory {
+        path: AbsolutePath::parse(absolute_path).expect("path"),
         parents: false,
     }
 }
 
 fn delete_path(absolute_path: &str) -> FilesystemOperation {
     FilesystemOperation::DeletePath {
-        absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+        path: AbsolutePath::parse(absolute_path).expect("path"),
         behavior: DeleteDirectoryBehavior::NonRecursive,
         expected_inode_id: None,
     }
@@ -337,7 +337,7 @@ async fn a_later_batch_candidate_observes_the_earlier_one() {
                 commit_id("delete-with-stale-binding"),
                 None,
                 FilesystemOperation::DeletePath {
-                    absolute_path: AbsolutePath::parse("/docs/readme.txt").expect("path"),
+                    path: AbsolutePath::parse("/docs/readme.txt").expect("path"),
                     behavior: DeleteDirectoryBehavior::NonRecursive,
                     expected_inode_id: Some(file_inode),
                 },
@@ -446,7 +446,7 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
         &namespace_id("demo"),
         commit_id("restore-replace"),
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/restore.txt").expect("path"),
+            path: AbsolutePath::parse("/restore.txt").expect("path"),
             content_ref: second.content_ref,
             behavior: DestinationBehavior::Replace,
             expected_revision_no: None,
@@ -469,7 +469,7 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
         &namespace_id("demo"),
         commit_id("restore-missing-content"),
         FilesystemOperation::RestoreRevision {
-            absolute_path: AbsolutePath::parse("/restore.txt").expect("path"),
+            path: AbsolutePath::parse("/restore.txt").expect("path"),
             source_revision_no: RevisionNo(1),
         },
         &context,
@@ -548,7 +548,7 @@ async fn a_guarded_put_fails_unprepared_before_revision_validation_without_conte
             commit_id("replace-stale-missing-content"),
             None,
             FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse("/docs/replace.txt").expect("path"),
+                path: AbsolutePath::parse("/docs/replace.txt").expect("path"),
                 content_ref: missing_content.clone(),
                 behavior: DestinationBehavior::Replace,
                 expected_revision_no: Some(RevisionNo(99)),
@@ -594,7 +594,7 @@ async fn restore_revision_missing_source_is_revision_not_found() {
         &namespace_id("demo"),
         commit_id("restore-missing-source"),
         FilesystemOperation::RestoreRevision {
-            absolute_path: AbsolutePath::parse("/docs/restore.txt").expect("path"),
+            path: AbsolutePath::parse("/docs/restore.txt").expect("path"),
             source_revision_no: RevisionNo(99),
         },
         &context,
@@ -879,7 +879,7 @@ async fn a_revision_guard_observes_an_earlier_operation_of_the_same_request() {
 
     let replace =
         |content_ref: loonfs_api::ContentRef, expected: u64| FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/docs/guarded.txt").expect("path"),
+            path: AbsolutePath::parse("/docs/guarded.txt").expect("path"),
             content_ref,
             behavior: DestinationBehavior::Replace,
             expected_revision_no: Some(RevisionNo(expected)),

--- a/crates/loonfs-core/tests/it/common/mod.rs
+++ b/crates/loonfs-core/tests/it/common/mod.rs
@@ -243,7 +243,7 @@ pub(crate) mod commit_split_support {
             namespace_id,
             test_commit_id(commit_id),
             FilesystemOperation::PutFile {
-                absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+                path: AbsolutePath::parse(absolute_path).expect("path"),
                 content_ref: content.content_ref,
                 behavior,
                 expected_revision_no: None,
@@ -284,8 +284,8 @@ pub(crate) mod commit_split_support {
             store,
             namespace_id,
             test_commit_id(commit_id),
-            FilesystemOperation::CreateDir {
-                absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+            FilesystemOperation::CreateDirectory {
+                path: AbsolutePath::parse(absolute_path).expect("path"),
                 parents: false,
             },
             context,

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -891,7 +891,7 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         &namespace_id,
         CommitId::parse("before-delete").expect("valid commit id"),
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/keep.txt").expect("path"),
+            path: AbsolutePath::parse("/keep.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
@@ -928,7 +928,7 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         &namespace_id,
         CommitId::parse("after-delete").expect("valid commit id"),
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/late.txt").expect("path"),
+            path: AbsolutePath::parse("/late.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -45,7 +45,7 @@ async fn put_file<S: ObjectStore + ?Sized>(
                     loonfs_api::CommitId::generate(),
                     None,
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+                        path: AbsolutePath::parse(absolute_path).expect("path"),
                         content_ref,
                         behavior: loonfs_api::DestinationBehavior::NoReplace,
                         expected_revision_no: None,

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -41,7 +41,7 @@ async fn delete_path<S: ObjectStore + ?Sized>(
         namespace_id,
         test_commit_id(commit_id),
         FilesystemOperation::DeletePath {
-            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+            path: AbsolutePath::parse(absolute_path).expect("path"),
             behavior: DeleteDirectoryBehavior::Recursive,
             expected_inode_id: None,
         },
@@ -62,7 +62,7 @@ async fn delete_path_non_recursive<S: ObjectStore + ?Sized>(
         namespace_id,
         test_commit_id(commit_id),
         FilesystemOperation::DeletePath {
-            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+            path: AbsolutePath::parse(absolute_path).expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: None,
         },
@@ -105,7 +105,7 @@ async fn copy_file_path<S: ObjectStore + ?Sized>(
         store,
         namespace_id,
         test_commit_id(commit_id),
-        FilesystemOperation::CopyFilePath {
+        FilesystemOperation::CopyPath {
             from_path: AbsolutePath::parse(from_path).expect("path"),
             to_path: AbsolutePath::parse(to_path).expect("path"),
             behavior: DestinationBehavior::NoReplace,
@@ -128,7 +128,7 @@ async fn restore_file_revision<S: ObjectStore + ?Sized>(
         namespace_id,
         test_commit_id(commit_id),
         FilesystemOperation::RestoreRevision {
-            absolute_path: AbsolutePath::parse(absolute_path).expect("path"),
+            path: AbsolutePath::parse(absolute_path).expect("path"),
             source_revision_no,
         },
         context,
@@ -983,8 +983,8 @@ async fn name_key_stays_typed_through_planning_and_fingerprint() {
     let request = CommitRequest::single(
         CommitId::parse("typed-name-key").expect("valid commit id"),
         Some("typed boundary".to_owned()),
-        FilesystemOperation::CreateDir {
-            absolute_path: AbsolutePath::parse("/Caf\u{e9}").expect("path"),
+        FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse("/Caf\u{e9}").expect("path"),
             parents: false,
         },
     );
@@ -1042,7 +1042,7 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         CommitId::parse("put-path").expect("valid commit id"),
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+            path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             content_ref: content.content_ref.clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
@@ -1072,7 +1072,7 @@ async fn path_intents_cover_basic_mutations() {
         &store,
         &namespace_id,
         CommitId::parse("copy-path").expect("valid commit id"),
-        FilesystemOperation::CopyFilePath {
+        FilesystemOperation::CopyPath {
             from_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/c.txt").expect("path"),
             behavior: DestinationBehavior::NoReplace,
@@ -1088,7 +1088,7 @@ async fn path_intents_cover_basic_mutations() {
         &namespace_id,
         CommitId::parse("delete-path").expect("valid commit id"),
         FilesystemOperation::DeletePath {
-            absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
+            path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: None,
         },
@@ -1128,7 +1128,7 @@ async fn path_intents_in_one_batch_see_tentative_state() {
                     CommitId::parse("put-batched-path").expect("valid commit id"),
                     None,
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+                        path: AbsolutePath::parse("/docs/a.txt").expect("path"),
                         content_ref: content.content_ref,
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
@@ -1464,7 +1464,7 @@ async fn path_move_writes_unbind_and_old_binding_stops_resolving() {
         &namespace_id("demo"),
         CommitId::parse("delete-old-binding").expect("valid commit id"),
         FilesystemOperation::DeletePath {
-            absolute_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
+            path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: Some(file.inode_id),
         },
@@ -1479,7 +1479,7 @@ async fn path_move_writes_unbind_and_old_binding_stops_resolving() {
         &namespace_id("demo"),
         CommitId::parse("delete-new-binding").expect("valid commit id"),
         FilesystemOperation::DeletePath {
-            absolute_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
+            path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DeleteDirectoryBehavior::NonRecursive,
             expected_inode_id: Some(file.inode_id),
         },
@@ -1919,7 +1919,7 @@ async fn copy_replace_appends_a_revision_to_the_destination_inode() {
         &store,
         &namespace_id,
         CommitId::parse("copy-replace").expect("valid commit id"),
-        FilesystemOperation::CopyFilePath {
+        FilesystemOperation::CopyPath {
             from_path: AbsolutePath::parse("/docs/a.txt").expect("path"),
             to_path: AbsolutePath::parse("/docs/b.txt").expect("path"),
             behavior: DestinationBehavior::Replace,

--- a/crates/loonfs-core/tests/it/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/it/visibility_equivalence.rs
@@ -78,8 +78,8 @@ impl VisibilityHarness {
     }
 
     async fn create_directory(&self, path: &str) -> Result<CommitResponse, CoreError> {
-        self.publish_operation(FilesystemOperation::CreateDir {
-            absolute_path: AbsolutePath::parse(path).expect("valid path"),
+        self.publish_operation(FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse(path).expect("valid path"),
             parents: false,
         })
         .await
@@ -105,7 +105,7 @@ impl VisibilityHarness {
                 CommitId::generate(),
                 None,
                 FilesystemOperation::PutFile {
-                    absolute_path: AbsolutePath::parse(path).expect("valid path"),
+                    path: AbsolutePath::parse(path).expect("valid path"),
                     content_ref,
                     behavior,
                     expected_revision_no: None,
@@ -122,7 +122,7 @@ impl VisibilityHarness {
         behavior: DeleteDirectoryBehavior,
     ) -> Result<CommitResponse, CoreError> {
         self.publish_operation(FilesystemOperation::DeletePath {
-            absolute_path: AbsolutePath::parse(path).expect("valid path"),
+            path: AbsolutePath::parse(path).expect("valid path"),
             behavior,
             expected_inode_id: None,
         })
@@ -139,7 +139,7 @@ impl VisibilityHarness {
     }
 
     async fn copy_file(&self, from_path: &str, to_path: &str) -> Result<CommitResponse, CoreError> {
-        self.publish_operation(FilesystemOperation::CopyFilePath {
+        self.publish_operation(FilesystemOperation::CopyPath {
             from_path: AbsolutePath::parse(from_path).expect("valid source path"),
             to_path: AbsolutePath::parse(to_path).expect("valid destination path"),
             behavior: DestinationBehavior::NoReplace,
@@ -153,7 +153,7 @@ impl VisibilityHarness {
         source_revision_no: RevisionNo,
     ) -> Result<CommitResponse, CoreError> {
         self.publish_operation(FilesystemOperation::RestoreRevision {
-            absolute_path: AbsolutePath::parse(path).expect("valid path"),
+            path: AbsolutePath::parse(path).expect("valid path"),
             source_revision_no,
         })
         .await
@@ -168,7 +168,7 @@ impl VisibilityHarness {
         self.publish_operation(FilesystemOperation::Undelete {
             inode_id,
             deleted_at_seq,
-            absolute_path: AbsolutePath::parse(path).expect("valid path"),
+            path: AbsolutePath::parse(path).expect("valid path"),
         })
         .await
     }
@@ -521,7 +521,7 @@ async fn move_across_a_delete_boundary_preserves_visibility_equivalence() {
     let rejected = harness
         .batched_commit(vec![
             FilesystemOperation::DeletePath {
-                absolute_path: AbsolutePath::parse("/reverse").expect("valid path"),
+                path: AbsolutePath::parse("/reverse").expect("valid path"),
                 behavior: DeleteDirectoryBehavior::Recursive,
                 expected_inode_id: None,
             },
@@ -551,7 +551,7 @@ async fn move_across_a_delete_boundary_preserves_visibility_equivalence() {
                 behavior: DestinationBehavior::NoReplace,
             },
             FilesystemOperation::DeletePath {
-                absolute_path: AbsolutePath::parse("/source").expect("valid path"),
+                path: AbsolutePath::parse("/source").expect("valid path"),
                 behavior: DeleteDirectoryBehavior::Recursive,
                 expected_inode_id: None,
             },

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -394,7 +394,7 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
             .await
             .expect("prepare atomic-commit content");
         operations.push(FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse(format!("/bounded-{index:04}.txt"))
+            path: AbsolutePath::parse(format!("/bounded-{index:04}.txt"))
                 .expect("valid absolute path"),
             content_ref: content.content_ref().clone(),
             behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-grep/tests/it/grep_service_differential.rs
+++ b/crates/loonfs-grep/tests/it/grep_service_differential.rs
@@ -105,7 +105,7 @@ async fn publish_same_content_files(
                     CommitId::generate(),
                     None,
                     FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse(format!("/{prefix}-{index:04}.txt"))
+                        path: AbsolutePath::parse(format!("/{prefix}-{index:04}.txt"))
                             .expect("batch path"),
                         content_ref: content_ref.clone(),
                         behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -13,14 +13,13 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use loonfs::publish::{
     ensure_mutation_path, CommitCandidate, CommitRequest, ContentPreparationError,
-    FilesystemOperation as CommitOperation,
 };
 use loonfs::{payload_class, ErrorCode, ListChangesOptions, TraceStoreKind};
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
-// The wire request and the core planner's request share one name across two
-// crates because they are the same language; the alias keeps both readable
-// in the handler that maps one onto the other.
+// The wire commit request and the runtime's differ only by the content
+// tokens, which this handler resolves and strips; the operations inside them
+// are one type. The alias keeps the two request names readable side by side.
 use loonfs_api::{
     decode_cursor,
     v0::{ChangesResponse, CommitResponse as ApiCommitResponse},
@@ -301,6 +300,23 @@ pub(super) async fn list_file_revisions(
     Ok(Json(response))
 }
 
+/// Every path an operation would mutate.
+fn mutation_paths(operation: &FilesystemOperation) -> Vec<&AbsolutePath> {
+    match operation {
+        FilesystemOperation::CreateDirectory { path, .. }
+        | FilesystemOperation::PutFile { path, .. }
+        | FilesystemOperation::DeletePath { path, .. }
+        | FilesystemOperation::Undelete { path, .. }
+        | FilesystemOperation::RestoreRevision { path, .. } => vec![path],
+        FilesystemOperation::MovePath {
+            from_path, to_path, ..
+        }
+        | FilesystemOperation::CopyPath {
+            from_path, to_path, ..
+        } => vec![from_path, to_path],
+    }
+}
+
 #[cfg_attr(
     feature = "openapi",
     utoipa::path(
@@ -370,80 +386,17 @@ pub(super) async fn apply_commit(
     };
     // Absolute-path grammar was validated while decoding the wire body. The
     // root remains a valid read path but is not a legal mutation target.
-    let validate_path = |path: AbsolutePath| {
-        ensure_mutation_path(&path).map_err(|error| {
+    //
+    // Every planner re-asserts this, so the pass is a duplicate; it stays
+    // because it rejects before the commit queue, and because dropping it
+    // would start attributing root rejections to an operation index the
+    // wire has never carried for them.
+    for path in operations.iter().flat_map(mutation_paths) {
+        ensure_mutation_path(path).map_err(|error| {
             ApiResponseError::core_for_namespace(&namespace_id, error)
                 .with_commit_id(&commit_id_for_errors)
         })?;
-        Ok(path)
-    };
-    let operations = operations
-        .into_iter()
-        .map(|operation| {
-            Ok(match operation {
-                FilesystemOperation::CreateDirectory { path, parents } => {
-                    CommitOperation::CreateDir {
-                        absolute_path: validate_path(path)?,
-                        parents,
-                    }
-                }
-                FilesystemOperation::PutFile {
-                    path,
-                    content_ref,
-                    behavior,
-                    expected_revision_no,
-                } => CommitOperation::PutFile {
-                    absolute_path: validate_path(path)?,
-                    content_ref,
-                    behavior,
-                    expected_revision_no,
-                },
-                FilesystemOperation::DeletePath {
-                    path,
-                    behavior,
-                    expected_inode_id,
-                } => CommitOperation::DeletePath {
-                    absolute_path: validate_path(path)?,
-                    behavior,
-                    expected_inode_id,
-                },
-                FilesystemOperation::MovePath {
-                    from_path,
-                    to_path,
-                    behavior,
-                } => CommitOperation::MovePath {
-                    from_path: validate_path(from_path)?,
-                    to_path: validate_path(to_path)?,
-                    behavior,
-                },
-                FilesystemOperation::CopyPath {
-                    from_path,
-                    to_path,
-                    behavior,
-                } => CommitOperation::CopyFilePath {
-                    from_path: validate_path(from_path)?,
-                    to_path: validate_path(to_path)?,
-                    behavior,
-                },
-                FilesystemOperation::RestoreRevision {
-                    path,
-                    source_revision_no,
-                } => CommitOperation::RestoreRevision {
-                    absolute_path: validate_path(path)?,
-                    source_revision_no,
-                },
-                FilesystemOperation::Undelete {
-                    inode_id,
-                    deleted_at_seq,
-                    path,
-                } => CommitOperation::Undelete {
-                    inode_id,
-                    deleted_at_seq,
-                    absolute_path: validate_path(path)?,
-                },
-            })
-        })
-        .collect::<Result<Vec<_>, ApiResponseError>>()?;
+    }
     let request = CommitRequest {
         commit_id,
         message,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -20,7 +20,7 @@ use loonfs_api::ErrorCode;
 use loonfs_api::{
     ChangeSeq, CommitId, DeleteDirectoryBehavior, DestinationBehavior, GrepRequest, NamespaceId,
 };
-use loonfs_client::{Client, ClientConfig, ClientError, CommitOptions, NamespacePath};
+use loonfs_client::{Client, ClientConfig, ClientError, MoveOptions, NamespacePath};
 use loonfs_grep::keyspace::{manifest_key as grep_manifest_key, root_key as grep_root_key};
 use loonfs_grep::root::{
     encode_grep_root, load_grep_root, GrepManifestId, GrepRootEnvelope, GrepRootPointer,
@@ -919,8 +919,11 @@ async fn http_missing_namespace_mutations_return_namespace_not_found() {
             .move_path(
                 &target,
                 &destination,
-                DestinationBehavior::NoReplace,
-                &CommitOptions::default(),
+                &MoveOptions {
+                    behavior: DestinationBehavior::NoReplace,
+                    commit_id: None,
+                    message: None,
+                },
             )
             .await,
         404,
@@ -1019,8 +1022,11 @@ async fn http_put_over_directory_and_move_into_existing_target_return_path_confl
             .move_path(
                 &from,
                 &to,
-                DestinationBehavior::NoReplace,
-                &CommitOptions::default(),
+                &MoveOptions {
+                    behavior: DestinationBehavior::NoReplace,
+                    commit_id: None,
+                    message: None,
+                },
             )
             .await,
         409,
@@ -1078,8 +1084,11 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
         .move_path(
             &from,
             &to,
-            DestinationBehavior::NoReplace,
-            &CommitOptions::default(),
+            &MoveOptions {
+                behavior: DestinationBehavior::NoReplace,
+                commit_id: None,
+                message: None,
+            },
         )
         .await
         .expect("move lands in the recreated subtree");

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -4,7 +4,7 @@
 
 use crate::common::http_split_support::*;
 use crate::common::start_server;
-use loonfs::publish::{CommitRequest as CoreCommitRequest, FilesystemOperation as CoreOperation};
+use loonfs::publish::CommitRequest as CoreCommitRequest;
 use loonfs::{CreateNamespaceOptions, FsWriter, ListChangesOptions, StoreConfig};
 use loonfs_api::{
     v0::CommittedChange, AbsolutePath, ChangeSeq, CommitId, CommitRequest, ContentRef,
@@ -51,8 +51,12 @@ fn change_identity(change: &CommittedChange) -> (ChangeSeq, String, Option<Strin
     )
 }
 
-/// The directory-then-two-files batch, in the wire language.
-fn wire_batch(first: &ContentRef, second: &ContentRef) -> Vec<FilesystemOperation> {
+/// The directory-then-two-files batch.
+///
+/// Both transports below build their operations from this one helper, which
+/// they can because there is one operation language: the served arm and the
+/// embedded arm differ only in the content each staged.
+fn batch(first: &ContentRef, second: &ContentRef) -> Vec<FilesystemOperation> {
     vec![
         FilesystemOperation::CreateDirectory {
             path: absolute(REPORTS_DIR),
@@ -108,7 +112,7 @@ async fn a_batch_commits_once_and_matches_the_same_batch_embedded() {
                     validated_content_token(&first),
                     validated_content_token(&second),
                 ],
-                operations: wire_batch(&first.content_ref, &second.content_ref),
+                operations: batch(&first.content_ref, &second.content_ref),
             },
         )
         .await
@@ -169,24 +173,7 @@ async fn a_batch_commits_once_and_matches_the_same_batch_embedded() {
             CoreCommitRequest {
                 commit_id: commit_id("batch-one"),
                 message: Some("import the reports".to_owned()),
-                operations: vec![
-                    CoreOperation::CreateDir {
-                        absolute_path: absolute(REPORTS_DIR),
-                        parents: false,
-                    },
-                    CoreOperation::PutFile {
-                        absolute_path: absolute(FIRST_FILE),
-                        content_ref: first_prepared.content_ref().clone(),
-                        behavior: DestinationBehavior::NoReplace,
-                        expected_revision_no: None,
-                    },
-                    CoreOperation::PutFile {
-                        absolute_path: absolute(SECOND_FILE),
-                        content_ref: second_prepared.content_ref().clone(),
-                        behavior: DestinationBehavior::NoReplace,
-                        expected_revision_no: None,
-                    },
-                ],
+                operations: batch(first_prepared.content_ref(), second_prepared.content_ref()),
             },
             vec![first_prepared, second_prepared],
         )
@@ -374,6 +361,118 @@ async fn an_empty_operation_list_is_rejected() {
     harness.server.abort();
 }
 
+/// The root is readable but never a mutation target, alone or inside a
+/// batch, and rejecting it commits nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_root_path_is_rejected_as_a_mutation_target() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-root-mutation",
+        "http-root-mutation",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+
+    let alone = harness
+        .client
+        .commit(
+            &namespace,
+            &CommitRequest {
+                commit_id: commit_id("root-alone"),
+                message: None,
+                content_tokens: Vec::new(),
+                operations: vec![FilesystemOperation::CreateDirectory {
+                    path: absolute("/"),
+                    parents: false,
+                }],
+            },
+        )
+        .await
+        .expect_err("the root cannot be created");
+    match alone {
+        ClientError::Api {
+            status,
+            code,
+            details,
+            ..
+        } => {
+            assert_eq!(status, 400);
+            assert_eq!(code, ErrorCode::InvalidRequest.as_str());
+            // One operation has one place to fail, so nothing disambiguates it.
+            assert_eq!(
+                details.and_then(|details| details.operation_index),
+                None,
+                "a one-operation request names no position"
+            );
+        }
+        other => unreachable!("expected invalid_request, got {other:?}"),
+    }
+
+    let in_batch = harness
+        .client
+        .commit(
+            &namespace,
+            &CommitRequest {
+                commit_id: commit_id("root-in-batch"),
+                message: None,
+                content_tokens: Vec::new(),
+                operations: vec![
+                    FilesystemOperation::CreateDirectory {
+                        path: absolute(REPORTS_DIR),
+                        parents: false,
+                    },
+                    FilesystemOperation::DeletePath {
+                        path: absolute("/"),
+                        behavior: DeleteDirectoryBehavior::Recursive,
+                        expected_inode_id: None,
+                    },
+                ],
+            },
+        )
+        .await
+        .expect_err("the root cannot be deleted");
+    match in_batch {
+        ClientError::Api {
+            status,
+            code,
+            details,
+            ..
+        } => {
+            assert_eq!(status, 400);
+            assert_eq!(code, ErrorCode::InvalidRequest.as_str());
+            // The root check runs over the whole request before anything is
+            // planned, so this is the one rejection a batch does not attribute
+            // to a position. Every other failure names its operation.
+            assert_eq!(
+                details.and_then(|details| details.operation_index),
+                None,
+                "the pre-queue root check rejects the request, not an operation"
+            );
+        }
+        other => unreachable!("expected invalid_request, got {other:?}"),
+    }
+
+    // The valid first operation of the rejected batch did not land either.
+    assert_eq!(
+        harness
+            .client
+            .namespace_status(&namespace)
+            .await
+            .expect("status")
+            .head_seq,
+        ChangeSeq(0)
+    );
+
+    harness.server.abort();
+}
+
 /// Replay over the wire: the same id with the same batch returns the
 /// original receipt, and the same id with a different batch conflicts.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -460,15 +559,15 @@ async fn a_commit_id_used_embedded_replays_over_http() {
 
     let operations = || {
         vec![
-            CoreOperation::CreateDir {
-                absolute_path: absolute(REPORTS_DIR),
+            FilesystemOperation::CreateDirectory {
+                path: absolute(REPORTS_DIR),
                 parents: false,
             },
-            CoreOperation::CreateDir {
-                absolute_path: absolute("/reports/2026"),
+            FilesystemOperation::CreateDirectory {
+                path: absolute("/reports/2026"),
                 parents: false,
             },
-            CoreOperation::MovePath {
+            FilesystemOperation::MovePath {
                 from_path: absolute("/reports/2026"),
                 to_path: absolute("/reports/2025"),
                 behavior: DestinationBehavior::NoReplace,

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -7,7 +7,8 @@ use loonfs_api::{
     ListPathEntriesResponse, RevisionNo,
 };
 use loonfs_client::{
-    ClientError, CommitOptions, CreateDirectoryOptions, NamespacePath, PutFileOptions,
+    ClientError, CreateDirectoryOptions, MoveOptions, NamespacePath, PutFileOptions,
+    RestoreRevisionOptions,
 };
 use loonfs_test_support::http::raw_agent;
 use loonfs_test_support::ids::namespace_id;
@@ -258,7 +259,7 @@ async fn http_restore_revision_appends_new_head_and_reports_change() {
         .restore_file_revision(
             &target,
             RevisionNo(1),
-            &CommitOptions {
+            &RestoreRevisionOptions {
                 commit_id: Some(CommitId::parse("req-restore-restore").expect("valid commit id")),
                 message: Some("restore revision".to_owned()),
             },
@@ -390,8 +391,11 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         .move_path(
             &target,
             &moved,
-            DestinationBehavior::NoReplace,
-            &CommitOptions::default(),
+            &MoveOptions {
+                behavior: DestinationBehavior::NoReplace,
+                commit_id: None,
+                message: None,
+            },
         )
         .await
         .expect("move path");
@@ -410,7 +414,7 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
 
     harness
         .client
-        .restore_file_revision(&moved, RevisionNo(1), &CommitOptions::default())
+        .restore_file_revision(&moved, RevisionNo(1), &RestoreRevisionOptions::default())
         .await
         .expect("path restore");
     assert_eq!(
@@ -453,7 +457,7 @@ async fn http_restore_revision_missing_source_returns_revision_not_found() {
         .restore_file_revision(
             &target,
             RevisionNo(99),
-            &CommitOptions {
+            &RestoreRevisionOptions {
                 commit_id: Some(
                     CommitId::parse("req-restore-missing-source-restore").expect("valid commit id"),
                 ),

--- a/crates/loonfs-server/tests/it/http_paths.rs
+++ b/crates/loonfs-server/tests/it/http_paths.rs
@@ -3,7 +3,7 @@
 use crate::common::http_split_support::*;
 use crate::common::start_server;
 use loonfs_api::{DeleteDirectoryBehavior, DestinationBehavior};
-use loonfs_client::{ClientError, CommitOptions, DeleteOptions, NamespacePath, PutFileOptions};
+use loonfs_client::{ClientError, CopyOptions, DeleteOptions, NamespacePath, PutFileOptions};
 use loonfs_test_support::http::raw_agent;
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
@@ -95,8 +95,11 @@ async fn http_put_no_replace_and_copy_preserve_cli_semantics() {
         .copy_path(
             &source,
             &destination,
-            DestinationBehavior::NoReplace,
-            &CommitOptions::default(),
+            &CopyOptions {
+                behavior: DestinationBehavior::NoReplace,
+                commit_id: None,
+                message: None,
+            },
         )
         .await
         .expect("copy path");

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -6,7 +6,9 @@ use loonfs_api::v0::{
     CreateCheckpointRequest, MaintenanceStepKind, MaintenanceStepRequest, ValidatedContentToken,
 };
 use loonfs_api::{AbsolutePath, CommitId, CommitRequest, DestinationBehavior, FilesystemOperation};
-use loonfs_client::{ClientError, CommitOptions, DeleteOptions, NamespacePath, PutFileOptions};
+use loonfs_client::{
+    ClientError, CopyOptions, DeleteOptions, MoveOptions, NamespacePath, PutFileOptions,
+};
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
 
@@ -319,8 +321,8 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         .copy_path(
             &source,
             &copied,
-            DestinationBehavior::NoReplace,
-            &CommitOptions {
+            &CopyOptions {
+                behavior: DestinationBehavior::NoReplace,
                 commit_id: Some(CommitId::parse("req-v1-copy").expect("valid commit id")),
                 message: None,
             },
@@ -332,8 +334,8 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         .copy_path(
             &source,
             &copied,
-            DestinationBehavior::NoReplace,
-            &CommitOptions {
+            &CopyOptions {
+                behavior: DestinationBehavior::NoReplace,
                 commit_id: Some(CommitId::parse("req-v1-copy").expect("valid commit id")),
                 message: None,
             },
@@ -360,8 +362,8 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         .move_path(
             &copied,
             &moved,
-            DestinationBehavior::NoReplace,
-            &CommitOptions {
+            &MoveOptions {
+                behavior: DestinationBehavior::NoReplace,
                 commit_id: Some(CommitId::parse("req-v1-move").expect("valid commit id")),
                 message: None,
             },
@@ -373,8 +375,8 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         .move_path(
             &copied,
             &moved,
-            DestinationBehavior::NoReplace,
-            &CommitOptions {
+            &MoveOptions {
+                behavior: DestinationBehavior::NoReplace,
                 commit_id: Some(CommitId::parse("req-v1-move").expect("valid commit id")),
                 message: None,
             },
@@ -458,8 +460,11 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
         .move_path(
             &host_a_target,
             &host_b_target,
-            DestinationBehavior::NoReplace,
-            &CommitOptions::default(),
+            &MoveOptions {
+                behavior: DestinationBehavior::NoReplace,
+                commit_id: None,
+                message: None,
+            },
         )
         .await
         .expect("host b takes over on first write");

--- a/crates/loonfs/src/fs/tests.rs
+++ b/crates/loonfs/src/fs/tests.rs
@@ -12,8 +12,7 @@ fn mutation_facade_exports_constructor_types() {
         message: None,
         operations: vec![
             FilesystemOperation::RestoreRevision {
-                absolute_path: parse_mutation_path("/docs/Report.txt")
-                    .expect("valid mutation path"),
+                path: parse_mutation_path("/docs/Report.txt").expect("valid mutation path"),
                 source_revision_no: RevisionNo(1),
             },
             FilesystemOperation::MovePath {
@@ -29,8 +28,8 @@ fn mutation_facade_exports_constructor_types() {
 
 #[test]
 fn single_operation_request_carries_exactly_one_operation() {
-    let operation = FilesystemOperation::CreateDir {
-        absolute_path: parse_mutation_path("/docs").expect("valid mutation path"),
+    let operation = FilesystemOperation::CreateDirectory {
+        path: parse_mutation_path("/docs").expect("valid mutation path"),
         parents: false,
     };
     let request = CommitRequest::single(

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -442,7 +442,7 @@ impl FsWriter {
                 options.commit_id.unwrap_or_else(CommitId::generate),
                 options.message.clone(),
                 FilesystemOperation::PutFile {
-                    absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     content_ref,
                     behavior: options.behavior,
                     expected_revision_no: options.expected_revision_no,
@@ -570,8 +570,8 @@ impl FsWriter {
             CommitRequest::single(
                 options.commit_id.unwrap_or_else(CommitId::generate),
                 options.message.clone(),
-                FilesystemOperation::CreateDir {
-                    absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                FilesystemOperation::CreateDirectory {
+                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     parents: options.parents,
                 },
             ),
@@ -597,7 +597,7 @@ impl FsWriter {
                 options.commit_id.unwrap_or_else(CommitId::generate),
                 options.message.clone(),
                 FilesystemOperation::DeletePath {
-                    absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     behavior: options.behavior,
                     expected_inode_id: options.expected_inode_id,
                 },
@@ -643,7 +643,7 @@ impl FsWriter {
             CommitRequest::single(
                 options.commit_id.unwrap_or_else(CommitId::generate),
                 options.message.clone(),
-                FilesystemOperation::CopyFilePath {
+                FilesystemOperation::CopyPath {
                     from_path: loonfs_core::path::parse_mutation_path(from_path)?,
                     to_path: loonfs_core::path::parse_mutation_path(to_path)?,
                     behavior: options.behavior,
@@ -667,7 +667,7 @@ impl FsWriter {
                 options.commit_id.unwrap_or_else(CommitId::generate),
                 options.message.clone(),
                 FilesystemOperation::RestoreRevision {
-                    absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     source_revision_no,
                 },
             ),
@@ -694,7 +694,7 @@ impl FsWriter {
                 FilesystemOperation::Undelete {
                     inode_id,
                     deleted_at_seq,
-                    absolute_path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                 },
             ),
         )

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -2,23 +2,25 @@
 //! request-to-options resolutions the server and embedded hosts share.
 //!
 //! The options that also parameterize the HTTP client's identical operations
-//! — [`PutFileOptions`], [`CreateDirectoryOptions`], [`DeleteOptions`] — are
-//! defined once in [`loonfs_api::options`] and re-exported here, so the two
-//! surfaces cannot drift a field apart. What stays defined below is either
-//! runtime-only (maintenance, checkpoints, namespace creation, change-feed
-//! paging) or shaped differently from the client's equivalent.
+//! are defined once in [`loonfs_api::options`] and re-exported here, so the
+//! two surfaces cannot drift a field apart. That is every path operation. What
+//! stays defined below is runtime-only: maintenance, checkpoints, namespace
+//! creation, and change-feed paging.
 //!
 //! Results are the `loonfs-api` wire shapes themselves: the handles return
 //! `MaintenanceStepResponse` and `GcResponse` directly, the same way they
 //! already return `CommitResponse` and `FlushWalResponse`.
 
-use crate::{CommitId, DestinationBehavior, EffectiveLimit, GcConfig};
+use crate::{EffectiveLimit, GcConfig};
 use loonfs_api::v0::{
     CreateCheckpointRequest, GcRequest, MaintenanceStepKind, MaintenanceStepRequest,
 };
 use loonfs_core::publish::WalTailPolicy;
 
-pub use loonfs_api::options::{CreateDirectoryOptions, DeleteOptions, PutFileOptions};
+pub use loonfs_api::options::{
+    CopyOptions, CreateDirectoryOptions, DeleteOptions, MoveOptions, PutFileOptions,
+    RestoreRevisionOptions, UndeleteOptions,
+};
 
 /// Options for one maintenance step.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -112,46 +114,6 @@ impl CreateCheckpointOptions {
 pub struct CreateNamespaceOptions {
     /// If true, creating an already-existing namespace is treated as success.
     pub allow_existing: bool,
-}
-
-/// Options for moving a path.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct MoveOptions {
-    /// Create-only or replace-existing behavior for the destination.
-    pub behavior: DestinationBehavior,
-    /// Optional idempotency key.
-    pub commit_id: Option<CommitId>,
-    /// Annotation recorded on the commit; part of the commit's identity.
-    pub message: Option<String>,
-}
-
-/// Options for copying a file path.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CopyOptions {
-    /// Create-only or replace-existing behavior for the destination.
-    pub behavior: DestinationBehavior,
-    /// Optional idempotency key.
-    pub commit_id: Option<CommitId>,
-    /// Annotation recorded on the commit; part of the commit's identity.
-    pub message: Option<String>,
-}
-
-/// Options for restoring a file revision by path.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct RestoreRevisionOptions {
-    /// Optional idempotency key.
-    pub commit_id: Option<CommitId>,
-    /// Annotation recorded on the commit; part of the commit's identity.
-    pub message: Option<String>,
-}
-
-/// Options for recovering a deleted file or subtree.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct UndeleteOptions {
-    /// Optional idempotency key.
-    pub commit_id: Option<CommitId>,
-    /// Annotation recorded on the commit; part of the commit's identity.
-    pub message: Option<String>,
 }
 
 /// Options for reading the change feed.

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -284,10 +284,10 @@ fn single_live_worker(publisher: &NamespacePublisher) -> bool {
         .is_some_and(|worker| !worker.liveness.is_finished())
 }
 
-/// Yields until the publisher's queue holds candidates the worker has not
-/// taken yet.
-async fn wait_for_queued_candidates(publisher: &NamespacePublisher) {
-    while queued_candidates(&publisher_state(publisher)) == 0 {
+/// Yields until the publisher's queue holds at least `expected` candidates
+/// the worker has not taken yet.
+async fn wait_for_queued_candidates(publisher: &NamespacePublisher, expected: usize) {
+    while queued_candidates(&publisher_state(publisher)) < expected {
         tokio::task::yield_now().await;
     }
 }
@@ -1039,40 +1039,69 @@ async fn mutations_admitted_after_a_queued_delete_wait_behind_it() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let writer = test_writer_with_interval(store.clone(), 400).await;
+    let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
+    let shared = store.clone() as SharedStore;
+    let writer = test_writer(shared.clone()).await;
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("bootstrap");
     let registry = writer.publisher();
 
-    // Warm the namespace: a cold one publishes its first submission
-    // immediately, so truly concurrent submissions could split across
-    // two publications. Inside the pacing interval the open batch
-    // deterministically holds both.
-    registry
-        .submit_commit(
-            namespace_id.clone(),
-            create_directory_request("warmup", "warmup"),
-        )
-        .await
-        .expect("warmup commit");
+    // Hold the cold publication in flight so both concurrent submissions are
+    // deterministically admitted to the pending batch behind it.
+    store.block_next();
+    let warmup = {
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move {
+            registry
+                .submit_commit(namespace_id, create_directory_request("warmup", "warmup"))
+                .await
+        })
+    };
+    store.wait_until_blocked().await;
 
     let request_a = create_directory_request("req-a", "alpha");
     let request_b = create_directory_request("req-b", "beta");
+    let response_a = {
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move { registry.submit_commit(namespace_id, request_a).await })
+    };
+    let response_b = {
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move { registry.submit_commit(namespace_id, request_b).await })
+    };
+    let publisher = registry.publisher_for(&namespace_id).expect("publisher");
+    wait_for_queued_candidates(&publisher, 2).await;
 
-    let (response_a, response_b) = tokio::join!(
-        registry.submit_commit(namespace_id.clone(), request_a),
-        registry.submit_commit(namespace_id.clone(), request_b)
+    store.release();
+    assert_eq!(
+        warmup
+            .await
+            .expect("warmup task")
+            .expect("warmup response")
+            .committed_seq,
+        ChangeSeq(1)
     );
-    assert_eq!(response_a.expect("response a").committed_seq, ChangeSeq(2));
-    assert_eq!(response_b.expect("response b").committed_seq, ChangeSeq(3));
+    let response_a = response_a
+        .await
+        .expect("response a task")
+        .expect("response a");
+    let response_b = response_b
+        .await
+        .expect("response b task")
+        .expect("response b");
+    let mut committed_seqs = [response_a.committed_seq, response_b.committed_seq];
+    committed_seqs.sort_unstable();
+    assert_eq!(committed_seqs, [ChangeSeq(2), ChangeSeq(3)]);
 
     // The warmup published alone; the two concurrent submissions share
     // one segment.
-    let wal_keys = store
+    let wal_keys = shared
         .list_prefix(&wal_segment_prefix("demo"))
         .await
         .expect("list wal");
@@ -1084,9 +1113,10 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn publisher_batches_plain_and_prepared_mutations_together() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let writer = test_writer_with_interval(store.clone(), 400).await;
+    let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
+    let shared = store.clone() as SharedStore;
+    let writer = test_writer(shared.clone()).await;
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
@@ -1106,24 +1136,28 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
         .upload_content(&namespace_id, &upload.upload_id, b"hello")
         .await
         .expect("stage content");
-    let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
+    let catalog = loonfs_core::control::load_namespace_catalog_entry(&shared, &namespace_id)
         .await
         .expect("load namespace catalog");
     let prepared_content =
-        loonfs_core::content::prepare_existing_content_ref(&store, &catalog, staged.content_ref)
+        loonfs_core::content::prepare_existing_content_ref(&shared, &catalog, staged.content_ref)
             .await
             .expect("prepare existing content");
     let registry = writer.publisher();
 
-    // Warm the namespace so the pacing interval deterministically holds
-    // the two concurrent submissions in one batch.
-    registry
-        .submit_commit(
-            namespace_id.clone(),
-            create_directory_request("warmup", "warmup"),
-        )
-        .await
-        .expect("warmup commit");
+    // Hold the cold publication in flight so both concurrent submissions are
+    // deterministically admitted to the pending batch behind it.
+    store.block_next();
+    let warmup = {
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move {
+            registry
+                .submit_commit(namespace_id, create_directory_request("warmup", "warmup"))
+                .await
+        })
+    };
+    store.wait_until_blocked().await;
 
     let plain = create_directory_request("plain-mutation", "alpha");
     let prepared = CommitRequest::single(
@@ -1136,24 +1170,48 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
             expected_revision_no: None,
         },
     );
-    let (plain_response, prepared_response) = tokio::join!(
-        registry.submit_commit(namespace_id.clone(), plain),
-        registry.submit_commit_with_prepared_content(
-            namespace_id.clone(),
-            prepared,
-            vec![prepared_content]
-        )
-    );
-    assert_eq!(
-        plain_response.expect("plain response").committed_seq,
-        ChangeSeq(2)
-    );
-    assert_eq!(
-        prepared_response.expect("prepared response").committed_seq,
-        ChangeSeq(3)
-    );
+    let plain_response = {
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move { registry.submit_commit(namespace_id, plain).await })
+    };
+    let prepared_response = {
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move {
+            registry
+                .submit_commit_with_prepared_content(namespace_id, prepared, vec![prepared_content])
+                .await
+        })
+    };
+    let publisher = registry.publisher_for(&namespace_id).expect("publisher");
+    wait_for_queued_candidates(&publisher, 2).await;
 
-    let wal_keys = store
+    store.release();
+    assert_eq!(
+        warmup
+            .await
+            .expect("warmup task")
+            .expect("warmup response")
+            .committed_seq,
+        ChangeSeq(1)
+    );
+    let plain_response = plain_response
+        .await
+        .expect("plain task")
+        .expect("plain response");
+    let prepared_response = prepared_response
+        .await
+        .expect("prepared task")
+        .expect("prepared response");
+    let mut committed_seqs = [
+        plain_response.committed_seq,
+        prepared_response.committed_seq,
+    ];
+    committed_seqs.sort_unstable();
+    assert_eq!(committed_seqs, [ChangeSeq(2), ChangeSeq(3)]);
+
+    let wal_keys = shared
         .list_prefix(&wal_segment_prefix("demo"))
         .await
         .expect("list wal");
@@ -1285,7 +1343,7 @@ async fn worker_survives_panic_and_processes_later_queue_items() {
         .get(&namespace_id)
         .expect("publisher exists while blocked")
         .clone();
-    wait_for_queued_candidates(&publisher).await;
+    wait_for_queued_candidates(&publisher, 1).await;
 
     store.release_into_panic();
     registry.close_admission();
@@ -1430,7 +1488,7 @@ async fn delete_queued_mid_publish_waits_behind_admitted_work() {
                 .await
         })
     };
-    wait_for_queued_candidates(&publisher).await;
+    wait_for_queued_candidates(&publisher, 1).await;
 
     let delete = {
         let registry = registry.clone();

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -339,8 +339,8 @@ fn create_directory_request(
     CommitRequest::single(
         CommitId::parse(commit_id.into()).expect("valid commit id"),
         None,
-        FilesystemOperation::CreateDir {
-            absolute_path: AbsolutePath::parse(format!("/{}", directory_name.as_ref()))
+        FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse(format!("/{}", directory_name.as_ref()))
                 .expect("valid absolute path"),
             parents: false,
         },
@@ -1130,7 +1130,7 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
         CommitId::parse("prepared-put").expect("valid commit id"),
         None,
         FilesystemOperation::PutFile {
-            absolute_path: AbsolutePath::parse("/file.txt").expect("path"),
+            path: AbsolutePath::parse("/file.txt").expect("path"),
             content_ref: prepared_content.content_ref().clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -116,10 +116,8 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
                     loonfs::CommitId::generate(),
                     None,
                     loonfs::publish::FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse(format!(
-                            "/tree/dir-000000/file-{index:09}.txt"
-                        ))
-                        .expect("path"),
+                        path: AbsolutePath::parse(format!("/tree/dir-000000/file-{index:09}.txt"))
+                            .expect("path"),
                         content_ref: content_ref.clone(),
                         behavior: loonfs::DestinationBehavior::NoReplace,
                         expected_revision_no: None,

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -206,7 +206,7 @@ fn put_request(commit_id: &str, path: &str, content_ref: loonfs::ContentRef) -> 
         CommitId::parse(commit_id).expect("valid commit id"),
         None,
         FilesystemOperation::PutFile {
-            absolute_path: parse_mutation_path(path).expect("valid mutation path"),
+            path: parse_mutation_path(path).expect("valid mutation path"),
             content_ref,
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
@@ -683,7 +683,7 @@ async fn replacing_put_fails_unprepared_without_content_io() {
                 CommitId::parse("unprepared-replace").expect("valid commit id"),
                 None,
                 FilesystemOperation::PutFile {
-                    absolute_path: parse_mutation_path("/file.txt").expect("valid mutation path"),
+                    path: parse_mutation_path("/file.txt").expect("valid mutation path"),
                     content_ref: content_ref.clone(),
                     behavior: DestinationBehavior::Replace,
                     expected_revision_no: None,
@@ -729,7 +729,7 @@ async fn prepared_commit_after_concurrent_preparations_uses_no_publication_conte
     // One request, four puts, three distinct refs: two of the puts share a
     // ref, so one proof covers both.
     let put = |path: &str, content_ref: loonfs::ContentRef| FilesystemOperation::PutFile {
-        absolute_path: parse_mutation_path(path).expect("valid mutation path"),
+        path: parse_mutation_path(path).expect("valid mutation path"),
         content_ref,
         behavior: DestinationBehavior::NoReplace,
         expected_revision_no: None,
@@ -797,7 +797,7 @@ async fn restore_revision_uses_retained_metadata_without_content_io() {
                 CommitId::parse("restore-first-revision").expect("valid commit id"),
                 None,
                 FilesystemOperation::RestoreRevision {
-                    absolute_path: parse_mutation_path("/file.txt").expect("valid mutation path"),
+                    path: parse_mutation_path("/file.txt").expect("valid mutation path"),
                     source_revision_no: RevisionNo(1),
                 },
             ),
@@ -900,8 +900,8 @@ async fn new_rejected_preparation_fails_before_path_planning_without_content_ope
     let intent = CommitRequest::single(
         CommitId::parse("new-rejected").expect("valid commit id"),
         None,
-        FilesystemOperation::CreateDir {
-            absolute_path: parse_mutation_path("/missing/child").expect("valid mutation path"),
+        FilesystemOperation::CreateDirectory {
+            path: parse_mutation_path("/missing/child").expect("valid mutation path"),
             parents: false,
         },
     );
@@ -1068,9 +1068,8 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
                     CommitRequest::single(
                         CommitId::parse("mixed-blocker").expect("valid commit id"),
                         None,
-                        FilesystemOperation::CreateDir {
-                            absolute_path: parse_mutation_path("/hold")
-                                .expect("valid mutation path"),
+                        FilesystemOperation::CreateDirectory {
+                            path: parse_mutation_path("/hold").expect("valid mutation path"),
                             parents: false,
                         },
                     ),

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -494,7 +494,7 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
                         CommitId::parse(commit_id).expect("valid commit id"),
                         None,
                         FilesystemOperation::PutFile {
-                            absolute_path: parse_mutation_path(path).expect("valid mutation path"),
+                            path: parse_mutation_path(path).expect("valid mutation path"),
                             content_ref,
                             behavior: DestinationBehavior::NoReplace,
                             expected_revision_no: None,
@@ -734,8 +734,8 @@ fn a_mutation_request_appears_in_change_feed() {
             CommitRequest::single(
                 commit_id.clone(),
                 Some("create docs".to_owned()),
-                FilesystemOperation::CreateDir {
-                    absolute_path: parse_mutation_path("/docs").expect("valid mutation path"),
+                FilesystemOperation::CreateDirectory {
+                    path: parse_mutation_path("/docs").expect("valid mutation path"),
                     parents: false,
                 },
             ),

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -486,8 +486,8 @@ fn create_directory_request(commit_id: &str, absolute_path: &str) -> CommitReque
     CommitRequest::single(
         CommitId::parse(commit_id).expect("valid commit id"),
         None,
-        FilesystemOperation::CreateDir {
-            absolute_path: parse_mutation_path(absolute_path).expect("valid mutation path"),
+        FilesystemOperation::CreateDirectory {
+            path: parse_mutation_path(absolute_path).expect("valid mutation path"),
             parents: false,
         },
     )

--- a/crates/loonfs/tests/it/publication.rs
+++ b/crates/loonfs/tests/it/publication.rs
@@ -109,7 +109,7 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
             CommitId::parse("parked-second").expect("valid commit id"),
             None,
             FilesystemOperation::PutFile {
-                absolute_path: parse_mutation_path("/b.txt").expect("mutation path"),
+                path: parse_mutation_path("/b.txt").expect("mutation path"),
                 content_ref: prepared_content_ref,
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -177,7 +177,7 @@ async fn warm_phase_request_accounting() {
                     loonfs::CommitId::generate(),
                     None,
                     loonfs::publish::FilesystemOperation::PutFile {
-                        absolute_path: AbsolutePath::parse(format!("/hot/file-{index:05}.txt"))
+                        path: AbsolutePath::parse(format!("/hot/file-{index:05}.txt"))
                             .expect("path"),
                         content_ref: content_ref.clone(),
                         behavior: loonfs::DestinationBehavior::NoReplace,

--- a/crates/loonfs/tests/it/undelete.rs
+++ b/crates/loonfs/tests/it/undelete.rs
@@ -593,16 +593,14 @@ fn undelete_rejects_deletions_from_the_same_commit() {
                 message: None,
                 operations: vec![
                     FilesystemOperation::DeletePath {
-                        absolute_path: parse_mutation_path("/docs/report.txt")
-                            .expect("valid mutation path"),
+                        path: parse_mutation_path("/docs/report.txt").expect("valid mutation path"),
                         behavior: DeleteDirectoryBehavior::Recursive,
                         expected_inode_id: Some(entry.inode_id),
                     },
                     FilesystemOperation::Undelete {
                         inode_id: entry.inode_id,
                         deleted_at_seq: guessed_seq,
-                        absolute_path: parse_mutation_path("/resurrected.txt")
-                            .expect("valid mutation path"),
+                        path: parse_mutation_path("/resurrected.txt").expect("valid mutation path"),
                     },
                 ],
             },


### PR DESCRIPTION
This PR gives the pre-planning commit language one Rust definition.

The problem... One language had three spellings: the public wire enum (`CreateDirectory`, frozen), a core-internal twin (`CreateDir`, free to change), and the fingerprint preimage (`create_dir`, frozen, with its own field order). The core twin's field types were already the api crate's own parsed types, so the server's 67-line translation renamed fields and nothing more. 

The fix...

- The core twin is deleted. Core re-exports `loonfs_api::FilesystemOperation`; every existing public path keeps compiling. Core's `CommitRequest` stays — it is the wire request minus content tokens, and that strip is real layering, now four lines.
- The server translation is gone (net −102 on the seven load-bearing files).
- The preimage enum is untouched, and now carries a guard comment stating that its variant names, field names, and field order are the v0 fingerprint preimage, frozen by the pinned tests below it. The whole wire-to-durable rename now lives in one function, directly above the hashes that freeze it.
- A grep proves the old spellings survive only inside the preimage and its mapping. (`ValidatedOp::CreateDir` elsewhere is a different, post-planning inode-level enum with different fields — not this language.)

The root-path guard stays, by measurement. Removing the server's pre-queue root check would have changed the wire for batches: a root mutation at position 1 would start reporting `details.operation_index = 1` where today it reports none. Both shapes are now pinned by a test, and the guard carries a comment saying it duplicates the planners on purpose. Separate decision for later, flagged: the API text promises `operation_index` on the first failing operation, and this pre-queue rejection is the one place that does not populate it — fixing that is a wire change either way.

"Options"...`MoveOptions`, `CopyOptions`, `RestoreRevisionOptions`, and `UndeleteOptions` move to `loonfs-api::options` beside the three already there. The client's four methods now mirror `FsWriter` signature for signature; its private `CommitOptions` is deleted; the four places the CLI rebuilt embedded option structs by hand are gone. The four types stay four — the module's stated rule is one type per operation, and a doc sentence now says so to keep them from being "simplified" into one.

