### PR TITLE
feat(reads): bounded-memory streaming reads

### DIFF
--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -160,6 +160,49 @@ impl StorageChecksum {
     }
 }
 
+/// One full-object checksum folded over a payload delivered in pieces.
+///
+/// This is the streaming form of [`StorageChecksum::matches`], for a reader
+/// that verifies an object it never holds whole. The two agree about what
+/// this build can recompute: [`StreamingChecksum::for_algorithm`] answers
+/// `None` for exactly the algorithms `matches` refuses to judge, so an
+/// unverifiable checksum is refused before any bytes move rather than after.
+#[derive(Debug)]
+pub enum StreamingChecksum {
+    /// SHA-256 folded over the payload.
+    Sha256(Sha256),
+    /// CRC-64/NVME folded over the payload.
+    Crc64nvme(Crc64Nvme),
+}
+
+impl StreamingChecksum {
+    /// Starts an empty digest for `algorithm`, or `None` when this build
+    /// cannot recompute that algorithm.
+    pub fn for_algorithm(algorithm: ChecksumAlgorithm) -> Option<Self> {
+        match algorithm {
+            ChecksumAlgorithm::Sha256 => Some(Self::Sha256(Sha256::new())),
+            ChecksumAlgorithm::Crc64nvme => Some(Self::Crc64nvme(Crc64Nvme::new())),
+            ChecksumAlgorithm::Crc32c => None,
+        }
+    }
+
+    /// Folds the next piece of the payload in, in order.
+    pub fn update(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Sha256(digest) => digest.update(bytes),
+            Self::Crc64nvme(digest) => digest.update(bytes),
+        }
+    }
+
+    /// Closes the digest over everything fed so far.
+    pub fn finish(self) -> StorageChecksum {
+        match self {
+            Self::Sha256(digest) => digest.finish(),
+            Self::Crc64nvme(digest) => digest.finish(),
+        }
+    }
+}
+
 /// CRC-64/NVME over a payload delivered in pieces.
 ///
 /// A direct multipart upload needs this digest twice over the same bytes:
