### PR TITLE
feat(trash): undelete restores in place when no path is given

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -260,7 +260,7 @@ pub enum FilesystemOperation {
     },
     /// Recover a deleted file or subtree: revoke the deletion of
     /// `inode_id` recorded at `deleted_at_seq` (both reported by the
-    /// delete and by the change feed) and re-bind it at `path`. Answers
+    /// delete and by the change feed) and re-bind it. Answers
     /// `not_deleted` when that generation is not the live one, so a stale
     /// request never cancels a later delete.
     #[cfg_attr(feature = "openapi", schema(title = "FsOpUndelete"))]
@@ -269,8 +269,15 @@ pub enum FilesystemOperation {
         inode_id: InodeId,
         /// Observed deletion sequence, which prevents cancelling a newer tombstone generation.
         deleted_at_seq: ChangeSeq,
-        /// Absolute destination path whose parent must be visible and whose name must be absent.
-        path: AbsolutePath,
+        /// Absolute destination path whose parent must be visible and whose
+        /// name must be absent. Absent means restore in place: re-bind
+        /// under the parent and name the deletion recorded, anchored on
+        /// the parent's identity rather than any remembered spelling, so
+        /// the entry lands correctly even when ancestors were renamed
+        /// since. A deletion that recorded no binding needs the explicit
+        /// path.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<AbsolutePath>,
     },
     /// Restore an older revision as the current revision for a path.
     #[cfg_attr(feature = "openapi", schema(title = "FsOpRestoreRevision"))]
