### PR TITLE
fix(cli): recovery hints and conflict messages say what they mean

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -100,6 +100,14 @@ pub struct ErrorDetails {
     /// Deletion generation actually active for the inode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_deletion_seq: Option<ChangeSeq>,
+    /// Head sequence a namespace delete required the namespace to still be
+    /// at.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_head_seq: Option<ChangeSeq>,
+    /// Head sequence the namespace was actually at, which is what a caller
+    /// that still means to delete it retries against.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual_head_seq: Option<ChangeSeq>,
 }
 
 /// Request to create a namespace.

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -2,9 +2,10 @@
 
 use super::output::CommandFailure;
 use crate::args::{CommandKind, TargetSelectorArgs};
+use crate::config::{ConfigLocation, ConfigSource};
 use crate::error::CliError;
 use crate::resolve::{load_cli_config, resolve_namespace, resolve_target_profile_from_config};
-use loonfs_api::{AbsolutePath, NamespaceId};
+use loonfs_api::{AbsolutePath, ChangeSeq, InodeId, NamespaceId};
 use loonfs_client::NamespacePath;
 use std::path::{Path, PathBuf};
 
@@ -187,6 +188,103 @@ pub(crate) fn render_target(namespace_id: &NamespaceId, absolute_path: &Absolute
     format!("{namespace_id}:{absolute_path}")
 }
 