@@ -385,7 +428,7 @@ fn validate_checksum_value(
 mod tests {
     use super::{
         ChecksumAlgorithm, ContentRef, ContentRefKind, ContentRefValidationError, Crc64Nvme,
-        StorageChecksum,
+        StorageChecksum, StreamingChecksum,
     };
     use crate::ids::ContentId;
 
@@ -513,6 +556,27 @@ mod tests {
         }
 
         assert_eq!(streamed.finish(), StorageChecksum::crc64nvme(&payload));
+    }
+
+    /// A verifying reader folds the same checksum the one-shot check
+    /// computes, and refuses the same algorithms it refuses — a reader that
+    /// disagreed with [`StorageChecksum::matches`] would accept or reject
+    /// objects the buffered read would not.
+    #[test]
+    fn a_streamed_checksum_agrees_with_the_whole_payload_at_once() {
+        let payload: Vec<u8> = (0..4096u32).map(|byte| byte as u8).collect();
+        for expected in [
+            StorageChecksum::sha256(&payload),
+            StorageChecksum::crc64nvme(&payload),
+        ] {
+            let mut streaming = StreamingChecksum::for_algorithm(expected.algorithm)
+                .expect("a producing algorithm folds");
+            for chunk in payload.chunks(97) {
+                streaming.update(chunk);
+            }
+            assert_eq!(streaming.finish(), expected);
+        }
+        assert!(StreamingChecksum::for_algorithm(ChecksumAlgorithm::Crc32c).is_none());
     }
 
     /// A checksum this build cannot recompute must answer "cannot tell",

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -96,7 +96,7 @@ pub use capability::{
 };
 pub use content::{
     ChecksumAlgorithm, ContentRef, ContentRefKind, ContentRefValidationError, Crc64Nvme, Sha256,
-    StorageChecksum,
+    StorageChecksum, StreamingChecksum,
 };
 pub use digest::sha256_digest;
 pub use error::{ErrorCode, ErrorKind};

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -352,6 +352,18 @@ Behavior notes
   and writes through a temporary file so an interrupted download leaves
   nothing truncated at the target
 
+  `loonfs get` writes a large file as it arrives and never holds it whole, so
+  what it costs in memory follows the transfer and not the file's size; an
+  embedded profile reads its own store in chunks, and a remote profile
+  receives one proxied response
+
+  A file destination is renamed into place only once the download is complete
+  and its content verified, so content that fails verification leaves nothing
+  at the destination. `loonfs get ... -` hands bytes to stdout as they
+  arrive, so the same failure exits nonzero after part of the file has
+  already been written — with `-`, the exit status is what says the content
+  was verified
+
   A recursive put, get, or cp works file by file with bounded concurrency,
   so a partial failure reruns per file; --commit-id names one commit, so
   `put -r` and `cp -r` reject it, and `get -r` rejects --revision for the

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -467,7 +467,14 @@ pub(crate) struct FilesystemGetArgs {
     pub target: TargetSelectorArgs,
     pub remote_path: String,
     /// Local destination (defaults to the remote basename; `-` streams to
-    /// stdout).
+    /// stdout). A large file is written as it arrives and never held whole,
+    /// so what a get costs in memory does not follow what it downloads. A
+    /// file destination is written beside itself and renamed into place only
+    /// once the download is complete and its content verified, so a failed
+    /// download leaves nothing there. Streaming to stdout hands bytes on as
+    /// they arrive, so content that fails verification at the end exits
+    /// nonzero after part of it has already been written — the exit status,
+    /// not the output, is what says the content was verified.
     pub local_destination: Option<String>,
     /// Download the directory tree rooted at `remote_path`, with bounded
     /// concurrency and per-file outcomes.

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -9,9 +9,10 @@ use crate::render::write_stderr_warning;
 use loonfs::{
     ByteStream, ChangesResponse, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    FsAdmin, FsReader, FsWriter, ListChangesOptions, MaintenanceHandle, MaintenanceJob,
-    MaintenanceJobId, MaintenanceStepConclusion, MaintenanceStepOptions, MoveOptions,
-    PutFileOptions, RestoreRevisionOptions, RuntimeError, SharedObjectStore, UndeleteOptions,
+    FileContentStream, FsAdmin, FsReader, FsWriter, ListChangesOptions, MaintenanceHandle,
+    MaintenanceJob, MaintenanceJobId, MaintenanceStepConclusion, MaintenanceStepOptions,
+    MoveOptions, PutFileOptions, ReadFileStreamOptions, RestoreRevisionOptions, RuntimeError,
+    SharedObjectStore, UndeleteOptions,
 };
 use loonfs_api::{
     v0::{
@@ -214,6 +215,22 @@ impl EmbeddedBackend {
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?;
         Ok(result.bytes)
+    }
+
+    /// Opens a file's content as bounded chunks, at the runtime's own chunk
+    /// size: what a download costs this process is that chunk, not the file.
+    pub(super) async fn read_file_stream(
+        &self,
+        spec: &NamespacePath,
+    ) -> Result<FileContentStream<SharedObjectStore>, BackendError> {
+        self.reader
+            .read_file_stream(
+                spec.namespace(),
+                spec.absolute_path().as_str(),
+                ReadFileStreamOptions::default(),
+            )
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
     }
 
     pub(super) async fn grep(

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -16,9 +16,10 @@
 
 mod embedded;
 
-use crate::backend_error::BackendError;
+use crate::backend_error::{map_namespace_scoped_runtime_error, BackendError};
 use crate::payload::LocalPayload;
 use crate::resolve::ResolvedTarget;
+use bytes::Bytes;
 use loonfs_api::{
     v0::{
         ChangesResponse, DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest,
@@ -37,7 +38,9 @@ use loonfs_client::{
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 
 pub(crate) use embedded::EmbeddedBackend;
-use loonfs::{MaintenanceJobId, MaintenanceStepConclusion};
+use loonfs::{
+    FileContentStream, MaintenanceJobId, MaintenanceStepConclusion, RuntimeError, SharedObjectStore,
+};
 
 /// How long a remote wait rests between status checks.
 ///
@@ -65,6 +68,45 @@ impl StepBudget {
             || self
                 .deadline_ms
                 .is_some_and(|deadline_ms| elapsed_ms >= deadline_ms)
+    }
+}
+
+/// One file's content, in the pieces the transport that opened it delivers.
+///
+/// The two arms exist because the transports genuinely differ, not because
+/// the commands above want to know which they got: both are consumed by the
+/// same [`FileDownload::next_chunk`] loop, so a download is written to disk
+/// or to standard output the same way whichever profile served it.
+pub(crate) enum FileDownload {
+    /// The embedded runtime's bounded stream. Boxed because a stream carries
+    /// its object key, reference, and running digest, and the whole arm is a
+    /// pointer beside it.
+    Streamed {
+        namespace_id: NamespaceId,
+        stream: Box<FileContentStream<SharedObjectStore>>,
+    },
+    /// Bytes the transport already holds whole.
+    Whole(Vec<u8>),
+}
+
+impl FileDownload {
+    /// The next piece of the file, or `None` at a verified end.
+    ///
+    /// A streamed download verifies size and digest on the call that reports
+    /// the end, so a caller that drives this to `None` has verified content
+    /// and a caller that stops early does not. Held bytes were verified
+    /// before they were handed over and answer in one piece.
+    pub(crate) async fn next_chunk(&mut self) -> Result<Option<Bytes>, BackendError> {
+        match self {
+            Self::Streamed {
+                namespace_id,
+                stream,
+            } => stream.next_chunk().await.map_err(|error| {
+                map_namespace_scoped_runtime_error(namespace_id, RuntimeError::Core(error))
+            }),
+            Self::Whole(bytes) if bytes.is_empty() => Ok(None),
+            Self::Whole(bytes) => Ok(Some(Bytes::from(std::mem::take(bytes)))),
+        }
     }
 }
 
@@ -255,6 +297,36 @@ impl ResolvedTarget {
         match self {
             Self::Embedded(target) => target.backend.get_file_bytes(spec).await,
             Self::Remote(target) => Ok(target.client.get_file_bytes(spec).await?),
+        }
+    }
+
+    /// Opens a download of one file, in the largest pieces the transport
+    /// hands out and no larger.
+    ///
+    /// An embedded profile reads its own store, so it streams: chunks arrive
+    /// one at a time and the file's size never becomes the command's memory.
+    /// A remote profile's proxied read answers with one response body, so it
+    /// arrives whole — the same bytes through the same loop, held rather than
+    /// streamed. A revision read is whole on both, because there is no
+    /// streaming revision read to call.
+    pub(crate) async fn open_file_download(
+        &self,
+        spec: &NamespacePath,
+        revision_no: Option<RevisionNo>,
+    ) -> Result<FileDownload, BackendError> {
+        if let Some(revision_no) = revision_no {
+            return Ok(FileDownload::Whole(
+                self.get_file_revision_bytes(spec, revision_no).await?,
+            ));
+        }
+        match self {
+            Self::Embedded(target) => Ok(FileDownload::Streamed {
+                namespace_id: spec.namespace().clone(),
+                stream: Box::new(target.backend.read_file_stream(spec).await?),
+            }),
+            Self::Remote(target) => Ok(FileDownload::Whole(
+                target.client.get_file_bytes(spec).await?,
+            )),
         }
     }
 

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -13,12 +13,13 @@ use crate::args::{
     FilesystemRevisionsArgs, FilesystemRmArgs, FilesystemTransferArgs, FilesystemUndeleteArgs,
     RuntimeBehavior, TrashArgs,
 };
+use crate::backend::FileDownload;
 use crate::error::CliError;
 use crate::payload::{read_whole_file, LocalPayload, STDIN_PATH};
 use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeKind, RevisionNo};
 use loonfs_client::{CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions};
 use std::fs;
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 // --- filesystem ---
@@ -32,13 +33,11 @@ fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliE
         .transpose()
 }
 
-/// Writes via a same-directory temp file and an atomic rename, so a failed
-/// or interrupted download never leaves a truncated file at the target.
-pub(super) fn write_local_file_atomically(
-    destination: &Path,
-    bytes: &[u8],
-    force: bool,
-) -> std::io::Result<()> {
+/// Opens the same-directory temp file a download is written into.
+///
+/// Dropping it deletes it, which is what makes a failed or interrupted
+/// download leave nothing behind at the target.
+fn open_partial_file(destination: &Path) -> std::io::Result<tempfile::NamedTempFile> {
     let file_name = destination
         .file_name()
         .ok_or_else(|| std::io::Error::other("destination has no file name"))?;
@@ -49,17 +48,38 @@ pub(super) fn write_local_file_atomically(
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    let mut temp = tempfile::Builder::new()
-        .prefix(&prefix)
-        .tempfile_in(parent)?;
-    temp.write_all(bytes)?;
-    temp.flush()?;
+    tempfile::Builder::new().prefix(&prefix).tempfile_in(parent)
+}
+
+/// Installs a completed download at its destination with one rename.
+///
+/// Only a download that finished — and, when it was streamed, verified —
+/// reaches this, so the file at the destination is never a truncated or
+/// unverified one.
+fn install_partial_file(
+    temp: tempfile::NamedTempFile,
+    destination: &Path,
+    force: bool,
+) -> std::io::Result<()> {
     let persisted = if force {
         temp.persist(destination)
     } else {
         temp.persist_noclobber(destination)
     };
     persisted.map(|_| ()).map_err(|error| error.error)
+}
+
+/// Writes via a same-directory temp file and an atomic rename, so a failed
+/// or interrupted download never leaves a truncated file at the target.
+pub(super) fn write_local_file_atomically(
+    destination: &Path,
+    bytes: &[u8],
+    force: bool,
+) -> std::io::Result<()> {
+    let mut temp = open_partial_file(destination)?;
+    temp.write_all(bytes)?;
+    temp.flush()?;
+    install_partial_file(temp, destination, force)
 }
 
 pub(crate) async fn run_filesystem_ls(
@@ -265,18 +285,18 @@ pub(crate) async fn run_filesystem_get(
     }
 
     let revision_no = args.revision.map(RevisionNo);
-    let bytes = match revision_no {
-        Some(revision_no) => {
-            context
-                .target
-                .get_file_revision_bytes(&spec, revision_no)
-                .await
-        }
-        None => context.target.get_file_bytes(&spec).await,
-    }
-    .map_err(|error| context.fail(kind, error))?;
+    let mut download = context
+        .target
+        .open_file_download(&spec, revision_no)
+        .await
+        .map_err(|error| context.fail(kind, error))?;
     let data = match args.local_destination.as_deref() {
-        Some("-") => CommandData::StreamBytes(bytes),
+        Some("-") => {
+            stream_download_to_stdout(&mut download)
+                .await
+                .map_err(|error| context.fail(kind, error))?;
+            CommandData::StreamedToStdout
+        }
         other => {
             let derived_name = other.is_none();
             let destination = destination_path_for_get(spec.absolute_path().as_str(), other)
@@ -285,23 +305,14 @@ pub(crate) async fn run_filesystem_get(
             // that has no revision history behind it, so clobbering it is
             // opt-in. `persist_noclobber` closes the race between checking
             // and installing the completed temporary file.
-            write_local_file_atomically(&destination, &bytes, args.force).map_err(|error| {
-                if !args.force && error.kind() == std::io::ErrorKind::AlreadyExists {
-                    return context.fail(kind, CliError::destination_exists(&destination));
-                }
-                let mut error = CliError::io_for_path(&destination, error);
-                if derived_name {
-                    error.message.push_str(
-                        "; if the remote name exceeds local filesystem limits, pass an \
-                         explicit destination or `-` for stdout",
-                    );
-                }
-                context.fail(kind, error)
-            })?;
+            let bytes_written =
+                stream_download_to_file(&mut download, &destination, args.force, derived_name)
+                    .await
+                    .map_err(|error| context.fail(kind, error))?;
             CommandData::FileTransfer {
                 target: render_target(&context.namespace, spec.absolute_path()),
                 destination: destination.display().to_string(),
-                bytes_written: bytes.len() as u64,
+                bytes_written,
             }
         }
     };
@@ -312,6 +323,74 @@ pub(crate) async fn run_filesystem_get(
         mode: Some(context.mode),
         data,
     })
+}
+
+/// Writes a download into its destination through the partial file, and
+/// installs it only once the download has ended cleanly.
+///
+/// The temp file is dropped — and so deleted — on any failure, including a
+/// streamed download whose content failed verification at its last chunk. An
+/// integrity failure therefore leaves no file at the destination at all,
+/// never a complete-looking one.
+async fn stream_download_to_file(
+    download: &mut FileDownload,
+    destination: &Path,
+    force: bool,
+    derived_name: bool,
+) -> Result<u64, CliError> {
+    let mut temp = open_partial_file(destination)
+        .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
+    let mut bytes_written = 0u64;
+    while let Some(chunk) = download.next_chunk().await? {
+        temp.write_all(&chunk)
+            .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
+        bytes_written += chunk.len() as u64;
+    }
+    temp.flush()
+        .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
+    install_partial_file(temp, destination, force)
+        .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
+    Ok(bytes_written)
+}
+
+/// Writes a download to standard output as it arrives.
+///
+/// Bytes are handed on chunk by chunk, so a streamed download that fails its
+/// verification at the end fails after some of the file has already been
+/// written. That is what streaming to a pipe means — `cat` behaves the same
+/// way — and it is why the exit status, not the output, is what says whether
+/// the content was verified.
+async fn stream_download_to_stdout(download: &mut FileDownload) -> Result<(), CliError> {
+    while let Some(chunk) = download.next_chunk().await? {
+        // Locked per chunk rather than held across the fetch: nothing else
+        // writes to stdout while a download runs, and a guard held across an
+        // await would pin this future to one thread.
+        io::stdout()
+            .lock()
+            .write_all(&chunk)
+            .map_err(CliError::io)?;
+    }
+    io::stdout().lock().flush().map_err(CliError::io)
+}
+
+/// Shapes a local write failure the way `get` has always reported one.
+fn local_destination_error(
+    destination: &Path,
+    error: std::io::Error,
+    force: bool,
+    derived_name: bool,
+) -> CliError {
+    if !force && error.kind() == std::io::ErrorKind::AlreadyExists {
+        return CliError::destination_exists(destination);
+    }
+    let mut error = CliError::io_for_path(destination, error);
+    if derived_name {
+        error.message.push_str(
+            "; if the remote name exceeds local filesystem limits, pass an \
+             explicit destination or `-` for stdout",
+        );
+    }
+    error
 }
 
 pub(crate) async fn run_filesystem_trash(

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -194,6 +194,11 @@ pub(crate) enum CommandData {
         commit_date: String,
     },
     StreamBytes(Vec<u8>),
+    /// The payload already went to standard output as it arrived, so there is
+    /// nothing left to render. `get -` reports this: a download that is
+    /// written chunk by chunk cannot also be handed to the renderer at the
+    /// end without holding all of it.
+    StreamedToStdout,
 }
 
 impl CommandData {

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -201,6 +201,8 @@ pub(crate) fn render_success(output: &CommandOutput, json_mode: bool) -> io::Res
             let mut stdout = io::stdout().lock();
             stdout.write_all(bytes)?;
         }
+        // Already written, chunk by chunk, by the command itself.
+        CommandData::StreamedToStdout => {}
         _ => {
             let rendered = human_success(output);
             let mut stdout = io::stdout().lock();
@@ -241,7 +243,7 @@ pub(crate) fn write_stderr_progress(message: impl std::fmt::Display) {
 
 pub(crate) fn json_success(output: &CommandOutput) -> io::Result<String> {
     match &output.data {
-        CommandData::StreamBytes(_) => Err(io::Error::new(
+        CommandData::StreamBytes(_) | CommandData::StreamedToStdout => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "streaming output does not support json rendering",
         )),
@@ -747,7 +749,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             commit,
             commit_date,
         } => format!("{version} ({commit} {commit_date})"),
-        CommandData::StreamBytes(_) => String::new(),
+        CommandData::StreamBytes(_) | CommandData::StreamedToStdout => String::new(),
     }
 }
 

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -642,6 +642,112 @@ fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
     assert_eq!(json_error(&no_destination)["code"], "invalid_input");
 }
 
+/// A payload of several download chunks, so a `get` that read the file whole
+/// and one that reads it in chunks are told apart by what comes back rather
+/// than by what a comment claims.
+fn multi_chunk_payload() -> Vec<u8> {
+    let len = 3 * loonfs::CONTENT_READ_CHUNK_BYTES as usize + 1_024;
+    (0..len).map(|offset| (offset % 251) as u8).collect()
+}
+
+/// A file many chunks long round-trips through an embedded profile to a
+/// local file and to standard output, byte for byte.
+#[test]
+fn a_multi_chunk_file_round_trips_to_a_file_and_to_stdout() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    let payload = multi_chunk_payload();
+
+    let local = harness.temp_dir.path().join("chunked.bin");
+    fs::write(&local, &payload).expect("write payload");
+    assert_success(&harness.run(&["put", local.to_str().expect("utf-8 path"), "/chunked.bin"]));
+
+    assert_eq!(
+        download(&harness, "/chunked.bin", "chunked-back.bin"),
+        payload,
+        "a downloaded file is the file that was uploaded"
+    );
+
+    let streamed = harness.run(&["get", "/chunked.bin", "-"]);
+    assert_success(&streamed);
+    assert_eq!(
+        streamed.stdout, payload,
+        "streaming to stdout writes the content and nothing else"
+    );
+}
+
+/// Content that no longer matches its reference fails the download, and
+/// fails it without leaving anything at the destination: no file, and no
+/// partial file beside it. A verified-looking local copy of unverified bytes
+/// is the outcome the temp-file-then-rename order exists to prevent.
+#[test]
+fn a_download_of_corrupted_content_leaves_nothing_at_the_destination() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = b"the bytes that were committed".to_vec();
+    let local = harness.temp_dir.path().join("source.bin");
+    fs::write(&local, &payload).expect("write payload");
+    assert_success(&harness.run(&["put", local.to_str().expect("utf-8 path"), "/doc.bin"]));
+
+    // Same length, different bytes: the reference's digest is the only
+    // thing that can tell, which is what the read has to notice.
+    let object = content_object_path(&harness.store_root("default"), payload.len() as u64);
+    let mut corrupted = payload.clone();
+    corrupted[0] ^= 0xff;
+    fs::write(&object, &corrupted).expect("corrupt content object");
+
+    let destination = harness.temp_dir.path().join("downloads").join("doc.bin");
+    fs::create_dir_all(destination.parent().expect("parent")).expect("create download dir");
+    let failed = harness.run(&[
+        "--json",
+        "get",
+        "/doc.bin",
+        destination.to_str().expect("utf-8 path"),
+    ]);
+    assert_failure(&failed);
+    assert_eq!(json_error(&failed)["code"], "namespace_corrupt");
+    assert!(
+        !destination.exists(),
+        "a failed download must not install a file"
+    );
+    let leftovers: Vec<PathBuf> = fs::read_dir(destination.parent().expect("parent"))
+        .expect("read download dir")
+        .map(|entry| entry.expect("dir entry").path())
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "the partial file must be cleaned up, found {leftovers:?}"
+    );
+}
+
+/// The one content object of a given length under a store root. Content
+/// objects live at `content-stores/<store>/objects/<shard>/<id>`, and the
+/// tests that use this write one file whose length nothing else shares.
+fn content_object_path(store_root: &Path, size_bytes: u64) -> PathBuf {
+    let objects = walkdir::WalkDir::new(store_root.join("content-stores"))
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry
+                    .metadata()
+                    .is_ok_and(|metadata| metadata.len() == size_bytes)
+        })
+        .map(|entry| entry.path().to_path_buf())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        objects.len(),
+        1,
+        "expected exactly one content object of {size_bytes} bytes, found {objects:?}"
+    );
+    objects.into_iter().next().expect("one content object")
+}
+
 /// The same two payloads over the remote transport. This deployment stores
 /// to a local filesystem, so it cannot authorize direct part uploads and
 /// the payload streams through the server instead — the fallback the client

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -14,6 +14,7 @@ use crate::path::read::{
     load_metadata_view, CurrentFileState, LoadedMetadataView, ReadLoadContext,
 };
 use crate::protocol::CompletedUpload;
+use crate::storage::content::FileContentStream;
 use crate::storage::content_admission::CompletedUploadReceipt;
 use crate::time::current_time_ms;
 use loonfs_api::v0::{
@@ -31,6 +32,7 @@ use loonfs_api::{
     StorageChecksum, TrashEntry, TrashPageCursor, UploadId,
 };
 use loonfs_objectstore::{ByteStream, ObjectStore};
+use std::num::NonZeroU64;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -237,6 +239,41 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         let view = self.load_read_view(context).await?;
         view.read_file_bytes(&self.store, path.as_ref(), max_content_bytes)
             .await
+    }
+
+    /// Opens a bounded streaming read of a file's current content against the
+    /// pinned runtime read context.
+    ///
+    /// The path resolves exactly as it does for [`Self::read_file`]; what
+    /// differs is everything after. The content arrives as `chunk_bytes`
+    /// ranged reads with the verifying digest folded over them, so what the
+    /// read costs in memory is one chunk rather than the file's size, and the
+    /// deployment's buffered-read cap deliberately does not apply — that cap
+    /// bounds what a caller materializes, and this caller materializes a
+    /// chunk.
+    ///
+    /// The pinned context resolves the path; it does not have to survive the
+    /// read. The reference names one immutable object at a random id, so no
+    /// commit landing mid-read can change the bytes under a reader.
+    pub async fn read_file_stream(
+        &self,
+        path: impl AsRef<str>,
+        context: &RuntimeReadContext,
+        chunk_bytes: NonZeroU64,
+    ) -> Result<FileContentStream<S>>
+    where
+        S: Clone,
+    {
+        let view = self.load_read_view(context).await?;
+        let (entry, content_ref) = view.resolve_file_content(path.as_ref()).await?;
+        Ok(FileContentStream::open(
+            self.store.clone(),
+            view.content_store_id(),
+            entry,
+            content_ref,
+            chunk_bytes,
+        )
+        .await?)
     }
 
     /// Lists one revision page for a path against the pinned runtime read context.

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -187,3 +187,6 @@ pub use gc::{delete_if_aged, gc_namespace, GcConfig, PassBudget};
 pub use namespace::BootstrapNamespaceError;
 pub use options::{BootstrapOptions, DeleteNamespaceOptions};
 pub use path::read::{CurrentFileState, MAX_RESOLVE_CURRENT_FILES};
+// The streaming read `loonfs`'s reader handle returns, and the chunk size it
+// reads in.
+pub use storage::content::{FileContentStream, CONTENT_READ_CHUNK_BYTES};

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -21,9 +21,9 @@ use crate::storage::content::read_durable_content_bytes;
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::{
-    AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentStoreId,
-    DirectoryPageCursor, DisplayName, FileRevision, FileRevisionsPageCursor, InodeId, InodeKind,
-    NamespaceId, Page, PageRequest, RevisionNo, TrashEntry, TrashPageCursor,
+    AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentRef,
+    ContentStoreId, DirectoryPageCursor, DisplayName, FileRevision, FileRevisionsPageCursor,
+    InodeId, InodeKind, NamespaceId, Page, PageRequest, RevisionNo, TrashEntry, TrashPageCursor,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -239,6 +239,23 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         absolute_path: &str,
         max_content_bytes: Option<u64>,
     ) -> Result<AuthoritativeFileBytes> {
+        let (entry, content_ref) = self.resolve_file_content(absolute_path).await?;
+        ensure_within_read_limit(content_ref.size_bytes, max_content_bytes)?;
+        let read = read_durable_content_bytes(store, &self.content_store_id, &content_ref).await?;
+        Ok(AuthoritativeFileBytes {
+            entry,
+            bytes: read.bytes,
+        })
+    }
+
+    /// Resolves a path to the file it names and the content reference its
+    /// current revision points at: the metadata half both the buffered read
+    /// and the streaming one run, so neither can resolve a path the other
+    /// would refuse.
+    pub(crate) async fn resolve_file_content(
+        &self,
+        absolute_path: &str,
+    ) -> Result<(AuthoritativePathEntry, ContentRef)> {
         let entry = self.resolve_path(absolute_path).await?;
         if entry.inode_kind != InodeKind::File {
             return Err(CoreError::ExpectedFile {
@@ -250,12 +267,12 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .content_ref
             .clone()
             .ok_or_else(|| CoreError::PathNotFound(absolute_path.to_owned()))?;
-        ensure_within_read_limit(content_ref.size_bytes, max_content_bytes)?;
-        let read = read_durable_content_bytes(store, &self.content_store_id, &content_ref).await?;
-        Ok(AuthoritativeFileBytes {
-            entry,
-            bytes: read.bytes,
-        })
+        Ok((entry, content_ref))
+    }
+
+    /// The content store this view's namespace is bound to.
+    pub(crate) fn content_store_id(&self) -> &ContentStoreId {
+        &self.content_store_id
     }
 
     pub(crate) async fn list_file_revisions_page(

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -7,12 +7,13 @@ use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::{
-    ChecksumAlgorithm, ContentId, ContentRef, ContentRefValidationError, ContentStoreId,
-    NamespaceId, Sha256, StorageChecksum,
+    AuthoritativePathEntry, ChecksumAlgorithm, ContentId, ContentRef, ContentRefValidationError,
+    ContentStoreId, NamespaceId, Sha256, StorageChecksum, StreamingChecksum,
 };
 use loonfs_objectstore::keys::content_blob;
-use loonfs_objectstore::{ByteStream, ObjectStore, ObjectStoreError, PutMode};
+use loonfs_objectstore::{ByteRange, ByteStream, ObjectStore, ObjectStoreError, PutMode};
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
@@ -226,6 +227,212 @@ pub(crate) async fn abort_unpublished_multipart_upload<S: ObjectStore + ?Sized>(
             error = %error,
             "failed to abandon the multipart upload of a terminated upload session"
         );
+    }
+}
+
+/// Bytes one ranged read of a content object fetches, and therefore the most
+/// of that object a streaming read holds at once.
+///
+/// The same 8 MiB the write path moves a large payload in
+/// ([`loonfs_objectstore::PROVIDER_MULTIPART_PART_BYTES`]): one transfer unit
+/// for both directions, large enough that per-request overhead disappears
+/// against the payload on a large object, small enough that a read's memory
+/// is a fixed few megabytes whatever the object's size.
+pub const CONTENT_READ_CHUNK_BYTES: u64 = 8 * 1024 * 1024;
+
+/// One file's current content, read as fixed-size ranged chunks.
+///
+/// This is the streaming twin of the buffered content read, for a reader that
+/// must not hold what it reads: chunks are fetched one range at a time and
+/// the verifying digest is folded as they go, so a 50 GiB object costs one
+/// chunk of memory rather than 50 GiB. It verifies exactly what the buffered
+/// read verifies — the declared size, and the reference's trusted whole-file
+/// SHA-256 when it has one, otherwise its own storage checksum, which for a
+/// provider-assembled object is the only full-object evidence there is. A
+/// reference whose checksum this build cannot recompute is refused when the
+/// stream is opened, before any byte is fetched, rather than after.
+///
+/// The object is immutable and named by a random content id, so nothing can
+/// rewrite it under a reader: chunk *n* and chunk *n+1* are always from the
+/// same object, and no revalidation between them is needed or done.
+///
+/// Verification lands on the final [`Self::next_chunk`] call — the one that
+/// reports the end of the content. A caller that stops early stops with
+/// unverified bytes, which is what streaming means and why the buffered read
+/// stays for callers that want the whole answer or none of it.
+pub struct FileContentStream<S> {
+    store: S,
+    entry: AuthoritativePathEntry,
+    object_key: String,
+    content_ref: ContentRef,
+    chunk_bytes: NonZeroU64,
+    /// Offset the next ranged read starts at; also how much has been read.
+    next_offset: u64,
+    /// The checksum the complete object must produce, folded so far.
+    digest: StreamingChecksum,
+    /// The value `digest` is closed against.
+    expected: StorageChecksum,
+    /// The verdict on the complete object, once there is one. Kept because a
+    /// digest can only be closed once: without it, asking again after the end
+    /// would fold a second, empty digest and report a mismatch that is not
+    /// one.
+    completion: Option<Result<(), DurableContentValidationError>>,
+}
+
+impl<S: ObjectStore> FileContentStream<S> {
+    /// Opens a streaming read of the object `content_ref` names.
+    ///
+    /// One `HeadObject` proves the object exists and is exactly as long as
+    /// the reference claims before any payload moves, which is what lets a
+    /// wrong-sized object fail without a partial answer having been handed
+    /// out. The reference's checksum algorithm is resolved here for the same
+    /// reason.
+    pub(crate) async fn open(
+        store: S,
+        content_store_id: &ContentStoreId,
+        entry: AuthoritativePathEntry,
+        content_ref: ContentRef,
+        chunk_bytes: NonZeroU64,
+    ) -> Result<Self, DurableContentValidationError> {
+        let object_key = content_object_key_for_ref(content_store_id, &content_ref)?;
+        validate_content_size(&store, &object_key, &content_ref).await?;
+        let expected = verifiable_checksum(&content_ref);
+        let digest = StreamingChecksum::for_algorithm(expected.algorithm).ok_or({
+            DurableContentValidationError::ContentChecksumUnverifiable {
+                object_key: object_key.clone(),
+                algorithm: content_ref.storage_checksum.algorithm,
+            }
+        })?;
+        Ok(Self {
+            store,
+            entry,
+            object_key,
+            content_ref,
+            chunk_bytes,
+            next_offset: 0,
+            digest,
+            expected,
+            completion: None,
+        })
+    }
+
+    /// The authoritative metadata entry the path resolved to.
+    pub fn entry(&self) -> &AuthoritativePathEntry {
+        &self.entry
+    }
+
+    /// Complete length of the content this stream reads.
+    pub fn size_bytes(&self) -> u64 {
+        self.content_ref.size_bytes
+    }
+
+    /// Fetches the next chunk, or reports the end of a verified read.
+    ///
+    /// `Ok(None)` is returned only after the folded digest and the byte count
+    /// agree with the reference; a mismatch fails this call instead. Chunks
+    /// arrive in order, and every one but the last is exactly the chunk size
+    /// this stream was opened with.
+    ///
+    /// This is the method callers outside this crate hold, so it speaks the
+    /// crate's error type: a content object that disagrees with its reference
+    /// is namespace corruption, and it is classified as such here rather than
+    /// at every call site.
+    pub async fn next_chunk(&mut self) -> Result<Option<Bytes>, CoreError> {
+        Ok(self.next_verified_chunk().await?)
+    }
+
+    async fn next_verified_chunk(
+        &mut self,
+    ) -> Result<Option<Bytes>, DurableContentValidationError> {
+        if self.next_offset == self.content_ref.size_bytes {
+            return self.completion().map(|()| None);
+        }
+        let end_exclusive = self
+            .next_offset
+            .saturating_add(self.chunk_bytes.get())
+            .min(self.content_ref.size_bytes);
+        let bytes = match self
+            .store
+            .get(
+                &self.object_key,
+                Some(ByteRange {
+                    start_inclusive: self.next_offset,
+                    end_exclusive,
+                }),
+            )
+            .await
+        {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => {
+                return Err(DurableContentValidationError::MissingContentObject {
+                    object_key: self.object_key.clone(),
+                })
+            }
+            Err(err) => {
+                return Err(DurableContentValidationError::Store {
+                    object_key: self.object_key.clone(),
+                    message: err.message(),
+                })
+            }
+        };
+        // A range ending past the object is truncated, so a short answer is
+        // an object that ended earlier than its reference says it does.
+        if bytes.len() as u64 != end_exclusive - self.next_offset {
+            return Err(DurableContentValidationError::ContentLengthMismatch {
+                object_key: self.object_key.clone(),
+                expected: self.content_ref.size_bytes,
+                actual: self.next_offset + bytes.len() as u64,
+            });
+        }
+        self.digest.update(&bytes);
+        self.next_offset += bytes.len() as u64;
+        Ok(Some(bytes))
+    }
+
+    /// The verdict on the complete object: computed the first time the end is
+    /// reached, and repeated on every later ask.
+    ///
+    /// The byte count needs no check of its own here. Every chunk is required
+    /// to arrive exactly as long as it was asked for, and no chunk is asked
+    /// for past the declared size, so reaching this point *is* having read
+    /// exactly `size_bytes` — checked against the object's own length by the
+    /// head request [`Self::open`] made.
+    fn completion(&mut self) -> Result<(), DurableContentValidationError> {
+        let verdict = match self.completion.take() {
+            Some(verdict) => verdict,
+            None => self.verify_complete(),
+        };
+        self.completion = Some(verdict.clone());
+        verdict
+    }
+
+    /// Closes the digest over everything read and holds it to the reference.
+    fn verify_complete(&mut self) -> Result<(), DurableContentValidationError> {
+        // Closing consumes the digest, which is why this runs exactly once.
+        let digest = std::mem::replace(
+            &mut self.digest,
+            StreamingChecksum::for_algorithm(self.expected.algorithm)
+                .expect("an algorithm this stream already folded stays recomputable"),
+        );
+        let actual = digest.finish();
+        if actual != self.expected {
+            return Err(DurableContentValidationError::ContentChecksumMismatch {
+                object_key: self.object_key.clone(),
+                expected: describe_checksum(&self.expected),
+                actual: describe_checksum(&actual),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl<S> std::fmt::Debug for FileContentStream<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileContentStream")
+            .field("object_key", &self.object_key)
+            .field("size_bytes", &self.content_ref.size_bytes)
+            .field("next_offset", &self.next_offset)
+            .finish_non_exhaustive()
     }
 }
 
@@ -574,12 +781,13 @@ async fn load_required_object<S: ObjectStore + ?Sized>(
 mod tests {
     use super::{
         read_durable_content_bytes, store_bytes_as_content_with_store_id,
-        validate_durable_content_reference, verify_durable_content_checksum,
-        DurableContentValidationError,
+        validate_durable_content_reference, verify_durable_content_checksum, CoreError,
+        DurableContentValidationError, FileContentStream, NonZeroU64,
     };
     use bytes::Bytes;
     use loonfs_api::{
-        ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind, ContentStoreId, StorageChecksum,
+        AuthoritativePathEntry, ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind,
+        ContentStoreId, StorageChecksum,
     };
     use loonfs_objectstore::keys::content_blob;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -849,6 +1057,239 @@ mod tests {
                 Bytes::from_static(b"identical payload")
             );
         }
+    }
+
+    /// Chunk size the streaming tests read in, small enough that a
+    /// many-chunk object is a few kilobytes rather than tens of megabytes.
+    const TEST_CHUNK_BYTES: u64 = 1024;
+
+    fn test_chunk_bytes() -> NonZeroU64 {
+        NonZeroU64::new(TEST_CHUNK_BYTES).expect("non-zero test chunk size")
+    }
+
+    fn payload(len: usize) -> Vec<u8> {
+        (0..len).map(|offset| (offset % 251) as u8).collect()
+    }
+
+    fn test_entry() -> AuthoritativePathEntry {
+        AuthoritativePathEntry {
+            namespace_id: loonfs_api::NamespaceId::parse("demo").expect("namespace id"),
+            absolute_path: loonfs_api::AbsolutePath::parse("/file.bin").expect("absolute path"),
+            inode_id: loonfs_api::InodeId(1),
+            inode_kind: loonfs_api::InodeKind::File,
+            head_seq: loonfs_api::ChangeSeq(1),
+            parent_inode_id: None,
+            display_name: None,
+            revision_no: None,
+            size_bytes: None,
+            content_ref: None,
+            committed_at_ms: None,
+        }
+    }
+
+    async fn open_stream<S: ObjectStore>(
+        store: S,
+        content_store_id: &ContentStoreId,
+        content_ref: &ContentRef,
+    ) -> Result<FileContentStream<S>, DurableContentValidationError> {
+        FileContentStream::open(
+            store,
+            content_store_id,
+            test_entry(),
+            content_ref.clone(),
+            test_chunk_bytes(),
+        )
+        .await
+    }
+
+    /// A streamed read hands back the object in chunks of the size it was
+    /// opened with, in order, and ends only after verifying the whole thing.
+    #[tokio::test]
+    async fn a_streamed_read_returns_the_object_one_chunk_at_a_time() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let bytes = payload(3 * TEST_CHUNK_BYTES as usize + 7);
+        let content_ref = content_ref(&bytes);
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+
+        let mut stream = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect("open stream");
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
+            chunks.push(chunk);
+        }
+
+        assert_eq!(chunks.len(), 4, "three full chunks and the remainder");
+        for chunk in &chunks[..3] {
+            assert_eq!(chunk.len() as u64, TEST_CHUNK_BYTES);
+        }
+        assert_eq!(chunks[3].len(), 7);
+        assert_eq!(chunks.concat(), bytes, "the object arrives byte-identical");
+    }
+
+    /// The end is an answer, not an event: a caller that asks again after it
+    /// gets the same verdict rather than a digest closed a second time over
+    /// nothing.
+    #[tokio::test]
+    async fn a_finished_stream_repeats_its_verdict() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let bytes = payload(TEST_CHUNK_BYTES as usize + 3);
+        let content_ref = content_ref(&bytes);
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+
+        let mut stream = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect("open stream");
+        while stream.next_chunk().await.expect("chunk").is_some() {}
+        assert!(stream.next_chunk().await.expect("verified end").is_none());
+        assert!(stream.next_chunk().await.expect("verified end").is_none());
+    }
+
+    /// An empty file has nothing to fetch and still verifies: the digest of
+    /// no bytes is the digest its reference carries.
+    #[tokio::test]
+    async fn a_streamed_read_of_an_empty_object_verifies_without_fetching() {
+        let (_temp_dir, inner, content_store_id) = test_store();
+        let store = CountingStore::new(inner, KeyPredicate::content_blob());
+        let content_ref = content_ref(b"");
+        put_content_object(&store, &content_store_id, &content_ref, b"").await;
+
+        store.reset();
+        let mut stream = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect("open stream");
+        assert!(stream.next_chunk().await.expect("verified end").is_none());
+        assert_eq!(
+            store.count(OperationClass::Read),
+            0,
+            "an empty object needs no ranged read"
+        );
+    }
+
+    /// A reference whose only evidence is a checksum this build cannot
+    /// recompute is refused before any byte moves, not after — a streamed
+    /// read that discovered this at the end would already have handed
+    /// unverifiable bytes to its caller.
+    #[tokio::test]
+    async fn a_streamed_read_refuses_a_reference_it_cannot_verify_before_reading() {
+        let (_temp_dir, inner, content_store_id) = test_store();
+        let store = CountingStore::new(inner, KeyPredicate::content_blob());
+        let bytes = b"crc only";
+        let mut content_ref = content_ref(bytes);
+        content_ref.whole_file_sha256 = None;
+        content_ref.storage_checksum = StorageChecksum {
+            algorithm: ChecksumAlgorithm::Crc32c,
+            value: "00000000".to_owned(),
+        };
+        put_content_object(&store, &content_store_id, &content_ref, bytes).await;
+
+        store.reset();
+        let err = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect_err("unverifiable checksum");
+        assert!(matches!(
+            err,
+            DurableContentValidationError::ContentChecksumUnverifiable { .. }
+        ));
+        assert_eq!(store.count(OperationClass::Read), 0);
+    }
+
+    /// The same evidence the buffered read holds bytes to, folded chunk by
+    /// chunk: a provider-assembled object carries only a CRC, and a streamed
+    /// read verifies it rather than waving it through.
+    #[tokio::test]
+    async fn a_streamed_read_verifies_a_reference_whose_only_evidence_is_a_crc64nvme() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let bytes = payload(2 * TEST_CHUNK_BYTES as usize);
+        let content_ref = ContentRef {
+            kind: ContentRefKind::BlobV1,
+            content_id: ContentId::generate(),
+            size_bytes: bytes.len() as u64,
+            storage_checksum: StorageChecksum::crc64nvme(&bytes),
+            whole_file_sha256: None,
+        };
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+
+        let mut stream = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect("open stream");
+        let mut read = Vec::new();
+        while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
+            read.extend_from_slice(&chunk);
+        }
+        assert_eq!(read, bytes);
+    }
+
+    /// Bytes that disagree with the reference fail the read at the call that
+    /// reports the end, after the chunks have been handed out. That is what
+    /// streaming costs, and why a caller that installs a file installs it
+    /// only once this call has returned.
+    #[tokio::test]
+    async fn a_streamed_read_rejects_an_object_that_does_not_match_its_reference() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let bytes = payload(2 * TEST_CHUNK_BYTES as usize);
+        let expected = content_ref(&bytes);
+        // Same id and same length, different bytes: only the digest can tell.
+        let mut planted = bytes.clone();
+        planted[0] ^= 0xff;
+        let planted_ref = ContentRef::blob_v1(expected.content_id.clone(), &planted);
+        put_content_object(&store, &content_store_id, &planted_ref, &planted).await;
+
+        let mut stream = open_stream(&store, &content_store_id, &expected)
+            .await
+            .expect("open stream");
+        let mut chunks = 0;
+        let err = loop {
+            match stream.next_chunk().await {
+                Ok(Some(_)) => chunks += 1,
+                Ok(None) => break None,
+                Err(err) => break Some(err),
+            }
+        }
+        .expect("a mismatched object must not report a verified end");
+        assert_eq!(chunks, 2, "the mismatch is reported after the last chunk");
+        assert!(matches!(
+            err,
+            CoreError::DurableContent(
+                DurableContentValidationError::ContentChecksumMismatch { .. }
+            )
+        ));
+    }
+
+    /// An object that is not there fails when the stream is opened, so a
+    /// caller learns it before it has written anything anywhere.
+    #[tokio::test]
+    async fn a_streamed_read_reports_a_missing_object_when_it_opens() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let content_ref = content_ref(b"never stored");
+
+        let err = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect_err("missing object");
+        assert!(matches!(
+            err,
+            DurableContentValidationError::MissingContentObject { .. }
+        ));
+    }
+
+    /// An object longer or shorter than its reference claims is caught
+    /// before any of it is handed out, by the same size check the buffered
+    /// read makes over the bytes it downloaded.
+    #[tokio::test]
+    async fn a_streamed_read_rejects_an_object_of_the_wrong_length() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let bytes = payload(TEST_CHUNK_BYTES as usize + 1);
+        let mut content_ref = content_ref(&bytes);
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+        content_ref.size_bytes += 1;
+
+        let err = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect_err("length mismatch");
+        assert!(matches!(
+            err,
+            DurableContentValidationError::ContentLengthMismatch { .. }
+        ));
     }
 
     fn test_store() -> (tempfile::TempDir, LocalFsStore, ContentStoreId) {

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -20,10 +20,11 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream, StreamExt};
 use loonfs_api::{sha256_digest, StorageChecksum};
