### PR TITLE
feat(cli): config resolution with escape hatches

### DIFF
--- a/configs/loonfs.local.example.toml
+++ b/configs/loonfs.local.example.toml
@@ -1,5 +1,6 @@
 # Example LoonFS CLI configuration for a local embedded profile.
-# The CLI reads this file from ~/.loonfs/config.toml; `loonfs init` writes it.
+# `loonfs init` writes this file, and `loonfs config path` prints where the
+# CLI reads it from.
 
 config_version = 1
 default_profile = "local"

--- a/configs/loonfs.remote.example.toml
+++ b/configs/loonfs.remote.example.toml
@@ -1,5 +1,5 @@
 # Example LoonFS CLI configuration for a remote profile that talks to a
-# LoonFS server. The CLI reads this file from ~/.loonfs/config.toml.
+# LoonFS server. `loonfs config path` prints where the CLI reads it from.
 
 config_version = 1
 default_profile = "remote"

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -11,6 +11,9 @@ Loon CLI Command Reference
 `loonfs` works with profiles, namespaces, and path-based filesystem operations.
 
 Global flags
+  --config <path>
+    Config file to use, ahead of LOONFS_CONFIG and the default location
+
   --json
     Emit JSON instead of human output
 
@@ -52,13 +55,35 @@ Setup and configuration
     fails when the config file already exists
 
   loonfs config path
-    Print the path to the CLI config file
+    Print the config file this invocation uses and which rule chose it
 
   loonfs config show
     Print the config file with secrets redacted
 
   loonfs version
     Print the version, commit, and build date
+
+Config file location
+  One config file per invocation, chosen by the first rule that applies:
+    1. --config <path>
+    2. LOONFS_CONFIG=<path>
+    3. $XDG_CONFIG_HOME/loonfs/config.toml, when XDG_CONFIG_HOME names an
+       absolute directory
+    4. ~/.loonfs/config.toml
+
+  A path given to --config or LOONFS_CONFIG is the file this invocation
+  uses whether or not it is there yet, and `loonfs init` creates the
+  directories it needs. That is the way past a config file this build will
+  not read: an unknown key is an error, so every command that reads the
+  file fails until it is fixed or stepped around, and each of those errors
+  names the file, what in it went wrong, and both ways past it.
+
+  `loonfs config path` reads nothing, so it keeps answering while the file
+  it names is unreadable.
+
+  While XDG_CONFIG_HOME is set but holds no config of its own, an existing
+  ~/.loonfs/config.toml stays in use and `loonfs config path` names the
+  preferred path to move it to.
 
 Profile management
   loonfs profile create <name> [profile-options]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -2,6 +2,7 @@
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::io::IsTerminal;
+use std::path::PathBuf;
 
 /// `loonfs x.y.z (commit date)`: the string served by both `--version` and
 /// the `version` subcommand, built from the metadata `build.rs` embeds.
