### PR TITLE
feat(cli): transfers report progress

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -26,6 +26,10 @@ Global flags
   --no-input
     Never prompt; fail instead when a value would be asked for
 
+  --no-progress
+    Say nothing about a transfer while it runs, on a terminal or under
+    --json
+
   -h, --help
     Show command help
 
@@ -364,6 +368,50 @@ Update options
     --auth-token <token>
     --ca-cert-path <path>
 
+Transfer progress
+  `loonfs get` and `loonfs put`, one file or a whole tree, say where they
+  have got to while they run. Never on stdout, which carries either the
+  file's bytes or the JSON result.
+
+  On a terminal, one line on stderr is redrawn in place: bytes moved, the
+  total when it is known, a percentage, a rate, and how long is left at
+  that rate. A tree also shows files finished out of files found. The line
+  is erased when the transfer ends. When stderr is not a terminal nothing
+  is printed, the way curl stays quiet in a pipeline.
+
+  With --json, stderr carries one JSON object per line instead, so an agent
+  can tell healthy work from a hang. That makes stderr a stream of JSON
+  documents under --json: these events while the command runs, then the
+  failure envelope if it failed. The names and fields below are stable.
+
+    {"kind":"file_started","op":"get","path":"/docs/a.bin",
+     "bytes_total":4096,"elapsed_ms":12}
+      One file began moving. bytes_total is left out when nothing knows it.
+
+    {"kind":"progress","op":"get","path":"/docs/a.bin","bytes_done":2048,
+     "bytes_total":4096,"files_done":0,"files_total":1,"rate_bps":10240,
+     "elapsed_ms":200}
+      Where the whole operation is. `path` is the file for a single
+      transfer and `<namespace>:<root>` for a tree. bytes_total and
+      files_total are null when they cannot be known — a piped put, or a
+      tree holding a file whose length the walk could not read. rate_bps is
+      the average over the transfer so far. Reported at most four times a
+      second, and whenever the whole-number percentage moves.
+
+    {"kind":"file_finished","op":"get","path":"/docs/a.bin",
+     "bytes_done":4096,"elapsed_ms":420}
+      One file finished, and what it actually moved.
+
+    {"kind":"phase","op":"put","path":"/docs/a.bin","phase":"committing",
+     "elapsed_ms":900}
+      A stretch where time passes and bytes do not, reported when it
+      starts. `committing` says an upload's payload has been read and the
+      commit is what is left.
+
+  `op` is `get` or `put`. --no-progress silences both forms, and neither is
+  produced for `loonfs cat` or for `loonfs get ... -`, which hand the file
+  itself to stdout.
+
 Behavior notes
   `loonfs cat` always streams raw bytes to stdout
 
@@ -419,4 +467,19 @@ Behavior notes
   same reason
 
   `loonfs mv` moves a directory in one commit and takes no -r
