### PR TITLE
fix(server): root rejections carry their operation index

### DIFF
--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -104,7 +104,7 @@ pub mod limits;
 /// reference model; `loonfs` reaches metadata only through the seams above.
 pub mod metadata;
 /// Path parsing and current-state resolution. Consumed by `loonfs`'s write
-/// path (`ensure_mutation_path`, `parse_mutation_path`).
+/// path (`parse_mutation_path`).
 pub mod path;
 /// The wall-clock boundary durable timestamps are stamped at. Consumed by
 /// `loonfs`, whose mutation contexts and maintenance clock stamp from the

--- a/crates/loonfs-core/src/path/helpers.rs
+++ b/crates/loonfs-core/src/path/helpers.rs
@@ -24,8 +24,11 @@ pub fn parse_mutation_path(absolute_path: &str) -> Result<AbsolutePath> {
 ///
 /// The absolute-path grammar is carried by the type; this rejects the root,
 /// which is readable but cannot be mutated. Intents can be built from parsed
-/// paths directly, so planning re-asserts this invariant.
-pub fn ensure_mutation_path(path: &AbsolutePath) -> Result<()> {
+/// paths directly, so planning is where the invariant is enforced, and
+/// planning is the only place: a caller that rejects the root ahead of the
+/// planners answers for the request rather than for the operation that
+/// named it.
+pub(crate) fn ensure_mutation_path(path: &AbsolutePath) -> Result<()> {
     if path.is_root() {
         return Err(CoreError::RootMutationForbidden);
     }

--- a/crates/loonfs-core/src/path/mod.rs
+++ b/crates/loonfs-core/src/path/mod.rs
@@ -4,4 +4,4 @@ pub(crate) mod helpers;
 pub(crate) mod read;
 pub(crate) mod write;
 
-pub use helpers::{ensure_mutation_path, parse_mutation_path};
+pub use helpers::parse_mutation_path;

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -11,9 +11,7 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use loonfs::publish::{
-    ensure_mutation_path, CommitCandidate, CommitRequest, ContentPreparationError,
-};
+use loonfs::publish::{CommitCandidate, CommitRequest, ContentPreparationError};
 use loonfs::{payload_class, ErrorCode, ListChangesOptions, TraceStoreKind};
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -23,7 +21,7 @@ use loonfs_api::ApiError;
 use loonfs_api::{
     decode_cursor,
     v0::{ChangesResponse, CommitResponse as ApiCommitResponse},
-    AbsolutePath, CommitRequest as ApiCommitRequest, DirectoryPageCursor, FileRevisionsPageCursor,
+    CommitRequest as ApiCommitRequest, DirectoryPageCursor, FileRevisionsPageCursor,
     FilesystemOperation, LimitError, ListFileRevisionsResponse, ListTrashResponse, PageCursorError,
     PageRequest, PaginationPolicy, RevisionNo,
 };
@@ -300,23 +298,6 @@ pub(super) async fn list_file_revisions(
     Ok(Json(response))
 }
 
-/// Every path an operation would mutate.
-fn mutation_paths(operation: &FilesystemOperation) -> Vec<&AbsolutePath> {
-    match operation {
-        FilesystemOperation::CreateDirectory { path, .. }
-        | FilesystemOperation::PutFile { path, .. }
-        | FilesystemOperation::DeletePath { path, .. }
-        | FilesystemOperation::Undelete { path, .. }
-        | FilesystemOperation::RestoreRevision { path, .. } => vec![path],
-        FilesystemOperation::MovePath {
-            from_path, to_path, ..
-        }
-        | FilesystemOperation::CopyPath {
-            from_path, to_path, ..
-        } => vec![from_path, to_path],
-    }
-}
-
 #[cfg_attr(
     feature = "openapi",
     utoipa::path(
@@ -324,7 +305,7 @@ fn mutation_paths(operation: &FilesystemOperation) -> Vec<&AbsolutePath> {
         path = "/v0/namespaces/{namespace}/commits",
         tag = "filesystem",
         summary = "Apply a commit",
-        description = "Applies one commit: an ordered, non-empty list of path operations that commit together as one logical commit, under one commit id that makes retries idempotent. A single-operation call is the one-element case. The first operation that fails aborts the whole request and names its position in `details.operation_index`.",
+        description = "Applies one commit: an ordered, non-empty list of path operations that commit together as one logical commit, under one commit id that makes retries idempotent. A single-operation call is the one-element case. The first operation that fails aborts the whole request, and a request carrying more than one operation names that operation's position in `details.operation_index`.",
         params(("namespace" = String, Path, description = "Namespace id")),
         request_body = ApiCommitRequest,
         responses(
@@ -384,19 +365,6 @@ pub(super) async fn apply_commit(
             .await?,
         ))
     };
-    // Absolute-path grammar was validated while decoding the wire body. The
-    // root remains a valid read path but is not a legal mutation target.
-    //
-    // Every planner re-asserts this, so the pass is a duplicate; it stays
-    // because it rejects before the commit queue, and because dropping it
-    // would start attributing root rejections to an operation index the
-    // wire has never carried for them.
-    for path in operations.iter().flat_map(mutation_paths) {
-        ensure_mutation_path(path).map_err(|error| {
-            ApiResponseError::core_for_namespace(&namespace_id, error)
-                .with_commit_id(&commit_id_for_errors)
-        })?;
-    }
     let request = CommitRequest {
         commit_id,
         message,

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -363,6 +363,10 @@ async fn an_empty_operation_list_is_rejected() {
 
 /// The root is readable but never a mutation target, alone or inside a
 /// batch, and rejecting it commits nothing.
+///
+/// The planners own the rule, so the rejection is attributed exactly like
+/// every other planning failure: a batch names the operation that stopped
+/// it, a one-operation request names nothing, and both echo the commit id.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn the_root_path_is_rejected_as_a_mutation_target() {
     let temp_dir = tempdir().expect("tempdir");
@@ -405,11 +409,15 @@ async fn the_root_path_is_rejected_as_a_mutation_target() {
         } => {
             assert_eq!(status, 400);
             assert_eq!(code, ErrorCode::InvalidRequest.as_str());
+            let details = details.expect("a failed commit carries details");
             // One operation has one place to fail, so nothing disambiguates it.
             assert_eq!(
-                details.and_then(|details| details.operation_index),
-                None,
+                details.operation_index, None,
                 "a one-operation request names no position"
+            );
+            assert_eq!(
+                details.commit_id.as_ref().map(CommitId::as_str),
+                Some("root-alone")
             );
         }
         other => unreachable!("expected invalid_request, got {other:?}"),
@@ -447,13 +455,17 @@ async fn the_root_path_is_rejected_as_a_mutation_target() {
         } => {
             assert_eq!(status, 400);
             assert_eq!(code, ErrorCode::InvalidRequest.as_str());
-            // The root check runs over the whole request before anything is
-            // planned, so this is the one rejection a batch does not attribute
-            // to a position. Every other failure names its operation.
+            let details = details.expect("a failed commit carries details");
+            // Planning stops at the root operation, so the batch names its
+            // position like it names every other failure's.
             assert_eq!(
-                details.and_then(|details| details.operation_index),
-                None,
-                "the pre-queue root check rejects the request, not an operation"
+                details.operation_index,
+                Some(1),
+                "the batch names the operation that stopped it"
+            );
+            assert_eq!(
+                details.commit_id.as_ref().map(CommitId::as_str),
+                Some("root-in-batch")
             );
         }
         other => unreachable!("expected invalid_request, got {other:?}"),
@@ -469,6 +481,33 @@ async fn the_root_path_is_rejected_as_a_mutation_target() {
             .head_seq,
         ChangeSeq(0)
     );
+
+    // The rule is the planners', so it is answered where every other path
+    // rule is: against a namespace that exists. A root mutation aimed at a
+    // namespace that does not answers for the namespace instead.
+    let unknown = harness
+        .client
+        .commit(
+            &namespace_id("missing"),
+            &CommitRequest {
+                commit_id: commit_id("root-unknown-namespace"),
+                message: None,
+                content_tokens: Vec::new(),
+                operations: vec![FilesystemOperation::CreateDirectory {
+                    path: absolute("/"),
+                    parents: false,
+                }],
+            },
+        )
+        .await
+        .expect_err("the namespace does not exist");
+    match unknown {
+        ClientError::Api { status, code, .. } => {
+            assert_eq!(status, 404);
+            assert_eq!(code, ErrorCode::NamespaceNotFound.as_str());
+        }
+        other => unreachable!("expected namespace_not_found, got {other:?}"),
+    }
 
     harness.server.abort();
 }

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -89,7 +89,7 @@ pub mod publish {
         MAX_COMMIT_CONTENT_TOKENS, MAX_COMMIT_EXTERNAL_CONTENT_REFS, MAX_COMMIT_MESSAGE_BYTES,
         MAX_COMMIT_OPERATIONS,
     };
-    pub use loonfs_core::path::{ensure_mutation_path, parse_mutation_path};
+    pub use loonfs_core::path::parse_mutation_path;
     pub use loonfs_core::publish::{
         CommitCandidate, CommitRequest, ContentPreparation, ContentPreparationError,
         FilesystemOperation, PreparedContent,

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1239,6 +1239,14 @@ This is the binding for the commit model in section 5.1: one `commit_id`,
 an optional `message`, and `operations` — an ordered, non-empty array of
 path operations. An empty array is `invalid_request`.
 
+The root path `/` is readable but never a mutation target. An operation that
+names it — as its own path, or as either end of a move or copy — is
+`invalid_request`. The rejection belongs to the operation rather than to the
+request, so it is attributed like every other failure: inside a batch it
+names its position, and it is decided against a namespace that exists, so a
+root mutation sent to an unknown namespace answers `namespace_not_found`
+first.
+
 Representative request:
 
 ```json

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -1125,7 +1125,7 @@
           "filesystem"
         ],
         "summary": "Apply a commit",
-        "description": "Applies one commit: an ordered, non-empty list of path operations that commit together as one logical commit, under one commit id that makes retries idempotent. A single-operation call is the one-element case. The first operation that fails aborts the whole request and names its position in `details.operation_index`.",
+        "description": "Applies one commit: an ordered, non-empty list of path operations that commit together as one logical commit, under one commit id that makes retries idempotent. A single-operation call is the one-element case. The first operation that fails aborts the whole request, and a request carrying more than one operation names that operation's position in `details.operation_index`.",
         "operationId": "apply_commit",
         "parameters": [
           {


### PR DESCRIPTION
This PR closes the last item from the review. 

Root rejections carry their operation index: The server's pre-queue root-path guard duplicated all seven planners and was the one rejection that never reported a position. The guard is now deleted; the planners answer. A batch whose root mutation sits at index N reports `details.operation_index: N` and the `operation N:` message prefix, like every other failing batch operation. The commit-id echo survives, pinned in both cases.