@@ -17,6 +18,9 @@ pub(crate) const LONG_VERSION: &str = concat!(
 #[derive(Debug, Parser)]
 #[command(name = "loonfs", version = LONG_VERSION)]
 pub(crate) struct Cli {
+    /// Config file to use, ahead of LOONFS_CONFIG and the default location.
+    #[arg(long, global = true, value_name = "PATH")]
+    pub config: Option<PathBuf>,
     /// Emit machine-readable JSON instead of human output.
     #[arg(long, global = true)]
     pub json: bool,

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -19,34 +19,41 @@ use loonfs_api::{
 };
 use loonfs_grep::{GREP_GC_JOB, GREP_INDEX_JOB};
 use std::collections::BTreeSet;
+use std::path::Path;
 
 // --- maintenance/admin plane ---
 
 pub(crate) async fn run_admin_command(
     kind: CommandKind,
+    config_path: &Path,
     command: AdminCommand,
 ) -> Result<CommandOutput, CommandFailure> {
     match command {
-        AdminCommand::Checkpoint(args) => run_admin_checkpoint(kind, args).await,
-        AdminCommand::CheckpointRelease(args) => run_admin_checkpoint_release(kind, args).await,
-        AdminCommand::Flush(args) => run_admin_flush(kind, args).await,
-        AdminCommand::RetentionAdvance(args) => run_admin_retention_advance(kind, args).await,
-        AdminCommand::Run(args) => run_admin_run(kind, args).await,
-        AdminCommand::Step(args) => run_admin_step(kind, args).await,
-        AdminCommand::Gc(args) => run_admin_gc(kind, args).await,
-        AdminCommand::ProbeStore(args) => run_admin_probe_store(kind, args).await,
-        AdminCommand::IndexEnable(args) => run_admin_index_enable(kind, args).await,
-        AdminCommand::IndexDisable(args) => run_admin_index_disable(kind, args).await,
-        AdminCommand::IndexStatus(args) => run_admin_index_status(kind, args).await,
-        AdminCommand::IndexGc(args) => run_admin_index_gc(kind, args).await,
+        AdminCommand::Checkpoint(args) => run_admin_checkpoint(kind, config_path, args).await,
+        AdminCommand::CheckpointRelease(args) => {
+            run_admin_checkpoint_release(kind, config_path, args).await
+        }
+        AdminCommand::Flush(args) => run_admin_flush(kind, config_path, args).await,
+        AdminCommand::RetentionAdvance(args) => {
+            run_admin_retention_advance(kind, config_path, args).await
+        }
+        AdminCommand::Run(args) => run_admin_run(kind, config_path, args).await,
+        AdminCommand::Step(args) => run_admin_step(kind, config_path, args).await,
+        AdminCommand::Gc(args) => run_admin_gc(kind, config_path, args).await,
+        AdminCommand::ProbeStore(args) => run_admin_probe_store(kind, config_path, args).await,
+        AdminCommand::IndexEnable(args) => run_admin_index_enable(kind, config_path, args).await,
+        AdminCommand::IndexDisable(args) => run_admin_index_disable(kind, config_path, args).await,
+        AdminCommand::IndexStatus(args) => run_admin_index_status(kind, config_path, args).await,
+        AdminCommand::IndexGc(args) => run_admin_index_gc(kind, config_path, args).await,
     }
 }
 
 async fn run_admin_step(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminStepArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let request = MaintenanceStepRequest {
         max_wal_tail_segments: args.max_wal_tail_segments,
         retention: args.retention.then_some(true),
@@ -69,9 +76,10 @@ async fn run_admin_step(
 
 async fn run_admin_gc(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminGcArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let single_pass = args.max_objects.is_some();
     let mut request = GcRequest {
         grace_window_ms: args.grace_window_ms,
@@ -132,9 +140,10 @@ fn accumulate_gc_response(total: &mut loonfs_api::GcResponse, pass: loonfs_api::
 
 async fn run_admin_checkpoint(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminCheckpointArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let request = CreateCheckpointRequest {
         name: args.name,
         ttl_ms: args.ttl_ms,
@@ -155,9 +164,10 @@ async fn run_admin_checkpoint(
 
 async fn run_admin_checkpoint_release(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminCheckpointReleaseArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let checkpoint_id = CheckpointId::parse(&args.checkpoint_id).map_err(|error| {
         context.fail(
             kind,
@@ -180,9 +190,10 @@ async fn run_admin_checkpoint_release(
 
 async fn run_admin_flush(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminNamespaceArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
         .maintenance_step(
@@ -209,9 +220,10 @@ async fn run_admin_flush(
 
 async fn run_admin_retention_advance(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminNamespaceArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
         .maintenance_step(
@@ -242,10 +254,11 @@ async fn run_admin_retention_advance(
 /// continuously until a signal, or as one bounded catch-up with `--drain`.
 async fn run_admin_run(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminRunArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let resolved = resolve_target_profile(explicit_profile, args.profile.no_retry)
+    let resolved = resolve_target_profile(config_path, explicit_profile, args.profile.no_retry)
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
@@ -309,10 +322,11 @@ async fn run_admin_run(
 /// store is the subject.
 async fn run_admin_probe_store(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminProbeStoreArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let resolved = resolve_target_profile(explicit_profile, args.profile.no_retry)
+    let resolved = resolve_target_profile(config_path, explicit_profile, args.profile.no_retry)
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
@@ -386,9 +400,10 @@ async fn shutdown_signal() {
 
 pub(crate) async fn run_admin_changes(
     kind: CommandKind,
+    config_path: &Path,
     args: ChangesArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let after_seq = ChangeSeq(args.after.unwrap_or(0));
     let response = context
         .target
@@ -412,9 +427,10 @@ pub(crate) async fn run_admin_changes(
 /// being written to cannot keep this command running.
 async fn run_admin_index_enable(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminIndexEnableArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
         .enable_grep_index(&context.namespace)
@@ -476,9 +492,10 @@ async fn run_admin_index_enable(
 
 async fn run_admin_index_status(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminNamespaceArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
         .grep_index_status(&context.namespace)
@@ -497,9 +514,10 @@ async fn run_admin_index_status(
 /// asks for one pass and its resume token.
 async fn run_admin_index_gc(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminIndexGcArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let single_pass = args.max_objects.is_some();
     // An omitted budget is left omitted: grep resolves it to the same
     // per-pass default the runtime uses, and one authority for that number
@@ -549,9 +567,10 @@ fn accumulate_grep_gc_response(
 
 async fn run_admin_index_disable(
     kind: CommandKind,
+    config_path: &Path,
     args: AdminNamespaceArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
         .disable_grep_index(&context.namespace)

--- a/crates/loonfs-cli/src/commands/config.rs
+++ b/crates/loonfs-cli/src/commands/config.rs
@@ -5,22 +5,26 @@ use super::output::{CommandData, CommandFailure, CommandOutput};
 use super::profile_config::{build_profile_from_create_spec, create_profile_spec_from_init};
 use crate::args::{CommandKind, ConfigCommand, InitArgs, RuntimeBehavior};
 use crate::config::{
-    default_config_path, load_config_for_repair, load_or_default_config, redacted_config_table,
-    save_config, ConfigLoad, ProfileConfig,
+    load_config_for_repair, load_or_default_config, redacted_config_table, save_config, ConfigLoad,
+    ConfigLocation, ProfileConfig,
 };
 use crate::error::CliError;
 use crate::profiles::add_profile;
 use crate::prompt;
+use std::path::Path;
 
 // --- init ---
 
+/// Writes the resolved config file, whichever way it was named, creating
+/// the directories it needs. Naming a path that holds no file yet is the
+/// way back from a default config this build refuses to read: init only
+/// ever touches the file resolution named.
 pub(crate) fn run_config_init(
     kind: CommandKind,
+    config_path: &Path,
     args: InitArgs,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let config_path = default_config_path().map_err(|error| fail(kind, None, None, error))?;
-
     let result = (|| -> Result<(String, ProfileConfig), CliError> {
         if config_path.exists() {
             return Err(CliError::config_already_exists(
@@ -35,10 +39,10 @@ pub(crate) fn run_config_init(
         };
         let profile = build_profile_from_create_spec(create_profile_spec_from_init(args), runtime)?;
 
-        let mut config = load_or_default_config(&config_path)?;
+        let mut config = load_or_default_config(config_path)?;
         let (profile_name, redacted) = add_profile(&mut config, &name, profile)?;
         config.default_profile = Some(profile_name.clone());
-        save_config(&config_path, &config)?;
+        save_config(config_path, &config)?;
         Ok((profile_name, redacted))
     })()
     .map_err(|error| fail(kind, None, None, error))?;
@@ -55,20 +59,29 @@ pub(crate) fn run_config_init(
 
 pub(crate) fn run_config_command(
     kind: CommandKind,
+    location: &ConfigLocation,
     command: ConfigCommand,
 ) -> Result<CommandOutput, CommandFailure> {
-    let config_path = default_config_path().map_err(|error| fail(kind, None, None, error))?;
+    let config_path = location.path.as_path();
     match command {
+        // Path never reads the file: the one command that answers "which
+        // config is this build even looking at" has to work while that file
+        // is one the build refuses to read.
         ConfigCommand::Path => Ok(CommandOutput {
             kind,
             profile: None,
             mode: None,
             data: CommandData::ConfigPath {
                 path: config_path.display().to_string(),
+                source: location.source,
+                preferred_path: location
+                    .preferred_path
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
             },
         }),
         ConfigCommand::Show => {
-            let loaded = load_config_for_repair(&config_path)
+            let loaded = load_config_for_repair(config_path)
                 .map_err(|error| fail(kind, None, None, error))?;
             let data = match loaded {
                 ConfigLoad::Valid(config) => CommandData::ConfigShow {

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -46,10 +46,11 @@ impl CommandContext {
 
 pub(crate) async fn resolve_command_context(
     kind: CommandKind,
+    config_path: &Path,
     target: &TargetSelectorArgs,
 ) -> Result<CommandContext, CommandFailure> {
     let explicit_profile = target.profile.profile.as_deref();
-    let loaded = load_cli_config()
+    let loaded = load_cli_config(config_path)
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let resolved = resolve_target_profile_from_config(
         &loaded.config,

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -64,9 +64,10 @@ pub(super) fn write_local_file_atomically(
 
 pub(crate) async fn run_filesystem_ls(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemLsArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = true;
     let spec = namespace_path(
         &context.namespace,
@@ -89,9 +90,10 @@ pub(crate) async fn run_filesystem_ls(
 
 pub(crate) async fn run_filesystem_stat(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemPathArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = true;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -111,9 +113,10 @@ pub(crate) async fn run_filesystem_stat(
 
 pub(crate) async fn run_filesystem_grep(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemGrepArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let path_prefix = args
         .path_prefix
         .as_deref()
@@ -168,9 +171,10 @@ pub(crate) async fn run_filesystem_grep(
 
 pub(crate) async fn run_filesystem_cat(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemCatArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -196,10 +200,11 @@ pub(crate) async fn run_filesystem_cat(
 
 pub(crate) async fn run_filesystem_get(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemGetArgs,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     if runtime.json && args.local_destination.as_deref() == Some("-") {
         return Err(fail(
             kind,
@@ -316,9 +321,10 @@ pub(crate) async fn run_filesystem_get(
 
 pub(crate) async fn run_filesystem_trash(
     kind: CommandKind,
+    config_path: &Path,
     args: TrashArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let response = context
         .target
         .list_trash(&context.namespace, args.limit, args.cursor.as_deref())
@@ -334,9 +340,10 @@ pub(crate) async fn run_filesystem_trash(
 
 pub(crate) async fn run_filesystem_revisions(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemRevisionsArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -360,10 +367,11 @@ pub(crate) async fn run_filesystem_revisions(
 
 pub(crate) async fn run_filesystem_put(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemPutArgs,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let local_path = PathBuf::from(&args.local_path);
     if local_path == Path::new(STDIN_PATH) {
         return run_filesystem_put_stdin(kind, args, context).await;
@@ -528,9 +536,10 @@ fn put_file_options(args: &FilesystemPutArgs) -> Result<PutFileOptions, CliError
 
 pub(crate) async fn run_filesystem_rm(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemRmArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -578,9 +587,10 @@ pub(crate) async fn run_filesystem_rm(
 
 pub(crate) async fn run_filesystem_restore(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemRestoreArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -614,9 +624,10 @@ pub(crate) async fn run_filesystem_restore(
 
 pub(crate) async fn run_filesystem_undelete(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemUndeleteArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -651,9 +662,10 @@ pub(crate) async fn run_filesystem_undelete(
 
 pub(crate) async fn run_filesystem_mkdir(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemMkdirArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -685,18 +697,20 @@ pub(crate) async fn run_filesystem_mkdir(
 
 pub(crate) async fn run_filesystem_mv(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemTransferArgs,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    run_filesystem_transfer(kind, args, TransferKind::Move, runtime).await
+    run_filesystem_transfer(kind, config_path, args, TransferKind::Move, runtime).await
 }
 
 pub(crate) async fn run_filesystem_cp(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemTransferArgs,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    run_filesystem_transfer(kind, args, TransferKind::Copy, runtime).await
+    run_filesystem_transfer(kind, config_path, args, TransferKind::Copy, runtime).await
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -707,11 +721,12 @@ enum TransferKind {
 
 async fn run_filesystem_transfer(
     kind: CommandKind,
+    config_path: &Path,
     args: FilesystemTransferArgs,
     transfer_kind: TransferKind,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, &args.target).await?;
+    let context = resolve_command_context(kind, config_path, &args.target).await?;
     if args.recursive && transfer_kind == TransferKind::Move {
         return Err(context.fail(
             kind,

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ mod recursive;
 pub(crate) use self::output::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
 
 use crate::args::{Cli, Command, RuntimeBehavior};
+use crate::config::resolve_config_location;
 
 pub(crate) async fn run(
     cli: Cli,
@@ -28,6 +29,12 @@ pub(crate) async fn run(
         });
     }
 
+    // One resolution for the whole invocation: every command below reads
+    // and writes the same file, whichever way it was named.
+    let location = resolve_config_location(cli.config.as_deref())
+        .map_err(|error| context::fail(kind, None, None, error))?;
+    let config_path = location.path.as_path();
+
     match cli.command {
         Command::Version => Ok(CommandOutput {
             kind,
@@ -39,29 +46,31 @@ pub(crate) async fn run(
                 commit_date: env!("LOON_GIT_COMMIT_DATE").to_owned(),
             },
         }),
-        Command::Init(args) => config::run_config_init(kind, args, runtime),
-        Command::Config { command } => config::run_config_command(kind, command),
-        Command::Profile { command } => profile::run_profile_command(kind, command, runtime),
-        Command::Namespace { command } => {
-            namespace::run_namespace_command(kind, command, runtime).await
+        Command::Init(args) => config::run_config_init(kind, config_path, args, runtime),
+        Command::Config { command } => config::run_config_command(kind, &location, command),
+        Command::Profile { command } => {
+            profile::run_profile_command(kind, config_path, command, runtime)
         }
-        Command::Use(args) => namespace::run_namespace_use(kind, args).await,
-        Command::Current(args) => namespace::run_namespace_current(kind, args).await,
-        Command::Ls(args) => fs::run_filesystem_ls(kind, args).await,
-        Command::Stat(args) => fs::run_filesystem_stat(kind, args).await,
-        Command::Cat(args) => fs::run_filesystem_cat(kind, args).await,
-        Command::Grep(args) => fs::run_filesystem_grep(kind, args).await,
-        Command::Get(args) => fs::run_filesystem_get(kind, args, runtime).await,
-        Command::Put(args) => fs::run_filesystem_put(kind, args, runtime).await,
-        Command::Revisions(args) => fs::run_filesystem_revisions(kind, args).await,
-        Command::Restore(args) => fs::run_filesystem_restore(kind, args).await,
-        Command::Undelete(args) => fs::run_filesystem_undelete(kind, args).await,
-        Command::Mkdir(args) => fs::run_filesystem_mkdir(kind, args).await,
-        Command::Rm(args) => fs::run_filesystem_rm(kind, args).await,
-        Command::Mv(args) => fs::run_filesystem_mv(kind, args, runtime).await,
-        Command::Cp(args) => fs::run_filesystem_cp(kind, args, runtime).await,
-        Command::Trash(args) => fs::run_filesystem_trash(kind, args).await,
-        Command::Changes(args) => admin::run_admin_changes(kind, args).await,
-        Command::Admin { command } => admin::run_admin_command(kind, command).await,
+        Command::Namespace { command } => {
+            namespace::run_namespace_command(kind, config_path, command, runtime).await
+        }
+        Command::Use(args) => namespace::run_namespace_use(kind, config_path, args).await,
+        Command::Current(args) => namespace::run_namespace_current(kind, config_path, args).await,
+        Command::Ls(args) => fs::run_filesystem_ls(kind, config_path, args).await,
+        Command::Stat(args) => fs::run_filesystem_stat(kind, config_path, args).await,
+        Command::Cat(args) => fs::run_filesystem_cat(kind, config_path, args).await,
+        Command::Grep(args) => fs::run_filesystem_grep(kind, config_path, args).await,
+        Command::Get(args) => fs::run_filesystem_get(kind, config_path, args, runtime).await,
+        Command::Put(args) => fs::run_filesystem_put(kind, config_path, args, runtime).await,
+        Command::Revisions(args) => fs::run_filesystem_revisions(kind, config_path, args).await,
+        Command::Restore(args) => fs::run_filesystem_restore(kind, config_path, args).await,
+        Command::Undelete(args) => fs::run_filesystem_undelete(kind, config_path, args).await,
+        Command::Mkdir(args) => fs::run_filesystem_mkdir(kind, config_path, args).await,
+        Command::Rm(args) => fs::run_filesystem_rm(kind, config_path, args).await,
+        Command::Mv(args) => fs::run_filesystem_mv(kind, config_path, args, runtime).await,
+        Command::Cp(args) => fs::run_filesystem_cp(kind, config_path, args, runtime).await,
+        Command::Trash(args) => fs::run_filesystem_trash(kind, config_path, args).await,
+        Command::Changes(args) => admin::run_admin_changes(kind, config_path, args).await,
+        Command::Admin { command } => admin::run_admin_command(kind, config_path, command).await,
     }
 }

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -13,27 +13,32 @@ use crate::prompt::prompt_line;
 use crate::resolve::{
     load_cli_config, parse_namespace_id, resolve_target_profile, resolve_target_profile_from_config,
 };
+use std::path::Path;
 
 // --- namespace ---
 
 pub(crate) async fn run_namespace_command(
     kind: CommandKind,
+    config_path: &Path,
     command: NamespaceCommand,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     match command {
-        NamespaceCommand::Create(args) => run_namespace_create(kind, args).await,
-        NamespaceCommand::Delete(args) => run_namespace_delete(kind, args, runtime).await,
-        NamespaceCommand::Fork(args) => run_namespace_fork(kind, args).await,
+        NamespaceCommand::Create(args) => run_namespace_create(kind, config_path, args).await,
+        NamespaceCommand::Delete(args) => {
+            run_namespace_delete(kind, config_path, args, runtime).await
+        }
+        NamespaceCommand::Fork(args) => run_namespace_fork(kind, config_path, args).await,
     }
 }
 
 async fn run_namespace_create(
     kind: CommandKind,
+    config_path: &Path,
     args: NamespaceCreateArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let resolved = resolve_target_profile(explicit_profile, args.profile.no_retry)
+    let resolved = resolve_target_profile(config_path, explicit_profile, args.profile.no_retry)
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
@@ -55,11 +60,12 @@ async fn run_namespace_create(
 
 async fn run_namespace_delete(
     kind: CommandKind,
+    config_path: &Path,
     args: NamespaceDeleteArgs,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let resolved = resolve_target_profile(explicit_profile, args.profile.no_retry)
+    let resolved = resolve_target_profile(config_path, explicit_profile, args.profile.no_retry)
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
@@ -120,10 +126,11 @@ async fn run_namespace_delete(
 
 async fn run_namespace_fork(
     kind: CommandKind,
+    config_path: &Path,
     args: NamespaceForkArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let resolved = resolve_target_profile(explicit_profile, args.profile.no_retry)
+    let resolved = resolve_target_profile(config_path, explicit_profile, args.profile.no_retry)
         .await
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
@@ -147,10 +154,11 @@ async fn run_namespace_fork(
 
 pub(crate) async fn run_namespace_use(
     kind: CommandKind,
+    config_path: &Path,
     args: NamespaceUseArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let mut loaded = load_cli_config()
+    let mut loaded = load_cli_config(config_path)
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let resolved =
         resolve_target_profile_from_config(&loaded.config, explicit_profile, args.profile.no_retry)
@@ -184,10 +192,11 @@ pub(crate) async fn run_namespace_use(
 
 pub(crate) async fn run_namespace_current(
     kind: CommandKind,
+    config_path: &Path,
     args: CurrentArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let loaded = load_cli_config()
+    let loaded = load_cli_config(config_path)
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let (profile_name, profile) =
         crate::profiles::resolve_profile(&loaded.config, explicit_profile)

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -1,7 +1,7 @@
 //! The typed command results the renderer turns into text or JSON.
 
 use crate::args::CommandKind;
-use crate::config::{CliConfig, ProfileConfig};
+use crate::config::{CliConfig, ConfigSource, ProfileConfig};
 use crate::error::CliError;
 use crate::profiles::ProfileSummary;
 use loonfs_api::v0::{
@@ -176,6 +176,12 @@ pub(crate) enum CommandData {
     },
     ConfigPath {
         path: String,
+        /// Which rule chose the path.
+        source: ConfigSource,
+        /// Where the file belongs now, while a legacy file is in use only
+        /// because the preferred location holds none yet.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        preferred_path: Option<String>,
     },
     ConfigShow {
         config: CliConfig,

--- a/crates/loonfs-cli/src/commands/profile.rs
+++ b/crates/loonfs-cli/src/commands/profile.rs
@@ -10,8 +10,8 @@ use crate::args::{
     CommandKind, ProfileCommand, ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavior,
 };
 use crate::config::{
-    default_config_path, load_config, load_config_for_repair, load_config_if_exists,
-    load_or_default_config, save_config, save_config_table, ConfigLoad, ProfileConfig,
+    load_config, load_config_for_repair, load_config_if_exists, load_or_default_config,
+    save_config, save_config_table, ConfigLoad, ProfileConfig,
 };
 use crate::error::CliError;
 use crate::profiles::{
@@ -25,14 +25,14 @@ use std::path::Path;
 
 pub(crate) fn run_profile_command(
     kind: CommandKind,
+    config_path: &Path,
     command: ProfileCommand,
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
-    let config_path = default_config_path().map_err(|error| fail(kind, None, None, error))?;
     match command {
-        ProfileCommand::Create(args) => run_profile_create(kind, &config_path, args, runtime),
+        ProfileCommand::Create(args) => run_profile_create(kind, config_path, args, runtime),
         ProfileCommand::List => {
-            let config = load_config_if_exists(&config_path)
+            let config = load_config_if_exists(config_path)
                 .map_err(|error| fail(kind, None, None, error))?;
             Ok(CommandOutput {
                 kind,
@@ -46,7 +46,7 @@ pub(crate) fn run_profile_command(
         }
         ProfileCommand::Show { name } => {
             let config =
-                load_config(&config_path).map_err(|error| fail(kind, name.clone(), None, error))?;
+                load_config(config_path).map_err(|error| fail(kind, name.clone(), None, error))?;
             let (profile_name, redacted) = show_profile(&config, name.as_deref())
                 .map_err(|error| fail(kind, name.clone(), None, error))?;
             Ok(CommandOutput {
@@ -56,9 +56,9 @@ pub(crate) fn run_profile_command(
                 data: CommandData::Profile(redacted),
             })
         }
-        ProfileCommand::Update(args) => run_profile_update(kind, &config_path, args, runtime),
-        ProfileCommand::Delete { name } => run_profile_delete(kind, &config_path, &name, runtime),
-        ProfileCommand::Use { name } => run_profile_use(kind, &config_path, &name),
+        ProfileCommand::Update(args) => run_profile_update(kind, config_path, args, runtime),
+        ProfileCommand::Delete { name } => run_profile_delete(kind, config_path, &name, runtime),
+        ProfileCommand::Use { name } => run_profile_use(kind, config_path, &name),
     }
 }
 

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -14,6 +14,25 @@ pub(crate) use loonfs_objectstore::StoreConfig;
 
 pub(crate) const CONFIG_VERSION: u32 = 1;
 
+/// Environment override for the config file, and the escape hatch a shell
+/// session reaches for when the default file is one the CLI will not read.
+pub(crate) const CONFIG_PATH_ENV: &str = "LOONFS_CONFIG";
+
+const CONFIG_FILE_NAME: &str = "config.toml";
+/// Directory under `$XDG_CONFIG_HOME`.
+const XDG_CONFIG_SUBDIR: &str = "loonfs";
+/// Directory under `$HOME`, where installs predating XDG support live.
+const LEGACY_CONFIG_SUBDIR: &str = ".loonfs";
+
+/// The way past a config file this build will not accept. Every failure to
+/// load the resolved file ends with it, because strict decoding is only
+/// safe while a rejected file can always be stepped around — otherwise one
+/// unknown key bricks every command, `loonfs init` included. The
+/// environment variable named here is [`CONFIG_PATH_ENV`].
+const CONFIG_REMEDY: &str = "fix that file, or run against a different one with `--config <path>` \
+     or `LOONFS_CONFIG=<path>`; `loonfs config path` prints the file in use, and \
+     `loonfs init --config <path>` writes a fresh one";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct CliConfig {
@@ -195,11 +214,103 @@ fn profile_store_error(profile_name: &str, error: &StoreConfigError) -> CliError
     }
 }
 
-pub(crate) fn default_config_path() -> Result<PathBuf, CliError> {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .ok_or_else(|| CliError::invalid_config("unable to determine the home directory"))?;
-    Ok(home.join(".loonfs").join("config.toml"))
+/// How [`resolve_config_location`] chose the file, so `config path` answers
+/// both "which file" and "why that one". The serialized spellings are the
+/// `--json` surface: `flag`, `env`, `xdg`, `legacy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ConfigSource {
+    /// The `--config` flag.
+    Flag,
+    /// The `LOONFS_CONFIG` environment variable.
+    Env,
+    /// `$XDG_CONFIG_HOME/loonfs/config.toml`.
+    Xdg,
+    /// `~/.loonfs/config.toml`.
+    Legacy,
+}
+
+/// The one config file this invocation reads and writes.
+pub(crate) struct ConfigLocation {
+    pub path: PathBuf,
+    pub source: ConfigSource,
+    /// Where the file belongs now. Set only while a legacy file is in use
+    /// because `XDG_CONFIG_HOME` is set and holds no config yet.
+    pub preferred_path: Option<PathBuf>,
+}
+
+impl ConfigLocation {
+    fn at(path: PathBuf, source: ConfigSource) -> Self {
+        Self {
+            path,
+            source,
+            preferred_path: None,
+        }
+    }
+}
+
+/// Resolves the config file for this invocation: `--config` beats
+/// `LOONFS_CONFIG` beats the default location.
+///
+/// The explicit forms win by being spelled, never by the named file
+/// existing — a path that is not there yet is still the path this
+/// invocation uses, which is what makes `loonfs init --config <path>` a way
+/// out of an unreadable default file.
+pub(crate) fn resolve_config_location(flag: Option<&Path>) -> Result<ConfigLocation, CliError> {
+    if let Some(path) = flag {
+        return Ok(ConfigLocation::at(path.to_path_buf(), ConfigSource::Flag));
+    }
+    if let Some(path) = non_empty_env_path(CONFIG_PATH_ENV) {
+        return Ok(ConfigLocation::at(path, ConfigSource::Env));
+    }
+    default_config_location()
+}
+
+/// The default location: `$XDG_CONFIG_HOME/loonfs/config.toml` when that
+/// variable names an absolute directory, and `~/.loonfs/config.toml`
+/// otherwise.
+///
+/// Existence decides exactly one thing here, and only for the migration:
+/// an install that predates XDG support keeps reading its `~/.loonfs` file
+/// until a config exists at the preferred path.
+fn default_config_location() -> Result<ConfigLocation, CliError> {
+    let legacy = legacy_config_path();
+    let Some(xdg_dir) = xdg_config_home() else {
+        let path = legacy.ok_or_else(|| {
+            CliError::invalid_config(format!(
+                "unable to determine the home directory; name the config file with \
+                 `--config <path>` or `{CONFIG_PATH_ENV}=<path>`"
+            ))
+        })?;
+        return Ok(ConfigLocation::at(path, ConfigSource::Legacy));
+    };
+    let xdg_path = xdg_dir.join(XDG_CONFIG_SUBDIR).join(CONFIG_FILE_NAME);
+    match legacy.filter(|path| !xdg_path.exists() && path.exists()) {
+        Some(legacy_path) => Ok(ConfigLocation {
+            path: legacy_path,
+            source: ConfigSource::Legacy,
+            preferred_path: Some(xdg_path),
+        }),
+        None => Ok(ConfigLocation::at(xdg_path, ConfigSource::Xdg)),
+    }
+}
+
+/// `XDG_CONFIG_HOME` when it names an absolute directory. The XDG spec
+/// calls an empty or relative value invalid, and ignoring it keeps a stray
+/// relative value from making the config file follow the working directory.
+fn xdg_config_home() -> Option<PathBuf> {
+    let path = PathBuf::from(std::env::var_os("XDG_CONFIG_HOME")?);
+    path.is_absolute().then_some(path)
+}
+
+fn legacy_config_path() -> Option<PathBuf> {
+    let home = non_empty_env_path("HOME")?;
+    Some(home.join(LEGACY_CONFIG_SUBDIR).join(CONFIG_FILE_NAME))
+}
+
+fn non_empty_env_path(name: &str) -> Option<PathBuf> {
+    let value = std::env::var_os(name)?;
+    (!value.is_empty()).then(|| PathBuf::from(value))
 }
 
 pub(crate) fn validate_profile_name(name: &str) -> Result<(), CliError> {
@@ -211,8 +322,8 @@ fn profile_field(name: &str, field: &str) -> String {
 }
 
 pub(crate) fn load_config(path: &Path) -> Result<CliConfig, CliError> {
-    let table = load_config_table(path)?;
-    decode_config_table(path, table)
+    let source = load_config_source(path)?;
+    decode_config_source(path, &source.text)
 }
 
 /// A config load for the repair commands. When the strict decode rejects the
@@ -228,38 +339,52 @@ pub(crate) enum ConfigLoad {
 }
 
 pub(crate) fn load_config_for_repair(path: &Path) -> Result<ConfigLoad, CliError> {
-    let table = load_config_table(path)?;
-    match decode_config_table(path, table.clone()) {
+    let source = load_config_source(path)?;
+    match decode_config_source(path, &source.text) {
         Ok(config) => Ok(ConfigLoad::Valid(config)),
         Err(error) => Ok(ConfigLoad::Degraded {
-            table,
+            table: source.table,
             error: Box::new(error),
         }),
     }
 }
 
-/// Stage one of loading: bytes to a loose TOML table, plus the version
-/// probe. Unknown fields and per-profile shape problems survive this stage;
-/// unreadable files, TOML syntax errors, and other config versions do not.
-fn load_config_table(path: &Path) -> Result<toml::Table, CliError> {
+/// A config file that got as far as being TOML of this version.
+struct ConfigDocument {
+    /// The file's own text, which the strict decode reads so its errors can
+    /// point at a line and column in it.
+    text: String,
+    /// The same file as a loose table, for the version probe and for the
+    /// repair commands.
+    table: toml::Table,
+}
+
+/// Stage one of loading: bytes to text and a loose TOML table, plus the
+/// version probe. Unknown fields and per-profile shape problems survive
+/// this stage; unreadable files, TOML syntax errors, and other config
+/// versions do not.
+fn load_config_source(path: &Path) -> Result<ConfigDocument, CliError> {
     let bytes = fs::read(path).map_err(|err| {
         if err.kind() == std::io::ErrorKind::NotFound {
-            CliError::invalid_config(format!("config file does not exist: {}", path.display()))
+            CliError::invalid_config(format!(
+                "config file does not exist: {}; run `loonfs init` to create it",
+                path.display()
+            ))
         } else {
-            CliError::invalid_config(format!("failed to read config {}: {err}", path.display()))
+            unusable_config(format!("failed to read config {}: {err}", path.display()))
         }
     })?;
-    let contents = std::str::from_utf8(&bytes).map_err(|err| {
-        CliError::invalid_config(format!("failed to decode config {}: {err}", path.display()))
+    let text = String::from_utf8(bytes).map_err(|err| {
+        unusable_config(format!("failed to decode config {}: {err}", path.display()))
     })?;
-    let table: toml::Table = toml::from_str(contents).map_err(|err| {
-        CliError::invalid_config(format!("failed to decode config {}: {err}", path.display()))
+    let table: toml::Table = toml::from_str(&text).map_err(|err| {
+        unusable_config(format!("failed to decode config {}: {err}", path.display()))
     })?;
     // Version before shape: a config written for another version should say
     // so directly, not surface as unknown-field noise from the strict decode.
     match table.get("config_version") {
         None => {
-            return Err(CliError::invalid_config(format!(
+            return Err(unusable_config(format!(
                 "config {} is missing `config_version`",
                 path.display()
             )));
@@ -267,31 +392,50 @@ fn load_config_table(path: &Path) -> Result<toml::Table, CliError> {
         Some(value) => match value.as_integer() {
             Some(version) if version == i64::from(CONFIG_VERSION) => {}
             Some(version) => {
-                return Err(CliError::invalid_config(format!(
+                return Err(unusable_config(format!(
                     "config {} declares `config_version = {version}`; this build supports \
                      `{CONFIG_VERSION}`",
                     path.display()
                 )));
             }
             None => {
-                return Err(CliError::invalid_config(format!(
+                return Err(unusable_config(format!(
                     "config {}: `config_version` must be an integer",
                     path.display()
                 )));
             }
         },
     }
-    Ok(table)
+    Ok(ConfigDocument { text, table })
 }
 
 /// Stage two of loading: the strict typed decode (`deny_unknown_fields`)
 /// plus semantic validation.
-fn decode_config_table(path: &Path, table: toml::Table) -> Result<CliConfig, CliError> {
-    let config: CliConfig = toml::Value::Table(table).try_into().map_err(|err| {
-        CliError::invalid_config(format!("failed to decode config {}: {err}", path.display()))
+///
+/// The decode reads the file's own text rather than the table stage one
+/// already built. That costs a second parse of a small file and buys the
+/// line, column, and quoted source line a TOML error carries only when it
+/// knows where in the text it is.
+fn decode_config_source(path: &Path, text: &str) -> Result<CliConfig, CliError> {
+    let config: CliConfig = toml::from_str(text).map_err(|err| {
+        unusable_config(format!("failed to decode config {}: {err}", path.display()))
     })?;
-    config.validate()?;
+    // Validation messages are field-rooted (`<profile>.store.<field>`), so
+    // the file they belong to is named here rather than in every check.
+    config.validate().map_err(|error| {
+        unusable_config(format!(
+            "invalid config {}: {}",
+            path.display(),
+            error.message
+        ))
+    })?;
     Ok(config)
+}
+
+/// Marks a config file this build will not read, so the failure carries the
+/// way past it. Every load failure but "no file yet" goes through here.
+fn unusable_config(problem: String) -> CliError {
+    CliError::invalid_config(format!("{problem}\n{CONFIG_REMEDY}"))
 }
 
 pub(crate) fn load_config_if_exists(path: &Path) -> Result<Option<CliConfig>, CliError> {
@@ -662,6 +806,33 @@ secret_access_key = "secret"
             "{}",
             unknown.message
         );
+    }
+
+    /// Strict decoding is only safe while a rejected file can be stepped
+    /// around, so every way of failing to load one offers both hatches.
+    #[test]
+    fn every_unreadable_config_offers_both_escape_hatches() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        let write = |contents: &str| std::fs::write(&path, contents).expect("write config");
+
+        for contents in [
+            "config_version = ",
+            "config_version = 2\n",
+            "default_profile = \"x\"\n",
+            "config_version = 1\ndefault_profil = \"typo\"\n",
+            // Semantic failures are as much a wall as shape failures.
+            "config_version = 1\ndefault_profile = \"missing\"\n",
+        ] {
+            write(contents);
+            let error = super::load_config(&path).expect_err("unreadable config");
+            assert!(error.message.contains("--config"), "{}", error.message);
+            assert!(
+                error.message.contains(super::CONFIG_PATH_ENV),
+                "{}",
+                error.message
+            );
+        }
     }
 
     #[test]

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -2,6 +2,7 @@
 
 use crate::args::CommandKind;
 use crate::commands::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
+use crate::config::ConfigSource;
 use crate::error::CliError;
 use loonfs_api::v0::{GrepIndexLifecycle, StoreProbeCheckOutcome, StoreProbeCheckResult};
 use loonfs_api::{GcResponse, NamespaceId, ReorganizeStepOutcome, WalFlushStepOutcome};
@@ -733,7 +734,24 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             }
             _ => format!("{from} -> {to} @ seq {committed_seq} (commit {commit_id})"),
         },
-        CommandData::ConfigPath { path } => path.clone(),
+        CommandData::ConfigPath {
+            path,
+            source,
+            preferred_path,
+        } => {
+            let chosen = match (source, preferred_path) {
+                (ConfigSource::Flag, _) => "from --config".to_owned(),
+                (ConfigSource::Env, _) => "from LOONFS_CONFIG".to_owned(),
+                (ConfigSource::Xdg, _) => "from XDG_CONFIG_HOME".to_owned(),
+                // The migration case: say where the file belongs, since
+                // moving it there is what makes this note go away.
+                (ConfigSource::Legacy, Some(preferred)) => {
+                    format!("legacy location; move it to {preferred} once convenient")
+                }
+                (ConfigSource::Legacy, None) => "default location".to_owned(),
+            };
+            format!("{path} ({chosen})")
+        }
         CommandData::ConfigShow { config } => {
             toml::to_string_pretty(config).unwrap_or_else(|_| "failed to render config".to_owned())
         }

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -3,7 +3,7 @@
 
 use crate::backend::EmbeddedBackend;
 use crate::backend_error::map_runtime_error;
-use crate::config::{default_config_path, load_config, CliConfig, ProfileConfig, StoreConfig};
+use crate::config::{load_config, CliConfig, ProfileConfig, StoreConfig};
 use crate::error::CliError;
 use crate::profiles::{default_namespace, resolve_profile};
 use loonfs::{FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreKind};
@@ -25,17 +25,20 @@ pub(crate) struct ResolvedNamespace {
     pub namespace: NamespaceId,
 }
 
-pub(crate) fn load_cli_config() -> Result<LoadedConfig, CliError> {
-    let path = default_config_path()?;
-    let config = load_config(&path)?;
-    Ok(LoadedConfig { path, config })
+pub(crate) fn load_cli_config(config_path: &std::path::Path) -> Result<LoadedConfig, CliError> {
+    let config = load_config(config_path)?;
+    Ok(LoadedConfig {
+        path: config_path.to_path_buf(),
+        config,
+    })
 }
 
 pub(crate) async fn resolve_target_profile(
+    config_path: &std::path::Path,
     explicit_profile: Option<&str>,
     no_retry: bool,
 ) -> Result<ResolvedProfile, CliError> {
-    let loaded = load_cli_config()?;
+    let loaded = load_cli_config(config_path)?;
     resolve_target_profile_from_config(&loaded.config, explicit_profile, no_retry).await
 }
 

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -9,6 +9,10 @@ use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
+/// A config file with no profiles: enough to load, for the tests that care
+/// about which file was loaded rather than what was in it.
+const MINIMAL_CONFIG: &str = "config_version = 1\n";
+
 #[test]
 fn profile_create_list_show_delete_work() {
     let harness = Harness::new();
@@ -155,6 +159,222 @@ root = "{}"
         !future_message.contains("future_setting"),
         "{future_message}"
     );
+}
+
+/// The resolution chain, first match wins: `--config`, then
+/// `LOONFS_CONFIG`, then `$XDG_CONFIG_HOME/loonfs/config.toml`, then
+/// `~/.loonfs/config.toml`.
+#[test]
+fn config_resolution_prefers_the_flag_then_the_environment_then_xdg_then_legacy() {
+    let harness = Harness::new();
+    harness.write_cli_config(MINIMAL_CONFIG);
+    let legacy_path = harness.config_path.display().to_string();
+
+    let xdg_home = harness.temp_dir.path().join("xdg");
+    let xdg_path = xdg_home.join("loonfs").join("config.toml");
+    let named_path = harness.temp_dir.path().join("named.toml");
+    let flagged_path = harness.temp_dir.path().join("flagged.toml");
+
+    // Without XDG the legacy path is simply the default, with nothing to
+    // migrate to.
+    let default = json_data(&harness.run(&["--json", "config", "path"]));
+    assert_eq!(default["path"], legacy_path);
+    assert_eq!(default["source"], "legacy");
+    assert!(default["preferred_path"].is_null(), "{default}");
+
+    // XDG set but holding no config: the existing legacy file keeps
+    // working, and the answer names where it belongs.
+    let migrating = json_data(&harness.run_with_env(
+        &[("XDG_CONFIG_HOME", &xdg_home)],
+        &["--json", "config", "path"],
+    ));
+    assert_eq!(migrating["path"], legacy_path);
+    assert_eq!(migrating["source"], "legacy");
+    assert_eq!(migrating["preferred_path"], xdg_path.display().to_string());
+
+    // A config at the preferred path wins as soon as one exists there.
+    fs::create_dir_all(xdg_path.parent().expect("xdg config dir")).expect("create xdg config dir");
+    fs::write(&xdg_path, MINIMAL_CONFIG).expect("write xdg config");
+    let xdg = json_data(&harness.run_with_env(
+        &[("XDG_CONFIG_HOME", &xdg_home)],
+        &["--json", "config", "path"],
+    ));
+    assert_eq!(xdg["path"], xdg_path.display().to_string());
+    assert_eq!(xdg["source"], "xdg");
+    assert!(xdg["preferred_path"].is_null(), "{xdg}");
+
+    // The environment beats both defaults, by being spelled rather than by
+    // the file it names existing.
+    let from_env = json_data(&harness.run_with_env(
+        &[
+            ("XDG_CONFIG_HOME", &xdg_home),
+            ("LOONFS_CONFIG", &named_path),
+        ],
+        &["--json", "config", "path"],
+    ));
+    assert_eq!(from_env["path"], named_path.display().to_string());
+    assert_eq!(from_env["source"], "env");
+    assert!(!named_path.exists(), "the named file need not exist yet");
+
+    // The flag beats everything, and being global it may follow the
+    // subcommand as readily as precede it.
+    for args in [
+        vec![
+            "--json",
+            "--config",
+            flagged_path.to_str().expect("utf-8 path"),
+            "config",
+            "path",
+        ],
+        vec![
+            "--json",
+            "config",
+            "path",
+            "--config",
+            flagged_path.to_str().expect("utf-8 path"),
+        ],
+    ] {
+        let from_flag = json_data(&harness.run_with_env(
+            &[
+                ("XDG_CONFIG_HOME", &xdg_home),
+                ("LOONFS_CONFIG", &named_path),
+            ],
+            &args,
+        ));
+        assert_eq!(from_flag["path"], flagged_path.display().to_string());
+        assert_eq!(from_flag["source"], "flag");
+    }
+}
+
+/// `config path` is the command that answers "which file is this build even
+/// looking at", so it never reads that file.
+#[test]
+fn config_path_answers_while_the_config_file_is_unreadable() {
+    let harness = Harness::new();
+    harness.write_cli_config("config_version = 1\nunknown_knob = true\n");
+
+    assert_failure(&harness.run(&["profile", "list"]));
+
+    let path = harness.run(&["--json", "config", "path"]);
+    assert_success(&path);
+    assert_eq!(
+        json_data(&path)["path"],
+        harness.config_path.display().to_string()
+    );
+    assert_eq!(json_data(&path)["source"], "legacy");
+
+    // The human line carries both answers: the file, and why that file.
+    let human = harness.run(&["config", "path"]);
+    assert_success(&human);
+    let shown = stdout_string(&human);
+    assert!(
+        shown.contains(&harness.config_path.display().to_string()),
+        "{shown}"
+    );
+    assert!(shown.contains("default location"), "{shown}");
+}
+
+/// The recovery path: an override reaches a config file of its own while
+/// the default file is one this build refuses to read.
+#[test]
+fn init_runs_through_an_override_while_the_default_config_is_unreadable() {
+    let harness = Harness::new();
+    harness.write_cli_config("config_version = 1\nunknown_knob = true\n");
+    let broken = fs::read_to_string(&harness.config_path).expect("read broken config");
+
+    let flagged_path = harness.temp_dir.path().join("recovery").join("config.toml");
+    let flagged = flagged_path.to_str().expect("utf-8 path");
+    let init = harness.run(&[
+        "--json",
+        "--config",
+        flagged,
+        "init",
+        "rescue",
+        "--mode",
+        "embedded",
+        "--store-kind",
+        "local-fs",
+        "--root",
+        harness.store_root("rescue").to_str().expect("utf-8 path"),
+    ]);
+    assert_success(&init);
+    assert_eq!(json_data(&init)["mode"], "embedded");
+    assert!(
+        flagged_path.exists(),
+        "init creates the directories it needs"
+    );
+
+    let list = harness.run(&["--json", "--config", flagged, "profile", "list"]);
+    assert_success(&list);
+    assert_eq!(json_data(&list)["profiles"][0]["name"], "rescue");
+
+    // The environment is the same way out.
+    let env_path = harness.temp_dir.path().join("by-env").join("config.toml");
+    let env_init = harness.run_with_env(
+        &[("LOONFS_CONFIG", &env_path)],
+        &[
+            "--json",
+            "init",
+            "byenv",
+            "--mode",
+            "embedded",
+            "--store-kind",
+            "local-fs",
+            "--root",
+            harness.store_root("byenv").to_str().expect("utf-8 path"),
+        ],
+    );
+    assert_success(&env_init);
+    let env_list = harness.run_with_env(
+        &[("LOONFS_CONFIG", &env_path)],
+        &["--json", "profile", "list"],
+    );
+    assert_success(&env_list);
+    assert_eq!(json_data(&env_list)["profiles"][0]["name"], "byenv");
+
+    // Neither route read or rewrote the file that started this.
+    assert_eq!(
+        fs::read_to_string(&harness.config_path).expect("read unchanged config"),
+        broken
+    );
+}
+
+/// A file this build will not read names itself, what in it went wrong, and
+/// the two ways past it.
+#[test]
+fn unreadable_config_errors_name_the_file_the_field_and_the_way_out() {
+    let harness = Harness::new();
+    harness.write_cli_config("config_version = 1\ndefault_profil = \"typo\"\n");
+
+    let list = harness.run(&["--json", "profile", "list"]);
+    assert_failure(&list);
+    let error = json_error(&list);
+    assert_eq!(error["code"], "invalid_config");
+    let message = error["message"].as_str().expect("json string");
+    assert!(
+        message.contains(&harness.config_path.display().to_string()),
+        "{message}"
+    );
+    assert!(message.contains("default_profil"), "{message}");
+    assert!(message.contains("line 2"), "{message}");
+    assert!(message.contains("--config"), "{message}");
+    assert!(message.contains("LOONFS_CONFIG"), "{message}");
+
+    // A semantic failure is just as much a wall, so it carries the same way
+    // past it.
+    harness.write_cli_config("config_version = 1\ndefault_profile = \"missing\"\n");
+    let unresolvable = harness.run(&["--json", "profile", "list"]);
+    assert_failure(&unresolvable);
+    let message = json_error(&unresolvable)["message"]
+        .as_str()
+        .expect("json string")
+        .to_owned();
+    assert!(
+        message.contains(&harness.config_path.display().to_string()),
+        "{message}"
+    );
+    assert!(message.contains("--config"), "{message}");
+    assert!(message.contains("LOONFS_CONFIG"), "{message}");
 }
 
 #[test]
@@ -3036,18 +3256,36 @@ impl Harness {
     }
 
     fn run(&self, args: &[&str]) -> Output {
-        Command::new(loon_binary_path())
+        self.command().args(args).output().expect("run loonfs")
+    }
+
+    /// Runs the CLI with `variables` in its environment, for the config
+    /// resolution the environment takes part in.
+    fn run_with_env(&self, variables: &[(&str, &Path)], args: &[&str]) -> Output {
+        let mut command = self.command();
+        for (name, value) in variables {
+            command.env(name, value);
+        }
+        command.args(args).output().expect("run loonfs")
+    }
+
+    /// Every invocation starts from the temp home with the config
+    /// environment cleared, so a developer's own `XDG_CONFIG_HOME` or
+    /// `LOONFS_CONFIG` can never decide which file a test reads.
+    fn command(&self) -> Command {
+        let mut command = Command::new(loon_binary_path());
+        command
             .env("HOME", &self.home_dir)
-            .args(args)
-            .output()
-            .expect("run loonfs")
+            .env_remove("XDG_CONFIG_HOME")
+            .env_remove("LOONFS_CONFIG");
+        command
     }
 
     /// Runs the CLI with a payload on standard input, which is the one
     /// source whose length is not knowable before it is read.
     fn run_with_stdin(&self, args: &[&str], stdin: &[u8]) -> Output {
-        let mut child = Command::new(loon_binary_path())
-            .env("HOME", &self.home_dir)
+        let mut child = self
+            .command()
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())


### PR DESCRIPTION
the CLI hardcoded `~/.loonfs/config.toml`, ignored `XDG_CONFIG_HOME`, and — because config decoding is strict — one unknown field in that file made every command fail, including `loonfs init`. The decision: keep the strictness, add the escape hatches. 

Fix: First match wins, and the explicit forms win by being spelled, not by the file existing:

1. `--config <path>` (global flag, before or after the subcommand)
2. `LOONFS_CONFIG=<path>`
3. `$XDG_CONFIG_HOME/loonfs/config.toml` — honored only when the variable names an absolute directory; empty or relative counts as unset, per the XDG spec, so a stray value cannot make the config follow the working directory
4. `~/.loonfs/config.toml`

One migration nicety, the single place existence is consulted: when XDG is set but holds no config yet and the legacy file exists, the legacy file is used and `config path` names the preferred location to move it to. As soon as a file exists at the XDG path, it wins.

Recovery: `loonfs init --config <path>` writes a fresh config even when the default file is unparseable. Every load failure names the file, carries toml's line/column and quoted source line (the strict decode now re-reads the file text so the error knows where it is — the old path named the field but no line), and ends with one fixed remedy sentence naming both hatches. Semantic validation failures now also name the file; they previously named none. Unknown fields still refuse — they just cannot brick you.

`config path` reads nothing, works under a broken file (pinned by a test), and now reports how the path was chosen: `<path> (from --config | from LOONFS_CONFIG | from XDG_CONFIG_HOME | default location | legacy location)`, with the preferred path during migration. JSON output carries `path`, a typed `source`, and `preferred_path` when migrating.