+// --- printed recovery commands ---
+
+/// The flags a printed `loonfs undelete` has to spell so that pasting it into
+/// a later shell still reaches the filesystem this command ran against.
+///
+/// Every one of them names something the CLI would otherwise take from
+/// ambient state that drifts between the print and the paste: the namespace
+/// comes from a config value `loonfs use` rewrites, the profile from another
+/// the `profile default` command rewrites, and the config file itself from a
+/// flag or an environment variable that a later shell need not repeat. The
+/// hint is only worth printing if it survives all three, so the flags are
+/// built once per invocation and shared by every entry it prints.
+pub(crate) struct UndeleteHint {
+    /// Rendered and already shell-quoted, for example
+    /// `--namespace demo --profile prod`. Never empty: `--namespace` is
+    /// unconditional.
+    context_flags: String,
+}
+
+impl UndeleteHint {
+    pub(crate) fn new(
+        context: &CommandContext,
+        location: &ConfigLocation,
+        explicit_profile: bool,
+    ) -> Self {
+        let mut context_flags = format!(" --namespace {}", shell_quote(context.namespace.as_str()));
+        // A bare invocation resolves the config's default profile, which is
+        // exactly the profile this run used whenever `--profile` went
+        // unspelled; spelling it means the default may be some other profile,
+        // and then the hint has to say which one it meant.
+        if explicit_profile {
+            context_flags.push_str(&format!(
+                " --profile {}",
+                shell_quote(&context.profile_name)
+            ));
+        }
+        // The flag and the environment variable both name a file that a bare
+        // invocation would not find on its own — the flag because it is not
+        // spelled again, the variable because a later shell need not still
+        // export it. The default locations need no flag: they are what a bare
+        // invocation looks at.
+        if matches!(location.source, ConfigSource::Flag | ConfigSource::Env) {
+            context_flags.push_str(&format!(
+                " --config {}",
+                shell_quote(&location.path.to_string_lossy())
+            ));
+        }
+        Self { context_flags }
+    }
+
+    /// The complete `loonfs undelete` invocation that recovers one deletion:
+    /// where it should land, and the inode plus deletion sequence that
+    /// identify the exact deletion being recovered.
+    ///
+    /// `destination` is absent for a deletion that recorded no name, which
+    /// has none to offer.
+    pub(crate) fn command(
+        &self,
+        destination: Option<&str>,
+        inode_id: InodeId,
+        deleted_at: ChangeSeq,
+    ) -> String {
+        // The placeholder is deliberately left unquoted: pasted unedited, a
+        // shell rejects it instead of recovering the entry to a file
+        // literally named `<path>`.
+        let destination = destination.map_or_else(|| PATH_PLACEHOLDER.to_owned(), shell_quote);
+        format!(
+            "loonfs undelete {destination} --inode {inode_id} --deleted-at {}{}",
+            deleted_at.0, self.context_flags
+        )
+    }
+}
+
+/// Stands in for the destination of a deletion that recorded no name, which
+/// the caller has to supply before the command will run.
+const PATH_PLACEHOLDER: &str = "<path>";
+
+/// Quotes an argument for a POSIX shell, leaving it alone when it needs no
+/// quoting.
+///
+/// Names may hold spaces and quotes (they are display strings, not
+/// identifiers), and so may profile names and config paths, so a printed
+/// command that is meant to be pasted has to survive them. Single quotes take
+/// everything literally, which is why the one character they cannot hold — a
+/// single quote — is spliced in as an escaped one outside them.
+fn shell_quote(argument: &str) -> String {
+    const SAFE: &str = "@%+=:,./-_";
+    if !argument.is_empty()
+        && argument
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || SAFE.contains(character))
+    {
+        return argument.to_owned();
+    }
+    format!("'{}'", argument.replace('\'', r#"'\''"#))
+}
+
 pub(crate) fn fail(
     kind: CommandKind,
     profile: Option<String>,
@@ -203,7 +301,26 @@ pub(crate) fn fail(
 
 #[cfg(test)]
 mod tests {
-    use super::{destination_user_path, parse_user_path};
+    use super::{destination_user_path, parse_user_path, shell_quote};
+
+    #[test]
+    fn quoting_leaves_ordinary_paths_alone_and_survives_a_quote() {
+        // Quoting everything would make the common command harder to read,
+        // so an argument a shell would pass through untouched stays bare.
+        assert_eq!(shell_quote("/docs/report.txt"), "/docs/report.txt");
+        assert_eq!(shell_quote("prod-2"), "prod-2");
+
+        assert_eq!(
+            shell_quote("/docs/Quarterly Report.PDF"),
+            "'/docs/Quarterly Report.PDF'"
+        );
+        // A single quote is the one character single quotes cannot hold, so
+        // it closes them, contributes an escaped quote, and reopens them.
+        assert_eq!(shell_quote("/tom's notes"), r#"'/tom'\''s notes'"#);
+        // Empty is not "nothing to quote": bare, it would vanish as an
+        // argument entirely.
+        assert_eq!(shell_quote(""), "''");
+    }
 
     #[test]
     fn user_paths_keep_wire_strictness_except_directory_intent() {

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -4,8 +4,9 @@
 use super::context::{
     default_remote_put_path, destination_path_for_get, destination_user_path, directory_intent,
     fail, namespace_path, parse_user_path, render_target, resolve_command_context, CommandContext,
+    UndeleteHint,
 };
-use super::output::{CommandData, CommandFailure, CommandOutput};
+use super::output::{CommandData, CommandFailure, CommandOutput, TrashListing};
 use super::partial::{self, PartialDownload, PartialMeta};
 use super::recursive;
 use crate::args::{
@@ -15,6 +16,7 @@ use crate::args::{
     RuntimeBehavior, TrashArgs,
 };
 use crate::backend::FileDownload;
+use crate::config::ConfigLocation;
 use crate::error::CliError;
 use crate::payload::{read_whole_file, LocalPayload, STDIN_PATH};
 use crate::progress::{ProgressOp, ProgressReporter};
@@ -508,20 +510,40 @@ fn local_destination_error(
 
 pub(crate) async fn run_filesystem_trash(
     kind: CommandKind,
-    config_path: &Path,
+    location: &ConfigLocation,
     args: TrashArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, config_path, &args.target).await?;
+    let context = resolve_command_context(kind, &location.path, &args.target).await?;
     let response = context
         .target
         .list_trash(&context.namespace, args.limit, args.cursor.as_deref())
         .await
         .map_err(|error| context.fail(kind, error))?;
+    let hint = UndeleteHint::new(&context, location, args.target.profile.profile.is_some());
+    // The listing carries the deleted binding's leaf name, not the directory
+    // it hung under, so the offered destination is that name at the root. It
+    // is a complete command; a caller who wants the original directory back
+    // edits the path, which is the same edit `undelete` already invites.
+    let recovery_commands = response
+        .entries
+        .iter()
+        .map(|entry| {
+            let destination = entry.display_name.as_ref().map(|name| format!("/{name}"));
+            hint.command(
+                destination.as_deref(),
+                entry.root_inode_id,
+                entry.deleted_at_seq,
+            )
+        })
+        .collect();
     Ok(CommandOutput {
         kind,
         profile: Some(context.profile_name),
         mode: Some(context.mode),
-        data: CommandData::Trash(response),
+        data: CommandData::Trash(TrashListing {
+            response,
+            recovery_commands,
+        }),
     })
 }
 
@@ -722,6 +744,7 @@ async fn commit_put(
             committed_seq: result.committed_seq,
             commit_id: result.commit_id,
             inode_id: None,
+            recovery_command: None,
         },
     })
 }
@@ -870,10 +893,10 @@ fn put_file_options(args: &FilesystemPutArgs) -> Result<PutFileOptions, CliError
 
 pub(crate) async fn run_filesystem_rm(
     kind: CommandKind,
-    config_path: &Path,
+    location: &ConfigLocation,
     args: FilesystemRmArgs,
 ) -> Result<CommandOutput, CommandFailure> {
-    let context = resolve_command_context(kind, config_path, &args.target).await?;
+    let context = resolve_command_context(kind, &location.path, &args.target).await?;
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
@@ -906,6 +929,15 @@ pub(crate) async fn run_filesystem_rm(
         .await
         .map_err(|error| context.fail(kind, error))?;
 
+    // The path just deleted is the destination that puts the entry back where
+    // it was, so the printed command is complete for this exact deletion.
+    let recovery_command =
+        UndeleteHint::new(&context, location, args.target.profile.profile.is_some()).command(
+            Some(spec.absolute_path().as_str()),
+            deleted_inode,
+            result.committed_seq,
+        );
+
     Ok(CommandOutput {
         kind,
         profile: Some(context.profile_name),
@@ -915,6 +947,7 @@ pub(crate) async fn run_filesystem_rm(
             committed_seq: result.committed_seq,
             commit_id: result.commit_id,
             inode_id: Some(deleted_inode),
+            recovery_command: Some(recovery_command),
         },
     })
 }
@@ -952,6 +985,7 @@ pub(crate) async fn run_filesystem_restore(
             committed_seq: result.committed_seq,
             commit_id: result.commit_id,
             inode_id: None,
+            recovery_command: None,
         },
     })
 }
@@ -990,6 +1024,7 @@ pub(crate) async fn run_filesystem_undelete(
             committed_seq: result.committed_seq,
             commit_id: result.commit_id,
             inode_id: Some(loonfs_api::InodeId(args.inode)),
+            recovery_command: None,
         },
     })
 }
