### PR TITLE
refactor(grep): manifests publish like everything else

### DIFF
--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -27,9 +27,11 @@ use thiserror::Error;
 /// error instead of a generic decode error. `kind` is deliberately a string
 /// (not an enum) so future kinds remain reportable.
 #[derive(Debug, Deserialize)]
-pub(crate) struct EnvelopeProbe {
-    pub(crate) kind: String,
-    pub(crate) format_version: u32,
+pub struct EnvelopeProbe {
+    /// Durable family declared by the stored object.
+    pub kind: String,
+    /// Family-independent version gate declared by the stored object.
+    pub format_version: u32,
 }
 
 /// Failure vocabulary shared by every envelope codec. Messages are
@@ -104,7 +106,7 @@ pub enum EnvelopeCodecError {
 }
 
 /// Requires the probed kind to be exactly `expected`.
-pub(crate) fn verify_kind(expected: &str, found: &str) -> Result<(), EnvelopeCodecError> {
+pub fn verify_kind(expected: &str, found: &str) -> Result<(), EnvelopeCodecError> {
     if found != expected {
         return Err(EnvelopeCodecError::KindMismatch {
             expected: expected.to_owned(),
@@ -116,11 +118,7 @@ pub(crate) fn verify_kind(expected: &str, found: &str) -> Result<(), EnvelopeCod
 
 /// Requires the probed format version to be exactly what this build writes
 /// for `kind` — no envelope family tolerates version skew.
-pub(crate) fn verify_version(
-    kind: &str,
-    found: u32,
-    supported: u32,
-) -> Result<(), EnvelopeCodecError> {
+pub fn verify_version(kind: &str, found: u32, supported: u32) -> Result<(), EnvelopeCodecError> {
     if found != supported {
         return Err(EnvelopeCodecError::UnsupportedFormatVersion {
             kind: kind.to_owned(),
@@ -132,7 +130,7 @@ pub(crate) fn verify_version(
 }
 
 /// Requires the stored checksum to match the payload bytes as stored.
-pub(crate) fn verify_payload_checksum(
+pub fn verify_payload_checksum(
     expected: &str,
     payload_bytes: &[u8],
 ) -> Result<(), EnvelopeCodecError> {
@@ -149,7 +147,7 @@ pub(crate) fn verify_payload_checksum(
 /// Requires an in-memory envelope's recorded checksum to still match its
 /// payload before encoding — a stale checksum means the caller mutated the
 /// payload without rebuilding the envelope.
-pub(crate) fn verify_checksum_fresh(
+pub fn verify_checksum_fresh(
     checksum: &str,
     payload_bytes: &[u8],
 ) -> Result<(), EnvelopeCodecError> {
@@ -197,9 +195,7 @@ impl From<StrictJsonEnvelopeDocument> for JsonEnvelopeDocument {
 
 /// The `sha256:<hex>` checksum a JSON payload will carry, computed over its
 /// canonical serialization.
-pub(crate) fn json_payload_checksum<T: Serialize>(
-    payload: &T,
-) -> Result<String, EnvelopeCodecError> {
+pub fn json_payload_checksum<T: Serialize>(payload: &T) -> Result<String, EnvelopeCodecError> {
     let bytes = serde_json::to_vec(payload)
         .map_err(|err| EnvelopeCodecError::PayloadEncode(err.to_string()))?;
     Ok(sha256_digest(&bytes))
@@ -208,7 +204,7 @@ pub(crate) fn json_payload_checksum<T: Serialize>(
 /// Encodes one JSON-bodied envelope, validating that the recorded version is
 /// what this build writes for `kind` and that the recorded checksum still
 /// matches the payload.
-pub(crate) fn encode_json_envelope<T: Serialize>(
+pub fn encode_json_envelope<T: Serialize>(
     kind: &str,
     format_version: u32,
     supported_version: u32,
@@ -230,10 +226,13 @@ pub(crate) fn encode_json_envelope<T: Serialize>(
 }
 
 /// A decoded JSON-bodied envelope's shared fields plus its parsed payload.
-pub(crate) struct DecodedJsonEnvelope<T> {
-    pub(crate) format_version: u32,
-    pub(crate) payload_checksum: String,
-    pub(crate) payload: T,
+pub struct DecodedJsonEnvelope<T> {
+    /// Version gate the stored object declared and this build accepted.
+    pub format_version: u32,
+    /// Digest verified against the payload fragment exactly as stored.
+    pub payload_checksum: String,
+    /// The family payload decoded from that verified fragment.
+    pub payload: T,
 }
 
 /// Decodes one JSON-bodied envelope: probe first (kind through
@@ -243,7 +242,7 @@ pub(crate) struct DecodedJsonEnvelope<T> {
 /// `classify_kind` lets a family with a kind registry report unknown kinds
 /// distinctly from mismatched ones; families with one kind pass
 /// [`verify_kind`] directly.
-pub(crate) fn decode_json_envelope<T: DeserializeOwned>(
+pub fn decode_json_envelope<T: DeserializeOwned>(
     bytes: &[u8],
     supported_version: u32,
     classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,
@@ -257,7 +256,7 @@ pub(crate) fn decode_json_envelope<T: DeserializeOwned>(
 /// Immutable envelope families tolerate unknown fields, while mutable control-object envelopes
 /// reject them. A tolerant read followed by rewrite would erase fields the current binary does
 /// not understand.
-pub(crate) fn decode_strict_json_envelope<T: DeserializeOwned>(
+pub fn decode_strict_json_envelope<T: DeserializeOwned>(
     bytes: &[u8],
     supported_version: u32,
     classify_kind: impl FnOnce(&str) -> Result<(), EnvelopeCodecError>,

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -58,9 +58,15 @@ pub mod wire {
     }
 
     pub mod envelope {
-        //! Errors shared by the durable envelope codecs.
+        //! The shared durable envelope codec: probe, validation rules, JSON
+        //! codec, and the one error vocabulary every family reports through.
+        //!
+        //! Published so a durable format outside this crate — a first-party
+        //! extension's own objects — parameterizes the same codec instead of
+        //! copying it and drifting from the rules in section 4 of the format
+        //! spec.
 
-        pub use crate::envelope::EnvelopeCodecError;
+        pub use crate::envelope::*;
     }
 
     pub mod sst_blocks {

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -214,7 +214,8 @@ pub struct DisableGrepIndexResponse {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GrepGcRequest {
     /// Reads this pass may spend before returning with a `next_cursor`.
-    /// Omit to walk the whole grep keyspace in one call.
+    /// Omit to take the same per-pass default the runtime's own collection
+    /// takes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_objects: Option<u64>,
     /// Opaque resume token returned as `next_cursor` by an earlier pass

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -500,8 +500,11 @@ async fn run_admin_index_gc(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &args.target).await?;
     let single_pass = args.max_objects.is_some();
+    // An omitted budget is left omitted: grep resolves it to the same
+    // per-pass default the runtime uses, and one authority for that number
+    // is what keeps a remote pass and an embedded one the same size.
     let mut request = GrepGcRequest {
-        max_objects: Some(args.max_objects.unwrap_or(loonfs::DEFAULT_GC_MAX_OBJECTS)),
+        max_objects: args.max_objects,
         cursor: None,
     };
     let mut response: Option<loonfs_api::v0::GrepGcResponse> = None;

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -1,7 +1,7 @@
 //! Grep-private cache for immutable manifests and decoded segment blocks.
 
 use crate::codec::IndexRow;
-use crate::root::GrepRootState;
+use crate::root::GrepManifestState;
 use loonfs::Recency;
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use std::collections::HashMap;
@@ -27,7 +27,7 @@ pub(crate) struct GrepBlockCacheKey {
 
 #[derive(Debug, Clone)]
 pub(crate) enum DecodedGrepBlock {
-    Manifest(Arc<GrepRootState>),
+    Manifest(Arc<GrepManifestState>),
     Filter(Arc<SegmentFilter>),
     Index(Arc<Vec<SegmentIndexEntry>>),
     Data(Arc<DecodedDataBlock<IndexRow>>),

--- a/crates/loonfs-grep/src/keyspace.rs
+++ b/crates/loonfs-grep/src/keyspace.rs
@@ -36,7 +36,7 @@ pub fn manifests_prefix(namespace_id: &NamespaceId) -> String {
     format!("{}manifests/", namespace_prefix(namespace_id))
 }
 
-/// Key of one immutable, content-derived grep manifest.
+/// Key of one immutable grep manifest, under the id its publisher minted.
 pub fn manifest_key(namespace_id: &NamespaceId, manifest_id: &GrepManifestId) -> String {
     format!(
         "{}{manifest_id}.manifest.json",
@@ -102,10 +102,8 @@ mod tests {
         let namespace_id = namespace_id();
         let segment_id = segment_id();
 
-        let manifest_id = GrepManifestId::parse(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-        )
-        .expect("valid manifest id");
+        let manifest_id = GrepManifestId::parse("gmf_0123456789abcdef0123456789abcdef")
+            .expect("valid manifest id");
 
         assert_eq!(
             namespace_prefix(&namespace_id),
@@ -121,7 +119,7 @@ mod tests {
         );
         assert_eq!(
             manifest_key(&namespace_id, &manifest_id),
-            "namespaces/docs/extensions/grep/manifests/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.manifest.json"
+            "namespaces/docs/extensions/grep/manifests/gmf_0123456789abcdef0123456789abcdef.manifest.json"
         );
         assert_eq!(
             segments_prefix(&namespace_id),
@@ -137,10 +135,8 @@ mod tests {
     fn built_keys_round_trip_through_the_parser() {
         let namespace_id = namespace_id();
         let segment_id = segment_id();
-        let manifest_id = GrepManifestId::parse(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-        )
-        .expect("valid manifest id");
+        let manifest_id = GrepManifestId::parse("gmf_0123456789abcdef0123456789abcdef")
+            .expect("valid manifest id");
 
         assert_eq!(
             parse_key(&root_key(&namespace_id)),
@@ -194,10 +190,8 @@ mod tests {
     fn core_key_parser_ignores_grep_extension_objects() {
         let namespace_id = namespace_id();
         let segment_id = segment_id();
-        let manifest_id = GrepManifestId::parse(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-        )
-        .expect("valid manifest id");
+        let manifest_id = GrepManifestId::parse("gmf_0123456789abcdef0123456789abcdef")
+            .expect("valid manifest id");
 
         for key in [
             root_key(&namespace_id),

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -103,7 +103,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
         else {
             return Ok(MaintenanceProbe::Idle);
         };
-        match root.state().lifecycle() {
+        match root.manifest_state().lifecycle() {
             // Nothing to maintain: the runner forgets this namespace until
             // an enable nudges it back.
             GrepLifecycle::Disabled => Ok(MaintenanceProbe::Idle),

--- a/crates/loonfs-grep/src/root/codec.rs
+++ b/crates/loonfs-grep/src/root/codec.rs
@@ -1,42 +1,45 @@
-//! Versioned JSON envelope codecs for grep root pointers and manifests.
+//! Grep's two durable families, parameterized over the shared envelope codec.
+//!
+//! Grep owns its kinds, its versions, and its payload invariants; the probe,
+//! the checksum rules, and the failure vocabulary are the ones every other
+//! LoonFS durable family reads and writes through.
 
-use super::error::GrepRootCodecError;
-use super::state::{GrepManifestId, GrepRootPointer, GrepRootState};
-use loonfs_api::sha256_digest;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue;
+use super::error::GrepEnvelopeCodecError;
+use super::state::{GrepManifestState, GrepRootPointer};
+use loonfs_api::wire::envelope::{
+    decode_json_envelope, decode_strict_json_envelope, encode_json_envelope, json_payload_checksum,
+    verify_kind, DecodedJsonEnvelope,
+};
 
 /// Durable kind string for a grep root-pointer envelope.
 pub const GREP_ROOT_KIND: &str = "grep_root";
 /// Durable kind string for a grep manifest envelope.
 pub const GREP_MANIFEST_KIND: &str = "grep_manifest";
-/// Durable v1 root-pointer format string. Unknown strings are rejected.
-pub const GREP_ROOT_FORMAT_VERSION: &str = "v1";
-/// Durable v1 manifest format string. Unknown strings are rejected.
-pub const GREP_MANIFEST_FORMAT_VERSION: &str = "v1";
+/// Sole root-pointer format version this build reads and writes.
+pub const GREP_ROOT_FORMAT_VERSION: u32 = 1;
+/// Sole manifest format version this build reads and writes.
+pub const GREP_MANIFEST_FORMAT_VERSION: u32 = 1;
 
 /// Verified in-memory representation of one grep root-pointer envelope.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrepRootEnvelope {
-    format_version: String,
+    format_version: u32,
     payload_checksum: String,
     pointer: GrepRootPointer,
 }
 
 impl GrepRootEnvelope {
     /// Builds a fresh root-pointer envelope over its canonical payload bytes.
-    pub fn from_pointer(pointer: GrepRootPointer) -> Result<Self, GrepRootCodecError> {
-        let payload = payload_bytes(&pointer)?;
+    pub fn from_pointer(pointer: GrepRootPointer) -> Result<Self, GrepEnvelopeCodecError> {
         Ok(Self {
-            format_version: GREP_ROOT_FORMAT_VERSION.to_owned(),
-            payload_checksum: sha256_digest(&payload),
+            format_version: GREP_ROOT_FORMAT_VERSION,
+            payload_checksum: json_payload_checksum(&pointer)?,
             pointer,
         })
     }
 
-    pub fn format_version(&self) -> &str {
-        &self.format_version
+    pub fn format_version(&self) -> u32 {
+        self.format_version
     }
 
     pub fn payload_checksum(&self) -> &str {
@@ -49,259 +52,97 @@ impl GrepRootEnvelope {
 }
 
 /// Verified in-memory representation of one immutable grep manifest.
+///
+/// The envelope describes the bytes and nothing about which object holds
+/// them: a manifest's identity is the key it was written under, which the
+/// root pointer names.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrepManifestEnvelope {
-    format_version: String,
+    format_version: u32,
     payload_checksum: String,
-    manifest_id: GrepManifestId,
-    state: GrepRootState,
+    state: GrepManifestState,
 }
 
 impl GrepManifestEnvelope {
-    /// Builds a manifest whose id is the SHA-256 of its canonical payload.
-    pub fn from_state(state: GrepRootState) -> Result<Self, GrepRootCodecError> {
+    /// Builds a manifest envelope over its canonical payload bytes.
+    pub fn from_state(state: GrepManifestState) -> Result<Self, GrepEnvelopeCodecError> {
         state.validate()?;
-        let payload = payload_bytes(&state)?;
-        let manifest_id = GrepManifestId::for_payload(&payload);
         Ok(Self {
-            format_version: GREP_MANIFEST_FORMAT_VERSION.to_owned(),
-            payload_checksum: manifest_id.payload_checksum(),
-            manifest_id,
+            format_version: GREP_MANIFEST_FORMAT_VERSION,
+            payload_checksum: json_payload_checksum(&state)?,
             state,
         })
     }
 
-    pub fn format_version(&self) -> &str {
-        &self.format_version
+    pub fn format_version(&self) -> u32 {
+        self.format_version
     }
 
     pub fn payload_checksum(&self) -> &str {
         &self.payload_checksum
     }
 
-    pub fn manifest_id(&self) -> &GrepManifestId {
-        &self.manifest_id
-    }
-
-    pub fn state(&self) -> &GrepRootState {
+    pub fn manifest_state(&self) -> &GrepManifestState {
         &self.state
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct EnvelopeProbe {
-    kind: String,
-    format_version: String,
-}
-
-#[derive(Serialize, Deserialize)]
-struct EnvelopeDocument {
-    kind: String,
-    format_version: String,
-    payload_checksum: String,
-    payload: Box<RawValue>,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct StrictEnvelopeDocument {
-    kind: String,
-    format_version: String,
-    payload_checksum: String,
-    payload: Box<RawValue>,
-}
-
-impl From<StrictEnvelopeDocument> for EnvelopeDocument {
-    fn from(document: StrictEnvelopeDocument) -> Self {
-        Self {
-            kind: document.kind,
-            format_version: document.format_version,
-            payload_checksum: document.payload_checksum,
-            payload: document.payload,
-        }
-    }
-}
-
 /// Encodes a root pointer after rechecking its version and checksum.
-pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepRootCodecError> {
-    encode_envelope(
+pub fn encode_grep_root(envelope: &GrepRootEnvelope) -> Result<Vec<u8>, GrepEnvelopeCodecError> {
+    Ok(encode_json_envelope(
         GREP_ROOT_KIND,
+        envelope.format_version,
         GREP_ROOT_FORMAT_VERSION,
-        &envelope.format_version,
         &envelope.payload_checksum,
         &envelope.pointer,
-    )
+    )?)
 }
 
 /// Decodes only the current root-pointer format and verifies exact payload bytes.
-pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepRootCodecError> {
-    let document = decode_strict_document(bytes, GREP_ROOT_KIND, GREP_ROOT_FORMAT_VERSION)?;
-    let pointer: GrepRootPointer = decode_payload(&document)?;
+///
+/// The pointer is a mutable control object, so unknown envelope and payload
+/// fields are corruption: a tolerant read followed by the publication rewrite
+/// would erase what this binary does not understand.
+pub fn decode_grep_root(bytes: &[u8]) -> Result<GrepRootEnvelope, GrepEnvelopeCodecError> {
+    let decoded: DecodedJsonEnvelope<GrepRootPointer> =
+        decode_strict_json_envelope(bytes, GREP_ROOT_FORMAT_VERSION, |found| {
+            verify_kind(GREP_ROOT_KIND, found)
+        })?;
     Ok(GrepRootEnvelope {
-        format_version: document.format_version,
-        payload_checksum: document.payload_checksum,
-        pointer,
+        format_version: decoded.format_version,
+        payload_checksum: decoded.payload_checksum,
+        pointer: decoded.payload,
     })
 }
 
 /// Encodes an immutable manifest after rechecking every boundary invariant.
 pub fn encode_grep_manifest(
     envelope: &GrepManifestEnvelope,
-) -> Result<Vec<u8>, GrepRootCodecError> {
+) -> Result<Vec<u8>, GrepEnvelopeCodecError> {
     envelope.state.validate()?;
-    let bytes = encode_envelope(
+    Ok(encode_json_envelope(
         GREP_MANIFEST_KIND,
+        envelope.format_version,
         GREP_MANIFEST_FORMAT_VERSION,
-        &envelope.format_version,
         &envelope.payload_checksum,
         &envelope.state,
-    )?;
-    let payload = payload_bytes(&envelope.state)?;
-    let actual_id = GrepManifestId::for_payload(&payload);
-    if actual_id != envelope.manifest_id {
-        return Err(GrepRootCodecError::StalePayloadChecksum {
-            checksum: envelope.manifest_id.payload_checksum(),
-            actual: actual_id.payload_checksum(),
-        });
-    }
-    Ok(bytes)
+    )?)
 }
 
-/// Decodes only the current manifest format, verifies it, and derives its id.
-pub fn decode_grep_manifest(bytes: &[u8]) -> Result<GrepManifestEnvelope, GrepRootCodecError> {
-    let document = decode_document(bytes, GREP_MANIFEST_KIND, GREP_MANIFEST_FORMAT_VERSION)?;
-    let state: GrepRootState = decode_payload(&document)?;
-    state.validate()?;
-    let manifest_id = GrepManifestId::for_payload(document.payload.get().as_bytes());
-    if manifest_id.payload_checksum() != document.payload_checksum {
-        return Err(GrepRootCodecError::ChecksumMismatch {
-            expected: document.payload_checksum,
-            actual: manifest_id.payload_checksum(),
-        });
-    }
+/// Decodes only the current manifest format and verifies it.
+///
+/// Manifests are immutable, so additive fields are tolerated: nothing
+/// rewrites these bytes, and a reader that drops what it cannot name loses
+/// nothing durable.
+pub fn decode_grep_manifest(bytes: &[u8]) -> Result<GrepManifestEnvelope, GrepEnvelopeCodecError> {
+    let decoded: DecodedJsonEnvelope<GrepManifestState> =
+        decode_json_envelope(bytes, GREP_MANIFEST_FORMAT_VERSION, |found| {
+            verify_kind(GREP_MANIFEST_KIND, found)
+        })?;
+    decoded.payload.validate()?;
     Ok(GrepManifestEnvelope {
-        format_version: document.format_version,
-        payload_checksum: manifest_id.payload_checksum(),
-        manifest_id,
-        state,
+        format_version: decoded.format_version,
+        payload_checksum: decoded.payload_checksum,
+        state: decoded.payload,
     })
-}
-
-fn encode_envelope<T: Serialize>(
-    kind: &str,
-    supported_version: &str,
-    format_version: &str,
-    payload_checksum: &str,
-    payload: &T,
-) -> Result<Vec<u8>, GrepRootCodecError> {
-    verify_version(format_version, supported_version)?;
-    let payload =
-        serde_json::to_string(payload).map_err(|error| GrepRootCodecError::PayloadEncode {
-            message: error.to_string(),
-        })?;
-    let actual = sha256_digest(payload.as_bytes());
-    if actual != payload_checksum {
-        return Err(GrepRootCodecError::StalePayloadChecksum {
-            checksum: payload_checksum.to_owned(),
-            actual,
-        });
-    }
-    let document = EnvelopeDocument {
-        kind: kind.to_owned(),
-        format_version: format_version.to_owned(),
-        payload_checksum: payload_checksum.to_owned(),
-        payload: RawValue::from_string(payload).map_err(|error| {
-            GrepRootCodecError::PayloadEncode {
-                message: error.to_string(),
-            }
-        })?,
-    };
-    serde_json::to_vec(&document).map_err(|error| GrepRootCodecError::EnvelopeEncode {
-        message: error.to_string(),
-    })
-}
-
-fn decode_document(
-    bytes: &[u8],
-    expected_kind: &str,
-    supported_version: &str,
-) -> Result<EnvelopeDocument, GrepRootCodecError> {
-    decode_probe(bytes, expected_kind, supported_version)?;
-    let document: EnvelopeDocument =
-        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
-            message: error.to_string(),
-        })?;
-    verify_document_checksum(&document)?;
-    Ok(document)
-}
-
-fn decode_strict_document(
-    bytes: &[u8],
-    expected_kind: &str,
-    supported_version: &str,
-) -> Result<EnvelopeDocument, GrepRootCodecError> {
-    decode_probe(bytes, expected_kind, supported_version)?;
-    let document: StrictEnvelopeDocument =
-        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
-            message: error.to_string(),
-        })?;
-    let document = EnvelopeDocument::from(document);
-    verify_document_checksum(&document)?;
-    Ok(document)
-}
-
-fn decode_probe(
-    bytes: &[u8],
-    expected_kind: &str,
-    supported_version: &str,
-) -> Result<(), GrepRootCodecError> {
-    let probe: EnvelopeProbe =
-        serde_json::from_slice(bytes).map_err(|error| GrepRootCodecError::EnvelopeDecode {
-            message: error.to_string(),
-        })?;
-    if probe.kind != expected_kind {
-        return Err(GrepRootCodecError::KindMismatch {
-            expected: expected_kind.to_owned(),
-            found: probe.kind,
-        });
-    }
-    verify_version(&probe.format_version, supported_version)?;
-    Ok(())
-}
-
-fn verify_document_checksum(document: &EnvelopeDocument) -> Result<(), GrepRootCodecError> {
-    let actual = sha256_digest(document.payload.get().as_bytes());
-    if actual != document.payload_checksum {
-        return Err(GrepRootCodecError::ChecksumMismatch {
-            expected: document.payload_checksum.clone(),
-            actual,
-        });
-    }
-    Ok(())
-}
-
-fn decode_payload<T: DeserializeOwned>(
-    document: &EnvelopeDocument,
-) -> Result<T, GrepRootCodecError> {
-    serde_json::from_str(document.payload.get()).map_err(|error| {
-        GrepRootCodecError::PayloadDecode {
-            message: error.to_string(),
-        }
-    })
-}
-
-fn payload_bytes<T: Serialize>(payload: &T) -> Result<Vec<u8>, GrepRootCodecError> {
-    serde_json::to_vec(payload).map_err(|error| GrepRootCodecError::PayloadEncode {
-        message: error.to_string(),
-    })
-}
-
-fn verify_version(found: &str, supported: &str) -> Result<(), GrepRootCodecError> {
-    if found != supported {
-        return Err(GrepRootCodecError::UnsupportedFormatVersion {
-            found: found.to_owned(),
-            supported: supported.to_owned(),
-        });
-    }
-    Ok(())
 }

--- a/crates/loonfs-grep/src/root/error.rs
+++ b/crates/loonfs-grep/src/root/error.rs
@@ -1,6 +1,7 @@
 //! Typed failures for grep root state, encoding, loading, and publication.
 
 use loonfs::StoreFailureClass;
+use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::{IndexSegmentId, NamespaceId};
 use thiserror::Error;
 
@@ -13,7 +14,7 @@ pub struct GrepManifestIdError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
-pub enum GrepRootStateError {
+pub enum GrepManifestStateError {
     #[error("unsupported grep index format version `{found}`: this build supports `{supported}`")]
     UnsupportedIndexFormatVersion { found: u32, supported: u32 },
     #[error("disabled grep root carries query-visible segments")]
@@ -52,27 +53,17 @@ pub enum GrepRootStateError {
     ReorganizeOutputDescriptorMismatch { segment_id: IndexSegmentId },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
+/// Failure encoding or decoding one grep root pointer or manifest.
+///
+/// Envelope-shaped failures are the shared vocabulary every durable family
+/// reports through; only grep's own payload invariants are named here.
+#[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum GrepRootCodecError {
-    #[error("failed to encode grep root payload: {message}")]
-    PayloadEncode { message: String },
-    #[error("failed to encode grep root envelope: {message}")]
-    EnvelopeEncode { message: String },
-    #[error("failed to decode grep root envelope: {message}")]
-    EnvelopeDecode { message: String },
-    #[error("failed to decode grep root payload: {message}")]
-    PayloadDecode { message: String },
-    #[error("grep root kind mismatch: expected `{expected}`, found `{found}`")]
-    KindMismatch { expected: String, found: String },
-    #[error("unsupported grep root format version `{found}`: this build supports `{supported}`")]
-    UnsupportedFormatVersion { found: String, supported: String },
-    #[error("grep root payload checksum mismatch: expected `{expected}`, actual `{actual}`")]
-    ChecksumMismatch { expected: String, actual: String },
-    #[error("grep root checksum `{checksum}` is stale for payload `{actual}`")]
-    StalePayloadChecksum { checksum: String, actual: String },
-    #[error("invalid grep root state: {0}")]
-    InvalidState(#[from] GrepRootStateError),
+pub enum GrepEnvelopeCodecError {
+    #[error(transparent)]
+    Envelope(#[from] EnvelopeCodecError),
+    #[error("invalid grep manifest state: {0}")]
+    InvalidState(#[from] GrepManifestStateError),
     #[error("invalid grep manifest id: {0}")]
     InvalidManifestId(#[from] GrepManifestIdError),
 }

--- a/crates/loonfs-grep/src/root/mod.rs
+++ b/crates/loonfs-grep/src/root/mod.rs
@@ -22,11 +22,13 @@ pub use codec::{
     GrepManifestEnvelope, GrepRootEnvelope, GREP_MANIFEST_FORMAT_VERSION, GREP_MANIFEST_KIND,
     GREP_ROOT_FORMAT_VERSION, GREP_ROOT_KIND,
 };
-pub use error::{GrepManifestIdError, GrepRootCodecError, GrepRootError, GrepRootStateError};
+pub use error::{
+    GrepEnvelopeCodecError, GrepManifestIdError, GrepManifestStateError, GrepRootError,
+};
 pub(crate) use state::ChangeFeedResume;
 pub use state::{
-    GrepIndexState, GrepLifecycle, GrepManifestId, GrepReorganizeState, GrepRootPointer,
-    GrepRootState, GrepSegmentRef, GREP_INDEX_FORMAT_VERSION,
+    GrepIndexState, GrepLifecycle, GrepManifestId, GrepManifestState, GrepReorganizeState,
+    GrepRootPointer, GrepSegmentRef, GREP_INDEX_FORMAT_VERSION,
 };
 pub use store::{
     advance_grep_root, load_grep_manifest, load_grep_root, load_grep_root_pointer, seed_grep_root,

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -1,7 +1,7 @@
 //! Constructor-validated grep manifest payload and its root pointer.
 
-use super::error::{GrepManifestIdError, GrepRootStateError};
-use loonfs_api::sha256_digest;
+use super::error::{GrepManifestIdError, GrepManifestStateError};
+use loonfs_api::generated_id;
 use loonfs_api::wire::sst_blocks::BlockHandle;
 use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, InodeId, NamespaceId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -9,8 +9,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::str::FromStr;
 
-const SHA256_PREFIX: &str = "sha256:";
-const SHA256_HEX_LEN: usize = 64;
+const GREP_MANIFEST_ID_PREFIX: &str = "gmf";
+const GREP_MANIFEST_ID_BODY_LEN: usize = 32;
 
 /// Version of the grep index state nested inside a v1 manifest.
 ///
@@ -21,27 +21,48 @@ const SHA256_HEX_LEN: usize = 64;
 /// apart after the fact.
 pub const GREP_INDEX_FORMAT_VERSION: u32 = 2;
 
-/// Content-derived identity of one immutable grep manifest payload.
+/// Durable object id for one immutable grep manifest candidate.
+///
+/// The id is drawn fresh for every candidate and names *which object*, never
+/// what it contains. A content-derived id would make an identical rebuild
+/// reuse the object an earlier publication left behind, and that reuse is
+/// what lets collection race a publication for a manifest the winner is
+/// about to point at. Integrity evidence rides
+/// [`GrepRootPointer::manifest_payload_checksum`] beside the id.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct GrepManifestId(String);
 
 impl GrepManifestId {
-    /// Parses the manifest id's 64-character lowercase SHA-256 hex form.
+    /// Generates an id no earlier candidate can carry.
+    pub fn generate() -> Self {
+        Self(generated_id(GREP_MANIFEST_ID_PREFIX))
+    }
+
+    /// Parses the `gmf_` marker plus a 32-character lowercase hex body.
     pub fn parse(value: impl AsRef<str>) -> Result<Self, GrepManifestIdError> {
         let value = value.as_ref();
-        if value.len() != SHA256_HEX_LEN {
+        let expected_prefix = format!("{GREP_MANIFEST_ID_PREFIX}_");
+        let Some(body) = value.strip_prefix(&expected_prefix) else {
             return Err(GrepManifestIdError {
                 value: value.to_owned(),
-                reason: format!("must contain exactly {SHA256_HEX_LEN} lowercase hex characters"),
+                reason: format!("must start with `{expected_prefix}`"),
+            });
+        };
+        if body.len() != GREP_MANIFEST_ID_BODY_LEN {
+            return Err(GrepManifestIdError {
+                value: value.to_owned(),
+                reason: format!(
+                    "body must be {GREP_MANIFEST_ID_BODY_LEN} lowercase hex characters"
+                ),
             });
         }
-        if !value
+        if !body
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
         {
             return Err(GrepManifestIdError {
                 value: value.to_owned(),
-                reason: "must contain only lowercase hex characters".to_owned(),
+                reason: "body must contain only lowercase hex characters".to_owned(),
             });
         }
         Ok(Self(value.to_owned()))
@@ -49,20 +70,6 @@ impl GrepManifestId {
 
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-
-    pub(crate) fn for_payload(payload: &[u8]) -> Self {
-        let digest = sha256_digest(payload);
-        Self(
-            digest
-                .strip_prefix(SHA256_PREFIX)
-                .expect("sha256_digest should carry the sha256 prefix")
-                .to_owned(),
-        )
-    }
-
-    pub(crate) fn payload_checksum(&self) -> String {
-        format!("{SHA256_PREFIX}{}", self.0)
     }
 }
 
@@ -128,18 +135,28 @@ impl<'de> Deserialize<'de> for GrepManifestId {
 }
 
 /// Small mutable control payload installed at `extensions/grep/root.json`.
+///
+/// The pointer names the manifest and carries its digest, so the object the
+/// key resolves to is bound to the bytes the publisher installed even though
+/// nothing about the id derives from them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GrepRootPointer {
     namespace_id: NamespaceId,
     manifest_id: GrepManifestId,
+    manifest_payload_checksum: String,
 }
 
 impl GrepRootPointer {
-    pub fn new(namespace_id: NamespaceId, manifest_id: GrepManifestId) -> Self {
+    pub fn new(
+        namespace_id: NamespaceId,
+        manifest_id: GrepManifestId,
+        manifest_payload_checksum: String,
+    ) -> Self {
         Self {
             namespace_id,
             manifest_id,
+            manifest_payload_checksum,
         }
     }
 
@@ -149,6 +166,11 @@ impl GrepRootPointer {
 
     pub fn manifest_id(&self) -> &GrepManifestId {
         &self.manifest_id
+    }
+
+    /// Must equal `payload_checksum` in the referenced manifest envelope.
+    pub fn manifest_payload_checksum(&self) -> &str {
+        &self.manifest_payload_checksum
     }
 }
 
@@ -353,21 +375,21 @@ pub struct GrepSegmentRef {
 /// Fields stay private so every constructed or decoded manifest passes the
 /// inexpensive reorganize/segment and run-allocation checks in [`Self::new`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GrepRootState {
+pub struct GrepManifestState {
     namespace_id: NamespaceId,
     lifecycle: GrepLifecycle,
     index: GrepIndexState,
     segments: Vec<GrepSegmentRef>,
 }
 
-impl GrepRootState {
-    /// Creates a root after validating its cross-field invariants.
+impl GrepManifestState {
+    /// Creates a manifest payload after validating its cross-field invariants.
     pub fn new(
         namespace_id: NamespaceId,
         lifecycle: GrepLifecycle,
         index: GrepIndexState,
         segments: Vec<GrepSegmentRef>,
-    ) -> Result<Self, GrepRootStateError> {
+    ) -> Result<Self, GrepManifestStateError> {
         let state = Self {
             namespace_id,
             lifecycle,
@@ -394,38 +416,38 @@ impl GrepRootState {
         &self.segments
     }
 
-    pub(super) fn validate(&self) -> Result<(), GrepRootStateError> {
+    pub(super) fn validate(&self) -> Result<(), GrepManifestStateError> {
         if self.index.format_version != GREP_INDEX_FORMAT_VERSION {
-            return Err(GrepRootStateError::UnsupportedIndexFormatVersion {
+            return Err(GrepManifestStateError::UnsupportedIndexFormatVersion {
                 found: self.index.format_version,
                 supported: GREP_INDEX_FORMAT_VERSION,
             });
         }
         if matches!(self.lifecycle, GrepLifecycle::Disabled) {
             if !self.segments.is_empty() {
-                return Err(GrepRootStateError::DisabledHasSegments);
+                return Err(GrepManifestStateError::DisabledHasSegments);
             }
             if self.index.reorganize.is_some() {
-                return Err(GrepRootStateError::DisabledHasReorganize);
+                return Err(GrepManifestStateError::DisabledHasReorganize);
             }
         }
 
         let mut by_id = BTreeMap::new();
         for segment in &self.segments {
             if segment.min_row_key > segment.max_row_key {
-                return Err(GrepRootStateError::InvalidSegmentRange {
+                return Err(GrepManifestStateError::InvalidSegmentRange {
                     segment_id: segment.segment_id.clone(),
                 });
             }
             if segment.run_ordinal >= self.index.next_run_ordinal {
-                return Err(GrepRootStateError::UnallocatedSegmentRunOrdinal {
+                return Err(GrepManifestStateError::UnallocatedSegmentRunOrdinal {
                     segment_id: segment.segment_id.clone(),
                     run_ordinal: segment.run_ordinal,
                     next_run_ordinal: self.index.next_run_ordinal,
                 });
             }
             if by_id.insert(&segment.segment_id, segment).is_some() {
-                return Err(GrepRootStateError::DuplicateSegmentId {
+                return Err(GrepManifestStateError::DuplicateSegmentId {
                     segment_id: segment.segment_id.clone(),
                 });
             }
@@ -442,9 +464,9 @@ fn validate_reorganize(
     reorganize: &GrepReorganizeState,
     next_run_ordinal: u64,
     segments: &BTreeMap<&IndexSegmentId, &GrepSegmentRef>,
-) -> Result<(), GrepRootStateError> {
+) -> Result<(), GrepManifestStateError> {
     if reorganize.run_ordinal >= next_run_ordinal {
-        return Err(GrepRootStateError::UnallocatedReorganizeRunOrdinal {
+        return Err(GrepManifestStateError::UnallocatedReorganizeRunOrdinal {
             run_ordinal: reorganize.run_ordinal,
             next_run_ordinal,
         });
@@ -453,12 +475,12 @@ fn validate_reorganize(
     let mut snapshot_ids = BTreeSet::new();
     for segment_id in &reorganize.snapshot_segment_ids {
         if !snapshot_ids.insert(segment_id) {
-            return Err(GrepRootStateError::DuplicateReorganizeSegmentId {
+            return Err(GrepManifestStateError::DuplicateReorganizeSegmentId {
                 segment_id: segment_id.clone(),
             });
         }
         if !segments.contains_key(segment_id) {
-            return Err(GrepRootStateError::MissingReorganizeSnapshotSegment {
+            return Err(GrepManifestStateError::MissingReorganizeSnapshotSegment {
                 segment_id: segment_id.clone(),
             });
         }
@@ -467,18 +489,18 @@ fn validate_reorganize(
     let mut output_ids = BTreeSet::new();
     for segment_id in &reorganize.output_segment_ids {
         if snapshot_ids.contains(segment_id) || !output_ids.insert(segment_id) {
-            return Err(GrepRootStateError::DuplicateReorganizeSegmentId {
+            return Err(GrepManifestStateError::DuplicateReorganizeSegmentId {
                 segment_id: segment_id.clone(),
             });
         }
         let Some(segment) = segments.get(segment_id) else {
-            return Err(GrepRootStateError::MissingReorganizeOutputSegment {
+            return Err(GrepManifestStateError::MissingReorganizeOutputSegment {
                 segment_id: segment_id.clone(),
             });
         };
         if segment.level != reorganize.output_level || segment.run_ordinal != reorganize.run_ordinal
         {
-            return Err(GrepRootStateError::ReorganizeOutputDescriptorMismatch {
+            return Err(GrepManifestStateError::ReorganizeOutputDescriptorMismatch {
                 segment_id: segment_id.clone(),
             });
         }

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -10,7 +10,7 @@ use super::codec::{
     GrepManifestEnvelope, GrepRootEnvelope,
 };
 use super::error::{GrepRootError, Result};
-use super::state::{GrepManifestId, GrepRootPointer, GrepRootState};
+use super::state::{GrepManifestId, GrepManifestState, GrepRootPointer};
 use crate::keyspace::{manifest_key, root_key};
 use bytes::Bytes;
 use loonfs::StoreFailureClass;
@@ -65,8 +65,13 @@ impl LoadedGrepRoot {
         &self.manifest
     }
 
-    pub fn state(&self) -> &GrepRootState {
-        self.manifest.state()
+    /// Object the pointer names, which is the manifest's whole identity.
+    pub fn manifest_id(&self) -> &GrepManifestId {
+        self.pointer.pointer().manifest_id()
+    }
+
+    pub fn manifest_state(&self) -> &GrepManifestState {
+        self.manifest.manifest_state()
     }
 
     pub fn metadata(&self) -> &ObjectMetadata {
@@ -105,13 +110,18 @@ pub async fn load_grep_root_pointer<S: ObjectStore + ?Sized>(
     }))
 }
 
-/// Loads and verifies one immutable manifest when it is present.
+/// Loads the immutable manifest a verified pointer names, when it is present.
+///
+/// The pointer carries the digest of the bytes its publisher installed, so
+/// the object the key resolves to is checked against what the pointer
+/// promised — the same binding a metadata root holds over its namespace
+/// manifest.
 pub async fn load_grep_manifest<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    manifest_id: &GrepManifestId,
+    pointer: &GrepRootPointer,
 ) -> Result<Option<GrepManifestEnvelope>> {
-    let object_key = manifest_key(namespace_id, manifest_id);
+    let object_key = manifest_key(namespace_id, pointer.manifest_id());
     let Some(bytes) = store
         .get(&object_key, None)
         .await
@@ -123,20 +133,21 @@ pub async fn load_grep_manifest<S: ObjectStore + ?Sized>(
         object_key: object_key.clone(),
         message: error.to_string(),
     })?;
-    if envelope.manifest_id() != manifest_id {
+    if envelope.payload_checksum() != pointer.manifest_payload_checksum() {
         return Err(GrepRootError::Corrupt {
             object_key,
             message: format!(
-                "manifest id mismatch: key names `{manifest_id}`, payload derives `{}`",
-                envelope.manifest_id()
+                "manifest payload checksum mismatch: pointer names `{}`, object carries `{}`",
+                pointer.manifest_payload_checksum(),
+                envelope.payload_checksum()
             ),
         });
     }
-    if envelope.state().namespace_id() != namespace_id {
+    if envelope.manifest_state().namespace_id() != namespace_id {
         return Err(GrepRootError::IdentityMismatch {
             object_key,
             expected: namespace_id.clone(),
-            actual: envelope.state().namespace_id().clone(),
+            actual: envelope.manifest_state().namespace_id().clone(),
         });
     }
     Ok(Some(envelope))
@@ -150,11 +161,10 @@ pub async fn load_grep_root<S: ObjectStore + ?Sized>(
     let Some(pointer) = load_grep_root_pointer(store, namespace_id).await? else {
         return Ok(None);
     };
-    let manifest_id = pointer.pointer().manifest_id();
-    let Some(manifest) = load_grep_manifest(store, namespace_id, manifest_id).await? else {
+    let Some(manifest) = load_grep_manifest(store, namespace_id, pointer.pointer()).await? else {
         return Err(GrepRootError::MissingManifest {
             root_key: pointer.object_key.clone(),
-            manifest_key: manifest_key(namespace_id, manifest_id),
+            manifest_key: manifest_key(namespace_id, pointer.pointer().manifest_id()),
         });
     };
     Ok(Some(LoadedGrepRoot { pointer, manifest }))
@@ -166,14 +176,15 @@ pub async fn load_grep_root<S: ObjectStore + ?Sized>(
 /// bytes. Its candidate manifest remains valid derived garbage for GC.
 pub async fn seed_grep_root<S: ObjectStore + ?Sized>(
     store: &S,
-    state: &GrepRootState,
+    state: &GrepManifestState,
 ) -> Result<LoadedGrepRoot> {
     let written = write_grep_manifest(store, state).await?;
     let manifest = written.envelope;
     let object_key = root_key(state.namespace_id());
     let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
         state.namespace_id().clone(),
-        manifest.manifest_id().clone(),
+        written.manifest_id,
+        manifest.payload_checksum().to_owned(),
     ))
     .map_err(|error| corrupt(&object_key, error))?;
     let bytes = encode_grep_root(&envelope).map_err(|error| corrupt(&object_key, error))?;
@@ -204,7 +215,7 @@ pub async fn seed_grep_root<S: ObjectStore + ?Sized>(
 pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
     store: &S,
     current: &LoadedGrepRoot,
-    next: &GrepRootState,
+    next: &GrepManifestState,
 ) -> Result<LoadedGrepRoot> {
     let expected_namespace_id = current.pointer.pointer().namespace_id();
     if next.namespace_id() != expected_namespace_id {
@@ -233,7 +244,8 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
     let written = write_grep_manifest(store, next).await?;
     let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
         next.namespace_id().clone(),
-        written.envelope.manifest_id().clone(),
+        written.manifest_id,
+        written.envelope.payload_checksum().to_owned(),
     ))
     .map_err(|error| corrupt(&current.pointer.object_key, error))?;
     let bytes =
@@ -256,11 +268,6 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
         }
         Err(error) => return Err(store_error(&current.pointer.object_key, &error)),
     };
-    // A content-addressed manifest observed through AlreadyExists may be
-    // deleted by grep GC before this pointer CAS lands. Verify after the CAS;
-    // if GC won, the candidate bytes are still in memory and recreate the
-    // same manifest id before the successful advance is returned.
-    verify_and_heal_advanced_manifest(store, next.namespace_id(), &written).await?;
     Ok(LoadedGrepRoot {
         pointer: LoadedGrepRootPointer {
             object_key: current.pointer.object_key.clone(),
@@ -272,44 +279,37 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
 }
 
 struct WrittenGrepManifest {
+    manifest_id: GrepManifestId,
     envelope: GrepManifestEnvelope,
-    bytes: Bytes,
 }
 
+/// Writes one candidate manifest under an identity nothing has used before.
+///
+/// The fresh id is what makes the write safe to leave alone until the
+/// pointer moves: no earlier publication's object stands at this key, so
+/// grep collection cannot be looking at it, and the grace window covers the
+/// rest of the publication budget.
 async fn write_grep_manifest<S: ObjectStore + ?Sized>(
     store: &S,
-    state: &GrepRootState,
+    state: &GrepManifestState,
 ) -> Result<WrittenGrepManifest> {
     let envelope = GrepManifestEnvelope::from_state(state.clone())
         .map_err(|error| corrupt(&root_key(state.namespace_id()), error))?;
-    let object_key = manifest_key(state.namespace_id(), envelope.manifest_id());
+    let manifest_id = GrepManifestId::generate();
+    let object_key = manifest_key(state.namespace_id(), &manifest_id);
     let bytes =
         Bytes::from(encode_grep_manifest(&envelope).map_err(|error| corrupt(&object_key, error))?);
+    // Create-only plus the byte check stay on this write even though a
+    // random id cannot collide: an occupied key here is corruption, and it
+    // must fail loudly rather than be overwritten.
     store
-        .put_immutable_verified(&object_key, bytes.clone())
+        .put_immutable_verified(&object_key, bytes)
         .await
         .map_err(immutable_write_error)?;
-    Ok(WrittenGrepManifest { envelope, bytes })
-}
-
-async fn verify_and_heal_advanced_manifest<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    written: &WrittenGrepManifest,
-) -> Result<()> {
-    let object_key = manifest_key(namespace_id, written.envelope.manifest_id());
-    if store
-        .head(&object_key)
-        .await
-        .map_err(|error| store_error(&object_key, &error))?
-        .is_some()
-    {
-        return Ok(());
-    }
-    store
-        .put_immutable_verified(&object_key, written.bytes.clone())
-        .await
-        .map_err(immutable_write_error)
+    Ok(WrittenGrepManifest {
+        manifest_id,
+        envelope,
+    })
 }
 
 fn corrupt(object_key: &str, error: impl ToString) -> GrepRootError {

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -12,7 +12,7 @@ use crate::keyspace::{manifest_key, segment_key};
 use crate::query::{plan_pattern, GramPlanOutcome, GramQueryPlan};
 use crate::reads::{published_revision, resolve_batch_size, NamespaceReads};
 use crate::root::{
-    load_grep_manifest, load_grep_root_pointer, ChangeFeedResume, GrepLifecycle, GrepRootState,
+    load_grep_manifest, load_grep_root_pointer, ChangeFeedResume, GrepLifecycle, GrepManifestState,
 };
 use crate::{GrepError, Result};
 use futures::future::{join_all, try_join_all};
@@ -129,7 +129,7 @@ impl GrepIndexSnapshot {
         };
         let manifest_id = pointer.pointer().manifest_id();
         let cache_key = GrepBlockCacheKey {
-            payload_checksum: manifest_id.payload_checksum(),
+            payload_checksum: pointer.pointer().manifest_payload_checksum().to_owned(),
             block_kind: GrepBlockKind::Manifest,
             block_offset: 0,
         };
@@ -148,20 +148,21 @@ impl GrepIndexSnapshot {
                 });
             }
             None => {
-                let manifest = match load_grep_manifest(store, namespace_id, manifest_id).await {
-                    Ok(Some(manifest)) => manifest,
-                    Ok(None) => {
-                        return Self::from_error(GrepError::CorruptIndex {
-                            message: format!(
-                                "grep root `{}` names missing manifest `{}`",
-                                pointer.object_key(),
-                                manifest_key(namespace_id, manifest_id)
-                            ),
-                        });
-                    }
-                    Err(error) => return Self::from_error(error.into()),
-                };
-                let state = Arc::new(manifest.state().clone());
+                let manifest =
+                    match load_grep_manifest(store, namespace_id, pointer.pointer()).await {
+                        Ok(Some(manifest)) => manifest,
+                        Ok(None) => {
+                            return Self::from_error(GrepError::CorruptIndex {
+                                message: format!(
+                                    "grep root `{}` names missing manifest `{}`",
+                                    pointer.object_key(),
+                                    manifest_key(namespace_id, manifest_id)
+                                ),
+                            });
+                        }
+                        Err(error) => return Self::from_error(error.into()),
+                    };
+                let state = Arc::new(manifest.manifest_state().clone());
                 service
                     .block_cache
                     .insert(cache_key, DecodedGrepBlock::Manifest(state.clone()));
@@ -180,7 +181,7 @@ impl GrepIndexSnapshot {
         Self::from_state(&state)
     }
 
-    fn from_state(root: &GrepRootState) -> Self {
+    fn from_state(root: &GrepManifestState) -> Self {
         // Only a steady root has a watermark, and only a watermark makes an
         // index answerable: the other two phases refuse the query outright
         // rather than borrow a sequence they do not own.

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -21,7 +21,7 @@ use crate::keyspace::{
 use crate::reads::{published_revision, NamespaceReads};
 use crate::root::{
     advance_grep_root, load_grep_root, seed_grep_root, ChangeFeedResume, GrepIndexState,
-    GrepLifecycle, GrepReorganizeState, GrepRootError, GrepRootState, GrepSegmentRef,
+    GrepLifecycle, GrepManifestState, GrepReorganizeState, GrepRootError, GrepSegmentRef,
     LoadedGrepRoot,
 };
 use crate::service::is_indexable_text_content;
@@ -31,7 +31,8 @@ use futures::future::try_join_all;
 use futures::StreamExt as _;
 use loonfs::{
     CheckpointFilesPageCursor, CoreError, CreateCheckpointOptions, FsAdmin, FsReader, RuntimeError,
-    StoreFailureClass, METADATA_PUBLICATION_BUDGET_MS,
+    StoreFailureClass, DEFAULT_GC_MAX_OBJECTS, GC_MIN_GRACE_WINDOW_MS,
+    METADATA_PUBLICATION_BUDGET_MS,
 };
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::sst_blocks::{
@@ -60,7 +61,22 @@ pub const GREP_BACKFILL_CHECKPOINT_TTL_MS: u64 = 24 * 60 * 60 * 1000;
 
 /// Unreferenced grep objects receive one hour of unconditional protection
 /// before grep-owned garbage collection may delete them.
+///
+/// The window has to outlast the longest publication that could still be
+/// holding an object it has not yet made reachable. Grep's publications are
+/// bounded by the same [`METADATA_PUBLICATION_BUDGET_MS`] the runtime's own
+/// are, so the runtime's derived floor is the bound grep must clear too.
 pub const GREP_GC_GRACE_WINDOW_MS: u64 = 60 * 60 * 1000;
+
+// The floor is derived from publication budgets and provider bounds rather
+// than chosen, so a window that stopped clearing it is a compile error here
+// instead of an unreproducible delete of an object a publication was about
+// to reference.
+const _: () = assert!(
+    GREP_GC_GRACE_WINDOW_MS >= GC_MIN_GRACE_WINDOW_MS,
+    "grep's grace window must outlast the longest publication that could still \
+     reference an object it has written"
+);
 
 const GREP_BACKFILL_CHECKPOINT_NAME: &str = "loonfs-grep-backfill";
 const GRAM_POSTING_BATCH_TARGET: usize = 256;
@@ -178,8 +194,9 @@ pub enum GrepReorganizeOutcome {
 /// Budgets and resume position for one grep garbage-collection pass.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GrepGcRequest {
-    /// Reads this pass may spend before returning a resume cursor. `None`
-    /// walks the whole grep keyspace in one call.
+    /// Reads this pass may spend before returning a resume cursor. Absent
+    /// resolves to the runtime's own per-pass default, so no caller can ask
+    /// for an unbounded walk by leaving the field out.
     pub max_objects: Option<u64>,
     /// Opaque token an earlier pass over the same namespace returned.
     pub cursor: Option<String>,
@@ -256,9 +273,12 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .await
             .map_err(GrepError::from)?
         {
-            if !matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
+            if !matches!(
+                current.manifest_state().lifecycle(),
+                GrepLifecycle::Disabled
+            ) {
                 return Ok(GrepEnableOutcome::AlreadyEnabled {
-                    state: current.state().lifecycle().clone(),
+                    state: current.manifest_state().lifecycle().clone(),
                 });
             }
         }
@@ -268,21 +288,24 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .await
             .map_err(GrepError::from)?;
         if let Some(current) = &current {
-            if !matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
+            if !matches!(
+                current.manifest_state().lifecycle(),
+                GrepLifecycle::Disabled
+            ) {
                 self.release_checkpoint_if_unreferenced(
                     namespace_id,
                     &checkpoint.checkpoint_id,
-                    current.state(),
+                    current.manifest_state(),
                 )
                 .await?;
                 return Ok(GrepEnableOutcome::AlreadyEnabled {
-                    state: current.state().lifecycle().clone(),
+                    state: current.manifest_state().lifecycle().clone(),
                 });
             }
         }
         let next_run_ordinal = current
             .as_ref()
-            .map_or(0, |root| root.state().index().next_run_ordinal);
+            .map_or(0, |root| root.manifest_state().index().next_run_ordinal);
         let next = backfilling_root(
             namespace_id,
             checkpoint.checkpoint_seq,
@@ -295,7 +318,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         };
         match published {
             Ok(published) => Ok(GrepEnableOutcome::Enabled {
-                state: published.state().lifecycle().clone(),
+                state: published.manifest_state().lifecycle().clone(),
             }),
             Err(GrepRootError::Conflict { .. }) => {
                 self.release_superseded_checkpoint_if_unreferenced(
@@ -319,17 +342,20 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         else {
             return Ok(GrepDisableOutcome::NotEnabled);
         };
-        if matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
+        if matches!(
+            current.manifest_state().lifecycle(),
+            GrepLifecycle::Disabled
+        ) {
             return Ok(GrepDisableOutcome::NotEnabled);
         }
-        let checkpoint_id = match current.state().lifecycle() {
+        let checkpoint_id = match current.manifest_state().lifecycle() {
             GrepLifecycle::Backfilling { checkpoint_id, .. } => Some(checkpoint_id.clone()),
             GrepLifecycle::Steady { .. } | GrepLifecycle::Disabled => None,
         };
-        let next = GrepRootState::new(
+        let next = GrepManifestState::new(
             namespace_id.clone(),
             GrepLifecycle::Disabled,
-            GrepIndexState::new(None, current.state().index().next_run_ordinal),
+            GrepIndexState::new(None, current.manifest_state().index().next_run_ordinal),
             Vec::new(),
         )
         .map_err(core_state_error)?;
@@ -358,12 +384,15 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         else {
             return Ok(build_report(namespace_id, GrepBuildOutcome::NotEnabled));
         };
-        if matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
+        if matches!(
+            current.manifest_state().lifecycle(),
+            GrepLifecycle::Disabled
+        ) {
             return Ok(build_report(namespace_id, GrepBuildOutcome::NotEnabled));
         }
         let reads = self.reads(namespace_id);
 
-        let collected = match current.state().lifecycle() {
+        let collected = match current.manifest_state().lifecycle() {
             GrepLifecycle::Backfilling {
                 target_seq,
                 cursor,
@@ -386,7 +415,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             // about a watermark it does not have.
             Ok(None) => {
                 let built_through_seq = current
-                    .state()
+                    .manifest_state()
                     .lifecycle()
                     .steady_watermark()
                     .map(|(built_through_seq, _)| built_through_seq)
@@ -426,22 +455,25 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .await
             .map_err(GrepError::from)?
             .map_or(GrepLifecycle::Disabled, |root| {
-                root.state().lifecycle().clone()
+                root.manifest_state().lifecycle().clone()
             }))
     }
 
     /// Reads the whole durable root, for a caller that wants the index
     /// bookkeeping beside the lifecycle. `None` where no root exists.
-    pub async fn root_state(&self, namespace_id: &NamespaceId) -> Result<Option<GrepRootState>> {
+    pub async fn root_state(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<Option<GrepManifestState>> {
         Ok(load_grep_root(&self.store, namespace_id)
             .await
             .map_err(GrepError::from)?
-            .map(|root| root.state().clone()))
+            .map(|root| root.manifest_state().clone()))
     }
 
     async fn seed_root(
         &self,
-        state: &GrepRootState,
+        state: &GrepManifestState,
     ) -> std::result::Result<LoadedGrepRoot, GrepRootError> {
         seed_grep_root(&self.store, state).await
     }
@@ -449,7 +481,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     async fn advance_root(
         &self,
         current: &LoadedGrepRoot,
-        next: &GrepRootState,
+        next: &GrepManifestState,
     ) -> std::result::Result<LoadedGrepRoot, GrepRootError> {
         advance_grep_root(&self.store, current, next).await
     }
@@ -485,7 +517,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         &self,
         namespace_id: &NamespaceId,
         checkpoint_id: &CheckpointId,
-        root: &GrepRootState,
+        root: &GrepManifestState,
     ) -> Result<()> {
         if !root_names_checkpoint(root, checkpoint_id) {
             self.release_checkpoint(namespace_id, checkpoint_id).await?;
@@ -502,8 +534,12 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .await
             .map_err(GrepError::from)?;
         if let Some(winner) = winner {
-            self.release_checkpoint_if_unreferenced(namespace_id, checkpoint_id, winner.state())
-                .await
+            self.release_checkpoint_if_unreferenced(
+                namespace_id,
+                checkpoint_id,
+                winner.manifest_state(),
+            )
+            .await
         } else {
             self.release_checkpoint(namespace_id, checkpoint_id).await
         }
@@ -514,7 +550,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         current: &LoadedGrepRoot,
     ) -> Result<GrepBuildReport> {
-        let previous_checkpoint_id = match current.state().lifecycle() {
+        let previous_checkpoint_id = match current.manifest_state().lifecycle() {
             GrepLifecycle::Backfilling { checkpoint_id, .. } => Some(checkpoint_id.clone()),
             GrepLifecycle::Steady { .. } | GrepLifecycle::Disabled => None,
         };
@@ -523,7 +559,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             namespace_id,
             checkpoint.checkpoint_seq,
             checkpoint.checkpoint_id.clone(),
-            current.state().index().next_run_ordinal,
+            current.manifest_state().index().next_run_ordinal,
         )?;
         match self.advance_root(current, &next).await {
             Ok(_) => {
@@ -566,21 +602,21 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             &self.store,
             namespace_id,
             unit.run_seq,
-            current.state().index().next_run_ordinal,
+            current.manifest_state().index().next_run_ordinal,
             rows,
             policy.max_rows_per_segment,
             INDEX_GRAMS_DELTA_LEVEL,
         )
         .await?;
         let segments_written = new_segments.len() as u64;
-        let mut segments = current.state().segments().to_vec();
+        let mut segments = current.manifest_state().segments().to_vec();
         segments.extend(new_segments);
         let next_run_ordinal =
-            current.state().index().next_run_ordinal + u64::from(segments_written > 0);
+            current.manifest_state().index().next_run_ordinal + u64::from(segments_written > 0);
         // A finished backfill turns steady at exactly the sequence its
         // checkpoint captured: the walk answered that state and no other, so
         // the watermark it hands the change feed is the target it reached.
-        let (lifecycle, completed_checkpoint_id) = match current.state().lifecycle() {
+        let (lifecycle, completed_checkpoint_id) = match current.manifest_state().lifecycle() {
             GrepLifecycle::Backfilling {
                 target_seq,
                 checkpoint_id,
@@ -612,10 +648,13 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             GrepLifecycle::Disabled => unreachable!("disabled returned before collection"),
         };
         let materialized = matches!(lifecycle, GrepLifecycle::Steady { .. });
-        let next = GrepRootState::new(
+        let next = GrepManifestState::new(
             namespace_id.clone(),
             lifecycle,
-            GrepIndexState::new(current.state().index().reorganize.clone(), next_run_ordinal),
+            GrepIndexState::new(
+                current.manifest_state().index().reorganize.clone(),
+                next_run_ordinal,
+            ),
             segments,
         )
         .map_err(core_state_error)?;
@@ -657,8 +696,8 @@ fn backfilling_root(
     target_seq: ChangeSeq,
     checkpoint_id: CheckpointId,
     next_run_ordinal: u64,
-) -> Result<GrepRootState> {
-    GrepRootState::new(
+) -> Result<GrepManifestState> {
+    GrepManifestState::new(
         namespace_id.clone(),
         GrepLifecycle::Backfilling {
             target_seq,
@@ -684,7 +723,7 @@ fn rebootstrap_required(error: &GrepError) -> bool {
     )
 }
 
-fn root_names_checkpoint(root: &GrepRootState, checkpoint_id: &CheckpointId) -> bool {
+fn root_names_checkpoint(root: &GrepManifestState, checkpoint_id: &CheckpointId) -> bool {
     matches!(
         root.lifecycle(),
         GrepLifecycle::Backfilling {
@@ -1045,69 +1084,77 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 GrepReorganizeOutcome::NotEnabled,
             ));
         };
-        if matches!(current.state().lifecycle(), GrepLifecycle::Disabled) {
+        if matches!(
+            current.manifest_state().lifecycle(),
+            GrepLifecycle::Disabled
+        ) {
             return Ok(reorganize_report(
                 namespace_id,
                 GrepReorganizeOutcome::NotEnabled,
             ));
         }
-        let (reorganize, next_run_ordinal) = match current.state().index().reorganize.clone() {
-            Some(reorganize) => (reorganize, current.state().index().next_run_ordinal),
-            None => {
-                let l0_runs = distinct_run_ordinals_at_level(
-                    current.state().segments(),
-                    INDEX_GRAMS_DELTA_LEVEL,
-                );
-                let mid_runs = distinct_run_ordinals_at_level(
-                    current.state().segments(),
-                    INDEX_GRAMS_MID_LEVEL,
-                );
-                let (snapshot_segment_ids, output_level) = if l0_runs >= policy.max_l0_runs.get() {
-                    (
-                        current
-                            .state()
-                            .segments()
-                            .iter()
-                            .filter(|segment| segment.level == INDEX_GRAMS_DELTA_LEVEL)
-                            .map(|segment| segment.segment_id.clone())
-                            .collect(),
+        let (reorganize, next_run_ordinal) =
+            match current.manifest_state().index().reorganize.clone() {
+                Some(reorganize) => (
+                    reorganize,
+                    current.manifest_state().index().next_run_ordinal,
+                ),
+                None => {
+                    let l0_runs = distinct_run_ordinals_at_level(
+                        current.manifest_state().segments(),
+                        INDEX_GRAMS_DELTA_LEVEL,
+                    );
+                    let mid_runs = distinct_run_ordinals_at_level(
+                        current.manifest_state().segments(),
                         INDEX_GRAMS_MID_LEVEL,
-                    )
-                } else if mid_runs >= policy.max_mid_runs.get() {
+                    );
+                    let (snapshot_segment_ids, output_level) =
+                        if l0_runs >= policy.max_l0_runs.get() {
+                            (
+                                current
+                                    .manifest_state()
+                                    .segments()
+                                    .iter()
+                                    .filter(|segment| segment.level == INDEX_GRAMS_DELTA_LEVEL)
+                                    .map(|segment| segment.segment_id.clone())
+                                    .collect(),
+                                INDEX_GRAMS_MID_LEVEL,
+                            )
+                        } else if mid_runs >= policy.max_mid_runs.get() {
+                            (
+                                current
+                                    .manifest_state()
+                                    .segments()
+                                    .iter()
+                                    .filter(|segment| segment.level != INDEX_GRAMS_DELTA_LEVEL)
+                                    .map(|segment| segment.segment_id.clone())
+                                    .collect(),
+                                INDEX_GRAMS_BASE_LEVEL,
+                            )
+                        } else {
+                            return Ok(reorganize_report(
+                                namespace_id,
+                                GrepReorganizeOutcome::NotNeeded { l0_runs, mid_runs },
+                            ));
+                        };
                     (
-                        current
-                            .state()
-                            .segments()
-                            .iter()
-                            .filter(|segment| segment.level != INDEX_GRAMS_DELTA_LEVEL)
-                            .map(|segment| segment.segment_id.clone())
-                            .collect(),
-                        INDEX_GRAMS_BASE_LEVEL,
+                        GrepReorganizeState {
+                            snapshot_segment_ids,
+                            output_segment_ids: Vec::new(),
+                            row_key_cursor: String::new(),
+                            output_level,
+                            run_ordinal: current.manifest_state().index().next_run_ordinal,
+                        },
+                        current.manifest_state().index().next_run_ordinal + 1,
                     )
-                } else {
-                    return Ok(reorganize_report(
-                        namespace_id,
-                        GrepReorganizeOutcome::NotNeeded { l0_runs, mid_runs },
-                    ));
-                };
-                (
-                    GrepReorganizeState {
-                        snapshot_segment_ids,
-                        output_segment_ids: Vec::new(),
-                        row_key_cursor: String::new(),
-                        output_level,
-                        run_ordinal: current.state().index().next_run_ordinal,
-                    },
-                    current.state().index().next_run_ordinal + 1,
-                )
-            }
-        };
+                }
+            };
         let snapshot = reorganize
             .snapshot_segment_ids
             .iter()
             .map(|segment_id| {
                 current
-                    .state()
+                    .manifest_state()
                     .segments()
                     .iter()
                     .find(|segment| &segment.segment_id == segment_id)
@@ -1149,7 +1196,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         )
         .await?;
         let segments_written = new_segments.len() as u64;
-        let mut segments = current.state().segments().to_vec();
+        let mut segments = current.manifest_state().segments().to_vec();
         let mut next_reorganize = reorganize.clone();
         next_reorganize.output_segment_ids.extend(
             new_segments
@@ -1167,9 +1214,9 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             next_reorganize.row_key_cursor = merged.next_cursor;
             Some(next_reorganize)
         };
-        let next = GrepRootState::new(
+        let next = GrepManifestState::new(
             namespace_id.clone(),
-            current.state().lifecycle().clone(),
+            current.manifest_state().lifecycle().clone(),
             GrepIndexState::new(reorganize, next_run_ordinal),
             segments,
         )
@@ -1218,7 +1265,11 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             None => GrepGcCursor::initial(namespace_id),
         };
         let mut report = GrepGcReport::default();
-        let mut budget = GcBudget::new(request.max_objects);
+        // An absent budget is the per-pass default, resolved here — the
+        // entry point an operator calls — because that is where the runtime
+        // resolves its own, and one authority is what keeps the two the
+        // same number.
+        let mut budget = GcBudget::new(Some(request.max_objects.unwrap_or(DEFAULT_GC_MAX_OBJECTS)));
         let reads = self.reads(namespace_id);
         // Liveness is decided once per pass — and re-decided per candidate
         // below, which is what authorizes a delete. This first read is
@@ -1300,11 +1351,13 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 budget.charge();
                 Ok(self.delete_if_unreferenced(key, now_ms, report).await?)
             }
-            // Grep segments and manifests are immutable. An identical
-            // rebuild can only recreate the same derived bytes at the same
-            // key; pointer advance verifies and heals its manifest after
-            // CAS, so aged unreachable objects need no condemned state
-            // before deletion.
+            // Grep segments and manifests are immutable and are written
+            // under freshly minted ids, so an unreferenced one is the
+            // leftover of a publication that already ended — no live
+            // publication can be about to point at this key. The grace
+            // window covers the one that has not ended yet, which is why
+            // aged unreachable objects need no condemned state before
+            // deletion.
             NamespaceLiveness::Live => {
                 budget.charge();
                 let root = match load_grep_root(&self.store, namespace_id).await {
@@ -1692,18 +1745,18 @@ async fn live_namespace_probe(reads: &NamespaceReads<'_>) -> Result<()> {
 }
 
 fn live_grep_keys(root: &LoadedGrepRoot) -> BTreeSet<String> {
-    let namespace_id = root.state().namespace_id();
+    let namespace_id = root.manifest_state().namespace_id();
     let mut live = BTreeSet::from([
         root_key(namespace_id),
-        manifest_key(namespace_id, root.manifest_envelope().manifest_id()),
+        manifest_key(namespace_id, root.manifest_id()),
     ]);
     live.extend(
-        root.state()
+        root.manifest_state()
             .segments()
             .iter()
             .map(|segment| segment_key(namespace_id, &segment.segment_id)),
     );
-    if let Some(reorganize) = &root.state().index().reorganize {
+    if let Some(reorganize) = &root.manifest_state().index().reorganize {
         live.extend(
             reorganize
                 .snapshot_segment_ids
@@ -1763,7 +1816,7 @@ fn ensure_publication_budget(timer: &impl MonotonicTimer, started_ms: u64) -> Re
     .into())
 }
 
-fn core_state_error(error: crate::root::GrepRootStateError) -> GrepError {
+fn core_state_error(error: crate::root::GrepManifestStateError) -> GrepError {
     CoreError::Internal(format!("failed to build grep root state: {error}")).into()
 }
 

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -76,7 +76,7 @@ async fn grams_built_through_seq(
         .await
         .expect("load grep root")
         .expect("grep root exists")
-        .state()
+        .manifest_state()
         .lifecycle()
         .steady_watermark()
         .expect("a steady grep root has a watermark")
@@ -249,7 +249,7 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
         .expect("load grep root")
         .expect("grep root exists");
     assert!(matches!(
-        root.state().lifecycle(),
+        root.manifest_state().lifecycle(),
         loonfs_grep::root::GrepLifecycle::Backfilling { .. }
     ));
     let error = host
@@ -440,7 +440,7 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
         .expect("load partial grep root")
         .expect("partial grep root");
     let (partial_seq, partial_event_index) = partial
-        .state()
+        .manifest_state()
         .lifecycle()
         .steady_watermark()
         .expect("the partial root is steady");
@@ -450,7 +450,7 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
         "the first step must stop within the atomic commit"
     );
     let prefix_segment_ids: BTreeSet<_> = partial
-        .state()
+        .manifest_state()
         .segments()
         .iter()
         .map(|segment| segment.segment_id.clone())
@@ -515,14 +515,14 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
         .expect("complete grep root");
     assert_eq!(
         complete
-            .state()
+            .manifest_state()
             .lifecycle()
             .steady_watermark()
             .expect("the complete root is steady"),
         (commit.committed_seq, 0)
     );
     let complete_segment_ids: BTreeSet<_> = complete
-        .state()
+        .manifest_state()
         .segments()
         .iter()
         .map(|segment| segment.segment_id.clone())
@@ -646,7 +646,7 @@ async fn grep_answers_identically_across_tiered_folds() {
         .expect("load grep root")
         .expect("grep root exists");
     let grams_levels: Vec<u32> = root
-        .state()
+        .manifest_state()
         .segments()
         .iter()
         .map(|segment| segment.level)
@@ -1296,7 +1296,7 @@ async fn a_fold_does_not_reuse_grep_private_index_blocks() {
         .expect("load grep root")
         .expect("grep root exists");
     let grams: Vec<(u32, u64)> = root
-        .state()
+        .manifest_state()
         .segments()
         .iter()
         .map(|segment| (segment.level, segment.run_ordinal))
@@ -1467,7 +1467,7 @@ async fn a_cold_fold_fans_out_its_segment_opens_within_the_io_cap() {
         .expect("load grep root")
         .expect("grep root exists");
     let grams: Vec<u32> = root
-        .state()
+        .manifest_state()
         .segments()
         .iter()
         .map(|segment| segment.level)

--- a/crates/loonfs-grep/tests/it/grep_service_differential.rs
+++ b/crates/loonfs-grep/tests/it/grep_service_differential.rs
@@ -217,7 +217,7 @@ async fn gram_segment_levels(
         .await
         .expect("load grep root")
         .expect("grep root exists")
-        .state()
+        .manifest_state()
         .segments()
         .iter()
         .map(|segment| segment.level)

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -18,9 +18,8 @@ use loonfs_grep::keyspace::{
     manifest_key, manifests_prefix, namespace_prefix, root_key, segment_key,
 };
 use loonfs_grep::root::{
-    advance_grep_root, encode_grep_manifest, encode_grep_root, load_grep_root, GrepIndexState,
-    GrepLifecycle, GrepManifestEnvelope, GrepManifestId, GrepRootEnvelope, GrepRootPointer,
-    GrepRootState,
+    advance_grep_root, encode_grep_root, load_grep_root, GrepIndexState, GrepLifecycle,
+    GrepManifestId, GrepManifestState, GrepRootEnvelope, GrepRootPointer,
 };
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepGcReport, GrepGcRequest,
@@ -240,10 +239,10 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
         .await
         .expect("load root")
         .expect("root exists");
-    let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.state().lifecycle() else {
+    let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.manifest_state().lifecycle() else {
         panic!(
             "enable must publish checkpointed backfill: {:?}",
-            root.state()
+            root.manifest_state()
         );
     };
     let checkpoint_id = checkpoint_id.clone();
@@ -286,7 +285,7 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
         .expect("root exists");
     let materialized_segment = segment_key(
         &namespace_id,
-        &materialized_root.state().segments()[0].segment_id,
+        &materialized_root.manifest_state().segments()[0].segment_id,
     );
 
     assert_eq!(
@@ -310,7 +309,7 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
         .expect("load disabled root")
         .expect("disabled root remains");
     assert!(matches!(
-        disabled_root.state().lifecycle(),
+        disabled_root.manifest_state().lifecycle(),
         GrepLifecycle::Disabled
     ));
     assert_eq!(
@@ -329,9 +328,9 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
         .await
         .expect("load re-enabled root")
         .expect("root exists");
-    assert!(root.state().segments().is_empty());
+    assert!(root.manifest_state().segments().is_empty());
     assert!(matches!(
-        root.state().lifecycle(),
+        root.manifest_state().lifecycle(),
         GrepLifecycle::Backfilling { .. }
     ));
     writer.shutdown_background().await.expect("shutdown");
@@ -524,16 +523,19 @@ async fn assert_fresh_backfill_attempt(
         cursor,
         checkpoint_id,
         ..
-    } = root.state().lifecycle()
+    } = root.manifest_state().lifecycle()
     else {
-        panic!("expected a checkpointed backfill: {:?}", root.state());
+        panic!(
+            "expected a checkpointed backfill: {:?}",
+            root.manifest_state()
+        );
     };
     assert_eq!(
         *cursor, None,
         "a rebootstrap restarts the walk from the beginning"
     );
     assert!(
-        root.state().segments().is_empty(),
+        root.manifest_state().segments().is_empty(),
         "a rebootstrap discards the incomplete projection"
     );
     let record = control::checkpoint_record(store, namespace_id, checkpoint_id)
@@ -557,7 +559,7 @@ async fn grep_segment_ids(
         .await
         .expect("load grep root")
         .expect("grep root exists")
-        .state()
+        .manifest_state()
         .segments()
         .iter()
         .map(|segment| segment.segment_id.clone())
@@ -572,7 +574,7 @@ async fn grep_built_through_seq(
         .await
         .expect("load grep root")
         .expect("grep root exists")
-        .state()
+        .manifest_state()
         .lifecycle()
         .steady_watermark()
         .expect("a steady grep root has a watermark")
@@ -951,17 +953,21 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
     );
 
     let missing_manifest_id =
-        GrepManifestId::parse("1111111111111111111111111111111111111111111111111111111111111111")
-            .expect("valid manifest id");
-    write_pointer(&*store, &namespace_id, missing_manifest_id).await;
+        GrepManifestId::parse("gmf_11111111111111111111111111111111").expect("valid manifest id");
+    write_pointer(
+        &*store,
+        &namespace_id,
+        missing_manifest_id,
+        sha256_digest(b"whatever the absent manifest would have carried"),
+    )
+    .await;
     assert_corrupt_index_error(
         "missing manifest",
         new_query(&store, &namespace_id, &request("needle")).await,
     );
 
     let corrupt_manifest_id =
-        GrepManifestId::parse("2222222222222222222222222222222222222222222222222222222222222222")
-            .expect("valid manifest id");
+        GrepManifestId::parse("gmf_22222222222222222222222222222222").expect("valid manifest id");
     store
         .put_overwrite(
             &manifest_key(&namespace_id, &corrupt_manifest_id),
@@ -969,7 +975,13 @@ async fn grep_root_lifecycle_pins_not_materialized_error_surface() {
         )
         .await
         .expect("write corrupt manifest");
-    write_pointer(&*store, &namespace_id, corrupt_manifest_id).await;
+    write_pointer(
+        &*store,
+        &namespace_id,
+        corrupt_manifest_id,
+        sha256_digest(b"corrupt manifest"),
+    )
+    .await;
     assert_corrupt_index_error(
         "corrupt manifest",
         new_query(&store, &namespace_id, &request("needle")).await,
@@ -1011,16 +1023,19 @@ async fn backfilling_root_without_checkpoint_id_is_index_corrupt() {
         .expect("load backfilling root")
         .expect("backfilling root exists");
     let manifest_bytes = store
-        .get(
-            &manifest_key(&namespace_id, root.manifest_envelope().manifest_id()),
-            None,
-        )
+        .get(&manifest_key(&namespace_id, root.manifest_id()), None)
         .await
         .expect("read backfilling manifest")
         .expect("backfilling manifest exists");
-    let corrupt_manifest_id =
+    let (corrupt_manifest_id, corrupt_payload_checksum) =
         write_manifest_without_checkpoint_id(&*store, &namespace_id, &manifest_bytes).await;
-    write_pointer(&*store, &namespace_id, corrupt_manifest_id).await;
+    write_pointer(
+        &*store,
+        &namespace_id,
+        corrupt_manifest_id,
+        corrupt_payload_checksum,
+    )
+    .await;
 
     assert_corrupt_index_error(
         "backfilling manifest missing checkpoint id",
@@ -1033,7 +1048,7 @@ async fn write_manifest_without_checkpoint_id(
     store: &dyn ObjectStore,
     namespace_id: &NamespaceId,
     manifest_bytes: &[u8],
-) -> GrepManifestId {
+) -> (GrepManifestId, String) {
     let mut document: serde_json::Value =
         serde_json::from_slice(manifest_bytes).expect("decode valid manifest document");
     document["payload"]["lifecycle"]
@@ -1045,12 +1060,7 @@ async fn write_manifest_without_checkpoint_id(
         serde_json::to_vec(&document["payload"]).expect("encode corrupt manifest payload");
     let payload_checksum = sha256_digest(&payload_bytes);
     document["payload_checksum"] = serde_json::Value::String(payload_checksum.clone());
-    let manifest_id = GrepManifestId::parse(
-        payload_checksum
-            .strip_prefix("sha256:")
-            .expect("sha256 digest should carry its algorithm prefix"),
-    )
-    .expect("checksum is a valid manifest id");
+    let manifest_id = GrepManifestId::generate();
     store
         .put_overwrite(
             &manifest_key(namespace_id, &manifest_id),
@@ -1058,17 +1068,21 @@ async fn write_manifest_without_checkpoint_id(
         )
         .await
         .expect("write manifest missing checkpoint id");
-    manifest_id
+    (manifest_id, payload_checksum)
 }
 
 async fn write_pointer(
     store: &dyn ObjectStore,
     namespace_id: &NamespaceId,
     manifest_id: GrepManifestId,
+    manifest_payload_checksum: String,
 ) {
-    let envelope =
-        GrepRootEnvelope::from_pointer(GrepRootPointer::new(namespace_id.clone(), manifest_id))
-            .expect("build pointer");
+    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+        namespace_id.clone(),
+        manifest_id,
+        manifest_payload_checksum,
+    ))
+    .expect("build pointer");
     store
         .put_overwrite(
             &root_key(namespace_id),
@@ -1121,7 +1135,7 @@ async fn planless_scan_covers_wal_revisions_at_or_below_index_watermark() {
         .expect("load grep root")
         .expect("grep root exists");
     assert_eq!(
-        grep_root.state().lifecycle().steady_watermark(),
+        grep_root.manifest_state().lifecycle().steady_watermark(),
         Some((head.seq, 0)),
         "the independent worker can advance past metadata materialization"
     );
@@ -1249,7 +1263,7 @@ async fn grep_worker_pins_fold_tail_and_pagination_results() {
         .expect("load root")
         .expect("root exists");
     let levels: BTreeSet<u32> = root
-        .state()
+        .manifest_state()
         .segments()
         .iter()
         .map(|segment| segment.level)
@@ -1351,7 +1365,7 @@ async fn fork_of_grep_enabled_namespace_starts_unmaterialized_without_manifest_s
         .await
         .expect("load source root")
         .expect("source root exists")
-        .state()
+        .manifest_state()
         .clone();
 
     writer
@@ -1396,7 +1410,7 @@ async fn fork_of_grep_enabled_namespace_starts_unmaterialized_without_manifest_s
         .await
         .expect("reload source root")
         .expect("source root still exists")
-        .state()
+        .manifest_state()
         .clone();
     assert_eq!(source_root_after, source_root_before);
     let source_response = new_query(&store, &source, &request("fork needle"))
@@ -1484,14 +1498,22 @@ async fn checkpoint_backfill_matches_incremental_worker_results() {
     writer.shutdown_background().await.expect("shutdown");
 }
 
+/// A collection pass that lands in the middle of a publication leaves the
+/// candidate manifest alone.
+///
+/// The grace window is the whole argument: the candidate was written
+/// moments ago under an id nothing has used before, and grep bounds its own
+/// publications by the same budget the runtime bounds its own by, which is
+/// what the derived grace floor is built from. So a pass that examines the
+/// key before the pointer moves must retain it.
 #[tokio::test]
-async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
+async fn a_publication_in_flight_keeps_its_candidate_through_a_collection_pass() {
     let temp_dir = tempdir().expect("tempdir");
     let base: SharedObjectStore =
         Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
-    let namespace_id = NamespaceId::parse("manifest-heal").expect("namespace id");
+    let namespace_id = NamespaceId::parse("manifest-race").expect("namespace id");
     let writer = FsWriter::builder_with_store(base.clone())
-        .writer_id("manifest-heal-writer")
+        .writer_id("manifest-race-writer")
         .min_publish_interval_ms(0)
         .build()
         .await
@@ -1504,7 +1526,7 @@ async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
         .put_file_bytes(
             &namespace_id,
             "/needle.txt",
-            b"verify and heal needle\n",
+            b"publication race needle\n",
             PutFileOptions::default(),
         )
         .await
@@ -1523,8 +1545,8 @@ async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
         .await
         .expect("load current root")
         .expect("root exists");
-    let current_state = current.state();
-    let next = GrepRootState::new(
+    let current_state = current.manifest_state();
+    let next = GrepManifestState::new(
         namespace_id.clone(),
         current_state.lifecycle().clone(),
         GrepIndexState::new(
@@ -1534,14 +1556,20 @@ async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
         current_state.segments().to_vec(),
     )
     .expect("valid successor state");
-    let candidate = GrepManifestEnvelope::from_state(next.clone()).expect("candidate manifest");
-    let candidate_key = manifest_key(&namespace_id, candidate.manifest_id());
-    base.put_if_absent(
-        &candidate_key,
-        Bytes::from(encode_grep_manifest(&candidate).expect("encode candidate")),
-    )
-    .await
-    .expect("pre-land the content-addressed candidate");
+    let manifests_before = base
+        .list_prefix(&manifests_prefix(&namespace_id))
+        .await
+        .expect("list manifests before the advance");
+    // A clock in the store's own domain: the moment the state this
+    // publication builds on became durable. Everything the publication
+    // itself writes is stamped at or after it.
+    let published_at_ms = base
+        .head(&root_key(&namespace_id))
+        .await
+        .expect("head the installed pointer")
+        .expect("an enabled namespace has a pointer")
+        .last_modified_ms
+        .expect("the local store stamps its objects");
 
     let blocking = Arc::new(BlockingGrepRootCasStore::new(
         base.clone(),
@@ -1553,34 +1581,56 @@ async fn pointer_advance_heals_a_manifest_deleted_after_already_exists() {
         blocking.wait_until_blocked().await;
         let report = worker(&store)
             .await
-            .garbage_collect_namespace(&namespace_id, u64::MAX, &GrepGcRequest::default())
+            .garbage_collect_namespace(&namespace_id, published_at_ms, &GrepGcRequest::default())
             .await;
-        let candidate_after_gc = store.head(&candidate_key).await;
         blocking.unblock();
-        (report, candidate_after_gc)
-    };
-    let (advanced, (report, candidate_after_gc)) = tokio::join!(advance, collect);
-
-    assert!(
         report
-            .expect("grep GC wins the manifest race")
-            .deleted_other_objects
-            >= 1
+    };
+    let (advanced, report) = tokio::join!(advance, collect);
+
+    let report = report.expect("collection pass runs mid-publication");
+    assert_eq!(
+        report.deleted_other_objects, 0,
+        "nothing the publication wrote is old enough to collect"
     );
-    assert!(candidate_after_gc
-        .expect("head candidate after GC")
-        .is_none());
-    advanced.expect("pointer advance verifies and heals its manifest");
+    assert!(
+        report.retained_candidates >= 1,
+        "the unreferenced candidate was examined and kept"
+    );
+    let advanced = advanced.expect("pointer advance completes");
+    let candidate_key = manifest_key(&namespace_id, advanced.manifest_id());
+    assert!(
+        !manifests_before.contains(&candidate_key),
+        "the candidate claimed an object no earlier publication wrote"
+    );
     assert!(store
         .head(&candidate_key)
         .await
-        .expect("head healed manifest")
+        .expect("head published manifest")
         .is_some());
-    let response = new_query(&store, &namespace_id, &request("verify and heal needle"))
+    let response = new_query(&store, &namespace_id, &request("publication race needle"))
         .await
-        .expect("query follows the healed pointer");
+        .expect("query follows the published pointer");
     assert_eq!(response.matches.len(), 1);
     assert_eq!(response.matches[0].absolute_path, "/needle.txt");
+
+    // And the retention above was the grace window, not an inert pass: past
+    // it, the superseded manifest goes and the published one stays.
+    let aged = worker(&store)
+        .await
+        .garbage_collect_namespace(
+            &namespace_id,
+            published_at_ms + GREP_GC_GRACE_WINDOW_MS + 1,
+            &GrepGcRequest::default(),
+        )
+        .await
+        .expect("collection pass after the grace window");
+    assert!(aged.deleted_other_objects >= 1);
+    assert!(store
+        .head(&candidate_key)
+        .await
+        .expect("head published manifest")
+        .is_some());
 }
 
 #[derive(Debug)]
@@ -1701,10 +1751,11 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         .await
         .expect("load live root")
         .expect("root exists");
-    let live_segment_key =
-        segment_key(&live_namespace, &live_root.state().segments()[0].segment_id);
-    let live_manifest_key =
-        manifest_key(&live_namespace, live_root.manifest_envelope().manifest_id());
+    let live_segment_key = segment_key(
+        &live_namespace,
+        &live_root.manifest_state().segments()[0].segment_id,
+    );
+    let live_manifest_key = manifest_key(&live_namespace, live_root.manifest_id());
     let orphan_key = segment_key(&live_namespace, &IndexSegmentId::generate());
     store
         .put(
@@ -1915,7 +1966,7 @@ async fn seed_collectable_namespace(root: &Path, namespace_id: &NamespaceId) -> 
 
 /// Aged, unreferenced segment keys with fixed ids, so two independently
 /// seeded stores hold the same collectable garbage under the same names —
-/// the live segment and manifest ids are content-derived and cannot match.
+/// the live segment and manifest ids are minted and cannot match.
 fn orphan_keys(namespace_id: &NamespaceId) -> Vec<String> {
     (0..6u8)
         .map(|index| {
@@ -1951,9 +2002,9 @@ async fn a_budgeted_grep_collection_walks_everything_an_unbudgeted_one_does() {
         .list_prefix(&namespace_prefix(&namespace_id))
         .await
         .expect("list paged-store keys");
-    // The live segment and manifest ids are content-derived and differ
-    // between the two stores; what must match is how many keys there are
-    // and which of them are collectable.
+    // The live segment and manifest ids are minted and differ between the
+    // two stores; what must match is how many keys there are and which of
+    // them are collectable.
     assert_eq!(
         whole_before.len(),
         paged_before.len(),

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -331,7 +331,7 @@ async fn wait_for_watermark<S: ObjectStore + 'static>(
                 .expect("load grep root")
             {
                 if root
-                    .state()
+                    .manifest_state()
                     .lifecycle()
                     .steady_watermark()
                     .is_some_and(|(reached, _)| reached >= built_through_seq)

--- a/crates/loonfs-grep/tests/it/root_format.rs
+++ b/crates/loonfs-grep/tests/it/root_format.rs
@@ -2,12 +2,14 @@
 
 #![allow(clippy::panic)]
 
+use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::wire::sst_blocks::BlockHandle;
 use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, InodeId};
 use loonfs_grep::root::{
-    decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root, GrepIndexState,
-    GrepLifecycle, GrepManifestEnvelope, GrepReorganizeState, GrepRootCodecError, GrepRootEnvelope,
-    GrepRootPointer, GrepRootState, GrepRootStateError, GrepSegmentRef,
+    decode_grep_manifest, decode_grep_root, encode_grep_manifest, encode_grep_root,
+    GrepEnvelopeCodecError, GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepManifestId,
+    GrepManifestState, GrepManifestStateError, GrepReorganizeState, GrepRootEnvelope,
+    GrepRootPointer, GrepSegmentRef,
 };
 use loonfs_test_support::ids::namespace_id;
 
@@ -15,24 +17,35 @@ use loonfs_test_support::ids::namespace_id;
 // field names, ordering, enum tags, or omission rules must change them
 // deliberately. Together they represent every lifecycle state.
 //
-// The envelope is still `v1`; what version 2 changed is the index state
+// The envelope is version 1; what index version 2 changed is the index state
 // nested inside it, which moved each phase's own watermark into the phase.
-const BACKFILLING_V2: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:5002cd1db3aef16bdc6cc413185add75a3d392f66f80f51a54e37278d413bbdf","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","target_seq":7,"cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":2,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const STEADY_V2: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"next_event_index":5},"index":{"format_version":2,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const DISABLED_V2: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":2,"next_run_ordinal":4},"segments":[]}}"#;
-const ADDITIVE_V2: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:f015075bf0949612b508d5d3a765028264cdbbcb01be060bd997c4d1904621b2","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"future_lifecycle":"ignored"},"index":{"format_version":2,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
+const BACKFILLING_V2: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:5002cd1db3aef16bdc6cc413185add75a3d392f66f80f51a54e37278d413bbdf","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","target_seq":7,"cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":2,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_V2: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"next_event_index":5},"index":{"format_version":2,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const DISABLED_V2: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":2,"next_run_ordinal":4},"segments":[]}}"#;
+const ADDITIVE_V2: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:f015075bf0949612b508d5d3a765028264cdbbcb01be060bd997c4d1904621b2","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"future_lifecycle":"ignored"},"index":{"format_version":2,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
 
-const BACKFILLING_POINTER_V2: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:c5573e40ba68f25bb977c0527efad030fa92eaa6c8303308ce6af5c7a4f6bc5a","payload":{"namespace_id":"docs","manifest_id":"5002cd1db3aef16bdc6cc413185add75a3d392f66f80f51a54e37278d413bbdf"}}"#;
-const STEADY_POINTER_V2: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:ca61e2f34ae4808e7a8de27df7457c3d477d8374c35178982d65512e4a891c74","payload":{"namespace_id":"docs","manifest_id":"b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff"}}"#;
-const DISABLED_POINTER_V2: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:a40f6d8acfcc8a1c11bc625ab46ab782885deb521277943e4ced2a5d74c4ef46","payload":{"namespace_id":"docs","manifest_id":"cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc"}}"#;
-const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":"v1","payload_checksum":"sha256:b09014e32fe81501ef34ca037c33ad6b3cbdf4424a16bd376462f84dd2d1b4bc","payload":{"namespace_id":"docs","manifest_id":"9b347bb59f8d589465bddb1104e57be2d6a3babfe8b54d0fc8721b91f1a8b6ad","future_pointer":true},"future_envelope":{"retained":true}}"#;
+// Pointer ids are minted, not derived, so each fixture names an arbitrary
+// id and carries the digest of the manifest it points at. That pairing is
+// the whole binding between a pointer and its bytes.
+const BACKFILLING_MANIFEST_ID: &str = "gmf_1a2b3c4d5e6f70819a2b3c4d5e6f7081";
+const STEADY_MANIFEST_ID: &str = "gmf_2b3c4d5e6f70819a2b3c4d5e6f708192";
+const DISABLED_MANIFEST_ID: &str = "gmf_3c4d5e6f70819a2b3c4d5e6f70819a2b";
+
+const BACKFILLING_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:00bc51efa86c740e2cef630738b44bbef5a831f81bb10e3e49efbf34225ea6b9","payload":{"namespace_id":"docs","manifest_id":"gmf_1a2b3c4d5e6f70819a2b3c4d5e6f7081","manifest_payload_checksum":"sha256:5002cd1db3aef16bdc6cc413185add75a3d392f66f80f51a54e37278d413bbdf"}}"#;
+const STEADY_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:9ca8910922c6d336cc40c90230b93b3dbea8d1d68b09d7960e9793904124741a","payload":{"namespace_id":"docs","manifest_id":"gmf_2b3c4d5e6f70819a2b3c4d5e6f708192","manifest_payload_checksum":"sha256:b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff"}}"#;
+const DISABLED_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:9f7642267b421acefb82ecf9447d44a0cc775fa18f33391f3767e12f50eeba0c","payload":{"namespace_id":"docs","manifest_id":"gmf_3c4d5e6f70819a2b3c4d5e6f70819a2b","manifest_payload_checksum":"sha256:cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc"}}"#;
+const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:b09014e32fe81501ef34ca037c33ad6b3cbdf4424a16bd376462f84dd2d1b4bc","payload":{"namespace_id":"docs","manifest_id":"gmf_4d5e6f70819a2b3c4d5e6f70819a2b3c","manifest_payload_checksum":"sha256:b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff","future_pointer":true},"future_envelope":{"retained":true}}"#;
+
+// The string spelling every grep envelope carried before the version became
+// a number, kept only to prove it is refused.
+const STRING_VERSION_MANIFEST: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":2,"next_run_ordinal":4},"segments":[]}}"#;
 
 // Version-1 index states, kept only to prove they are refused. Each spelled
 // a backfill's target and a steady index's progress with one field, so a
 // decoder that accepted them could not tell which meaning it had read.
-const BACKFILLING_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:a629f619356fda3c1d5789df1082221494bdec8ae182b6883748c73346a0fae9","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":1,"built_through_seq":7,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const STEADY_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:c7d26cf67191665af1c6985ad742fa9ef36cfe635a6577b4e02d79e112fe02cf","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_event_index":5,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const DISABLED_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
+const BACKFILLING_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:a629f619356fda3c1d5789df1082221494bdec8ae182b6883748c73346a0fae9","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":1,"built_through_seq":7,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:c7d26cf67191665af1c6985ad742fa9ef36cfe635a6577b4e02d79e112fe02cf","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_event_index":5,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const DISABLED_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
 
 #[test]
 fn encoded_manifests_and_pointers_match_frozen_bytes() {
@@ -49,20 +62,36 @@ fn encoded_manifests_and_pointers_match_frozen_bytes() {
                 .expect("manifest JSON is UTF-8");
         assert_eq!(actual, expected);
 
+        let (manifest_id, expected) = match manifest.manifest_state().lifecycle() {
+            GrepLifecycle::Backfilling { .. } => (BACKFILLING_MANIFEST_ID, BACKFILLING_POINTER_V1),
+            GrepLifecycle::Steady { .. } => (STEADY_MANIFEST_ID, STEADY_POINTER_V1),
+            GrepLifecycle::Disabled => (DISABLED_MANIFEST_ID, DISABLED_POINTER_V1),
+        };
         let pointer = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
             namespace_id("docs"),
-            manifest.manifest_id().clone(),
+            GrepManifestId::parse(manifest_id).expect("valid manifest id"),
+            manifest.payload_checksum().to_owned(),
         ))
         .expect("build pointer envelope");
         let actual = String::from_utf8(encode_grep_root(&pointer).expect("encode grep pointer"))
             .expect("pointer JSON is UTF-8");
-        let expected = match manifest.state().lifecycle() {
-            GrepLifecycle::Backfilling { .. } => BACKFILLING_POINTER_V2,
-            GrepLifecycle::Steady { .. } => STEADY_POINTER_V2,
-            GrepLifecycle::Disabled => DISABLED_POINTER_V2,
-        };
         assert_eq!(actual, expected);
     }
+}
+
+/// A manifest's identity is minted, never read out of its bytes, so two
+/// candidates over identical state are two distinct objects.
+#[test]
+fn identical_manifest_state_mints_distinct_ids() {
+    let first = GrepManifestId::generate();
+    let second = GrepManifestId::generate();
+
+    assert_ne!(first, second);
+    assert!(first.as_str().starts_with("gmf_"));
+    assert_eq!(
+        GrepManifestId::parse(first.as_str()).expect("a generated id parses"),
+        first
+    );
 }
 
 /// Every phase survives a round trip carrying exactly its own fields, and
@@ -88,7 +117,7 @@ fn every_lifecycle_phase_round_trips_carrying_only_its_own_position() {
         assert_eq!(
             decode_grep_manifest(&encoded)
                 .expect("decode grep manifest")
-                .state(),
+                .manifest_state(),
             &state
         );
     }
@@ -99,13 +128,16 @@ fn immutable_manifest_decoder_reads_frozen_bytes_with_additive_fields() {
     let decoded =
         decode_grep_manifest(ADDITIVE_V2.as_bytes()).expect("decode additive manifest fixture");
 
-    assert_eq!(decoded.state(), &sample_steady_root(ChangeSeq(11), 0));
+    assert_eq!(
+        decoded.manifest_state(),
+        &sample_steady_root(ChangeSeq(11), 0)
+    );
 }
 
 #[test]
 fn mutable_pointer_payload_rejects_unknown_fields_as_corruption() {
     let mut document: serde_json::Value =
-        serde_json::from_str(STEADY_POINTER_V2).expect("decode pointer fixture");
+        serde_json::from_str(STEADY_POINTER_V1).expect("decode pointer fixture");
     document["payload"]["field_from_the_future"] = serde_json::Value::from(true);
     let payload = serde_json::to_string(&document["payload"]).expect("encode edited payload");
     document["payload_checksum"] =
@@ -117,7 +149,9 @@ fn mutable_pointer_payload_rejects_unknown_fields_as_corruption() {
 
     assert!(matches!(
         decode_grep_root(edited.as_bytes()),
-        Err(GrepRootCodecError::PayloadDecode { .. })
+        Err(GrepEnvelopeCodecError::Envelope(
+            EnvelopeCodecError::PayloadDecode(_)
+        ))
     ));
 }
 
@@ -125,7 +159,32 @@ fn mutable_pointer_payload_rejects_unknown_fields_as_corruption() {
 fn mutable_pointer_envelope_rejects_unknown_fields_as_corruption() {
     assert!(matches!(
         decode_grep_root(ADDITIVE_POINTER_V1.as_bytes()),
-        Err(GrepRootCodecError::EnvelopeDecode { .. })
+        Err(GrepEnvelopeCodecError::Envelope(
+            EnvelopeCodecError::EnvelopeDecode(_)
+        ))
+    ));
+}
+
+/// The envelope version is a number, like every other durable family's.
+/// The string spelling grep used to write is not an older version to be
+/// tolerated — it is not a version at all, and the probe says so.
+#[test]
+fn decoder_rejects_the_string_format_version_without_a_shim() {
+    assert!(matches!(
+        decode_grep_manifest(STRING_VERSION_MANIFEST.as_bytes()),
+        Err(GrepEnvelopeCodecError::Envelope(
+            EnvelopeCodecError::EnvelopeDecode(_)
+        ))
+    ));
+    assert!(matches!(
+        decode_grep_root(
+            STRING_VERSION_MANIFEST
+                .replacen("grep_manifest", "grep_root", 1)
+                .as_bytes()
+        ),
+        Err(GrepEnvelopeCodecError::Envelope(
+            EnvelopeCodecError::EnvelopeDecode(_)
+        ))
     ));
 }
 
@@ -140,8 +199,8 @@ fn mutable_pointer_envelope_rejects_unknown_fields_as_corruption() {
 fn decoder_rejects_version_one_index_state_without_a_shim() {
     assert!(matches!(
         decode_grep_manifest(DISABLED_INDEX_V1.as_bytes()),
-        Err(GrepRootCodecError::InvalidState(
-            GrepRootStateError::UnsupportedIndexFormatVersion {
+        Err(GrepEnvelopeCodecError::InvalidState(
+            GrepManifestStateError::UnsupportedIndexFormatVersion {
                 found: 1,
                 supported: 2
             }
@@ -153,20 +212,22 @@ fn decoder_rejects_version_one_index_state_without_a_shim() {
     for fixture in [BACKFILLING_INDEX_V1, STEADY_INDEX_V1] {
         assert!(matches!(
             decode_grep_manifest(fixture.as_bytes()),
-            Err(GrepRootCodecError::PayloadDecode { .. })
+            Err(GrepEnvelopeCodecError::Envelope(
+                EnvelopeCodecError::PayloadDecode(_)
+            ))
         ));
     }
 }
 
 #[test]
 fn decoder_rejects_unknown_version_without_fallback() {
-    let wrong_version =
-        STEADY_V2.replacen("\"format_version\":\"v1\"", "\"format_version\":\"v7\"", 1);
+    let wrong_version = STEADY_V2.replacen("\"format_version\":1", "\"format_version\":7", 1);
 
     assert!(matches!(
         decode_grep_manifest(wrong_version.as_bytes()),
-        Err(GrepRootCodecError::UnsupportedFormatVersion { found, supported })
-            if found == "v7" && supported == "v1"
+        Err(GrepEnvelopeCodecError::Envelope(
+            EnvelopeCodecError::UnsupportedFormatVersion { kind, found, supported }
+        )) if kind == "grep_manifest" && found == 7 && supported == 1
     ));
 }
 
@@ -176,7 +237,9 @@ fn decoder_rejects_corrupted_checksum() {
 
     assert!(matches!(
         decode_grep_manifest(corrupted.as_bytes()),
-        Err(GrepRootCodecError::ChecksumMismatch { .. })
+        Err(GrepEnvelopeCodecError::Envelope(
+            EnvelopeCodecError::ChecksumMismatch { .. }
+        ))
     ));
 }
 
@@ -186,7 +249,9 @@ fn decoder_rejects_truncated_payload() {
 
     assert!(matches!(
         decode_grep_manifest(truncated),
-        Err(GrepRootCodecError::EnvelopeDecode { .. })
+        Err(GrepEnvelopeCodecError::Envelope(
+            EnvelopeCodecError::EnvelopeDecode(_)
+        ))
     ));
 }
 
@@ -202,7 +267,7 @@ fn constructor_rejects_fold_segment_mismatch() {
     });
 
     assert!(matches!(
-        GrepRootState::new(
+        GrepManifestState::new(
             namespace_id("docs"),
             GrepLifecycle::Steady {
                 built_through_seq: ChangeSeq(7),
@@ -211,11 +276,11 @@ fn constructor_rejects_fold_segment_mismatch() {
             index,
             vec![segment_ref(1, 1, 0, 0)]
         ),
-        Err(GrepRootStateError::MissingReorganizeSnapshotSegment { .. })
+        Err(GrepManifestStateError::MissingReorganizeSnapshotSegment { .. })
     ));
 }
 
-fn sample_backfilling_root() -> GrepRootState {
+fn sample_backfilling_root() -> GrepManifestState {
     let fold = GrepReorganizeState {
         snapshot_segment_ids: vec![segment_id(1), segment_id(2)],
         output_segment_ids: vec![segment_id(3)],
@@ -223,7 +288,7 @@ fn sample_backfilling_root() -> GrepRootState {
         output_level: 1,
         run_ordinal: 3,
     };
-    GrepRootState::new(
+    GrepManifestState::new(
         namespace_id("docs"),
         GrepLifecycle::Backfilling {
             target_seq: ChangeSeq(7),
@@ -241,8 +306,8 @@ fn sample_backfilling_root() -> GrepRootState {
     .expect("valid backfilling root")
 }
 
-fn sample_steady_root(built_through_seq: ChangeSeq, next_event_index: u32) -> GrepRootState {
-    GrepRootState::new(
+fn sample_steady_root(built_through_seq: ChangeSeq, next_event_index: u32) -> GrepManifestState {
+    GrepManifestState::new(
         namespace_id("docs"),
         GrepLifecycle::Steady {
             built_through_seq,
@@ -254,8 +319,8 @@ fn sample_steady_root(built_through_seq: ChangeSeq, next_event_index: u32) -> Gr
     .expect("valid steady root")
 }
 
-fn sample_disabled_root() -> GrepRootState {
-    GrepRootState::new(
+fn sample_disabled_root() -> GrepManifestState {
+    GrepManifestState::new(
         namespace_id("docs"),
         GrepLifecycle::Disabled,
         GrepIndexState::new(None, 4),

--- a/crates/loonfs-grep/tests/it/root_store.rs
+++ b/crates/loonfs-grep/tests/it/root_store.rs
@@ -7,11 +7,11 @@ use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_grep::keyspace::{manifest_key, manifests_prefix, root_key};
 use loonfs_grep::root::{
     advance_grep_root, encode_grep_manifest, encode_grep_root, load_grep_root, seed_grep_root,
-    GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepRootEnvelope, GrepRootError,
-    GrepRootPointer, GrepRootState,
+    GrepIndexState, GrepLifecycle, GrepManifestEnvelope, GrepManifestId, GrepManifestState,
+    GrepRootEnvelope, GrepRootError, GrepRootPointer,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{ObjectStore, PutMode};
+use loonfs_objectstore::{ImmutableWriteError, ObjectStore, PutMode};
 use loonfs_test_support::ids::namespace_id;
 
 #[tokio::test]
@@ -21,10 +21,11 @@ async fn load_rejects_namespace_identity_mismatch() {
     let requested = namespace_id("requested");
     let wrong = root(namespace_id("other"), ChangeSeq(0));
     let manifest = GrepManifestEnvelope::from_state(wrong).expect("manifest envelope");
+    let manifest_id = GrepManifestId::generate();
     let manifest_bytes = encode_grep_manifest(&manifest).expect("encode manifest");
     store
         .put(
-            &manifest_key(&requested, manifest.manifest_id()),
+            &manifest_key(&requested, &manifest_id),
             Bytes::from(manifest_bytes),
             PutMode::CreateIfAbsent,
         )
@@ -32,7 +33,8 @@ async fn load_rejects_namespace_identity_mismatch() {
         .expect("write mismatched manifest");
     let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
         requested.clone(),
-        manifest.manifest_id().clone(),
+        manifest_id,
+        manifest.payload_checksum().to_owned(),
     ))
     .expect("pointer envelope");
     let bytes = encode_grep_root(&envelope).expect("encode pointer");
@@ -64,23 +66,62 @@ async fn seed_succeeds_once_and_second_seed_conflicts() {
     ));
 }
 
-/// A manifest id is the digest of its payload, and the rest of the envelope
-/// is family constants, so this writer cannot produce two different byte
-/// strings for one id. A foreign writer or a damaged object still can, and
-/// the immutable-write byte check is what catches it.
+/// Republishing identical state writes a new object rather than adopting the
+/// one an earlier publication left behind. Nothing about a manifest's key
+/// derives from its bytes, which is what stops collection of an old
+/// candidate from ever reaching a new publication's manifest.
 #[tokio::test]
-async fn same_manifest_id_with_different_envelope_bytes_is_corrupt() {
+async fn identical_state_publishes_a_fresh_manifest_object() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = namespace_id("docs");
+    let successor = root(namespace_id.clone(), ChangeSeq(1));
+    let seeded = seed_grep_root(&store, &root(namespace_id.clone(), ChangeSeq(0)))
+        .await
+        .expect("seed root");
+
+    let first = advance_grep_root(&store, &seeded, &successor)
+        .await
+        .expect("first advance");
+    let second = advance_grep_root(&store, &first, &successor)
+        .await
+        .expect("second advance over identical state");
+
+    assert_eq!(
+        first.manifest_envelope().payload_checksum(),
+        second.manifest_envelope().payload_checksum(),
+        "the two candidates carry the very same bytes"
+    );
+    assert_ne!(
+        first.manifest_id(),
+        second.manifest_id(),
+        "and still occupy different objects"
+    );
+    assert_eq!(
+        store
+            .list_prefix(&manifests_prefix(&namespace_id))
+            .await
+            .expect("list candidate manifests")
+            .len(),
+        3
+    );
+}
+
+/// A manifest key is claimed create-only, so an occupant carrying other
+/// bytes is corruption rather than something to overwrite. A random id
+/// cannot collide, so only a foreign writer or a damaged object gets here.
+#[tokio::test]
+async fn a_manifest_key_occupied_by_other_bytes_is_corrupt() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = LocalFsStore::new(temp_dir.path()).expect("local store");
     let namespace_id = namespace_id("docs");
     let state = root(namespace_id.clone(), ChangeSeq(0));
-
-    // Occupy the manifest key this seed will claim with different bytes.
     let envelope = GrepManifestEnvelope::from_state(state.clone()).expect("manifest envelope");
-    let key = manifest_key(&namespace_id, envelope.manifest_id());
+    let bytes = encode_grep_manifest(&envelope).expect("encode manifest");
+    let manifest_id = GrepManifestId::generate();
     store
         .put(
-            &key,
+            &manifest_key(&namespace_id, &manifest_id),
             Bytes::from_static(b"not the manifest these bytes claim to be"),
             PutMode::Overwrite,
         )
@@ -88,8 +129,13 @@ async fn same_manifest_id_with_different_envelope_bytes_is_corrupt() {
         .expect("plant divergent manifest bytes");
 
     assert!(matches!(
-        seed_grep_root(&store, &state).await,
-        Err(GrepRootError::Corrupt { .. })
+        store
+            .put_immutable_verified(
+                &manifest_key(&namespace_id, &manifest_id),
+                Bytes::from(bytes)
+            )
+            .await,
+        Err(ImmutableWriteError::DifferentObject { .. })
     ));
 }
 
@@ -140,7 +186,7 @@ async fn racing_advancers_have_one_winner_and_loser_can_reload_and_retry() {
         .expect("final load succeeds")
         .expect("root exists");
     assert_eq!(
-        final_root.state().lifecycle().steady_watermark(),
+        final_root.manifest_state().lifecycle().steady_watermark(),
         Some((ChangeSeq(3), 0))
     );
 }
@@ -163,8 +209,8 @@ async fn stale_etag_advance_fails_after_concurrent_advance() {
     ));
 }
 
-fn root(namespace_id: NamespaceId, built_through_seq: ChangeSeq) -> GrepRootState {
-    GrepRootState::new(
+fn root(namespace_id: NamespaceId, built_through_seq: ChangeSeq) -> GrepManifestState {
+    GrepManifestState::new(
         namespace_id,
         GrepLifecycle::Steady {
             built_through_seq,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -623,7 +623,7 @@ async fn built_through_seq(state: &AppState, namespace_id: &NamespaceId) -> Chan
         .await
         .expect("load grep root")
         .expect("an enabled namespace has a grep root")
-        .state()
+        .manifest_state()
         .lifecycle()
         .steady_watermark()
         .expect("a steady grep root has a watermark")
@@ -738,8 +738,7 @@ async fn grep_error_missing_manifest_is_index_corrupt_and_core_reads_survive() {
     let namespace_id = namespace_id("grep-error-missing-manifest");
     let writer = seed_grep_error_namespace(&store, &namespace_id).await;
     let manifest_id =
-        GrepManifestId::parse("1111111111111111111111111111111111111111111111111111111111111111")
-            .expect("manifest id");
+        GrepManifestId::parse("gmf_11111111111111111111111111111111").expect("manifest id");
     write_grep_pointer(&*store, &namespace_id, namespace_id.clone(), manifest_id).await;
     writer.shutdown_background().await.expect("shutdown writer");
 
@@ -754,8 +753,7 @@ async fn grep_error_corrupt_manifest_is_index_corrupt_and_core_reads_survive() {
     let namespace_id = namespace_id("grep-error-manifest");
     let writer = seed_grep_error_namespace(&store, &namespace_id).await;
     let manifest_id =
-        GrepManifestId::parse("2222222222222222222222222222222222222222222222222222222222222222")
-            .expect("manifest id");
+        GrepManifestId::parse("gmf_22222222222222222222222222222222").expect("manifest id");
     store
         .put_overwrite(
             &grep_manifest_key(&namespace_id, &manifest_id),
@@ -777,8 +775,7 @@ async fn grep_error_identity_mismatch_is_index_corrupt_and_core_reads_survive() 
     let namespace_id = namespace_id("grep-error-identity");
     let writer = seed_grep_error_namespace(&store, &namespace_id).await;
     let manifest_id =
-        GrepManifestId::parse("3333333333333333333333333333333333333333333333333333333333333333")
-            .expect("manifest id");
+        GrepManifestId::parse("gmf_33333333333333333333333333333333").expect("manifest id");
     write_grep_pointer(
         &*store,
         &namespace_id,
@@ -2007,9 +2004,14 @@ async fn write_grep_pointer(
     pointer_namespace_id: NamespaceId,
     manifest_id: GrepManifestId,
 ) {
-    let envelope =
-        GrepRootEnvelope::from_pointer(GrepRootPointer::new(pointer_namespace_id, manifest_id))
-            .expect("build grep pointer");
+    // Every caller here injects a fault the load hits before it compares
+    // digests, so any well-formed digest stands in for the real one.
+    let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
+        pointer_namespace_id,
+        manifest_id,
+        loonfs_api::sha256_digest(b"a manifest these tests never reach"),
+    ))
+    .expect("build grep pointer");
     store
         .put_overwrite(
             &grep_root_key(stored_namespace_id),

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -177,7 +177,7 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
         .expect("load disabled root")
         .expect("disabled root");
     assert!(matches!(
-        disabled.state().lifecycle(),
+        disabled.manifest_state().lifecycle(),
         GrepLifecycle::Disabled
     ));
     settle(&lifecycle).await;
@@ -187,7 +187,7 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
                 .await
                 .expect("reload disabled root")
                 .expect("disabled root")
-                .state()
+                .manifest_state()
                 .lifecycle(),
             GrepLifecycle::Disabled
         ),
@@ -289,7 +289,7 @@ async fn first_query_after_restart_resumes_stale_and_mid_backfill_namespaces() {
         .expect("load root")
         .expect("backfill root");
     assert!(matches!(
-        root.state().lifecycle(),
+        root.manifest_state().lifecycle(),
         GrepLifecycle::Backfilling { .. }
     ));
     writer.shutdown_background().await.expect("shutdown writer");
@@ -439,11 +439,11 @@ async fn maintain_only_keeps_the_index_built_without_serving_searches() {
         .expect("load root")
         .expect("maintained root");
     assert!(matches!(
-        root.state().lifecycle(),
+        root.manifest_state().lifecycle(),
         GrepLifecycle::Steady { .. }
     ));
     assert!(
-        !root.state().segments().is_empty(),
+        !root.manifest_state().segments().is_empty(),
         "the index this deployment maintains holds real segments"
     );
     lifecycle.shutdown().await.expect("drain lifecycle");
@@ -576,7 +576,7 @@ async fn lifecycle_of(store: &SharedObjectStore, namespace_id: &NamespaceId) -> 
         .await
         .expect("load grep root")
         .expect("an enabled namespace has a grep root")
-        .state()
+        .manifest_state()
         .lifecycle()
         .clone()
 }

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -120,10 +120,8 @@ mod tests {
             .put_overwrite(&root_key(&namespace_id), Bytes::from_static(b"grep root"))
             .await
             .expect("grep root");
-        let grep_manifest_id = GrepManifestId::parse(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-        )
-        .expect("valid grep manifest id");
+        let grep_manifest_id = GrepManifestId::parse("gmf_0123456789abcdef0123456789abcdef")
+            .expect("valid grep manifest id");
         store
             .put_overwrite(
                 &manifest_key(&namespace_id, &grep_manifest_id),

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -66,7 +66,9 @@ pub use loonfs_api::{
     PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::{MetadataTableCacheConfig, Recency};
-pub use loonfs_core::limits::{DEFAULT_GC_MAX_OBJECTS, METADATA_PUBLICATION_BUDGET_MS};
+pub use loonfs_core::limits::{
+    DEFAULT_GC_MAX_OBJECTS, GC_MIN_GRACE_WINDOW_MS, METADATA_PUBLICATION_BUDGET_MS,
+};
 pub use loonfs_core::{
     BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor,
     CurrentFileState, DeleteNamespaceOptions, Error as CoreError, ErrorCode, ErrorKind, GcConfig,

--- a/docs/design/content-search-index.md
+++ b/docs/design/content-search-index.md
@@ -111,8 +111,9 @@ possible; metadata families keep byte-identical output.
 
 Segments live under
 `namespaces/{namespace}/extensions/grep/segments/`. The small mutable
-`extensions/grep/root.json` pointer names an immutable, content-derived
-manifest under `extensions/grep/manifests/`; that manifest records the
+`extensions/grep/root.json` pointer names an immutable manifest under
+`extensions/grep/manifests/`, minted under a fresh id and bound to the
+pointer by its payload digest; that manifest records the
 query-visible segments, the lifecycle, run-ordinal allocation, and any
 in-progress reorganization snapshot, outputs, and cursor. The pointer and
 manifests are independent of the namespace manifest, so core never has to
@@ -326,13 +327,13 @@ deletion under a reverified tombstone needs no grep-specific condemned state.
 The index job never collects: a build or fold step writes and publishes, and
 reclaiming what it orphaned is a separate operation somebody asks for.
 
-Grep manifests are content-addressed, so two identical builders derive the
-same manifest id. A worker that observes its create-if-absent as already
-present can race GC deleting that unreachable candidate before the worker's
-pointer CAS. Every successful pointer advance therefore HEADs its manifest
-after the CAS and, if absent, re-puts the still-buffered bytes with
-create-if-absent before returning. This verify-and-heal step closes the race
-without adding mutable state to an immutable family.
+Every candidate manifest is written under a freshly minted id, so an
+identical rebuild claims a new object rather than adopting the one an earlier
+publication left behind. That is what keeps collection and publication apart:
+an unreferenced manifest always belongs to a publication that has already
+ended, and the grace window — no shorter than the runtime's derived floor —
+covers the one that has not. The pointer carries the manifest's payload
+digest, so nothing is lost by an id that says nothing about its bytes.
 
 Postings for revisions that later become unobservable are not
 dropped in the first version. They are harmless — verification

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -569,7 +569,7 @@ A representative v0 binding is shown below.
 | Read the grep index's lifecycle | `GET /v0/admin/namespaces/{ns}/grep/index` (one grep root read, no side effects; requires a deployment that maintains the index) |
 | Enable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/enable` (CAS-publishes the independent grep root into checkpointed backfill and nudges the deployment's maintenance runner; requires a deployment that maintains the index; idempotent) |
 | Disable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/disable` (CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
-| Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (one explicit pass over only that namespace's grep extension; `max_objects` bounds the reads it spends and returns a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
+| Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (one explicit pass over only that namespace's grep extension; `max_objects` bounds the reads it spends and defaults to 1024 when omitted, returning a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
 | Probe the store contract | `POST /v0/admin/store/probe` (the one admin route whose subject is the store rather than a namespace; body carries no options today and `{}` is the request; see below) |
 | Scrape metrics | `GET /metrics` (Prometheus text exposition; authorized, unlike the liveness routes — see below) |
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1666,9 +1666,9 @@ Two rules make these envelopes evolvable:
 | --- | --- | --- | --- |
 | WAL segment | `namespace_wal_segment` | CBOR envelope, zstd-compressed; CBOR payload | 1 |
 | Metadata segment | none (section 4.2.1) | block sections, per-block zstd + CRC32C | 1 (via manifest) |
-| Grep root pointer | `grep_root` | JSON, uncompressed | `v1` |
-| Grep manifest | `grep_manifest` | JSON, uncompressed | `v1` |
-| Grep segment | none (section 4.2.2) | block sections, per-block zstd + CRC32C | `v1` (via the grep manifest) |
+| Grep root pointer | `grep_root` | JSON, uncompressed | 1 |
+| Grep manifest | `grep_manifest` | JSON, uncompressed | 1 |
+| Grep segment | none (section 4.2.2) | block sections, per-block zstd + CRC32C | 1 (via the grep manifest) |
 | Namespace manifest | `namespace_manifest` | JSON, uncompressed | 1 |
 | Control objects (head, metadata root, WAL floor) | per-kind snake_case names | JSON, uncompressed | 1 (tracked per kind) |
 | Checkpoint record | `checkpoint_record` | JSON, uncompressed | 1 |
@@ -1720,25 +1720,33 @@ namespaces/{namespace_id}/extensions/grep/
 └── segments/{segment_id}.sst.zst
 ```
 
-`manifest_id` is the 64-character lowercase hex portion of the SHA-256 digest
-of the exact manifest payload fragment. The manifest envelope's
-`payload_checksum` is `sha256:{manifest_id}`. Namespace manifests carry no
+`manifest_id` is `gmf_` followed by 32 lowercase hex characters, drawn fresh
+for every candidate. It names *which object* holds the manifest and says
+nothing about its contents: a content-derived id would make an identical
+rebuild reuse the object an earlier publication left behind, and that reuse
+is what would let collection race a publication for a manifest the winner is
+about to point at. The bytes are bound to the pointer instead, through
+`manifest_payload_checksum`. Namespace manifests carry no
 grep pointer, watermark, lifecycle, or segment references. A fork therefore
 starts without grep state until grep is enabled for the target.
 
 `root.json` is a small mutable pointer envelope with these fields, in order:
 
-- envelope: `kind = "grep_root"`, `format_version = "v1"`,
+- envelope: `kind = "grep_root"`, `format_version = 1`,
   `payload_checksum`, and raw JSON `payload`;
-- payload: `namespace_id` and `manifest_id`.
+- payload: `namespace_id`, `manifest_id`, and `manifest_payload_checksum`,
+  which must equal the named manifest envelope's own `payload_checksum`.
 
 Each immutable manifest has the same envelope grammar with
-`kind = "grep_manifest"` and `format_version = "v1"`. Its payload is the full
+`kind = "grep_manifest"` and `format_version = 1`. Its payload is the full
 grep state: `namespace_id`, `lifecycle`, nested `index` bookkeeping, and the
 `segments` descriptors. Both decoders verify the checksum over the exact
 stored payload fragment before decoding, reject unknown versions and kind
-mismatches without fallback, and validate namespace, manifest-id, lifecycle,
-fold, run-allocation, and segment invariants at every boundary. The mutable
+mismatches without fallback, and validate namespace, lifecycle,
+fold, run-allocation, and segment invariants at every boundary. A manifest
+load additionally requires the loaded envelope's `payload_checksum` to equal
+what the pointer promised, which is the same binding a metadata root holds
+over its namespace manifest. The mutable
 root-pointer decoder rejects unknown envelope and payload fields; the
 immutable manifest decoder tolerates additive fields.
 
@@ -1763,9 +1771,9 @@ A gram-index segment uses the section 4.2.1 block grammar unchanged —
 prefix-compressed data blocks, one bloom filter block, one index block,
 handles and checksums in the grep-manifest descriptor — with a grep-owned row
 payload instead of metadata rows. The tokenizer, row shapes, and posting
-encoding below are frozen by grep format `v1`; their evolution follows the
-rules in section 4.3 and always permits rebuilding this derived work
-(section 6.6).
+encoding below are frozen by grep manifest format version 1; their evolution
+follows the rules in section 4.3 and always permits rebuilding this derived
+work (section 6.6).
 
 - The **tokenizer** is every overlapping three-byte window (gram) of an
   eligible revision's content, after folding ASCII letters to lower case.
@@ -1784,17 +1792,19 @@ rules in section 4.3 and always permits rebuilding this derived work
 - Several rows may carry the same gram (within a segment and across
   segments); readers union their batches.
 
-Publication writes segments first, writes the content-derived manifest with
-create-if-absent semantics, and finally installs `root.json` with one etag
-compare-and-swap (or create-if-absent for the first pointer). A pointer-CAS
-loser's manifest and segments remain unreachable derived garbage; grep GC
-reclaims them after its grace window. Because an identical rebuild derives
-the same manifest id, an AlreadyExists observation can race that collection:
-after a successful pointer CAS, the publisher HEADs the installed manifest
-and re-puts its still-buffered bytes with create-if-absent if GC removed it.
-The pointer is returned only after that verification/heal completes. Query
-readers load the pointer afresh, then load the immutable manifest it names;
-decoded manifests may be cached by manifest id.
+Publication writes segments first, writes the manifest under a freshly minted
+id with create-if-absent semantics, and finally installs `root.json` with one
+etag compare-and-swap (or create-if-absent for the first pointer). A
+pointer-CAS loser's manifest and segments remain unreachable derived garbage;
+grep GC reclaims them after its grace window. Because every candidate is
+written under an id no earlier publication used, an unreferenced manifest is
+always the leftover of a publication that has already ended, and the grace
+window covers the one that has not: it is at least the derived minimum grace
+window ("Garbage collection", rule 1), and grep enforces the same publication
+budget the runtime's own publications do. Query readers load the pointer
+afresh, then load the immutable manifest it names and check its
+`payload_checksum` against the pointer; decoded manifests may be cached by
+that checksum.
 
 The namespace-scoped layout is maintained only when that namespace is named
 by an enable, publish, query, detached assignment, or explicit GC operation;

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4165,7 +4165,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Reads this pass may spend before returning with a `next_cursor`.\nOmit to walk the whole grep keyspace in one call.",
+            "description": "Reads this pass may spend before returning with a `next_cursor`.\nOmit to take the same per-pass default the runtime's own collection\ntakes.",
             "minimum": 0
           }
         }


### PR DESCRIPTION
This PR makes grep publish durable state the way everything else does. 

One envelope codec: The api crate's envelope codec was generic but crate-private, so grep had re-derived it: probe and document types, strict and tolerant decoding, checksum and version checks, and eight re-worded error variants. The codec is now public as `loonfs_api::wire::envelope` (the same exposure as `wire::sst_blocks`, which grep already reuses). Grep's `root/codec.rs` fell from 307 lines to 143: the four grep wrappers now parameterize the shared codec, the strict-pointer / tolerant-manifest split is preserved, and the eight copied error variants collapsed into one `#[from]` of the shared error.

Numeric format versions: The grep envelopes said `"v1"` (a string) while the nested index state said `2` (a number) — both conventions in one document. Both envelope families now use `format_version: 1` as a number, like every other durable family. The old string encoding is rejected outright, with a test. The format.md version table now shows one convention.

Manifests get fresh random ids; the repair protocol dies. A grep manifest's object id was the checksum of its payload. An identical rebuild therefore reused an existing object — which grep GC could delete mid-race — so every publication did a HEAD after the pointer swing and re-wrote the manifest if it had vanished, and kept the manifest bytes buffered just for that rewrite. The race was real and reachable. Now: every candidate mints a fresh `gmf_`-prefixed random id (the same shape as its sibling segment ids), losers are ordinary unreachable garbage inside the grace window, and the heal, the buffered bytes, and the per-publication HEAD are deleted, along with the spec paragraph that made the repair normative. The integrity check the checksum-derived id provided did not disappear: the root pointer now carries `manifest_payload_checksum` beside the id — exactly how core's metadata root binds its manifest — and manifest load verifies it. 
