### PR TITLE
feat(cli): interrupted transfers resume

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -368,6 +368,39 @@ Update options
     --auth-token <token>
     --ca-cert-path <path>
 
+Interrupted transfers
+  A transfer killed part way is picked up by rerunning the same command.
+  Nothing is asked for and no flag turns it on: a rerun either finds
+  something to continue from or starts over, and says which.
+
+  A download writes into `.<name>.loonfs-partial` beside its destination,
+  with a `.meta` note naming the content those bytes belong to. A rerun
+  continues from them when the note still describes the file it resolves
+  now, and starts over — silently, dropping the bytes — when it does not:
+  a different file at that path, a different revision, or a note this
+  build cannot read. Both files are removed when the download installs at
+  its destination and when it fails and says so, so the only run that
+  leaves anything behind is one that was killed. Verification still covers
+  the whole file: the bytes already on disk are folded back into the same
+  digest as the ones fetched, so a partial that is not really this file's
+  fails the rerun instead of landing.
+
+  A download the server proxies — a remote file under the deployment's
+  cap — arrives in one response and has no midpoint to resume from, so it
+  starts over.
+
+  An upload resumes only where the transfer had parts to lose: a remote
+  profile's direct multipart upload of a file past 8 MiB. The parts that
+  landed are recorded under $XDG_STATE_HOME/loonfs/uploads (or
+  ~/.loonfs/state/uploads when XDG_STATE_HOME is unset), and a rerun sends
+  only the ones still missing — or, when the transfer had actually
+  finished and only the commit was lost, commits what is already stored
+  and sends nothing. A source that changed since the record was written
+  starts over, because the parts already stored came from bytes that are
+  gone. The record is removed when the upload commits. Embedded profiles,
+  proxied uploads, and `loonfs put -` keep no record: there is no session
+  to rejoin, and a pipe cannot be read a second time.
+
 Transfer progress
   `loonfs get` and `loonfs put`, one file or a whole tree, say where they
   have got to while they run. Never on stdout, which carries either the
@@ -405,8 +438,10 @@ Transfer progress
     {"kind":"phase","op":"put","path":"/docs/a.bin","phase":"committing",
      "elapsed_ms":900}
       A stretch where time passes and bytes do not, reported when it
-      starts. `committing` says an upload's payload has been read and the
-      commit is what is left.
+      starts, with `bytes_done` as it stood at that moment. `committing`
+      says an upload's payload has been read and the commit is what is
+      left; `resuming` says a download picked up bytes an interrupted run
+      left behind, and `bytes_done` is how many.
 
   `op` is `get` or `put`. --no-progress silences both forms, and neither is
   produced for `loonfs cat` or for `loonfs get ... -`, which hand the file
@@ -446,8 +481,8 @@ Behavior notes
   download lands inside it under its remote name
 
   `loonfs get` refuses to overwrite an existing local file without --force,
-  and writes through a temporary file so an interrupted download leaves
-  nothing truncated at the target
+  and writes through a partial file beside the target, so an interrupted
+  download leaves nothing truncated at the target itself
 
   `loonfs get` writes a large file as it arrives and never holds it whole, so
   what it costs in memory follows the transfer and not the file's size; an

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -240,15 +240,23 @@ impl EmbeddedBackend {
 
     /// Opens a file's content as bounded chunks, at the runtime's own chunk
     /// size: what a download costs this process is that chunk, not the file.
+    ///
+    /// `start_offset` skips what the caller already holds; the stream still
+    /// verifies the whole object, so those bytes reach it through
+    /// [`FileContentStream::fold_resumed_prefix`] before it reads anything.
     pub(super) async fn read_file_stream(
         &self,
         spec: &NamespacePath,
+        start_offset: u64,
     ) -> Result<FileContentStream<SharedObjectStore>, BackendError> {
         self.reader
             .read_file_stream(
                 spec.namespace(),
                 spec.absolute_path().as_str(),
-                ReadFileStreamOptions::default(),
+                ReadFileStreamOptions {
+                    start_offset,
+                    ..ReadFileStreamOptions::default()
+                },
             )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -20,18 +20,19 @@ use crate::backend_error::{map_namespace_scoped_runtime_error, BackendError};
 use crate::payload::LocalPayload;
 use crate::progress::ProgressReporter;
 use crate::resolve::ResolvedTarget;
+use crate::uploads::UploadJournal;
 use bytes::Bytes;
 use loonfs_api::{
     v0::{
         ChangesResponse, DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest,
         GrepGcResponse, GrepIndexLifecycle, GrepIndexStatusResponse, StoreProbeRequest,
-        StoreProbeResponse,
+        StoreProbeResponse, UploadStatusResponse,
     },
-    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
-    CreateCheckpointResponse, DeleteNamespaceResponse, GrepRequest, GrepResponse, InodeId,
-    ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest,
-    MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
-    ReleaseCheckpointResponse, RevisionNo,
+    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, ContentRef,
+    CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse, GrepRequest,
+    GrepResponse, InodeId, ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse,
+    MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse,
+    NamespaceSummary, ReleaseCheckpointResponse, RevisionNo, UploadId,
 };
 use loonfs_client::{
     CopyOptions, CreateDirectoryOptions, DeleteOptions, DirectDownloadStream, MoveOptions,
@@ -87,10 +88,14 @@ pub(crate) enum FileDownload {
     Streamed {
         namespace_id: NamespaceId,
         stream: Box<FileContentStream<SharedObjectStore>>,
+        resumed_from: u64,
     },
     /// A remote object-store response, streamed and verified by the client
     /// against the content reference in its download grant.
-    Direct(Box<DirectDownloadStream>),
+    Direct {
+        stream: Box<DirectDownloadStream>,
+        resumed_from: u64,
+    },
     /// Bytes the transport already holds whole.
     Whole(Vec<u8>),
 }
@@ -107,12 +112,40 @@ impl FileDownload {
             Self::Streamed {
                 namespace_id,
                 stream,
+                ..
             } => stream.next_chunk().await.map_err(|error| {
                 map_namespace_scoped_runtime_error(namespace_id, RuntimeError::Core(error))
             }),
-            Self::Direct(stream) => stream.next_chunk().await.map_err(BackendError::from),
+            Self::Direct { stream, .. } => stream.next_chunk().await.map_err(BackendError::from),
             Self::Whole(bytes) if bytes.is_empty() => Ok(None),
             Self::Whole(bytes) => Ok(Some(Bytes::from(std::mem::take(bytes)))),
+        }
+    }
+
+    /// Where this download actually starts, which is not always where it was
+    /// asked to: a transport that answers whole has no partial answer to
+    /// pick up from and begins at zero however much the caller holds.
+    pub(crate) fn resumed_from(&self) -> u64 {
+        match self {
+            Self::Streamed { resumed_from, .. } | Self::Direct { resumed_from, .. } => {
+                *resumed_from
+            }
+            Self::Whole(_) => 0,
+        }
+    }
+
+    /// Hands a resumed download the bytes below its start, so its
+    /// verification still covers the whole file.
+    ///
+    /// Both streaming arms check a digest over the complete object, so a
+    /// download that skipped a prefix refuses to read until it has been told
+    /// what the prefix was. A held answer never resumed, so it has nothing
+    /// to be told.
+    pub(crate) fn fold_resumed_prefix(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Streamed { stream, .. } => stream.fold_resumed_prefix(bytes),
+            Self::Direct { stream, .. } => stream.fold_resumed_prefix(bytes),
+            Self::Whole(_) => {}
         }
     }
 }