@@ -1050,6 +1085,7 @@ pub(crate) async fn run_filesystem_mkdir(
             committed_seq: result.committed_seq,
             commit_id: result.commit_id,
             inode_id: None,
+            recovery_command: None,
         },
     })
 }

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -67,10 +67,10 @@ pub(crate) async fn run(
         Command::Restore(args) => fs::run_filesystem_restore(kind, config_path, args).await,
         Command::Undelete(args) => fs::run_filesystem_undelete(kind, config_path, args).await,
         Command::Mkdir(args) => fs::run_filesystem_mkdir(kind, config_path, args).await,
-        Command::Rm(args) => fs::run_filesystem_rm(kind, config_path, args).await,
+        Command::Rm(args) => fs::run_filesystem_rm(kind, &location, args).await,
         Command::Mv(args) => fs::run_filesystem_mv(kind, config_path, args, runtime).await,
         Command::Cp(args) => fs::run_filesystem_cp(kind, config_path, args, runtime).await,
-        Command::Trash(args) => fs::run_filesystem_trash(kind, config_path, args).await,
+        Command::Trash(args) => fs::run_filesystem_trash(kind, &location, args).await,
         Command::Changes(args) => admin::run_admin_changes(kind, config_path, args).await,
         Command::Admin { command } => admin::run_admin_command(kind, config_path, command).await,
     }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -24,6 +24,21 @@ pub(crate) struct TreeTransferFailure {
     pub error: CliError,
 }
 
+/// A trash page plus the recovery command printed beside each entry.
+///
+/// The commands are rendered rather than carried as parts because the JSON
+/// envelope already publishes every field a script would build its own
+/// command from; a ready-to-paste line is a convenience for the human table,
+/// so it is skipped on the wire and the response shape stays the API's.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct TrashListing {
+    #[serde(flatten)]
+    pub response: loonfs_api::ListTrashResponse,
+    /// One complete `loonfs undelete` per entry, in `response.entries` order.
+    #[serde(skip)]
+    pub recovery_commands: Vec<String>,
+}
+
 /// One assigned `{job, namespace}` key, as a drain left it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct MaintenanceKeyReport {
@@ -122,7 +137,7 @@ pub(crate) enum CommandData {
     GrepIndexStatus(GrepIndexStatusResponse),
     GrepIndexCollected(GrepGcResponse),
     Changes(ChangesResponse),
-    Trash(loonfs_api::ListTrashResponse),
+    Trash(TrashListing),
     PathEntries {
         entries: Vec<AuthoritativePathEntry>,
         /// Where a bounded listing stopped, and how to resume it. Present
@@ -175,6 +190,10 @@ pub(crate) enum CommandData {
         /// `loonfs undelete`.
         #[serde(skip_serializing_if = "Option::is_none")]
         inode_id: Option<InodeId>,
+        /// The `loonfs undelete` that puts this deletion back, set by `rm`
+        /// alone. Human-only, for the reason [`TrashListing`] gives.
+        #[serde(skip)]
+        recovery_command: Option<String>,
     },
     /// A `mkdir -p` whose target was already a directory. Nothing was
     /// committed, so there is no commit to report — the directory the

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -446,7 +446,8 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             }
             lines.join("\n")
         }
