### PR TITLE
fix(cli): recursive get creates its destination

### DIFF
--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -470,7 +470,8 @@ pub(crate) struct FilesystemGetArgs {
     /// stdout).
     pub local_destination: Option<String>,
     /// Download the directory tree rooted at `remote_path`, with bounded
-    /// concurrency and per-file outcomes.
+    /// concurrency and per-file outcomes. The local destination is created
+    /// if it does not exist.
     #[arg(short, long)]
     pub recursive: bool,
     /// Download this revision instead of the current content.

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -203,7 +203,8 @@ pub(crate) async fn run_put_tree(
 }
 
 /// Downloads a directory tree. Local directories are created for every
-/// remote directory — including empty ones — before any file lands.
+/// remote directory — including empty ones, and including the destination
+/// root itself — before any file lands.
 pub(crate) async fn run_get_tree(
     kind: CommandKind,
     context: &CommandContext,
@@ -212,8 +213,19 @@ pub(crate) async fn run_get_tree(
     force: bool,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let listing = walk_remote_tree(context, kind, remote_root).await?;
     let mut tally = TreeTally::new();
+    // The destination root, with any missing parents, belongs to this
+    // command the way `cp -r`'s target directory belongs to `cp`. It is made
+    // before the walk so a destination that can never hold the tree costs
+    // one error instead of a full traversal, and its failure ends the
+    // command: every file below would fail the same way, and one named
+    // error beats one per file. It counts like `cp -r` counts its own
+    // destination root, so the same tree reports the same directory total
+    // whichever way it is transferred.
+    std::fs::create_dir_all(local_root)
+        .map_err(|error| context.fail(kind, CliError::io_for_path(local_root, error)))?;
+    tally.directories += 1;
+    let listing = walk_remote_tree(context, kind, remote_root).await?;
 
     for components in &listing.directories {
         let local_dir = local_root.join(components.join("/"));

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1087,6 +1087,231 @@ fn recursive_transfers_roundtrip_a_tree() {
     assert_eq!(json_error(&mv_recursive)["code"], "invalid_input");
 }
 
+/// A recursive get creates the destination it was handed, parents included,
+/// the way `cp -r` creates its target. The shape that used to fail on every
+/// file is a remote directory holding nothing but files: no subdirectory
+/// existed to create the root as a side effect of its own `mkdir`.
+#[test]
+fn recursive_get_creates_an_absent_destination_root_in_both_modes() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("embedded");
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "get-destination"));
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "remote",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]);
+    assert_success(&add_remote);
+
+    let flat = harness.temp_dir.path().join("flat");
+    fs::create_dir_all(&flat).expect("create flat source");
+    for name in ["a.txt", "b.txt"] {
+        fs::write(flat.join(name), name.as_bytes()).expect("write source file");
+    }
+
+    for profile in ["embedded", "remote"] {
+        assert_success(&harness.run(&["namespace", "create", "--profile", profile, "demo"]));
+        assert_success(&harness.run(&["use", "--profile", profile, "demo"]));
+        assert_success(&harness.run(&[
+            "put",
+            "-r",
+            "--profile",
+            profile,
+            flat.to_str().expect("utf-8 path"),
+            "/flat",
+        ]));
+        // A directory holding nothing, inside another holding nothing.
+        assert_success(&harness.run(&["mkdir", "-p", "--profile", profile, "/nested/empty/inner"]));
+
+        // Files with no subdirectory among them: nothing but the transfer
+        // itself can bring the destination root into being. Neither the root
+        // nor its parent exists here.
+        let destination = harness.temp_dir.path().join(profile).join("dest");
+        let get = harness.run(&[
+            "--json",
+            "get",
+            "-r",
+            "--profile",
+            profile,
+            "/flat",
+            destination.to_str().expect("utf-8 path"),
+        ]);
+        assert_success(&get);
+        let data = json_data(&get);
+        assert_eq!(data["files"], 2, "{data}");
+        // The destination root, counted the way `cp -r` counts its own.
+        assert_eq!(data["directories"], 1, "{data}");
+        assert_eq!(data["failures"].as_array().expect("failures").len(), 0);
+        assert_eq!(
+            fs::read(destination.join("a.txt")).expect("downloaded a.txt"),
+            b"a.txt"
+        );
+
+        // Empty directories, nested, land as local directories.
+        let nested = harness.temp_dir.path().join(profile).join("nested");
+        let nested_get = harness.run(&[
+            "--json",
+            "get",
+            "-r",
+            "--profile",
+            profile,
+            "/nested",
+            nested.to_str().expect("utf-8 path"),
+        ]);
+        assert_success(&nested_get);
+        let nested_data = json_data(&nested_get);
+        assert_eq!(nested_data["files"], 0, "{nested_data}");
+        assert_eq!(nested_data["directories"], 3, "{nested_data}");
+        assert!(nested.join("empty/inner").is_dir());
+
+        // A tree with nothing in it at all still leaves the caller with the
+        // directory they named.
+        let empty_destination = harness.temp_dir.path().join(profile).join("only-empty");
+        let empty = harness.run(&[
+            "--json",
+            "get",
+            "-r",
+            "--profile",
+            profile,
+            "/nested/empty/inner",
+            empty_destination.to_str().expect("utf-8 path"),
+        ]);
+        assert_success(&empty);
+        let empty_data = json_data(&empty);
+        assert_eq!(empty_data["files"], 0, "{empty_data}");
+        assert_eq!(empty_data["directories"], 1, "{empty_data}");
+        assert!(empty_destination.is_dir());
+    }
+}
+
+/// One unwritable destination path fails alone. A local file sitting where a
+/// directory has to go takes down that directory and the files under it —
+/// each named on its own — while every sibling still lands.
+#[test]
+fn recursive_get_names_only_the_paths_it_could_not_write_in_both_modes() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("embedded");
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "get-partial"));
+    let add_remote = harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "remote",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]);
+    assert_success(&add_remote);
+
+    let tree = harness.temp_dir.path().join("tree");
+    fs::create_dir_all(tree.join("docs")).expect("create docs");
+    fs::create_dir_all(tree.join("other")).expect("create other");
+    fs::write(tree.join("top.txt"), b"top").expect("write top");
+    fs::write(tree.join("docs/a.txt"), b"alpha").expect("write a");
+    fs::write(tree.join("docs/b.txt"), b"beta").expect("write b");
+    fs::write(tree.join("other/c.txt"), b"gamma").expect("write c");
+
+    for profile in ["embedded", "remote"] {
+        assert_success(&harness.run(&["namespace", "create", "--profile", profile, "demo"]));
+        assert_success(&harness.run(&["use", "--profile", profile, "demo"]));
+        assert_success(&harness.run(&[
+            "put",
+            "-r",
+            "--profile",
+            profile,
+            tree.to_str().expect("utf-8 path"),
+            "/src",
+        ]));
+
+        // A plain file occupies the place `docs` has to be.
+        let destination = harness.temp_dir.path().join(profile);
+        fs::create_dir_all(&destination).expect("create destination");
+        fs::write(destination.join("docs"), b"in the way").expect("block docs");
+
+        let get = harness.run(&[
+            "--json",
+            "get",
+            "-r",
+            "--profile",
+            profile,
+            "/src",
+            destination.to_str().expect("utf-8 path"),
+        ]);
+        assert_failure(&get);
+        let data = json_data(&get);
+        assert_eq!(data["files"], 2, "{data}");
+        // The destination root and `other`; `docs` is the one that failed.
+        assert_eq!(data["directories"], 2, "{data}");
+
+        // The blocked directory is named by the local path that failed, the
+        // files under it by the remote paths that could not be written.
+        let failed: Vec<&str> = data["failures"]
+            .as_array()
+            .expect("failures")
+            .iter()
+            .map(|failure| failure["path"].as_str().expect("failure path"))
+            .collect();
+        assert_eq!(failed.len(), 3, "{data}");
+        assert!(
+            failed.contains(&destination.join("docs").to_str().expect("utf-8 path")),
+            "{data}"
+        );
+        assert!(failed.contains(&"/src/docs/a.txt"), "{data}");
+        assert!(failed.contains(&"/src/docs/b.txt"), "{data}");
+        for failure in data["failures"].as_array().expect("failures") {
+            assert_eq!(failure["error"]["code"], "io_error", "{data}");
+        }
+
+        // Everything outside the blocked subtree downloaded.
+        assert_eq!(
+            fs::read(destination.join("top.txt")).expect("downloaded top.txt"),
+            b"top"
+        );
+        assert_eq!(
+            fs::read(destination.join("other/c.txt")).expect("downloaded c.txt"),
+            b"gamma"
+        );
+    }
+}
+
+/// One file into a directory that does not exist fails, exactly as `cp` into
+/// a missing parent fails: only `-r`, which owns the destination tree it is
+/// asked to build, creates directories.
+#[test]
+fn single_file_get_refuses_a_missing_parent_directory() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("payload.txt");
+    fs::write(&payload, b"body").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/docs/a.txt"]));
+
+    let missing = harness.temp_dir.path().join("no-such-dir");
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "/docs/a.txt",
+        missing.join("a.txt").to_str().expect("utf-8 path"),
+    ]);
+    assert_failure(&get);
+    assert_eq!(json_error(&get)["code"], "io_error");
+    assert!(!missing.exists(), "a failed get created no directory");
+}
+
 #[test]
 fn rm_recursive_deletes_a_populated_directory_in_one_commit() {
     let harness = Harness::new();


### PR DESCRIPTION
loonfs get -r` failed every file when its destination directory did not exist.

Root cause: The recursive download created a local directory for every remote directory it walked, but never for the root it was handed. A tree with subdirectories hid the bug, because creating the first subdirectory created the root as a side effect. A directory holding nothing but files — the audit's shape — had nothing that created the root, so every file failed to open its temp file.

Fix: The destination root (and its missing parents) is created before the remote walk starts. Two invariants, stated in comments: the root is created first, so a destination that can never exist costs one named error instead of a 10,000-entry traversal producing 10,000 failures; and a root that cannot be created fails the whole command, because every file below it would fail identically. Failures below the root stay per-path, as before. Empty remote directories now materialize as local directories, including a wholly empty tree yielding the directory the caller named.

Single-file `get` is unchanged: `loonfs get /docs/a.txt /missing/a.txt` fails, and plain `cp` fails identically on the same arguments (verified side by side). Only `-r`, which is asked to build a tree, builds directories. A test pins this and asserts a failed single-file get creates nothing.

Some notes:

- The semantics are `mkdir -p`-like for the root (intermediate parents are created), which is what folder downloads do everywhere; strict `cp -r` would refuse a missing grandparent.
- The JSON summary's `directories` count now includes the destination root, matching what `cp -r` already reported for the same tree. Shape unchanged, number +1.
- Files under a subdirectory that failed to materialize are still attempted individually; per-file outcomes are the module's contract.
