### PR TITLE
fix(content): embedded staging joins the session lifecycle

### DIFF
--- a/crates/loonfs-core/src/content.rs
+++ b/crates/loonfs-core/src/content.rs
@@ -6,7 +6,6 @@
 pub use crate::protocol::CompletedUpload;
 pub use crate::storage::content::{
     prepare_existing_content_ref, prepare_stored_content, store_bytes_as_content,
-    store_bytes_as_content_with_store_id, store_stream_as_content_with_store_id,
     DurableContentValidationError, StoredContent,
 };
 pub use crate::storage::content_admission::{

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -15,7 +15,7 @@ use crate::path::read::{
 };
 use crate::protocol::CompletedUpload;
 use crate::storage::content::FileContentStream;
-use crate::storage::content_admission::CompletedUploadReceipt;
+use crate::storage::content_admission::{CompletedUploadReceipt, PreparedContent};
 use crate::time::current_time_ms;
 use loonfs_api::v0::{
     AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, ChangesResponse, CommitResponse,
@@ -621,17 +621,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         upload_id: &UploadId,
         request: &CompleteUploadRequest,
     ) -> Result<CompletedUpload> {
-        // The caller resolved a catalog for a different namespace, which is
-        // a wiring mistake rather than anything the request did. Naming the
-        // two namespaces says more than naming a content id would, and a
-        // multipart completion has no content id to name anyway.
-        if catalog.namespace_id() != &self.namespace_id {
-            return Err(CoreError::Internal(format!(
-                "upload completion for namespace `{}` was given namespace `{}`'s catalog",
-                self.namespace_id,
-                catalog.namespace_id()
-            )));
-        }
+        let catalog = self.own_catalog(catalog)?;
         crate::protocol::complete_upload(
             &self.store,
             &self.namespace_id,
@@ -641,6 +631,72 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             &self.mutation_context()?,
         )
         .await
+    }
+
+    /// Stages bytes this process holds as content a session owns, ready to
+    /// publish here.
+    ///
+    /// This is the whole upload lifecycle for the caller that is also the
+    /// uploader: a session opens, the bytes land under the identity it
+    /// allocated, and the session completes — with no wire step between them
+    /// and no receipt at the end, because the publication happens in this
+    /// process and takes the reference directly. What it does not skip is
+    /// the session record, which is what content garbage collection reads to
+    /// decide an object's fate; without one the bytes would be reachable by
+    /// nothing and reclaimable by nothing.
+    ///
+    /// Two small control writes on top of the content write, in that order.
+    pub async fn stage_owned_bytes(
+        &self,
+        catalog: &VerifiedNamespaceCatalogEntry,
+        bytes: &[u8],
+    ) -> Result<PreparedContent> {
+        crate::protocol::stage_owned_bytes(
+            &self.store,
+            self.own_catalog(catalog)?,
+            bytes,
+            &self.mutation_context()?,
+        )
+        .await
+    }
+
+    /// Stages a streamed payload as content a session owns, hashing it on
+    /// the way through instead of holding it.
+    ///
+    /// The streaming twin of [`Self::stage_owned_bytes`]; ownership and cost
+    /// are identical.
+    pub async fn stage_owned_stream(
+        &self,
+        catalog: &VerifiedNamespaceCatalogEntry,
+        body: ByteStream,
+    ) -> Result<PreparedContent> {
+        crate::protocol::stage_owned_stream(
+            &self.store,
+            self.own_catalog(catalog)?,
+            body,
+            &self.mutation_context()?,
+        )
+        .await
+    }
+
+    /// Refuses a catalog resolved for some other namespace.
+    ///
+    /// A mismatch is the host's wiring mistake rather than anything a request
+    /// did, so naming the two namespaces says more than naming what was being
+    /// written would — and a multipart completion has no content id to name
+    /// anyway.
+    fn own_catalog<'c>(
+        &self,
+        catalog: &'c VerifiedNamespaceCatalogEntry,
+    ) -> Result<&'c VerifiedNamespaceCatalogEntry> {
+        if catalog.namespace_id() != &self.namespace_id {
+            return Err(CoreError::Internal(format!(
+                "an operation on namespace `{}` was given namespace `{}`'s catalog",
+                self.namespace_id,
+                catalog.namespace_id()
+            )));
+        }
+        Ok(catalog)
     }
 
     /// Aborts an upload session, then deletes the content object it owned.

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -8,7 +8,8 @@
 //!
 //! - [`uploads`] stages content before metadata can reference it: begin,
 //!   stage, and complete durable upload sessions, including direct-put
