### PR TITLE
fix(cli): recursive put streams each file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,7 @@ dependencies = [
  "loonfs-client",
  "loonfs-grep",
  "loonfs-objectstore",
+ "loonfs-test-support",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -37,6 +37,9 @@ walkdir.workspace = true
 [dev-dependencies]
 ureq.workspace = true
 insta = { version = "1.39", features = ["json"] }
+# The store wrappers that make "this transfer never held the file" a
+# checkable claim rather than a comment.
+loonfs-test-support = { path = "../loonfs-test-support" }
 
 [lints]
 workspace = true

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -401,6 +401,12 @@ Interrupted transfers
   proxied uploads, and `loonfs put -` keep no record: there is no session
   to rejoin, and a pipe cannot be read a second time.
 
+  A tree resumes file by file, on the same terms. Each file of a `put -r`
+  keeps its own record, named by the profile, namespace, remote path, and
+  local file that decide which upload it is, so rerunning the command
+  picks up whichever files were interrupted and re-uploads none that
+  committed.
+
 Transfer progress
   `loonfs get` and `loonfs put`, one file or a whole tree, say where they
   have got to while they run. Never on stdout, which carries either the
@@ -441,7 +447,9 @@ Transfer progress
       starts, with `bytes_done` as it stood at that moment. `committing`
       says an upload's payload has been read and the commit is what is
       left; `resuming` says a download picked up bytes an interrupted run
-      left behind, and `bytes_done` is how many.
+      left behind, and `bytes_done` is how many. Only a transfer of one
+      file reports these: a tree has several files in flight at once, so
+      no one file's stretch is the operation's.
 
   `op` is `get` or `put`. --no-progress silences both forms, and neither is
   produced for `loonfs cat` or for `loonfs get ... -`, which hand the file
@@ -473,7 +481,10 @@ Behavior notes
 
   `loonfs put` reads a large file or a pipe once, a piece at a time, so what
   it costs in memory follows the transfer and not the payload's size; a
-  file small enough to hold is still uploaded in one request
+  file small enough to hold is still uploaded in one request. `put -r`
+  uploads every file of a tree the same way, so a tree holding a file
+  larger than this process could hold costs no more memory than a tree of
+  small ones
 
   If `loonfs get` omits the local destination, the CLI writes to `./<remote-filename>`
 
@@ -506,9 +517,9 @@ Behavior notes
   How much of a transfer is watchable follows how it travels. A streamed or
   direct download reports bytes as they land, and so does a streamed
   upload; a proxied download and a small buffered upload are one request
-  each, so they go from nothing to done in one step. A recursive put
-  uploads one file per request, so a tree's byte count advances a whole
-  file at a time
+  each, so they go from nothing to done in one step. A tree is the same
+  file by file: its byte count moves through a large file as that file is
+  read, and advances a whole file at a time over the small ones
 
   An embedded profile's edit latency grows with the WAL tail between
   maintenance passes: every write appends, and reads replay what has not

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -21,7 +21,8 @@ use crate::progress::{ProgressOp, ProgressReporter};
 use crate::uploads::{SourceIdentity, UploadJournal};
 use loonfs_api::v0::UploadSessionStatus;
 use loonfs_api::{
-    CommitId, DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeKind, RevisionNo,
+    CommitId, CommitResponse, DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeKind,
+    RevisionNo,
 };
 use loonfs_client::{CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions};
 use std::fs;
@@ -688,10 +689,6 @@ async fn run_filesystem_put_stdin(
 }
 
 /// Writes one payload and renders what the commit did.
-///
-/// The payload decides how it travels: one that is small enough to hold
-/// goes as bytes, and one that is large — or that cannot say how large it
-/// is — is read once, in pieces, whichever transport the profile selects.
 async fn commit_put(
     kind: CommandKind,
     context: &CommandContext,
@@ -708,45 +705,8 @@ async fn commit_put(
     ));
     progress.expect(size_bytes, Some(1));
     progress.file_started(spec.absolute_path().as_str(), size_bytes);
-    // Only a payload large enough to travel in parts has anything an
-    // interruption could leave half-done, and only a source that can be
-    // opened twice can pick it up: a pipe is gone once it is read.
-    let journal = match payload.resumable_source() {
-        Some(local_path) => resume_journal(context, spec, local_path),
-        None => None,
-    };
-    if let Some(journal) = journal.as_ref() {
-        if let Some(committed) =
-            commit_a_finished_upload(kind, context, spec, options, journal, &progress).await?
-        {
-            return Ok(committed);
-        }
-    }
-    let result = match payload.holdable_file() {
-        // A payload small enough to hold travels as one request, so there is
-        // no midpoint to report: it is read, and then the commit is all
-        // that is left.
-        Some(path) => {
-            let bytes = read_whole_file(path)
-                .await
-                .map_err(|error| context.fail(kind, error))?;
-            progress.advance(bytes.len() as u64);
-            progress.phase("committing");
-            context.target.put_file_bytes(spec, &bytes, options).await
-        }
-        None => {
-            context
-                .target
-                .put_file_stream(spec, payload, options, &progress, journal.as_ref())
-                .await
-        }
-    };
+    let result = put_payload(context, spec, payload, options, &progress).await;
     if result.is_ok() {
-        // The record exists to survive an interruption, and this upload was
-        // not interrupted.
-        if let Some(journal) = journal.as_ref() {
-            journal.forget();
-        }
         let moved = progress.bytes_done();
         progress.file_finished(spec.absolute_path().as_str(), moved);
     }
@@ -764,6 +724,67 @@ async fn commit_put(
             inode_id: None,
         },
     })
