### PR TITLE
fix(uploads): a changed message keeps the reuse conflict

### DIFF
--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -1304,15 +1304,16 @@ impl Client {
     /// Uploads bytes and commits them at a path.
     ///
     /// Re-running this with a `commit_id` that already committed is safe
-    /// when the bytes are the same. A commit's identity names *which*
+    /// when the request is the same. A commit's identity names *which*
     /// content object it wrote, and a re-run necessarily uploads a fresh
     /// one, so the server sees a different commit and reports
     /// `commit_id_reuse_conflict`. This resolves that the only honest way
     /// available: it reads back what the commit id actually committed and
-    /// compares its content against the bytes just sent. Equal means the
-    /// operation had already succeeded and the original answer is returned;
-    /// anything else — different bytes, or content this build cannot
-    /// compare — surfaces the conflict.
+    /// compares it against the request just made. The same content under
+    /// the same message means the operation had already succeeded and the
+    /// original answer is returned; anything else — different bytes, a
+    /// different message, or content this build cannot compare — surfaces
+    /// the conflict.
     ///
     /// The freshly uploaded duplicate object is then referenced by nothing.
     /// That is by design, not a leak: content garbage collection reclaims an
@@ -1399,8 +1400,14 @@ impl Client {
         match response {
             Ok(response) => Ok(response),
             Err(error) if error.code() == Some(ErrorCode::CommitIdReuseConflict) => {
-                self.reconcile_commit_id_reuse(spec.namespace(), &commit_id, uploaded, error)
-                    .await
+                self.reconcile_commit_id_reuse(
+                    spec.namespace(),
+                    &commit_id,
+                    options.message.as_deref(),
+                    uploaded,
+                    error,
+                )
+                .await
             }
             Err(error) => Err(error),
         }
@@ -1408,16 +1415,18 @@ impl Client {
 
     /// Decides whether a reused commit id already did this exact work.
     ///
-    /// The evidence is the committed content itself, read back from the
-    /// change feed at the sequence the conflict reported, and compared
-    /// against the bytes that were just uploaded. Nothing weaker counts:
-    /// every way of failing to prove the two are the same — including a
+    /// The evidence is the committed change itself, read back from the
+    /// change feed at the sequence the conflict reported: its message
+    /// against the one this request asked for, and its content against the
+    /// bytes that were just uploaded. Nothing weaker counts: every way of
+    /// failing to prove the two requests are the same — including a
     /// comparison this client cannot make — leaves the original conflict
     /// standing, never agreement.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,
         commit_id: &CommitId,
+        message: Option<&str>,
         uploaded: UploadedContent<'_>,
         conflict: ClientError,
     ) -> Result<ApiCommitResponse> {
@@ -1430,6 +1439,16 @@ impl Client {
         else {
             return Err(conflict);
         };
+        // The message is part of a commit's identity, so a rerun that
+        // changed it asked for a different mutation and the server's
+        // conflict is the honest answer. Equality here is the server
+        // fingerprint's: the message is taken as given — absent serializes
+        // as `null`, an empty message as `""` — so no message and an empty
+        // message are different commits, and this comparison must not fold
+        // them together.
+        if committed.message.as_deref() != message {
+            return Err(conflict);
+        }
         let Some(content_ref) = committed_content_ref(&committed) else {
             return Err(conflict);
         };

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -5,9 +5,12 @@ use crate::common::start_server;
 use loonfs_api::v0::{
     CreateCheckpointRequest, MaintenanceStepKind, MaintenanceStepRequest, ValidatedContentToken,
 };
-use loonfs_api::{AbsolutePath, CommitId, CommitRequest, DestinationBehavior, FilesystemOperation};
+use loonfs_api::{
+    AbsolutePath, ChangeSeq, CommitId, CommitRequest, DestinationBehavior, FilesystemOperation,
+};
 use loonfs_client::{
-    ClientError, CopyOptions, DeleteOptions, MoveOptions, NamespacePath, PutFileOptions,
+    ClientError, CopyOptions, CreateDirectoryOptions, DeleteOptions, MoveOptions, NamespacePath,
+    PutFileOptions,
 };
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
@@ -193,6 +196,185 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
         Err(ClientError::Api { code, .. }) => {
             assert_eq!(code, "commit_id_reuse_conflict")
         }
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
+    harness.server.abort();
+}
+
+/// The message is part of a commit's identity, so re-uploading the same
+/// bytes under a changed message is a different mutation and the conflict
+/// stands. The bytes matching is exactly what makes this worth pinning:
+/// content evidence alone would call this a successful retry and quietly
+/// keep the original annotation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_put_conflict_stands_when_only_the_message_changed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-message",
+        "http-message",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let target = NamespacePath::parse("demo", "/docs/message.txt").expect("target");
+    let commit_id = CommitId::parse("req-message-put").expect("valid commit id");
+    let options = |message: &str| PutFileOptions {
+        behavior: DestinationBehavior::Replace,
+        commit_id: Some(commit_id.clone()),
+        message: Some(message.to_owned()),
+        expected_revision_no: None,
+    };
+
+    let first = harness
+        .client
+        .put_file_bytes(&target, b"stable bytes\n", &options("import batch"))
+        .await
+        .expect("first put");
+    let replay = harness
+        .client
+        .put_file_bytes(&target, b"stable bytes\n", &options("import batch"))
+        .await
+        .expect("re-uploading an identical request is idempotent");
+    assert_eq!(replay, first);
+
+    match harness
+        .client
+        .put_file_bytes(&target, b"stable bytes\n", &options("second thoughts"))
+        .await
+    {
+        Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
+    // Absent and empty are different messages too: the fingerprint takes
+    // the annotation as given, so `null` and `""` are different commits and
+    // the client compares them the same way.
+    match harness
+        .client
+        .put_file_bytes(
+            &target,
+            b"stable bytes\n",
+            &PutFileOptions {
+                message: None,
+                ..options("unused")
+            },
+        )
+        .await
+    {
+        Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
+    let changes = harness
+        .client
+        .list_changes(&namespace, ChangeSeq(0), None)
+        .await
+        .expect("list changes");
+    let committed = changes
+        .changes
+        .iter()
+        .find(|change| change.seq == first.committed_seq)
+        .expect("the committed change is on the feed");
+    assert_eq!(
+        committed.message.as_deref(),
+        Some("import batch"),
+        "the refused rerun did not rewrite the annotation that landed"
+    );
+    let entry = harness.client.stat_path(&target).await.expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "the refused rerun published no revision"
+    );
+
+    harness.server.abort();
+}
+
+/// The mutations that upload nothing reconcile nothing — the server's own
+/// identity check is the whole answer — so a changed message conflicts
+/// there whatever the put path does. These anchor that the client-side
+/// reconciliation is not the only thing keeping the contract: one commit
+/// built by the caller, and one `mkdir`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_commit_and_mkdir_conflict_when_only_the_message_changed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-message-anchor",
+        "http-message-anchor",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+
+    // A commit the caller built: the request that reaches the server is
+    // identical apart from its message.
+    let commit_id = CommitId::parse("req-message-commit").expect("valid commit id");
+    let commit_request = |message: &str| {
+        CommitRequest::single(
+            commit_id.clone(),
+            Some(message.to_owned()),
+            FilesystemOperation::CreateDirectory {
+                path: AbsolutePath::parse("/direct").expect("path"),
+                parents: true,
+            },
+        )
+    };
+    let first = harness
+        .client
+        .commit(&namespace, &commit_request("one"))
+        .await
+        .expect("first commit");
+    let replay = harness
+        .client
+        .commit(&namespace, &commit_request("one"))
+        .await
+        .expect("an identical retry replays");
+    assert_eq!(replay, first);
+    match harness
+        .client
+        .commit(&namespace, &commit_request("two"))
+        .await
+    {
+        Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
+    // And the same through the convenience call.
+    let pinned = NamespacePath::parse("demo", "/pinned").expect("pinned target");
+    let mkdir_options = |message: &str| CreateDirectoryOptions {
+        commit_id: Some(CommitId::parse("req-message-mkdir").expect("valid commit id")),
+        message: Some(message.to_owned()),
+        parents: true,
+    };
+    let first = harness
+        .client
+        .create_directory(&pinned, &mkdir_options("one"))
+        .await
+        .expect("first mkdir");
+    let replay = harness
+        .client
+        .create_directory(&pinned, &mkdir_options("one"))
+        .await
+        .expect("an identical retry replays");
+    assert_eq!(replay, first);
+    match harness
+        .client
+        .create_directory(&pinned, &mkdir_options("two"))
+        .await
+    {
+        Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
         other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
     }
 

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -148,14 +148,14 @@ impl FsWriter {
         )
     )]
     /// Re-running this with a `commit_id` that already committed is safe
-    /// when the bytes are the same. A commit's identity names *which*
+    /// when the request is the same. A commit's identity names *which*
     /// content object it wrote, and a re-run necessarily stages a fresh
     /// one, so the publisher sees a different commit and reports
     /// `commit_id_reuse_conflict`. This resolves that by reading back what
-    /// the commit id actually committed and comparing its content against
-    /// the bytes just staged: equal means the operation had already
-    /// succeeded. Different bytes, or content this build cannot compare,
-    /// surface the conflict.
+    /// the commit id actually committed and comparing it against the
+    /// request just made: same content and same message means the
+    /// operation had already succeeded. Different bytes, a different
+    /// message, or content this build cannot compare surface the conflict.
     ///
     /// The freshly staged duplicate object is then referenced by nothing.
     /// That is by design, not a leak: content garbage collection reclaims an
@@ -171,6 +171,7 @@ impl FsWriter {
         self.core.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
         let commit_id = options.commit_id.clone();
+        let message = options.message.clone();
         let prepared_content = self.prepare_file_bytes(namespace_id, bytes).await?;
         let published = self
             .put_file_prepared(namespace_id, absolute_path, prepared_content, options)
@@ -178,6 +179,7 @@ impl FsWriter {
         self.settle_put(
             namespace_id,
             commit_id,
+            message,
             published,
             StagedPayload::Bytes(bytes),
         )
@@ -219,6 +221,7 @@ impl FsWriter {
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
         let commit_id = options.commit_id.clone();
+        let message = options.message.clone();
         let prepared_content = self.prepare_file_stream(namespace_id, body).await?;
         // The prepared reference describes the bytes that just went past,
         // and with the payload gone it is the only description of them that
@@ -230,6 +233,7 @@ impl FsWriter {
         self.settle_put(
             namespace_id,
             commit_id,
+            message,
             published,
             StagedPayload::Streamed(&staged),
         )
@@ -242,13 +246,20 @@ impl FsWriter {
         &self,
         namespace_id: &NamespaceId,
         commit_id: Option<CommitId>,
+        message: Option<String>,
         published: Result<CommitResponse>,
         staged: StagedPayload<'_>,
     ) -> Result<CommitResponse> {
         match (published, commit_id) {
             (Err(error), Some(commit_id)) if error.code() == ErrorCode::CommitIdReuseConflict => {
-                self.reconcile_commit_id_reuse(namespace_id, &commit_id, staged, error)
-                    .await
+                self.reconcile_commit_id_reuse(
+                    namespace_id,
+                    &commit_id,
+                    message.as_deref(),
+                    staged,
+                    error,
+                )
+                .await
             }
             (published, _) => published,
         }
@@ -256,16 +267,17 @@ impl FsWriter {
 
     /// Decides whether a reused commit id already did this exact work.
     ///
-    /// The evidence is the committed content itself, read from the change
-    /// feed at the sequence the conflict reported and compared against the
-    /// bytes just staged. Nothing weaker counts: every way of failing to
-    /// prove the two are the same — including a comparison this build
-    /// cannot make — leaves the original conflict standing, never
-    /// agreement.
+    /// The evidence is the committed change itself, read from the change
+    /// feed at the sequence the conflict reported: its message against the
+    /// one this request asked for, and its content against the bytes just
+    /// staged. Nothing weaker counts: every way of failing to prove the two
+    /// requests are the same — including a comparison this build cannot
+    /// make — leaves the original conflict standing, never agreement.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,
         commit_id: &CommitId,
+        message: Option<&str>,
         staged: StagedPayload<'_>,
         conflict: RuntimeError,
     ) -> Result<CommitResponse> {
@@ -278,6 +290,15 @@ impl FsWriter {
         else {
             return Err(conflict);
         };
+        // The message is part of a commit's identity, so a rerun that
+        // changed it asked for a different mutation and the conflict is the
+        // honest answer. Equality here is the fingerprint's: it serializes
+        // the message as given — absent becomes `null`, an empty message
+        // becomes `""` — so no message and an empty message are different
+        // commits, and this comparison must not fold them together.
+        if committed.message.as_deref() != message {
+            return Err(conflict);
+        }
         let Some(content_ref) = committed_content_ref(&committed) else {
             return Err(conflict);
         };

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -10,9 +10,11 @@
 use crate::common::{open_runtime_async, store, TestRuntime};
 use bytes::Bytes;
 use futures::StreamExt;
+use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
 use loonfs::{
-    ByteStream, CommitId, CreateNamespaceOptions, DestinationBehavior, MaintenanceStepKind,
-    MaintenanceStepOptions, NamespaceId, PutFileOptions, ReorganizeStepOutcome,
+    ByteStream, ChangeSeq, CommitId, CreateDirectoryOptions, CreateNamespaceOptions,
+    DestinationBehavior, ListChangesOptions, MaintenanceStepKind, MaintenanceStepOptions,
+    NamespaceId, PutFileOptions, ReorganizeStepOutcome,
 };
 use loonfs_api::ErrorCode;
 use tempfile::tempdir;
@@ -36,6 +38,31 @@ fn options(commit_id: &CommitId) -> PutFileOptions {
         message: None,
         expected_revision_no: None,
     }
+}
+
+fn options_with_message(commit_id: &CommitId, message: Option<&str>) -> PutFileOptions {
+    PutFileOptions {
+        message: message.map(ToOwned::to_owned),
+        ..options(commit_id)
+    }
+}
+
+/// What the feed says the commit at a sequence was annotated with.
+async fn feed_message(
+    runtime: &TestRuntime,
+    namespace_id: &NamespaceId,
+    seq: ChangeSeq,
+) -> Option<String> {
+    let page = runtime
+        .reader
+        .list_changes(namespace_id, ChangeSeq(0), ListChangesOptions::default())
+        .await
+        .expect("list changes");
+    page.changes
+        .into_iter()
+        .find(|change| change.seq == seq)
+        .expect("the committed change is on the feed")
+        .message
 }
 
 async fn namespace(runtime: &TestRuntime) -> NamespaceId {
@@ -133,6 +160,194 @@ async fn same_length_different_bytes_conflict() {
         .await
         .expect_err("same length is not the same content");
 
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+}
+
+/// The same bytes under the same message are the same commit, so the rerun
+/// replays the sequence that already landed — the message being present
+/// changes nothing about that.
+#[tokio::test]
+async fn rerunning_a_put_with_the_same_message_replays_on_identical_bytes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+    let options = || options_with_message(&commit_id, Some("import batch"));
+
+    let first = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options())
+        .await
+        .expect("first put");
+    let rerun = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options())
+        .await
+        .expect("rerunning an identical request is idempotent");
+
+    assert_eq!(rerun, first);
+    assert_eq!(
+        feed_message(&runtime, &namespace_id, first.committed_seq).await,
+        Some("import batch".to_owned())
+    );
+}
+
+/// The message is part of a commit's identity, so the same bytes under a
+/// changed message are a different mutation and the conflict stands. The
+/// bytes matching is exactly what makes this worth pinning: content
+/// evidence alone would call this a successful retry and quietly keep the
+/// original annotation.
+#[tokio::test]
+async fn a_changed_message_under_a_used_commit_id_still_conflicts() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+
+    let first = runtime
+        .put_file_bytes(
+            &namespace_id,
+            PATH,
+            b"stable bytes\n",
+            options_with_message(&commit_id, Some("import batch")),
+        )
+        .await
+        .expect("first put");
+    let error = runtime
+        .put_file_bytes(
+            &namespace_id,
+            PATH,
+            b"stable bytes\n",
+            options_with_message(&commit_id, Some("second thoughts")),
+        )
+        .await
+        .expect_err("a changed message is a different commit");
+
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+    assert_eq!(
+        feed_message(&runtime, &namespace_id, first.committed_seq).await,
+        Some("import batch".to_owned()),
+        "the refused rerun did not rewrite the annotation that landed"
+    );
+    let entry = runtime
+        .stat_path(&namespace_id, PATH)
+        .await
+        .expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "the refused rerun published no revision"
+    );
+}
+
+/// Absent and empty are different messages: the fingerprint serializes the
+/// annotation as given, so `null` and `""` are different commits. The
+/// reconciliation compares them the same way rather than folding both into
+/// "no message".
+#[tokio::test]
+async fn an_empty_message_does_not_replay_an_absent_one() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+
+    let first = runtime
+        .put_file_bytes(
+            &namespace_id,
+            PATH,
+            b"stable bytes\n",
+            options_with_message(&commit_id, None),
+        )
+        .await
+        .expect("first put");
+    let error = runtime
+        .put_file_bytes(
+            &namespace_id,
+            PATH,
+            b"stable bytes\n",
+            options_with_message(&commit_id, Some("")),
+        )
+        .await
+        .expect_err("an empty message is not the absent message");
+
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+    assert_eq!(
+        feed_message(&runtime, &namespace_id, first.committed_seq).await,
+        None
+    );
+}
+
+/// The mutations that never uploaded anything reconcile nothing — the
+/// publisher's own identity check is the whole answer — so a changed
+/// message conflicts there whatever the put path does. This anchors that
+/// the reconciliation added for put did not become the only thing keeping
+/// the contract.
+#[tokio::test]
+async fn a_changed_message_on_mkdir_still_conflicts() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-mkdir").expect("valid commit id");
+    let options = |message: &str| CreateDirectoryOptions {
+        commit_id: Some(commit_id.clone()),
+        message: Some(message.to_owned()),
+        parents: true,
+    };
+
+    let first = runtime
+        .writer
+        .create_directory(&namespace_id, "/pinned", options("one"))
+        .await
+        .expect("first mkdir");
+    let replay = runtime
+        .writer
+        .create_directory(&namespace_id, "/pinned", options("one"))
+        .await
+        .expect("an identical retry replays");
+    assert_eq!(replay, first);
+
+    let error = runtime
+        .writer
+        .create_directory(&namespace_id, "/pinned", options("two"))
+        .await
+        .expect_err("a changed message is a different commit");
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+}
+
+/// The same anchor one layer down, where the caller builds the commit
+/// itself: the request that reaches the publisher is identical apart from
+/// its message, and that alone conflicts.
+#[tokio::test]
+async fn a_changed_message_on_a_direct_commit_still_conflicts() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-commit").expect("valid commit id");
+    let request = |message: &str| {
+        CommitRequest::single(
+            commit_id.clone(),
+            Some(message.to_owned()),
+            FilesystemOperation::CreateDirectory {
+                path: parse_mutation_path("/direct").expect("path"),
+                parents: true,
+            },
+        )
+    };
+
+    let first = runtime
+        .writer
+        .commit(&namespace_id, request("one"))
+        .await
+        .expect("first commit");
+    let replay = runtime
+        .writer
+        .commit(&namespace_id, request("one"))
+        .await
+        .expect("an identical retry replays");
+    assert_eq!(replay, first);
+
+    let error = runtime
+        .writer
+        .commit(&namespace_id, request("two"))
+        .await
+        .expect_err("a changed message is a different commit");
     assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -431,8 +431,8 @@ answer on its own.
 
 **Client-side retry reconciliation.** Rerunning a whole upload-then-commit
 sequence under one `commit_id` — the shape of a command rerun, where no
-`content_ref` survived the first attempt — is nonetheless safe on identical
-bytes. A client that composes upload and commit must, on
+`content_ref` survived the first attempt — is nonetheless safe when the
+request is identical. A client that composes upload and commit must, on
 `commit_id_reuse_conflict`, resolve it as follows before surfacing it:
 
 1. Find what that `commit_id` committed. There is no read keyed by commit
@@ -441,8 +441,14 @@ bytes. A client that composes upload and commit must, on
    — and take the row whose `commit_id` matches. If `details.committed_seq`
    is absent, or the feed answers `rebootstrap_required` because retention
    has moved past that sequence, or the row there names some other commit,
-   there is nothing to compare: go straight to rule 4.
-2. Compare the committed content against what was just uploaded: the
+   there is nothing to compare: go straight to rule 5.
+2. Compare the committed change's `message` against the one the request
+   asked for. The message is part of the commit's identity, so a rerun that
+   changed it asked for a different mutation: go to rule 5. Compare the
+   annotations exactly as the server fingerprints them — an absent message
+   and an empty one are different commits, so a client must not fold both
+   into "no message".
+3. Compare the committed content against what was just uploaded: the
    content's `whole_file_sha256` when it has one, and otherwise its
    `storage_checksum`, after checking `size_bytes`.
 
@@ -453,16 +459,17 @@ bytes. A client that composes upload and commit must, on
    `crc64nvme` it claimed at completion, which is also what the reference
    the server minted carries. Both are evidence about the same bytes; they
    differ only in which digests they can answer for, and a digest the
-   upload never computed falls to rule 4 rather than being guessed at.
-3. Equal content means the logical operation had already succeeded: report
-   the commit that landed, with its original `committed_seq`.
-4. Anything else surfaces a failure. Different content is the
-   `commit_id_reuse_conflict` unchanged, and so is a commit the client
-   could not locate — an absent `committed_seq`, or a sequence retention no
-   longer answers for. Content the client *cannot* compare — a checksum
-   algorithm it does not implement — is reported as a failure naming why it
-   could not reconcile. **A comparison that cannot be made is never
-   reported as success.**
+   upload never computed falls to rule 5 rather than being guessed at.
+4. The same message over equal content means the logical operation had
+   already succeeded: report the commit that landed, with its original
+   `committed_seq`.
+5. Anything else surfaces a failure. Different content is the
+   `commit_id_reuse_conflict` unchanged, and so are a changed message and a
+   commit the client could not locate — an absent `committed_seq`, or a
+   sequence retention no longer answers for. Content the client *cannot*
+   compare — a checksum algorithm it does not implement — is reported as a
+   failure naming why it could not reconcile. **A comparison that cannot be
+   made is never reported as success.**
 
 The duplicate content object the rerun uploaded is then referenced by
 nothing. That is by design: it is a completed upload whose content no


### PR DESCRIPTION
`loonfs put` with the same commit id, identical bytes, and a CHANGED `--message` replayed success and silently kept the original message. Direct API commits and `mkdir` already conflicted correctly — only the put path misbehaved.

Root cause: The message is part of the commit fingerprint, so core correctly raises `commit_id_reuse_conflict` when only the message changes. But the put-retry reconciliation — the client-side algorithm that turns "the bytes you retried already landed" into success — compared content only: committed seq, content ref, size, digest. It never compared the message, so it swallowed a real conflict.

Fix: Both reconcilers (embedded runtime and HTTP client) gain the missing gate: the requested message must equal the committed change's message, or the original conflict stands, exactly like every other bail gate. The gate sits right after the feed row is read, before the content checks, because it is a fact about the commit rather than its bytes.

The None-versus-empty rule: An absent message and an empty message are different commits: the fingerprint serializes absent as `null` and empty as `""`, producing different digests, and nothing between the CLI and the WAL normalizes one into the other. The gate therefore uses exact equality — folding them together would report success for a request core had judged a different mutation. Stated as an invariant comment in both reconcilers and pinned by a test.