-//!   targets that move bytes past the server.
+//!   targets that move bytes past the server and the in-process staging
+//!   writes that are both ends of an upload at once.
 //! - [`publish_view`] loads the publish-time metadata view: the current head
 //!   plus the WAL tail replayed over the manifest, with head-etag freshness
 //!   checks against concurrent publishers.
@@ -36,5 +37,6 @@ pub use self::uploads::CompletedUpload;
 pub(crate) use self::uploads::{
     abort_upload, begin_direct_multipart_upload_target, begin_direct_put_upload_target,
     begin_upload, complete_upload, direct_multipart_part_targets, read_upload_status,
-    upload_content, upload_streamed_content, AbandonedUpload,
+    stage_owned_bytes, stage_owned_stream, upload_content, upload_streamed_content,
+    AbandonedUpload,
 };

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -7,6 +7,13 @@
 //! durable transition, never before it, so whichever transition wins is what
 //! happened and the loser reports a terminal error instead of undoing
 //! anything.
+//!
+//! Every content object in a namespace is written through a session, whether
+//! its bytes came from a remote peer or from the process doing the
+//! publishing (see [`stage_owned_bytes`]). That is what makes content
+//! collectable: the session record is the only thing that names an object
+//! before metadata does, so an object with no record would be reachable by
+//! nothing and reclaimable by nothing.
 
 use crate::context::MutationContext;
 use crate::control_update::{
@@ -23,7 +30,7 @@ use crate::limits::{
     MAX_MULTIPART_PART_BYTES, MAX_SIGNED_PARTS_PER_REQUEST, MIN_MULTIPART_PART_BYTES,
     UPLOAD_SESSION_LEASE_MS,
 };
-use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::namespace::catalog::{load_namespace_content_store_id, VerifiedNamespaceCatalogEntry};
 use crate::namespace::control::load_namespace_head_control;
 use crate::storage::content::{
     abort_unpublished_multipart_upload, delete_unpublished_content_object,
@@ -723,6 +730,33 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
             }
         };
 
+    freeze_completed_session(
+        store,
+        namespace_id,
+        content_store_id,
+        upload_id,
+        &verified,
+        now_ms,
+    )
+    .await
+}
+
+/// Freezes a verified reference as one session's final word.
+///
+/// Every completion lands here, whatever established the reference above it:
+/// a remote peer's bytes proven against the object that came to rest, or an
+/// in-process staging write proven by the write this runtime performed
+/// itself. By this point both hold the same thing, so the transition that
+/// makes content publishable — and, from the other side, collectable — has
+/// one implementation.
+async fn freeze_completed_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
+    upload_id: &UploadId,
+    verified: &ContentRef,
+    now_ms: u64,
+) -> Result<CompletedUpload> {
     update_upload_session(
         store,
         namespace_id,
@@ -769,6 +803,148 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
         },
     )
     .await