+}
+
+/// Uploads one payload and commits it at `spec`: the one way this CLI
+/// moves a file, whether the command named it or a recursive walk found it.
+///
+/// The payload decides how it travels, and nothing else does. One small
+/// enough to hold goes as bytes; one that is large — or that cannot say how
+/// large it is — is read once, in pieces, whichever transport the profile
+/// selects, so what the upload costs in memory follows the transport's
+/// window and not the file's length. Where a payload travels in parts, an
+/// interrupted transfer of it is picked up rather than started over.
+///
+/// `progress` counts what the payload gives up. A tree hands the same
+/// reporter to every file it is uploading, which is why the counting lives
+/// here rather than in the callers.
+pub(super) async fn put_payload(
+    context: &CommandContext,
+    spec: &NamespacePath,
+    payload: &LocalPayload,
+    options: &PutFileOptions,
+    progress: &Arc<ProgressReporter>,
+) -> Result<CommitResponse, CliError> {
+    // Only a payload large enough to travel in parts has anything an
+    // interruption could leave half-done, and only a source that can be
+    // opened twice can pick it up: a pipe is gone once it is read.
+    let journal = match payload.resumable_source() {
+        Some(local_path) => resume_journal(context, spec, local_path),
+        None => None,
+    };
+    if let Some(journal) = journal.as_ref() {
+        if let Some(committed) =
+            commit_a_finished_upload(context, spec, options, journal, progress).await?
+        {
+            return Ok(committed);
+        }
+    }
+    let result = match payload.holdable_file() {
+        // A payload small enough to hold travels as one request, so there is
+        // no midpoint to report: it is read, and then the commit is all
+        // that is left.
+        Some(path) => {
+            let bytes = read_whole_file(path).await?;
+            progress.advance(bytes.len() as u64);
+            progress.phase("committing");
+            context.target.put_file_bytes(spec, &bytes, options).await
+        }
+        None => {
+            context
+                .target
+                .put_file_stream(spec, payload, options, progress, journal.as_ref())
+                .await
+        }
+    };
+    if result.is_ok() {
+        // The record exists to survive an interruption, and this upload was
+        // not interrupted.
+        if let Some(journal) = journal.as_ref() {
+            journal.forget();
+        }
+    }
+    result.map_err(CliError::from)
 }
 
 /// The record an interrupted upload of this payload would have left, or