-        CommandData::Trash(response) => {
+        CommandData::Trash(listing) => {
+            let response = &listing.response;
             let mut lines = vec![
                 format!(
                     "trash for {} (head seq {})",
@@ -454,24 +455,18 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                 ),
                 "DELETED\tNAME\tINODE\tSEQ\tRECOVER".to_owned(),
             ];
-            for entry in &response.entries {
+            // The commands were built one per entry, in this order.
+            for (entry, recovery_command) in response.entries.iter().zip(&listing.recovery_commands)
+            {
                 let name = entry
                     .display_name
                     .as_ref()
                     .map(|name| name.as_str().to_owned())
                     .unwrap_or_else(|| "-".to_owned());
-                let destination = entry
-                    .display_name
-                    .as_ref()
-                    .map(|name| format!("/{name}"))
-                    .unwrap_or_else(|| "<path>".to_owned());
                 lines.push(format!(
-                    "{}\t{}\t{}\t{}\tloonfs undelete {} --inode {} --deleted-at {}",
+                    "{}\t{}\t{}\t{}\t{recovery_command}",
                     format_utc_ms(entry.deleted_at_ms),
                     name,
-                    entry.root_inode_id,
-                    entry.deleted_at_seq.0,
-                    destination,
                     entry.root_inode_id,
                     entry.deleted_at_seq.0,
                 ));
@@ -744,16 +739,16 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             target,
             committed_seq,
             commit_id,
-            inode_id,
+            recovery_command,
+            ..
         } => match output.kind {
             CommandKind::FilesystemPut => {
                 format!("stored {target} @ seq {committed_seq} (commit {commit_id})")
             }
-            CommandKind::FilesystemRm => match inode_id {
-                Some(inode_id) => format!(
+            CommandKind::FilesystemRm => match recovery_command {
+                Some(recovery_command) => format!(
                     "removed {target} @ seq {committed_seq} (commit {commit_id}); \
-                     recover with `loonfs undelete <path> --inode {inode_id} \
-                     --deleted-at {committed_seq}`"
+                     recover with `{recovery_command}`"
                 ),
                 None => format!("removed {target} @ seq {committed_seq} (commit {commit_id})"),
             },

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -559,6 +559,14 @@ fn put_expected_revision_replaces_only_the_observed_revision() {
     ]);
     assert_failure(&stale);
     assert_eq!(json_error(&stale)["code"], "stale_revision");
+    // The rejection reads as a sentence, with both revisions in it and no
+    // Rust formatting of the one that may be absent.
+    let stale_error = json_error(&stale);
+    let message = stale_error["message"].as_str().unwrap_or_default();
+    assert!(
+        message.ends_with("expected revision 1, found revision 2"),
+        "{message}"
+    );
     let cat = harness.run(&["cat", "/doc.txt"]);
     assert_success(&cat);
     assert_eq!(cat.stdout, b"v2");
@@ -3436,6 +3444,53 @@ fn namespace_delete_without_yes_fails_cleanly_when_not_interactive() {
 
     let deleted = harness.run(&["--json", "namespace", "delete", "demo", "--yes"]);
     assert_success(&deleted);
+}
+
+/// A refused precondition has to say what it wanted and what it found, or
+/// the caller cannot tell a raced delete from a mistyped sequence.
+#[test]
+fn namespace_delete_reports_both_head_sequences_when_the_precondition_fails() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("doc.txt");
+    fs::write(&payload, b"body").expect("write payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/doc.txt"]));
+
+    let stale = harness.run(&[
+        "--json",
+        "namespace",
+        "delete",
+        "demo",
+        "--yes",
+        "--expected-head-seq",
+        "0",
+    ]);
+    assert_failure(&stale);
+    let error = json_error(&stale);
+    assert_eq!(error["code"], "stale_head");
+    assert_eq!(error["message"], "expected head sequence 0, found 1");
+
+    // The same sentence is what a human run prints, since the renderer
+    // writes the message through unchanged.
+    let human = harness.run(&[
+        "namespace",
+        "delete",
+        "demo",
+        "--yes",
+        "--expected-head-seq",
+        "0",
+    ]);
+    assert_failure(&human);
+    assert_eq!(
+        stderr_string(&human).trim_end(),
+        "expected head sequence 0, found 1"
+    );
+
+    // Refusing deleted nothing, so the namespace is still readable.
+    assert_success(&harness.run(&["--json", "ls", "/"]));
 }
 
 #[test]

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1717,6 +1717,136 @@ fn trash_lists_recoverable_deletions_with_their_handles() {
     assert!(json_data(&page)["next_cursor"].is_null());
 }
 
+/// The printed recovery commands are meant to be pasted, so they name the
+/// namespace they belong to and quote a path a shell would otherwise split.
+#[test]
+fn recovery_hints_name_their_namespace_and_quote_the_path() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("doc.txt");
+    fs::write(&payload, b"body").expect("write payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/docs/Quarterly Report.PDF",
+    ]));
+    let inode = json_data(&harness.run(&["--json", "stat", "/docs/Quarterly Report.PDF"]))
+        ["inode_id"]
+        .as_u64()
+        .expect("the stored inode id");
+
+    // Nothing here is spelled on the command line, so the namespace is the
+    // only ambient value the hint has to pin down.
+    let removed = harness.run(&["rm", "/docs/Quarterly Report.PDF"]);
+    assert_success(&removed);
+    let entry = json_data(&harness.run(&["--json", "trash"]))["entries"][0].clone();
+    let deleted_at = entry["deleted_at_seq"].as_u64().expect("the deletion seq");
+    assert_eq!(
+        hinted_recovery_command(&removed),
+        format!(
+            "loonfs undelete '/docs/Quarterly Report.PDF' --inode {inode} \
+             --deleted-at {deleted_at} --namespace demo"
+        )
+    );
+
+    // The trash table offers the same command for the same deletion. It
+    // recovers to the recorded name at the root, because a listed deletion
+    // carries the name it deleted and not the directory that held it.
+    let listed = harness.run(&["trash"]);
+    assert_success(&listed);
+    assert_eq!(
+        trash_recovery_command(&listed, "Quarterly Report.PDF"),
+        format!(
+            "loonfs undelete '/Quarterly Report.PDF' --inode {inode} \
+             --deleted-at {deleted_at} --namespace demo"
+        )
+    );
+
+    // Pasting the hint into a shell recovers the file, which is the whole
+    // reason the path is quoted.
+    let replayed = harness.replay_in_shell(&hinted_recovery_command(&removed));
+    assert_success(&replayed);
+    let cat = harness.run(&["cat", "/docs/Quarterly Report.PDF"]);
+    assert_success(&cat);
+    assert_eq!(cat.stdout, b"body");
+}
+
+/// A hint that leaves out a profile or a config file a bare invocation would
+/// not find again sends the paste at some other filesystem, so both are
+/// spelled whenever this run did not reach them the default way.
+#[test]
+fn recovery_hints_name_a_profile_and_config_a_bare_invocation_would_miss() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    harness.add_embedded_profile("staging");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+    assert_success(&harness.run(&["namespace", "create", "release", "--profile", "staging"]));
+
+    let payload = harness.temp_dir.path().join("doc.txt");
+    fs::write(&payload, b"body").expect("write payload");
+    let put = |extra: &[&str]| {
+        let mut args = vec!["put", payload.to_str().expect("utf-8 path"), "/notes.txt"];
+        args.extend_from_slice(extra);
+        assert_success(&harness.run(&args));
+    };
+
+    // A spelled --profile means the config's default is some other profile,
+    // so the hint has to say which one it meant.
+    put(&["--profile", "staging", "--namespace", "release"]);
+    let removed = harness.run(&[
+        "rm",
+        "/notes.txt",
+        "--profile",
+        "staging",
+        "--namespace",
+        "release",
+    ]);
+    assert_success(&removed);
+    let command = hinted_recovery_command(&removed);
+    assert!(
+        command.ends_with(" --namespace release --profile staging"),
+        "{command}"
+    );
+
+    // The config flag names a file a later paste would not look at.
+    let elsewhere = harness.temp_dir.path().join("elsewhere.toml");
+    let elsewhere_arg = elsewhere.to_str().expect("utf-8 config path");
+    fs::copy(&harness.config_path, &elsewhere).expect("copy the config aside");
+    put(&[]);
+    let removed = harness.run(&["--config", elsewhere_arg, "rm", "/notes.txt"]);
+    assert_success(&removed);
+    let command = hinted_recovery_command(&removed);
+    assert!(
+        command.ends_with(&format!(" --namespace demo --config {elsewhere_arg}")),
+        "{command}"
+    );
+
+    // So does the environment variable: the pasting shell need not still
+    // export it, so the hint carries the path instead of relying on it.
+    put(&[]);
+    let removed = harness.run_with_env(&[("LOONFS_CONFIG", elsewhere_arg)], &["rm", "/notes.txt"]);
+    assert_success(&removed);
+    let command = hinted_recovery_command(&removed);
+    assert!(
+        command.ends_with(&format!(" --namespace demo --config {elsewhere_arg}")),
+        "{command}"
+    );
+
+    // The default locations need no flag: they are what a bare invocation
+    // reads.
+    put(&[]);
+    let removed = harness.run(&["rm", "/notes.txt"]);
+    assert_success(&removed);
+    let command = hinted_recovery_command(&removed);
+    assert!(command.ends_with(" --namespace demo"), "{command}");
+    assert!(!command.contains("--config"), "{command}");
+    assert!(!command.contains("--profile"), "{command}");
+}
+
 #[test]
 fn human_output_shows_dates_and_event_names() {
     let harness = Harness::new();
@@ -3207,6 +3337,18 @@ fn remote_undelete_recovers_through_http() {
         .as_u64()
         .expect("rm reports the deletion sequence");
 
+    // The hint is built from the invocation, not the backend, so a remote
+    // profile prints the same command an embedded one would.
+    let listed = harness.run(&["trash"]);
+    assert_success(&listed);
+    assert_eq!(
+        trash_recovery_command(&listed, "wire.txt"),
+        format!(
+            "loonfs undelete /wire.txt --inode {inode_id} \
+             --deleted-at {deleted_at} --namespace demo"
+        )
+    );
+
     let recovered = harness.run(&[
         "--json",
         "undelete",
@@ -4636,6 +4778,25 @@ impl Harness {
         command
     }
 
+    /// Runs a command the CLI printed the way a user would: through a shell,
+    /// which is what makes the quoting in it load-bearing. Only the `loonfs`
+    /// the hint spells is swapped for the binary under test.
+    fn replay_in_shell(&self, command: &str) -> Output {
+        let arguments = command
+            .strip_prefix("loonfs ")
+            .expect("a printed command invokes loonfs");
+        let binary = loon_binary_path();
+        let script = format!("'{}' {arguments}", binary.display());
+        Command::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .env("HOME", &self.home_dir)
+            .env_remove("XDG_CONFIG_HOME")
+            .env_remove("LOONFS_CONFIG")
+            .output()
+            .expect("replay the printed command")
+    }
+
     /// Runs the CLI with a payload on standard input, which is the one
     /// source whose length is not knowable before it is read.
     fn run_with_stdin(&self, args: &[&str], stdin: &[u8]) -> Output {
@@ -4868,6 +5029,35 @@ fn assert_failure(output: &Output) {
 
 fn stdout_string(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// The command a `rm` hint spells, taken from between its backticks.
+fn hinted_recovery_command(output: &Output) -> String {
+    let text = stdout_string(output);
+    let hint = text
+        .split_once("recover with `")
+        .and_then(|(_, rest)| rest.split_once('`'))
+        .map(|(command, _)| command.to_owned());
+    assert!(
+        hint.is_some(),
+        "expected a backtick-delimited recovery hint, got:\n{text}"
+    );
+    hint.expect("checked just above")
+}
+
+/// The `RECOVER` cell of the one trash row naming `display_name`.
+fn trash_recovery_command(output: &Output, display_name: &str) -> String {
+    let table = stdout_string(output);
+    let cell = table
+        .lines()
+        .find(|line| line.split('\t').nth(1) == Some(display_name))
+        .and_then(|row| row.split('\t').nth(4))
+        .map(ToOwned::to_owned);
+    assert!(
+        cell.is_some(),
+        "expected a trash row for `{display_name}`, got:\n{table}"
+    );
+    cell.expect("checked just above")
 }
 
 fn stderr_string(output: &Output) -> String {

--- a/crates/loonfs-core/src/commit/validate_error.rs
+++ b/crates/loonfs-core/src/commit/validate_error.rs
@@ -83,7 +83,8 @@ pub enum CommitValidationError {
         actual_kind: InodeKind,
     },
     #[error(
-        "replace base revision mismatch for inode `{inode_id}`: expected `{expected}`, actual `{actual:?}`"
+        "replace base revision mismatch for inode `{inode_id}`: {}",
+        revision_mismatch(.expected, .actual)
     )]
     ReplaceFileBaseRevisionMismatch {
         inode_id: InodeId,
@@ -98,7 +99,8 @@ pub enum CommitValidationError {
         actual_kind: InodeKind,
     },
     #[error(
-        "restore base revision mismatch for inode `{inode_id}`: expected `{expected}`, actual `{actual:?}`"
+        "restore base revision mismatch for inode `{inode_id}`: {}",
+        revision_mismatch(.expected, .actual)
     )]
     RestoreRevisionBaseRevisionMismatch {
         inode_id: InodeId,
@@ -252,4 +254,17 @@ pub enum CommitValidationError {
     OpIndexOverflow,
     #[error("delta index overflow")]
     DeltaIndexOverflow,
+}
+
+/// What a base-revision guard asked for against what it found, in words.
+///
+/// The revision it found is absent when the file carries no revision at all,
+/// and that case reads as a sentence rather than printing the `Option` — a
+/// message is for a person, while the same pair rides the wire as typed
+/// `expected_revision` and `actual_revision` details for a program.
+fn revision_mismatch(expected: &RevisionNo, actual: &Option<RevisionNo>) -> String {
+    match actual {
+        Some(actual) => format!("expected revision {expected}, found revision {actual}"),
+        None => format!("expected revision {expected}, found no revision"),
+    }
 }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -199,6 +199,19 @@ pub enum CoreError {
     NamespaceExists { namespace_id: NamespaceId },
     #[error("namespace `{namespace_id}` is deleted")]
     NamespaceDeleted { namespace_id: NamespaceId },
+    /// A caller-supplied `expected_head_seq` did not match the head.
+    ///
+    /// Distinct from the publish path's [`CommitHeadPublishError::StaleHead`],
+    /// which reports a race the caller never asked about: this is a
+    /// precondition the caller wrote, so the rejection owes it both numbers —
+    /// what it asked for and what the namespace was actually at — and a
+    /// caller that meant to delete the current head can retry against the
+    /// sequence it found. Both carry the `stale_head` code.
+    #[error("expected head sequence {expected}, found {actual}")]
+    StaleHeadPrecondition {
+        expected: ChangeSeq,
+        actual: ChangeSeq,
+    },
     /// A batch stopped at one of its operations. A mutation commits all of
     /// its operations or none of them, so this names the operation that
     /// stopped the request and carries the failure it produced. The wire code
@@ -392,6 +405,7 @@ impl CoreError {
             CoreError::ContentTooLarge { .. } => ErrorCode::ContentTooLarge,
             CoreError::NamespaceExists { .. } => ErrorCode::NamespaceExists,
             CoreError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
+            CoreError::StaleHeadPrecondition { .. } => ErrorCode::StaleHead,
             CoreError::CommitIdReuseConflict { .. } => ErrorCode::CommitIdReuseConflict,
             CoreError::ContentPreparation(_) => ErrorCode::ContentNotPrepared,
             CoreError::CommitQueueFull => ErrorCode::CommitQueueFull,
@@ -463,6 +477,11 @@ impl CoreError {
             } => Some(ErrorDetails {
                 after_seq: Some(*after_seq),
                 retention_floor_seq: Some(*retention_floor_seq),
+                ..ErrorDetails::default()
+            }),
+            CoreError::StaleHeadPrecondition { expected, actual } => Some(ErrorDetails {
+                expected_head_seq: Some(*expected),
+                actual_head_seq: Some(*actual),
                 ..ErrorDetails::default()
             }),
             CoreError::CommitValidation(error) => commit_validation_details(error),
@@ -942,6 +961,51 @@ mod tests {
         assert_eq!(details.inode_id, Some(InodeId(7)));
         assert_eq!(details.expected_revision, Some(RevisionNo(2)));
         assert_eq!(details.actual_revision, Some(RevisionNo(5)));
+        // The prose says the same thing in words, so neither revision
+        // reaches a reader as Rust formatting.
+        assert!(
+            stale
+                .to_string()
+                .ends_with("expected revision 2, found revision 5"),
+            "{stale}"
+        );
+
+        // A file with no revision at all reads as a sentence rather than
+        // printing the absent value.
+        let unversioned =
+            CoreError::CommitValidation(CommitValidationError::ReplaceFileBaseRevisionMismatch {
+                inode_id: InodeId(7),
+                expected: RevisionNo(2),
+                actual: None,
+            });
+        assert!(
+            unversioned
+                .to_string()
+                .ends_with("expected revision 2, found no revision"),
+            "{unversioned}"
+        );
+        assert_eq!(
+            unversioned
+                .details()
+                .expect("stale-revision details")
+                .actual_revision,
+            None
+        );
+
+        // A refused `expected_head_seq` carries both sequences, so a caller
+        // that still means to delete knows what to retry against.
+        let precondition = CoreError::StaleHeadPrecondition {
+            expected: ChangeSeq(41),
+            actual: ChangeSeq(45),
+        };
+        assert_eq!(precondition.code(), ErrorCode::StaleHead);
+        assert_eq!(
+            precondition.to_string(),
+            "expected head sequence 41, found 45"
+        );
+        let details = precondition.details().expect("head-sequence details");
+        assert_eq!(details.expected_head_seq, Some(ChangeSeq(41)));
+        assert_eq!(details.actual_head_seq, Some(ChangeSeq(45)));
 
         // Errors without machine-usable identity stay detail-free.
         assert!(CoreError::Internal("boom".to_owned()).details().is_none());

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -72,9 +72,10 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
 
         if let Some(expected) = options.expected_head_seq {
             if head.seq != expected {
-                return Err(CoreError::HeadPublish(
-                    crate::commit::CommitHeadPublishError::StaleHead,
-                ));
+                return Err(CoreError::StaleHeadPrecondition {
+                    expected,
+                    actual: head.seq,
+                });
             }
         }
 

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -192,10 +192,15 @@ async fn ensure_fork_checkpoint_lease_holds<S: ObjectStore + ?Sized>(
         .expires_at_ms
         .is_some_and(|expires_at_ms| expires_at_ms > now_ms.saturating_add(FORK_GUARD_MARGIN_MS));
     if !holds {
-        return lost(format!(
-            "the lease ({:?}) is inside the {FORK_GUARD_MARGIN_MS}ms guard margin at {now_ms}",
-            record.expires_at_ms
-        ));
+        // Both arms name the same failure — the lease cannot be trusted to
+        // outlast this read — and each says which way it fell short.
+        return lost(match record.expires_at_ms {
+            Some(expires_at_ms) => format!(
+                "its lease expires at {expires_at_ms} ms, inside the \
+                 {FORK_GUARD_MARGIN_MS}ms guard margin at {now_ms}"
+            ),
+            None => "the record carries no lease".to_owned(),
+        });
     }
     Ok(())
 }

--- a/crates/loonfs-server/tests/it/http_smoke.rs
+++ b/crates/loonfs-server/tests/it/http_smoke.rs
@@ -48,9 +48,22 @@ async fn delete_namespace_is_terminal_and_retires_the_id() {
         .await
         .expect_err("stale precondition");
     match stale {
-        ClientError::Api { status, code, .. } => {
+        ClientError::Api {
+            status,
+            code,
+            message,
+            details,
+            ..
+        } => {
             assert_eq!(status, 409);
             assert_eq!(code, "stale_head");
+            // The rejection reports both sequences, so a caller that still
+            // means to delete knows what to retry against without parsing
+            // anything: in words for a person, typed for a program.
+            assert_eq!(message, "expected head sequence 0, found 1");
+            let details = details.expect("a stale precondition carries its sequences");
+            assert_eq!(details.expected_head_seq, Some(ChangeSeq(0)));
+            assert_eq!(details.actual_head_seq, Some(ChangeSeq(1)));
         }
         other => unreachable!("expected stale_head, got {other:?}"),
     }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -217,6 +217,7 @@ The codes that populate it:
 | `stale_revision` | `inode_id`, `expected_revision`, `actual_revision` (absent when the inode has no current revision) |
 | `commit_id_reuse_conflict` | `commit_id`, plus `committed_seq` when the conflict was decided against a durable commit receipt — the sequence that `commit_id` already landed at. Absent when nothing has committed under the id yet and two live requests are claiming it at once |
 | `rebootstrap_required` | `after_seq`, `retention_floor_seq` |
+| `stale_head` | `expected_head_seq`, `actual_head_seq`, when the failure was a caller-supplied `expected_head_seq` precondition rather than a raced head advance. A caller that still means to delete retries against the sequence it found |
 | `not_deleted` | `inode_id`, plus `requested_deletion_seq` and `active_deletion_seq` when a live deletion exists at a different generation |
 | any failed commit | `commit_id` — the idempotency key the request committed under, echoed so failed and uncertain outcomes carry the caller's reconciliation handle (section 5.2) |
 | any commit carrying more than one operation | `operation_index` — the position of the operation that stopped the request (section 5.1) |
@@ -246,7 +247,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `content_not_prepared` | 409 | A path put or explicit create/replace operation references external content without a matching admission, or carries a rejected relevant token. Prepare the content and retry with its proof. |
 | `path_conflict` | 409 | The destination path is already bound. |
 | `directory_not_empty` | 409 | The directory has children and the operation is not recursive. |
-| `stale_head` | 409 | The write raced a head advance; retry against fresh state. |
+| `stale_head` | 409 | The write raced a head advance, or a caller-supplied `expected_head_seq` no longer matches the head; retry against fresh state. |
 | `stale_revision` | 409 | A caller-supplied base revision is no longer current. |
 | `not_deleted` | 409 | The undelete target is not the root of a live deletion; nothing to recover. |
 | `writer_fenced` | 409 | The writer epoch was superseded by another session. |
@@ -1070,7 +1071,10 @@ already swept has nothing left pointing at it and is not reclaimed.
 
 The optional `expected_head_seq` query parameter deletes only if the head is
 still at that sequence, failing with `stale_head` otherwise — the same
-race-explicit pattern preconditions give file mutations.
+race-explicit pattern preconditions give file mutations. That rejection
+reports both sequences, in the message and as `expected_head_seq` and
+`actual_head_seq` details, so a caller that still means to delete can retry
+against the sequence it found.
 
 ```json
 {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3573,6 +3573,17 @@
               }
             ]
           },
+          "actual_head_seq": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Head sequence the namespace was actually at, which is what a caller\nthat still means to delete it retries against."
+              }
+            ]
+          },
           "actual_revision": {
             "oneOf": [
               {
@@ -3614,6 +3625,17 @@
               {
                 "$ref": "#/components/schemas/ChangeSeq",
                 "description": "Sequence at which that commit id already landed. Present when the\nfailure was decided against a durable commit receipt, which is what\nholds the sequence; absent when nothing has committed under the id\nyet and two live requests are simply claiming it at once."
+              }
+            ]
+          },
+          "expected_head_seq": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Head sequence a namespace delete required the namespace to still be\nat."
               }
             ]
           },


### PR DESCRIPTION
This PR addresses two things: recovery commands that lose their context, and conflict messages that leak Rust formatting.

Recovery hints carry their full context: The commands `trash` and `rm` print are now copy-paste-safe against context drift:

- `--namespace` is always spelled.
- `--profile` is spelled when the invocation spelled one — an unspelled profile is what a bare invocation resolves anyway, and a redundant explicit profile beats a wrong implicit one.
- `--config` is spelled when the config came from the flag or the environment variable, because a bare paste later would not find that file; the environment case prints the path so the hint works without the variable. XDG and legacy locations are what a bare invocation reads, so no flag.
- Paths, profile names, and config paths are shell-quoted; a test replays the printed hint through `sh -c` to prove a name with spaces actually pastes.
- `rm`'s hint fills the exact path it deleted instead of the `<path>` placeholder.

Sample: ``recover with `loonfs undelete '/docs/Quarterly Report.PDF' --inode 3 --deleted-at 2 --namespace demo` ``

Conflicts report their numbers in plain language: `expected `2`, actual `Some(RevisionNo(5))`` becomes `expected revision 2, found revision 5`; an absent revision reads `found no revision`; the fork-lease guard names its timestamps instead of debug-printing an Option. Stale namespace deletion now reports `expected head sequence 41, found 45` and carries `expected_head_seq` / `actual_head_seq` in the error details (additive; the details table in the spec gains the row). The error code stays `stale_head` — a new core variant classifies to it, which incidentally separates the precondition failure from the publish race that used to share one message. Machine-readable details keep their typed values throughout; this is Display-layer only.