@@ -1154,7 +1161,7 @@ mod tests {
                 FilesystemOperation::Undelete {
                     inode_id: InodeId(7),
                     deleted_at_seq: ChangeSeq(8),
-                    path: path("/docs/restored"),
+                    path: Some(path("/docs/restored")),
                 },
                 serde_json::json!({
                     "kind": "undelete",

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -198,10 +198,14 @@ History and recovery
     List recoverable deletions: what was deleted, when, and the exact
     `loonfs undelete` command that recovers each one
 
-  loonfs undelete <path> --inode <id> --deleted-at <seq>
-    Recover a deleted file or directory at <path>; --inode and --deleted-at
-    come from `loonfs trash` or the `rm` output and name one exact deletion,
-    so a stale command cannot cancel a later delete
+  loonfs undelete [<path>] --inode <id> --deleted-at <seq>
+    Recover a deleted file or directory; --inode and --deleted-at come from
+    `loonfs trash` or the `rm` output and name one exact deletion, so a
+    stale command cannot cancel a later delete. Omit <path> to restore in
+    place — the entry re-binds under the parent and name its deletion
+    recorded, which lands correctly even if the enclosing directories were
+    renamed since. Pass <path> to recover somewhere else, or when the
+    deletion recorded no binding
 
   loonfs changes [--after <seq>] [--limit <n>]
     List committed changes after a sequence number, from the start of

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -589,8 +589,12 @@ pub(crate) struct FilesystemRestoreArgs {
 pub(crate) struct FilesystemUndeleteArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
-    /// Destination path for the recovered file or directory.
-    pub path: String,
+    /// Destination path for the recovered file or directory. Omit to
+    /// restore in place: the entry re-binds under the parent and name its
+    /// deletion recorded, which lands correctly even when the enclosing
+    /// directories were renamed since. A deletion that recorded no binding
+    /// needs the explicit path.
+    pub path: Option<String>,
     /// Inode id of the deleted item, as reported by `rm` and the change
     /// feed.
     #[arg(long)]

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -20,11 +20,12 @@ use loonfs_api::{
         GrepIndexLifecycle, GrepIndexStatusResponse, StoreProbeCheckOutcome, StoreProbeCheckResult,
         StoreProbeResponse,
     },
-    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, CreateCheckpointRequest,
-    CreateCheckpointResponse, EffectiveLimit, ErrorCode, GrepRequest, GrepResponse, InodeId,
-    ListCheckpointsResponse, ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse,
-    MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, PaginationPolicy, ReleaseCheckpointResponse, RevisionNo,
+    AbsolutePath, AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse,
+    CreateCheckpointRequest, CreateCheckpointResponse, EffectiveLimit, ErrorCode, GrepRequest,
+    GrepResponse, InodeId, ListCheckpointsResponse, ListFileRevisionsResponse,
+    ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest, MaintenanceStepResponse,
+    NamespaceId, NamespaceStatusResponse, NamespaceSummary, PaginationPolicy,
+    ReleaseCheckpointResponse, RevisionNo,
 };
 use loonfs_client::NamespacePath;
 use loonfs_grep::{
@@ -740,17 +741,18 @@ impl EmbeddedBackend {
 
     pub(super) async fn undelete(
         &self,
-        spec: &NamespacePath,
+        namespace: &NamespaceId,
+        path: Option<&AbsolutePath>,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
         options: &UndeleteOptions,
     ) -> Result<CommitResponse, BackendError> {
-        self.publish_with_maintenance_recovery(spec.namespace(), || {
+        self.publish_with_maintenance_recovery(namespace, || {
             self.writer.undelete(
-                spec.namespace(),
+                namespace,
                 inode_id,
                 deleted_at_seq,
-                spec.absolute_path().as_str(),
+                path.map(|path| path.as_str()),
                 options.clone(),
             )
         })

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -28,7 +28,7 @@ use loonfs_api::{
         GrepGcResponse, GrepIndexLifecycle, GrepIndexStatusResponse, StoreProbeRequest,
         StoreProbeResponse, UploadStatusResponse,
     },
-    AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, ContentRef,
+    AbsolutePath, AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, ContentRef,
     CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse, GrepRequest,
     GrepResponse, InodeId, ListCheckpointsResponse, ListFileRevisionsResponse,
     ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest, MaintenanceStepResponse,
@@ -741,12 +741,14 @@ impl ResolvedTarget {
         }
     }
 
-    /// Recovers a deleted file or subtree to the spec's path; `inode_id`
-    /// and `deleted_at_seq` are the identity and committed sequence the
-    /// delete reported.
+    /// Recovers a deleted file or subtree; `inode_id` and `deleted_at_seq`
+    /// are the identity and committed sequence the delete reported. An
+    /// absent `path` restores in place, under the parent and name the
+    /// deletion recorded.
     pub(crate) async fn undelete(
         &self,
-        spec: &NamespacePath,
+        namespace: &NamespaceId,
+        path: Option<&AbsolutePath>,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
         options: &UndeleteOptions,
@@ -755,12 +757,12 @@ impl ResolvedTarget {
             Self::Embedded(target) => {
                 target
                     .backend
-                    .undelete(spec, inode_id, deleted_at_seq, options)
+                    .undelete(namespace, path, inode_id, deleted_at_seq, options)
                     .await
             }
             Self::Remote(target) => Ok(target
                 .client
-                .undelete(spec, inode_id, deleted_at_seq, options)
+                .undelete(namespace, inode_id, deleted_at_seq, path, options)
                 .await?),
         }
     }

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -238,24 +238,28 @@ impl UndeleteHint {
         Self { context_flags }
     }
 
-    /// The complete `loonfs undelete` invocation that recovers one deletion:
-    /// where it should land, and the inode plus deletion sequence that
-    /// identify the exact deletion being recovered.
+    /// The complete `loonfs undelete` invocation that recovers one deletion.
     ///
-    /// `destination` is absent for a deletion that recorded no name, which
-    /// has none to offer.
+    /// A deletion that recorded its binding restores in place — the entry
+    /// re-binds under the parent and name the delete recorded — so the
+    /// pasted command names no destination at all. One that recorded no
+    /// binding needs the caller to supply where it should land.
     pub(crate) fn command(
         &self,
-        destination: Option<&str>,
+        recorded_binding: bool,
         inode_id: InodeId,
         deleted_at: ChangeSeq,
     ) -> String {
         // The placeholder is deliberately left unquoted: pasted unedited, a
         // shell rejects it instead of recovering the entry to a file
         // literally named `<path>`.
-        let destination = destination.map_or_else(|| PATH_PLACEHOLDER.to_owned(), shell_quote);
+        let destination = if recorded_binding {
+            String::new()
+        } else {
+            format!("{PATH_PLACEHOLDER} ")
+        };
         format!(
-            "loonfs undelete {destination} --inode {inode_id} --deleted-at {}{}",
+            "loonfs undelete {destination}--inode {inode_id} --deleted-at {}{}",
             deleted_at.0, self.context_flags
         )
     }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -520,17 +520,15 @@ pub(crate) async fn run_filesystem_trash(
         .await
         .map_err(|error| context.fail(kind, error))?;
     let hint = UndeleteHint::new(&context, location, args.target.profile.profile.is_some());
-    // The listing carries the deleted binding's leaf name, not the directory
-    // it hung under, so the offered destination is that name at the root. It
-    // is a complete command; a caller who wants the original directory back
-    // edits the path, which is the same edit `undelete` already invites.
+    // An entry that recorded its binding restores in place with no
+    // destination in the command; only a legacy entry that recorded none
+    // still needs the caller to supply one.
     let recovery_commands = response
         .entries
         .iter()
         .map(|entry| {
-            let destination = entry.display_name.as_ref().map(|name| format!("/{name}"));
             hint.command(
-                destination.as_deref(),
+                entry.display_name.is_some(),
                 entry.root_inode_id,
                 entry.deleted_at_seq,
             )
@@ -929,14 +927,16 @@ pub(crate) async fn run_filesystem_rm(
         .await
         .map_err(|error| context.fail(kind, error))?;
 
-    // The path just deleted is the destination that puts the entry back where
-    // it was, so the printed command is complete for this exact deletion.
-    let recovery_command =
-        UndeleteHint::new(&context, location, args.target.profile.profile.is_some()).command(
-            Some(spec.absolute_path().as_str()),
-            deleted_inode,
-            result.committed_seq,
-        );
+    // A delete resolved through a path always records its binding, so the
+    // printed command restores in place with no destination — and keeps
+    // working even if the enclosing directories are renamed before the
+    // paste.
+    let recovery_command = UndeleteHint::new(
+        &context,
+        location,
+        args.target.profile.profile.is_some(),
+    )
+    .command(true, deleted_inode, result.committed_seq);
 
     Ok(CommandOutput {
         kind,
@@ -997,14 +997,21 @@ pub(crate) async fn run_filesystem_undelete(
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = false;
-    let spec = namespace_path(&context.namespace, &args.path, allow_root)
+    // An absent path restores in place; the destination is then the parent
+    // and name the deletion recorded, which no path here could name better.
+    let spec = args
+        .path
+        .as_deref()
+        .map(|path| namespace_path(&context.namespace, path, allow_root))
+        .transpose()
         .map_err(|error| context.fail(kind, error))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
     let result = context
         .target
         .undelete(
-            &spec,
+            &context.namespace,
+            spec.as_ref().map(|spec| spec.absolute_path()),
             loonfs_api::InodeId(args.inode),
             loonfs_api::ChangeSeq(args.deleted_at),
             &loonfs_client::UndeleteOptions {
@@ -1015,12 +1022,16 @@ pub(crate) async fn run_filesystem_undelete(
         .await
         .map_err(|error| context.fail(kind, error))?;
 
+    let target = match spec.as_ref() {
+        Some(spec) => render_target(&context.namespace, spec.absolute_path()),
+        None => format!("{}:(restored in place)", context.namespace),
+    };
     Ok(CommandOutput {
         kind,
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::FileMutation {
-            target: render_target(&context.namespace, spec.absolute_path()),
+            target,
             committed_seq: result.committed_seq,
             commit_id: result.commit_id,
             inode_id: Some(loonfs_api::InodeId(args.inode)),

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1754,23 +1754,17 @@ fn recovery_hints_name_their_namespace_and_quote_the_path() {
     let deleted_at = entry["deleted_at_seq"].as_u64().expect("the deletion seq");
     assert_eq!(
         hinted_recovery_command(&removed),
-        format!(
-            "loonfs undelete '/docs/Quarterly Report.PDF' --inode {inode} \
-             --deleted-at {deleted_at} --namespace demo"
-        )
+        format!("loonfs undelete --inode {inode} --deleted-at {deleted_at} --namespace demo")
     );
 
-    // The trash table offers the same command for the same deletion. It
-    // recovers to the recorded name at the root, because a listed deletion
-    // carries the name it deleted and not the directory that held it.
+    // The trash table offers the same command for the same deletion. Neither
+    // names a destination: a recorded binding restores in place, under the
+    // parent and name the delete recorded.
     let listed = harness.run(&["trash"]);
     assert_success(&listed);
     assert_eq!(
         trash_recovery_command(&listed, "Quarterly Report.PDF"),
-        format!(
-            "loonfs undelete '/Quarterly Report.PDF' --inode {inode} \
-             --deleted-at {deleted_at} --namespace demo"
-        )
+        format!("loonfs undelete --inode {inode} --deleted-at {deleted_at} --namespace demo")
     );
 
     // Pasting the hint into a shell recovers the file, which is the whole
@@ -3313,6 +3307,89 @@ fn rm_reports_the_inode_and_undelete_recovers_it() {
     assert_eq!(json_error(&again)["code"], "not_deleted");
 }
 
+/// A pathless undelete restores in place: it re-binds under the parent
+/// inode and name the deletion recorded. Renaming the parent between the
+/// delete and the recovery is the proof that the anchor is identity, not a
+/// remembered path — the entry comes back inside the parent's new name.
+#[test]
+fn an_undelete_without_a_path_restores_in_place() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("report.txt");
+    fs::write(&payload, b"quarterly numbers").expect("payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/docs/report.txt",
+    ]));
+
+    let removed = harness.run(&["rm", "/docs/report.txt"]);
+    assert_success(&removed);
+    // The printed recovery command names no destination: in place needs
+    // none.
+    let recovery = hinted_recovery_command(&removed);
+    assert!(
+        recovery.starts_with("loonfs undelete --inode "),
+        "{recovery}"
+    );
+    let trash = harness.run(&["--json", "trash"]);
+    assert_success(&trash);
+    let entry = json_data(&trash)["entries"][0].clone();
+    let inode_id = entry["root_inode_id"]
+        .as_u64()
+        .expect("trash reports the deleted inode id");
+    let deleted_at = entry["deleted_at_seq"]
+        .as_u64()
+        .expect("trash reports the deletion sequence");
+
+    // The parent moves on while the file sits in the trash.
+    assert_success(&harness.run(&["mv", "/docs", "/archive"]));
+
+    let recovered = harness.run(&[
+        "--json",
+        "undelete",
+        "--inode",
+        &inode_id.to_string(),
+        "--deleted-at",
+        &deleted_at.to_string(),
+    ]);
+    assert_success(&recovered);
+    assert_eq!(json_data(&recovered)["target"], "demo:(restored in place)");
+    let cat = harness.run(&["cat", "/archive/report.txt"]);
+    assert_success(&cat);
+    assert_eq!(cat.stdout, b"quarterly numbers");
+
+    // The trash listing offers the same pathless command.
+    fs::write(&payload, b"second life").expect("payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/archive/notes.txt",
+    ]));
+    assert_success(&harness.run(&["rm", "/archive/notes.txt"]));
+    let listed = harness.run(&["trash"]);
+    assert_success(&listed);
+    assert!(
+        trash_recovery_command(&listed, "notes.txt").starts_with("loonfs undelete --inode "),
+        "trash offers a pathless in-place command"
+    );
+
+    // A stale pathless handle answers the same code a pathed one does.
+    let stale = harness.run(&[
+        "--json",
+        "undelete",
+        "--inode",
+        &inode_id.to_string(),
+        "--deleted-at",
+        &deleted_at.to_string(),
+    ]);
+    assert_failure(&stale);
+    assert_eq!(json_error(&stale)["code"], "not_deleted");
+}
+
 #[test]
 fn remote_undelete_recovers_through_http() {
     let harness = Harness::new();
@@ -3352,7 +3429,7 @@ fn remote_undelete_recovers_through_http() {
     assert_eq!(
         trash_recovery_command(&listed, "wire.txt"),
         format!(
-            "loonfs undelete /wire.txt --inode {inode_id} \
+            "loonfs undelete --inode {inode_id} \
              --deleted-at {deleted_at} --namespace demo"
         )
     );

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -2042,22 +2042,25 @@ impl Client {
     /// path.
     pub async fn undelete(
         &self,
-        spec: &NamespacePath,
+        namespace: &NamespaceId,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
+        path: Option<&AbsolutePath>,
         options: &UndeleteOptions,
     ) -> Result<ApiCommitResponse> {
+        // An absent destination restores in place: the entry re-binds under
+        // the parent and name its deletion recorded.
         let commit_id = options.commit_id.clone().unwrap_or_else(CommitId::generate);
         let response = self
             .commit(
-                spec.namespace(),
+                namespace,
                 &CommitRequest::single(
                     commit_id,
                     options.message.clone(),
                     FilesystemOperation::Undelete {
                         inode_id,
                         deleted_at_seq,
-                        path: spec.absolute_path().clone(),
+                        path: path.cloned(),
                     },
                 ),
             )

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -233,7 +233,7 @@ async fn undelete<S: ObjectStore + ?Sized>(
         FilesystemOperation::Undelete {
             inode_id,
             deleted_at_seq,
-            path: AbsolutePath::parse(absolute_path).expect("path"),
+            path: Some(AbsolutePath::parse(absolute_path).expect("path")),
         },
         context,
     )

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -758,6 +758,32 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     /// row it removes, so one ascending walk decides the page: a marker hides
     /// the generation whose key it repeats, and every other listed row is an
     /// entry. Reads stop as soon as `limit` entries are in hand.
+    /// Point-reads one live recoverable deletion by its exact handle.
+    ///
+    /// Answers through the same merged walk the trash listing uses, so a
+    /// revoked generation, a stale sequence, and a never-deleted inode all
+    /// answer `None` — the pager's removal-marker rule stays the one
+    /// authority, never a second decode of the family.
+    pub(crate) async fn recoverable_deletion(
+        &self,
+        deleted_at_seq: ChangeSeq,
+        root_inode_id: InodeId,
+    ) -> Result<Option<RecoverableDeletion>, CoreError> {
+        // The pager resumes strictly after a (sequence, inode) pair, and no
+        // inode sits between a pair and its predecessor, so starting after
+        // the predecessor makes the wanted pair the first candidate. Inode
+        // zero is unallocated, so a zero predecessor cannot skip a real row.
+        let Some(predecessor) = root_inode_id.0.checked_sub(1).map(InodeId) else {
+            return Ok(None);
+        };
+        let mut page = self
+            .active_deletions_page(Some((deleted_at_seq, predecessor)), 1)
+            .await?;
+        Ok(page.pop().filter(|deletion| {
+            deletion.deleted_at_seq == deleted_at_seq && deletion.root_inode_id == root_inode_id
+        }))
+    }
+
     pub(super) async fn active_deletions_page(
         &self,
         start_after: Option<(ChangeSeq, InodeId)>,

--- a/crates/loonfs-core/src/path/write/plan_create.rs
+++ b/crates/loonfs-core/src/path/write/plan_create.rs
@@ -6,7 +6,9 @@ use super::planning_helpers::{
     publish_reject_tombstoned_path_ancestor, publish_resolve_parent_directory, PlannedOperation,
     PublishPathPlanningView,
 };
-use crate::commit::{CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition};
+use crate::commit::{
+    CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition, CommitValidationError,
+};
 use crate::error::{CoreError, Result};
 use crate::path::helpers::{ensure_mutation_path, final_component};
 use loonfs_api::{
@@ -72,30 +74,60 @@ pub(super) async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
 pub(super) async fn plan_publish_undelete<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
     deleted_at_seq: ChangeSeq,
-    absolute_path: &AbsolutePath,
+    absolute_path: Option<&AbsolutePath>,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<PlannedOperation> {
-    ensure_mutation_path(absolute_path)?;
-    publish_reject_tombstoned_path_ancestor(view, absolute_path).await?;
-    match view
-        .metadata_state
-        .resolve_visible_path(absolute_path)
-        .await
-    {
-        Ok(existing) => {
-            return Err(CoreError::DestinationExists {
-                path: absolute_path.as_str().to_owned(),
-                existing_display_name: Some(existing.display_name),
-            });
+    let (parent_inode_id, display_name) = match absolute_path {
+        Some(absolute_path) => {
+            ensure_mutation_path(absolute_path)?;
+            publish_reject_tombstoned_path_ancestor(view, absolute_path).await?;
+            match view
+                .metadata_state
+                .resolve_visible_path(absolute_path)
+                .await
+            {
+                Ok(existing) => {
+                    return Err(CoreError::DestinationExists {
+                        path: absolute_path.as_str().to_owned(),
+                        existing_display_name: Some(existing.display_name),
+                    });
+                }
+                Err(error) if is_missing_visible_path(&error) => {}
+                Err(error) => return Err(error),
+            }
+            // The destination parent must already exist: recovery targets a
+            // place the caller can see, and commit validation re-checks the
+            // tombstone root, the parent, and the name under the publish
+            // lock.
+            let parent_inode_id = publish_resolve_parent_directory(view, absolute_path).await?;
+            (parent_inode_id, final_component(absolute_path)?.clone())
         }
-        Err(error) if is_missing_visible_path(&error) => {}
-        Err(error) => return Err(error),
-    }
-    // The destination parent must already exist: recovery targets a place
-    // the caller can see, and commit validation re-checks the tombstone
-    // root, the parent, and the name under the publish lock.
-    let parent_inode_id = publish_resolve_parent_directory(view, absolute_path).await?;
-    let display_name = final_component(absolute_path)?;
+        // In place: re-bind under the parent and name the deletion recorded,
+        // anchored on the parent's identity rather than a remembered
+        // spelling, so recovery lands correctly even when ancestors were
+        // renamed since. Planning takes no courtesy looks at the parent or
+        // the name — the preconditions below decide both under the publish
+        // lock, and their rejections already speak the right vocabulary.
+        None => {
+            let Some(deletion) = view
+                .metadata_state
+                .recoverable_deletion(deleted_at_seq, inode_id)
+                .await?
+            else {
+                return Err(CommitValidationError::UndeleteTargetNotDeleted { inode_id }.into());
+            };
+            match (deletion.parent_inode_id, deletion.display_name) {
+                (Some(parent_inode_id), Some(display_name)) => (parent_inode_id, display_name),
+                _ => {
+                    return Err(CoreError::InvalidCommitRequest(
+                        "the deletion recorded no binding to restore into; \
+                         pass a destination path"
+                            .to_owned(),
+                    ));
+                }
+            }
+        }
+    };
     Ok(PlannedOperation::new(
         vec![ApiCommitOp::Undelete {
             inode_id,

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -91,7 +91,11 @@ enum OperationFingerprintInput<'a> {
     Undelete {
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
-        absolute_path: &'a str,
+        // Preimage-additive: `Some` serializes as the bare string it always
+        // was, so every stored undelete fingerprint is unchanged; `None`
+        // serializes as `null`, a new distinct preimage for the in-place
+        // form. Both shapes are pinned below.
+        absolute_path: Option<&'a str>,
     },
 }
 
@@ -188,7 +192,7 @@ fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFing
         } => OperationFingerprintInput::Undelete {
             inode_id: *inode_id,
             deleted_at_seq: *deleted_at_seq,
-            absolute_path: path.as_str(),
+            absolute_path: path.as_ref().map(|path| path.as_str()),
         },
     }
 }
@@ -343,7 +347,7 @@ async fn plan_operation<S: ObjectStore + ?Sized>(
             inode_id,
             deleted_at_seq,
             path,
-        } => plan_publish_undelete(*inode_id, *deleted_at_seq, path, view).await,
+        } => plan_publish_undelete(*inode_id, *deleted_at_seq, path.as_ref(), view).await,
     }
 }
 
@@ -481,6 +485,58 @@ mod tests {
         assert_eq!(
             fingerprint.as_str(),
             "v0:sha256:edc8e06bd0a651e9470198875ec44c8fcd7d9b95f162fe1d7ca46011c27e2818"
+        );
+    }
+
+    /// Pins the exact stored fingerprint for an undelete with a destination
+    /// path.
+    ///
+    /// This literal is what proves the in-place form was preimage-additive:
+    /// the path became optional and this value did not move, because a
+    /// present path serializes as the bare string it always was.
+    #[test]
+    fn undelete_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let mut fixed = request(FilesystemOperation::Undelete {
+            inode_id: InodeId(42),
+            deleted_at_seq: ChangeSeq(17),
+            path: Some(AbsolutePath::parse("/docs/report.txt").expect("path")),
+        });
+        fixed.commit_id = CommitId::parse("c_00000000000000000000000000000044").expect("commit id");
+
+        let fingerprint = commit_fingerprint(&namespace_id, &fixed).expect("fingerprint");
+
+        // The mechanism behind "did not move": a present option serializes
+        // as the bare value, so wrapping the preimage field changed no
+        // stored byte.
+        assert_eq!(
+            serde_json::to_value(Some("/docs/report.txt")).expect("serialize"),
+            serde_json::to_value("/docs/report.txt").expect("serialize"),
+        );
+        assert_eq!(
+            fingerprint.as_str(),
+            "v0:sha256:1f4fa76d65aa64903a7d44cead91600a97c0bac9ec3a01ac51f0cd1130eff3d6"
+        );
+    }
+
+    /// Pins the exact stored fingerprint for an in-place undelete, whose
+    /// absent path serializes as `null` — a distinct preimage from every
+    /// pathed form.
+    #[test]
+    fn in_place_undelete_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let mut fixed = request(FilesystemOperation::Undelete {
+            inode_id: InodeId(42),
+            deleted_at_seq: ChangeSeq(17),
+            path: None,
+        });
+        fixed.commit_id = CommitId::parse("c_00000000000000000000000000000044").expect("commit id");
+
+        let fingerprint = commit_fingerprint(&namespace_id, &fixed).expect("fingerprint");
+
+        assert_eq!(
+            fingerprint.as_str(),
+            "v0:sha256:4d7737cdc3888e3613dad0ec7d752e8daac089c8b528301cf0eba9307fa1cc4c"
         );
     }
 

--- a/crates/loonfs-core/tests/it/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/it/visibility_equivalence.rs
@@ -168,7 +168,7 @@ impl VisibilityHarness {
         self.publish_operation(FilesystemOperation::Undelete {
             inode_id,
             deleted_at_seq,
-            path: AbsolutePath::parse(path).expect("valid path"),
+            path: Some(AbsolutePath::parse(path).expect("valid path")),
         })
         .await
     }

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -845,7 +845,7 @@ async fn a_recursive_delete_hides_matches_and_an_undelete_restores_them() {
             &namespace_id,
             docs_inode_id,
             deleted.committed_seq,
-            "/docs",
+            Some("/docs"),
             loonfs::UndeleteOptions::default(),
         )
         .await

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -706,9 +706,14 @@ impl FsWriter {
         namespace_id: &NamespaceId,
         inode_id: InodeId,
         deleted_at_seq: ChangeSeq,
-        absolute_path: &str,
+        absolute_path: Option<&str>,
         options: UndeleteOptions,
     ) -> Result<CommitResponse> {
+        // An absent destination restores in place: the entry re-binds under
+        // the parent and name its deletion recorded.
+        let path = absolute_path
+            .map(loonfs_core::path::parse_mutation_path)
+            .transpose()?;
         self.commit(
             namespace_id,
             CommitRequest::single(
@@ -717,7 +722,7 @@ impl FsWriter {
                 FilesystemOperation::Undelete {
                     inode_id,
                     deleted_at_seq,
-                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                    path,
                 },
             ),
         )

--- a/crates/loonfs/tests/it/bulk_file_reads.rs
+++ b/crates/loonfs/tests/it/bulk_file_reads.rs
@@ -199,7 +199,7 @@ async fn build_mixed_namespace(fs: &TestRuntime, namespace_id: &NamespaceId) {
             namespace_id,
             recovered_inode_id,
             deleted_at_seq,
-            "/notes/restored.txt",
+            Some("/notes/restored.txt"),
             UndeleteOptions::default(),
         )
         .await
@@ -655,7 +655,7 @@ async fn resolve_current_files_answers_the_whole_matrix_in_input_order() {
             &namespace_id,
             recovered,
             recovered_deleted_at_seq,
-            "/m/recovered-again.txt",
+            Some("/m/recovered-again.txt"),
             UndeleteOptions::default(),
         )
         .await

--- a/crates/loonfs/tests/it/undelete.rs
+++ b/crates/loonfs/tests/it/undelete.rs
@@ -100,7 +100,7 @@ fn undelete_recovers_a_deleted_file_and_generations_stay_scoped() {
         &namespace_id,
         inode_id,
         first_deletion,
-        "/docs/recovered.txt",
+        Some("/docs/recovered.txt"),
         loonfs::UndeleteOptions::default(),
     ))
     .expect("undelete");
@@ -131,7 +131,7 @@ fn undelete_recovers_a_deleted_file_and_generations_stay_scoped() {
         &namespace_id,
         inode_id,
         first_deletion,
-        "/docs/again.txt",
+        Some("/docs/again.txt"),
         loonfs::UndeleteOptions::default(),
     ))
     .expect_err("double undelete should conflict");
@@ -154,7 +154,7 @@ fn undelete_recovers_a_deleted_file_and_generations_stay_scoped() {
         &namespace_id,
         inode_id,
         first_deletion,
-        "/docs/stale.txt",
+        Some("/docs/stale.txt"),
         loonfs::UndeleteOptions::default(),
     ))
     .expect_err("stale generation handle must not clear the newer deletion");
@@ -175,7 +175,7 @@ fn undelete_recovers_a_deleted_file_and_generations_stay_scoped() {
         &namespace_id,
         inode_id,
         second_deletion,
-        "/docs/report.txt",
+        Some("/docs/report.txt"),
         loonfs::UndeleteOptions::default(),
     ))
     .expect("undelete the active generation");
@@ -230,7 +230,7 @@ fn undelete_recovers_a_deleted_subtree_and_rejects_covered_children() {
         &namespace_id,
         child_inode,
         deletion,
-        "/docs/a-alone.txt",
+        Some("/docs/a-alone.txt"),
         loonfs::UndeleteOptions::default(),
     ))
     .expect_err("child of a deleted directory is not the deletion root");
@@ -243,7 +243,7 @@ fn undelete_recovers_a_deleted_subtree_and_rejects_covered_children() {
         &namespace_id,
         directory_inode,
         deletion,
-        "/docs/notes",
+        Some("/docs/notes"),
         loonfs::UndeleteOptions::default(),
     ))
     .expect("undelete the subtree root");
@@ -308,7 +308,7 @@ fn undelete_of_an_ancestor_keeps_independently_deleted_children_hidden() {
         &namespace_id,
         directory_inode,
         ancestor_deletion,
-        "/docs/notes",
+        Some("/docs/notes"),
         loonfs::UndeleteOptions::default(),
     ))
     .expect("undelete the ancestor");
@@ -356,7 +356,7 @@ fn undelete_survives_checkpoints_and_reopen_in_both_orders() {
             &namespace_id,
             inode_id,
             deletion,
-            "/docs/report.txt",
+            Some("/docs/report.txt"),
             loonfs::UndeleteOptions::default(),
         ))
         .expect("undelete before checkpoint");
@@ -423,7 +423,7 @@ fn undelete_survives_checkpoints_and_reopen_in_both_orders() {
             &namespace_id,
             inode_id,
             second_deletion,
-            "/docs/report.txt",
+            Some("/docs/report.txt"),
             loonfs::UndeleteOptions::default(),
         ))
         .expect("undelete a checkpointed deletion after reopen");
@@ -479,7 +479,7 @@ fn change_feed_reports_the_deletion_generation_an_undelete_takes() {
         &namespace_id,
         inode_id,
         deletion,
-        "/docs/report.txt",
+        Some("/docs/report.txt"),
         loonfs::UndeleteOptions::default(),
     ))
     .expect("undelete");
@@ -600,7 +600,9 @@ fn undelete_rejects_deletions_from_the_same_commit() {
                     FilesystemOperation::Undelete {
                         inode_id: entry.inode_id,
                         deleted_at_seq: guessed_seq,
-                        path: parse_mutation_path("/resurrected.txt").expect("valid mutation path"),
+                        path: Some(
+                            parse_mutation_path("/resurrected.txt").expect("valid mutation path"),
+                        ),
                     },
                 ],
             },

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1481,10 +1481,10 @@ and path revision restore:
 ```
 
 and undelete, which recovers a deleted file or subtree by re-binding the
-deletion's root inode at a destination path — the inode's identity and
-retained revision history come back with it. The request names both halves
-of the recovery handle the delete reported (and the change feed carries):
-the inode id and the deletion's committed sequence.
+deletion's root inode — the inode's identity and retained revision history
+come back with it. The request names both halves of the recovery handle the
+delete reported (and the change feed carries): the inode id and the
+deletion's committed sequence.
 
 ```json
 {
@@ -1500,11 +1500,21 @@ the inode id and the deletion's committed sequence.
 }
 ```
 
+`path` is optional. When present, it is the destination: its parent must
+exist and be visible, and its name must be free. When absent, the entry
+restores in place — it re-binds under the parent inode and name its
+deletion recorded, anchored on the parent's identity rather than a
+remembered spelling, so recovery lands correctly even when the enclosing
+directories were renamed after the delete. A deletion that recorded no
+binding (early tombstones carry none) answers `invalid_request` and needs
+the explicit path. The in-place parent and name obey the same rules a path
+would: the parent must not be deleted, and the name must be free, each
+answering its usual code otherwise.
+
 Only the root of a deletion can be undeleted, and only the exact deletion
 generation named by `deleted_at_seq` — anything else answers `not_deleted`
 with the requested and active generations in the details, so a stale
-recovery request can never cancel a later deletion. The destination parent
-must exist and be visible, and the destination name must be free.
+recovery request can never cancel a later deletion.
 
 ### 6.9 Upload transport
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4268,11 +4268,10 @@
           {
             "type": "object",
             "title": "FsOpUndelete",
-            "description": "Recover a deleted file or subtree: revoke the deletion of\n`inode_id` recorded at `deleted_at_seq` (both reported by the\ndelete and by the change feed) and re-bind it at `path`. Answers\n`not_deleted` when that generation is not the live one, so a stale\nrequest never cancels a later delete.",
+            "description": "Recover a deleted file or subtree: revoke the deletion of\n`inode_id` recorded at `deleted_at_seq` (both reported by the\ndelete and by the change feed) and re-bind it. Answers\n`not_deleted` when that generation is not the live one, so a stale\nrequest never cancels a later delete.",
             "required": [
               "inode_id",
               "deleted_at_seq",
-              "path",
               "kind"
             ],
             "properties": {
@@ -4291,8 +4290,15 @@
                 ]
               },
               "path": {
-                "$ref": "#/components/schemas/AbsolutePath",
-                "description": "Absolute destination path whose parent must be visible and whose name must be absent."
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AbsolutePath",
+                    "description": "Absolute destination path whose parent must be visible and whose\nname must be absent. Absent means restore in place: re-bind\nunder the parent and name the deletion recorded, anchored on\nthe parent's identity rather than any remembered spelling, so\nthe entry lands correctly even when ancestors were renamed\nsince. A deletion that recorded no binding needs the explicit\npath."
+                  }
+                ]
               }
             }
           },


### PR DESCRIPTION
This PR resolves trash recovery losing its destination: undelete's destination path becomes optional, and an absent path restores in place.

Why: The original idea (expose the entry's original path in trash listings) has no minimal implementation: the metadata model deliberately has no bounded inode-to-path resolution, the changes feed is inode-based by design, and nothing durable records deleted paths. Restoring by identity dissolves the problem instead of solving it: the deletion row already records the parent inode and name, and re-binding under the parent's identity lands correctly even when the enclosing directories were renamed after the delete — something no remembered path string could do.

The operation: `path` on the undelete operation is now optional. Present, it behaves exactly as before. Absent, the planner reads the recorded binding through a new point lookup that reuses the trash pager's merged walk — so the removal-marker rule stays the single authority, and a revoked generation, stale sequence, or never-deleted inode all answer `not_deleted`. A deletion that recorded no binding (early tombstones carry none) answers `invalid_request` naming the remedy. No planning-time courtesy checks were added: the existing name-absent and ancestor preconditions decide under the publish lock, in their usual vocabulary.