@@ -793,13 +814,12 @@ fn resume_journal(
 /// aborted, or gone — leaves this to the ordinary upload, which the
 /// recorded parts make cheap anyway.
 async fn commit_a_finished_upload(
-    kind: CommandKind,
     context: &CommandContext,
     spec: &NamespacePath,
     options: &PutFileOptions,
     journal: &UploadJournal,
     progress: &ProgressReporter,
-) -> Result<Option<CommandOutput>, CommandFailure> {
+) -> Result<Option<CommitResponse>, CliError> {
     let Some(resume) = journal.resume() else {
         return Ok(None);
     };
@@ -827,19 +847,7 @@ async fn commit_a_finished_upload(
     if result.is_ok() {
         journal.forget();
     }
-    progress.finish();
-    let result = result.map_err(|error| context.fail(kind, error))?;
-    Ok(Some(CommandOutput {
-        kind,
-        profile: Some(context.profile_name.clone()),
-        mode: Some(context.mode.clone()),
-        data: CommandData::FileMutation {
-            target: render_target(&context.namespace, spec.absolute_path()),
-            committed_seq: result.committed_seq,
-            commit_id: result.commit_id,
-            inode_id: None,
-        },
-    }))
+    Ok(Some(result?))
 }
 
 fn put_file_options(args: &FilesystemPutArgs) -> Result<PutFileOptions, CliError> {

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -13,6 +13,7 @@ use super::context::CommandContext;
 use super::output::{CommandData, CommandFailure, CommandOutput, TreeTransferFailure};
 use crate::args::{CommandKind, RuntimeBehavior};
 use crate::error::CliError;
+use crate::payload::LocalPayload;
 use crate::progress::{ProgressOp, ProgressReporter};
 use crate::render::write_stderr_progress;
 use futures::StreamExt;
@@ -176,41 +177,50 @@ pub(crate) async fn run_put_tree(
     ));
     progress.expect(tree_bytes(&files), Some(files.len() as u64));
     let outcomes = futures::stream::iter(files.into_iter().map(|job| {
-        let backend = &context.target;
-        let namespace = context.namespace.clone();
         let message = message.clone();
         let progress = Arc::clone(&progress);
         let remote = format!("{}/{}", remote_root.trim_end_matches('/'), job.remote);
         async move {
-            let spec = match NamespacePath::parse(namespace.as_str(), &remote) {
+            let spec = match NamespacePath::parse(context.namespace.as_str(), &remote) {
                 Ok(spec) => spec,
                 Err(error) => return (remote, Err(CliError::invalid_input(error.to_string()))),
             };
-            progress.file_started(&remote, job.size_bytes);
-            let bytes = match std::fs::read(&job.local) {
-                Ok(bytes) => bytes,
-                Err(error) => return (remote, Err(CliError::io_for_path(&job.local, error))),
+            // The walk states a file's length when the filesystem gave it
+            // one, and that length is what decides how the payload travels.
+            // A file that still cannot state one fails on its own rather
+            // than taking the tree with it.
+            let size_bytes = match job.size_bytes {
+                Some(size_bytes) => size_bytes,
+                None => match std::fs::metadata(&job.local) {
+                    Ok(metadata) => metadata.len(),
+                    Err(error) => return (remote, Err(CliError::io_for_path(&job.local, error))),
+                },
             };
-            let result = backend
-                .put_file_bytes(
-                    &spec,
-                    &bytes,
-                    &PutFileOptions {
-                        behavior,
-                        commit_id: None,
-                        message: message.clone(),
-                        expected_revision_no: None,
-                    },
-                )
-                .await
-                .map(|_| spec_target(&spec))
-                .map_err(CliError::from);
-            // One file of a tree uploads as a single request, so the tree's
-            // count advances a whole file at a time: what it reports is
-            // files stored, measured in bytes.
+            progress.file_started(&remote, Some(size_bytes));
+            // One file of a tree travels exactly as a single `put` of it
+            // would: held whole while it is small enough to hold, read once
+            // in pieces past that, and resumed from its own record where a
+            // single put would resume. So a tree holding a file this process
+            // could not hold costs no more memory than a tree of small ones,
+            // and its bytes are counted as they are read rather than a whole
+            // file at a time.
+            let payload = LocalPayload::file(&job.local, size_bytes);
+            let result = super::fs::put_payload(
+                context,
+                &spec,
+                &payload,
+                &PutFileOptions {
+                    behavior,
+                    commit_id: None,
+                    message,
+                    expected_revision_no: None,
+                },
+                &progress,
+            )
+            .await
+            .map(|_| spec_target(&spec));
             if result.is_ok() {
-                progress.advance(bytes.len() as u64);
-                progress.file_finished(&remote, bytes.len() as u64);
+                progress.file_finished(&remote, size_bytes);
             }
             (remote, result)
         }
@@ -610,4 +620,135 @@ async fn walk_remote_tree(
         }
     }
     Ok(tree)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::args::RuntimeBehavior;
+    use crate::progress::ProgressMode;
+    use crate::resolve::{EmbeddedTarget, ResolvedTarget};
+    use loonfs::{SharedObjectStore, TraceStoreKind};
+    use loonfs_api::NamespaceId;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
+    use loonfs_objectstore::PROVIDER_MULTIPART_PART_BYTES;
+    use loonfs_test_support::stores::BufferWatchStore;
+
+    /// A file of two transfer parts and a bit: enough that holding it whole
+    /// would show up plainly against holding one part of it, and enough that
+    /// the end of the payload is discovered rather than computed.
+    const LARGE_FILE_BYTES: usize = 2 * PROVIDER_MULTIPART_PART_BYTES as usize + 4_096;
+    const SMALL_FILE: &[u8] = b"small enough to hold";
+
+    fn payload(len: usize) -> Vec<u8> {
+        (0..len).map(|offset| (offset % 251) as u8).collect()
+    }
+
+    /// A run nobody is watching: the accounting still happens, it is just
+    /// not reported, which is what a test wants of it.
+    fn unwatched() -> RuntimeBehavior {
+        RuntimeBehavior {
+            json: true,
+            no_input: true,
+            interactive: false,
+            progress: ProgressMode::Off,
+        }
+    }
+
+    /// A tree upload against a store that reports every payload buffer it is
+    /// handed, and the namespace to upload into.
+    async fn watched_context(
+        store_dir: &std::path::Path,
+    ) -> (CommandContext, Arc<BufferWatchStore<LocalFsStore>>) {
+        let watched = Arc::new(BufferWatchStore::watching_content(
+            LocalFsStore::new(store_dir).expect("create local-fs store"),
+        ));
+        let store: SharedObjectStore = watched.clone();
+        let target =
+            EmbeddedTarget::over_store(store, Some("put-tree-test"), TraceStoreKind::LocalFs)
+                .await
+                .expect("build embedded target");
+        let namespace = NamespaceId::parse("demo").expect("valid namespace id");
+        let context = CommandContext {
+            profile_name: "default".to_owned(),
+            mode: "embedded".to_owned(),
+            namespace: namespace.clone(),
+            target: ResolvedTarget::Embedded(Box::new(target)),
+        };
+        context
+            .target
+            .create_namespace(&namespace)
+            .await
+            .expect("create namespace");
+        (context, watched)
+    }
+
+    /// A tree's largest file is never held whole. Each file travels the way
+    /// a single `put` of it would, so the payload of one too large to hold
+    /// crosses the store boundary in transfer parts — and the measurement is
+    /// retention at that boundary, not a reading of the process.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_recursive_put_never_holds_a_whole_file() {
+        let store_dir = tempfile::tempdir().expect("tempdir");
+        let (context, watched) = watched_context(store_dir.path()).await;
+
+        let tree = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tree.path().join("docs")).expect("create tree dirs");
+        let large = payload(LARGE_FILE_BYTES);
+        std::fs::write(tree.path().join("docs/big.bin"), &large).expect("write large file");
+        std::fs::write(tree.path().join("small.txt"), SMALL_FILE).expect("write small file");
+
+        let output = match run_put_tree(
+            CommandKind::FilesystemPut,
+            &context,
+            tree.path(),
+            "/up",
+            false,
+            None,
+            unwatched(),
+        )
+        .await
+        {
+            Ok(output) => output,
+            Err(failure) => unreachable!("recursive put failed: {:?}", failure.error),
+        };
+        let CommandData::TreeTransfer {
+            files, failures, ..
+        } = output.data
+        else {
+            unreachable!("a recursive put reports a tree transfer");
+        };
+        assert_eq!(files, 2);
+        assert!(failures.is_empty(), "{failures:?}");
+
+        // Read the peaks before reading anything back: a download crosses
+        // the same boundary and would count as payload too.
+        let peaks = watched.peaks();
+        assert_eq!(
+            peaks.total_bytes,
+            (LARGE_FILE_BYTES + SMALL_FILE.len()) as u64,
+            "every payload byte crossed the store boundary exactly once"
+        );
+        assert!(
+            peaks.largest_buffer_bytes <= PROVIDER_MULTIPART_PART_BYTES,
+            "no single buffer may exceed one part: largest was {}",
+            peaks.largest_buffer_bytes
+        );
+        assert!(
+            peaks.peak_live_bytes <= PROVIDER_MULTIPART_PART_BYTES + SMALL_FILE.len() as u64,
+            "the tree held {} bytes at once, past one part of its largest file",
+            peaks.peak_live_bytes
+        );
+
+        let spec = NamespacePath::parse("demo", "/up/docs/big.bin").expect("valid namespace path");
+        assert_eq!(
+            context
+                .target
+                .get_file_bytes(&spec)
+                .await
+                .expect("read the uploaded file back"),
+            large,
+            "the file that landed is the file that was walked"
+        );
+    }
 }

--- a/crates/loonfs-cli/src/progress.rs
+++ b/crates/loonfs-cli/src/progress.rs
@@ -109,6 +109,13 @@ impl ProgressState {
             done.saturating_mul(100) / total
         })
     }
+
+    /// Whether this operation covers more than one file — a tree, or an
+    /// operation that never said how many. What one file's progress means
+    /// for the whole depends on it.
+    fn many_files(&self) -> bool {
+        self.files_total.is_none_or(|total| total > 1)
+    }
 }
 
 /// Counts one operation's bytes and says so, at a rate a human or an agent