+}
+
+/// The session one in-process staging write fills, from the identity it
+/// allocated to the record that will hold its outcome.
+struct OwnedStagingSession {
+    upload_id: UploadId,
+    content_id: ContentId,
+}
+
+/// Stages bytes this runtime holds under a session that owns them.
+///
+/// The convenience write paths are both ends of an upload at once: the bytes
+/// are already here, so there is no target to hand out, no claim to check,
+/// and no receipt to mint — the publication that follows happens in this
+/// process and takes the reference directly. What they do not skip is the
+/// session, because that is the half of the lifecycle content garbage
+/// collection reads.
+///
+/// The session record is durable before the object exists. That ordering is
+/// the ownership guarantee rather than an optimization: a record written
+/// afterwards leaves a window in which a crash strands bytes nothing names,
+/// which is the exact leak this path exists to close. It costs two small
+/// control writes on top of the content write, and they are sequential for
+/// the same reason.
+pub(crate) async fn stage_owned_bytes<S: ObjectStore + ?Sized>(
+    store: &S,
+    catalog: &VerifiedNamespaceCatalogEntry,
+    bytes: &[u8],
+    context: &MutationContext,
+) -> Result<PreparedContent> {
+    let session = open_owned_staging_session(store, catalog, context).await?;
+    let stored = stage_bytes_under_content_id(
+        store,
+        catalog.content_store_id().clone(),
+        session.content_id,
+        bytes,
+    )
+    .await?;
+    complete_owned_staging(
+        store,
+        catalog,
+        &session.upload_id,
+        stored.content_ref,
+        context,
+    )
+    .await
+}
+
+/// Stages a payload this runtime forwards under a session that owns it.
+///
+/// The streaming twin of [`stage_owned_bytes`]: the bytes are hashed on
+/// their way to the store rather than held, and everything about ownership
+/// is identical.
+pub(crate) async fn stage_owned_stream<S: ObjectStore + ?Sized>(
+    store: &S,
+    catalog: &VerifiedNamespaceCatalogEntry,
+    body: ByteStream,
+    context: &MutationContext,
+) -> Result<PreparedContent> {
+    let session = open_owned_staging_session(store, catalog, context).await?;
+    let content_store_id = catalog.content_store_id().clone();
+    let staged =
+        stage_streamed_under_content_id(store, content_store_id, session.content_id, body).await?;
+    if staged.already_present {
+        // The identity is 128 fresh random bits and this session has made no
+        // earlier attempt, so an occupied key is corruption rather than a
+        // replay, and it fails loudly.
+        return Err(CoreError::Internal(format!(
+            "content object `{}` already holds bytes under a freshly minted identity",
+            content_blob(
+                catalog.content_store_id().as_str(),
+                &staged.content_ref.content_id
+            )
+        )));
+    }
+    complete_owned_staging(
+        store,
+        catalog,
+        &session.upload_id,
+        staged.content_ref,
+        context,
+    )
+    .await
+}
+
+/// Opens the session that will own a content object this runtime is about to
+/// write.
+///
+/// It is a service-proxied session because that is what it is: the bytes pass
+/// through this process on the way to the store. The upload id is never
+/// handed out, so the record has exactly one later reader — garbage
+/// collection, which learns from it that the object has an owner and what
+/// became of it.
+async fn open_owned_staging_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    catalog: &VerifiedNamespaceCatalogEntry,
+    context: &MutationContext,
+) -> Result<OwnedStagingSession> {
+    // No availability check, unlike the sessions a remote peer opens. This
+    // caller holds a catalog read off the namespace's own head, and the
+    // publication it is staging for is the admission decision: a namespace
+    // deleted in between refuses there, and a collection pass on a terminal
+    // namespace reaches nothing, so it reclaims this session and the object
+    // it holds like any other completed content nobody references.
+    let session = NewUploadSession::service_proxied();
+    let content_id = session.content_id.clone();
+    let upload_id = create_upload_session(store, catalog.namespace_id(), session, context).await?;
+    Ok(OwnedStagingSession {
+        upload_id,
+        content_id,
+    })
+}
+
+/// Completes the session an in-process staging write just filled.
+///
+/// Nothing is verified here and nothing needs to be: this runtime wrote the
+/// object and hashed the payload doing it, which is the same evidence a
+/// service-proxied completion accepts from its own staged reference.
+///
+/// A failure before this point leaves an open session whose lease passes and
+/// whose sweep deletes both record and object, so no error path aborts: this
+/// session is unreachable by anyone else, the only way the transition fails
+/// is a store that is not answering, and an abort call is the least likely
+/// thing to get through it. Expiry costs a wait; a second failed write costs
+/// the wait anyway.
+async fn complete_owned_staging<S: ObjectStore + ?Sized>(
+    store: &S,
+    catalog: &VerifiedNamespaceCatalogEntry,
+    upload_id: &UploadId,
+    content_ref: ContentRef,
+    context: &MutationContext,
+) -> Result<PreparedContent> {
+    Ok(freeze_completed_session(
+        store,
+        catalog.namespace_id(),
+        catalog.content_store_id(),
+        upload_id,
+        &content_ref,
+        context.now_ms,
+    )
+    .await?
+    .prepared)
 }
 
 /// Aborts an upload session, then cleans up what it was writing.

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -599,6 +599,9 @@ async fn validate_content_size<S: ObjectStore + ?Sized>(
     Ok(())
 }
 
+/// Plants durable content under a fresh identity, resolving the namespace's
+/// content store first. See [`store_bytes_as_content_with_store_id`] for
+/// what this is for and what it is not.
 #[tracing::instrument(
     level = "info",
     name = "loonfs.phase",
@@ -615,8 +618,8 @@ pub async fn store_bytes_as_content<S: ObjectStore + ?Sized>(
     store_bytes_as_content_with_store_id(store, content_store_id, bytes).await
 }
 
-/// Stages bytes when the caller already knows the namespace's content-store
-/// binding (it is immutable, so a handle can resolve it once).
+/// Plants durable content for a caller that already knows the namespace's
+/// content-store binding.
 ///
 /// Every call mints its own content identity, so two writers staging the
 /// same bytes produce two objects rather than racing for one key. Sharing a
