### PR TITLE
refactor(grep): gc rides the shared plumbing and the runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,6 @@ name = "loonfs-grep"
 version = "0.1.1"
 dependencies = [
  "async-trait",
- "base64",
  "bytes",
  "ciborium",
  "futures",

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -110,10 +110,10 @@ pub use ids::{
 };
 pub use name_policy::name_key_for_display_name;
 pub use pagination::{
-    decode_cursor, encode_cursor, DirectoryPageCursor, EffectiveLimit, FileRevisionsPageCursor,
-    GrepPageCursor, LimitError, Page, PageCursor, PageCursorError, PageRequest, PaginationPolicy,
-    PaginationPolicyError, TrashPageCursor, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT,
-    PAGE_CURSOR_VERSION,
+    decode_cursor, decode_namespace_cursor, encode_cursor, DirectoryPageCursor, EffectiveLimit,
+    FileRevisionsPageCursor, GrepPageCursor, LimitError, NamespaceCursor, NamespaceCursorError,
+    Page, PageCursor, PageCursorError, PageRequest, PaginationPolicy, PaginationPolicyError,
+    TrashPageCursor, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, PAGE_CURSOR_VERSION,
 };
 pub use path::{
     AbsolutePath, DisplayName, PathComponent, PathError, MAX_DISPLAY_NAME_BYTES, MAX_PATH_BYTES,

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -2,7 +2,7 @@
 //! cursors each paginated endpoint round-trips.
 
 use crate::capability::{LIMIT_PAGINATION_DEFAULT, LIMIT_PAGINATION_MAX};
-use crate::{ChangeSeq, InodeId, NameKey, RevisionNo};
+use crate::{ChangeSeq, InodeId, NameKey, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::num::NonZeroU32;
@@ -345,6 +345,60 @@ pub fn decode_cursor<C: PageCursor>(value: &str) -> Result<C, PageCursorError> {
     let envelope: CursorEnvelope<C> = serde_json::from_slice(&bytes)
         .map_err(|error| PageCursorError::InvalidJson(error.to_string()))?;
     Ok(envelope.cursor)
+}
+
+/// A cursor that resumes an enumeration of one namespace's own keyspace.
+///
+/// Maintenance passes walk keys rather than rows, and their cursors are
+/// enumeration shortcuts and nothing else: a pass re-reads whatever
+/// authorizes the work it does, whatever position it resumed from, so a
+/// cursor that is lost or refused costs a repeated walk and never a wrong
+/// decision. What the binding buys is that a token minted for another
+/// namespace, another job, or another key family is refused instead of
+/// quietly skipping the keys between here and wherever it points.
+pub trait NamespaceCursor: PageCursor {
+    /// Namespace whose keyspace this cursor walks.
+    fn namespace_id(&self) -> &NamespaceId;
+
+    /// Key the enumeration stopped at, or `None` at the start.
+    fn last_key(&self) -> Option<&str>;
+
+    /// Prefix every key this cursor may name lies under.
+    fn key_prefix(&self) -> String;
+}
+
+/// Decodes a cursor issued for `expected_namespace_id`'s own keyspace.
+pub fn decode_namespace_cursor<C: NamespaceCursor>(
+    token: &str,
+    expected_namespace_id: &NamespaceId,
+) -> Result<C, NamespaceCursorError> {
+    let cursor: C = decode_cursor(token)?;
+    if cursor.namespace_id() != expected_namespace_id {
+        return Err(NamespaceCursorError::ForeignNamespace);
+    }
+    let prefix = cursor.key_prefix();
+    if cursor
+        .last_key()
+        .is_some_and(|key| !key.starts_with(&prefix))
+    {
+        return Err(NamespaceCursorError::OutsideKeyspace);
+    }
+    Ok(cursor)
+}
+
+/// Why a namespace-bound cursor cannot resume the enumeration replaying it.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NamespaceCursorError {
+    /// Not a cursor this enumeration issued: unreadable, or from another
+    /// endpoint, job, or cursor version.
+    #[error(transparent)]
+    Malformed(#[from] PageCursorError),
+    /// A cursor for a different namespace than the one replaying it.
+    #[error("cursor belongs to a different namespace")]
+    ForeignNamespace,
+    /// A cursor naming a key outside the prefix its enumeration walks.
+    #[error("cursor names a key outside the enumeration it resumes")]
+    OutsideKeyspace,
 }
 
 /// Invalid opaque page cursor.

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -170,8 +170,9 @@ Maintenance
   loonfs admin run --namespace <ns>... [--job <job>...] [--drain] [--max-steps <n>] [--deadline-ms <ms>]
     Host maintenance for the namespaces named here, continuously until a
     signal; nothing discovers namespaces, so at least one --namespace is
-    required. --job selects `metadata`, `core-gc`, or `grep-index`, all
-    three when omitted. --drain catches every assigned namespace up and
+    required. --job selects `metadata`, `core-gc`, `grep-index`, or
+    `grep-gc`, all four when omitted. --drain catches every assigned
+    namespace up and
     exits instead, which suits cron, and --max-steps or --deadline-ms bound
     the drain, exit nonzero, and report where every namespace stopped
 

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -688,6 +688,8 @@ pub(crate) enum MaintenanceJobArg {
     CoreGc,
     /// Build and fold the gram content index.
     GrepIndex,
+    /// Reclaim one namespace's unreferenced grep objects per step.
+    GrepGc,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -27,8 +27,9 @@ use loonfs_api::{
 };
 use loonfs_client::NamespacePath;
 use loonfs_grep::{
-    GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepIndexSnapshot,
-    GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads, GREP_INDEX_JOB,
+    GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepGcJob,
+    GrepIndexSnapshot, GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads, GREP_GC_JOB,
+    GREP_INDEX_JOB,
 };
 use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, StoreProbeReport};
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
@@ -378,6 +379,11 @@ impl EmbeddedBackend {
                     self.grep_worker(),
                     GramIndexBuildPolicy::default(),
                 )))
+                .map_err(map_runtime_error)?;
+        }
+        if jobs.contains(&GREP_GC_JOB) {
+            self.writer
+                .register_maintenance_job(Arc::new(GrepGcJob::new(self.grep_worker())))
                 .map_err(map_runtime_error)?;
         }
         jobs.iter()

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -17,7 +17,7 @@ use loonfs_api::{
     ChangeSeq, CheckpointId, CreateCheckpointRequest, ErrorCode, GcRequest, MaintenanceStepKind,
     MaintenanceStepRequest,
 };