@@ -171,6 +204,16 @@ impl MaintenanceDrainProgress {
 /// in. Remote profiles are served by a server that runs its own runner;
 /// stepping one from here would be a second scheduler over the same
 /// namespaces, and there is no remote step to drive anyway.
+/// Refuses upload-session bookkeeping to a profile that has no sessions.
+/// An embedded profile stages content through its own runtime, so there is
+/// no session to ask after and nothing an interrupted upload could rejoin.
+fn upload_sessions_need_a_remote_profile() -> BackendError {
+    BackendError::new(
+        loonfs_api::ErrorCode::NotSupported.as_str(),
+        "upload sessions belong to a server; an embedded profile stages content itself",
+    )
+}
+
 fn maintenance_host_needs_an_embedded_profile() -> BackendError {
     BackendError::new(
         loonfs_api::ErrorCode::NotSupported.as_str(),
@@ -336,18 +379,31 @@ impl ResolvedTarget {
     /// A remote file past the deployment's proxy cap streams straight from
     /// object storage under a download grant; a smaller proxied response
     /// arrives whole. Every arm is verified before it reports its end.
+    ///
+    /// `start_offset` asks the two streaming arms to skip bytes the caller
+    /// already holds — a download picking up where an interrupted one
+    /// stopped. Only they can: a proxied read and a retained revision arrive
+    /// in one response, so they start over and say so through
+    /// [`FileDownload::resumed_from`].
     pub(crate) async fn open_file_download(
         &self,
         spec: &NamespacePath,
         revision_no: Option<RevisionNo>,
         size_bytes: Option<u64>,
+        start_offset: u64,
     ) -> Result<FileDownload, BackendError> {
         if let (Self::Remote(target), Some(size_bytes)) = (self, size_bytes) {
             if target.client.offers_direct_download(size_bytes).await {
                 let grant = target.client.begin_download(spec, revision_no).await?;
-                return Ok(FileDownload::Direct(Box::new(
-                    target.client.open_direct_download(&grant).await?,
-                )));
+                return Ok(FileDownload::Direct {
+                    stream: Box::new(
+                        target
+                            .client
+                            .open_direct_download_at(&grant, start_offset)
+                            .await?,
+                    ),
+                    resumed_from: start_offset,
+                });
             }
         }
         if let Some(revision_no) = revision_no {
@@ -358,7 +414,8 @@ impl ResolvedTarget {
         match self {
             Self::Embedded(target) => Ok(FileDownload::Streamed {
                 namespace_id: spec.namespace().clone(),
-                stream: Box::new(target.backend.read_file_stream(spec).await?),
+                stream: Box::new(target.backend.read_file_stream(spec, start_offset).await?),
+                resumed_from: start_offset,
             }),
             Self::Remote(target) => Ok(FileDownload::Whole(
                 target.client.get_file_bytes(spec).await?,
@@ -546,12 +603,18 @@ impl ResolvedTarget {
     /// spell a byte stream in their own terms, and only one arm ever runs.
     /// `progress` counts what the payload gives up, so both arms report the
     /// same bytes for the same file.
+    /// `journal` is where a remote profile records a direct multipart upload
+    /// so an interrupted one can pick up. Only that transport has anything
+    /// to record: an embedded profile stages through its own runtime with no
+    /// session to rejoin, and a proxied upload is one request with no parts
+    /// to have half-finished.
     pub(crate) async fn put_file_stream(
         &self,
         spec: &NamespacePath,
         payload: &LocalPayload,
         options: &PutFileOptions,
         progress: &Arc<ProgressReporter>,
+        journal: Option<&UploadJournal>,
     ) -> Result<CommitResponse, BackendError> {
         match self {
             Self::Embedded(target) => {
@@ -560,8 +623,47 @@ impl ResolvedTarget {
             }
             Self::Remote(target) => {
                 let source = payload.open_source(progress).await?;
-                Ok(target.client.put_file_stream(spec, source, options).await?)
+                let Some(journal) = journal else {
+                    return Ok(target.client.put_file_stream(spec, source, options).await?);
+                };
+                let resume = journal.resume();
+                Ok(target
+                    .client
+                    .put_file_stream_resumable(spec, source, options, journal, resume.as_ref())
+                    .await?)
             }
+        }
+    }
+
+    /// Reads what became of an upload session a previous run opened.
+    pub(crate) async fn read_upload_status(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+    ) -> Result<UploadStatusResponse, BackendError> {
+        match self {
+            Self::Embedded(_) => Err(upload_sessions_need_a_remote_profile()),
+            Self::Remote(target) => Ok(target
+                .client
+                .read_upload_status(namespace_id, upload_id)
+                .await?),
+        }
+    }
+
+    /// Commits content an upload session already completed, moving no bytes.
+    pub(crate) async fn commit_completed_upload(
+        &self,
+        spec: &NamespacePath,
+        content_ref: ContentRef,
+        validated_content_token: Option<String>,
+        options: &PutFileOptions,
+    ) -> Result<CommitResponse, BackendError> {
+        match self {
+            Self::Embedded(_) => Err(upload_sessions_need_a_remote_profile()),
+            Self::Remote(target) => Ok(target
+                .client
+                .commit_completed_upload(spec, content_ref, validated_content_token, options)
+                .await?),
         }
     }
 

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -6,6 +6,7 @@ use super::context::{
     fail, namespace_path, parse_user_path, render_target, resolve_command_context, CommandContext,
 };
 use super::output::{CommandData, CommandFailure, CommandOutput};
+use super::partial::{self, PartialDownload, PartialMeta};
 use super::recursive;
 use crate::args::{
     CommandKind, FilesystemCatArgs, FilesystemGetArgs, FilesystemGrepArgs, FilesystemLsArgs,
@@ -17,6 +18,8 @@ use crate::backend::FileDownload;
 use crate::error::CliError;
 use crate::payload::{read_whole_file, LocalPayload, STDIN_PATH};
 use crate::progress::{ProgressOp, ProgressReporter};
+use crate::uploads::{SourceIdentity, UploadJournal};
+use loonfs_api::v0::UploadSessionStatus;
 use loonfs_api::{
     CommitId, DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeKind, RevisionNo,
 };
@@ -35,49 +38,6 @@ fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliE
                 .map_err(|error| CliError::invalid_input(format!("invalid --commit-id: {error}")))
         })
         .transpose()
-}
-
-/// Opens the same-directory temp file a download is written into.
-///
-/// Dropping it deletes it, which is what makes a failed or interrupted
-/// download leave nothing behind at the target.
-fn open_partial_file(destination: &Path) -> std::io::Result<tempfile::NamedTempFile> {
-    let file_name = destination
-        .file_name()
-        .ok_or_else(|| std::io::Error::other("destination has no file name"))?;
-    let mut prefix = std::ffi::OsString::from(".");
-    prefix.push(file_name);
-    prefix.push(".loonfs-partial-");
-    tempfile::Builder::new()
-        .prefix(&prefix)
-        .tempfile_in(partial_file_parent(destination))
-}
-
-/// The directory a destination's partial file is created in — its own, and
-/// the working directory for a bare file name.
-fn partial_file_parent(destination: &Path) -> &Path {
-    destination
-        .parent()
-        .filter(|path| !path.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."))
-}
-
-/// Installs a completed download at its destination with one rename.
-///
-/// Only a download that finished — and, when it was streamed, verified —
-/// reaches this, so the file at the destination is never a truncated or
-/// unverified one.
-fn install_partial_file(
-    temp: tempfile::NamedTempFile,
-    destination: &Path,
-    force: bool,
-) -> std::io::Result<()> {
-    let persisted = if force {
-        temp.persist(destination)
-    } else {
-        temp.persist_noclobber(destination)
-    };
-    persisted.map(|_| ()).map_err(|error| error.error)
 }
 
 pub(crate) async fn run_filesystem_ls(
@@ -350,54 +310,78 @@ pub(crate) async fn run_filesystem_get(
     }
 
     let revision_no = args.revision.map(RevisionNo);
+    if args.local_destination.as_deref() == Some("-") {
+        // No progress and no resume: standard output is carrying the file,
+        // and bytes already piped onward are somewhere this CLI cannot see.
+        let mut download = context
+            .target
+            .open_file_download(&spec, revision_no, entry.size_bytes, 0)
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        stream_download_to_stdout(&mut download)
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        return Ok(CommandOutput {
+            kind,
+            profile: Some(context.profile_name),
+            mode: Some(context.mode),
+            data: CommandData::StreamedToStdout,
+        });
+    }
+
+    let derived_name = args.local_destination.is_none();
+    let destination = destination_path_for_get(
+        spec.absolute_path().as_str(),
+        args.local_destination.as_deref(),
+    )
+    .map_err(|error| context.fail(kind, error))?;
+    // Where a download starts is decided before it is opened: the bytes an
+    // interrupted run left are named after this destination, and how many of
+    // them still describe the content resolved just now is how far in this
+    // one begins. A file with no content reference to compare against — one
+    // this build cannot identify — starts over.
+    let meta = entry
+        .content_ref
+        .as_ref()
+        .map(|content_ref| PartialMeta::describe(content_ref, revision_no));
+    let start_offset = meta
+        .as_ref()
+        .map_or(0, |meta| partial::resumable_bytes(&destination, meta));
     let mut download = context
         .target
-        .open_file_download(&spec, revision_no, entry.size_bytes)
+        .open_file_download(&spec, revision_no, entry.size_bytes, start_offset)
         .await
         .map_err(|error| context.fail(kind, error))?;
-    let data = match args.local_destination.as_deref() {
-        Some("-") => {
-            // No progress: standard output is carrying the file, and a
-            // caller piping bytes onward is not watching a line anyway.
-            stream_download_to_stdout(&mut download)
-                .await
-                .map_err(|error| context.fail(kind, error))?;
-            CommandData::StreamedToStdout
-        }
-        other => {
-            let derived_name = other.is_none();
-            let destination = destination_path_for_get(spec.absolute_path().as_str(), other)
-                .map_err(|error| context.fail(kind, error))?;
-            let progress = Arc::new(ProgressReporter::new(
-                runtime,
-                ProgressOp::Get,
-                spec.absolute_path().as_str(),
-            ));
-            progress.expect(entry.size_bytes, Some(1));
-            progress.file_started(spec.absolute_path().as_str(), entry.size_bytes);
-            // The local working copy is the one thing this CLI touches
-            // that has no revision history behind it, so clobbering it is
-            // opt-in. `persist_noclobber` closes the race between checking
-            // and installing the completed temporary file.
-            let written = stream_download_to_file(
-                &mut download,
-                &destination,
-                args.force,
-                derived_name,
-                &progress,
-            )
-            .await;
-            if let Ok(bytes_written) = &written {
-                progress.file_finished(spec.absolute_path().as_str(), *bytes_written);
-            }
-            progress.finish();
-            let bytes_written = written.map_err(|error| context.fail(kind, error))?;
-            CommandData::FileTransfer {
-                target: render_target(&context.namespace, spec.absolute_path()),
-                destination: destination.display().to_string(),
-                bytes_written,
-            }
-        }
+
+    let progress = Arc::new(ProgressReporter::new(
+        runtime,
+        ProgressOp::Get,
+        spec.absolute_path().as_str(),
+    ));
+    progress.expect(entry.size_bytes, Some(1));
+    progress.file_started(spec.absolute_path().as_str(), entry.size_bytes);
+    // The local working copy is the one thing this CLI touches that has no
+    // revision history behind it, so clobbering it is opt-in.
+    // `persist_noclobber` closes the race between checking and installing
+    // the completed partial file.
+    let written = stream_download_to_file(
+        &mut download,
+        &destination,
+        meta.as_ref(),
+        args.force,
+        derived_name,
+        &progress,
+    )
+    .await;
+    if let Ok(bytes_written) = &written {
+        progress.file_finished(spec.absolute_path().as_str(), *bytes_written);
+    }
+    progress.finish();
+    let bytes_written = written.map_err(|error| context.fail(kind, error))?;
+    let data = CommandData::FileTransfer {
+        target: render_target(&context.namespace, spec.absolute_path()),
+        destination: destination.display().to_string(),
+        bytes_written,
     };
 
     Ok(CommandOutput {
@@ -411,29 +395,47 @@ pub(crate) async fn run_filesystem_get(
 /// Writes a download into its destination through the partial file, and
 /// installs it only once the download has ended cleanly.
 ///
-/// The temp file is dropped — and so deleted — on any failure, including a
-/// streamed download whose content failed verification at its last chunk. An
-/// integrity failure therefore leaves no file at the destination at all,
-/// never a complete-looking one.
+/// The partial file is deleted on any failure, including a streamed download
+/// whose content failed verification at its last chunk. An integrity failure
+/// therefore leaves no file at the destination at all, never a
+/// complete-looking one, and nothing beside it for a rerun to build on.
+///
+/// A download that never reported anything — a killed process — is the one
+/// that leaves its partial and its note behind, and the one a rerun picks
+/// up. Whatever it picks up is folded into the same verification the whole
+/// file gets, so bytes that turn out not to be the file's fail the rerun
+/// rather than reaching the destination.
 pub(super) async fn stream_download_to_file(
     download: &mut FileDownload,
     destination: &Path,
+    meta: Option<&PartialMeta>,
     force: bool,
     derived_name: bool,
     progress: &ProgressReporter,
 ) -> Result<u64, CliError> {
-    let mut temp = open_partial_file(destination)
+    let resumed_from = download.resumed_from();
+    let mut partial = PartialDownload::open(destination, meta, resumed_from)
         .map_err(|error| local_open_error(destination, error, force, derived_name))?;
-    let mut bytes_written = 0u64;
+    partial
+        .fold_into(download)
+        .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
+    progress.already_done(resumed_from);
+    if resumed_from > 0 {
+        // Folding a head start back into the verification takes time and
+        // moves nothing, and it is the one thing about this run a caller
+        // could not otherwise tell: it fetches less than the file.
+        progress.phase("resuming");
+    }
+    let mut bytes_written = resumed_from;
     while let Some(chunk) = download.next_chunk().await? {
-        temp.write_all(&chunk)
+        partial
+            .write_all(&chunk)
             .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
         bytes_written += chunk.len() as u64;
         progress.advance(chunk.len() as u64);
     }
-    temp.flush()
-        .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
-    install_partial_file(temp, destination, force)
+    partial
+        .install(destination, force)
         .map_err(|error| local_destination_error(destination, error, force, derived_name))?;
     Ok(bytes_written)
 }
@@ -461,9 +463,9 @@ async fn stream_download_to_stdout(download: &mut FileDownload) -> Result<(), Cl
 /// Shapes the failure to open a download's partial file.
 ///
 /// A missing directory is the one failure whose underlying error is about the
-/// wrong thing: it names the temporary file this CLI picked, whose random
-/// suffix the caller never asked for and cannot act on. The parent they have
-/// to create is what the message says instead.
+/// wrong thing: it names the partial file this CLI picked, which the caller
+/// never asked for and cannot act on. The parent they have to create is what
+/// the message says instead.
 fn local_open_error(
     destination: &Path,
     error: std::io::Error,
@@ -476,7 +478,7 @@ fn local_open_error(
             format!(
                 "i/o error for `{}`: parent directory `{}` does not exist",
                 destination.display(),
-                partial_file_parent(destination).display()
+                partial::parent_of(destination).display()
             ),
         );
     }
@@ -706,6 +708,20 @@ async fn commit_put(
     ));
     progress.expect(size_bytes, Some(1));
     progress.file_started(spec.absolute_path().as_str(), size_bytes);
+    // Only a payload large enough to travel in parts has anything an
+    // interruption could leave half-done, and only a source that can be
+    // opened twice can pick it up: a pipe is gone once it is read.
+    let journal = match payload.resumable_source() {
+        Some(local_path) => resume_journal(context, spec, local_path),
+        None => None,
+    };
+    if let Some(journal) = journal.as_ref() {
+        if let Some(committed) =
+            commit_a_finished_upload(kind, context, spec, options, journal, &progress).await?
+        {
+            return Ok(committed);
+        }
+    }
     let result = match payload.holdable_file() {
         // A payload small enough to hold travels as one request, so there is
         // no midpoint to report: it is read, and then the commit is all
@@ -721,11 +737,16 @@ async fn commit_put(
         None => {
             context
                 .target
-                .put_file_stream(spec, payload, options, &progress)
+                .put_file_stream(spec, payload, options, &progress, journal.as_ref())
                 .await
         }
     };
     if result.is_ok() {
+        // The record exists to survive an interruption, and this upload was
+        // not interrupted.
+        if let Some(journal) = journal.as_ref() {
+            journal.forget();
+        }
         let moved = progress.bytes_done();
         progress.file_finished(spec.absolute_path().as_str(), moved);
     }
@@ -743,6 +764,82 @@ async fn commit_put(
             inode_id: None,
         },
     })
+}
+
+/// The record an interrupted upload of this payload would have left, or
+/// nothing when there is nowhere to keep one.
+fn resume_journal(
+    context: &CommandContext,
+    spec: &NamespacePath,
+    local_path: &Path,
+) -> Option<UploadJournal> {
+    let source = SourceIdentity::of(local_path).ok()?;
+    UploadJournal::for_upload(
+        &context.profile_name,
+        context.namespace.as_str(),
+        spec.absolute_path().as_str(),
+        local_path,
+        source,
+    )
+}
+
+/// Commits an upload whose bytes all landed before it was interrupted,
+/// without sending any of them again.
+///
+/// An interruption between the last part and the commit leaves a session
+/// the server already completed: the object is assembled and admitted, and
+/// only the commit is missing. Asking the session what became of it is one
+/// round trip and saves the whole transfer. Any other answer — still open,
+/// aborted, or gone — leaves this to the ordinary upload, which the
+/// recorded parts make cheap anyway.
+async fn commit_a_finished_upload(
+    kind: CommandKind,
+    context: &CommandContext,
+    spec: &NamespacePath,
+    options: &PutFileOptions,
+    journal: &UploadJournal,
+    progress: &ProgressReporter,
+) -> Result<Option<CommandOutput>, CommandFailure> {
+    let Some(resume) = journal.resume() else {
+        return Ok(None);
+    };
+    let Ok(status) = context
+        .target
+        .read_upload_status(&context.namespace, &resume.upload_id)
+        .await
+    else {
+        return Ok(None);
+    };
+    let UploadSessionStatus::Completed {
+        content_ref,
+        validated_content_token,
+        ..
+    } = status.status
+    else {
+        return Ok(None);
+    };
+    progress.already_done(content_ref.size_bytes);
+    progress.phase("committing");
+    let result = context
+        .target
+        .commit_completed_upload(spec, content_ref, validated_content_token, options)
+        .await;
+    if result.is_ok() {
+        journal.forget();
+    }
+    progress.finish();
+    let result = result.map_err(|error| context.fail(kind, error))?;
+    Ok(Some(CommandOutput {
+        kind,
+        profile: Some(context.profile_name.clone()),
+        mode: Some(context.mode.clone()),
+        data: CommandData::FileMutation {
+            target: render_target(&context.namespace, spec.absolute_path()),
+            committed_seq: result.committed_seq,
+            commit_id: result.commit_id,
+            inode_id: None,
+        },
+    }))
 }
 
 fn put_file_options(args: &FilesystemPutArgs) -> Result<PutFileOptions, CliError> {

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ mod context;
 mod fs;
 mod namespace;
 mod output;
+mod partial;
 mod profile;
 mod profile_config;
 mod recursive;

--- a/crates/loonfs-cli/src/commands/partial.rs
+++ b/crates/loonfs-cli/src/commands/partial.rs
@@ -1,0 +1,287 @@
+//! The file a download writes into before it is installed, and the note
+//! beside it saying which content it holds.
+//!
+//! Both are named from the destination rather than randomly, because a
+//! rerun has to find them: that is the whole of how an interrupted download
+//! picks up where it stopped. Both are deleted once the download reaches a
+//! verdict — installed at the destination, or failed and reported — so the
+//! only run that leaves bytes behind is one that never got to clean up,
+//! which is exactly the run worth resuming.
+
+use crate::backend::FileDownload;
+use crate::error::CliError;
+use loonfs_api::{ContentRef, RevisionNo};
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Seek, Write};
+use std::path::{Path, PathBuf};
+
+/// Suffix of the file a download's bytes land in.
+const PARTIAL_SUFFIX: &str = ".loonfs-partial";
+/// Suffix of the note beside it.
+const META_SUFFIX: &str = ".loonfs-partial.meta";
+/// How much of a partial file is read at a time when its bytes are folded
+/// back into a resumed download's verification. Bounded for the same reason
+/// the download itself is: a resumed 50 GiB file must not cost 50 GiB.
+const FOLD_CHUNK_BYTES: usize = 1024 * 1024;
+
+/// What the bytes in a partial file are, so a rerun can tell whether they
+/// are still the bytes it wants.
+///
+/// The content id settles it on its own: content objects are immutable and
+/// randomly identified, so the same id is the same bytes and a different id
+/// is a different file. The rest is recorded because a partial disagreeing
+/// with any of it is not worth resuming either, and because a note this
+/// build cannot read at all is the same answer — start over.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PartialMeta {
+    content_id: String,
+    size_bytes: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    whole_file_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    revision_no: Option<u64>,
+}
+
+impl PartialMeta {
+    /// Describes the content a download is about to fetch.
+    pub(super) fn describe(content_ref: &ContentRef, revision_no: Option<RevisionNo>) -> Self {
+        Self {
+            content_id: content_ref.content_id.to_string(),
+            size_bytes: content_ref.size_bytes,
+            whole_file_sha256: content_ref.whole_file_sha256.clone(),
+            revision_no: revision_no.map(|revision_no| revision_no.0),
+        }
+    }
+}
+
+/// How much of a destination's partial file a fresh download of `meta` may
+/// pick up, which is none of it unless everything agrees.
+///
+/// Every disagreement answers zero and says nothing: a stale partial is not
+/// a failure, it is a download that starts over.
+pub(super) fn resumable_bytes(destination: &Path, meta: &PartialMeta) -> u64 {
+    let (Some(partial_path), Some(meta_path)) = (
+        sibling(destination, PARTIAL_SUFFIX),
+        sibling(destination, META_SUFFIX),
+    ) else {
+        return 0;
+    };
+    let Ok(recorded) = std::fs::read(&meta_path) else {
+        return 0;
+    };
+    if serde_json::from_slice::<PartialMeta>(&recorded)
+        .ok()
+        .as_ref()
+        != Some(meta)
+    {
+        return 0;
+    }
+    let Ok(metadata) = std::fs::metadata(&partial_path) else {
+        return 0;
+    };
+    // A partial longer than the content is not a prefix of it, whatever the
+    // note says.
+    if metadata.len() > meta.size_bytes {
+        return 0;
+    }
+    metadata.len()
+}
+
+/// A download's bytes on their way to a destination.
+pub(super) struct PartialDownload {
+    file: tempfile::NamedTempFile,
+    /// The note, held as a temporary path so it is removed on exactly the
+    /// occasions the bytes are.
+    _meta: tempfile::TempPath,
+    path: PathBuf,
+    resumed_from: u64,
+}
+
+impl PartialDownload {
+    /// Opens the partial file for a download that starts at `resume_from`,
+    /// and lays the note down beside it.
+    ///
+    /// The note is written before the first byte: bytes on disk with
+    /// nothing saying what they are cannot be resumed from, and a rerun
+    /// that guessed would be worse than one that started over. Content this
+    /// build cannot identify gets no note at all, which is the same answer
+    /// spelled by its absence.
+    pub(super) fn open(
+        destination: &Path,
+        meta: Option<&PartialMeta>,
+        resume_from: u64,
+    ) -> std::io::Result<Self> {
+        let (Some(path), Some(meta_path)) = (
+            sibling(destination, PARTIAL_SUFFIX),
+            sibling(destination, META_SUFFIX),
+        ) else {
+            return Err(std::io::Error::other("destination has no file name"));
+        };
+        match meta {
+            Some(meta) => {
+                let encoded = serde_json::to_vec(meta).map_err(std::io::Error::other)?;
+                std::fs::write(&meta_path, encoded)?;
+            }
+            // A stale note from an earlier run must not outlive the bytes it
+            // described.
+            None => drop(std::fs::remove_file(&meta_path)),
+        }
+        let meta = tempfile::TempPath::try_from_path(&meta_path)?;
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)?;
+        // One call covers both cases: it drops a longer partial's tail, and
+        // it empties one this download is not resuming at all.
+        file.set_len(resume_from)?;
+        file.seek(std::io::SeekFrom::Start(resume_from))?;
+        Ok(Self {
+            file: tempfile::NamedTempFile::from_parts(
+                file,
+                tempfile::TempPath::try_from_path(&path)?,
+            ),
+            _meta: meta,
+            path,
+            resumed_from: resume_from,
+        })
+    }
+
+    /// Hands the download the bytes already on disk, so its verification
+    /// still covers the whole file and not merely the part this run
+    /// fetched.
+    pub(super) fn fold_into(&self, download: &mut FileDownload) -> std::io::Result<()> {
+        if self.resumed_from == 0 {
+            return Ok(());
+        }
+        let mut reader = std::fs::File::open(&self.path)?;
+        let mut buffer = vec![0u8; FOLD_CHUNK_BYTES];
+        let mut remaining = self.resumed_from;
+        while remaining > 0 {
+            let wanted = buffer.len().min(remaining as usize);
+            reader.read_exact(&mut buffer[..wanted])?;
+            download.fold_resumed_prefix(&buffer[..wanted]);
+            remaining -= wanted as u64;
+        }
+        Ok(())
+    }
+
+    pub(super) fn write_all(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        self.file.write_all(bytes)
+    }
+
+    /// Installs the completed download at its destination with one rename,
+    /// and takes the note away with it.
+    ///
+    /// Only a download that finished — and, when it was streamed, verified
+    /// — reaches this, so the file at the destination is never a truncated
+    /// or unverified one.
+    pub(super) fn install(mut self, destination: &Path, force: bool) -> std::io::Result<()> {
+        self.file.flush()?;
+        let persisted = if force {
+            self.file.persist(destination)
+        } else {
+            self.file.persist_noclobber(destination)
+        };
+        persisted.map(|_| ()).map_err(|error| error.error)
+    }
+}
+
+/// The sibling of `destination` carrying `suffix`, as a hidden file in the
+/// destination's own directory so the rename that installs it never crosses
+/// a filesystem.
+fn sibling(destination: &Path, suffix: &str) -> Option<PathBuf> {
+    let file_name = destination.file_name()?;
+    let mut name = std::ffi::OsString::from(".");
+    name.push(file_name);
+    name.push(suffix);
+    Some(parent_of(destination).join(name))
+}
+
+/// The directory a destination's partial file is created in — its own, and
+/// the working directory for a bare file name.
+pub(super) fn parent_of(destination: &Path) -> &Path {
+    destination
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+/// Shapes a note this build wrote and cannot now read. Nothing surfaces it:
+/// it is the reason a resume did not happen, not a failure of the download.
+#[allow(dead_code)]
+fn unreadable_note(error: serde_json::Error) -> CliError {
+    CliError::invalid_input(format!("unreadable partial-download note: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loonfs_api::{ContentId, ContentRef};
+
+    fn meta_for(bytes: &[u8]) -> PartialMeta {
+        PartialMeta::describe(&ContentRef::blob_v1(ContentId::generate(), bytes), None)
+    }
+
+    /// A partial whose note matches the content being fetched is picked up
+    /// at exactly the length on disk.
+    #[test]
+    fn a_matching_note_resumes_at_what_is_on_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let destination = dir.path().join("file.bin");
+        let meta = meta_for(b"0123456789");
+
+        assert_eq!(
+            resumable_bytes(&destination, &meta),
+            0,
+            "nothing on disk resumes nothing"
+        );
+        let mut partial =
+            PartialDownload::open(&destination, Some(&meta), 0).expect("open partial");
+        partial.write_all(b"0123").expect("write");
+        drop(partial);
+        assert_eq!(
+            resumable_bytes(&destination, &meta),
+            0,
+            "a partial whose download reached a verdict is gone"
+        );
+    }
+
+    /// The note is what makes bytes resumable, and it has to describe the
+    /// content this run resolved: a different file, a different revision, or
+    /// a note this build cannot read all start over.
+    #[test]
+    fn a_note_that_does_not_match_starts_over() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let destination = dir.path().join("file.bin");
+        let meta = meta_for(b"0123456789");
+        let partial_path = sibling(&destination, PARTIAL_SUFFIX).expect("partial path");
+        let meta_path = sibling(&destination, META_SUFFIX).expect("meta path");
+
+        std::fs::write(&partial_path, b"0123").expect("write partial");
+        std::fs::write(
+            &meta_path,
+            serde_json::to_vec(&meta).expect("encode the note"),
+        )
+        .expect("write note");
+        assert_eq!(resumable_bytes(&destination, &meta), 4);
+
+        // A different content id is a different file at the same path.
+        assert_eq!(resumable_bytes(&destination, &meta_for(b"9876543210")), 0);
+
+        // A partial longer than the content is not a prefix of it.
+        std::fs::write(&partial_path, vec![0u8; 11]).expect("overlong partial");
+        assert_eq!(resumable_bytes(&destination, &meta), 0);
+
+        // A note this build cannot read is no note at all.
+        std::fs::write(&partial_path, b"0123").expect("write partial");
+        std::fs::write(&meta_path, b"{\"content_id\":").expect("write torn note");
+        assert_eq!(resumable_bytes(&destination, &meta), 0);
+
+        // Bytes with no note beside them say nothing about themselves.
+        std::fs::remove_file(&meta_path).expect("remove note");
+        assert_eq!(resumable_bytes(&destination, &meta), 0);
+    }
+}

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -38,6 +38,11 @@ struct FileJob {
     /// on either transfer it is what lets the whole tree be measured before
     /// the first byte moves.
     size_bytes: Option<u64>,
+    /// What the remote file's content is, when a listing named it. It rides
+    /// along so a download interrupted part way can tell whether the bytes
+    /// it left behind are still the bytes it wants. An upload's jobs come
+    /// from a local walk and name no remote content.
+    content_ref: Option<loonfs_api::ContentRef>,
 }
 
 struct TreeTally {
@@ -290,9 +295,17 @@ pub(crate) async fn run_get_tree(
             // One file of a tree travels exactly as a single `get` of it
             // would: past the deployment's proxy cap it streams straight
             // from object storage, and the walk already read the size that
-            // decides which.
+            // decides which. It resumes the same way too, from bytes an
+            // interrupted run of this transfer left beside that file.
+            let meta = job
+                .content_ref
+                .as_ref()
+                .map(|content_ref| super::partial::PartialMeta::describe(content_ref, None));
+            let start_offset = meta
+                .as_ref()
+                .map_or(0, |meta| super::partial::resumable_bytes(&local, meta));
             let mut download = match backend
-                .open_file_download(&spec, None, job.size_bytes)
+                .open_file_download(&spec, None, job.size_bytes, start_offset)
                 .await
             {
                 Ok(download) => download,
@@ -303,6 +316,7 @@ pub(crate) async fn run_get_tree(
             let written = super::fs::stream_download_to_file(
                 &mut download,
                 &local,
+                meta.as_ref(),
                 force,
                 derived_name,
                 &progress,
@@ -499,6 +513,7 @@ fn collect_local_tree(
                 // way — the failure that matters surfaces when the file is
                 // read.
                 size_bytes: entry.metadata().ok().map(|metadata| metadata.len()),
+                content_ref: None,
             });
         } else {
             tally.fail(
@@ -589,6 +604,7 @@ async fn walk_remote_tree(
                     local: PathBuf::from(child_components.join("/")),
                     remote: format!("{remote_dir}/{name}", name = name.as_str()),
                     size_bytes: entry.size_bytes,
+                    content_ref: entry.content_ref,
                 }),
             }
         }

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -16,6 +16,7 @@ mod progress;
 mod prompt;
 mod render;
 mod resolve;
+mod uploads;
 
 use clap::Parser;
 use std::process::ExitCode;

--- a/crates/loonfs-cli/src/payload.rs
+++ b/crates/loonfs-cli/src/payload.rs
@@ -51,6 +51,21 @@ impl LocalPayload {
         }
     }
 
+    /// The local file an interrupted upload of this payload could pick up
+    /// from, when there is one.
+    ///
+    /// Two things have to hold. The payload must travel in parts — a
+    /// smaller one is a single request, which either happened or did not —
+    /// and its source must be openable a second time, because a resumed
+    /// upload reads every byte again to fold the checksum the assembly is
+    /// verified against. A pipe fails the second on its own.
+    pub(crate) fn resumable_source(&self) -> Option<&Path> {
+        match self {
+            Self::File { path, size_bytes } if *size_bytes >= STREAMING_PUT_MIN_BYTES => Some(path),
+            _ => None,
+        }
+    }
+
     /// Opens the payload for the in-process runtime.
     pub(crate) async fn open_byte_stream(
         &self,

--- a/crates/loonfs-cli/src/progress.rs
+++ b/crates/loonfs-cli/src/progress.rs
@@ -69,6 +69,9 @@ impl ProgressOp {
 #[derive(Debug)]
 struct ProgressState {
     bytes_done: u64,
+    /// Bytes this run actually moved, which is what a rate is about. It
+    /// trails `bytes_done` by whatever an interrupted run left behind.
+    bytes_moved: u64,
     bytes_total: Option<u64>,
     files_done: u64,
     files_total: Option<u64>,
@@ -140,6 +143,7 @@ impl ProgressReporter {
             started_ms,
             state: Mutex::new(ProgressState {
                 bytes_done: 0,
+                bytes_moved: 0,
                 bytes_total: None,
                 files_done: 0,
                 files_total: None,
@@ -173,6 +177,20 @@ impl ProgressReporter {
         self.lock().bytes_done
     }
 
+    /// Credits bytes a previous, interrupted run already moved.
+    ///
+    /// They count toward the total and the percentage, because they are
+    /// part of the file that will be there at the end. They do not count
+    /// toward the rate: this run did not move them, and pretending it did
+    /// would make the first estimate of what is left a fantasy.
+    pub(crate) fn already_done(&self, bytes: u64) {
+        if !self.enabled() || bytes == 0 {
+            return;
+        }
+        let mut state = self.lock();
+        state.bytes_done = state.bytes_done.saturating_add(bytes);
+    }
+
     /// Adds bytes a transfer just moved, reporting when a report is due.
     pub(crate) fn advance(&self, bytes: u64) {
         if !self.enabled() {
@@ -181,6 +199,7 @@ impl ProgressReporter {
         let now_ms = self.timer.monotonic_now_ms();
         let mut state = self.lock();
         state.bytes_done = state.bytes_done.saturating_add(bytes);
+        state.bytes_moved = state.bytes_moved.saturating_add(bytes);
         if state.due(now_ms) {
             self.report(&mut state, now_ms);
         }
@@ -230,22 +249,24 @@ impl ProgressReporter {
     }
 
     /// A stretch where time passes and bytes do not — the commit a finished
-    /// upload waits on. Emitted at the transition, not on a timer.
+    /// upload waits on, or the head start a resumed download begins from.
+    /// Emitted at the transition, not on a timer.
     pub(crate) fn phase(&self, phase: &str) {
         if !self.enabled() {
             return;
         }
         let now_ms = self.timer.monotonic_now_ms();
+        let mut state = self.lock();
         match self.mode {
             ProgressMode::Events => self.emit_event(&Event::Phase {
                 kind: "phase",
                 op: self.op.as_str(),
                 path: &self.path,
                 phase,
+                bytes_done: state.bytes_done,
                 elapsed_ms: now_ms.saturating_sub(self.started_ms),
             }),
             ProgressMode::Human => {
-                let mut state = self.lock();
                 let line = format!("{} {} {phase}...", self.op.as_str(), self.path);
                 self.draw(&mut state, &line);
             }
@@ -284,7 +305,7 @@ impl ProgressReporter {
 
     fn report(&self, state: &mut ProgressState, now_ms: u64) {
         let elapsed_ms = now_ms.saturating_sub(self.started_ms);
-        let rate_bps = rate_bps(state.bytes_done, elapsed_ms);
+        let rate_bps = rate_bps(state.bytes_moved, elapsed_ms);
         match self.mode {
             ProgressMode::Events => self.emit_event(&Event::Progress {
                 kind: "progress",
@@ -392,6 +413,7 @@ enum Event<'a> {
         op: &'static str,
         path: &'a str,
         phase: &'a str,
+        bytes_done: u64,
         elapsed_ms: u64,
     },
 }
@@ -449,6 +471,7 @@ mod tests {
     fn state(bytes_done: u64, bytes_total: Option<u64>) -> ProgressState {
         ProgressState {
             bytes_done,
+            bytes_moved: bytes_done,
             bytes_total,
             files_done: 0,
             files_total: None,
@@ -477,6 +500,7 @@ mod tests {
     fn a_report_waits_for_the_interval_or_a_new_percentage() {
         let mut state = ProgressState {
             bytes_done: 10,
+            bytes_moved: 10,
             bytes_total: Some(1_000),
             files_done: 0,
             files_total: None,

--- a/crates/loonfs-cli/src/uploads.rs
+++ b/crates/loonfs-cli/src/uploads.rs
@@ -1,0 +1,379 @@
+//! Where an interrupted upload's bookkeeping lives between runs.
+//!
+//! An upload session records the geometry it was opened with and nothing
+//! per part — parts are the uploading client's own account, deliberately —
+//! so the only record of what landed is the one this CLI keeps. It keeps it
+//! under the user's state directory, keyed by the upload it describes, and
+//! deletes it the moment the upload commits or is abandoned.
+//!
+//! Only a remote profile's direct multipart upload has anything to record.
+//! An embedded profile stages through its own runtime with no session to
+//! rejoin, and a payload small enough to travel in one request has no parts
+//! to have half-finished.
+
+use loonfs_api::v0::CompletedUploadPart;
+use loonfs_api::{StorageChecksum, UploadId};
+use loonfs_client::{MultipartUploadJournal, MultipartUploadResume};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Directory under `$XDG_STATE_HOME`.
+const XDG_STATE_SUBDIR: &str = "loonfs";
+/// Directory under `$HOME`, matching where a config file lives when XDG
+/// says nothing.
+const LEGACY_STATE_SUBDIR: &str = ".loonfs/state";
+/// Directory both roots hold the per-upload files in.
+const UPLOADS_SUBDIR: &str = "uploads";
+
+/// What one interrupted upload got through.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UploadState {
+    upload_id: String,
+    part_size_bytes: u64,
+    parts: Vec<StatePart>,
+    source: SourceIdentity,
+}
+
+/// One part already in object storage, as the provider acknowledged it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StatePart {
+    part_number: u32,
+    etag: String,
+    crc64nvme: String,
+}
+
+/// Enough of the local file to notice it is not the same file any more.
+///
+/// A payload that changed under a half-finished upload cannot be resumed
+/// into: the parts already in object storage came from bytes that no longer
+/// exist, and completing the assembly would produce an object matching
+/// neither version. Length and modification time are what a filesystem
+/// offers cheaply, and disagreeing on either is enough to start over.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SourceIdentity {
+    size_bytes: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    modified_ms: Option<u64>,
+}
+
+impl SourceIdentity {
+    /// Reads a local file's identity. A modification time the filesystem
+    /// will not state leaves the length as the whole check, which is weaker
+    /// and still better than nothing.
+    pub(crate) fn of(path: &Path) -> std::io::Result<Self> {
+        let metadata = std::fs::metadata(path)?;
+        let modified_ms = metadata.modified().ok().and_then(|modified| {
+            modified
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()
+                .map(|since| since.as_millis() as u64)
+        });
+        Ok(Self {
+            size_bytes: metadata.len(),
+            modified_ms,
+        })
+    }
+}
+
+/// The record of one upload, and where it is kept.
+///
+/// Named by a digest of everything that decides which upload this is: two
+/// puts of different files, to different paths, in different namespaces, or
+/// through different profiles are different uploads and never share a
+/// record.
+#[derive(Debug)]
+pub(crate) struct UploadJournal {
+    path: PathBuf,
+    source: SourceIdentity,
+    /// What this run has been told, held until it is written down. Every
+    /// change is flushed immediately: a record that lags the object store
+    /// makes a rerun send parts that already landed, which is wasteful, and
+    /// a record that leads it makes a rerun claim parts that did not, which
+    /// fails the assembly.
+    state: Mutex<Option<UploadState>>,
+}
+
+impl UploadJournal {
+    /// The journal for one upload, or nothing when there is nowhere to keep
+    /// it. A resume nobody can record is not a failure; it is an upload that
+    /// starts over if it is interrupted.
+    pub(crate) fn for_upload(
+        profile: &str,
+        namespace: &str,
+        remote_path: &str,
+        local_path: &Path,
+        source: SourceIdentity,
+    ) -> Option<Self> {
+        let key = StorageChecksum::sha256(
+            format!(
+                "{profile}\u{0}{namespace}\u{0}{remote_path}\u{0}{}",
+                local_path.display()
+            )
+            .as_bytes(),
+        )
+        .value;
+        Some(Self {
+            path: uploads_dir()?.join(format!("{key}.json")),
+            source,
+            state: Mutex::new(None),
+        })
+    }
+
+    /// What an earlier run of this upload got through, when its record is
+    /// still about the same bytes.
+    ///
+    /// Every disagreement answers nothing and takes the record away with
+    /// it: a stale record is not a failure, it is an upload that starts
+    /// over.
+    pub(crate) fn resume(&self) -> Option<MultipartUploadResume> {
+        let recorded = std::fs::read(&self.path).ok()?;
+        let recorded: UploadState = serde_json::from_slice(&recorded).ok().or_else(|| {
+            self.forget();
+            None
+        })?;
+        if recorded.source != self.source {
+            self.forget();
+            return None;
+        }
+        let upload_id = UploadId::parse(&recorded.upload_id).ok().or_else(|| {
+            self.forget();
+            None
+        })?;
+        let resume = MultipartUploadResume {
+            upload_id,
+            part_size_bytes: recorded.part_size_bytes,
+            parts: recorded
+                .parts
+                .iter()
+                .map(|part| CompletedUploadPart {
+                    part_number: part.part_number,
+                    etag: part.etag.clone(),
+                    crc64nvme: part.crc64nvme.clone(),
+                })
+                .collect(),
+        };
+        // The run that picks this up appends to it: a resumed upload that is
+        // itself interrupted must leave a record of everything that landed,
+        // not only of what landed before it started.
+        *self.lock() = Some(recorded);
+        Some(resume)
+    }
+
+    /// Removes the record. Called when the upload commits, and whenever
+    /// what is on disk turns out to describe something else.
+    pub(crate) fn forget(&self) {
+        let _ = std::fs::remove_file(&self.path);
+        *self.lock() = None;
+    }
+
+    /// Writes the record down. Nothing surfaces a failure: an upload that
+    /// cannot be recorded still uploads, it just cannot be resumed.
+    fn flush(&self, state: &UploadState) {
+        let Some(parent) = self.path.parent() else {
+            return;
+        };
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+        if let Ok(encoded) = serde_json::to_vec(state) {
+            let _ = std::fs::write(&self.path, encoded);
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<UploadState>> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl MultipartUploadJournal for UploadJournal {
+    fn began(&self, upload_id: &UploadId, part_size_bytes: u64) {
+        let state = UploadState {
+            upload_id: upload_id.to_string(),
+            part_size_bytes,
+            parts: Vec::new(),
+            source: self.source.clone(),
+        };
+        self.flush(&state);
+        *self.lock() = Some(state);
+    }
+
+    fn part_completed(&self, part: &CompletedUploadPart) {
+        let mut held = self.lock();
+        let Some(state) = held.as_mut() else {
+            // No session was opened and no record was picked up, so this
+            // part belongs to an upload nobody is keeping track of.
+            return;
+        };
+        state.parts.push(StatePart {
+            part_number: part.part_number,
+            etag: part.etag.clone(),
+            crc64nvme: part.crc64nvme.clone(),
+        });
+        self.flush(state);
+    }
+}
+
+/// Where per-upload records live: `$XDG_STATE_HOME/loonfs/uploads` when that
+/// variable names an absolute directory, and `~/.loonfs/state/uploads`
+/// otherwise — the same order, and the same reasoning, as the config file's.
+fn uploads_dir() -> Option<PathBuf> {
+    if let Some(state_home) = absolute_env_path("XDG_STATE_HOME") {
+        return Some(state_home.join(XDG_STATE_SUBDIR).join(UPLOADS_SUBDIR));
+    }
+    let home = absolute_env_path("HOME")?;
+    Some(home.join(LEGACY_STATE_SUBDIR).join(UPLOADS_SUBDIR))
+}
+
+/// An environment variable naming an absolute directory. The XDG spec calls
+/// an empty or relative value invalid, and ignoring it keeps a stray
+/// relative value from making state follow the working directory.
+fn absolute_env_path(name: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(std::env::var_os(name)?);
+    path.is_absolute().then_some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(size_bytes: u64, modified_ms: u64) -> SourceIdentity {
+        SourceIdentity {
+            size_bytes,
+            modified_ms: Some(modified_ms),
+        }
+    }
+
+    fn journal_at(dir: &Path, remote_path: &str, source: SourceIdentity) -> UploadJournal {
+        UploadJournal {
+            path: dir.join(format!("{}.json", remote_path.replace('/', "_"))),
+            source,
+            state: Mutex::new(None),
+        }
+    }
+
+    fn part(part_number: u32) -> CompletedUploadPart {
+        CompletedUploadPart {
+            part_number,
+            etag: format!("\"etag-{part_number}\""),
+            crc64nvme: "00000000000000".to_owned(),
+        }
+    }
+
+    fn upload_id() -> UploadId {
+        UploadId::parse("upl_00000000000000000000000000000001").expect("valid upload id")
+    }
+
+    /// What a run records is exactly what the next one picks up, part by
+    /// part, and committing takes the record away.
+    #[test]
+    fn a_record_hands_the_next_run_the_parts_that_landed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = identity(1024, 7);
+        let journal = journal_at(dir.path(), "/big.bin", source.clone());
+        assert_eq!(journal.resume(), None, "nothing recorded resumes nothing");
+
+        journal.began(&upload_id(), 1024 * 1024);
+        journal.part_completed(&part(1));
+        journal.part_completed(&part(2));
+
+        let resumed = journal_at(dir.path(), "/big.bin", source.clone())
+            .resume()
+            .expect("a record of the same upload");
+        assert_eq!(resumed.upload_id, upload_id());
+        assert_eq!(resumed.part_size_bytes, 1024 * 1024);
+        assert_eq!(
+            resumed
+                .parts
+                .iter()
+                .map(|p| p.part_number)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        // A run that resumed and was interrupted again leaves a record of
+        // everything that landed, its own parts included.
+        let second = journal_at(dir.path(), "/big.bin", source.clone());
+        second.resume().expect("a record to pick up");
+        second.part_completed(&part(3));
+        assert_eq!(
+            journal_at(dir.path(), "/big.bin", source)
+                .resume()
+                .expect("a record")
+                .parts
+                .iter()
+                .map(|p| p.part_number)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+
+        journal.forget();
+        assert_eq!(journal.resume(), None, "a committed upload keeps nothing");
+    }
+
+    /// A payload that changed under a half-finished upload cannot be
+    /// resumed into: the parts already stored came from bytes that are gone.
+    #[test]
+    fn a_source_that_changed_invalidates_its_record() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let journal = journal_at(dir.path(), "/big.bin", identity(1024, 7));
+        journal.began(&upload_id(), 1024 * 1024);
+        journal.part_completed(&part(1));
+
+        let rewritten = journal_at(dir.path(), "/big.bin", identity(1024, 8));
+        assert_eq!(rewritten.resume(), None, "a newer file is a different file");
+        assert!(
+            !rewritten.path.exists(),
+            "an invalidated record is removed rather than left to mislead"
+        );
+
+        let resized = journal_at(dir.path(), "/big.bin", identity(2048, 7));
+        assert_eq!(resized.resume(), None, "a longer file is a different file");
+    }
+
+    /// A record this build cannot read is no record at all, and does not
+    /// survive to confuse the next run either.
+    #[test]
+    fn an_unreadable_record_is_discarded() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let journal = journal_at(dir.path(), "/big.bin", identity(1024, 7));
+        std::fs::write(&journal.path, b"{\"upload_id\":").expect("write torn record");
+        assert_eq!(journal.resume(), None);
+        assert!(!journal.path.exists());
+    }
+
+    /// Two uploads are the same upload only when everything that names one
+    /// agrees.
+    #[test]
+    fn the_record_is_named_by_what_decides_which_upload_it_is() {
+        let source = identity(1024, 7);
+        let path = |profile, namespace, remote, local| {
+            UploadJournal::for_upload(profile, namespace, remote, Path::new(local), source.clone())
+                .map(|journal| journal.path)
+        };
+        let baseline = path("default", "demo", "/big.bin", "/tmp/big.bin");
+        assert!(baseline.is_some(), "a home directory names a state file");
+        assert_eq!(
+            baseline,
+            path("default", "demo", "/big.bin", "/tmp/big.bin")
+        );
+        assert_ne!(baseline, path("other", "demo", "/big.bin", "/tmp/big.bin"));
+        assert_ne!(
+            baseline,
+            path("default", "prod", "/big.bin", "/tmp/big.bin")
+        );
+        assert_ne!(
+            baseline,
+            path("default", "demo", "/other.bin", "/tmp/big.bin")
+        );
+        assert_ne!(
+            baseline,
+            path("default", "demo", "/big.bin", "/tmp/other.bin")
+        );
+    }
+}

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1151,6 +1151,142 @@ fn a_download_of_corrupted_content_leaves_nothing_at_the_destination() {
     );
 }
 
+/// The bytes and the note an interrupted download leaves beside its
+/// destination, as this CLI names them.
+fn partial_paths(destination: &Path) -> (PathBuf, PathBuf) {
+    let name = destination
+        .file_name()
+        .expect("destination file name")
+        .to_str()
+        .expect("utf-8 name");
+    let parent = destination.parent().expect("destination parent");
+    (
+        parent.join(format!(".{name}.loonfs-partial")),
+        parent.join(format!(".{name}.loonfs-partial.meta")),
+    )
+}
+
+/// Lays down the bytes and note an interrupted download of `remote_path`
+/// would have left, having got `held` bytes in.
+fn leave_a_partial_download(
+    harness: &Harness,
+    remote_path: &str,
+    destination: &Path,
+    payload: &[u8],
+    held: usize,
+) {
+    let stat = harness.run(&["--json", "stat", remote_path]);
+    assert_success(&stat);
+    let content_ref = json_data(&stat)["content_ref"].clone();
+    let (partial, meta) = partial_paths(destination);
+    fs::write(&partial, &payload[..held]).expect("write partial bytes");
+    let mut note = serde_json::json!({
+        "content_id": content_ref["content_id"],
+        "size_bytes": content_ref["size_bytes"],
+    });
+    if let Some(sha256) = content_ref.get("whole_file_sha256") {
+        note["whole_file_sha256"] = sha256.clone();
+    }
+    fs::write(&meta, serde_json::to_vec(&note).expect("encode note")).expect("write note");
+}
+
+/// A download that stopped part way is picked up rather than started over:
+/// the bytes already on disk are fetched again by nobody, and the file that
+/// lands is still verified as a whole.
+#[test]
+fn an_interrupted_download_resumes_from_what_it_already_has() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = streaming_payload();
+    let source = harness.temp_dir.path().join("source.bin");
+    fs::write(&source, &payload).expect("write payload");
+    assert_success(&harness.run(&["put", source.to_str().expect("utf-8 path"), "/big.bin"]));
+
+    let destination = harness.temp_dir.path().join("big.bin");
+    let held = 3 * 1024 * 1024;
+    leave_a_partial_download(&harness, "/big.bin", &destination, &payload, held);
+
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "/big.bin",
+        destination.to_str().expect("utf-8 path"),
+    ]);
+    assert_success(&get);
+    assert_eq!(
+        fs::read(&destination).expect("read destination"),
+        payload,
+        "a resumed download still lands the whole verified file"
+    );
+
+    let resuming: Vec<Value> = events_of_kind(&get, "phase")
+        .into_iter()
+        .filter(|event| event["phase"] == "resuming")
+        .collect();
+    assert_eq!(resuming.len(), 1, "one resume to report: {resuming:?}");
+    assert_eq!(
+        resuming[0]["bytes_done"], held as u64,
+        "the run started at what was already on disk, not at zero"
+    );
+
+    let (partial, meta) = partial_paths(&destination);
+    assert!(!partial.exists(), "an installed download leaves no partial");
+    assert!(!meta.exists(), "and takes its note with it");
+}
+
+/// The note is what makes leftover bytes resumable. Bytes belonging to
+/// other content, and bytes with nothing vouching for them, are dropped
+/// without a word and the download starts over.
+#[test]
+fn a_partial_that_does_not_describe_this_file_is_started_over() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = streaming_payload();
+    let source = harness.temp_dir.path().join("source.bin");
+    fs::write(&source, &payload).expect("write payload");
+    assert_success(&harness.run(&["put", source.to_str().expect("utf-8 path"), "/big.bin"]));
+    assert_success(&harness.run(&["put", source.to_str().expect("utf-8 path"), "/other.bin"]));
+
+    // The note of a different file: same length, same bytes, and a content
+    // id that says it is not this object.
+    let destination = harness.temp_dir.path().join("big.bin");
+    let held = 3 * 1024 * 1024;
+    leave_a_partial_download(&harness, "/other.bin", &destination, &payload, held);
+
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "/big.bin",
+        destination.to_str().expect("utf-8 path"),
+    ]);
+    assert_success(&get);
+    assert_eq!(fs::read(&destination).expect("read destination"), payload);
+    assert!(
+        events_of_kind(&get, "phase").is_empty(),
+        "a download that started over reports no resume"
+    );
+
+    // Bytes with no note beside them say nothing about themselves either.
+    let elsewhere = harness.temp_dir.path().join("again.bin");
+    let (partial, _) = partial_paths(&elsewhere);
+    fs::write(&partial, &payload[..held]).expect("write orphan partial");
+    let get = harness.run(&[
+        "--json",
+        "get",
+        "/big.bin",
+        elsewhere.to_str().expect("utf-8 path"),
+    ]);
+    assert_success(&get);
+    assert_eq!(fs::read(&elsewhere).expect("read destination"), payload);
+    assert!(events_of_kind(&get, "phase").is_empty());
+}
+
 /// The one content object of a given length under a store root. Content
 /// objects live at `content-stores/<store>/objects/<shard>/<id>`, and the
 /// tests that use this write one file whose length nothing else shares.

--- a/crates/loonfs-client/src/download_tests.rs
+++ b/crates/loonfs-client/src/download_tests.rs
@@ -145,6 +145,82 @@ async fn a_streamed_read_writes_the_granted_object_and_reports_its_length() {
     assert_eq!(sink, payload);
 }
 
+/// A download that stopped part way asks for the rest with a `Range`, on
+/// the grant it already has: the signature does not cover that header, so
+/// one grant serves the whole object or any part of it. The bytes already
+/// held still count toward the digest, so the verdict is over the whole
+/// file.
+#[tokio::test]
+async fn a_resumed_download_asks_for_the_rest_and_verifies_the_whole_file() {
+    let payload = b"the first half and then the second half".to_vec();
+    let held = 10;
+    let content_ref = ContentRef::blob_v1(ContentId::generate(), &payload);
+    let client = client();
+
+    let guard = test_transport::script([Outcome::Success(payload[held..].to_vec())]);
+    let mut download = client
+        .open_direct_download_at(
+            &grant(content_ref, "http://example.invalid/object"),
+            held as u64,
+        )
+        .await
+        .expect("resumed grant");
+    download.fold_resumed_prefix(&payload[..held]);
+    let mut received = Vec::new();
+    while let Some(chunk) = download.next_chunk().await.expect("chunk") {
+        received.extend_from_slice(&chunk);
+    }
+
+    assert_eq!(
+        received,
+        payload[held..],
+        "only the bytes past the resume point arrive"
+    );
+    let sent = guard.sent();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(
+        sent[0].header("range"),
+        Some("bytes=10-"),
+        "the rest is asked for by range: {sent:?}"
+    );
+}
+
+/// A download that starts at zero asks for no range at all, and one that
+/// resumes without handing over what it holds reads nothing.
+#[tokio::test]
+async fn a_resume_is_refused_until_it_accounts_for_what_it_holds() {
+    let payload = b"a whole object".to_vec();
+    let content_ref = ContentRef::blob_v1(ContentId::generate(), &payload);
+    let client = client();
+
+    let guard = test_transport::script([Outcome::Success(payload.clone())]);
+    let mut whole = client
+        .open_direct_download(&grant(content_ref.clone(), "http://example.invalid/object"))
+        .await
+        .expect("grant");
+    while whole.next_chunk().await.expect("chunk").is_some() {}
+    assert_eq!(
+        guard.sent()[0].header("range"),
+        None,
+        "a download of the whole object names no range"
+    );
+    drop(guard);
+
+    let _guard = test_transport::script([Outcome::Success(payload[4..].to_vec())]);
+    let mut resumed = client
+        .open_direct_download_at(&grant(content_ref, "http://example.invalid/object"), 4)
+        .await
+        .expect("resumed grant");
+    let error = resumed
+        .next_chunk()
+        .await
+        .expect_err("the skipped bytes are still owed");
+    assert!(
+        matches!(&error, ClientError::Http(message) if message.contains("resumed at offset 4")),
+        "unexpected error: {error}"
+    );
+}
+
 /// A capability is a URL and a method, and this client sends the method it
 /// was given rather than assuming one.
 #[tokio::test]

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -202,13 +202,43 @@ pub struct DirectDownloadStream {
     path: AbsolutePath,
     sha256: Option<Sha256>,
     size_bytes: u64,
+    /// Offset this stream was opened at: zero for the whole object, and the
+    /// length of what the caller already holds for a resumed download.
+    resumed_from: u64,
+    /// How much of that head start the caller has folded in. Nothing is
+    /// read until it reaches `resumed_from`, because the verdict is over
+    /// the whole object either way.
+    prefix_folded: u64,
     finished: bool,
 }
 
 impl DirectDownloadStream {
+    /// Hands the stream part of what the caller already holds, in order,
+    /// from the object's first byte.
+    ///
+    /// A resumed download still checks the whole object's digest, so the
+    /// bytes it will never receive have to be folded into the same hash as
+    /// the ones it does. Feeding the wrong bytes fails the download at its
+    /// end, which is right: the grant's reference is the authority on what
+    /// the object holds, not the partial copy on the caller's disk.
+    pub fn fold_resumed_prefix(&mut self, bytes: &[u8]) {
+        if let Some(sha256) = self.sha256.as_mut() {
+            sha256.update(bytes);
+        }
+        self.prefix_folded = self.prefix_folded.saturating_add(bytes.len() as u64);
+    }
+
     /// Returns the next response-body chunk, or `None` once the complete
     /// object has passed its declared-length and whole-file digest checks.
     pub async fn next_chunk(&mut self) -> Result<Option<Bytes>> {
+        if self.prefix_folded != self.resumed_from {
+            return Err(ClientError::Http(format!(
+                "a download of `{}` resumed at offset {} was given {} bytes of what it \
+                 skipped; verification covers the whole object, so all of them are needed \
+                 first",
+                self.path, self.resumed_from, self.prefix_folded
+            )));
+        }
         if self.finished {
             return Ok(None);
         }
@@ -259,6 +289,47 @@ impl DirectDownloadStream {
             }
         }
     }
+}
+
+/// What a caller keeps so an interrupted direct multipart upload can pick
+/// up rather than start over.
+///
+/// The parts are the caller's own bookkeeping, deliberately: an upload
+/// session records the geometry it was opened with and nothing per part, so
+/// the only account of which parts landed is the one the uploading client
+/// kept. Resuming with fewer parts than actually landed re-sends them,
+/// which is harmless; resuming with parts that did not land fails the
+/// completion, which is the assembly refusing to be wrong.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultipartUploadResume {
+    pub upload_id: UploadId,
+    /// The part size the session was opened with. A resumed upload must cut
+    /// the payload exactly as the interrupted one did, or the parts it
+    /// sends will not line up with the ones already there.
+    pub part_size_bytes: u64,
+    pub parts: Vec<CompletedUploadPart>,
+}
+
+/// Where a caller records a direct multipart upload as it happens, so a
+/// later run can resume it.
+///
+/// Both methods are called on the thread driving the upload, between
+/// network round trips, so an implementation that writes to disk is doing
+/// it at the right moment: after the part it describes is durable, and
+/// before the next one starts.
+pub trait MultipartUploadJournal: Send + Sync {
+    /// A session was opened, with the part geometry the server chose.
+    fn began(&self, upload_id: &UploadId, part_size_bytes: u64);
+    /// One part landed in object storage.
+    fn part_completed(&self, part: &CompletedUploadPart);
+}
+
+/// How one upload survives an interruption: what an earlier run got
+/// through, and where this one writes down what it gets through.
+#[derive(Clone, Copy, Default)]
+struct UploadContinuity<'a> {
+    resume: Option<&'a MultipartUploadResume>,
+    journal: Option<&'a dyn MultipartUploadJournal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -629,6 +700,23 @@ impl Client {
         &self,
         download: &BeginDownloadResponse,
     ) -> Result<DirectDownloadStream> {
+        self.open_direct_download_at(download, 0).await
+    }
+
+    /// Opens a download grant's body from `start_offset`, for a caller that
+    /// already holds the bytes below it.
+    ///
+    /// The offset rides a `Range` header, which the presigned signature does
+    /// not cover: one grant serves the whole object or any part of it, so a
+    /// resumed download needs no different grant than a fresh one. The
+    /// stream still reports on the whole object, so a nonzero offset obliges
+    /// the caller to hand over what it holds through
+    /// [`DirectDownloadStream::fold_resumed_prefix`] before driving it.
+    pub async fn open_direct_download_at(
+        &self,
+        download: &BeginDownloadResponse,
+        start_offset: u64,
+    ) -> Result<DirectDownloadStream> {
         let ObjectTransferAccess::PresignedUrl {
             method,
             url,
@@ -640,9 +728,18 @@ impl Client {
                 "unsupported presigned download method `{method}`"
             )));
         }
+        if start_offset > download.content_ref.size_bytes {
+            return Err(ClientError::Http(format!(
+                "cannot resume a download of `{}` at offset {start_offset} of {} bytes",
+                download.absolute_path, download.content_ref.size_bytes
+            )));
+        }
         let mut request = WireRequest::presigned(reqwest::Method::GET, url);
         for (name, value) in headers {
             request = request.header(name, value);
+        }
+        if start_offset > 0 {
+            request = request.header("range", format!("bytes={start_offset}-"));
         }
         let body = self.call_for_response_stream(&request).await?;
         Ok(DirectDownloadStream {
@@ -654,7 +751,11 @@ impl Client {
                 .whole_file_sha256
                 .as_ref()
                 .map(|_| Sha256::new()),
-            size_bytes: 0,
+            // The counter measures the whole object, not this response, so
+            // the length check at the end lands where it always did.
+            size_bytes: start_offset,
+            resumed_from: start_offset,
+            prefix_folded: 0,
             finished: false,
         })
     }
@@ -1186,7 +1287,11 @@ impl Client {
     ) -> Result<StagedContent> {
         if bytes.len() as u64 >= STREAMING_PUT_MIN_BYTES && self.offers_direct_multipart().await {
             return self
-                .stage_via_multipart(namespace_id, MultipartPayload::Held(bytes))
+                .stage_via_multipart(
+                    namespace_id,
+                    MultipartPayload::Held(bytes),
+                    UploadContinuity::default(),
+                )
                 .await;
         }
         self.stage_bytes_via_server(namespace_id, bytes).await
@@ -1202,6 +1307,7 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         source: PayloadSource,
+        continuity: UploadContinuity<'_>,
     ) -> Result<StagedContent> {
         // A source that knows it is small has nothing to gain from parts,
         // exactly as a held payload of that size does not. A source that
@@ -1213,9 +1319,11 @@ impl Client {
         if !known_small && self.offers_direct_multipart().await {
             let (stream, _) = source.into_stream();
             return self
-                .stage_via_multipart(namespace_id, MultipartPayload::Streamed(stream))
+                .stage_via_multipart(namespace_id, MultipartPayload::Streamed(stream), continuity)
                 .await;
         }
+        // Nothing to resume off this path: a proxied upload is one request
+        // with no session behind it, so there are no parts to have landed.
         self.stage_source_via_server(namespace_id, source).await
     }
 
@@ -1242,18 +1350,36 @@ impl Client {
         &self,
         namespace_id: &NamespaceId,
         payload: MultipartPayload<'_>,
+        continuity: UploadContinuity<'_>,
     ) -> Result<StagedContent> {
-        let begin = self
-            .begin_direct_multipart(namespace_id, DirectMultipartUploadOptions::default())
-            .await?;
-        let upload_id = begin.upload_id.clone();
-        let Some(multipart) = begin.direct_multipart else {
-            return Err(ClientError::Http(
-                "server accepted direct_multipart without part geometry".to_owned(),
-            ));
+        // A resumed upload rejoins the session a previous run opened, at the
+        // part size that run was given. Asking for a new one would open a
+        // second session and orphan the parts already in object storage.
+        let (upload_id, part_size_bytes) = match continuity.resume {
+            Some(resume) => (resume.upload_id.clone(), resume.part_size_bytes),
+            None => {
+                let begin = self
+                    .begin_direct_multipart(namespace_id, DirectMultipartUploadOptions::default())
+                    .await?;
+                let Some(multipart) = begin.direct_multipart else {
+                    return Err(ClientError::Http(
+                        "server accepted direct_multipart without part geometry".to_owned(),
+                    ));
+                };
+                if let Some(journal) = continuity.journal {
+                    journal.began(&begin.upload_id, multipart.part_size_bytes);
+                }
+                (begin.upload_id, multipart.part_size_bytes)
+            }
         };
         let uploaded = self
-            .upload_every_part(namespace_id, &upload_id, payload, multipart.part_size_bytes)
+            .upload_every_part(
+                namespace_id,
+                &upload_id,
+                payload,
+                part_size_bytes,
+                continuity,
+            )
             .await;
         let uploaded = match uploaded {
             Ok(uploaded) => uploaded,
@@ -1297,15 +1423,24 @@ impl Client {
     /// in a single request, uploads them together, and only then reads the
     /// next wave — so the payload's length never enters into how much of it
     /// is resident.
+    /// A resumed upload still reads every byte: the whole-object checksum
+    /// completion verifies the assembly against is folded over the payload
+    /// in one forward pass, so a part already in object storage is cut,
+    /// folded, and then let go rather than sent again. What resuming saves
+    /// is the network, which is the part that was expensive.
     async fn upload_every_part(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
         payload: MultipartPayload<'_>,
         part_size_bytes: u64,
+        continuity: UploadContinuity<'_>,
     ) -> Result<UploadedObject> {
         let part_size = usize::try_from(part_size_bytes)
             .map_err(|_| ClientError::Http("part size does not fit this platform".to_owned()))?;
+        let landed = continuity
+            .resume
+            .map_or::<&[CompletedUploadPart], _>(&[], |resume| &resume.parts);
         let mut source = payload.into_parts_of(part_size);
         let mut whole_object = Crc64Nvme::new();
         let mut size_bytes = 0u64;
@@ -1314,28 +1449,38 @@ impl Client {
 
         loop {
             let mut wave = Vec::with_capacity(DIRECT_MULTIPART_PARTS_IN_FLIGHT);
+            let mut source_ended = false;
             while wave.len() < DIRECT_MULTIPART_PARTS_IN_FLIGHT {
                 let Some(bytes) = source.next_part().await? else {
+                    source_ended = true;
                     break;
                 };
                 whole_object.update(&bytes);
                 size_bytes += bytes.len() as u64;
+                let part_number = next_part_number;
+                next_part_number += 1;
+                if let Some(landed) = landed.iter().find(|part| part.part_number == part_number) {
+                    parts.push(landed.clone());
+                    continue;
+                }
                 wave.push(PendingPart {
                     claim: UploadPartChecksumClaim {
-                        part_number: next_part_number,
+                        part_number,
                         crc64nvme: StorageChecksum::crc64nvme(&bytes).value,
                     },
                     bytes,
                 });
-                next_part_number += 1;
             }
-            if wave.is_empty() {
-                break;
+            if !wave.is_empty() {
+                let uploaded = self.upload_wave(namespace_id, upload_id, wave).await?;
+                if let Some(journal) = continuity.journal {
+                    for part in &uploaded {
+                        journal.part_completed(part);
+                    }
+                }
+                parts.extend(uploaded);
             }
-            let complete = wave.len() == DIRECT_MULTIPART_PARTS_IN_FLIGHT;
-            parts.extend(self.upload_wave(namespace_id, upload_id, wave).await?);
-            if !complete {
-                // A short wave is the only proof the source ended.
+            if source_ended {
                 break;
             }
         }
@@ -1558,13 +1703,86 @@ impl Client {
         source: PayloadSource,
         options: &PutFileOptions,
     ) -> Result<ApiCommitResponse> {
+        self.put_file_stream_continuing(spec, source, options, UploadContinuity::default())
+            .await
+    }
+
+    /// [`Self::put_file_stream`] for a caller that intends to survive an
+    /// interruption.
+    ///
+    /// `journal` is told the session's id and geometry when it opens and
+    /// told every part as it lands; `resume` hands back what an earlier run
+    /// of the same upload recorded, so this one sends only the parts still
+    /// missing. Both apply to the direct multipart transport alone: a
+    /// proxied upload is a single request with no session behind it and
+    /// nothing to resume from, and it ignores them.
+    ///
+    /// The source is read from its first byte either way. That is not
+    /// waste — the checksum the assembly is verified against covers the
+    /// whole object, so every byte has to be folded whether or not it also
+    /// has to be sent — and it means the source has to be one that can be
+    /// opened again. A pipe cannot, which is why nothing that reads one
+    /// should be calling this.
+    pub async fn put_file_stream_resumable(
+        &self,
+        spec: &NamespacePath,
+        source: PayloadSource,
+        options: &PutFileOptions,
+        journal: &dyn MultipartUploadJournal,
+        resume: Option<&MultipartUploadResume>,
+    ) -> Result<ApiCommitResponse> {
+        self.put_file_stream_continuing(
+            spec,
+            source,
+            options,
+            UploadContinuity {
+                resume,
+                journal: Some(journal),
+            },
+        )
+        .await
+    }
+
+    async fn put_file_stream_continuing(
+        &self,
+        spec: &NamespacePath,
+        source: PayloadSource,
+        options: &PutFileOptions,
+        continuity: UploadContinuity<'_>,
+    ) -> Result<ApiCommitResponse> {
         let staged = self
-            .stage_source_as_content_ref(spec.namespace(), source)
+            .stage_source_as_content_ref(spec.namespace(), source, continuity)
             .await?;
         // The staged reference is what the server verified about the bytes
         // that just went past, and with the payload gone it is the only
         // description of them that still exists.
         let uploaded = staged.content_ref.clone();
+        self.commit_staged_file(spec, staged, options, UploadedContent::Streamed(&uploaded))
+            .await
+    }
+
+    /// Commits content an upload session already completed, for a caller
+    /// that finished the transfer and was interrupted before the commit.
+    ///
+    /// The reference and the token come from
+    /// [`Self::read_upload_status`] reporting the session `Completed`: the
+    /// bytes are in object storage and admitted, so the only thing left to
+    /// do is name them at a path. Nothing is re-uploaded.
+    pub async fn commit_completed_upload(
+        &self,
+        spec: &NamespacePath,
+        content_ref: ContentRef,
+        validated_content_token: Option<String>,
+        options: &PutFileOptions,
+    ) -> Result<ApiCommitResponse> {
+        let uploaded = content_ref.clone();
+        let staged = StagedContent {
+            validated_content_token: validated_content_token.map(|token| ValidatedContentToken {
+                content_ref: content_ref.clone(),
+                token,
+            }),
+            content_ref,
+        };
         self.commit_staged_file(spec, staged, options, UploadedContent::Streamed(&uploaded))
             .await
     }

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -12,7 +12,7 @@ use futures::stream::StreamExt;
 use loonfs_api::v0::{DirectMultipartUpload, UploadMode};
 use loonfs_api::{CapabilityDocument, ContentId, ContentRef, PROFILE_CORE_V0, PROTOCOL_VERSION};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Part geometry the scripted server hands back. Smaller than the default
 /// so the test's payload stays cheap, and a server is free to choose it.
@@ -136,6 +136,19 @@ fn client() -> Client {
     .expect("valid client config")
 }
 
+/// A client whose failures are the test's own, not the retry policy's, so a
+/// scripted conversation is exactly as long as it reads.
+fn client_without_retry() -> Client {
+    Client::new(ClientConfig {
+        server_url: "http://example.invalid".to_owned(),
+        auth_token: None,
+        request_timeout_ms: None,
+        disable_transient_retry: true,
+        ca_cert_path: None,
+    })
+    .expect("valid client config")
+}
+
 fn json(value: &impl serde::Serialize) -> Outcome {
     Outcome::Success(serde_json::to_vec(value).expect("serialize scripted response"))
 }
@@ -238,6 +251,149 @@ fn multipart_script(parts: u32, uploaded: ContentRef) -> Vec<Outcome> {
     script.push(completed(uploaded));
     script.push(commit_landed());
     script
+}
+
+/// A journal that keeps what it is told, so a test can hand it back as the
+/// record of an interrupted run.
+#[derive(Debug, Default)]
+struct RecordingJournal {
+    began: Mutex<Option<(UploadId, u64)>>,
+    parts: Mutex<Vec<CompletedUploadPart>>,
+}
+
+impl RecordingJournal {
+    fn resume(&self) -> MultipartUploadResume {
+        let began = self.began.lock().expect("journal lock").clone();
+        let (upload_id, part_size_bytes) = began.expect("the session was opened");
+        MultipartUploadResume {
+            upload_id,
+            part_size_bytes,
+            parts: self.parts.lock().expect("journal lock").clone(),
+        }
+    }
+
+    fn part_numbers(&self) -> Vec<u32> {
+        self.parts
+            .lock()
+            .expect("journal lock")
+            .iter()
+            .map(|part| part.part_number)
+            .collect()
+    }
+}
+
+impl MultipartUploadJournal for RecordingJournal {
+    fn began(&self, upload_id: &UploadId, part_size_bytes: u64) {
+        *self.began.lock().expect("journal lock") = Some((upload_id.clone(), part_size_bytes));
+    }
+
+    fn part_completed(&self, part: &CompletedUploadPart) {
+        self.parts.lock().expect("journal lock").push(part.clone());
+    }
+}
+
+/// The conversation a resumed upload has: no `begin` — it rejoins the
+/// session it was given — and signing plus uploads only for the parts still
+/// missing.
+fn resumed_script(missing: &[u32], uploaded: ContentRef) -> Vec<Outcome> {
+    let mut script = vec![capabilities(true)];
+    let window = DIRECT_MULTIPART_PARTS_IN_FLIGHT;
+    for wave in missing.chunks(window) {
+        script.push(signed_parts(wave[0], wave.len() as u32));
+        for part_number in wave {
+            script.push(Outcome::PartAccepted(format!("\"etag-{part_number}\"")));
+        }
+    }
+    script.push(completed(uploaded));
+    script.push(commit_landed());
+    script
+}
+
+/// An upload interrupted after some parts landed picks the session back up
+/// and sends only what is missing. Every byte is still read — the assembly
+/// is verified against a checksum over the whole object — but the parts
+/// already in object storage are not sent a second time.
+#[tokio::test]
+async fn a_resumed_multipart_put_uploads_only_the_parts_that_are_missing() {
+    let payload = payload(TEST_PAYLOAD_BYTES);
+    let uploaded = content_ref(&payload);
+    let journal = RecordingJournal::default();
+
+    // The first run gets through two waves and is cut off before the third
+    // is signed: the script runs out where the interruption did.
+    let landed = DIRECT_MULTIPART_PARTS_IN_FLIGHT as u32 * 2;
+    let mut first = vec![capabilities(true), begin_multipart()];
+    for wave in 0..2u32 {
+        let first_part = wave * DIRECT_MULTIPART_PARTS_IN_FLIGHT as u32 + 1;
+        first.push(signed_parts(
+            first_part,
+            DIRECT_MULTIPART_PARTS_IN_FLIGHT as u32,
+        ));
+        for part_number in first_part..first_part + DIRECT_MULTIPART_PARTS_IN_FLIGHT as u32 {
+            first.push(Outcome::PartAccepted(format!("\"etag-{part_number}\"")));
+        }
+    }
+    // The signing request for the third wave never lands, and the abort
+    // that follows a failed session does not either. Retry is off so each
+    // is one attempt and the script stays exactly this long.
+    first.push(Outcome::TransportFailure);
+    first.push(Outcome::TransportFailure);
+    let transport = test_transport::script(first);
+    let interrupted = client_without_retry()
+        .put_file_stream_resumable(
+            &spec(),
+            PayloadSource::sized_stream(
+                futures::stream::once({
+                    let payload = payload.clone();
+                    async move { Ok(Bytes::from(payload)) }
+                })
+                .boxed(),
+                payload.len() as u64,
+            ),
+            &PutFileOptions::default(),
+            &journal,
+            None,
+        )
+        .await;
+    assert!(interrupted.is_err(), "the third wave never got signed");
+    assert_eq!(
+        journal.part_numbers(),
+        (1..=landed).collect::<Vec<_>>(),
+        "the journal holds exactly the parts that landed"
+    );
+    let resume = journal.resume();
+    assert_eq!(resume.part_size_bytes, TEST_PART_BYTES);
+    drop(transport);
+
+    // The rerun sends only parts 9 onward.
+    let missing: Vec<u32> = (landed + 1..=TEST_PAYLOAD_PARTS).collect();
+    let (source, retention) = watched_source(&payload, TEST_PART_BYTES as usize);
+    let transport = test_transport::script(resumed_script(&missing, uploaded));
+    let resumed_journal = RecordingJournal::default();
+    client()
+        .put_file_stream_resumable(
+            &spec(),
+            source,
+            &PutFileOptions::default(),
+            &resumed_journal,
+            Some(&resume),
+        )
+        .await
+        .expect("a resumed multipart put should land");
+
+    assert_eq!(
+        resumed_journal.part_numbers(),
+        missing,
+        "only the missing parts were uploaded"
+    );
+    assert_eq!(
+        retention.total_bytes(),
+        TEST_PAYLOAD_BYTES as u64,
+        "every byte is still folded into the whole-object checksum"
+    );
+    // capabilities + one signing request + one PUT per missing part +
+    // completion + commit, and no `begin`: the session was rejoined.
+    assert_eq!(transport.attempts(), 1 + 1 + missing.len() + 2);
 }
 
 /// A large put reads its source once and never holds more of it than the

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -191,7 +191,7 @@ impl Client {
         request: &WireRequest,
     ) -> Result<PayloadStream> {
         #[cfg(test)]
-        if let Some(outcome) = test_transport::next() {
+        if let Some(outcome) = test_transport::next(request) {
             return match outcome {
                 Ok(response) => {
                     Ok(
@@ -282,7 +282,7 @@ impl Client {
         body: Option<&Bytes>,
     ) -> std::result::Result<WireResponse, FailedAttempt> {
         #[cfg(test)]
-        if let Some(outcome) = test_transport::next() {
+        if let Some(outcome) = test_transport::next(request) {
             return outcome;
         }
         let mut builder = self.build(request);
@@ -303,7 +303,7 @@ impl Client {
         size_bytes: Option<u64>,
     ) -> std::result::Result<WireResponse, FailedAttempt> {
         #[cfg(test)]
-        if let Some(outcome) = test_transport::next() {
+        if let Some(outcome) = test_transport::next(request) {
             // Drain the body so a scripted test still observes the source
             // being read exactly once, as a real send would.
             let mut body = body;
@@ -481,7 +481,7 @@ async fn transient_retry_pause(backoff: Duration) {
 
 #[cfg(test)]
 pub(crate) mod test_transport {
-    use super::{FailedAttempt, WireResponse};
+    use super::{FailedAttempt, WireRequest, WireResponse};
     use crate::ClientError;
     use std::cell::RefCell;
     use std::collections::VecDeque;
@@ -498,6 +498,26 @@ pub(crate) mod test_transport {
     struct State {
         outcomes: VecDeque<Outcome>,
         attempts: usize,
+        /// What each attempt asked for, so a test can hold the client to the
+        /// request it made and not only to the answer it accepted.
+        sent: Vec<SentRequest>,
+    }
+
+    /// One request a scripted attempt carried.
+    #[derive(Debug, Clone)]
+    pub(crate) struct SentRequest {
+        #[allow(dead_code, reason = "part of what a scripted attempt carried")]
+        pub url: String,
+        pub headers: Vec<(String, String)>,
+    }
+
+    impl SentRequest {
+        pub(crate) fn header(&self, name: &str) -> Option<&str> {
+            self.headers
+                .iter()
+                .find(|(header, _)| header.eq_ignore_ascii_case(name))
+                .map(|(_, value)| value.as_str())
+        }
     }
 
     // A thread-local is sound here because client tests run on the default
@@ -517,6 +537,18 @@ pub(crate) mod test_transport {
                     .as_ref()
                     .expect("test transport should be installed")
                     .attempts
+            })
+        }
+
+        /// Every request the client sent, in order.
+        pub(crate) fn sent(&self) -> Vec<SentRequest> {
+            STATE.with(|state| {
+                state
+                    .borrow()
+                    .as_ref()
+                    .expect("test transport should be installed")
+                    .sent
+                    .clone()
             })
         }
     }
@@ -546,17 +578,22 @@ pub(crate) mod test_transport {
             let replaced = state.borrow_mut().replace(State {
                 outcomes: outcomes.into_iter().collect(),
                 attempts: 0,
+                sent: Vec::new(),
             });
             assert!(replaced.is_none(), "test transport already installed");
         });
         Guard
     }
 
-    pub(super) fn next() -> Option<Result<WireResponse, FailedAttempt>> {
+    pub(super) fn next(request: &WireRequest) -> Option<Result<WireResponse, FailedAttempt>> {
         STATE.with(|state| {
             let mut state = state.borrow_mut();
             let state = state.as_mut()?;
             state.attempts += 1;
+            state.sent.push(SentRequest {
+                url: request.url.clone(),
+                headers: request.headers.clone(),
+            });
             let outcome = state
                 .outcomes
                 .pop_front()

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -255,23 +255,36 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     /// The pinned context resolves the path; it does not have to survive the
     /// read. The reference names one immutable object at a random id, so no
     /// commit landing mid-read can change the bytes under a reader.
+    ///
+    /// `start_offset` skips bytes the caller already holds; the stream still
+    /// verifies the whole object, so those bytes reach it through
+    /// [`FileContentStream::fold_resumed_prefix`] before it fetches
+    /// anything.
     pub async fn read_file_stream(
         &self,
         path: impl AsRef<str>,
         context: &RuntimeReadContext,
         chunk_bytes: NonZeroU64,
+        start_offset: u64,
     ) -> Result<FileContentStream<S>>
     where
         S: Clone,
     {
         let view = self.load_read_view(context).await?;
         let (entry, content_ref) = view.resolve_file_content(path.as_ref()).await?;
+        if start_offset > content_ref.size_bytes {
+            return Err(CoreError::ResumeOffsetOutOfRange {
+                start_offset,
+                size_bytes: content_ref.size_bytes,
+            });
+        }
         Ok(FileContentStream::open(
             self.store.clone(),
             view.content_store_id(),
             entry,
             content_ref,
             chunk_bytes,
+            start_offset,
         )
         .await?)
     }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -92,6 +92,19 @@ pub enum CoreError {
     /// splits the batch; nothing was read.
     #[error("asked for {requested} items, over the {max} one batch answers")]
     BatchTooLarge { requested: usize, max: usize },
+    /// A streamed read was asked to start past the end of the content it
+    /// reads. Nothing was read.
+    #[error("cannot start a read at offset {start_offset} of {size_bytes}-byte content")]
+    ResumeOffsetOutOfRange { start_offset: u64, size_bytes: u64 },
+    /// A streamed read that starts past zero was driven before the bytes it
+    /// skipped were folded into its verification. Verification covers the
+    /// whole object, so it cannot begin until the caller has handed over
+    /// what it already holds. Nothing was read.
+    #[error(
+        "a read resumed at offset {start_offset} was given {folded} bytes of what it skipped; \
+         verification covers the whole object, so all of them are needed first"
+    )]
+    ResumePrefixIncomplete { start_offset: u64, folded: u64 },
     #[error("expected file at `{path}` but found `{kind}`")]
     ExpectedFile { path: String, kind: InodeKind },
     #[error("expected directory at `{path}` but found `{kind}`")]
@@ -371,6 +384,8 @@ impl CoreError {
             | CoreError::InvalidUploadContent(_)
             | CoreError::InvalidCursor(_)
             | CoreError::BatchTooLarge { .. }
+            | CoreError::ResumeOffsetOutOfRange { .. }
+            | CoreError::ResumePrefixIncomplete { .. }
             | CoreError::NonDirectoryPathComponent(_) => ErrorCode::InvalidRequest,
             CoreError::PathNotFound(_) => ErrorCode::PathNotFound,
             CoreError::RevisionNotFound { .. } => ErrorCode::RevisionNotFound,

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -268,6 +268,14 @@ pub struct FileContentStream<S> {
     chunk_bytes: NonZeroU64,
     /// Offset the next ranged read starts at; also how much has been read.
     next_offset: u64,
+    /// Offset this stream was opened at. Zero for a read of the whole
+    /// object, and the length of what the caller already holds for a
+    /// resumed one.
+    resumed_from: u64,
+    /// How much of that head start the caller has folded in so far. The
+    /// stream fetches nothing until this reaches `resumed_from`, because
+    /// the verdict is over the whole object either way.
+    prefix_folded: u64,
     /// The checksum the complete object must produce, folded so far.
     digest: StreamingChecksum,
     /// The value `digest` is closed against.
@@ -287,12 +295,16 @@ impl<S: ObjectStore> FileContentStream<S> {
     /// wrong-sized object fail without a partial answer having been handed
     /// out. The reference's checksum algorithm is resolved here for the same
     /// reason.
+    /// `start_offset` is where the caller already is: bytes below it are
+    /// never fetched, and [`Self::fold_resumed_prefix`] is how they still
+    /// reach the digest.
     pub(crate) async fn open(
         store: S,
         content_store_id: &ContentStoreId,
         entry: AuthoritativePathEntry,
         content_ref: ContentRef,
         chunk_bytes: NonZeroU64,
+        start_offset: u64,
     ) -> Result<Self, DurableContentValidationError> {
         let object_key = content_object_key_for_ref(content_store_id, &content_ref)?;
         validate_content_size(&store, &object_key, &content_ref).await?;
@@ -309,11 +321,26 @@ impl<S: ObjectStore> FileContentStream<S> {
             object_key,
             content_ref,
             chunk_bytes,
-            next_offset: 0,
+            next_offset: start_offset,
+            resumed_from: start_offset,
+            prefix_folded: 0,
             digest,
             expected,
             completion: None,
         })
+    }
+
+    /// Hands the stream part of what the caller already holds, in order,
+    /// from the object's first byte.
+    ///
+    /// A resumed read still reports on the whole object, so the bytes it
+    /// will never fetch have to be folded into the same digest that closes
+    /// over the ones it does. Feeding the wrong bytes fails verification at
+    /// the end, which is exactly right: the reference is the authority on
+    /// what the object holds, not the partial copy on the caller's disk.
+    pub fn fold_resumed_prefix(&mut self, bytes: &[u8]) {
+        self.digest.update(bytes);
+        self.prefix_folded = self.prefix_folded.saturating_add(bytes.len() as u64);
     }
 
     /// The authoritative metadata entry the path resolved to.
@@ -330,14 +357,22 @@ impl<S: ObjectStore> FileContentStream<S> {
     ///
     /// `Ok(None)` is returned only after the folded digest and the byte count
     /// agree with the reference; a mismatch fails this call instead. Chunks
-    /// arrive in order, and every one but the last is exactly the chunk size
-    /// this stream was opened with.
+    /// arrive in order from wherever the stream started, and every one but
+    /// the last is exactly the chunk size this stream was opened with.
     ///
     /// This is the method callers outside this crate hold, so it speaks the
     /// crate's error type: a content object that disagrees with its reference
     /// is namespace corruption, and it is classified as such here rather than
-    /// at every call site.
+    /// at every call site. A resumed stream that has not been told what it
+    /// skipped is the caller's own mistake instead, and says so before
+    /// anything is fetched.
     pub async fn next_chunk(&mut self) -> Result<Option<Bytes>, CoreError> {
+        if self.prefix_folded != self.resumed_from {
+            return Err(CoreError::ResumePrefixIncomplete {
+                start_offset: self.resumed_from,
+                folded: self.prefix_folded,
+            });
+        }
         Ok(self.next_verified_chunk().await?)
     }
 
@@ -394,9 +429,11 @@ impl<S: ObjectStore> FileContentStream<S> {
     ///
     /// The byte count needs no check of its own here. Every chunk is required
     /// to arrive exactly as long as it was asked for, and no chunk is asked
-    /// for past the declared size, so reaching this point *is* having read
-    /// exactly `size_bytes` — checked against the object's own length by the
-    /// head request [`Self::open`] made.
+    /// for past the declared size, so reaching this point *is* having folded
+    /// exactly `size_bytes` — the resumed head start, which the first
+    /// [`Self::next_chunk`] refuses to start without, plus everything
+    /// fetched from it to the end. The object's own length was checked
+    /// against the reference by the head request [`Self::open`] made.
     fn completion(&mut self) -> Result<(), DurableContentValidationError> {
         let verdict = match self.completion.take() {
             Some(verdict) => verdict,
@@ -1092,12 +1129,22 @@ mod tests {
         content_store_id: &ContentStoreId,
         content_ref: &ContentRef,
     ) -> Result<FileContentStream<S>, DurableContentValidationError> {
+        open_stream_at(store, content_store_id, content_ref, 0).await
+    }
+
+    async fn open_stream_at<S: ObjectStore>(
+        store: S,
+        content_store_id: &ContentStoreId,
+        content_ref: &ContentRef,
+        start_offset: u64,
+    ) -> Result<FileContentStream<S>, DurableContentValidationError> {
         FileContentStream::open(
             store,
             content_store_id,
             test_entry(),
             content_ref.clone(),
             test_chunk_bytes(),
+            start_offset,
         )
         .await
     }
@@ -1143,6 +1190,96 @@ mod tests {
         while stream.next_chunk().await.expect("chunk").is_some() {}
         assert!(stream.next_chunk().await.expect("verified end").is_none());
         assert!(stream.next_chunk().await.expect("verified end").is_none());
+    }
+
+    /// A resumed read fetches only what it does not already have, and still
+    /// closes its verdict over the whole object.
+    #[tokio::test]
+    async fn a_resumed_read_fetches_only_the_rest_and_verifies_all_of_it() {
+        let (_temp_dir, inner, content_store_id) = test_store();
+        let store = CountingStore::new(inner, KeyPredicate::content_blob());
+        let bytes = payload(3 * TEST_CHUNK_BYTES as usize);
+        let content_ref = content_ref(&bytes);
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+
+        let held = 2 * TEST_CHUNK_BYTES as usize;
+        store.reset();
+        let mut stream = open_stream_at(&store, &content_store_id, &content_ref, held as u64)
+            .await
+            .expect("open stream");
+        stream.fold_resumed_prefix(&bytes[..held]);
+        let mut fetched = Vec::new();
+        while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
+            fetched.extend_from_slice(&chunk);
+        }
+        assert_eq!(
+            fetched,
+            bytes[held..],
+            "a resumed read hands back only what it fetched"
+        );
+        assert_eq!(
+            store.count(OperationClass::Read),
+            1,
+            "one chunk was left to fetch, so one ranged read happened"
+        );
+    }
+
+    /// The prefix is part of the verdict, not a formality: bytes that are
+    /// not the object's fail the read at its end, and a stream driven before
+    /// it has them refuses to fetch anything at all.
+    #[tokio::test]
+    async fn a_resumed_read_holds_the_prefix_to_the_same_verdict() {
+        let (_temp_dir, inner, content_store_id) = test_store();
+        let store = CountingStore::new(inner, KeyPredicate::content_blob());
+        let bytes = payload(2 * TEST_CHUNK_BYTES as usize);
+        let content_ref = content_ref(&bytes);
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+        let held = TEST_CHUNK_BYTES as usize;
+
+        store.reset();
+        let mut unfed = open_stream_at(&store, &content_store_id, &content_ref, held as u64)
+            .await
+            .expect("open stream");
+        let err = unfed.next_chunk().await.expect_err("prefix still owed");
+        assert!(
+            matches!(
+                err,
+                CoreError::ResumePrefixIncomplete {
+                    start_offset,
+                    folded: 0
+                } if start_offset == held as u64
+            ),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            store.count(OperationClass::Read),
+            0,
+            "nothing is fetched until the stream has what it skipped"
+        );
+
+        let mut wrong = open_stream_at(&store, &content_store_id, &content_ref, held as u64)
+            .await
+            .expect("open stream");
+        wrong.fold_resumed_prefix(&vec![0u8; held]);
+        let verdict = loop {
+            match wrong.next_chunk().await {
+                Ok(Some(_)) => continue,
+                // A verified end is the only thing that reports `None`, so
+                // this arm would mean bad bytes had been accepted.
+                #[allow(clippy::panic, reason = "the failure this test exists to catch")]
+                Ok(None) => panic!("a prefix that is not the object's verified"),
+                Err(error) => break error,
+            }
+        };
+        assert!(
+            matches!(
+                verdict,
+                CoreError::DurableContent(
+                    DurableContentValidationError::ContentChecksumMismatch { .. }
+                )
+            ),
+            "a prefix that is not the object's fails the whole read: {verdict}"
+        );
     }
 
     /// An empty file has nothing to fetch and still verifies: the digest of

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -180,6 +180,12 @@ impl FsReader {
     ///
     /// The deployment's buffered-read cap does not apply here. That cap
     /// bounds what one call materializes, and this call materializes a chunk.
+    ///
+    /// [`ReadFileStreamOptions::start_offset`] resumes a read the caller
+    /// already began. Verification stays over the whole object, so a
+    /// resumed stream refuses to fetch anything until it has been handed
+    /// the bytes below its start through
+    /// [`FileContentStream::fold_resumed_prefix`].
     pub async fn read_file_stream(
         &self,
         namespace_id: &NamespaceId,
@@ -188,7 +194,12 @@ impl FsReader {
     ) -> Result<FileContentStream<SharedObjectStore>> {
         let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
         let stream = engine
-            .read_file_stream(absolute_path, &read_context, options.chunk_bytes)
+            .read_file_stream(
+                absolute_path,
+                &read_context,
+                options.chunk_bytes,
+                options.start_offset,
+            )
             .await?;
         self.core
             .inner

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -135,6 +135,15 @@ pub struct ReadFileStreamOptions {
     /// declares its own. Non-zero by type, so there is no chunk size that
     /// makes no progress.
     pub chunk_bytes: NonZeroU64,
+    /// Where the read starts, for a caller that already holds the bytes
+    /// below it — an interrupted download picking up where it stopped.
+    ///
+    /// The read still reports on the whole object, so a nonzero offset
+    /// obliges the caller to hand over what it holds through
+    /// [`FileContentStream::fold_resumed_prefix`](loonfs_core::FileContentStream::fold_resumed_prefix)
+    /// before driving the stream. Zero reads from the first byte and asks
+    /// nothing of the caller.
+    pub start_offset: u64,
 }
 
 impl Default for ReadFileStreamOptions {
@@ -142,6 +151,7 @@ impl Default for ReadFileStreamOptions {
         Self {
             chunk_bytes: NonZeroU64::new(loonfs_core::CONTENT_READ_CHUNK_BYTES)
                 .expect("the default read chunk size is non-zero"),
+            start_offset: 0,
         }
     }
 }

--- a/crates/loonfs/tests/it/streamed_read.rs
+++ b/crates/loonfs/tests/it/streamed_read.rs
@@ -35,6 +35,7 @@ fn payload(len: usize) -> Vec<u8> {
 fn chunked() -> ReadFileStreamOptions {
     ReadFileStreamOptions {
         chunk_bytes: NonZeroU64::new(CHUNK_BYTES).expect("non-zero chunk size"),
+        ..ReadFileStreamOptions::default()
     }
 }
 


### PR DESCRIPTION
Fix: interrupted transfers resume instead of restarting from byte zero. It stacks on the progress PR.

Downloads resume automatically (both profiles). The partial file gets a deterministic name (`.{name}.loonfs-partial`) plus a small sidecar recording what is being fetched: content id, size, whole-file sha256, revision. On the next `get`, if the sidecar matches the content the command resolves now — content ids are immutable identities, so a match means the same bytes — the digest is folded over the existing partial bytes and the transfer continues from that offset: embedded through a new `start_offset` on the streaming read, remote through `Range: bytes=N-` on a fresh grant (the presigned URL's signature ignores Range, pinned in #471). Anything stale or unreadable starts fresh, silently (`deny_unknown_fields` on the sidecar makes an unreadable note mean start-over). Verification stays end-to-end: the stream refuses to fetch until the prefix is folded, and a wrong prefix fails with the checksum mismatch. Atomicity survives the deterministic naming — both files ride temp-path guards, so a failed run still cleans up and installs never clobber.

Uploads resume when a durable session exists: remote direct multipart: After each completed part, the CLI journals `{upload_id, part size, parts with etags, source size+mtime}` under `$XDG_STATE_HOME/loonfs/uploads/` (legacy fallback beside the config file). A rerun of the same put finds the journal, checks the source identity, and asks the server via `read_upload_status`: an Open session uploads only the missing parts; a Completed session skips straight to commit with the returned content ref and token; a vanished session or changed source deletes the journal and starts fresh. The journal is removed on successful commit.