@@ -624,45 +627,19 @@ pub async fn store_bytes_as_content<S: ObjectStore + ?Sized>(
 /// allowed to upload could learn whether specific known bytes were already
 /// in a shared content store. Retry idempotency, the thing that dedup was
 /// quietly providing, belongs to the upload session instead.
-pub async fn store_bytes_as_content_with_store_id<S: ObjectStore + ?Sized>(
+///
+/// So does reclamation, which is why this is a fixture rather than a write
+/// path. The object it writes belongs to no session, and a session record is
+/// the only handle anything has on a content object before metadata names
+/// one — so nothing will ever collect it. Production staging opens a session
+/// ([`crate::protocol::stage_owned_bytes`]); immortal bytes are what a test
+/// wants and what a namespace does not.
+pub(crate) async fn store_bytes_as_content_with_store_id<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: ContentStoreId,
     bytes: &[u8],
 ) -> Result<StoredContent, CoreError> {
     stage_bytes_under_content_id(store, content_store_id, ContentId::generate(), bytes).await
-}
-
-/// Stages a streamed payload under a freshly minted identity.
-///
-/// The streaming twin of [`store_bytes_as_content_with_store_id`], for
-/// writers whose payload arrives in pieces or whose length is not known in
-/// advance. It produces the same acknowledged [`StoredContent`], so
-/// everything downstream — preparation, publication, verified reads — is
-/// unchanged.
-pub async fn store_stream_as_content_with_store_id<S: ObjectStore + ?Sized>(
-    store: &S,
-    content_store_id: ContentStoreId,
-    body: ByteStream,
-) -> Result<StoredContent, CoreError> {
-    let content_id = ContentId::generate();
-    let object_key = content_blob(content_store_id.as_str(), &content_id);
-    let staged =
-        stage_streamed_under_content_id(store, content_store_id.clone(), content_id, body).await?;
-    if staged.already_present {
-        // The identity is 128 fresh random bits, so an occupied key is not
-        // a race with anyone: it is corruption, and it fails loudly.
-        return Err(CoreError::Internal(format!(
-            "content object `{object_key}` already holds bytes under a freshly minted identity"
-        )));
-    }
-
-    Ok(StoredContent {
-        content_store_id,
-        object_key,
-        file_size_bytes: staged.content_ref.size_bytes,
-        content_ref: staged.content_ref,
-        _write_acknowledged: StoredContentWriteAcknowledgement,
-    })
 }
 
 /// What a streamed staging write established about the content object.

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -158,8 +158,9 @@ impl FsWriter {
     /// message, or content this build cannot compare surface the conflict.
     ///
     /// The freshly staged duplicate object is then referenced by nothing.
-    /// That is by design, not a leak: content garbage collection reclaims an
-    /// unreferenced object once its grace passes.
+    /// That is by design, not a leak: it is a completed upload session's
+    /// content that no metadata names, and content garbage collection
+    /// reclaims exactly that once the reclamation grace passes.
     pub async fn put_file_bytes(
         &self,
         namespace_id: &NamespaceId,
@@ -349,9 +350,19 @@ impl FsWriter {
 
     /// Stages file bytes as durable content for later publication.
     ///
-    /// Preparation performs one content PUT and no content reads. A publish
-    /// that fails afterward leaves only a GC-covered orphan behind an
-    /// unmoved head.
+    /// Preparation performs one content PUT and no content reads, plus the
+    /// two small control writes of the upload session that owns the object:
+    /// the session record lands before the bytes do, and the completion
+    /// after them. That is what a publish failing afterwards costs, and all
+    /// it costs — the object is a completed session's unpublished content,
+    /// which garbage collection reclaims once nothing references it and the
+    /// reclamation grace has passed.
+    ///
+    /// The same window bounds how long the returned value stays worth
+    /// holding. A prepared reference carries no clock and never expires by
+    /// itself, but the bytes behind it are protected only while its session
+    /// is inside that grace, so a prepared reference is for publishing now,
+    /// not for keeping.
     #[tracing::instrument(
         level = "info",
         name = "loonfs.prepare",
@@ -375,16 +386,10 @@ impl FsWriter {
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
-        let stored = loonfs_core::content::store_bytes_as_content_with_store_id(
-            &self.core.inner.store,
-            catalog.content_store_id().clone(),
-            bytes,
-        )
-        .await?;
-        Ok(
-            loonfs_core::content::prepare_stored_content(&catalog, stored)
-                .map_err(CoreError::from)?,
-        )
+        Ok(self
+            .engine(namespace_id)
+            .stage_owned_bytes(&catalog, bytes)
+            .await?)
     }
 
     /// Stages a streamed payload as durable content for later publication.
@@ -416,16 +421,10 @@ impl FsWriter {
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
-        let stored = loonfs_core::content::store_stream_as_content_with_store_id(
-            &self.core.inner.store,
-            catalog.content_store_id().clone(),
-            body,
-        )
-        .await?;
-        Ok(
-            loonfs_core::content::prepare_stored_content(&catalog, stored)
-                .map_err(CoreError::from)?,
-        )
+        Ok(self
+            .engine(namespace_id)
+            .stage_owned_stream(&catalog, body)
+            .await?)
     }
 
     /// Publishes a file revision from already-prepared content.

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -404,14 +404,31 @@ async fn read_after_write_is_served_from_seeded_caches() {
         )
         .await
         .expect("steady-state put");
-    // The publish itself must read the live head and root for freshness;
-    // nothing else.
+    // The publish must read the live head and root for freshness, and the
+    // upload session that owns the staged content has to be read to be
+    // completed on its own etag. One of each, and nothing else.
     let write_gets = recording.take_get_keys();
-    assert!(
+    let uploads_prefix = loonfs_objectstore::keys::upload_session_prefix(namespace_id.as_str());
+    let classify = |suffix: &str| {
         write_gets
             .iter()
-            .all(|key| key.ends_with("/wal/head.json") || key.ends_with("/metadata/root.json")),
-        "a steady-state write reads only the live head and root, got {write_gets:?}"
+            .filter(|key| key.ends_with(suffix))
+            .count()
+    };
+    assert_eq!(classify("/wal/head.json"), 1, "got {write_gets:?}");
+    assert_eq!(classify("/metadata/root.json"), 1, "got {write_gets:?}");
+    assert_eq!(
+        write_gets
+            .iter()
+            .filter(|key| key.starts_with(&uploads_prefix))
+            .count(),
+        1,
+        "one staging session is opened and completed per put, got {write_gets:?}"
+    );
+    assert_eq!(
+        write_gets.len(),
+        3,
+        "a steady-state write reads nothing beyond those three, got {write_gets:?}"
     );
 
     reader

--- a/crates/loonfs/tests/it/main.rs
+++ b/crates/loonfs/tests/it/main.rs
@@ -23,6 +23,7 @@ mod publication;
 mod publish_observer;
 mod request_accounting;
 mod runtime_config;
+mod staged_content_reclamation;
 mod streamed_put;
 mod streamed_read;
 mod undelete;

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -1,0 +1,385 @@
+//! What garbage collection can reach after an embedded convenience put.
+//!
+//! The convenience puts stage their own bytes, so they are both ends of an
+//! upload at once. They still open a session for the object they write,
+//! because the session record is the only handle anything has on a content
+//! object before metadata references it. These tests hold that to its
+//! consequence: every blob one of these puts writes is eventually either
+//! referenced by metadata or reclaimed, and none of them is immortal.
+//!
+//! Garbage collection is driven through `loonfs_core::gc_namespace` rather
+//! than `FsAdmin::gc_namespace`, because the admin handle stamps its pass
+//! from the wall clock and these deadlines are days out. The store is the
+//! same one the runtime wrote through, so the pass sees exactly what the
+//! puts left behind.
+
+#![allow(clippy::panic)]
+// Runtime integration tests use panic in helper assertions for precise diagnostics.
+
+use crate::common::{open_runtime_async, store, TestRuntime};
+use loonfs::{
+    ContentRef, CreateNamespaceOptions, GcConfig, GcResponse, NamespaceId, PutFileOptions,
+    SharedObjectStore,
+};
+use loonfs_core::limits::{CONTENT_RECLAMATION_GRACE_MS, UPLOAD_SESSION_LEASE_MS};
+use loonfs_core::MutationContext;
+use loonfs_objectstore::layout::DurableObjectFamily;
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_objectstore::ObjectStore;
+use loonfs_test_support::stores::{
+    CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+/// The grace a pass is configured with, well above the enforced floor so
+/// the derived content grace is what decides these tests.
+const GRACE_MS: u64 = 60 * 60 * 1000;
+
+fn config() -> GcConfig {
+    GcConfig {
+        grace_window_ms: GRACE_MS,
+        max_objects: None,
+        cursor: None,
+    }
+}
+
+/// Runs one pass at a fabricated clock. The runtime stamped its sessions
+/// from the real clock, so every deadline here is measured from that.
+async fn collect(store: &SharedObjectStore, namespace_id: &NamespaceId, now_ms: u64) -> GcResponse {
+    loonfs_core::gc_namespace(
+        store.as_ref(),
+        namespace_id,
+        &config(),
+        &MutationContext {
+            writer_id: "reclamation-test".to_owned(),
+            now_ms,
+        },
+    )
+    .await
+    .expect("garbage collection")
+}
+
+async fn namespace(runtime: &TestRuntime) -> NamespaceId {
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    runtime
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    namespace_id
+}
+
+/// The object key one staged reference lives at.
+async fn content_key(
+    store: &SharedObjectStore,
+    namespace_id: &NamespaceId,
+    content_ref: &ContentRef,
+) -> String {
+    let content_store_id =
+        loonfs::control::load_namespace_catalog_entry(store.as_ref(), namespace_id)
+            .await
+            .expect("load namespace catalog")
+            .content_store_id()
+            .clone();
+    loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id)
+}
+
+async fn exists(store: &SharedObjectStore, key: &str) -> bool {
+    store.head(key).await.expect("head object").is_some()
+}
+
+/// Every upload-session record the namespace still holds.
+async fn session_keys(store: &SharedObjectStore, namespace_id: &NamespaceId) -> Vec<String> {
+    store
+        .list_prefix(&loonfs_objectstore::keys::upload_session_prefix(
+            namespace_id.as_str(),
+        ))
+        .await
+        .expect("list upload sessions")
+}
+
+/// A prepared reference that never reaches a commit is not a leak. It is a
+/// completed session's content that no metadata names, which is the one
+/// thing content collection exists to reclaim.
+#[tokio::test]
+async fn content_prepared_and_never_published_is_reclaimed_with_its_session() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let runtime = open_runtime_async(store.clone(), "prepare-only").await;
+    let namespace_id = namespace(&runtime).await;
+    // A published file, so the reference scan has a root to read and the
+    // verdict on the prepared object is "absent" rather than "unknown".
+    runtime
+        .writer
+        .put_file_bytes(
+            &namespace_id,
+            "/docs/live.txt",
+            b"live",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("published put");
+
+    let prepared = runtime
+        .writer
+        .prepare_file_bytes(&namespace_id, b"never published")
+        .await
+        .expect("prepare content");
+    let orphan_key = content_key(&store, &namespace_id, prepared.content_ref()).await;
+    assert!(exists(&store, &orphan_key).await);
+
+    let staged_at_ms = loonfs::current_time_ms().expect("wall clock");
+    let inside = collect(&store, &namespace_id, staged_at_ms).await;
+    assert_eq!(inside.deleted_content_objects, 0);
+    assert!(
+        exists(&store, &orphan_key).await,
+        "inside the grace a receipt could still admit a commit for these bytes"
+    );
+
+    let past = collect(
+        &store,
+        &namespace_id,
+        staged_at_ms + CONTENT_RECLAMATION_GRACE_MS + 1,
+    )
+    .await;
+    assert_eq!(
+        past.deleted_content_objects, 1,
+        "the prepared object is the one reclamation"
+    );
+    assert_eq!(
+        past.deleted_upload_sessions, 2,
+        "both sessions have said everything they will say"
+    );
+    assert!(!exists(&store, &orphan_key).await);
+    assert!(session_keys(&store, &namespace_id).await.is_empty());
+}
+
+/// Published content answers to metadata from then on. Its session record
+/// still ages out, and taking that record must not take the bytes with it.
+#[tokio::test]
+async fn a_published_put_keeps_its_content_and_loses_only_the_session_record() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let runtime = open_runtime_async(store.clone(), "published-put").await;
+    let namespace_id = namespace(&runtime).await;
+    runtime
+        .writer
+        .put_file_bytes(
+            &namespace_id,
+            "/docs/kept.txt",
+            b"kept",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("published put");
+    let content_ref = runtime
+        .reader
+        .stat_path(&namespace_id, "/docs/kept.txt")
+        .await
+        .expect("stat file")
+        .content_ref
+        .expect("a file carries a content ref");
+    let published_key = content_key(&store, &namespace_id, &content_ref).await;
+
+    let report = collect(
+        &store,
+        &namespace_id,
+        loonfs::current_time_ms().expect("wall clock") + CONTENT_RECLAMATION_GRACE_MS + 1,
+    )
+    .await;
+
+    assert_eq!(report.deleted_upload_sessions, 1);
+    assert_eq!(
+        report.deleted_content_objects, 0,
+        "metadata protects the bytes the moment the commit lands"
+    );
+    assert!(exists(&store, &published_key).await);
+    assert_eq!(
+        runtime
+            .reader
+            .get_file_bytes(&namespace_id, "/docs/kept.txt")
+            .await
+            .expect("read the file back")
+            .bytes,
+        b"kept"
+    );
+}
+
+/// Re-running a put under a commit id that already committed stages a
+/// second object and then reconciles against the first. The duplicate is
+/// referenced by nothing, and this is what "not a leak" has to mean: it
+/// goes, and the object the commit actually named stays.
+#[tokio::test]
+async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survives() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let runtime = open_runtime_async(store.clone(), "retrying-writer").await;
+    let namespace_id = namespace(&runtime).await;
+    let options = || PutFileOptions {
+        commit_id: Some(loonfs::CommitId::parse("cmt_reconciled").expect("valid commit id")),
+        ..PutFileOptions::default()
+    };
+
+    let first = runtime
+        .writer
+        .put_file_bytes(&namespace_id, "/docs/retry.txt", b"same bytes", options())
+        .await
+        .expect("first put");
+    let committed_key = content_key(
+        &store,
+        &namespace_id,
+        &runtime
+            .reader
+            .stat_path(&namespace_id, "/docs/retry.txt")
+            .await
+            .expect("stat file")
+            .content_ref
+            .expect("a file carries a content ref"),
+    )
+    .await;
+
+    let retry = runtime
+        .writer
+        .put_file_bytes(&namespace_id, "/docs/retry.txt", b"same bytes", options())
+        .await
+        .expect("the rerun reconciles against what the commit id landed");
+    assert_eq!(
+        retry.committed_seq, first.committed_seq,
+        "the rerun reports the original commit, not a second one"
+    );
+    assert_eq!(
+        session_keys(&store, &namespace_id).await.len(),
+        2,
+        "one session per staging write, published or not"
+    );
+
+    let report = collect(
+        &store,
+        &namespace_id,
+        loonfs::current_time_ms().expect("wall clock") + CONTENT_RECLAMATION_GRACE_MS + 1,
+    )
+    .await;
+
+    assert_eq!(report.deleted_upload_sessions, 2);
+    assert_eq!(
+        report.deleted_content_objects, 1,
+        "exactly the duplicate the rerun staged"
+    );
+    assert!(
+        exists(&store, &committed_key).await,
+        "the object the commit named is referenced and stays"
+    );
+    assert_eq!(
+        runtime
+            .reader
+            .get_file_bytes(&namespace_id, "/docs/retry.txt")
+            .await
+            .expect("read the file back")
+            .bytes,
+        b"same bytes"
+    );
+}
+
+/// The session record is durable before the content write is attempted, so
+/// a staging write that dies mid-flight leaves an owner behind rather than
+/// nothing. What the owner buys is the expiry sweep: the record ages out of
+/// its lease and takes whatever it was writing with it.
+#[tokio::test]
+async fn staging_that_fails_leaves_a_session_the_expiry_sweep_reclaims() {
+    let temp_dir = tempdir().expect("tempdir");
+    // A refused precondition rather than a transport failure: the immutable
+    // write retries the second for most of a minute before giving up, and
+    // what this test is about is the state a failed staging write leaves,
+    // not how long it takes to fail.
+    let failing = Arc::new(FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::content_blob(),
+        OperationClass::Put,
+        InjectedError::PreconditionFailed,
+    ));
+    let store: SharedObjectStore = failing.clone();
+    let runtime = open_runtime_async(store.clone(), "failing-writer").await;
+    let namespace_id = namespace(&runtime).await;
+
+    failing.fail_all();
+    runtime
+        .writer
+        .put_file_bytes(
+            &namespace_id,
+            "/docs/lost.txt",
+            b"never lands",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect_err("the content write fails");
+    failing.clear();
+
+    assert_eq!(
+        session_keys(&store, &namespace_id).await.len(),
+        1,
+        "the session that would have owned the bytes is durable before they are written"
+    );
+
+    let staged_at_ms = loonfs::current_time_ms().expect("wall clock");
+    let inside = collect(&store, &namespace_id, staged_at_ms).await;
+    assert_eq!(
+        inside.deleted_upload_sessions, 0,
+        "the lease has not passed"
+    );
+
+    // Past the lease and its grace the session aborts; a grace after that
+    // stamp the record itself is reaped.
+    let aborted_at_ms = staged_at_ms + UPLOAD_SESSION_LEASE_MS + GRACE_MS + 1;
+    collect(&store, &namespace_id, aborted_at_ms).await;
+    let reaped = collect(&store, &namespace_id, aborted_at_ms + GRACE_MS + 1).await;
+    assert_eq!(reaped.deleted_upload_sessions, 1);
+    assert!(session_keys(&store, &namespace_id).await.is_empty());
+}
+
+/// What ownership costs, pinned so it stays deliberate: one create-if-absent
+/// for the record that claims the content id, and one compare-and-swap to
+/// freeze what was written under it. Reading the record for that swap's etag
+/// is the third and last control operation a put adds.
+#[tokio::test]
+async fn a_put_pays_two_control_writes_for_the_session_that_owns_its_content() {
+    let temp_dir = tempdir().expect("tempdir");
+    let sessions = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::family(DurableObjectFamily::UploadSession),
+    ));
+    let store: SharedObjectStore = sessions.clone();
+    let runtime = open_runtime_async(store, "counted-writer").await;
+    let namespace_id = namespace(&runtime).await;
+
+    sessions.reset();
+    runtime
+        .writer
+        .put_file_bytes(
+            &namespace_id,
+            "/docs/counted.txt",
+            b"counted",
+            PutFileOptions::default(),
+        )
+        .await
+        .expect("put file");
+
+    let counts = sessions.snapshot();
+    assert_eq!(
+        counts.create_if_absent_puts, 1,
+        "one record opens, claiming the content id before the bytes exist"
+    );
+    assert_eq!(
+        counts.compare_and_swaps, 1,
+        "one swap freezes the reference the write produced"
+    );
+    assert_eq!(counts.overwrite_puts, 0, "a session is never clobbered");
+    assert_eq!(
+        counts.operations(OperationClass::Read),
+        1,
+        "the swap reads the etag it swaps on, and nothing else reads a session"
+    );
+    assert_eq!(
+        counts.deletes, 0,
+        "only collection removes a session record"
+    );
+}

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -322,6 +322,18 @@ response together with the same evidence. These are embedded conveniences,
 not HTTP operations; hosted clients continue to carry validated content
 tokens on the existing wire requests.
 
+Staging is staging wherever it happens, so `prepare_file_bytes` opens an
+upload session for the object it writes, exactly as a remote upload does: the
+session record lands before the bytes and completes after them, and the
+reference the caller receives is a completed session's content. That is what
+bounds how long the value is worth holding. A prepared reference carries no
+clock and never expires by itself, but the bytes behind it are protected only
+while its session is inside the content-reclamation grace — the same window
+that bounds a remote upload's receipts (section 6.3; format spec, "Garbage
+collection", rule 11). Past it, content nothing references is reclaimed
+whether the reference that named it is still in a caller's hands or not, so
+prepared content is for publishing now rather than for keeping.
+
 ### 5.1 Commit identity and race guards
 
 A commit is one request: a `commit_id` — a client-generated stable

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2112,7 +2112,12 @@ publishing CAS) — under these rules:
    pass is still sound at delete time — which is why the content family
    needs no delete-time re-verification. The constants live beside `T` in
    `loonfs-core`'s `limits` module and the inequality is a compile-time
-   assertion. The reasoning above assumes a content object is referenced
+   assertion. A publication in the same process that completed the session
+   holds its admission directly instead of carrying a receipt, so nothing
+   expires it; what bounds it is the same grace, and a host that stages
+   content and publishes it much later has to publish inside that grace for
+   the same reason a remote client has to re-read its session for a fresh
+   receipt. The reasoning above assumes a content object is referenced
    only by the namespace whose session created it and by fork descendants
    reading through a pinned basis; a same-content-store copy across
    namespaces (section 2.8) would have to root the reference on the source


### PR DESCRIPTION
This PR closes the content-ownership gap: the embedded convenience puts staged blobs with no upload-session record, so a crashed put's blob (or the duplicate that a reconciled retry stages) was never reclaimed by anything, while the format spec claimed session-owned reclamation is the only content GC and the code comments claimed coverage that did not exist. So the decision is: embedded staging joins the session lifecycle, making the spec's claim true on every production write path.

The mechanism: `prepare_file_bytes` / `prepare_file_stream` (and therefore both convenience puts) now write an Open session record owning the ContentId before the blob exists, and complete that session after the verified write. The ordering is stated as an invariant vs. an optimization: a record durable before the object is what makes the object "owned". The commit path is unchanged — embedded commits still take the ContentRef directly; the session exists for GC ownership, not admission.

One authority and no parallel path: The Completed compare-and-swap was lifted verbatim out of `complete_upload` into one shared function both surfaces end at: a remote peer's bytes proven against the object that landed, an in-process write proven by the write the runtime performed itself. The Open record is the existing session-creation path, unchanged. The now-dead bare-staging helpers are deleted or demoted; the one that remains public is a test fixture and now says so.