+use std::io::SeekFrom;
 use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs::{self, File, OpenOptions};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::Mutex;
 
 /// Lock file serializing mutations across processes sharing one store root.
@@ -345,6 +346,13 @@ impl LocalFsStore {
         Ok(Some(ObjectBody { metadata, bytes }))
     }
 
+    /// Reads the whole object, or exactly one range of it.
+    ///
+    /// A ranged read seeks to its start and reads only its length, so it
+    /// holds the range and never the object. That is what a caller reading a
+    /// large object in bounded chunks is promised, and a store that
+    /// materialized the whole object to answer each chunk would break the
+    /// promise on this provider alone.
     async fn get_object(&self, key: &str, range: Option<ByteRange>) -> Result<Option<Vec<u8>>> {
         let path = self.resolve_key(key)?;
         let mut file = match File::open(&path).await {
@@ -353,28 +361,36 @@ impl LocalFsStore {
             Err(err) => return Err(io_error(key, err)),
         };
 
-        let mut bytes = Vec::new();
-        file.read_to_end(&mut bytes)
+        let Some(range) = range else {
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)
+                .await
+                .map_err(|err| io_error(key, err))?;
+            return Ok(Some(bytes));
+        };
+
+        let invalid_range = || ObjectStoreError::InvalidRange {
+            object_key: key.to_owned(),
+        };
+        let size_bytes = file
+            .metadata()
+            .await
+            .map_err(|err| io_error(key, err))?
+            .len();
+        if range.end_exclusive < range.start_inclusive || range.start_inclusive > size_bytes {
+            return Err(invalid_range());
+        }
+        // A range ending past the object is truncated, never refused.
+        let end_exclusive = range.end_exclusive.min(size_bytes);
+        file.seek(SeekFrom::Start(range.start_inclusive))
             .await
             .map_err(|err| io_error(key, err))?;
-
-        match range {
-            None => Ok(Some(bytes)),
-            Some(range) => {
-                let invalid_range = || ObjectStoreError::InvalidRange {
-                    object_key: key.to_owned(),
-                };
-                let start = usize::try_from(range.start_inclusive).map_err(|_| invalid_range())?;
-                let mut end = usize::try_from(range.end_exclusive).map_err(|_| invalid_range())?;
-
-                if end < start || start > bytes.len() {
-                    return Err(invalid_range());
-                }
-
-                end = end.min(bytes.len());
-                Ok(Some(bytes[start..end].to_vec()))
-            }
-        }
+        let mut bytes = Vec::new();
+        file.take(end_exclusive - range.start_inclusive)
+            .read_to_end(&mut bytes)
+            .await
+            .map_err(|err| io_error(key, err))?;
+        Ok(Some(bytes))
     }
 
     async fn put_object(&self, key: &str, bytes: &[u8], mode: PutMode) -> Result<ObjectMetadata> {
@@ -756,7 +772,7 @@ mod tests {
     // Tests panic in unexpected match arms for precise diagnostics.
 
     use super::LocalFsStore;
-    use super::{ObjectStore, ObjectStoreError, PutMode};
+    use super::{ByteRange, ObjectStore, ObjectStoreError, PutMode};
     use crate::keys::{upload_session, wal_head};
     use bytes::Bytes;
     use std::fs;
@@ -846,6 +862,63 @@ mod tests {
         assert_eq!(head.etag, second.etag);
         assert_eq!(head.size_bytes, second.size_bytes);
         assert_ne!(first, second);
+    }
+
+    /// The range contract a chunked reader depends on: ranges answer their
+    /// own bytes, an end past the object is truncated rather than refused,
+    /// and a start past the object or a descending range is refused.
+    #[tokio::test]
+    async fn ranged_reads_answer_their_range_and_refuse_impossible_ones() {
+        let temp_dir = TestDir::new("ranged-reads");
+        let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
+        let key = wal_head("ns-1");
+        let payload = Bytes::from_static(b"0123456789");
+        store
+            .put(&key, payload.clone(), PutMode::Overwrite)
+            .await
+            .expect("seed object");
+
+        let range = |start_inclusive, end_exclusive| {
+            Some(ByteRange {
+                start_inclusive,
+                end_exclusive,
+            })
+        };
+        assert_eq!(
+            store.get(&key, range(0, 4)).await.expect("leading range"),
+            Some(Bytes::from_static(b"0123"))
+        );
+        assert_eq!(
+            store.get(&key, range(4, 7)).await.expect("middle range"),
+            Some(Bytes::from_static(b"456"))
+        );
+        assert_eq!(
+            store
+                .get(&key, range(7, 99))
+                .await
+                .expect("range past the end is truncated"),
+            Some(Bytes::from_static(b"789"))
+        );
+        assert_eq!(
+            store
+                .get(&key, range(10, 10))
+                .await
+                .expect("a range at the end is empty, not missing"),
+            Some(Bytes::new())
+        );
+        assert!(matches!(
+            store.get(&key, range(11, 12)).await,
+            Err(ObjectStoreError::InvalidRange { .. })
+        ));
+        assert!(matches!(
+            store.get(&key, range(6, 2)).await,
+            Err(ObjectStoreError::InvalidRange { .. })
+        ));
+        assert!(store
+            .get(&wal_head("ns-missing"), range(0, 4))
+            .await
+            .expect("a ranged read of a missing object is absent, not an error")
+            .is_none());
     }
 
     /// Readers race each overwrite rename to exercise replacement visibility across runtime workers.

--- a/crates/loonfs-test-support/src/stores/buffer_watch_store.rs
+++ b/crates/loonfs-test-support/src/stores/buffer_watch_store.rs
@@ -1,18 +1,19 @@
-//! Watches how much of a payload a write path holds in memory at once.
+//! Watches how much of a payload a transfer path holds in memory at once.
 //!
-//! A streamed write's whole promise is that peak memory follows the part
+//! A streamed transfer's whole promise is that peak memory follows the chunk
 //! size rather than the object size, and that promise is easy to lose by
-//! accident: one `collect()` on the way through, one decorator that does
-//! not forward `put_streamed` and falls back to buffering, and a large
-//! upload is materialized again with nothing failing.
+//! accident: one `collect()` on the way through, one decorator that does not
+//! forward `put_streamed` and falls back to buffering, one read that asks for
+//! no range and gets the whole object — and a large transfer is materialized
+//! again with nothing failing.
 //!
 //! This wrapper makes the promise checkable without measuring the process.
 //! It sits above a store and watches every payload buffer that crosses the
-//! boundary — a whole-payload `put`, or each chunk of a `put_streamed`
-//! stream — recording the largest one and the most bytes alive at any
-//! instant. Liveness is exact: each chunk handed downstream carries a drop
-//! guard, so the counter falls when the consumer actually releases it, not
-//! when the wrapper guesses it has.
+//! boundary in either direction — a whole-payload `put`, each chunk of a
+//! `put_streamed` stream, and each `get`, whole or ranged — recording the
+//! largest one and the most bytes alive at any instant. Liveness is exact:
+//! each buffer handed on carries a drop guard, so the counter falls when the
+//! consumer actually releases it, not when the wrapper guesses it has.
 
 use super::KeyPredicate;
 use async_trait::async_trait;
@@ -158,12 +159,27 @@ impl<S: ObjectStore> ObjectStore for BufferWatchStore<S> {
         self.inner.get_with_metadata(key).await
     }
 
+    /// A read's answer is a payload buffer like any other: one whole object
+    /// for an unranged read, one range for a chunked one. The caller's drop
+    /// is what releases it, so a reader that accumulates chunks shows up as
+    /// bytes alive rather than as chunks that were merely handed out.
     async fn get(
         &self,
         key: &str,
         range: Option<ByteRange>,
     ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
+        let bytes = self.inner.get(key, range).await?;
+        let Some(bytes) = bytes else {
+            return Ok(None);
+        };
+        if !self.matches(key) {
+            return Ok(Some(bytes));
+        }
+        self.peaks.observe(bytes.len() as u64);
+        Ok(Some(Bytes::from_owner(WatchedChunk {
+            bytes,
+            peaks: Arc::clone(&self.peaks),
+        })))
     }
 
     async fn put(

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -8,8 +8,9 @@ use crate::Result;
 use crate::{
     AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ChangesResponse,
     CheckpointFilesPage, CheckpointFilesPageCursor, CheckpointId, ContentRef, CoreError,
-    CurrentFileState, InodeId, ListChangesOptions, ListFileRevisionsResponse,
-    ListPathEntriesResponse, NamespaceId, RevisionNo, RuntimeError,
+    CurrentFileState, FileContentStream, InodeId, ListChangesOptions, ListFileRevisionsResponse,
+    ListPathEntriesResponse, NamespaceId, ReadFileStreamOptions, RevisionNo, RuntimeError,
+    SharedObjectStore,
 };
 use loonfs_api::{
     encode_cursor, AbsolutePath, DirectoryPageCursor, FileRevisionsPageCursor, PageRequest,
@@ -161,6 +162,38 @@ impl FsReader {
             .cache_stats
             .record_latest_metadata_view_read();
         Ok(read)
+    }
+
+    /// Reads a file's current content as bounded chunks instead of one buffer.
+    ///
+    /// This is [`Self::get_file_bytes`] for a caller that should not hold what
+    /// it reads: the content arrives one ranged read at a time with the
+    /// verifying digest folded over it, so a 50 GiB file costs one chunk of
+    /// memory rather than 50 GiB. The verification is the buffered read's,
+    /// unweakened — declared size, plus the reference's trusted whole-file
+    /// SHA-256 when it has one and its storage checksum when that is the only
+    /// full-object evidence there is — and it lands on the final
+    /// [`FileContentStream::next_chunk`] call. A caller that stops early
+    /// stops with unverified bytes; a caller that wants the whole answer or
+    /// none of it uses [`Self::get_file_bytes`].
+    ///
+    /// The deployment's buffered-read cap does not apply here. That cap
+    /// bounds what one call materializes, and this call materializes a chunk.
+    pub async fn read_file_stream(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        options: ReadFileStreamOptions,
+    ) -> Result<FileContentStream<SharedObjectStore>> {
+        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let stream = engine
+            .read_file_stream(absolute_path, &read_context, options.chunk_bytes)
+            .await?;
+        self.core
+            .inner
+            .cache_stats
+            .record_latest_metadata_view_read();
+        Ok(stream)
     }
 
     /// Reads one page of the files visible in the state a checkpoint pins,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -73,8 +73,8 @@ pub use loonfs_core::time::current_time_ms;
 pub use loonfs_core::{
     delete_if_aged, BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage,
     CheckpointFilesPageCursor, CurrentFileState, DeleteNamespaceOptions, Error as CoreError,
-    ErrorCode, ErrorKind, GcConfig, MetadataViewError, PassBudget, StoreFailureClass, WriterFence,
-    MAX_RESOLVE_CURRENT_FILES,
+    ErrorCode, ErrorKind, FileContentStream, GcConfig, MetadataViewError, PassBudget,
+    StoreFailureClass, WriterFence, CONTENT_READ_CHUNK_BYTES, MAX_RESOLVE_CURRENT_FILES,
 };
 pub use publisher::PublishObserver;
 
@@ -149,7 +149,7 @@ pub use maintenance_runner::{
 pub use options::{
     gc_config_from_request, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteOptions, ListChangesOptions, MaintenanceStepOptions, MoveOptions,
-    PutFileOptions, RestoreRevisionOptions, UndeleteOptions,
+    PutFileOptions, ReadFileStreamOptions, RestoreRevisionOptions, UndeleteOptions,
 };
 pub use trace::{payload_class, TraceMode, TraceStoreKind};
 

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -16,6 +16,7 @@ use loonfs_api::v0::{
     CreateCheckpointRequest, GcRequest, MaintenanceStepKind, MaintenanceStepRequest,
 };
 use loonfs_core::publish::WalTailPolicy;
+use std::num::NonZeroU64;
 
 pub use loonfs_api::options::{
     CopyOptions, CreateDirectoryOptions, DeleteOptions, MoveOptions, PutFileOptions,
@@ -121,6 +122,28 @@ pub struct CreateNamespaceOptions {
 pub struct ListChangesOptions {
     /// Page limit; `None` resolves the default pagination policy.
     pub limit: Option<EffectiveLimit>,
+}
+
+/// Options for a streaming file read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadFileStreamOptions {
+    /// Bytes one ranged read fetches, which is the most of the file the read
+    /// holds at once. Defaults to
+    /// [`CONTENT_READ_CHUNK_BYTES`](loonfs_core::CONTENT_READ_CHUNK_BYTES);
+    /// a caller with a tighter memory budget than that says so here, the way
+    /// a caller of [`FsReader::read_content_ref`](crate::FsReader::read_content_ref)
+    /// declares its own. Non-zero by type, so there is no chunk size that
+    /// makes no progress.
+    pub chunk_bytes: NonZeroU64,
+}
+
+impl Default for ReadFileStreamOptions {
+    fn default() -> Self {
+        Self {
+            chunk_bytes: NonZeroU64::new(loonfs_core::CONTENT_READ_CHUNK_BYTES)
+                .expect("the default read chunk size is non-zero"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/loonfs/tests/it/main.rs
+++ b/crates/loonfs/tests/it/main.rs
@@ -24,4 +24,5 @@ mod publish_observer;
 mod request_accounting;
 mod runtime_config;
 mod streamed_put;
+mod streamed_read;
 mod undelete;

--- a/crates/loonfs/tests/it/streamed_read.rs
+++ b/crates/loonfs/tests/it/streamed_read.rs
@@ -1,0 +1,194 @@
+//! What an embedded streaming read costs in memory, and what it verifies.
+//!
+//! The claim is that a read's memory follows its chunk size and not the
+//! file's length, and the proof is retention at the store boundary: every
+//! buffer the store hands back reports when it is released, so the peak is
+//! exact rather than sampled. The buffered read is measured beside it as the
+//! control — it is supposed to hold the whole file, and the difference
+//! between the two numbers is the whole point of the streaming one.
+
+use crate::common::{open_runtime_async, store, TestRuntime};
+use loonfs::{
+    CreateNamespaceOptions, DestinationBehavior, ErrorCode, FsReader, NamespaceId, PutFileOptions,
+    ReadFileStreamOptions, SharedObjectStore,
+};
+use loonfs_objectstore::keys::content_blob;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::ObjectStore;
+use loonfs_test_support::stores::BufferWatchStore;
+use std::num::NonZeroU64;
+use std::path::Path;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+const PATH: &str = "/big.bin";
+/// Small enough to keep the test in kilobytes, and read in enough chunks
+/// that a read holding the file whole could not hide inside one.
+const CHUNK_BYTES: u64 = 64 * 1024;
+const CHUNKS: u64 = 10;
+const PAYLOAD_BYTES: usize = (CHUNK_BYTES * CHUNKS) as usize + 17;
+
+fn payload(len: usize) -> Vec<u8> {
+    (0..len).map(|offset| (offset % 251) as u8).collect()
+}
+
+fn chunked() -> ReadFileStreamOptions {
+    ReadFileStreamOptions {
+        chunk_bytes: NonZeroU64::new(CHUNK_BYTES).expect("non-zero chunk size"),
+    }
+}
+
+async fn namespace(runtime: &TestRuntime) -> NamespaceId {
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    runtime
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    namespace_id
+}
+
+/// Writes the payload through a plain store, so only the read that follows
+/// is measured, and returns a reader over a watched view of the same root.
+async fn written_file(
+    root: &Path,
+    bytes: &[u8],
+) -> (NamespaceId, Arc<BufferWatchStore<LocalFsStore>>, FsReader) {
+    let runtime = open_runtime_async(store(root), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    runtime
+        .writer
+        .put_file_bytes(
+            &namespace_id,
+            PATH,
+            bytes,
+            PutFileOptions {
+                behavior: DestinationBehavior::Replace,
+                ..PutFileOptions::default()
+            },
+        )
+        .await
+        .expect("put file");
+
+    let watched = Arc::new(BufferWatchStore::watching_content(
+        LocalFsStore::new(root).expect("create local-fs store"),
+    ));
+    let store: SharedObjectStore = watched.clone();
+    let reader = FsReader::builder_with_store(store)
+        .build()
+        .await
+        .expect("build reader");
+    (namespace_id, watched, reader)
+}
+
+/// A streamed read never holds more of the file than one chunk, and every
+/// byte crosses the store boundary exactly once.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_streamed_read_holds_one_chunk_of_its_file() {
+    let temp_dir = tempdir().expect("tempdir");
+    let payload = payload(PAYLOAD_BYTES);
+    let (namespace_id, watched, reader) = written_file(temp_dir.path(), &payload).await;
+
+    let mut stream = reader
+        .read_file_stream(&namespace_id, PATH, chunked())
+        .await
+        .expect("open stream");
+    assert_eq!(stream.size_bytes(), PAYLOAD_BYTES as u64);
+    assert_eq!(stream.entry().absolute_path.as_str(), PATH);
+
+    let mut read = Vec::with_capacity(PAYLOAD_BYTES);
+    let mut chunks = 0u64;
+    // Each chunk is dropped before the next is asked for, which is what a
+    // consumer writing to a file or a pipe does, and what the liveness
+    // number below is about.
+    while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
+        assert!(chunk.len() as u64 <= CHUNK_BYTES);
+        read.extend_from_slice(&chunk);
+        chunks += 1;
+        let peaks = watched.peaks();
+        assert!(
+            peaks.peak_live_bytes <= CHUNK_BYTES,
+            "the read held {} bytes at once, past its one-chunk window",
+            peaks.peak_live_bytes
+        );
+    }
+
+    assert_eq!(
+        read, payload,
+        "the file that arrives is the file that landed"
+    );
+    assert_eq!(chunks, CHUNKS + 1, "ten full chunks and the remainder");
+    let peaks = watched.peaks();
+    assert_eq!(
+        peaks.total_bytes, PAYLOAD_BYTES as u64,
+        "every byte crossed the store boundary exactly once"
+    );
+    assert!(
+        peaks.largest_buffer_bytes <= CHUNK_BYTES,
+        "no single buffer may exceed one chunk: largest was {}",
+        peaks.largest_buffer_bytes
+    );
+}
+
+/// The control the number above is measured against: the buffered read is
+/// supposed to hold the whole file, and does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_buffered_read_holds_the_whole_file() {
+    let temp_dir = tempdir().expect("tempdir");
+    let payload = payload(PAYLOAD_BYTES);
+    let (namespace_id, watched, reader) = written_file(temp_dir.path(), &payload).await;
+
+    let read = reader
+        .get_file_bytes(&namespace_id, PATH)
+        .await
+        .expect("buffered read");
+
+    assert_eq!(read.bytes, payload);
+    assert_eq!(
+        watched.peaks().largest_buffer_bytes,
+        PAYLOAD_BYTES as u64,
+        "the buffered read materializes the file in one buffer"
+    );
+}
+
+/// Content that disagrees with its reference fails the read, and fails it at
+/// the end — after the chunks are out, which is exactly why a caller that
+/// installs a file installs it only once the stream has ended cleanly.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_streamed_read_rejects_content_that_stopped_matching_its_reference() {
+    let temp_dir = tempdir().expect("tempdir");
+    let payload = payload(PAYLOAD_BYTES);
+    let (namespace_id, _watched, reader) = written_file(temp_dir.path(), &payload).await;
+
+    // Same length, different bytes: nothing but the digest can tell, which
+    // is the case the read exists to catch.
+    let entry = reader
+        .stat_path(&namespace_id, PATH)
+        .await
+        .expect("stat file");
+    let content_ref = entry.content_ref.expect("a file has content");
+    let catalog =
+        loonfs::control::load_namespace_catalog_entry(&store(temp_dir.path()), &namespace_id)
+            .await
+            .expect("load catalog");
+    let key = content_blob(catalog.content_store_id().as_str(), &content_ref.content_id);
+    let mut corrupted = payload.clone();
+    corrupted[0] ^= 0xff;
+    store(temp_dir.path())
+        .put_overwrite(&key, corrupted.into())
+        .await
+        .expect("overwrite content object");
+
+    let mut stream = reader
+        .read_file_stream(&namespace_id, PATH, chunked())
+        .await
+        .expect("open stream");
+    let error = loop {
+        match stream.next_chunk().await {
+            Ok(Some(_)) => continue,
+            Ok(None) => break None,
+            Err(error) => break Some(error),
+        }
+    }
+    .expect("corrupted content must not report a verified end");
+    assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+}


### PR DESCRIPTION
Memory fix -- embedded downloads buffered whole objects — a 50 GiB readback peaked at 12.6 GB RSS. Reads are now streamed in fixed ranged chunks with the digest folded as bytes pass, so peak memory is one chunk regardless of object size.

The stream in question: `FsReader::read_file_stream(namespace, path, options)` resolves the path exactly like the buffered read (the resolution is now one shared function, so the two cannot diverge), then fetches the immutable content object in ranged reads of `CONTENT_READ_CHUNK_BYTES` (8 MiB — deliberately the sibling of the multipart part size: one transfer unit in both directions). The caller pulls with `next_chunk()`; the call that reports the end verifies total length and digest, and the verdict is memoized. Verification is identical to the buffered path — trusted whole-file sha256 when present, otherwise the reference's own storage checksum — with one strictness improvement: a checksum algorithm this build cannot recompute is refused at open, before any bytes move, where the buffered read refused only after downloading. The blob is immutable by identity, so chunked reads cannot observe torn writes; a comment says so instead of adding revalidation.

The CLI: Embedded `get` streams for both destinations. A file destination keeps the exact partial-file safety: bytes stream into the `.loonfs-partial-*` temp file and the rename happens only after verification, so an integrity failure can never leave a verified-looking final file (a test corrupts the stored object and proves nothing lands). Stdout streams as chunks arrive; a verification failure then exits nonzero after partial output — inherent to streaming, documented in the command help.

**Two riders...**

- LocalFsStore's ranged read used to read the whole file and slice it — fine for one whole-object read, catastrophic under a chunked reader (6,400 whole-file reads for 50 GiB). It now seeks and reads the range, same contract, newly pinned by a test.
- The buffer-watching test store now observes read buffers, which is what makes the memory claim measurable.

**Measured.** A 655,377-byte file read in 64 KiB chunks: largest single buffer 65,536 bytes, peak live bytes at most 65,536 (asserted after every chunk), every byte crossing the store boundary exactly once. The control test beside it shows the buffered read holding all 655,377 bytes at once. At production sizes that is 8 MiB for a 50 GiB file instead of 50 GiB.