@@ -251,12 +258,20 @@ impl ProgressReporter {
     /// A stretch where time passes and bytes do not — the commit a finished
     /// upload waits on, or the head start a resumed download begins from.
     /// Emitted at the transition, not on a timer.
+    ///
+    /// A transfer of several files reports none of these. Each file of a
+    /// tree passes through the same stretches, several at a time, so one
+    /// file entering its commit says nothing about where the operation is —
+    /// and on a terminal it would leave the line flickering between the two.
     pub(crate) fn phase(&self, phase: &str) {
         if !self.enabled() {
             return;
         }
-        let now_ms = self.timer.monotonic_now_ms();
         let mut state = self.lock();
+        if state.many_files() {
+            return;
+        }
+        let now_ms = self.timer.monotonic_now_ms();
         match self.mode {
             ProgressMode::Events => self.emit_event(&Event::Phase {
                 kind: "phase",
@@ -330,7 +345,7 @@ impl ProgressReporter {
     }
 
     fn human_line(&self, state: &ProgressState, rate_bps: u64) -> String {
-        let tree = state.files_total.is_none_or(|total| total > 1);
+        let tree = state.many_files();
         let mut line = format!("{} {}", self.op.as_str(), self.path);
         if let Some(files_total) = state.files_total.filter(|_| tree) {
             line.push_str(&format!("  {}/{files_total} files", state.files_done));

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -138,16 +138,29 @@ impl EmbeddedTarget {
         store_config: &StoreConfig,
         writer_id: Option<&str>,
     ) -> Result<Self, CliError> {
-        let writer_id = writer_id
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(default_writer_id);
-        let trace_store_kind = TraceStoreKind::from(store_config.kind());
         // One command drives all three handles from one runtime, so they
         // deliberately share one provider client.
         let store: SharedObjectStore = store_config
             .configured_object_store()
             .map_err(|err| CliError::invalid_config(format!("invalid store config: {err}")))?
             .into_shared();
+        Self::over_store(store, writer_id, TraceStoreKind::from(store_config.kind())).await
+    }
+
+    /// Opens the runtime handles over a store the caller already holds.
+    ///
+    /// [`Self::new`] opens the profile's configured store and hands it here.
+    /// It is a seam rather than an extension point: it exists so a caller
+    /// that has to watch what crosses the store boundary can hand in a store
+    /// it wrapped.
+    pub(crate) async fn over_store(
+        store: SharedObjectStore,
+        writer_id: Option<&str>,
+        trace_store_kind: TraceStoreKind,
+    ) -> Result<Self, CliError> {
+        let writer_id = writer_id
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(default_writer_id);
         let writer = FsWriter::builder_with_store(store.clone())
             .writer_id(writer_id.clone())
             // The server's policy: publishes past the WAL threshold schedule

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -768,6 +768,10 @@ fn commit_messages_ride_the_feed_and_bind_identity() {
     );
 }
 
+/// A file small enough that a tree holding it uploads it in one request,
+/// beside one that is not.
+const SMALL_TREE_FILE: &[u8] = b"small enough to hold";
+
 /// A payload past the size at which a put stops holding its bytes whole.
 /// It is the smallest payload that exercises the streaming path at all.
 fn streaming_payload() -> Vec<u8> {
@@ -924,6 +928,12 @@ fn a_recursive_transfer_counts_files_and_bytes_for_the_whole_tree() {
     assert_eq!(last["bytes_done"], tree_bytes);
     assert_eq!(last["bytes_total"], tree_bytes);
     assert_eq!(last["files_total"], 3);
+    assert!(
+        events_of_kind(&put, "phase").is_empty(),
+        "several files of a tree are in flight at once, so no one file's \
+         commit is the operation's: {:?}",
+        events_of_kind(&put, "phase")
+    );
 
     let back = harness.temp_dir.path().join("back");
     let get = harness.run(&[
@@ -945,6 +955,169 @@ fn a_recursive_transfer_counts_files_and_bytes_for_the_whole_tree() {
     assert_eq!(last["bytes_total"], tree_bytes);
     assert_eq!(last["files_done"], 3);
     assert_eq!(last["files_total"], 3);
+}
+
+/// A tree's large file is read once, a piece at a time, exactly as a single
+/// `put` of it is. So the tree's byte count moves through that file rather
+/// than jumping over it once the whole thing has been read — which is what
+/// an upload that held each file whole could only ever report.
+#[test]
+fn a_recursive_put_counts_a_large_file_as_it_is_read() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let tree = harness.temp_dir.path().join("tree");
+    fs::create_dir_all(tree.join("docs")).expect("create tree dirs");
+    let payload = streaming_payload();
+    fs::write(tree.join("docs/big.bin"), &payload).expect("write big");
+    fs::write(tree.join("small.txt"), SMALL_TREE_FILE).expect("write small");
+    let tree_bytes = (payload.len() + SMALL_TREE_FILE.len()) as u64;
+
+    let put = harness.run(&[
+        "--json",
+        "put",
+        "-r",
+        tree.to_str().expect("utf-8 path"),
+        "/up",
+    ]);
+    assert_success(&put);
+    assert_eq!(json_data(&put)["files"], 2);
+
+    let counts: Vec<u64> = events_of_kind(&put, "progress")
+        .iter()
+        .map(|event| event["bytes_done"].as_u64().expect("a byte count"))
+        .collect();
+    // The only counts a whole-file-at-a-time upload could ever report.
+    let whole_files = [
+        0,
+        SMALL_TREE_FILE.len() as u64,
+        payload.len() as u64,
+        tree_bytes,
+    ];
+    assert!(
+        counts.iter().any(|count| !whole_files.contains(count)),
+        "a payload read in pieces reports counts taken part way through it: {counts:?}"
+    );
+    assert_eq!(counts.last(), Some(&tree_bytes), "{counts:?}");
+    assert_eq!(
+        download(&harness, "/up/docs/big.bin", "big-back.bin"),
+        payload
+    );
+}
+
+/// The same tree over the remote transport, where a large file is the one
+/// upload with parts to lose. Each file keeps its own resume record, named
+/// by the profile, namespace, remote path, and local file that decide which
+/// upload it is — and a run that committed leaves none of them behind.
+#[test]
+fn a_recursive_put_streams_a_large_file_over_the_remote_transport() {
+    let harness = Harness::new();
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "recursive-remote"));
+    assert_success(&harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "default",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]));
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let tree = harness.temp_dir.path().join("tree");
+    fs::create_dir_all(tree.join("docs")).expect("create tree dirs");
+    let payload = streaming_payload();
+    fs::write(tree.join("docs/big.bin"), &payload).expect("write big");
+    fs::write(tree.join("small.txt"), SMALL_TREE_FILE).expect("write small");
+
+    let state_home = harness.temp_dir.path().join("state");
+    let put = harness.run_with_env(
+        &[("XDG_STATE_HOME", state_home.as_path())],
+        &[
+            "--json",
+            "put",
+            "-r",
+            tree.to_str().expect("utf-8 path"),
+            "/up",
+        ],
+    );
+    assert_success(&put);
+    assert_eq!(json_data(&put)["files"], 2);
+    assert_eq!(
+        download(&harness, "/up/docs/big.bin", "big-back.bin"),
+        payload
+    );
+    assert_eq!(
+        download(&harness, "/up/small.txt", "small-back.txt"),
+        SMALL_TREE_FILE
+    );
+
+    let records: Vec<PathBuf> = fs::read_dir(state_home.join("loonfs").join("uploads"))
+        .map(|entries| {
+            entries
+                .map(|entry| entry.expect("dir entry").path())
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        records.is_empty(),
+        "an upload that committed keeps no record for a rerun to pick up: {records:?}"
+    );
+}
+
+/// What a tree holds that is neither a file nor a directory is named and
+/// skipped rather than silently dropped, and the walk carries on around it.
+/// Unix only: nothing else in the suite can make one.
+#[cfg(unix)]
+#[test]
+fn a_recursive_put_names_what_it_will_not_transfer() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let tree = harness.temp_dir.path().join("tree");
+    fs::create_dir_all(&tree).expect("create tree dir");
+    fs::write(tree.join("real.txt"), b"real").expect("write file");
+    std::os::unix::fs::symlink(tree.join("real.txt"), tree.join("link.txt")).expect("make symlink");
+
+    let put = harness.run(&[
+        "--json",
+        "put",
+        "-r",
+        tree.to_str().expect("utf-8 path"),
+        "/up",
+    ]);
+    assert_failure(&put);
+    let data = json_data(&put);
+    assert_eq!(
+        data["files"], 1,
+        "the regular file still transferred: {data}"
+    );
+    let failures = data["failures"].as_array().expect("failures");
+    assert_eq!(failures.len(), 1, "{data}");
+    assert!(
+        failures[0]["path"]
+            .as_str()
+            .expect("a path")
+            .ends_with("link.txt"),
+        "{data}"
+    );
+    assert!(
+        failures[0]["error"]["message"]
+            .as_str()
+            .expect("a message")
+            .contains("symlinks and special"),
+        "{data}"
+    );
+    assert_success(&harness.run(&["--json", "stat", "/up/real.txt"]));
 }
 
 /// Nobody asked, so nobody is told: a run whose standard error is a pipe


### PR DESCRIPTION
`put -r` read each file whole into memory before uploading, so a tree containing one large file could exhaust the CLI while a single `put` of the same file streamed with bounded memory.

One way to move a payload: The single-put logic — resume-journal lookup, finished-upload commit, the buffered-versus-streamed choice, journal cleanup — is extracted into `put_payload`, and the recursive walk now calls it per file instead of `std::fs::read`. There is no recursive-specific upload policy: a large file inside a tree travels exactly as it would alone (streamed, direct multipart on capable remote deployments, resume-journaled), and small files keep the cheaper buffered path with its retry behavior. Failures stay per-file; the walk continues.