-use loonfs_grep::GREP_INDEX_JOB;
+use loonfs_grep::{GREP_GC_JOB, GREP_INDEX_JOB};
 use std::collections::BTreeSet;
 
 // --- maintenance/admin plane ---
@@ -345,6 +345,7 @@ fn job_id(job: MaintenanceJobArg) -> MaintenanceJobId {
         MaintenanceJobArg::Metadata => MaintenanceJobId::METADATA,
         MaintenanceJobArg::CoreGc => MaintenanceJobId::GC,
         MaintenanceJobArg::GrepIndex => GREP_INDEX_JOB,
+        MaintenanceJobArg::GrepGc => GREP_GC_JOB,
     }
 }
 

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -2420,14 +2420,14 @@ fn admin_run_drains_an_assignment_and_leaves_the_work_done() {
     assert_eq!(data["drained"], true);
     assert_eq!(data["budget_exhausted"], false);
     let keys = data["keys"].as_array().expect("json array");
-    assert_eq!(keys.len(), 6, "three jobs over two namespaces: {data}");
+    assert_eq!(keys.len(), 8, "four jobs over two namespaces: {data}");
     assert!(
         keys.iter().all(|key| key["settled"] == true),
         "an unbudgeted drain settles every key: {data}"
     );
     assert_eq!(
         data["jobs"],
-        serde_json::json!(["metadata", "gc", "grep-index"])
+        serde_json::json!(["metadata", "gc", "grep-index", "grep-gc"])
     );
 
     for namespace in ["alpha", "beta"] {
@@ -2511,7 +2511,7 @@ fn admin_run_requires_an_assignment_and_names_the_jobs_it_hosts() {
     let unknown_job = harness.run(&["admin", "run", "--namespace", "alpha", "--job", "bogus"]);
     assert_failure(&unknown_job);
     let message = stderr_string(&unknown_job);
-    for job in ["metadata", "core-gc", "grep-index"] {
+    for job in ["metadata", "core-gc", "grep-index", "grep-gc"] {
         assert!(
             message.contains(job),
             "the valid set must be listed: {message}"

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -24,29 +24,34 @@ use super::config::GcConfig;
 /// charge attached to it, and that running out stops the pass instead of
 /// letting it finish "just this one thing" unboundedly.
 #[derive(Debug)]
-pub(super) struct PassBudget {
+pub struct PassBudget {
     max_objects: Option<u64>,
     spent: u64,
 }
 
 impl PassBudget {
-    pub(super) fn of(config: &GcConfig) -> Self {
+    /// Meters a pass at `max_objects` units, or at nothing when absent.
+    pub fn new(max_objects: Option<u64>) -> Self {
         Self {
-            max_objects: config.max_objects,
+            max_objects,
             spent: 0,
         }
+    }
+
+    pub(super) fn of(config: &GcConfig) -> Self {
+        Self::new(config.max_objects)
     }
 
     /// True once nothing further may be charged: the caller stops where it
     /// stands. The sweep returns its cursor; the content reference scan
     /// gives up on collecting and the pass defers that reclamation.
-    pub(super) fn exhausted(&self) -> bool {
+    pub fn exhausted(&self) -> bool {
         self.max_objects
             .is_some_and(|max_objects| self.spent >= max_objects)
     }
 
     /// Charges one unit for work already done.
-    pub(super) fn charge(&mut self) {
+    pub fn charge(&mut self) {
         self.spent = self.spent.saturating_add(1);
     }
 

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -1,8 +1,10 @@
 //! Opaque, namespace-bound cursors for bounded GC enumeration.
 
 use crate::error::{CoreError, Result};
-use base64::Engine as _;
-use loonfs_api::NamespaceId;
+use loonfs_api::{
+    decode_namespace_cursor, encode_cursor, NamespaceCursor, NamespaceCursorError, NamespaceId,
+    PageCursor,
+};
 use loonfs_objectstore::keys::{
     checkpoint_prefix, metadata_manifest_prefix, metadata_table_prefix, upload_session_prefix,
     wal_segment_prefix,
@@ -59,6 +61,24 @@ pub(super) struct GcCursor {
     pub(super) last_key: Option<String>,
 }
 
+impl PageCursor for GcCursor {
+    const KIND: &'static str = "core_gc";
+}
+
+impl NamespaceCursor for GcCursor {
+    fn namespace_id(&self) -> &NamespaceId {
+        &self.namespace_id
+    }
+
+    fn last_key(&self) -> Option<&str> {
+        self.last_key.as_deref()
+    }
+
+    fn key_prefix(&self) -> String {
+        self.family.prefix(&self.namespace_id)
+    }
+}
+
 impl GcCursor {
     pub(super) fn initial(namespace_id: &NamespaceId) -> Self {
         Self {
@@ -77,29 +97,17 @@ impl GcCursor {
     }
 
     pub(super) fn decode(token: &str, namespace_id: &NamespaceId) -> Result<Self> {
-        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(token)
-            .map_err(|_| invalid_cursor())?;
-        let cursor: Self = serde_json::from_slice(&bytes).map_err(|_| invalid_cursor())?;
-        if cursor.namespace_id != *namespace_id {
-            return Err(CoreError::InvalidGcConfig(
-                "cursor belongs to a different namespace".to_owned(),
-            ));
-        }
-        if cursor
-            .last_key
-            .as_ref()
-            .is_some_and(|key| !key.starts_with(&cursor.family.prefix(namespace_id)))
-        {
-            return Err(invalid_cursor());
-        }
-        Ok(cursor)
+        decode_namespace_cursor(token, namespace_id).map_err(|error| match error {
+            NamespaceCursorError::ForeignNamespace => CoreError::InvalidGcConfig(error.to_string()),
+            NamespaceCursorError::Malformed(_) | NamespaceCursorError::OutsideKeyspace => {
+                invalid_cursor()
+            }
+        })
     }
 
     pub(super) fn encode(&self) -> Result<String> {
-        let bytes = serde_json::to_vec(self)
-            .map_err(|error| CoreError::Internal(format!("failed to encode GC cursor: {error}")))?;
-        Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+        encode_cursor(self)
+            .map_err(|error| CoreError::Internal(format!("failed to encode GC cursor: {error}")))
     }
 }
 
@@ -110,18 +118,23 @@ fn invalid_cursor() -> CoreError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use loonfs_api::wire::hex::hex_encode_bytes;
+
+    fn token_over(payload: &serde_json::Value) -> String {
+        hex_encode_bytes(&serde_json::to_vec(payload).expect("encode payload"))
+    }
 
     #[test]
     fn cursor_decode_tolerates_additive_fields() {
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
-        let payload = serde_json::json!({
+        let token = token_over(&serde_json::json!({
+            "v": 1,
+            "kind": "core_gc",
             "namespace_id": "demo",
             "family": "metadata_tables",
             "last_key": "namespaces/demo/metadata/tables/table.sst.zst",
             "future_field": {"ignored": true}
-        });
-        let token = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .encode(serde_json::to_vec(&payload).expect("encode payload"));
+        }));
 
         let cursor = GcCursor::decode(&token, &namespace_id).expect("decode cursor");
         assert_eq!(cursor.family, CandidateFamily::MetadataTables);
@@ -145,13 +158,30 @@ mod tests {
         assert!(GcCursor::decode(&token, &namespace_id).is_ok());
         assert!(GcCursor::decode(&token, &other_namespace_id).is_err());
 
-        let malformed = serde_json::json!({
+        let wrong_family_prefix = token_over(&serde_json::json!({
+            "v": 1,
+            "kind": "core_gc",
             "namespace_id": "demo",
             "family": "wal_segments",
             "last_key": "namespaces/demo/checkpoints/checkpoint.json"
-        });
-        let malformed = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .encode(serde_json::to_vec(&malformed).expect("encode malformed payload"));
-        assert!(GcCursor::decode(&malformed, &namespace_id).is_err());
+        }));
+        assert!(GcCursor::decode(&wrong_family_prefix, &namespace_id).is_err());
+    }
+
+    /// Core and grep collect the same namespace under two cursors of the
+    /// same shape. The kind is what stops one job resuming the other's
+    /// position.
+    #[test]
+    fn a_cursor_from_another_job_is_refused() {
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let foreign_kind = token_over(&serde_json::json!({
+            "v": 1,
+            "kind": "grep_gc",
+            "namespace_id": "demo",
+            "family": "wal_segments",
+            "last_key": "namespaces/demo/wal/segments/segment.wal.zst"
+        }));
+
+        assert!(GcCursor::decode(&foreign_kind, &namespace_id).is_err());
     }
 }

--- a/crates/loonfs-core/src/gc/mod.rs
+++ b/crates/loonfs-core/src/gc/mod.rs
@@ -19,5 +19,7 @@ mod run;
 mod tests;
 mod uploads;
 
+pub use budget::PassBudget;
 pub use config::GcConfig;
+pub use reap::delete_if_aged;
 pub use run::gc_namespace;

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -8,7 +8,6 @@
 use crate::checkpoint::record::encode_checkpoint_record;
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
-use loonfs_api::v0::GcResponse;
 use loonfs_api::wire::control::{
     decode_control_object, CheckpointOwner, CheckpointRecordLifecycle, CheckpointRecordState,
     ControlObjectKind,
@@ -117,34 +116,35 @@ pub(super) async fn sweep_checkpoint_record<S: ObjectStore + ?Sized>(
     }
 }
 
-pub(super) async fn delete_if_aged<S: ObjectStore + ?Sized>(
+/// Deletes one unreferenced candidate if the grace window has passed over
+/// it, counting it as retained otherwise.
+///
+/// Answers whether the key was deleted. Store failures surface unmapped so
+/// each collector keeps its own error vocabulary; everything about the
+/// decision itself — which timestamp, what an absent one means, what the
+/// window is measured against — is the same wherever objects age out, so it
+/// is decided once here.
+pub async fn delete_if_aged<S: ObjectStore + ?Sized>(
     store: &S,
     key: &str,
     grace_window_ms: u64,
-    context: &MutationContext,
-    report: &mut GcResponse,
-) -> Result<bool> {
-    let Some(metadata) = store
-        .head(key)
-        .await
-        .map_err(|error| CoreError::store(key, &error))?
-    else {
+    now_ms: u64,
+    retained_candidates: &mut u64,
+) -> std::result::Result<bool, ObjectStoreError> {
+    let Some(metadata) = store.head(key).await? else {
         // Already gone; nothing to count.
         return Ok(false);
     };
     let Some(last_modified_ms) = metadata.last_modified_ms else {
         // No provider timestamp: treat as young, retain (rule 1).
-        report.retained_candidates += 1;
+        *retained_candidates += 1;
         return Ok(false);
     };
-    if context.now_ms.saturating_sub(last_modified_ms) < grace_window_ms {
-        report.retained_candidates += 1;
+    if now_ms.saturating_sub(last_modified_ms) < grace_window_ms {
+        *retained_candidates += 1;
         return Ok(false);
     }
-    store
-        .delete(key)
-        .await
-        .map_err(|error| CoreError::store(key, &error))?;
+    store.delete(key).await?;
     Ok(true)
 }
 

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -203,7 +203,16 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         CandidateFamily::WalSegments => {
             if sweep.live.wal_segments.contains(key) {
                 report.retained_candidates += 1;
-            } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
+            } else if delete_if_aged(
+                store,
+                key,
+                config.grace_window_ms,
+                context.now_ms,
+                &mut report.retained_candidates,
+            )
+            .await
+            .map_err(|error| CoreError::store(key, &error))?
+            {
                 report.deleted_wal_segments += 1;
             }
         }
@@ -211,7 +220,16 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
             // Rule 5 is sticky across every re-collection in this pass.
             if sweep.degraded || sweep.live.tables.contains(key) {
                 report.retained_candidates += 1;
-            } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
+            } else if delete_if_aged(
+                store,
+                key,
+                config.grace_window_ms,
+                context.now_ms,
+                &mut report.retained_candidates,
+            )
+            .await
+            .map_err(|error| CoreError::store(key, &error))?
+            {
                 report.deleted_metadata_tables += 1;
             }
         }
@@ -222,7 +240,16 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
             };
             if sweep.degraded || live_or_unrecognized {
                 report.retained_candidates += 1;
-            } else if delete_if_aged(store, key, config.grace_window_ms, context, report).await? {
+            } else if delete_if_aged(
+                store,
+                key,
+                config.grace_window_ms,
+                context.now_ms,
+                &mut report.retained_candidates,
+            )
+            .await
+            .map_err(|error| CoreError::store(key, &error))?
+            {
                 report.deleted_manifests += 1;
             }
         }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -183,7 +183,7 @@ pub use error::{
     Error, ErrorCode, ErrorKind, MetadataProjectionLoadError, MetadataViewError, StoreFailureClass,
     WriterFence,
 };
-pub use gc::{gc_namespace, GcConfig};
+pub use gc::{delete_if_aged, gc_namespace, GcConfig, PassBudget};
 pub use namespace::BootstrapNamespaceError;
 pub use options::{BootstrapOptions, DeleteNamespaceOptions};
 pub use path::read::{CurrentFileState, MAX_RESOLVE_CURRENT_FILES};

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 
 [dependencies]
 async-trait.workspace = true
-base64.workspace = true
 bytes.workspace = true
 futures.workspace = true
 loonfs = { path = "../loonfs" }

--- a/crates/loonfs-grep/README.md
+++ b/crates/loonfs-grep/README.md
@@ -12,6 +12,7 @@ namespaces on the command line:
 ```console
 loonfs admin run --namespace docs --namespace source --job grep-index
 loonfs admin run --namespace docs --job grep-index --drain
+loonfs admin run --namespace docs --job grep-gc --drain
 loonfs admin index-gc docs
 ```
 
@@ -19,7 +20,9 @@ Without `--drain` the command hosts the runner until a signal, asserting its ass
 interval so a quiet namespace stays covered. With `--drain` it catches every assigned namespace up
 and exits, which suits cron; `--max-steps` and `--deadline-ms` bound it and it reports where each
 namespace stopped. Omitting `--job` hosts metadata and collection too, so one process can own
-everything a namespace nobody is writing to needs. `loonfs admin index-gc` collects one namespace's
+everything a namespace nobody is writing to needs. Collection is its own job, `grep-gc`: it shares
+the runner's admission and permits and resumes where the last pass stopped, but nothing schedules
+it on grep's behalf. `loonfs admin index-gc` runs the same passes directly against one namespace's
 grep-owned keyspace, including reaping aged extension state for an absent or tombstoned namespace.
 
 Bounded-step budgets are `GrepWorkerConfig`, which a server reads from its `[grep]` table:

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -79,7 +79,7 @@ mod worker;
 pub use config::{GrepWorkerConfig, GrepWorkerConfigError};
 pub use error::GrepError as Error;
 pub use error::{GrepError, Result};
-pub use maintenance::{GrepMaintenanceJob, GREP_INDEX_JOB};
+pub use maintenance::{GrepGcJob, GrepMaintenanceJob, GREP_GC_JOB, GREP_INDEX_JOB};
 pub use reads::NamespaceReads;
 pub use service::{
     GrepIndexSnapshot, GrepService, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT,

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -1,15 +1,19 @@
-//! Grep's executor for the runtime's maintenance runner.
+//! Grep's two executors for the runtime's maintenance runner: building the
+//! index, and reclaiming what building it leaves behind.
 //!
-//! The index is upkeep like any other: one bounded unit of work against
-//! durable state, published through a compare-and-swap, reported as a
-//! conclusion. Registering this job is all a host does — the runner it
-//! registers with owns admission, the permit pool every maintenance family
-//! shares, backoff, and shutdown, so grep brings no scheduler of its own.
+//! Both are upkeep like any other: one bounded unit of work against durable
+//! state, published through a compare-and-swap, reported as a conclusion.
+//! Registering them is all a host does — the runner they register with owns
+//! admission, the permit pool every maintenance family shares, backoff, and
+//! shutdown, so grep brings no scheduler of its own.
 
 use crate::root::{load_grep_root, GrepLifecycle};
-use crate::{GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepReorganizeOutcome, GrepWorker};
+use crate::{
+    GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepGcReport, GrepGcRequest,
+    GrepReorganizeOutcome, GrepWorker,
+};
 use loonfs::{
-    MaintenanceJob, MaintenanceJobId, MaintenanceProbe, MaintenanceStepConclusion,
+    current_time_ms, MaintenanceJob, MaintenanceJobId, MaintenanceProbe, MaintenanceStepConclusion,
     MaintenanceStepResult, NamespaceId, Result, RuntimeError,
 };
 use loonfs_api::ErrorCode;
@@ -17,6 +21,8 @@ use loonfs_objectstore::ObjectStore;
 
 /// Identity of the grep-index job wherever it is registered.
 pub const GREP_INDEX_JOB: MaintenanceJobId = MaintenanceJobId::new("grep-index");
+/// Identity of the grep-collection job wherever it is registered.
+pub const GREP_GC_JOB: MaintenanceJobId = MaintenanceJobId::new("grep-gc");
 
 /// One change is all a probe needs to see to know there is work.
 const PROBE_CHANGE_LIMIT: usize = 1;
@@ -139,6 +145,120 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
     }
 }
 
+/// Reclaims one namespace's unreferenced grep objects, one bounded pass at
+/// a time.
+///
+/// The enumeration cursor is the runner's, not this job's: it arrives as the
+/// step's `continuation` and leaves as the result's, exactly as the
+/// runtime's own collection carries its cursor. That costs nothing here,
+/// because the cursor was never authority — a resumed pass re-reads liveness
+/// and rebuilds the live key set just as a fresh one does, so a cursor lost
+/// with the process costs re-enumeration and can never authorize a deletion.
+#[derive(Debug, Clone)]
+pub struct GrepGcJob<S> {
+    worker: GrepWorker<S>,
+}
+
+impl<S: ObjectStore + Clone> GrepGcJob<S> {
+    /// Creates the executor a host registers, over the worker that owns
+    /// grep's durable keyspace.
+    pub fn new(worker: GrepWorker<S>) -> Self {
+        Self { worker }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepGcJob<S> {
+    fn id(&self) -> MaintenanceJobId {
+        GREP_GC_JOB
+    }
+
+    async fn step(
+        &self,
+        namespace_id: &NamespaceId,
+        continuation: Option<&str>,
+    ) -> Result<MaintenanceStepResult> {
+        let request = GrepGcRequest {
+            // The pass resolves the absent candidate budget to the per-step
+            // default, which is what bounds it.
+            max_objects: None,
+            cursor: continuation.map(str::to_owned),
+        };
+        let now_ms = current_time_ms()?;
+        let report = match self
+            .worker
+            .garbage_collect_namespace(namespace_id, now_ms, &request)
+            .await
+        {
+            Ok(report) => report,
+            Err(error) if continuation.is_some() && error.code() == ErrorCode::InvalidRequest => {
+                // With every other option fixed, the one thing this pass can
+                // be asked to reject is the cursor it was resumed with.
+                // Concluding without one hands the runner an empty
+                // continuation and takes the key again, which restarts
+                // enumeration — always sound, because every pass rebuilds
+                // its own safety proof from durable state.
+                tracing::info!(
+                    namespace_id = %namespace_id,
+                    error = %error,
+                    "grep collection rejected its resume position; restarting the pass"
+                );
+                return Ok(MaintenanceStepResult::concluded(
+                    MaintenanceStepConclusion::Superseded,
+                ));
+            }
+            Err(error) => return Err(step_failure(namespace_id, "grep_gc", error)),
+        };
+        Ok(grep_gc_step_result(report, continuation))
+    }
+
+    async fn probe(&self, _namespace_id: &NamespaceId) -> Result<MaintenanceProbe> {
+        // Collection has no cheap question: whether anything is reclaimable
+        // is what a pass finds out, and a pass is not a probe. Grep's
+        // reclamation is explicit and per namespace, so what brings this job
+        // back is somebody asking for it.
+        Ok(MaintenanceProbe::Idle)
+    }
+}
+
+/// One collection pass, read as one conclusion.
+///
+/// Progress is where the enumeration got to, never what the counters say. A
+/// pass that hands back a cursor past the one it was given walked keyspace
+/// and has more to walk, so it runs again. A pass that hands back the very
+/// cursor it started from decided nothing at all, and repeating it
+/// immediately would repeat that exact result, so it parks like any other
+/// zero-progress step.
+///
+/// A pass that walked the whole prefix is finished: idle when it freed
+/// nothing, eligible again when it did. A namespace it could not read
+/// liveness or a root for suppressed deletions it might otherwise have made,
+/// so it parks distinctly rather than reading as idle.
+fn grep_gc_step_result(
+    report: GrepGcReport,
+    submitted_cursor: Option<&str>,
+) -> MaintenanceStepResult {
+    let conclusion = match report.next_cursor.as_deref() {
+        Some(next_cursor) if Some(next_cursor) == submitted_cursor => {
+            MaintenanceStepConclusion::Blocked
+        }
+        Some(_) => MaintenanceStepConclusion::Progressed,
+        None if report.deleted_segments > 0 || report.deleted_other_objects > 0 => {
+            MaintenanceStepConclusion::Progressed
+        }
+        None if report.namespace_degraded => MaintenanceStepConclusion::Blocked,
+        None => MaintenanceStepConclusion::Idle,
+    };
+    MaintenanceStepResult {
+        conclusion,
+        continuation: report.next_cursor,
+        // Grep objects age against one fixed grace window rather than
+        // against leases a write path plants, so a pass observes no deadline
+        // to hand back. What brings the job round again is a nudge.
+        not_before_ms: None,
+    }
+}
+
 /// Namespace states with no index to maintain: one that was never created,
 /// and one whose tombstone leaves nothing to index.
 fn has_nothing_to_index(error: &GrepError) -> bool {
@@ -254,6 +374,67 @@ mod tests {
         assert_eq!(
             reorganize_conclusion(&GrepReorganizeOutcome::Superseded),
             MaintenanceStepConclusion::Superseded
+        );
+    }
+
+    /// Where the enumeration got to is the whole conclusion, so a pass that
+    /// hands back the position it was given has nothing to gain from being
+    /// run again at once.
+    #[test]
+    fn a_collection_pass_concludes_on_where_its_enumeration_reached() {
+        let stopped = grep_gc_step_result(
+            GrepGcReport {
+                next_cursor: Some("second-page".to_owned()),
+                ..GrepGcReport::default()
+            },
+            Some("first-page"),
+        );
+        assert_eq!(stopped.conclusion, MaintenanceStepConclusion::Progressed);
+        assert_eq!(stopped.continuation.as_deref(), Some("second-page"));
+
+        assert_eq!(
+            grep_gc_step_result(
+                GrepGcReport {
+                    next_cursor: Some("first-page".to_owned()),
+                    ..GrepGcReport::default()
+                },
+                Some("first-page"),
+            )
+            .conclusion,
+            MaintenanceStepConclusion::Blocked
+        );
+    }
+
+    /// A finished walk reports what it freed, and a namespace it could not
+    /// read parks rather than passing for idle.
+    #[test]
+    fn a_finished_pass_separates_reclamation_from_an_unreadable_namespace() {
+        assert_eq!(
+            grep_gc_step_result(GrepGcReport::default(), None).conclusion,
+            MaintenanceStepConclusion::Idle
+        );
+        assert_eq!(
+            grep_gc_step_result(
+                GrepGcReport {
+                    deleted_segments: 2,
+                    ..GrepGcReport::default()
+                },
+                None,
+            )
+            .conclusion,
+            MaintenanceStepConclusion::Progressed
+        );
+        assert_eq!(
+            grep_gc_step_result(
+                GrepGcReport {
+                    namespace_degraded: true,
+                    retained_candidates: 3,
+                    ..GrepGcReport::default()
+                },
+                None,
+            )
+            .conclusion,
+            MaintenanceStepConclusion::Blocked
         );
     }
 

--- a/crates/loonfs-grep/src/root/error.rs
+++ b/crates/loonfs-grep/src/root/error.rs
@@ -64,8 +64,6 @@ pub enum GrepEnvelopeCodecError {
     Envelope(#[from] EnvelopeCodecError),
     #[error("invalid grep manifest state: {0}")]
     InvalidState(#[from] GrepManifestStateError),
-    #[error("invalid grep manifest id: {0}")]
-    InvalidManifestId(#[from] GrepManifestIdError),
 }
 
 /// Failure to load or publish a grep root.

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -26,21 +26,21 @@ use crate::root::{
 };
 use crate::service::is_indexable_text_content;
 use crate::{GrepError, Result};
-use base64::Engine as _;
 use futures::future::try_join_all;
 use futures::StreamExt as _;
 use loonfs::{
-    CheckpointFilesPageCursor, CoreError, CreateCheckpointOptions, FsAdmin, FsReader, RuntimeError,
-    StoreFailureClass, DEFAULT_GC_MAX_OBJECTS, GC_MIN_GRACE_WINDOW_MS,
-    METADATA_PUBLICATION_BUDGET_MS,
+    delete_if_aged, CheckpointFilesPageCursor, CoreError, CreateCheckpointOptions, FsAdmin,
+    FsReader, PassBudget, RuntimeError, StoreFailureClass, DEFAULT_GC_MAX_OBJECTS,
+    GC_MIN_GRACE_WINDOW_MS, METADATA_PUBLICATION_BUDGET_MS,
 };
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::sst_blocks::{
     index_blocks_for_key_range, DecodedDataBlock, SegmentBlocksBuilder, SegmentIndexEntry,
 };
 use loonfs_api::{
-    sha256_digest, ChangeSeq, CheckpointId, ContentRef, ErrorCode, IndexSegmentId, InodeId,
-    NamespaceId, RevisionNo,
+    decode_namespace_cursor, encode_cursor, sha256_digest, ChangeSeq, CheckpointId, ContentRef,
+    ErrorCode, IndexSegmentId, InodeId, NamespaceCursor, NamespaceCursorError, NamespaceId,
+    PageCursor, RevisionNo,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
@@ -1269,7 +1269,8 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         // entry point an operator calls — because that is where the runtime
         // resolves its own, and one authority is what keeps the two the
         // same number.
-        let mut budget = GcBudget::new(Some(request.max_objects.unwrap_or(DEFAULT_GC_MAX_OBJECTS)));
+        let mut budget =
+            PassBudget::new(Some(request.max_objects.unwrap_or(DEFAULT_GC_MAX_OBJECTS)));
         let reads = self.reads(namespace_id);
         // Liveness is decided once per pass — and re-decided per candidate
         // below, which is what authorizes a delete. This first read is
@@ -1334,7 +1335,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         liveness: NamespaceLiveness,
         key: &str,
         now_ms: u64,
-        budget: &mut GcBudget,
+        budget: &mut PassBudget,
         report: &mut GrepGcReport,
     ) -> Result<bool> {
         match liveness {
@@ -1391,40 +1392,20 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         now_ms: u64,
         report: &mut GrepGcReport,
     ) -> Result<bool> {
-        if delete_if_aged(&self.store, key, now_ms, report).await? {
+        if delete_if_aged(
+            &self.store,
+            key,
+            GREP_GC_GRACE_WINDOW_MS,
+            now_ms,
+            &mut report.retained_candidates,
+        )
+        .await
+        .map_err(|error| core_store_error(key, &error))?
+        {
             count_deleted_key(key, report);
             return Ok(true);
         }
         Ok(false)
-    }
-}
-
-/// The reads one garbage-collection pass may spend.
-///
-/// A key costs more than its listing: deciding it re-reads liveness or the
-/// grep root, and reading its age is another round trip. Charging those to
-/// the same budget is what keeps `max_objects` a bound on the work the pass
-/// does rather than only on the keys it names.
-struct GcBudget {
-    max_objects: Option<u64>,
-    spent: u64,
-}
-
-impl GcBudget {
-    fn new(max_objects: Option<u64>) -> Self {
-        Self {
-            max_objects,
-            spent: 0,
-        }
-    }
-
-    fn charge(&mut self) {
-        self.spent = self.spent.saturating_add(1);
-    }
-
-    fn exhausted(&self) -> bool {
-        self.max_objects
-            .is_some_and(|max_objects| self.spent >= max_objects)
     }
 }
 
@@ -1439,6 +1420,24 @@ struct GrepGcCursor {
     namespace_id: NamespaceId,
     #[serde(default)]
     last_key: Option<String>,
+}
+
+impl PageCursor for GrepGcCursor {
+    const KIND: &'static str = "grep_gc";
+}
+
+impl NamespaceCursor for GrepGcCursor {
+    fn namespace_id(&self) -> &NamespaceId {
+        &self.namespace_id
+    }
+
+    fn last_key(&self) -> Option<&str> {
+        self.last_key.as_deref()
+    }
+
+    fn key_prefix(&self) -> String {
+        namespace_prefix(&self.namespace_id)
+    }
 }
 
 impl GrepGcCursor {
@@ -1464,40 +1463,25 @@ impl GrepGcCursor {
     }
 
     fn decode(token: &str, namespace_id: &NamespaceId) -> Result<Self> {
-        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(token)
-            .map_err(|_| malformed_gc_cursor())?;
-        let cursor: Self = serde_json::from_slice(&bytes).map_err(|_| malformed_gc_cursor())?;
-        if cursor.namespace_id != *namespace_id {
-            return Err(GrepError::Runtime(RuntimeError::Core(
-                CoreError::InvalidGcConfig("cursor belongs to a different namespace".to_owned()),
-            )));
-        }
-        let prefix = namespace_prefix(namespace_id);
-        if cursor
-            .last_key
-            .as_ref()
-            .is_some_and(|key| !key.starts_with(&prefix))
-        {
-            return Err(malformed_gc_cursor());
-        }
-        Ok(cursor)
+        decode_namespace_cursor(token, namespace_id).map_err(|error| match error {
+            NamespaceCursorError::ForeignNamespace => {
+                CoreError::InvalidGcConfig(error.to_string()).into()
+            }
+            NamespaceCursorError::Malformed(_) | NamespaceCursorError::OutsideKeyspace => {
+                malformed_gc_cursor()
+            }
+        })
     }
 
     fn encode(&self) -> Result<String> {
-        let bytes = serde_json::to_vec(self).map_err(|error| {
-            GrepError::Runtime(RuntimeError::Core(CoreError::Internal(format!(
-                "failed to encode grep GC cursor: {error}"
-            ))))
-        })?;
-        Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+        encode_cursor(self).map_err(|error| {
+            CoreError::Internal(format!("failed to encode grep GC cursor: {error}")).into()
+        })
     }
 }
 
 fn malformed_gc_cursor() -> GrepError {
-    GrepError::Runtime(RuntimeError::Core(CoreError::InvalidGcConfig(
-        "cursor is malformed".to_owned(),
-    )))
+    CoreError::InvalidGcConfig("cursor is malformed".to_owned()).into()
 }
 
 fn reorganize_report(
@@ -1766,34 +1750,6 @@ fn live_grep_keys(root: &LoadedGrepRoot) -> BTreeSet<String> {
         );
     }
     live
-}
-
-async fn delete_if_aged<S: ObjectStore + ?Sized>(
-    store: &S,
-    key: &str,
-    now_ms: u64,
-    report: &mut GrepGcReport,
-) -> Result<bool> {
-    let Some(metadata) = store
-        .head(key)
-        .await
-        .map_err(|error| core_store_error(key, &error))?
-    else {
-        return Ok(false);
-    };
-    let Some(last_modified_ms) = metadata.last_modified_ms else {
-        report.retained_candidates += 1;
-        return Ok(false);
-    };
-    if now_ms.saturating_sub(last_modified_ms) < GREP_GC_GRACE_WINDOW_MS {
-        report.retained_candidates += 1;
-        return Ok(false);
-    }
-    store
-        .delete(key)
-        .await
-        .map_err(|error| core_store_error(key, &error))?;
-    Ok(true)
 }
 
 fn count_deleted_key(key: &str, report: &mut GrepGcReport) {

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -13,7 +13,9 @@ use loonfs::{
 use loonfs_api::{ChangeSeq, IndexSegmentId, NamespaceId};
 use loonfs_grep::keyspace::{root_key, segment_key};
 use loonfs_grep::root::load_grep_root;
-use loonfs_grep::{GramIndexBuildPolicy, GrepMaintenanceJob, GrepWorker, GREP_INDEX_JOB};
+use loonfs_grep::{
+    GramIndexBuildPolicy, GrepGcJob, GrepMaintenanceJob, GrepWorker, GREP_GC_JOB, GREP_INDEX_JOB,
+};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -266,6 +268,129 @@ async fn catch_up<S: ObjectStore + Clone + Send + Sync + 'static>(
     panic!("the grep job did not catch up");
 }
 
+/// The collection job is the reclaiming half the index job deliberately
+/// leaves undone, and a nudge is what asks for it.
+#[tokio::test]
+async fn a_nudge_collects_what_indexing_left_behind() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(AgedGrepStore::new(temp_dir.path()));
+    let namespace_id = NamespaceId::parse("collect").expect("namespace id");
+    let writer = seed(store.clone(), &namespace_id).await;
+    put_file(&writer, &namespace_id, "collect-put").await;
+    let worker = worker(store.clone(), "collect-worker").await;
+    worker.enable(&namespace_id).await.expect("enable grep");
+    let orphan = segment_key(&namespace_id, &IndexSegmentId::generate());
+    store
+        .put_overwrite(&orphan, Bytes::from_static(b"orphan"))
+        .await
+        .expect("write orphan");
+
+    let host = host_writer(store.clone(), "collect-host", 2).await;
+    host.register_maintenance_job(Arc::new(GrepGcJob::new(worker.clone())))
+        .expect("register the grep collection job");
+    host.maintenance().nudge(GREP_GC_JOB, &namespace_id);
+
+    wait_for_deletion(&store, &orphan).await;
+    assert!(
+        store
+            .head(&root_key(&namespace_id))
+            .await
+            .expect("head root")
+            .is_some(),
+        "the pointer a live namespace still names is never a candidate"
+    );
+    host.shutdown_background()
+        .await
+        .expect("settle host maintenance");
+}
+
+/// A resume position the collector refuses restarts the pass instead of
+/// failing the key: every pass rebuilds its own safety proof, so starting
+/// over is always sound.
+#[tokio::test]
+async fn a_refused_resume_position_restarts_the_collection_pass() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("resume").expect("namespace id");
+    let writer = seed(store.clone(), &namespace_id).await;
+    put_file(&writer, &namespace_id, "resume-put").await;
+    let worker = worker(store.clone(), "resume-worker").await;
+    worker.enable(&namespace_id).await.expect("enable grep");
+    let job = GrepGcJob::new(worker);
+
+    assert_eq!(
+        job.step(&namespace_id, Some("not-a-cursor"))
+            .await
+            .expect("a refused cursor is not a step failure")
+            .conclusion,
+        MaintenanceStepConclusion::Superseded
+    );
+    let fresh = job.step(&namespace_id, None).await.expect("fresh pass");
+    assert_eq!(fresh.conclusion, MaintenanceStepConclusion::Idle);
+    assert_eq!(fresh.continuation, None);
+}
+
+/// Grep objects age out against provider timestamps, so a collection test
+/// needs candidates the provider reports as older than the grace window.
+#[derive(Debug)]
+struct AgedGrepStore {
+    inner: LocalFsStore,
+}
+
+impl AgedGrepStore {
+    fn new(root: &Path) -> Self {
+        Self {
+            inner: LocalFsStore::new(root).expect("local store"),
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for AgedGrepStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        Ok(self.inner.head(key).await?.map(|mut metadata| {
+            metadata.last_modified_ms = Some(0);
+            metadata
+        }))
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+        self.inner.list_prefix(prefix).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
 /// A writer that only hosts the runner: it serves no namespace of its own,
 /// so every step its pool admits is a grep step.
 async fn host_writer<S: ObjectStore + 'static>(
@@ -313,6 +438,20 @@ async fn put_file(writer: &FsWriter, namespace_id: &NamespaceId, commit_id: &str
         commit_id,
     )
     .await;
+}
+
+/// Waits for the runner's collection steps to reclaim one key.
+#[allow(clippy::disallowed_methods)]
+async fn wait_for_deletion<S: ObjectStore + 'static>(store: &Arc<S>, key: &str) {
+    // The pass reports what it reclaimed durably and nowhere else; this
+    // polls that durable state under a bounded timeout.
+    tokio::time::timeout(WAIT, async {
+        while store.head(key).await.expect("head candidate").is_some() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("`{key}` was never collected"));
 }
 
 /// Waits for the runner's steps to publish a root at `built_through_seq`.

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -12,7 +12,7 @@ use loonfs::{
     SharedObjectStore, TraceMode, TraceStoreKind,
 };
 use loonfs_api::NamespaceId;
-use loonfs_grep::{GrepMaintenanceJob, GrepService, GrepWorker, GREP_INDEX_JOB};
+use loonfs_grep::{GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker, GREP_INDEX_JOB};
 use loonfs_objectstore::presign::ObjectTransferIssuer;
 use std::ffi::OsString;
 use std::net::SocketAddr;
@@ -269,6 +269,20 @@ pub(super) async fn app_with_store_and_transfer_issuer(
         ));
         writer
             .register_maintenance_job(job.clone())
+            .map_err(|error| ServerConfigError::InvalidField {
+                field: "grep",
+                reason: error.to_string(),
+            })?;
+        // Reclaiming what the index leaves behind is upkeep for the same
+        // namespaces, gated by the same switch: a deployment that builds
+        // grep objects is the one that should collect them.
+        writer
+            .register_maintenance_job(Arc::new(GrepGcJob::new(
+                grep_worker
+                    .as_ref()
+                    .expect("an index-maintaining deployment composes a grep worker")
+                    .clone(),
+            )))
             .map_err(|error| ServerConfigError::InvalidField {
                 field: "grep",
                 reason: error.to_string(),

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -69,10 +69,12 @@ pub use loonfs_core::cache::{MetadataTableCacheConfig, Recency};
 pub use loonfs_core::limits::{
     DEFAULT_GC_MAX_OBJECTS, GC_MIN_GRACE_WINDOW_MS, METADATA_PUBLICATION_BUDGET_MS,
 };
+pub use loonfs_core::time::current_time_ms;
 pub use loonfs_core::{
-    BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor,
-    CurrentFileState, DeleteNamespaceOptions, Error as CoreError, ErrorCode, ErrorKind, GcConfig,
-    MetadataViewError, StoreFailureClass, WriterFence, MAX_RESOLVE_CURRENT_FILES,
+    delete_if_aged, BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage,
+    CheckpointFilesPageCursor, CurrentFileState, DeleteNamespaceOptions, Error as CoreError,
+    ErrorCode, ErrorKind, GcConfig, MetadataViewError, PassBudget, StoreFailureClass, WriterFence,
+    MAX_RESOLVE_CURRENT_FILES,
 };
 pub use publisher::PublishObserver;
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -79,9 +79,10 @@ A step may also hand back an opaque continuation — where it stopped, for the n
 | `metadata` | Flush the WAL tail past its threshold, then fold one bounded reorganization unit. | Automatic. Nudged by publication. |
 | `gc` | One bounded mark-and-sweep pass. | Automatic, and clock-driven: work becomes eligible when a lease expires or a grace window passes, so the deadlines that create reclaimable state are what plant the wakeup. |
 | `grep-index` | One bounded gram-index build or fold unit. | Automatic where a host maintains the index. Nudged by enable, publication, and queries that find the index behind. |
+| `grep-gc` | One bounded pass over one namespace's grep keyspace. | Registered where a host maintains the index, on the same switch. Never nudged by anything the index does: like grep collection generally, somebody asks for it. |
 | retention (*not a job*) | Advance the retention floor. | **Never automatic.** There is no job id to register; an operator asks for it. |
 
-Retention is the one deliberate exception, and it is a moral distinction rather than a safety budget. Collection reclaims state that is provably dead; advancing the retention floor surrenders replay history that is still there. So collection runs on its own and retention is asked for explicitly, through the maintenance step's `retention` opt-in or the typed admin operation. Grep collection is likewise explicit and per namespace.
+Retention is the one deliberate exception, and it is a moral distinction rather than a safety budget. Collection reclaims state that is provably dead; advancing the retention floor surrenders replay history that is still there. So collection runs on its own and retention is asked for explicitly, through the maintenance step's `retention` opt-in or the typed admin operation. Grep collection is likewise explicit and per namespace: `grep-gc` is a job so that a pass resumes where the last one stopped and shares the runner's admission and permits, but nothing schedules it on grep's behalf.
 
 ### Coverage: touched and assigned
 


### PR DESCRIPTION
This PR is the second half of the grep idiom work. 

One namespace-bound cursor shell: Core's GC cursor and grep's were the same object minus one field, with byte-identical encoding and the same error strings, wrapped at different depths. `loonfs_api::pagination` — which both crates already use for query paging — gains a small `NamespaceCursor` extension: namespace binding, last-key resume, and key-prefix validation on top of the existing `PageCursor` machinery. Core's cursor is `kind = "core_gc"`, grep's is `"grep_gc"`, which fixes a latent confusion: the two cursors for the same namespace used to be indistinguishable, and each decoder would accept the other's token. A test now proves a grep token is refused by the core decoder. The observable error codes for malformed and cross-namespace cursors are unchanged and pinned.

One budget, one aging check: Grep's `GcBudget` was a strict subset of core's `PassBudget`; it is deleted and core's is public. `delete_if_aged` existed twice, line for line; it is now one shared function taking plain milliseconds, returning the store error unmapped so each collector keeps its own error vocabulary — the one thing that was genuinely crate-local. Grep also drops its `base64` dependency along the way.

Grep GC joins the runner: The grep maintenance job used to discard its continuation, so the resumable pass Phase C built could only be driven by hand over HTTP. A second job, `grep-gc`, now mirrors the core GC job: the cursor threads through the continuation; the same cursor coming back concludes Blocked, an advanced cursor or a pass that freed something concludes Progressed, a degraded namespace concludes Blocked, and a clean empty pass concludes Idle; a rejected resume position restarts the pass the same way core's job does. It registers everywhere the index job registers — the server (under the same maintain-gate), `loonfs admin run --job grep-gc`, and the docs.

