### PR TITLE
fix(cli): embedded details and an honest gc summary

### DIFF
--- a/crates/loonfs-cli/src/backend_error.rs
+++ b/crates/loonfs-cli/src/backend_error.rs
@@ -121,7 +121,15 @@ pub(crate) fn map_runtime_error(error: RuntimeError) -> BackendError {
     match error {
         RuntimeError::Config(message) => BackendError::invalid_config(message),
         RuntimeError::RuntimeTask(message) => BackendError::runtime_error(message),
-        error => BackendError::new(error.code().as_str(), error.to_string()),
+        // The embedded surface reports the same structured details a server
+        // puts in its error envelope for the same condition, so `--json`
+        // consumers read one contract from both backends.
+        error => BackendError {
+            code: error.code().as_str().to_owned(),
+            message: error.to_string(),
+            request_id: None,
+            details: error.details().map(Box::new),
+        },
     }
 }
 
@@ -154,7 +162,24 @@ pub(crate) fn map_namespace_scoped_grep_error(
 
 #[cfg(test)]
 mod tests {
-    use super::{BackendError, ClientError};
+    use super::{map_runtime_error, BackendError, ClientError};
+    use loonfs::RuntimeError;
+    use loonfs_api::ChangeSeq;
+
+    #[test]
+    fn embedded_runtime_errors_carry_their_structured_details() {
+        let error = map_runtime_error(RuntimeError::Core(
+            loonfs::CoreError::StaleHeadPrecondition {
+                expected: ChangeSeq(41),
+                actual: ChangeSeq(45),
+            },
+        ));
+
+        assert_eq!(error.code, "stale_head");
+        let details = error.details.expect("core details survive the seam");
+        assert_eq!(details.expected_head_seq, Some(ChangeSeq(41)));
+        assert_eq!(details.actual_head_seq, Some(ChangeSeq(45)));
+    }
 
     #[test]
     fn api_errors_pass_their_code_and_message_through_verbatim() {

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -212,6 +212,7 @@ fn accumulate_gc_response(total: &mut loonfs_api::GcResponse, pass: loonfs_api::
     total.deleted_manifests += pass.deleted_manifests;
     total.deleted_checkpoint_records += pass.deleted_checkpoint_records;
     total.released_fork_checkpoints += pass.released_fork_checkpoints;
+    total.released_expired_checkpoints += pass.released_expired_checkpoints;
     total.deleted_upload_sessions += pass.deleted_upload_sessions;
     total.deleted_content_objects += pass.deleted_content_objects;
     total.released_missing_basis_checkpoints += pass.released_missing_basis_checkpoints;
@@ -219,6 +220,14 @@ fn accumulate_gc_response(total: &mut loonfs_api::GcResponse, pass: loonfs_api::
     total.retained.add(&pass.retained);
     total.degraded_retention |= pass.degraded_retention;
     total.content_reclamation_deferred |= pass.content_reclamation_deferred;
+    // The summary keeps the soonest obligation any pass reported — the same
+    // soonest-wake rule the maintenance runner applies. A later pass with
+    // nothing deferred does not erase an earlier pass's pending horizon.
+    total.next_reclamation_at_ms = match (total.next_reclamation_at_ms, pass.next_reclamation_at_ms)
+    {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, b) => a.or(b),
+    };
     total.next_cursor = pass.next_cursor;
 }
 
@@ -700,6 +709,31 @@ mod tests {
     use super::*;
     use crate::progress::ProgressMode;
     use loonfs_api::{GcResponse, NamespaceId, RetainedReason};
+
+    /// The multi-pass summary folds every counter and keeps the soonest
+    /// reclamation obligation any pass reported: a later pass with nothing
+    /// deferred does not erase an earlier pass's pending horizon.
+    #[test]
+    fn the_summary_folds_expired_releases_and_keeps_the_soonest_horizon() {
+        let namespace = NamespaceId::parse("demo").expect("namespace id");
+        let mut total = GcResponse::empty(namespace.clone());
+
+        let mut first = GcResponse::empty(namespace.clone());
+        first.released_expired_checkpoints = 2;
+        first.next_reclamation_at_ms = Some(9_000);
+        accumulate_gc_response(&mut total, first);
+
+        let mut second = GcResponse::empty(namespace.clone());
+        second.released_expired_checkpoints = 1;
+        accumulate_gc_response(&mut total, second);
+
+        let mut third = GcResponse::empty(namespace);
+        third.next_reclamation_at_ms = Some(12_000);
+        accumulate_gc_response(&mut total, third);
+
+        assert_eq!(total.released_expired_checkpoints, 3);
+        assert_eq!(total.next_reclamation_at_ms, Some(9_000));
+    }
 
     fn runtime(json: bool) -> RuntimeBehavior {
         RuntimeBehavior {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -567,6 +567,11 @@ fn put_expected_revision_replaces_only_the_observed_revision() {
         message.ends_with("expected revision 1, found revision 2"),
         "{message}"
     );
+    // The embedded backend carries the same structured details a server's
+    // envelope would, so `--json` consumers read one contract from both
+    // profiles.
+    assert_eq!(stale_error["details"]["expected_revision"], 1);
+    assert_eq!(stale_error["details"]["actual_revision"], 2);
     let cat = harness.run(&["cat", "/doc.txt"]);
     assert_success(&cat);
     assert_eq!(cat.stdout, b"v2");

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -2725,6 +2725,7 @@ fn accumulate_report(total: &mut GcResponse, pass: &GcResponse) {
     total.deleted_manifests += pass.deleted_manifests;
     total.deleted_checkpoint_records += pass.deleted_checkpoint_records;
     total.released_fork_checkpoints += pass.released_fork_checkpoints;
+    total.released_expired_checkpoints += pass.released_expired_checkpoints;
     total.deleted_upload_sessions += pass.deleted_upload_sessions;
     total.deleted_content_objects += pass.deleted_content_objects;
     total.released_missing_basis_checkpoints += pass.released_missing_basis_checkpoints;
@@ -2732,6 +2733,11 @@ fn accumulate_report(total: &mut GcResponse, pass: &GcResponse) {
     total.retained.add(&pass.retained);
     total.degraded_retention |= pass.degraded_retention;
     total.content_reclamation_deferred |= pass.content_reclamation_deferred;
+    total.next_reclamation_at_ms = match (total.next_reclamation_at_ms, pass.next_reclamation_at_ms)
+    {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, b) => a.or(b),
+    };
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -55,6 +55,19 @@ impl BootstrapNamespaceError {
             BootstrapNamespaceError::Core(error) => error.code(),
         }
     }
+
+    /// Returns the structured context the code's consumers report beside it,
+    /// mirroring [`CoreError::details`](crate::Error::details): only the
+    /// wrapped core failure carries any.
+    pub fn details(&self) -> Option<loonfs_api::ErrorDetails> {
+        match self {
+            BootstrapNamespaceError::Core(error) => error.details(),
+            BootstrapNamespaceError::EmptyHolderId
+            | BootstrapNamespaceError::NamespaceAlreadyExists { .. }
+            | BootstrapNamespaceError::NamespaceDeleted { .. }
+            | BootstrapNamespaceError::Head(_) => None,
+        }
+    }
 }
 
 pub(crate) async fn bootstrap_namespace<S: ObjectStore + ?Sized>(

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -195,4 +195,18 @@ impl RuntimeError {
             Self::RuntimeTask(_) => ErrorCode::ServerError,
         }
     }
+
+    /// Returns the structured context the code's consumers report beside it.
+    ///
+    /// The embedded surface carries the same details a server puts in its
+    /// error envelope for the same condition, so both backends serve one
+    /// contract. Only the engine attaches any; runtime-local failures have
+    /// no structured half.
+    pub fn details(&self) -> Option<loonfs_api::ErrorDetails> {
+        match self {
+            Self::Core(error) => error.details(),
+            Self::Bootstrap(error) => error.details(),
+            Self::Config(_) | Self::RuntimeTask(_) => None,
+        }
+    }
 }


### PR DESCRIPTION
The embedded backend forwards error details: The CLI's JSON envelope always had a `details` field, and the remote backend fills it from the server's envelope — but the embedded backend dropped every error's structured half: the seam built its error from code and message alone, and the runtime error offered no way to ask for more. The runtime error now has a `details()` accessor mirroring `code()` — the engine's details pass through, bootstrap delegates to its wrapped core failure, runtime-local failures have none — and the seam's catch-all arm carries them. Both backends now serve one contract: a unit test pins the seam (stale-head details survive with both sequences), and the existing guarded-put CLI test now asserts `details.expected_revision` / `actual_revision` through the embedded profile in `--json`.

The GC summary folds every counter and keeps the soonest horizon: The multi-pass accumulation never folded `released_expired_checkpoints` and dropped `next_reclamation_at_ms` entirely. The summary now keeps the soonest obligation any pass reported — the same soonest-wake rule the maintenance runner applies — so a later pass with nothing deferred does not erase an earlier pass's pending horizon. The test-side twin in the GC equivalence tests gets the same two folds, and a unit test pins the fold-and-soonest behavior across three passes.