+
+  How much of a transfer is watchable follows how it travels. A streamed or
+  direct download reports bytes as they land, and so does a streamed
+  upload; a proxied download and a small buffered upload are one request
+  each, so they go from nothing to done in one step. A recursive put
+  uploads one file per request, so a tree's byte count advances a whole
+  file at a time
+
+  An embedded profile's edit latency grows with the WAL tail between
+  maintenance passes: every write appends, and reads replay what has not
+  been folded into the metadata yet, so a namespace that is written to and
+  never maintained gets slower. Embedded profiles run maintenance manually
+  — `loonfs admin run --namespace <ns>` hosts it, `--drain` catches up and
+  exits, and `loonfs admin step` runs one pass — while a server runs its
+  own automatically for the namespaces it serves
 ```

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -1,5 +1,6 @@
 //! The clap argument grammar for every `loonfs` command.
 
+use crate::progress::ProgressMode;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -27,6 +28,9 @@ pub(crate) struct Cli {
     /// Never prompt; fail instead when input would be required.
     #[arg(long, global = true)]
     pub no_input: bool,
+    /// Say nothing about a transfer while it runs.
+    #[arg(long, global = true)]
+    pub no_progress: bool,
     #[command(subcommand)]
     pub command: Command,
 }
@@ -823,6 +827,8 @@ pub(crate) struct RuntimeBehavior {
     pub json: bool,
     pub no_input: bool,
     pub interactive: bool,
+    /// How a transfer that takes human time says where it has got to.
+    pub progress: ProgressMode,
 }
 
 impl RuntimeBehavior {
@@ -835,6 +841,11 @@ impl RuntimeBehavior {
             json: cli.json,
             no_input: cli.no_input,
             interactive,
+            // Progress asks standard error alone, not the terminal pair
+            // `interactive` needs: a `put` fed by a pipe still has a
+            // terminal to draw on, and `--no-input` says nothing about
+            // whether anyone is watching.
+            progress: ProgressMode::detect(cli.no_progress, cli.json),
         }
     }
 }

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -18,6 +18,7 @@ mod embedded;
 
 use crate::backend_error::{map_namespace_scoped_runtime_error, BackendError};
 use crate::payload::LocalPayload;
+use crate::progress::ProgressReporter;
 use crate::resolve::ResolvedTarget;
 use bytes::Bytes;
 use loonfs_api::{
@@ -37,6 +38,7 @@ use loonfs_client::{
     NamespacePath, PutFileOptions, RestoreRevisionOptions, UndeleteOptions,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
+use std::sync::Arc;
 
 pub(crate) use embedded::EmbeddedBackend;
 use loonfs::{
@@ -542,19 +544,22 @@ impl ResolvedTarget {
     ///
     /// The payload is opened per arm rather than shared: the two runtimes
     /// spell a byte stream in their own terms, and only one arm ever runs.
+    /// `progress` counts what the payload gives up, so both arms report the
+    /// same bytes for the same file.
     pub(crate) async fn put_file_stream(
         &self,
         spec: &NamespacePath,
         payload: &LocalPayload,
         options: &PutFileOptions,
+        progress: &Arc<ProgressReporter>,
     ) -> Result<CommitResponse, BackendError> {
         match self {
             Self::Embedded(target) => {
-                let body = payload.open_byte_stream().await?;
+                let body = payload.open_byte_stream(progress).await?;
                 target.backend.put_file_stream(spec, body, options).await
             }
             Self::Remote(target) => {
-                let source = payload.open_source().await?;
+                let source = payload.open_source(progress).await?;
                 Ok(target.client.put_file_stream(spec, source, options).await?)
             }
         }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -16,6 +16,7 @@ use crate::args::{
 use crate::backend::FileDownload;
 use crate::error::CliError;
 use crate::payload::{read_whole_file, LocalPayload, STDIN_PATH};
+use crate::progress::{ProgressOp, ProgressReporter};
 use loonfs_api::{
     CommitId, DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeKind, RevisionNo,
 };
@@ -23,6 +24,7 @@ use loonfs_client::{CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFil
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 // --- filesystem ---
 
@@ -355,6 +357,8 @@ pub(crate) async fn run_filesystem_get(
         .map_err(|error| context.fail(kind, error))?;
     let data = match args.local_destination.as_deref() {
         Some("-") => {
+            // No progress: standard output is carrying the file, and a
+            // caller piping bytes onward is not watching a line anyway.
             stream_download_to_stdout(&mut download)
                 .await
                 .map_err(|error| context.fail(kind, error))?;
@@ -364,14 +368,30 @@ pub(crate) async fn run_filesystem_get(
             let derived_name = other.is_none();
             let destination = destination_path_for_get(spec.absolute_path().as_str(), other)
                 .map_err(|error| context.fail(kind, error))?;
+            let progress = Arc::new(ProgressReporter::new(
+                runtime,
+                ProgressOp::Get,
+                spec.absolute_path().as_str(),
+            ));
+            progress.expect(entry.size_bytes, Some(1));
+            progress.file_started(spec.absolute_path().as_str(), entry.size_bytes);
             // The local working copy is the one thing this CLI touches
             // that has no revision history behind it, so clobbering it is
             // opt-in. `persist_noclobber` closes the race between checking
             // and installing the completed temporary file.
-            let bytes_written =
-                stream_download_to_file(&mut download, &destination, args.force, derived_name)
-                    .await
-                    .map_err(|error| context.fail(kind, error))?;
+            let written = stream_download_to_file(
+                &mut download,
+                &destination,
+                args.force,
+                derived_name,
+                &progress,
+            )
+            .await;
+            if let Ok(bytes_written) = &written {
+                progress.file_finished(spec.absolute_path().as_str(), *bytes_written);
+            }
+            progress.finish();
+            let bytes_written = written.map_err(|error| context.fail(kind, error))?;
             CommandData::FileTransfer {
                 target: render_target(&context.namespace, spec.absolute_path()),
                 destination: destination.display().to_string(),
@@ -400,6 +420,7 @@ pub(super) async fn stream_download_to_file(
     destination: &Path,
     force: bool,
     derived_name: bool,
+    progress: &ProgressReporter,
 ) -> Result<u64, CliError> {
     let mut temp = open_partial_file(destination)
         .map_err(|error| local_open_error(destination, error, force, derived_name))?;
@@ -408,6 +429,7 @@ pub(super) async fn stream_download_to_file(
         temp.write_all(&chunk)
             .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
         bytes_written += chunk.len() as u64;
+        progress.advance(chunk.len() as u64);
     }
     temp.flush()
         .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
@@ -536,7 +558,7 @@ pub(crate) async fn run_filesystem_put(
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let local_path = PathBuf::from(&args.local_path);
     if local_path == Path::new(STDIN_PATH) {
-        return run_filesystem_put_stdin(kind, args, context).await;
+        return run_filesystem_put_stdin(kind, args, context, runtime).await;
     }
 
     let metadata = fs::metadata(&local_path)
@@ -607,7 +629,16 @@ pub(crate) async fn run_filesystem_put(
     let spec = NamespacePath::new(context.namespace.clone(), remote_path);
     let payload = LocalPayload::file(&local_path, metadata.len());
     let options = put_file_options(&args).map_err(|error| context.fail(kind, error))?;
-    commit_put(kind, &context, &spec, &payload, &options).await
+    commit_put(
+        kind,
+        &context,
+        &spec,
+        &payload,
+        &options,
+        runtime,
+        Some(metadata.len()),
+    )
+    .await
 }
 
 /// `loonfs put - <remote>`: standard input, whose length is not knowable, so
@@ -619,6 +650,7 @@ async fn run_filesystem_put_stdin(
     kind: CommandKind,
     args: FilesystemPutArgs,
     context: CommandContext,
+    runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     if args.recursive {
         return Err(context.fail(
@@ -639,7 +671,18 @@ async fn run_filesystem_put_stdin(
         parse_user_path(remote_path, false).map_err(|error| context.fail(kind, error))?;
     let spec = NamespacePath::new(context.namespace.clone(), remote_path);
     let options = put_file_options(&args).map_err(|error| context.fail(kind, error))?;
-    commit_put(kind, &context, &spec, &LocalPayload::Stdin, &options).await
+    // A pipe cannot say how long it is, so there is a byte count but never a
+    // total, a percentage, or an estimate.
+    commit_put(
+        kind,
+        &context,
+        &spec,
+        &LocalPayload::Stdin,
+        &options,
+        runtime,
+        None,
+    )
+    .await
 }
 
 /// Writes one payload and renders what the commit did.
@@ -653,17 +696,41 @@ async fn commit_put(
     spec: &NamespacePath,
     payload: &LocalPayload,
     options: &PutFileOptions,
+    runtime: RuntimeBehavior,
+    size_bytes: Option<u64>,
 ) -> Result<CommandOutput, CommandFailure> {
+    let progress = Arc::new(ProgressReporter::new(
+        runtime,
+        ProgressOp::Put,
+        spec.absolute_path().as_str(),
+    ));
+    progress.expect(size_bytes, Some(1));
+    progress.file_started(spec.absolute_path().as_str(), size_bytes);
     let result = match payload.holdable_file() {
+        // A payload small enough to hold travels as one request, so there is
+        // no midpoint to report: it is read, and then the commit is all
+        // that is left.
         Some(path) => {
             let bytes = read_whole_file(path)
                 .await
                 .map_err(|error| context.fail(kind, error))?;
+            progress.advance(bytes.len() as u64);
+            progress.phase("committing");
             context.target.put_file_bytes(spec, &bytes, options).await
         }
-        None => context.target.put_file_stream(spec, payload, options).await,
+        None => {
+            context
+                .target
+                .put_file_stream(spec, payload, options, &progress)
+                .await
+        }
+    };
+    if result.is_ok() {
+        let moved = progress.bytes_done();
+        progress.file_finished(spec.absolute_path().as_str(), moved);
     }
-    .map_err(|error| context.fail(kind, error))?;
+    progress.finish();
+    let result = result.map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -46,11 +46,18 @@ fn open_partial_file(destination: &Path) -> std::io::Result<tempfile::NamedTempF
     let mut prefix = std::ffi::OsString::from(".");
     prefix.push(file_name);
     prefix.push(".loonfs-partial-");
-    let parent = destination
+    tempfile::Builder::new()
+        .prefix(&prefix)
+        .tempfile_in(partial_file_parent(destination))
+}
+
+/// The directory a destination's partial file is created in — its own, and
+/// the working directory for a bare file name.
+fn partial_file_parent(destination: &Path) -> &Path {
+    destination
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    tempfile::Builder::new().prefix(&prefix).tempfile_in(parent)
+        .unwrap_or_else(|| Path::new("."))
 }
 
 /// Installs a completed download at its destination with one rename.
@@ -395,7 +402,7 @@ pub(super) async fn stream_download_to_file(
     derived_name: bool,
 ) -> Result<u64, CliError> {
     let mut temp = open_partial_file(destination)
-        .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
+        .map_err(|error| local_open_error(destination, error, force, derived_name))?;
     let mut bytes_written = 0u64;
     while let Some(chunk) = download.next_chunk().await? {
         temp.write_all(&chunk)
@@ -427,6 +434,31 @@ async fn stream_download_to_stdout(download: &mut FileDownload) -> Result<(), Cl
             .map_err(CliError::io)?;
     }
     io::stdout().lock().flush().map_err(CliError::io)
+}
+
+/// Shapes the failure to open a download's partial file.
+///
+/// A missing directory is the one failure whose underlying error is about the
+/// wrong thing: it names the temporary file this CLI picked, whose random
+/// suffix the caller never asked for and cannot act on. The parent they have
+/// to create is what the message says instead.
+fn local_open_error(
+    destination: &Path,
+    error: std::io::Error,
+    force: bool,
+    derived_name: bool,
+) -> CliError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        return CliError::new(
+            "io_error",
+            format!(
+                "i/o error for `{}`: parent directory `{}` does not exist",
+                destination.display(),
+                partial_file_parent(destination).display()
+            ),
+        );
+    }
+    local_destination_error(destination, error, force, derived_name)
 }
 
 /// Shapes a local write failure the way `get` has always reported one.

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -1250,6 +1250,7 @@ mod tests {
             json: false,
             no_input: true,
             interactive: false,
+            progress: crate::progress::ProgressMode::Off,
         }
     }
 }

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -13,12 +13,14 @@ use super::context::CommandContext;
 use super::output::{CommandData, CommandFailure, CommandOutput, TreeTransferFailure};
 use crate::args::{CommandKind, RuntimeBehavior};
 use crate::error::CliError;
+use crate::progress::{ProgressOp, ProgressReporter};
 use crate::render::write_stderr_progress;
 use futures::StreamExt;
 use loonfs_api::DestinationBehavior;
 use loonfs_api::InodeKind;
 use loonfs_client::{CreateDirectoryOptions, NamespacePath, PutFileOptions};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// How many per-file operations run at once. Matches the reference server's
 /// default upload concurrency; deliberately a constant, not a flag, until a
@@ -30,11 +32,11 @@ const TREE_TRANSFER_CONCURRENCY: usize = 8;
 struct FileJob {
     local: PathBuf,
     remote: String,
-    /// The remote file's length, when a listing stated one. It decides how
-    /// a download travels — past the deployment's proxy cap the bytes come
-    /// straight from object storage — so it rides along from the walk that
-    /// already read it. An upload's jobs come from a local walk and carry
-    /// no remote size at all.
+    /// The file's length, when the walk that found it stated one. On a
+    /// download it also decides how the bytes travel — past the
+    /// deployment's proxy cap they come straight from object storage — and
+    /// on either transfer it is what lets the whole tree be measured before
+    /// the first byte moves.
     size_bytes: Option<u64>,
 }
 
@@ -59,6 +61,15 @@ impl TreeTally {
             error,
         });
     }
+}
+
+/// What the whole tree weighs, or nothing at all when even one file's
+/// length is unknown: a total that is missing some files would misreport
+/// every percentage derived from it.
+fn tree_bytes(files: &[FileJob]) -> Option<u64> {
+    files
+        .iter()
+        .try_fold(0u64, |total, job| Some(total + job.size_bytes?))
 }
 
 fn joined_remote(root: &str, components: &[String]) -> String {
@@ -153,16 +164,24 @@ pub(crate) async fn run_put_tree(
         }
     }
 
+    let progress = Arc::new(ProgressReporter::new(
+        runtime,
+        ProgressOp::Put,
+        format!("{}:{}", context.namespace, remote_root),
+    ));
+    progress.expect(tree_bytes(&files), Some(files.len() as u64));
     let outcomes = futures::stream::iter(files.into_iter().map(|job| {
         let backend = &context.target;
         let namespace = context.namespace.clone();
         let message = message.clone();
+        let progress = Arc::clone(&progress);
         let remote = format!("{}/{}", remote_root.trim_end_matches('/'), job.remote);
         async move {
             let spec = match NamespacePath::parse(namespace.as_str(), &remote) {
                 Ok(spec) => spec,
                 Err(error) => return (remote, Err(CliError::invalid_input(error.to_string()))),
             };
+            progress.file_started(&remote, job.size_bytes);
             let bytes = match std::fs::read(&job.local) {
                 Ok(bytes) => bytes,
                 Err(error) => return (remote, Err(CliError::io_for_path(&job.local, error))),
@@ -181,12 +200,20 @@ pub(crate) async fn run_put_tree(
                 .await
                 .map(|_| spec_target(&spec))
                 .map_err(CliError::from);
+            // One file of a tree uploads as a single request, so the tree's
+            // count advances a whole file at a time: what it reports is
+            // files stored, measured in bytes.
+            if result.is_ok() {
+                progress.advance(bytes.len() as u64);
+                progress.file_finished(&remote, bytes.len() as u64);
+            }
             (remote, result)
         }
     }))
     .buffer_unordered(TREE_TRANSFER_CONCURRENCY)
     .collect::<Vec<_>>()
     .await;
+    progress.finish();
     for (remote, result) in outcomes {
         match result {
             Ok(target) => {
@@ -244,9 +271,16 @@ pub(crate) async fn run_get_tree(
         }
     }
 
+    let progress = Arc::new(ProgressReporter::new(
+        runtime,
+        ProgressOp::Get,
+        format!("{}:{}", context.namespace, remote_root),
+    ));
+    progress.expect(tree_bytes(&listing.files), Some(listing.files.len() as u64));
     let outcomes = futures::stream::iter(listing.files.into_iter().map(|job| {
         let backend = &context.target;
         let namespace = context.namespace.clone();
+        let progress = Arc::clone(&progress);
         let local = local_root.join(job.local);
         async move {
             let spec = match NamespacePath::parse(namespace.as_str(), &job.remote) {
@@ -264,17 +298,26 @@ pub(crate) async fn run_get_tree(
                 Ok(download) => download,
                 Err(error) => return (job.remote, Err(error.into())),
             };
+            progress.file_started(&job.remote, job.size_bytes);
             let derived_name = false;
-            let written =
-                super::fs::stream_download_to_file(&mut download, &local, force, derived_name)
-                    .await
-                    .map(|_| local.display().to_string());
-            (job.remote, written)
+            let written = super::fs::stream_download_to_file(
+                &mut download,
+                &local,
+                force,
+                derived_name,
+                &progress,
+            )
+            .await;
+            if let Ok(bytes_written) = &written {
+                progress.file_finished(&job.remote, *bytes_written);
+            }
+            (job.remote, written.map(|_| local.display().to_string()))
         }
     }))
     .buffer_unordered(TREE_TRANSFER_CONCURRENCY)
     .collect::<Vec<_>>()
     .await;
+    progress.finish();
     for (remote, result) in outcomes {
         match result {
             Ok(local) => {
@@ -451,8 +494,11 @@ fn collect_local_tree(
             files.push(FileJob {
                 local: entry.path().to_path_buf(),
                 remote: components.join("/"),
-                // An upload's source is local; there is no remote size yet.
-                size_bytes: None,
+                // A local length nobody can read leaves the tree's total
+                // unknown rather than wrong, and the upload proceeds either
+                // way — the failure that matters surfaces when the file is
+                // read.
+                size_bytes: entry.metadata().ok().map(|metadata| metadata.len()),
             });
         } else {
             tally.fail(

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -12,6 +12,7 @@ mod config;
 mod error;
 mod payload;
 mod profiles;
+mod progress;
 mod prompt;
 mod render;
 mod resolve;

--- a/crates/loonfs-cli/src/payload.rs
+++ b/crates/loonfs-cli/src/payload.rs
@@ -8,10 +8,12 @@
 
 use crate::backend_error::BackendError;
 use crate::error::CliError;
+use crate::progress::ProgressReporter;
 use futures::stream::StreamExt;
 use loonfs::{ByteStream, ObjectStoreError};
 use loonfs_client::{PayloadSource, STREAMING_PUT_MIN_BYTES};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Standard input's spelling on the command line.
 pub(crate) const STDIN_PATH: &str = "-";
@@ -50,18 +52,64 @@ impl LocalPayload {
     }
 
     /// Opens the payload for the in-process runtime.
-    pub(crate) async fn open_byte_stream(&self) -> Result<ByteStream, BackendError> {
-        Ok(as_object_store_stream(self.open_source().await?))
+    pub(crate) async fn open_byte_stream(
+        &self,
+        progress: &Arc<ProgressReporter>,
+    ) -> Result<ByteStream, BackendError> {
+        Ok(as_object_store_stream(self.open_source(progress).await?))
     }
 
     /// Opens the payload for the HTTP client.
-    pub(crate) async fn open_source(&self) -> Result<PayloadSource, BackendError> {
-        match self {
+    ///
+    /// The source counts itself as it is read, which is the one place an
+    /// upload's bytes are observable without reaching into a transport: past
+    /// here they belong to the runtime that is staging them. That puts the
+    /// count slightly ahead of the wire — a direct multipart upload holds a
+    /// few parts in flight — so what it reports is payload read, which is
+    /// what a caller watching their own file wants to know.
+    pub(crate) async fn open_source(
+        &self,
+        progress: &Arc<ProgressReporter>,
+    ) -> Result<PayloadSource, BackendError> {
+        let source = match self {
             Self::File { path, .. } => PayloadSource::open_file(path).await.map_err(|error| {
                 BackendError::io_error(format!("i/o error for `{}`: {error}", path.display()))
-            }),
-            Self::Stdin => Ok(PayloadSource::reader(tokio::io::stdin())),
-        }
+            })?,
+            Self::Stdin => PayloadSource::reader(tokio::io::stdin()),
+        };
+        Ok(counted_source(source, Arc::clone(progress)))
+    }
+}
+
+/// Wraps a source so every byte read off it is counted, and the end of the
+/// payload announces the phase that follows it.
+///
+/// The commit is the part a finished upload waits on with no bytes moving,
+/// so the transition is reported where it actually happens: when the source
+/// runs dry.
+fn counted_source(source: PayloadSource, progress: Arc<ProgressReporter>) -> PayloadSource {
+    if !progress.enabled() {
+        return source;
+    }
+    let (stream, size_bytes) = source.into_stream();
+    let counted =
+        futures::stream::unfold((stream, progress), |(mut stream, progress)| async move {
+            match stream.next().await {
+                Some(Ok(chunk)) => {
+                    progress.advance(chunk.len() as u64);
+                    Some((Ok(chunk), (stream, progress)))
+                }
+                Some(Err(error)) => Some((Err(error), (stream, progress))),
+                None => {
+                    progress.phase("committing");
+                    None
+                }
+            }
+        })
+        .boxed();
+    match size_bytes {
+        Some(size_bytes) => PayloadSource::sized_stream(counted, size_bytes),
+        None => PayloadSource::stream(counted),
     }
 }
 

--- a/crates/loonfs-cli/src/progress.rs
+++ b/crates/loonfs-cli/src/progress.rs
@@ -1,0 +1,568 @@
+//! Live progress for the transfers that take human time.
+//!
+//! Two audiences, one accounting. A terminal gets a single line redrawn in
+//! place; `--json` gets one JSON object per line. Both go to standard error,
+//! because standard output already carries either the result document or the
+//! file's own bytes. Neither is produced when standard error is not a
+//! terminal and nobody asked for events, which is how `curl` behaves and why
+//! a piped `loonfs get` stays silent.
+//!
+//! The event names and field names are a contract: agents parse them.
+
+use crate::args::RuntimeBehavior;
+use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
+use std::io::{IsTerminal, Write};
+use std::sync::Mutex;
+
+/// The shortest gap between two reports of one operation.
+///
+/// Four a second is live enough for a terminal and few enough that an agent
+/// parsing the stream reads less progress than transfer.
+const MIN_REPORT_INTERVAL_MS: u64 = 250;
+
+/// How a running transfer is described, decided once per invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProgressMode {
+    /// One line on a terminal's standard error, redrawn in place.
+    Human,
+    /// One JSON object per line on standard error, beside the result
+    /// document on standard output.
+    Events,
+    /// Nothing at all.
+    Off,
+}
+
+impl ProgressMode {
+    /// Reads the mode off the invocation: `--no-progress` silences it,
+    /// `--json` asks for events, and a terminal on standard error is what
+    /// makes the human line worth drawing.
+    pub(crate) fn detect(no_progress: bool, json: bool) -> Self {
+        if no_progress {
+            Self::Off
+        } else if json {
+            Self::Events
+        } else if std::io::stderr().is_terminal() {
+            Self::Human
+        } else {
+            Self::Off
+        }
+    }
+}
+
+/// Which transfer an event is about. The value an agent sees in `op`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProgressOp {
+    Get,
+    Put,
+}
+
+impl ProgressOp {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Get => "get",
+            Self::Put => "put",
+        }
+    }
+}
+
+/// What the accounting knows right now.
+#[derive(Debug)]
+struct ProgressState {
+    bytes_done: u64,
+    bytes_total: Option<u64>,
+    files_done: u64,
+    files_total: Option<u64>,
+    /// The file of a tree that started most recently, which is what a
+    /// terminal line names.
+    current: Option<String>,
+    /// Byte count of the last report, so a report that would say exactly
+    /// what the last one said is skipped.
+    reported_bytes: Option<u64>,
+    reported_ms: u64,
+    reported_percent: Option<u64>,
+    /// Width of the human line currently on screen, so the next one can
+    /// erase what it does not cover.
+    drawn_width: usize,
+}
+
+impl ProgressState {
+    /// Whether a report is due: no more often than the interval allows,
+    /// unless the whole-number percentage moved, and never a repeat of what
+    /// the last report already said.
+    fn due(&self, now_ms: u64) -> bool {
+        if self.reported_bytes == Some(self.bytes_done) {
+            return false;
+        }
+        let Some(reported_ms) = self.reported_bytes.map(|_| self.reported_ms) else {
+            return true;
+        };
+        now_ms.saturating_sub(reported_ms) >= MIN_REPORT_INTERVAL_MS
+            || self.percent() != self.reported_percent
+    }
+
+    fn percent(&self) -> Option<u64> {
+        self.bytes_total.filter(|total| *total > 0).map(|total| {
+            let done = self.bytes_done.min(total);
+            done.saturating_mul(100) / total
+        })
+    }
+}
+
+/// Counts one operation's bytes and says so, at a rate a human or an agent
+/// can use.
+///
+/// Shared behind an `Arc` by recursive transfers, whose per-file jobs run
+/// several at a time, so the accounting is one operation's and not one
+/// file's. The lock is never held across an await.
+#[derive(Debug)]
+pub(crate) struct ProgressReporter {
+    mode: ProgressMode,
+    op: ProgressOp,
+    /// What a `progress` event names: the file for a single transfer, the
+    /// root for a tree.
+    path: String,
+    timer: StdMonotonicTimer,
+    started_ms: u64,
+    state: Mutex<ProgressState>,
+}
+
+impl ProgressReporter {
+    /// A reporter for one operation over `path`, silent unless the
+    /// invocation asked for progress.
+    pub(crate) fn new(runtime: RuntimeBehavior, op: ProgressOp, path: impl Into<String>) -> Self {
+        let timer = StdMonotonicTimer::default();
+        let started_ms = timer.monotonic_now_ms();
+        Self {
+            mode: runtime.progress,
+            op,
+            path: path.into(),
+            timer,
+            started_ms,
+            state: Mutex::new(ProgressState {
+                bytes_done: 0,
+                bytes_total: None,
+                files_done: 0,
+                files_total: None,
+                current: None,
+                reported_bytes: None,
+                reported_ms: started_ms,
+                reported_percent: None,
+                drawn_width: 0,
+            }),
+        }
+    }
+
+    /// Whether anything is listening. Callers skip the accounting entirely
+    /// when nothing is.
+    pub(crate) fn enabled(&self) -> bool {
+        self.mode != ProgressMode::Off
+    }
+
+    /// States the size of what is about to move, when it is knowable.
+    pub(crate) fn expect(&self, bytes_total: Option<u64>, files_total: Option<u64>) {
+        if !self.enabled() {
+            return;
+        }
+        let mut state = self.lock();
+        state.bytes_total = bytes_total;
+        state.files_total = files_total;
+    }
+
+    /// What this operation has moved so far.
+    pub(crate) fn bytes_done(&self) -> u64 {
+        self.lock().bytes_done
+    }
+
+    /// Adds bytes a transfer just moved, reporting when a report is due.
+    pub(crate) fn advance(&self, bytes: u64) {
+        if !self.enabled() {
+            return;
+        }
+        let now_ms = self.timer.monotonic_now_ms();
+        let mut state = self.lock();
+        state.bytes_done = state.bytes_done.saturating_add(bytes);
+        if state.due(now_ms) {
+            self.report(&mut state, now_ms);
+        }
+    }
+
+    /// One file of a tree started moving.
+    pub(crate) fn file_started(&self, path: &str, bytes_total: Option<u64>) {
+        if !self.enabled() {
+            return;
+        }
+        if self.mode == ProgressMode::Human {
+            // Several files of a tree are in flight at once, so the line
+            // names the one that started last: enough to see the transfer
+            // moving through the tree without pretending it is serial.
+            self.lock().current = Some(path.to_owned());
+            return;
+        }
+        self.emit_event(&Event::File {
+            kind: "file_started",
+            op: self.op.as_str(),
+            path,
+            bytes_total,
+            bytes_done: None,
+            elapsed_ms: self.elapsed_ms(),
+        });
+    }
+
+    /// One file of a tree finished, with what it actually moved.
+    pub(crate) fn file_finished(&self, path: &str, bytes_done: u64) {
+        if !self.enabled() {
+            return;
+        }
+        {
+            let mut state = self.lock();
+            state.files_done = state.files_done.saturating_add(1);
+        }
+        if self.mode == ProgressMode::Events {
+            self.emit_event(&Event::File {
+                kind: "file_finished",
+                op: self.op.as_str(),
+                path,
+                bytes_total: None,
+                bytes_done: Some(bytes_done),
+                elapsed_ms: self.elapsed_ms(),
+            });
+        }
+    }
+
+    /// A stretch where time passes and bytes do not — the commit a finished
+    /// upload waits on. Emitted at the transition, not on a timer.
+    pub(crate) fn phase(&self, phase: &str) {
+        if !self.enabled() {
+            return;
+        }
+        let now_ms = self.timer.monotonic_now_ms();
+        match self.mode {
+            ProgressMode::Events => self.emit_event(&Event::Phase {
+                kind: "phase",
+                op: self.op.as_str(),
+                path: &self.path,
+                phase,
+                elapsed_ms: now_ms.saturating_sub(self.started_ms),
+            }),
+            ProgressMode::Human => {
+                let mut state = self.lock();
+                let line = format!("{} {} {phase}...", self.op.as_str(), self.path);
+                self.draw(&mut state, &line);
+            }
+            ProgressMode::Off => {}
+        }
+    }
+
+    /// Ends the operation: a last report of where it got to, and a terminal
+    /// left as clean as it was found.
+    pub(crate) fn finish(&self) {
+        if !self.enabled() {
+            return;
+        }
+        let now_ms = self.timer.monotonic_now_ms();
+        let mut state = self.lock();
+        if self.mode == ProgressMode::Events {
+            self.report(&mut state, now_ms);
+            return;
+        }
+        self.erase(&mut state);
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        self.timer
+            .monotonic_now_ms()
+            .saturating_sub(self.started_ms)
+    }
+
+    /// Recovers a poisoned lock rather than failing a transfer over it: the
+    /// state behind it is a byte count nobody's correctness rests on.
+    fn lock(&self) -> std::sync::MutexGuard<'_, ProgressState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn report(&self, state: &mut ProgressState, now_ms: u64) {
+        let elapsed_ms = now_ms.saturating_sub(self.started_ms);
+        let rate_bps = rate_bps(state.bytes_done, elapsed_ms);
+        match self.mode {
+            ProgressMode::Events => self.emit_event(&Event::Progress {
+                kind: "progress",
+                op: self.op.as_str(),
+                path: &self.path,
+                bytes_done: state.bytes_done,
+                bytes_total: state.bytes_total,
+                files_done: state.files_done,
+                files_total: state.files_total,
+                rate_bps,
+                elapsed_ms,
+            }),
+            ProgressMode::Human => {
+                let line = self.human_line(state, rate_bps);
+                self.draw(state, &line);
+            }
+            ProgressMode::Off => return,
+        }
+        state.reported_bytes = Some(state.bytes_done);
+        state.reported_ms = now_ms;
+        state.reported_percent = state.percent();
+    }
+
+    fn human_line(&self, state: &ProgressState, rate_bps: u64) -> String {
+        let tree = state.files_total.is_none_or(|total| total > 1);
+        let mut line = format!("{} {}", self.op.as_str(), self.path);
+        if let Some(files_total) = state.files_total.filter(|_| tree) {
+            line.push_str(&format!("  {}/{files_total} files", state.files_done));
+        }
+        line.push_str(&format!("  {}", byte_size(state.bytes_done)));
+        match (state.bytes_total, state.percent()) {
+            (Some(total), Some(percent)) => {
+                line.push_str(&format!("/{}  {percent}%", byte_size(total)));
+            }
+            _ => line.push_str("  (size unknown)"),
+        }
+        line.push_str(&format!("  {}/s", byte_size(rate_bps)));
+        if let Some(eta) = eta_seconds(state.bytes_done, state.bytes_total, rate_bps) {
+            line.push_str(&format!("  eta {}", clock(eta)));
+        }
+        if let Some(current) = state.current.as_deref().filter(|_| tree) {
+            line.push_str(&format!("  {current}"));
+        }
+        line
+    }
+
+    /// Redraws the one line in place, covering whatever the last one left.
+    fn draw(&self, state: &mut ProgressState, line: &str) {
+        let padding = state.drawn_width.saturating_sub(line.chars().count());
+        let _ = write!(
+            std::io::stderr().lock(),
+            "\r{line}{:padding$}",
+            "",
+            padding = padding
+        );
+        let _ = std::io::stderr().lock().flush();
+        state.drawn_width = line.chars().count();
+    }
+
+    fn erase(&self, state: &mut ProgressState) {
+        if state.drawn_width == 0 {
+            return;
+        }
+        let width = state.drawn_width;
+        let _ = write!(std::io::stderr().lock(), "\r{:width$}\r", "", width = width);
+        let _ = std::io::stderr().lock().flush();
+        state.drawn_width = 0;
+    }
+
+    fn emit_event(&self, event: &Event<'_>) {
+        let Ok(line) = serde_json::to_string(event) else {
+            return;
+        };
+        let _ = writeln!(std::io::stderr().lock(), "{line}");
+    }
+}
+
+/// The event vocabulary, as agents parse it off standard error.
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+enum Event<'a> {
+    Progress {
+        kind: &'static str,
+        op: &'static str,
+        path: &'a str,
+        bytes_done: u64,
+        bytes_total: Option<u64>,
+        files_done: u64,
+        files_total: Option<u64>,
+        rate_bps: u64,
+        elapsed_ms: u64,
+    },
+    File {
+        kind: &'static str,
+        op: &'static str,
+        path: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        bytes_total: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        bytes_done: Option<u64>,
+        elapsed_ms: u64,
+    },
+    Phase {
+        kind: &'static str,
+        op: &'static str,
+        path: &'a str,
+        phase: &'a str,
+        elapsed_ms: u64,
+    },
+}
+
+/// Whole bytes a second, averaged over the transfer so far. Zero until a
+/// millisecond has passed, which is the only honest answer before then.
+fn rate_bps(bytes_done: u64, elapsed_ms: u64) -> u64 {
+    if elapsed_ms == 0 {
+        return 0;
+    }
+    bytes_done.saturating_mul(1_000) / elapsed_ms
+}
+
+/// Seconds left at the current average rate, when both the total and the
+/// rate are known.
+fn eta_seconds(bytes_done: u64, bytes_total: Option<u64>, rate_bps: u64) -> Option<u64> {
+    let total = bytes_total?;
+    if rate_bps == 0 {
+        return None;
+    }
+    Some(total.saturating_sub(bytes_done) / rate_bps)
+}
+
+/// Binary units, three significant figures, as every transfer tool spells
+/// them.
+fn byte_size(bytes: u64) -> String {
+    const UNITS: [&str; 6] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+/// `MM:SS`, or `HH:MM:SS` once there is an hour to show.
+fn clock(seconds: u64) -> String {
+    let (hours, minutes, seconds) = (seconds / 3_600, (seconds / 60) % 60, seconds % 60);
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes}:{seconds:02}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(bytes_done: u64, bytes_total: Option<u64>) -> ProgressState {
+        ProgressState {
+            bytes_done,
+            bytes_total,
+            files_done: 0,
+            files_total: None,
+            current: None,
+            reported_bytes: None,
+            reported_ms: 0,
+            reported_percent: None,
+            drawn_width: 0,
+        }
+    }
+
+    fn silent_reporter(op: ProgressOp, path: &str) -> ProgressReporter {
+        ProgressReporter::new(
+            RuntimeBehavior {
+                json: false,
+                no_input: false,
+                interactive: false,
+                progress: ProgressMode::Off,
+            },
+            op,
+            path,
+        )
+    }
+
+    #[test]
+    fn a_report_waits_for_the_interval_or_a_new_percentage() {
+        let mut state = ProgressState {
+            bytes_done: 10,
+            bytes_total: Some(1_000),
+            files_done: 0,
+            files_total: None,
+            current: None,
+            reported_bytes: None,
+            reported_ms: 0,
+            reported_percent: None,
+            drawn_width: 0,
+        };
+        assert!(state.due(0), "the first report never waits");
+
+        state.reported_bytes = Some(10);
+        state.reported_percent = Some(1);
+        assert!(
+            !state.due(10_000),
+            "a report that would repeat itself is skipped however long it has been"
+        );
+
+        state.bytes_done = 11;
+        assert!(
+            !state.due(0),
+            "bytes inside the same percent wait for the interval"
+        );
+        assert!(state.due(MIN_REPORT_INTERVAL_MS));
+
+        state.bytes_done = 20;
+        assert!(state.due(0), "a new whole percent does not wait");
+    }
+
+    #[test]
+    fn an_unknown_total_has_no_percentage_and_no_eta() {
+        assert_eq!(state(10, None).percent(), None);
+        assert_eq!(eta_seconds(10, None, 1_000), None);
+    }
+
+    /// One file states what it is and how far along; a tree adds the file
+    /// count and names the file that started last.
+    #[test]
+    fn a_terminal_line_says_what_a_watcher_needs() {
+        let one_file = silent_reporter(ProgressOp::Get, "/docs/big.bin");
+        let mut single = state(512 * 1_024, Some(1_024 * 1_024));
+        single.files_total = Some(1);
+        single.current = Some("/docs/big.bin".to_owned());
+        assert_eq!(
+            one_file.human_line(&single, 256 * 1_024),
+            "get /docs/big.bin  512.0 KiB/1.0 MiB  50%  256.0 KiB/s  eta 0:02"
+        );
+
+        let tree = silent_reporter(ProgressOp::Put, "demo:/up");
+        let mut many = state(300, Some(1_000));
+        many.files_done = 2;
+        many.files_total = Some(10);
+        many.current = Some("/up/docs/a.txt".to_owned());
+        assert_eq!(
+            tree.human_line(&many, 100),
+            "put demo:/up  2/10 files  300 B/1000 B  30%  100 B/s  eta 0:07  /up/docs/a.txt"
+        );
+
+        // A pipe has no total, so it has no percentage and nothing to
+        // estimate — only what has gone by.
+        let piped = silent_reporter(ProgressOp::Put, "/piped.bin");
+        let mut unknown = state(2_048, None);
+        unknown.files_total = Some(1);
+        assert_eq!(
+            piped.human_line(&unknown, 1_024),
+            "put /piped.bin  2.0 KiB  (size unknown)  1.0 KiB/s"
+        );
+    }
+
+    #[test]
+    fn a_rate_needs_elapsed_time_and_an_eta_needs_a_rate() {
+        assert_eq!(rate_bps(1_000, 0), 0);
+        assert_eq!(rate_bps(1_000, 1_000), 1_000);
+        assert_eq!(eta_seconds(0, Some(2_000), 0), None);
+        assert_eq!(eta_seconds(500, Some(2_000), 500), Some(3));
+    }
+
+    #[test]
+    fn sizes_and_clocks_read_the_way_transfer_tools_spell_them() {
+        assert_eq!(byte_size(0), "0 B");
+        assert_eq!(byte_size(1_023), "1023 B");
+        assert_eq!(byte_size(1_024), "1.0 KiB");
+        assert_eq!(byte_size(1_536), "1.5 KiB");
+        assert_eq!(byte_size(5 * 1_024 * 1_024 * 1_024), "5.0 GiB");
+        assert_eq!(clock(9), "0:09");
+        assert_eq!(clock(75), "1:15");
+        assert_eq!(clock(3_725), "1:02:05");
+    }
+}

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -787,6 +787,212 @@ fn download(harness: &Harness, remote_path: &str, name: &str) -> Vec<u8> {
     fs::read(&local).expect("read downloaded file")
 }
 
+/// Events of one kind, in the order they were reported.
+fn events_of_kind(output: &Output, kind: &str) -> Vec<Value> {
+    json_progress_events(output)
+        .into_iter()
+        .filter(|event| event["kind"] == kind)
+        .collect()
+}
+
+/// A download that takes real time says where it has got to, in events an
+/// agent can tell apart from a hang, and says so without disturbing the
+/// result document on standard output.
+#[test]
+fn a_download_reports_its_progress_to_an_agent() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = streaming_payload();
+    let local = harness.temp_dir.path().join("big.bin");
+    fs::write(&local, &payload).expect("write payload");
+    assert_success(&harness.run(&["put", local.to_str().expect("utf-8 path"), "/big.bin"]));
+
+    let back = harness.temp_dir.path().join("back.bin");
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "/big.bin",
+        back.to_str().expect("utf-8 path"),
+    ]);
+    assert_success(&get);
+    assert_eq!(json_data(&get)["bytes_written"], payload.len() as u64);
+
+    let started = events_of_kind(&get, "file_started");
+    assert_eq!(started.len(), 1, "one file, one start: {started:?}");
+    assert_eq!(started[0]["op"], "get");
+    assert_eq!(started[0]["path"], "/big.bin");
+    assert_eq!(started[0]["bytes_total"], payload.len() as u64);
+
+    let progress = events_of_kind(&get, "progress");
+    assert!(
+        !progress.is_empty(),
+        "a download past one chunk reports as it lands"
+    );
+    let last = progress.last().expect("a progress event");
+    assert_eq!(last["op"], "get");
+    assert_eq!(last["bytes_done"], payload.len() as u64);
+    assert_eq!(last["bytes_total"], payload.len() as u64);
+    assert_eq!(last["files_total"], 1);
+    assert!(last["rate_bps"].is_u64(), "a rate is always reported");
+    assert!(last["elapsed_ms"].is_u64());
+
+    let finished = events_of_kind(&get, "file_finished");
+    assert_eq!(finished.len(), 1, "one file, one finish: {finished:?}");
+    assert_eq!(finished[0]["bytes_done"], payload.len() as u64);
+    assert_eq!(finished[0]["path"], "/big.bin");
+}
+
+/// An upload counts the payload as it is read and then names the commit,
+/// which is the stretch where time passes and no bytes move.
+#[test]
+fn an_upload_reports_bytes_read_and_then_the_commit() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = streaming_payload();
+    let local = harness.temp_dir.path().join("big.bin");
+    fs::write(&local, &payload).expect("write payload");
+    let put = harness.run(&[
+        "--json",
+        "put",
+        local.to_str().expect("utf-8 path"),
+        "/big.bin",
+    ]);
+    assert_success(&put);
+
+    let progress = events_of_kind(&put, "progress");
+    let last = progress.last().expect("a progress event");
+    assert_eq!(last["op"], "put");
+    assert_eq!(last["path"], "/big.bin");
+    assert_eq!(last["bytes_done"], payload.len() as u64);
+    assert_eq!(last["bytes_total"], payload.len() as u64);
+
+    let phases = events_of_kind(&put, "phase");
+    assert_eq!(phases.len(), 1, "one transition to report: {phases:?}");
+    assert_eq!(phases[0]["phase"], "committing");
+    assert_eq!(phases[0]["op"], "put");
+
+    // A payload with no knowable length still counts its bytes; it just
+    // has no total to measure them against.
+    let piped = harness.run_with_stdin(&["--json", "put", "-", "/piped.bin"], &payload);
+    assert_success(&piped);
+    let piped_progress = events_of_kind(&piped, "progress");
+    let last = piped_progress.last().expect("a progress event");
+    assert_eq!(last["bytes_done"], payload.len() as u64);
+    assert!(
+        last["bytes_total"].is_null(),
+        "a pipe has no total: {last:?}"
+    );
+}
+
+/// A tree is measured as a tree: one operation's bytes and files, plus a
+/// start and a finish for every file inside it.
+#[test]
+fn a_recursive_transfer_counts_files_and_bytes_for_the_whole_tree() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let tree = harness.temp_dir.path().join("tree");
+    fs::create_dir_all(tree.join("docs")).expect("create tree dirs");
+    fs::write(tree.join("top.txt"), b"top").expect("write top");
+    fs::write(tree.join("docs/a.txt"), b"alpha").expect("write a");
+    fs::write(tree.join("docs/b.txt"), b"beta").expect("write b");
+    let tree_bytes = (b"top".len() + b"alpha".len() + b"beta".len()) as u64;
+
+    let put = harness.run(&[
+        "--json",
+        "put",
+        "-r",
+        tree.to_str().expect("utf-8 path"),
+        "/up",
+    ]);
+    assert_success(&put);
+    assert_eq!(events_of_kind(&put, "file_started").len(), 3);
+    assert_eq!(events_of_kind(&put, "file_finished").len(), 3);
+    let last = events_of_kind(&put, "progress")
+        .pop()
+        .expect("a progress event");
+    assert_eq!(last["op"], "put");
+    assert_eq!(last["path"], "demo:/up");
+    assert_eq!(last["bytes_done"], tree_bytes);
+    assert_eq!(last["bytes_total"], tree_bytes);
+    assert_eq!(last["files_total"], 3);
+
+    let back = harness.temp_dir.path().join("back");
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "-r",
+        "/up",
+        back.to_str().expect("utf-8 path"),
+    ]);
+    assert_success(&get);
+    assert_eq!(events_of_kind(&get, "file_started").len(), 3);
+    assert_eq!(events_of_kind(&get, "file_finished").len(), 3);
+    let last = events_of_kind(&get, "progress")
+        .pop()
+        .expect("a progress event");
+    assert_eq!(last["op"], "get");
+    assert_eq!(last["path"], "demo:/up");
+    assert_eq!(last["bytes_done"], tree_bytes);
+    assert_eq!(last["bytes_total"], tree_bytes);
+    assert_eq!(last["files_done"], 3);
+    assert_eq!(last["files_total"], 3);
+}
+
+/// Nobody asked, so nobody is told: a run whose standard error is a pipe
+/// and which asked for no events says nothing about the transfer, and
+/// --no-progress silences the agent stream too.
+#[test]
+fn progress_is_silent_unless_someone_is_watching() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let local = harness.temp_dir.path().join("doc.txt");
+    fs::write(&local, b"body").expect("write payload");
+    let put = harness.run(&["put", local.to_str().expect("utf-8 path"), "/doc.txt"]);
+    assert_success(&put);
+    assert_eq!(
+        stderr_string(&put),
+        "",
+        "a piped run draws no line, the way curl does not"
+    );
+
+    let quiet = harness.run(&[
+        "--json",
+        "--no-progress",
+        "put",
+        local.to_str().expect("utf-8 path"),
+        "/quiet.txt",
+    ]);
+    assert_success(&quiet);
+    assert_eq!(
+        stderr_string(&quiet),
+        "",
+        "--no-progress silences the event stream"
+    );
+
+    // A failure still reports itself, and is still the last document on
+    // standard error when progress preceded it.
+    let clash = harness.run(&[
+        "--json",
+        "put",
+        local.to_str().expect("utf-8 path"),
+        "/doc.txt",
+    ]);
+    assert_failure(&clash);
+    assert_eq!(json_error(&clash)["code"], "path_conflict");
+}
+
 /// A large file and a pipe both round-trip through an embedded profile,
 /// and the retry contract holds for them exactly as it does for a payload
 /// small enough to hold.
@@ -4367,8 +4573,32 @@ fn json_data(output: &Output) -> Value {
     parse_json(&output.stdout)["data"].clone()
 }
 
+/// The failure envelope, which is the last document on standard error.
+///
+/// Under `--json` standard error carries a stream of JSON documents, not
+/// one: a transfer reports progress there while it runs, and the envelope
+/// comes last.
 fn json_error(output: &Output) -> Value {
-    parse_json(&output.stderr)["error"].clone()
+    json_stderr_documents(output)
+        .pop()
+        .expect("a failure envelope on stderr")["error"]
+        .clone()
+}
+
+/// Every JSON document standard error carried, in order.
+fn json_stderr_documents(output: &Output) -> Vec<Value> {
+    serde_json::Deserializer::from_slice(&output.stderr)
+        .into_iter::<Value>()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("parse the json documents on stderr")
+}
+
+/// The progress events of one run, in the order they were reported.
+fn json_progress_events(output: &Output) -> Vec<Value> {
+    json_stderr_documents(output)
+        .into_iter()
+        .filter(|document| document.get("error").is_none() && document.get("data").is_none())
+        .collect()
 }
 
 fn sorted_object_keys(value: &Value) -> Vec<String> {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1634,7 +1634,17 @@ fn single_file_get_refuses_a_missing_parent_directory() {
         missing.join("a.txt").to_str().expect("utf-8 path"),
     ]);
     assert_failure(&get);
-    assert_eq!(json_error(&get)["code"], "io_error");
+    let error = json_error(&get);
+    assert_eq!(error["code"], "io_error");
+    let message = error["message"].as_str().expect("error message");
+    assert!(
+        message.contains(missing.to_str().expect("utf-8 path")),
+        "the message names the directory to create, got: {message}"
+    );
+    assert!(
+        !message.contains(".loonfs-partial"),
+        "the message keeps the CLI's own temporary file out of it, got: {message}"
+    );
     assert!(!missing.exists(), "a failed get created no directory");
 }
 


### PR DESCRIPTION
Small fix -- transfers stop being silent (no progress). 

A CLI-side reporter; no library crate changes. Bytes are observed where the CLI already touches them: counting wrappers around upload sources, and the pull loops the CLI drives for downloads.

