### PR TITLE
fix(uploads): a put retry verifies the entire fingerprint

### DIFF
--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -1,0 +1,651 @@
+//! Commit identity fingerprints (format spec, "Commit identity
+//! fingerprints"): a stable digest over a mutation's semantic content, used
+//! to decide whether a reused commit id carries the same mutation or a
+//! conflicting one.
+//!
+//! This lives beside [`FilesystemOperation`], the one operation language it
+//! hashes, because every surface has to compute the same value from it: the
+//! engine stamps it on a commit receipt, and a client reconciling a
+//! reused-id conflict recomputes it to prove the retry is the same request.
+//! One function is the authority; nobody re-derives the rules.
+//!
+//! The commit id is not in the preimage. The id is the key a mutation is
+//! filed under; the fingerprint is what was filed. Comparing the two is the
+//! whole of the reuse check.
+
+use crate::{
+    AbsolutePath, ChangeSeq, ContentRef, DeleteDirectoryBehavior, DestinationBehavior,
+    FilesystemOperation, InodeId, NamespaceId, RevisionNo,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use thiserror::Error;
+
+/// Domain separator for the one mutation fingerprint preimage.
+const COMMIT_FINGERPRINT_DOMAIN: &str = "loonfs.commit.semantic.v0";
+
+/// Scheme-and-algorithm tag carried by every stored fingerprint value.
+///
+/// `v0` names the canonicalization rules (domain string plus the frozen v0
+/// preimage encoding; format spec, "Commit identity fingerprints") and
+/// `sha256` the digest algorithm, so either can change later without
+/// re-interpreting values already stored in WAL records and commit receipts.
+const FINGERPRINT_SCHEME: &str = "v0:sha256";
+
+/// A canonical preimage that could not be encoded.
+///
+/// The preimage is built here from validated types with no encoding failure
+/// modes, so this reports a bug in the encoder rather than anything a caller
+/// did.
+#[derive(Debug, Error)]
+#[error("failed to encode the commit fingerprint preimage: {0}")]
+pub struct SemanticFingerprintError(#[from] serde_json::Error);
+
+/// Computes a stored fingerprint value (`v0:sha256:<64 lowercase hex>`) from
+/// a canonical preimage.
+///
+/// The preimage's compact JSON encoding is the durable contract: the
+/// pinned-value tests below fail if it drifts.
+fn fingerprint_digest<T>(preimage: &T) -> Result<String, SemanticFingerprintError>
+where
+    T: Serialize,
+{
+    let bytes = serde_json::to_vec(preimage)?;
+    Ok(fingerprint_bytes(&bytes))
+}
+
+fn fingerprint_bytes(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut value = String::with_capacity(FINGERPRINT_SCHEME.len() + 1 + digest.len() * 2);
+    value.push_str(FINGERPRINT_SCHEME);
+    value.push(':');
+    for byte in digest {
+        write!(&mut value, "{byte:02x}").expect("writing to a String should not fail");
+    }
+    value
+}
+
+/// Canonical preimage for one operation inside a mutation fingerprint.
+///
+/// The serde representation is durable contract (format spec, "Commit
+/// identity fingerprints"): the same normalized request must fingerprint
+/// identically across releases. A pinned-value test below fails if the
+/// encoding drifts.
+///
+/// The variant names, the field names, and the field order below are all part
+/// of that preimage under the [`COMMIT_FINGERPRINT_DOMAIN`] tag, and none of
+/// them tracks the wire enum. They deliberately differ from it — `CreateDir`
+/// against the wire's `CreateDirectory`, `absolute_path` against its `path`,
+/// `behavior` ahead of `content_ref` in the put — because renaming a wire
+/// field must not silently restate every already-published commit's identity.
+/// [`operation_fingerprint_input`] is the one place the wire spelling is
+/// translated into this one; nothing else may name these variants. Change any
+/// of it and every stored fingerprint disagrees with its recomputed value,
+/// which the pinned tests below exist to catch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum OperationFingerprintInput<'a> {
+    CreateDir {
+        absolute_path: &'a str,
+        parents: bool,
+    },
+    // The put guard joins the preimage for the same reason as the delete
+    // guard below: a changed expected revision is a different logical
+    // request and must conflict rather than replay a receipt.
+    PutFile {
+        absolute_path: &'a str,
+        behavior: DestinationBehavior,
+        content_ref: ContentRefFingerprintInput<'a>,
+        expected_revision_no: Option<RevisionNo>,
+    },
+    // Identity covers the complete caller-visible logical request. A changed
+    // delete guard must conflict instead of replaying the old receipt
+    // without checking the new guard.
+    DeletePath {
+        absolute_path: &'a str,
+        behavior: DeleteDirectoryBehavior,
+        expected_inode_id: Option<InodeId>,
+    },
+    MovePath {
+        from_path: &'a str,
+        to_path: &'a str,
+        behavior: DestinationBehavior,
+    },
+    CopyFilePath {
+        from_path: &'a str,
+        to_path: &'a str,
+        behavior: DestinationBehavior,
+    },
+    RestoreRevision {
+        absolute_path: &'a str,
+        source_revision_no: RevisionNo,
+    },
+    Undelete {
+        inode_id: InodeId,
+        deleted_at_seq: ChangeSeq,
+        // Preimage-additive: `Some` serializes as the bare string it always
+        // was, so every stored undelete fingerprint is unchanged; `None`
+        // serializes as `null`, a new distinct preimage for the in-place
+        // form. Both shapes are pinned below.
+        absolute_path: Option<&'a str>,
+    },
+}
+
+/// Canonical preimage for the content a put attaches.
+///
+/// Identity is *which object*, so the id and its length are the whole of it.
+/// The checksums are evidence about those bytes, pinned to the id by the
+/// verification every write and read already performs, and they are left out
+/// deliberately: a reference that named the same object with a differently
+/// spelled checksum would otherwise read as a different mutation.
+///
+/// The consequence is worth stating plainly. A retry that re-runs the whole
+/// operation, upload included, mints a new content object, so it is a
+/// different request and a reused commit id conflicts. Retrying a commit
+/// means sending the same `ContentRef` again — which replays — not uploading
+/// the bytes again.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ContentRefFingerprintInput<'a> {
+    kind: &'a str,
+    content_id: &'a str,
+    size_bytes: u64,
+}
+
+fn content_ref_fingerprint_input(content_ref: &ContentRef) -> ContentRefFingerprintInput<'_> {
+    ContentRefFingerprintInput {
+        kind: content_ref.kind.as_str(),
+        content_id: content_ref.content_id.as_str(),
+        size_bytes: content_ref.size_bytes,
+    }
+}
+
+/// Renames one wire operation into its durable preimage.
+///
+/// This is the whole of the wire-to-fingerprint translation. The left side
+/// follows [`FilesystemOperation`] and may be renamed with it; the right side
+/// is frozen (see [`OperationFingerprintInput`]).
+fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFingerprintInput<'_> {
+    match operation {
+        FilesystemOperation::CreateDirectory { path, parents } => {
+            OperationFingerprintInput::CreateDir {
+                absolute_path: path.as_str(),
+                parents: *parents,
+            }
+        }
+        FilesystemOperation::PutFile {
+            path,
+            content_ref,
+            behavior,
+            expected_revision_no,
+        } => OperationFingerprintInput::PutFile {
+            absolute_path: path.as_str(),
+            behavior: *behavior,
+            content_ref: content_ref_fingerprint_input(content_ref),
+            expected_revision_no: *expected_revision_no,
+        },
+        FilesystemOperation::DeletePath {
+            path,
+            behavior,
+            expected_inode_id,
+        } => OperationFingerprintInput::DeletePath {
+            absolute_path: path.as_str(),
+            behavior: *behavior,
+            expected_inode_id: *expected_inode_id,
+        },
+        FilesystemOperation::MovePath {
+            from_path,
+            to_path,
+            behavior,
+        } => OperationFingerprintInput::MovePath {
+            from_path: from_path.as_str(),
+            to_path: to_path.as_str(),
+            behavior: *behavior,
+        },
+        FilesystemOperation::CopyPath {
+            from_path,
+            to_path,
+            behavior,
+        } => OperationFingerprintInput::CopyFilePath {
+            from_path: from_path.as_str(),
+            to_path: to_path.as_str(),
+            behavior: *behavior,
+        },
+        FilesystemOperation::RestoreRevision {
+            path,
+            source_revision_no,
+        } => OperationFingerprintInput::RestoreRevision {
+            absolute_path: path.as_str(),
+            source_revision_no: *source_revision_no,
+        },
+        FilesystemOperation::Undelete {
+            inode_id,
+            deleted_at_seq,
+            path,
+        } => OperationFingerprintInput::Undelete {
+            inode_id: *inode_id,
+            deleted_at_seq: *deleted_at_seq,
+            absolute_path: path.as_ref().map(|path| path.as_str()),
+        },
+    }
+}
+
+/// The semantic identity of one mutation request: what a reused commit id is
+/// compared against.
+///
+/// A one-operation convenience call and a one-element batch are the same
+/// request, so they reach this function with the same shape and fingerprint
+/// identically; there is no separate single-operation form to keep in step.
+pub fn semantic_commit_fingerprint(
+    namespace_id: &NamespaceId,
+    message: Option<&str>,
+    operations: &[FilesystemOperation],
+) -> Result<String, SemanticFingerprintError> {
+    #[derive(Serialize)]
+    struct CanonicalCommit<'a> {
+        domain: &'static str,
+        namespace_id: &'a str,
+        operations: Vec<OperationFingerprintInput<'a>>,
+        message: Option<&'a str>,
+    }
+
+    fingerprint_digest(&CanonicalCommit {
+        domain: COMMIT_FINGERPRINT_DOMAIN,
+        namespace_id: namespace_id.as_str(),
+        operations: operations.iter().map(operation_fingerprint_input).collect(),
+        message,
+    })
+}
+
+/// The fingerprint the original request must have had, if this retry is the
+/// same single put with only the content id renamed.
+///
+/// Rerunning a whole upload-then-commit sequence stages a fresh content
+/// object, so the retry's own fingerprint can never match a landed one. This
+/// substitutes the committed reference for the staged one and fingerprints
+/// the request that results: everything else a put can ask for — the path,
+/// the replacement behavior, the expected revision, the annotation, and that
+/// the commit was this one operation and nothing more — has to agree for the
+/// value to match. Whether the two content objects hold the same bytes is a
+/// separate question, answered by digest evidence rather than by this.
+pub fn put_retry_fingerprint(
+    namespace_id: &NamespaceId,
+    path: &AbsolutePath,
+    behavior: DestinationBehavior,
+    expected_revision_no: Option<RevisionNo>,
+    message: Option<&str>,
+    committed_content_ref: &ContentRef,
+) -> Result<String, SemanticFingerprintError> {
+    let operation = FilesystemOperation::PutFile {
+        path: path.clone(),
+        content_ref: committed_content_ref.clone(),
+        behavior,
+        expected_revision_no,
+    };
+    semantic_commit_fingerprint(namespace_id, message, std::slice::from_ref(&operation))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ContentId;
+
+    /// Pins the exact stored fingerprint for a fixed one-operation request.
+    ///
+    /// If this fails, the canonical preimage changed (format spec, "Commit
+    /// identity fingerprints") and every persisted fingerprint would disagree
+    /// with recomputed ones, breaking retry idempotency across versions. Do
+    /// not update the literal without bumping the fingerprint scheme tag.
+    #[test]
+    fn commit_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        let fingerprint = semantic_commit_fingerprint(&namespace_id, None, &[create_dir("/docs")])
+            .expect("fingerprint");
+
+        assert_eq!(
+            fingerprint,
+            "v0:sha256:85894f53a16c2c0be95afc39b245280101f3e2a414f044c87be8eb9f1980dbcd"
+        );
+    }
+
+    /// Pins the exact stored fingerprint encoding for a guarded delete.
+    #[test]
+    fn guarded_delete_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        let fingerprint = semantic_commit_fingerprint(
+            &namespace_id,
+            None,
+            &[FilesystemOperation::DeletePath {
+                path: AbsolutePath::parse("/docs").expect("path"),
+                behavior: DeleteDirectoryBehavior::NonRecursive,
+                expected_inode_id: Some(InodeId(42)),
+            }],
+        )
+        .expect("fingerprint");
+
+        assert_eq!(
+            fingerprint,
+            "v0:sha256:edc8e06bd0a651e9470198875ec44c8fcd7d9b95f162fe1d7ca46011c27e2818"
+        );
+    }
+
+    /// Pins the exact stored fingerprint for an undelete with a destination
+    /// path.
+    ///
+    /// This literal is what proves the in-place form was preimage-additive:
+    /// the path became optional and this value did not move, because a
+    /// present path serializes as the bare string it always was.
+    #[test]
+    fn undelete_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        let fingerprint = semantic_commit_fingerprint(
+            &namespace_id,
+            None,
+            &[FilesystemOperation::Undelete {
+                inode_id: InodeId(42),
+                deleted_at_seq: ChangeSeq(17),
+                path: Some(AbsolutePath::parse("/docs/report.txt").expect("path")),
+            }],
+        )
+        .expect("fingerprint");
+
+        // The mechanism behind "did not move": a present option serializes
+        // as the bare value, so wrapping the preimage field changed no
+        // stored byte.
+        assert_eq!(
+            serde_json::to_value(Some("/docs/report.txt")).expect("serialize"),
+            serde_json::to_value("/docs/report.txt").expect("serialize"),
+        );
+        assert_eq!(
+            fingerprint,
+            "v0:sha256:1f4fa76d65aa64903a7d44cead91600a97c0bac9ec3a01ac51f0cd1130eff3d6"
+        );
+    }
+
+    /// Pins the exact stored fingerprint for an in-place undelete, whose
+    /// absent path serializes as `null` — a distinct preimage from every
+    /// pathed form.
+    #[test]
+    fn in_place_undelete_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        let fingerprint = semantic_commit_fingerprint(
+            &namespace_id,
+            None,
+            &[FilesystemOperation::Undelete {
+                inode_id: InodeId(42),
+                deleted_at_seq: ChangeSeq(17),
+                path: None,
+            }],
+        )
+        .expect("fingerprint");
+
+        assert_eq!(
+            fingerprint,
+            "v0:sha256:4d7737cdc3888e3613dad0ec7d752e8daac089c8b528301cf0eba9307fa1cc4c"
+        );
+    }
+
+    /// Pins the exact stored fingerprint for a put, which is the only
+    /// operation whose preimage embeds a content reference.
+    ///
+    /// The literal covers the canonical content-ref form — kind, content id,
+    /// size, and nothing else. Adding a checksum to that form, or reordering
+    /// it, would change this value and silently break replay for every
+    /// already-published put.
+    #[test]
+    fn put_file_fingerprint_value_is_pinned() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        let fingerprint = semantic_commit_fingerprint(
+            &namespace_id,
+            None,
+            &[FilesystemOperation::PutFile {
+                path: AbsolutePath::parse("/docs/report.txt").expect("path"),
+                content_ref: ContentRef::blob_v1(
+                    ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
+                    b"pinned put bytes",
+                ),
+                behavior: DestinationBehavior::NoReplace,
+                expected_revision_no: None,
+            }],
+        )
+        .expect("fingerprint");
+
+        assert_eq!(
+            fingerprint,
+            "v0:sha256:3febc279ebb36c013f734095bebdba3c0a59bf8cbd82d205b53adbf00c112d59"
+        );
+    }
+
+    fn create_dir(path: &str) -> FilesystemOperation {
+        FilesystemOperation::CreateDirectory {
+            path: AbsolutePath::parse(path).expect("path"),
+            parents: false,
+        }
+    }
+
+    fn put(path: &str, content_ref: ContentRef) -> FilesystemOperation {
+        FilesystemOperation::PutFile {
+            path: AbsolutePath::parse(path).expect("path"),
+            content_ref,
+            behavior: DestinationBehavior::NoReplace,
+            expected_revision_no: None,
+        }
+    }
+
+    /// Two references to the same object with different checksum evidence
+    /// are the same mutation: identity is which object a put attaches, and
+    /// the checksums are pinned to that object by verification elsewhere.
+    #[test]
+    fn checksum_evidence_is_outside_mutation_identity() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let content_ref = ContentRef::blob_v1(
+            ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
+            b"pinned put bytes",
+        );
+        let without_trusted_digest = ContentRef {
+            whole_file_sha256: None,
+            ..content_ref.clone()
+        };
+
+        assert_eq!(
+            semantic_commit_fingerprint(
+                &namespace_id,
+                None,
+                &[put("/docs/report.txt", content_ref)]
+            )
+            .expect("fingerprint"),
+            semantic_commit_fingerprint(
+                &namespace_id,
+                None,
+                &[put("/docs/report.txt", without_trusted_digest)]
+            )
+            .expect("fingerprint")
+        );
+    }
+
+    /// A different content object is a different mutation, which is what
+    /// makes a re-upload under a used commit id conflict instead of replay.
+    #[test]
+    fn a_different_content_object_changes_mutation_identity() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let bytes = b"identical bytes, two uploads";
+        let first = ContentRef::blob_v1(ContentId::generate(), bytes);
+        let second = ContentRef::blob_v1(ContentId::generate(), bytes);
+
+        assert_ne!(
+            semantic_commit_fingerprint(&namespace_id, None, &[put("/docs/report.txt", first)])
+                .expect("fingerprint"),
+            semantic_commit_fingerprint(&namespace_id, None, &[put("/docs/report.txt", second)])
+                .expect("fingerprint")
+        );
+    }
+
+    #[test]
+    fn a_message_changes_mutation_identity() {
+        // The annotation is part of what the caller asked for: replaying a
+        // commit id with a different message must conflict, so the message
+        // joins the preimage.
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let without = semantic_commit_fingerprint(&namespace_id, None, &[create_dir("/docs")])
+            .expect("fingerprint");
+        let with = semantic_commit_fingerprint(
+            &namespace_id,
+            Some("import batch"),
+            &[create_dir("/docs")],
+        )
+        .expect("fingerprint");
+
+        assert_ne!(without, with);
+    }
+
+    #[test]
+    fn commit_fingerprint_changes_when_logical_inputs_change() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let baseline = semantic_commit_fingerprint(&namespace_id, None, &[create_dir("/docs")])
+            .expect("baseline");
+        let changed = semantic_commit_fingerprint(&namespace_id, None, &[create_dir("/drafts")])
+            .expect("changed");
+
+        assert_ne!(baseline, changed);
+    }
+
+    /// Operation order is part of the request: reordering is a different
+    /// logical mutation, so it must not replay the first one's receipt.
+    #[test]
+    fn operation_order_changes_mutation_identity() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+
+        assert_ne!(
+            semantic_commit_fingerprint(&namespace_id, None, &[create_dir("/a"), create_dir("/b")])
+                .expect("forward fingerprint"),
+            semantic_commit_fingerprint(&namespace_id, None, &[create_dir("/b"), create_dir("/a")])
+                .expect("reversed fingerprint")
+        );
+    }
+
+    /// The retry helper is not a second spelling of the preimage: it builds
+    /// the same single-put request a caller would have sent and hands it to
+    /// the same function.
+    #[test]
+    fn put_retry_fingerprint_matches_the_equivalent_single_operation_request() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let path = AbsolutePath::parse("/docs/report.txt").expect("path");
+        let content_ref = ContentRef::blob_v1(
+            ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
+            b"pinned put bytes",
+        );
+
+        let by_hand = semantic_commit_fingerprint(
+            &namespace_id,
+            Some("import batch"),
+            &[FilesystemOperation::PutFile {
+                path: path.clone(),
+                content_ref: content_ref.clone(),
+                behavior: DestinationBehavior::Replace,
+                expected_revision_no: Some(RevisionNo(4)),
+            }],
+        )
+        .expect("hand-built fingerprint");
+
+        assert_eq!(
+            put_retry_fingerprint(
+                &namespace_id,
+                &path,
+                DestinationBehavior::Replace,
+                Some(RevisionNo(4)),
+                Some("import batch"),
+                &content_ref,
+            )
+            .expect("retry fingerprint"),
+            by_hand
+        );
+    }
+
+    /// Everything a put can ask for beyond its content is inside the value,
+    /// which is what makes comparing the whole fingerprint a complete proof
+    /// rather than a partial one.
+    #[test]
+    fn put_retry_fingerprint_changes_with_every_request_field() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let path = AbsolutePath::parse("/a.txt").expect("path");
+        let content_ref = ContentRef::blob_v1(ContentId::generate(), b"hello");
+        let baseline = put_retry_fingerprint(
+            &namespace_id,
+            &path,
+            DestinationBehavior::Replace,
+            None,
+            None,
+            &content_ref,
+        )
+        .expect("baseline");
+
+        for (label, variant) in [
+            (
+                "path",
+                put_retry_fingerprint(
+                    &namespace_id,
+                    &AbsolutePath::parse("/b.txt").expect("path"),
+                    DestinationBehavior::Replace,
+                    None,
+                    None,
+                    &content_ref,
+                ),
+            ),
+            (
+                "behavior",
+                put_retry_fingerprint(
+                    &namespace_id,
+                    &path,
+                    DestinationBehavior::NoReplace,
+                    None,
+                    None,
+                    &content_ref,
+                ),
+            ),
+            (
+                "expected revision",
+                put_retry_fingerprint(
+                    &namespace_id,
+                    &path,
+                    DestinationBehavior::Replace,
+                    Some(RevisionNo(2)),
+                    None,
+                    &content_ref,
+                ),
+            ),
+            (
+                "message",
+                put_retry_fingerprint(
+                    &namespace_id,
+                    &path,
+                    DestinationBehavior::Replace,
+                    None,
+                    Some(""),
+                    &content_ref,
+                ),
+            ),
+            (
+                "namespace",
+                put_retry_fingerprint(
+                    &NamespaceId::parse("other").expect("valid namespace id"),
+                    &path,
+                    DestinationBehavior::Replace,
+                    None,
+                    None,
+                    &content_ref,
+                ),
+            ),
+        ] {
+            assert_ne!(
+                baseline,
+                variant.expect("variant fingerprint"),
+                "a changed {label} must change the fingerprint"
+            );
+        }
+    }
+}

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -13,6 +13,13 @@
 //! surfaces, so this crate — the shared vocabulary — owns the single
 //! definition rather than each surface keeping its own copy to drift.
 //!
+//! One module is a function rather than a shape: `commit_identity` computes
+//! the durable fingerprint of a mutation. It lives here for the same reason
+//! the operation language does — the engine that stamps a fingerprint on a
+//! commit receipt and the client that recomputes one to prove a retry is the
+//! same request must produce identical values, so there is one implementation
+//! and no second reading of the rules.
+//!
 //! Module rule: v0 HTTP shapes live in [`v0`]; the crate root keeps the
 //! ids/paths/errors/wire-format modules and re-exports the common v0
 //! surface as a curated explicit list below.
@@ -20,6 +27,7 @@
 #![warn(missing_docs)]
 
 mod capability;
+mod commit_identity;
 mod content;
 mod control;
 mod digest;
@@ -93,6 +101,9 @@ pub use capability::{
     LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
     LIMIT_UPLOAD_MAX_CONCURRENT, LIMIT_UPLOAD_MAX_CONTENT_BYTES, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
     PROFILE_QUERY_V0, PROTOCOL_VERSION,
+};
+pub use commit_identity::{
+    put_retry_fingerprint, semantic_commit_fingerprint, SemanticFingerprintError,
 };
 pub use content::{
     ChecksumAlgorithm, ContentRef, ContentRefKind, ContentRefValidationError, Crc64Nvme, Sha256,

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -59,6 +59,14 @@ pub struct ErrorDetails {
     /// yet and two live requests are simply claiming it at once.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub committed_seq: Option<ChangeSeq>,
+    /// Semantic identity of the mutation that already landed under that
+    /// commit id, from the same receipt as `committed_seq` and present
+    /// exactly when it is. A retry recomputes this value from the request it
+    /// just made — see
+    /// [`put_retry_fingerprint`](crate::put_retry_fingerprint) — and equality
+    /// is what proves the two are the same request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub committed_fingerprint: Option<String>,
     /// Position, in the request's operation list, of the operation that
     /// failed. A commit applies all of its operations or none of them, so
     /// this names the one that stopped the whole request.

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1193,6 +1193,9 @@ fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
     let local = harness.temp_dir.path().join("big.bin");
     fs::write(&local, &payload).expect("write payload");
     let local_path = local.to_str().expect("utf-8 path");
+    // `--force` on every run of this id, first included: the replacement
+    // behavior is part of a commit's identity, so a rerun that adds the
+    // flag is asking for a different mutation and conflicts.
     let first = harness.run(&[
         "--json",
         "put",
@@ -1200,6 +1203,7 @@ fn large_and_piped_puts_round_trip_through_an_embedded_profile() {
         "/big.bin",
         "--commit-id",
         "pinned-big",
+        "--force",
     ]);
     assert_success(&first);
     assert_eq!(download(&harness, "/big.bin", "big-back.bin"), payload);

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -81,14 +81,6 @@ enum UploadedContent<'a> {
 }
 
 impl UploadedContent<'_> {
-    /// Complete length of what was uploaded.
-    fn size_bytes(&self) -> u64 {
-        match self {
-            Self::Bytes(bytes) => bytes.len() as u64,
-            Self::Streamed(content_ref) => content_ref.size_bytes,
-        }
-    }
-
     /// Whether the upload's bytes produce this checksum.
     ///
     /// `None` is a refusal to answer — the algorithm is one this build
@@ -136,26 +128,43 @@ fn uploaded_matches_committed(uploaded: &UploadedContent<'_>, content_ref: &Cont
     uploaded.matches(&evidence) == Some(true)
 }
 
-/// Where a reuse conflict says the commit id already landed.
+/// What a reuse conflict says the commit id already landed as: where, and
+/// the semantic identity of the mutation that landed there.
 ///
 /// The server decides the conflict against a durable receipt, and the
-/// receipt holds the sequence, so the error body carries it. It is absent
-/// only when nothing has committed under the id yet — two conflicting
-/// requests claiming it at once — and then there is nothing to read back.
-fn reported_committed_seq(error: &ClientError) -> Option<ChangeSeq> {
+/// receipt holds both, so the error body carries both. They are absent only
+/// when nothing has committed under the id yet — two conflicting requests
+/// claiming it at once — and then there is nothing to read back.
+fn reported_commit_receipt(error: &ClientError) -> Option<(ChangeSeq, String)> {
     match error {
-        ClientError::Api { details, .. } => details.as_ref()?.committed_seq,
+        ClientError::Api { details, .. } => {
+            let details = details.as_ref()?;
+            Some((
+                details.committed_seq?,
+                details.committed_fingerprint.clone()?,
+            ))
+        }
         _ => None,
     }
 }
 
-/// The content one committed change wrote, if it wrote any.
-fn committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
-    change.events.iter().find_map(|event| match event {
+/// The content one committed change wrote, when it wrote exactly one.
+///
+/// A single put's commit produces exactly one content-bearing event: the
+/// file's `created` or `content_changed`. Auto-created parent directories
+/// appear as `created` without a content ref, and no other change kind
+/// carries content at all, so "exactly one" holds for a put however many
+/// directories it had to make. Anything else — nothing, or several — is not
+/// the commit a single put produces, and the caller leaves the conflict
+/// standing rather than picking one.
+fn sole_committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
+    let mut content = change.events.iter().filter_map(|event| match event {
         FilesystemChange::Created { content_ref, .. } => content_ref.as_ref(),
         FilesystemChange::ContentChanged { content_ref, .. } => Some(content_ref),
         _ => None,
-    })
+    });
+    let only = content.next()?;
+    content.next().is_none().then_some(only)
 }
 
 pub use config::ClientConfig;
@@ -1835,14 +1844,8 @@ impl Client {
         match response {
             Ok(response) => Ok(response),
             Err(error) if error.code() == Some(ErrorCode::CommitIdReuseConflict) => {
-                self.reconcile_commit_id_reuse(
-                    spec.namespace(),
-                    &commit_id,
-                    options.message.as_deref(),
-                    uploaded,
-                    error,
-                )
-                .await
+                self.reconcile_commit_id_reuse(spec, &commit_id, options, uploaded, error)
+                    .await
             }
             Err(error) => Err(error),
         }
@@ -1850,22 +1853,32 @@ impl Client {
 
     /// Decides whether a reused commit id already did this exact work.
     ///
-    /// The evidence is the committed change itself, read back from the
-    /// change feed at the sequence the conflict reported: its message
-    /// against the one this request asked for, and its content against the
-    /// bytes that were just uploaded. Nothing weaker counts: every way of
-    /// failing to prove the two requests are the same — including a
-    /// comparison this client cannot make — leaves the original conflict
-    /// standing, never agreement.
+    /// The proof is the commit's whole semantic identity, not a selection of
+    /// its parts. The conflict reports the fingerprint the server's receipt
+    /// holds; this reads the one change that commit id landed, rebuilds this
+    /// request's fingerprint with the committed content reference in place
+    /// of the freshly uploaded one, and requires the two to be equal. That
+    /// covers the path, the replacement behavior, the expected revision, the
+    /// annotation, and that the original commit was this one put — every
+    /// field a future request gains is covered the day it joins the
+    /// preimage. What the fingerprint cannot speak to is whether the two
+    /// content objects hold the same bytes, so digest evidence answers that
+    /// separately.
+    ///
+    /// Nothing weaker counts: every way of failing to prove the two requests
+    /// are the same — including a comparison this client cannot make —
+    /// leaves the original conflict standing, never agreement.
     async fn reconcile_commit_id_reuse(
         &self,
-        namespace_id: &NamespaceId,
+        spec: &NamespacePath,
         commit_id: &CommitId,
-        message: Option<&str>,
+        options: &PutFileOptions,
         uploaded: UploadedContent<'_>,
         conflict: ClientError,
     ) -> Result<ApiCommitResponse> {
-        let Some(committed_seq) = reported_committed_seq(&conflict) else {
+        let namespace_id = spec.namespace();
+        let Some((committed_seq, committed_fingerprint)) = reported_commit_receipt(&conflict)
+        else {
             return Err(conflict);
         };
         let Some(committed) = self
@@ -1874,20 +1887,18 @@ impl Client {
         else {
             return Err(conflict);
         };
-        // The message is part of a commit's identity, so a rerun that
-        // changed it asked for a different mutation and the server's
-        // conflict is the honest answer. Equality here is the server
-        // fingerprint's: the message is taken as given — absent serializes
-        // as `null`, an empty message as `""` — so no message and an empty
-        // message are different commits, and this comparison must not fold
-        // them together.
-        if committed.message.as_deref() != message {
-            return Err(conflict);
-        }
-        let Some(content_ref) = committed_content_ref(&committed) else {
+        let Some(content_ref) = sole_committed_content_ref(&committed) else {
             return Err(conflict);
         };
-        if content_ref.size_bytes != uploaded.size_bytes() {
+        let retried = loonfs_api::put_retry_fingerprint(
+            namespace_id,
+            spec.absolute_path(),
+            options.behavior,
+            options.expected_revision_no,
+            options.message.as_deref(),
+            content_ref,
+        );
+        if retried.ok().as_deref() != Some(committed_fingerprint.as_str()) {
             return Err(conflict);
         }
         if !uploaded_matches_committed(&uploaded, content_ref) {

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -591,7 +591,6 @@ fn streamed_evidence_answers_only_the_digests_it_has() {
     let bytes = b"the same bytes twice";
     let sha256 = ContentRef::blob_v1(ContentId::generate(), bytes);
     let streamed = UploadedContent::Streamed(&sha256);
-    assert_eq!(streamed.size_bytes(), bytes.len() as u64);
     assert_eq!(
         streamed.matches(&StorageChecksum::sha256(bytes)),
         Some(true)
@@ -635,7 +634,6 @@ fn streamed_evidence_answers_only_the_digests_it_has() {
 fn held_evidence_recomputes_whatever_it_is_asked() {
     let bytes = b"held in memory";
     let held = UploadedContent::Bytes(bytes);
-    assert_eq!(held.size_bytes(), bytes.len() as u64);
     assert_eq!(held.matches(&StorageChecksum::sha256(bytes)), Some(true));
     assert_eq!(held.matches(&StorageChecksum::crc64nvme(bytes)), Some(true));
     assert_eq!(

--- a/crates/loonfs-core/src/commit/identity.rs
+++ b/crates/loonfs-core/src/commit/identity.rs
@@ -2,45 +2,15 @@
 //! fingerprints"): a stable digest over a mutation's semantic content, used
 //! to decide whether a reused commit id carries the same mutation or a
 //! conflicting one.
+//!
+//! The digest itself is computed by
+//! [`loonfs_api::semantic_commit_fingerprint`], because the HTTP client has
+//! to compute the same value and does not depend on this crate. What stays
+//! here is core's name for one: a value that reached this crate through
+//! [`crate::path::write::commit_fingerprint`] and is therefore comparable
+//! against a stored receipt.
 
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use std::fmt::Write as _;
-
-/// Domain separator for the one mutation fingerprint preimage.
-pub(crate) const COMMIT_FINGERPRINT_DOMAIN: &str = "loonfs.commit.semantic.v0";
-
-/// Scheme-and-algorithm tag carried by every stored fingerprint value.
-///
-/// `v0` names the canonicalization rules (domain string plus the frozen v0
-/// preimage encoding; format spec, "Commit identity fingerprints") and
-/// `sha256` the digest algorithm, so either can change later without
-/// re-interpreting values already stored in WAL records and commit receipts.
-const FINGERPRINT_SCHEME: &str = "v0:sha256";
-
-/// Computes a stored fingerprint value (`v0:sha256:<64 lowercase hex>`) from
-/// a canonical preimage.
-///
-/// The preimage's compact JSON encoding is the durable contract: a
-/// pinned-value test in `path::write::planner` fails if it drifts.
-pub(crate) fn fingerprint_digest<T>(preimage: &T) -> Result<String, serde_json::Error>
-where
-    T: Serialize,
-{
-    let bytes = serde_json::to_vec(preimage)?;
-    Ok(fingerprint_bytes(&bytes))
-}
-
-fn fingerprint_bytes(bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    let mut value = String::with_capacity(FINGERPRINT_SCHEME.len() + 1 + digest.len() * 2);
-    value.push_str(FINGERPRINT_SCHEME);
-    value.push(':');
-    for byte in digest {
-        write!(&mut value, "{byte:02x}").expect("writing to a String should not fail");
-    }
-    value
-}
 
 /// The semantic identity of one mutation request: what a reused commit id is
 /// compared against.

--- a/crates/loonfs-core/src/commit/mod.rs
+++ b/crates/loonfs-core/src/commit/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! A planned commit is validated against a metadata view into a commit plan,
 //! the plan is materialized into WAL deltas, and the result is framed for
-//! publication. Submodules follow that pipeline; `identity` defines the
+//! publication. Submodules follow that pipeline; `identity` names the
 //! fingerprint that makes reused commit ids safe to compare, and `ops` holds
 //! the inode-level vocabulary path operations compile into.
 
@@ -22,7 +22,6 @@ mod validate_error;
 
 pub(crate) use self::durable_adapter::wal_payload_from_materialized_commit;
 pub use self::identity::CommitFingerprint;
-pub(crate) use self::identity::{fingerprint_digest, COMMIT_FINGERPRINT_DOMAIN};
 pub(crate) use self::ir::CommitIr;
 pub(crate) use self::materialize::{materialize_commit, MaterializedCommit};
 pub use self::materialize::{CommitOpResult, MaterializedCommitDelta};

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -131,6 +131,12 @@ pub enum CoreError {
         /// live requests are claiming it at once, which is the one case a
         /// caller cannot reconcile by reading the feed.
         committed_seq: Option<ChangeSeq>,
+        /// Semantic identity of the mutation that landed under the id, taken
+        /// from the same receipt as `committed_seq` and present exactly when
+        /// it is. Reporting it is what lets a retry prove it is the same
+        /// request by recomputing one value, rather than comparing whichever
+        /// fields it thought to compare.
+        committed_fingerprint: Option<String>,
     },
     #[error(transparent)]
     ContentPreparation(#[from] ContentPreparationError),
@@ -466,9 +472,11 @@ impl CoreError {
             CoreError::CommitIdReuseConflict {
                 commit_id,
                 committed_seq,
+                committed_fingerprint,
             } => Some(ErrorDetails {
                 commit_id: CommitId::parse(commit_id).ok(),
                 committed_seq: *committed_seq,
+                committed_fingerprint: committed_fingerprint.clone(),
                 ..ErrorDetails::default()
             }),
             CoreError::RebootstrapRequired {
@@ -931,10 +939,12 @@ mod tests {
             .ends_with("epoch 3 was fenced by epoch 4"));
 
         // A conflict decided against a durable receipt names where the
-        // commit id landed, which is what a retry reads back.
+        // commit id landed and what landed there, which is what a retry
+        // reads back and proves itself against.
         let reuse = CoreError::CommitIdReuseConflict {
             commit_id: "retry-key-1".to_owned(),
             committed_seq: Some(ChangeSeq(9)),
+            committed_fingerprint: Some("v0:sha256:abc".to_owned()),
         };
         let details = reuse.details().expect("reuse details");
         assert_eq!(
@@ -942,14 +952,21 @@ mod tests {
             Some(CommitId::parse("retry-key-1").expect("valid commit id"))
         );
         assert_eq!(details.committed_seq, Some(ChangeSeq(9)));
+        assert_eq!(
+            details.committed_fingerprint.as_deref(),
+            Some("v0:sha256:abc")
+        );
 
-        // A conflict between two live claims has no landed commit to name.
+        // A conflict between two live claims has no landed commit to name,
+        // so it carries neither half of the receipt.
         let contended = CoreError::CommitIdReuseConflict {
             commit_id: "retry-key-1".to_owned(),
             committed_seq: None,
+            committed_fingerprint: None,
         };
         let details = contended.details().expect("reuse details");
         assert_eq!(details.committed_seq, None);
+        assert_eq!(details.committed_fingerprint, None);
 
         let stale =
             CoreError::CommitValidation(CommitValidationError::ReplaceFileBaseRevisionMismatch {

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -10,18 +10,14 @@ use super::plan_restore::plan_publish_restore_revision;
 use super::plan_transfer::{plan_publish_copy_file_path, plan_publish_move_path};
 use super::planning_helpers::{PlannedOperation, PublishPathPlanningView};
 use crate::commit::{
-    allocates_inode, fingerprint_digest, validate_ops, CommitFingerprint, CommitOp,
-    OpValidationCursor, PlannedOp, PublishValidationView, COMMIT_FINGERPRINT_DOMAIN,
+    allocates_inode, validate_ops, CommitFingerprint, CommitOp, OpValidationCursor, PlannedOp,
+    PublishValidationView,
 };
 use crate::error::{CoreError, Result};
 use crate::metadata::{MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
-use loonfs_api::ChangeSeq;
-use loonfs_api::{
-    ContentRef, DeleteDirectoryBehavior, DestinationBehavior, InodeId, NamespaceId, RevisionNo,
-};
+use loonfs_api::{ChangeSeq, InodeId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
-use serde::Serialize;
 
 /// One mutation request compiled into a commit's operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,197 +29,26 @@ pub(crate) struct PlannedCommit {
     pub(crate) resulting_next_inode_id: InodeId,
 }
 
-/// Canonical preimage for one operation inside a mutation fingerprint.
-///
-/// The serde representation is durable contract (format spec, "Commit
-/// identity fingerprints"): the same normalized request must fingerprint
-/// identically across releases. A pinned-value test below fails if the
-/// encoding drifts.
-///
-/// The variant names, the field names, and the field order below are all part
-/// of that preimage under the [`COMMIT_FINGERPRINT_DOMAIN`] tag, and none of
-/// them tracks the wire enum. They deliberately differ from it — `CreateDir`
-/// against the wire's `CreateDirectory`, `absolute_path` against its `path`,
-/// `behavior` ahead of `content_ref` in the put — because renaming a wire
-/// field must not silently restate every already-published commit's identity.
-/// [`operation_fingerprint_input`] is the one place the wire spelling is
-/// translated into this one; nothing else may name these variants. Change any
-/// of it and every stored fingerprint disagrees with its recomputed value,
-/// which the pinned tests below exist to catch.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum OperationFingerprintInput<'a> {
-    CreateDir {
-        absolute_path: &'a str,
-        parents: bool,
-    },
-    // The put guard joins the preimage for the same reason as the delete
-    // guard below: a changed expected revision is a different logical
-    // request and must conflict rather than replay a receipt.
-    PutFile {
-        absolute_path: &'a str,
-        behavior: DestinationBehavior,
-        content_ref: ContentRefFingerprintInput<'a>,
-        expected_revision_no: Option<RevisionNo>,
-    },
-    // Identity covers the complete caller-visible logical request. A changed
-    // delete guard must conflict instead of replaying the old receipt
-    // without checking the new guard.
-    DeletePath {
-        absolute_path: &'a str,
-        behavior: DeleteDirectoryBehavior,
-        expected_inode_id: Option<InodeId>,
-    },
-    MovePath {
-        from_path: &'a str,
-        to_path: &'a str,
-        behavior: DestinationBehavior,
-    },
-    CopyFilePath {
-        from_path: &'a str,
-        to_path: &'a str,
-        behavior: DestinationBehavior,
-    },
-    RestoreRevision {
-        absolute_path: &'a str,
-        source_revision_no: RevisionNo,
-    },
-    Undelete {
-        inode_id: InodeId,
-        deleted_at_seq: ChangeSeq,
-        // Preimage-additive: `Some` serializes as the bare string it always
-        // was, so every stored undelete fingerprint is unchanged; `None`
-        // serializes as `null`, a new distinct preimage for the in-place
-        // form. Both shapes are pinned below.
-        absolute_path: Option<&'a str>,
-    },
-}
-
-/// Canonical preimage for the content a put attaches.
-///
-/// Identity is *which object*, so the id and its length are the whole of it.
-/// The checksums are evidence about those bytes, pinned to the id by the
-/// verification every write and read already performs, and they are left out
-/// deliberately: a reference that named the same object with a differently
-/// spelled checksum would otherwise read as a different mutation.
-///
-/// The consequence is worth stating plainly. A retry that re-runs the whole
-/// operation, upload included, mints a new content object, so it is a
-/// different request and a reused commit id conflicts. Retrying a commit
-/// means sending the same `ContentRef` again — which replays — not uploading
-/// the bytes again.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct ContentRefFingerprintInput<'a> {
-    kind: &'a str,
-    content_id: &'a str,
-    size_bytes: u64,
-}
-
-fn content_ref_fingerprint_input(content_ref: &ContentRef) -> ContentRefFingerprintInput<'_> {
-    ContentRefFingerprintInput {
-        kind: content_ref.kind.as_str(),
-        content_id: content_ref.content_id.as_str(),
-        size_bytes: content_ref.size_bytes,
-    }
-}
-
-/// Renames one wire operation into its durable preimage.
-///
-/// This is the whole of the wire-to-fingerprint translation. The left side
-/// follows [`FilesystemOperation`] and may be renamed with it; the right side
-/// is frozen (see [`OperationFingerprintInput`]).
-fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFingerprintInput<'_> {
-    match operation {
-        FilesystemOperation::CreateDirectory { path, parents } => {
-            OperationFingerprintInput::CreateDir {
-                absolute_path: path.as_str(),
-                parents: *parents,
-            }
-        }
-        FilesystemOperation::PutFile {
-            path,
-            content_ref,
-            behavior,
-            expected_revision_no,
-        } => OperationFingerprintInput::PutFile {
-            absolute_path: path.as_str(),
-            behavior: *behavior,
-            content_ref: content_ref_fingerprint_input(content_ref),
-            expected_revision_no: *expected_revision_no,
-        },
-        FilesystemOperation::DeletePath {
-            path,
-            behavior,
-            expected_inode_id,
-        } => OperationFingerprintInput::DeletePath {
-            absolute_path: path.as_str(),
-            behavior: *behavior,
-            expected_inode_id: *expected_inode_id,
-        },
-        FilesystemOperation::MovePath {
-            from_path,
-            to_path,
-            behavior,
-        } => OperationFingerprintInput::MovePath {
-            from_path: from_path.as_str(),
-            to_path: to_path.as_str(),
-            behavior: *behavior,
-        },
-        FilesystemOperation::CopyPath {
-            from_path,
-            to_path,
-            behavior,
-        } => OperationFingerprintInput::CopyFilePath {
-            from_path: from_path.as_str(),
-            to_path: to_path.as_str(),
-            behavior: *behavior,
-        },
-        FilesystemOperation::RestoreRevision {
-            path,
-            source_revision_no,
-        } => OperationFingerprintInput::RestoreRevision {
-            absolute_path: path.as_str(),
-            source_revision_no: *source_revision_no,
-        },
-        FilesystemOperation::Undelete {
-            inode_id,
-            deleted_at_seq,
-            path,
-        } => OperationFingerprintInput::Undelete {
-            inode_id: *inode_id,
-            deleted_at_seq: *deleted_at_seq,
-            absolute_path: path.as_ref().map(|path| path.as_str()),
-        },
-    }
-}
-
 /// The semantic identity of one mutation request.
 ///
-/// A one-operation convenience call and a one-element batch are the same
-/// type, so they reach this function with the same shape and fingerprint
-/// identically; there is no separate single-operation form to keep in step.
+/// The fingerprint itself is `loonfs-api`'s: the crate that owns the one
+/// operation language owns its identity function, because the HTTP client
+/// has to compute the same value to reconcile a reused-id conflict and does
+/// not depend on this crate. All this adds is core's vocabulary — the
+/// request shape on the way in, `CommitFingerprint` and `CoreError` on the
+/// way out.
+///
+/// The commit id is not an input. It is the key the mutation is filed
+/// under; the fingerprint is what was filed.
 pub(crate) fn commit_fingerprint(
     namespace_id: &NamespaceId,
     request: &CommitRequest,
 ) -> Result<CommitFingerprint> {
-    #[derive(Serialize)]
-    struct CanonicalCommit<'a> {
-        domain: &'static str,
-        namespace_id: &'a str,
-        operations: Vec<OperationFingerprintInput<'a>>,
-        message: Option<&'a str>,
-    }
-
-    fingerprint_digest(&CanonicalCommit {
-        domain: COMMIT_FINGERPRINT_DOMAIN,
-        namespace_id: namespace_id.as_str(),
-        operations: request
-            .operations
-            .iter()
-            .map(operation_fingerprint_input)
-            .collect(),
-        message: request.message.as_deref(),
-    })
+    loonfs_api::semantic_commit_fingerprint(
+        namespace_id,
+        request.message.as_deref(),
+        &request.operations,
+    )
     .map(CommitFingerprint::new_unchecked)
     .map_err(|err| CoreError::Internal(format!("failed to fingerprint mutation: {err}")))
 }
@@ -423,7 +248,9 @@ mod tests {
     use crate::path::write::ops::{delete_path, put_file_bytes};
     use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
-    use loonfs_api::{AbsolutePath, CommitId, RevisionNo};
+    use loonfs_api::{
+        AbsolutePath, CommitId, DeleteDirectoryBehavior, DestinationBehavior, RevisionNo,
+    };
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use tempfile::tempdir;
 
@@ -449,199 +276,9 @@ mod tests {
         }
     }
 
-    /// Pins the exact stored fingerprint for a fixed one-operation request.
-    ///
-    /// If this fails, the canonical preimage changed (format spec, "Commit
-    /// identity fingerprints") and every persisted fingerprint would disagree
-    /// with recomputed ones, breaking retry idempotency across versions. Do
-    /// not update the literal without bumping the fingerprint scheme tag.
-    #[test]
-    fn commit_fingerprint_value_is_pinned() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let mut fixed = request(create_dir("/docs"));
-        fixed.commit_id = CommitId::parse("c_00000000000000000000000000000042").expect("commit id");
-
-        let fingerprint = commit_fingerprint(&namespace_id, &fixed).expect("fingerprint");
-
-        assert_eq!(
-            fingerprint.as_str(),
-            "v0:sha256:85894f53a16c2c0be95afc39b245280101f3e2a414f044c87be8eb9f1980dbcd"
-        );
-    }
-
-    /// Pins the exact stored fingerprint encoding for a guarded delete.
-    #[test]
-    fn guarded_delete_fingerprint_value_is_pinned() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let mut fixed = request(FilesystemOperation::DeletePath {
-            path: AbsolutePath::parse("/docs").expect("path"),
-            behavior: DeleteDirectoryBehavior::NonRecursive,
-            expected_inode_id: Some(InodeId(42)),
-        });
-        fixed.commit_id = CommitId::parse("c_00000000000000000000000000000043").expect("commit id");
-
-        let fingerprint = commit_fingerprint(&namespace_id, &fixed).expect("fingerprint");
-
-        assert_eq!(
-            fingerprint.as_str(),
-            "v0:sha256:edc8e06bd0a651e9470198875ec44c8fcd7d9b95f162fe1d7ca46011c27e2818"
-        );
-    }
-
-    /// Pins the exact stored fingerprint for an undelete with a destination
-    /// path.
-    ///
-    /// This literal is what proves the in-place form was preimage-additive:
-    /// the path became optional and this value did not move, because a
-    /// present path serializes as the bare string it always was.
-    #[test]
-    fn undelete_fingerprint_value_is_pinned() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let mut fixed = request(FilesystemOperation::Undelete {
-            inode_id: InodeId(42),
-            deleted_at_seq: ChangeSeq(17),
-            path: Some(AbsolutePath::parse("/docs/report.txt").expect("path")),
-        });
-        fixed.commit_id = CommitId::parse("c_00000000000000000000000000000044").expect("commit id");
-
-        let fingerprint = commit_fingerprint(&namespace_id, &fixed).expect("fingerprint");
-
-        // The mechanism behind "did not move": a present option serializes
-        // as the bare value, so wrapping the preimage field changed no
-        // stored byte.
-        assert_eq!(
-            serde_json::to_value(Some("/docs/report.txt")).expect("serialize"),
-            serde_json::to_value("/docs/report.txt").expect("serialize"),
-        );
-        assert_eq!(
-            fingerprint.as_str(),
-            "v0:sha256:1f4fa76d65aa64903a7d44cead91600a97c0bac9ec3a01ac51f0cd1130eff3d6"
-        );
-    }
-
-    /// Pins the exact stored fingerprint for an in-place undelete, whose
-    /// absent path serializes as `null` — a distinct preimage from every
-    /// pathed form.
-    #[test]
-    fn in_place_undelete_fingerprint_value_is_pinned() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let mut fixed = request(FilesystemOperation::Undelete {
-            inode_id: InodeId(42),
-            deleted_at_seq: ChangeSeq(17),
-            path: None,
-        });
-        fixed.commit_id = CommitId::parse("c_00000000000000000000000000000044").expect("commit id");
-
-        let fingerprint = commit_fingerprint(&namespace_id, &fixed).expect("fingerprint");
-
-        assert_eq!(
-            fingerprint.as_str(),
-            "v0:sha256:4d7737cdc3888e3613dad0ec7d752e8daac089c8b528301cf0eba9307fa1cc4c"
-        );
-    }
-
-    /// Pins the exact stored fingerprint for a put, which is the only
-    /// operation whose preimage embeds a content reference.
-    ///
-    /// The literal covers the canonical content-ref form — kind, content id,
-    /// size, and nothing else. Adding a checksum to that form, or reordering
-    /// it, would change this value and silently break replay for every
-    /// already-published put.
-    #[test]
-    fn put_file_fingerprint_value_is_pinned() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let mut fixed = request(FilesystemOperation::PutFile {
-            path: AbsolutePath::parse("/docs/report.txt").expect("path"),
-            content_ref: ContentRef::blob_v1(
-                loonfs_api::ContentId::parse("con_0123456789abcdef0123456789abcdef")
-                    .expect("content id"),
-                b"pinned put bytes",
-            ),
-            behavior: DestinationBehavior::NoReplace,
-            expected_revision_no: None,
-        });
-        fixed.commit_id = CommitId::parse("c_00000000000000000000000000000044").expect("commit id");
-
-        let fingerprint = commit_fingerprint(&namespace_id, &fixed).expect("fingerprint");
-
-        assert_eq!(
-            fingerprint.as_str(),
-            "v0:sha256:3febc279ebb36c013f734095bebdba3c0a59bf8cbd82d205b53adbf00c112d59"
-        );
-    }
-
-    /// Two references to the same object with different checksum evidence
-    /// are the same mutation: identity is which object a put attaches, and
-    /// the checksums are pinned to that object by verification elsewhere.
-    #[test]
-    fn checksum_evidence_is_outside_mutation_identity() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let content_ref = ContentRef::blob_v1(
-            loonfs_api::ContentId::parse("con_0123456789abcdef0123456789abcdef")
-                .expect("content id"),
-            b"pinned put bytes",
-        );
-        let without_trusted_digest = ContentRef {
-            whole_file_sha256: None,
-            ..content_ref.clone()
-        };
-        let build = |content_ref| {
-            request(FilesystemOperation::PutFile {
-                path: AbsolutePath::parse("/docs/report.txt").expect("path"),
-                content_ref,
-                behavior: DestinationBehavior::NoReplace,
-                expected_revision_no: None,
-            })
-        };
-
-        assert_eq!(
-            commit_fingerprint(&namespace_id, &build(content_ref)).expect("fingerprint"),
-            commit_fingerprint(&namespace_id, &build(without_trusted_digest)).expect("fingerprint")
-        );
-    }
-
-    /// A different content object is a different mutation, which is what
-    /// makes a re-upload under a used commit id conflict instead of replay.
-    #[test]
-    fn a_different_content_object_changes_mutation_identity() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let build = |content_ref| {
-            request(FilesystemOperation::PutFile {
-                path: AbsolutePath::parse("/docs/report.txt").expect("path"),
-                content_ref,
-                behavior: DestinationBehavior::NoReplace,
-                expected_revision_no: None,
-            })
-        };
-        let bytes = b"identical bytes, two uploads";
-        let first = ContentRef::blob_v1(loonfs_api::ContentId::generate(), bytes);
-        let second = ContentRef::blob_v1(loonfs_api::ContentId::generate(), bytes);
-
-        assert_ne!(
-            commit_fingerprint(&namespace_id, &build(first)).expect("fingerprint"),
-            commit_fingerprint(&namespace_id, &build(second)).expect("fingerprint")
-        );
-    }
-
-    #[test]
-    fn a_message_changes_mutation_identity() {
-        // The annotation is part of what the caller asked for: replaying a
-        // commit id with a different message must conflict, so the message
-        // joins the preimage.
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let build = |message: Option<&str>| {
-            CommitRequest::single(
-                CommitId::parse("mkdir-docs").expect("valid commit id"),
-                message.map(ToOwned::to_owned),
-                create_dir("/docs"),
-            )
-        };
-        let without = commit_fingerprint(&namespace_id, &build(None)).expect("fingerprint");
-        let with =
-            commit_fingerprint(&namespace_id, &build(Some("import batch"))).expect("fingerprint");
-        assert_ne!(without.as_str(), with.as_str());
-    }
-
+    /// The commit id is the key, not the identity: two requests that differ
+    /// only in the id they are filed under are the same mutation, which is
+    /// what makes a reused id comparable against a receipt at all.
     #[test]
     fn commit_fingerprint_is_stable_for_canonical_paths() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -667,17 +304,6 @@ mod tests {
         assert_eq!(left, right);
     }
 
-    #[test]
-    fn commit_fingerprint_changes_when_logical_inputs_change() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let baseline =
-            commit_fingerprint(&namespace_id, &request(create_dir("/docs"))).expect("baseline");
-        let changed =
-            commit_fingerprint(&namespace_id, &request(create_dir("/drafts"))).expect("changed");
-
-        assert_ne!(baseline, changed);
-    }
-
     /// A one-operation convenience call and a one-element batch are the same
     /// request, so they cannot fingerprint differently.
     #[test]
@@ -694,29 +320,6 @@ mod tests {
         assert_eq!(
             commit_fingerprint(&namespace_id, &convenience).expect("convenience fingerprint"),
             commit_fingerprint(&namespace_id, &batch).expect("batch fingerprint")
-        );
-    }
-
-    /// Operation order is part of the request: reordering is a different
-    /// logical mutation, so it must not replay the first one's receipt.
-    #[test]
-    fn operation_order_changes_mutation_identity() {
-        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let commit_id = CommitId::parse("two-ops").expect("valid commit id");
-        let forward = CommitRequest {
-            commit_id: commit_id.clone(),
-            message: None,
-            operations: vec![create_dir("/a"), create_dir("/b")],
-        };
-        let reversed = CommitRequest {
-            commit_id,
-            message: None,
-            operations: vec![create_dir("/b"), create_dir("/a")],
-        };
-
-        assert_ne!(
-            commit_fingerprint(&namespace_id, &forward).expect("forward fingerprint"),
-            commit_fingerprint(&namespace_id, &reversed).expect("reversed fingerprint")
         );
     }
 

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -83,6 +83,7 @@ impl BatchDedup {
                 CoreError::CommitIdReuseConflict {
                     commit_id: commit_id.to_string(),
                     committed_seq: None,
+                    committed_fingerprint: None,
                 },
             )));
         }
@@ -200,11 +201,13 @@ async fn resolve_commit_id_reuse<S: ObjectStore + ?Sized>(
     if let Some(existing) = view.find_commit_receipt(commit_id).await? {
         return Ok(Some(CandidateAdmission::Settled(
             if existing.semantic_commit_fingerprint != semantic_identity.as_str() {
-                // The receipt holds where the id landed; reporting it is
-                // what turns a caller's reconciliation into one feed read.
+                // The receipt holds where the id landed and what landed
+                // there; reporting both is what turns a caller's
+                // reconciliation into one feed read and one comparison.
                 Err(CoreError::CommitIdReuseConflict {
                     commit_id: commit_id.to_string(),
                     committed_seq: Some(existing.committed_seq),
+                    committed_fingerprint: Some(existing.semantic_commit_fingerprint.clone()),
                 })
             } else {
                 Ok(commit_response_from_commit_receipt(namespace_id, &existing))

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -1283,11 +1283,15 @@ async fn batch_commit_rejects_duplicate_commit_id_with_different_fingerprint() {
     responses[0].as_ref().expect("primary commit");
     let error = responses[1].as_ref().expect_err("duplicate conflict");
     // Neither claim had committed when the batch admitted them, so the
-    // conflict has no landed sequence to name.
+    // conflict has no receipt to name: neither the sequence nor the
+    // fingerprint a retry would reconcile against.
     assert!(matches!(
         error,
-        CoreError::CommitIdReuseConflict { commit_id, committed_seq: None }
-            if commit_id == "req-conflict"
+        CoreError::CommitIdReuseConflict {
+            commit_id,
+            committed_seq: None,
+            committed_fingerprint: None,
+        } if commit_id == "req-conflict"
     ));
 
     let wal_keys = store
@@ -1359,11 +1363,17 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
     .await
     .expect_err("conflicting retry");
     // The receipt decided this one, so the conflict names where the id
-    // landed — the sequence a retry reads back to reconcile.
+    // landed and what landed there — the sequence a retry reads back, and
+    // the identity it proves itself against.
     assert!(matches!(
         conflict,
-        CoreError::CommitIdReuseConflict { commit_id, committed_seq }
-            if commit_id == "same-path-request" && committed_seq == Some(first.committed_seq)
+        CoreError::CommitIdReuseConflict {
+            commit_id,
+            committed_seq,
+            committed_fingerprint: Some(fingerprint),
+        } if commit_id == "same-path-request"
+            && committed_seq == Some(first.committed_seq)
+            && fingerprint.starts_with("v0:sha256:")
     ));
 
     let wal_keys = store
@@ -1484,8 +1494,11 @@ async fn delete_path_commit_id_reuse_includes_expected_inode_id() {
         .expect_err("changed guard must conflict");
         assert!(matches!(
             error,
-            CoreError::CommitIdReuseConflict { commit_id: reused, committed_seq: Some(_) }
-                if reused == commit_id
+            CoreError::CommitIdReuseConflict {
+                commit_id: reused,
+                committed_seq: Some(_),
+                committed_fingerprint: Some(_),
+            } if reused == commit_id
         ));
     }
 

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -7,6 +7,7 @@ use loonfs_api::v0::{
 };
 use loonfs_api::{
     AbsolutePath, ChangeSeq, CommitId, CommitRequest, DestinationBehavior, FilesystemOperation,
+    RevisionNo,
 };
 use loonfs_client::{
     ClientError, CopyOptions, CreateDirectoryOptions, DeleteOptions, MoveOptions, NamespacePath,
@@ -287,6 +288,234 @@ async fn http_put_conflict_stands_when_only_the_message_changed() {
         Some("import batch"),
         "the refused rerun did not rewrite the annotation that landed"
     );
+    let entry = harness.client.stat_path(&target).await.expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "the refused rerun published no revision"
+    );
+
+    harness.server.abort();
+}
+
+/// The same bytes written somewhere else are a different mutation, and no
+/// amount of matching payload makes them the same one. Content evidence
+/// alone would call this a successful retry and leave `/b.txt` unwritten
+/// forever, which is why the client proves the whole request fingerprint.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_put_conflict_stands_when_only_the_path_changed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-path",
+        "http-path",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let commit_id = CommitId::parse("req-path-put").expect("valid commit id");
+    let options = PutFileOptions {
+        behavior: DestinationBehavior::Replace,
+        commit_id: Some(commit_id.clone()),
+        message: Some("import batch".to_owned()),
+        expected_revision_no: None,
+    };
+
+    let first_target = NamespacePath::parse("demo", "/a.txt").expect("first target");
+    let first = harness
+        .client
+        .put_file_bytes(&first_target, b"stable bytes\n", &options)
+        .await
+        .expect("first put");
+
+    let second_target = NamespacePath::parse("demo", "/b.txt").expect("second target");
+    match harness
+        .client
+        .put_file_bytes(&second_target, b"stable bytes\n", &options)
+        .await
+    {
+        Err(ClientError::Api { code, details, .. }) => {
+            assert_eq!(code, "commit_id_reuse_conflict");
+            // The receipt named both halves of what landed, so the client
+            // had everything it needed and still refused.
+            let details = details.expect("structured details");
+            assert_eq!(details.committed_seq, Some(first.committed_seq));
+            let fingerprint = details
+                .committed_fingerprint
+                .expect("the receipt's semantic identity");
+            assert!(fingerprint.starts_with("v0:sha256:"), "got `{fingerprint}`");
+        }
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
+    match harness.client.stat_path(&second_target).await {
+        Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
+        other => unreachable!("the refused rerun wrote nothing, got {other:?}"),
+    }
+    let entry = harness
+        .client
+        .stat_path(&first_target)
+        .await
+        .expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "the refused rerun published no revision"
+    );
+
+    harness.server.abort();
+}
+
+/// The replacement behavior and the expected-revision guard are part of
+/// what the caller asked for, so the same bytes at the same path under
+/// either one changed are different mutations.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_put_conflict_stands_when_only_a_guard_changed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-guard",
+        "http-guard",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let target = NamespacePath::parse("demo", "/docs/guard.txt").expect("target");
+    let commit_id = CommitId::parse("req-guard-put").expect("valid commit id");
+    let replacing = PutFileOptions {
+        behavior: DestinationBehavior::Replace,
+        commit_id: Some(commit_id.clone()),
+        message: None,
+        expected_revision_no: None,
+    };
+
+    let first = harness
+        .client
+        .put_file_bytes(&target, b"stable bytes\n", &replacing)
+        .await
+        .expect("first put");
+
+    match harness
+        .client
+        .put_file_bytes(
+            &target,
+            b"stable bytes\n",
+            &PutFileOptions {
+                behavior: DestinationBehavior::NoReplace,
+                ..replacing.clone()
+            },
+        )
+        .await
+    {
+        Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
+    match harness
+        .client
+        .put_file_bytes(
+            &target,
+            b"stable bytes\n",
+            &PutFileOptions {
+                expected_revision_no: Some(RevisionNo(1)),
+                ..replacing
+            },
+        )
+        .await
+    {
+        Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
+    let entry = harness.client.stat_path(&target).await.expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "neither refused rerun published a revision"
+    );
+
+    harness.server.abort();
+}
+
+/// A commit that did more than one thing is not the commit a single put
+/// makes, however well its put half lines up. The operation list is inside
+/// the fingerprint, so the count alone settles this.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_single_put_does_not_replay_a_multi_operation_commit() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-batch",
+        "http-batch",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let target = NamespacePath::parse("demo", "/docs/batch.txt").expect("target");
+    let commit_id = CommitId::parse("req-batch-put").expect("valid commit id");
+
+    let staged = stage_uploaded_content(&harness.client, &namespace, b"stable bytes\n").await;
+    let first = harness
+        .client
+        .commit(
+            &namespace,
+            &CommitRequest {
+                commit_id: commit_id.clone(),
+                message: None,
+                content_tokens: vec![ValidatedContentToken {
+                    content_ref: staged.content_ref.clone(),
+                    token: staged
+                        .validated_content_token
+                        .clone()
+                        .expect("completion returns a content token"),
+                }],
+                operations: vec![
+                    FilesystemOperation::PutFile {
+                        path: AbsolutePath::parse("/docs/batch.txt").expect("path"),
+                        content_ref: staged.content_ref.clone(),
+                        behavior: DestinationBehavior::Replace,
+                        expected_revision_no: None,
+                    },
+                    FilesystemOperation::CreateDirectory {
+                        path: AbsolutePath::parse("/reports").expect("path"),
+                        parents: true,
+                    },
+                ],
+            },
+        )
+        .await
+        .expect("first two-operation commit");
+
+    match harness
+        .client
+        .put_file_bytes(
+            &target,
+            b"stable bytes\n",
+            &PutFileOptions {
+                behavior: DestinationBehavior::Replace,
+                commit_id: Some(commit_id),
+                message: None,
+                expected_revision_no: None,
+            },
+        )
+        .await
+    {
+        Err(ClientError::Api { code, .. }) => assert_eq!(code, "commit_id_reuse_conflict"),
+        other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
+    }
+
     let entry = harness.client.stat_path(&target).await.expect("stat path");
     assert_eq!(
         entry.head_seq, first.committed_seq,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -33,14 +33,6 @@ enum StagedPayload<'a> {
 }
 
 impl StagedPayload<'_> {
-    /// Complete length of what was staged.
-    fn size_bytes(&self) -> u64 {
-        match self {
-            Self::Bytes(bytes) => bytes.len() as u64,
-            Self::Streamed(content_ref) => content_ref.size_bytes,
-        }
-    }
-
     /// Whether the staged bytes produce this checksum. `None` is a refusal
     /// to answer, never agreement.
     fn matches(&self, expected: &StorageChecksum) -> Option<bool> {
@@ -60,28 +52,41 @@ impl StagedPayload<'_> {
     }
 }
 
-/// Where a reuse conflict says the commit id already landed.
+/// What a reuse conflict says the commit id already landed as: where, and
+/// the semantic identity of the mutation that landed there.
 ///
 /// The publisher decides the conflict against a durable receipt, and the
-/// receipt holds the sequence, so the error carries it. It is absent only
-/// when nothing has committed under the id yet — two conflicting requests
+/// receipt holds both, so the error carries both. They are absent only when
+/// nothing has committed under the id yet — two conflicting requests
 /// claiming it at once — and then there is nothing to read back.
-fn reported_committed_seq(error: &RuntimeError) -> Option<ChangeSeq> {
+fn reported_commit_receipt(error: &RuntimeError) -> Option<(ChangeSeq, String)> {
     match error {
-        RuntimeError::Core(CoreError::CommitIdReuseConflict { committed_seq, .. }) => {
-            *committed_seq
-        }
+        RuntimeError::Core(CoreError::CommitIdReuseConflict {
+            committed_seq,
+            committed_fingerprint,
+            ..
+        }) => Some(((*committed_seq)?, committed_fingerprint.clone()?)),
         _ => None,
     }
 }
 
-/// The content one committed change wrote, if it wrote any.
-fn committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
-    change.events.iter().find_map(|event| match event {
+/// The content one committed change wrote, when it wrote exactly one.
+///
+/// A single put's commit produces exactly one content-bearing event: the
+/// file's `Created` or `ContentChanged`. Auto-created parent directories
+/// appear as `Created` without a content ref, and no other change kind
+/// carries content at all, so "exactly one" holds for a put however many
+/// directories it had to make. Anything else — nothing, or several — is not
+/// the commit a single put produces, and the caller leaves the conflict
+/// standing rather than picking one.
+fn sole_committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
+    let mut content = change.events.iter().filter_map(|event| match event {
         FilesystemChange::Created { content_ref, .. } => content_ref.as_ref(),
         FilesystemChange::ContentChanged { content_ref, .. } => Some(content_ref),
         _ => None,
-    })
+    });
+    let only = content.next()?;
+    content.next().is_none().then_some(only)
 }
 
 /// Whether the committed reference provably holds the bytes just staged.
@@ -152,10 +157,11 @@ impl FsWriter {
     /// content object it wrote, and a re-run necessarily stages a fresh
     /// one, so the publisher sees a different commit and reports
     /// `commit_id_reuse_conflict`. This resolves that by reading back what
-    /// the commit id actually committed and comparing it against the
-    /// request just made: same content and same message means the
-    /// operation had already succeeded. Different bytes, a different
-    /// message, or content this build cannot compare surface the conflict.
+    /// the commit id actually committed and rebuilding this request's
+    /// fingerprint around it: an identical value plus bytes that provably
+    /// agree means the operation had already succeeded. Anything else —
+    /// a different path, behavior, guard, message, or payload, or content
+    /// this build cannot compare — surfaces the conflict.
     ///
     /// The freshly staged duplicate object is then referenced by nothing.
     /// That is by design, not a leak: it is a completed upload session's
@@ -171,16 +177,15 @@ impl FsWriter {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
-        let commit_id = options.commit_id.clone();
-        let message = options.message.clone();
+        let attempt = options.clone();
         let prepared_content = self.prepare_file_bytes(namespace_id, bytes).await?;
         let published = self
             .put_file_prepared(namespace_id, absolute_path, prepared_content, options)
             .await;
         self.settle_put(
             namespace_id,
-            commit_id,
-            message,
+            absolute_path,
+            &attempt,
             published,
             StagedPayload::Bytes(bytes),
         )
@@ -221,8 +226,7 @@ impl FsWriter {
         options: PutFileOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        let commit_id = options.commit_id.clone();
-        let message = options.message.clone();
+        let attempt = options.clone();
         let prepared_content = self.prepare_file_stream(namespace_id, body).await?;
         // The prepared reference describes the bytes that just went past,
         // and with the payload gone it is the only description of them that
@@ -233,8 +237,8 @@ impl FsWriter {
             .await;
         self.settle_put(
             namespace_id,
-            commit_id,
-            message,
+            absolute_path,
+            &attempt,
             published,
             StagedPayload::Streamed(&staged),
         )
@@ -246,17 +250,18 @@ impl FsWriter {
     async fn settle_put(
         &self,
         namespace_id: &NamespaceId,
-        commit_id: Option<CommitId>,
-        message: Option<String>,
+        absolute_path: &str,
+        attempt: &PutFileOptions,
         published: Result<CommitResponse>,
         staged: StagedPayload<'_>,
     ) -> Result<CommitResponse> {
-        match (published, commit_id) {
+        match (published, attempt.commit_id.as_ref()) {
             (Err(error), Some(commit_id)) if error.code() == ErrorCode::CommitIdReuseConflict => {
                 self.reconcile_commit_id_reuse(
                     namespace_id,
-                    &commit_id,
-                    message.as_deref(),
+                    absolute_path,
+                    commit_id,
+                    attempt,
                     staged,
                     error,
                 )
@@ -268,21 +273,32 @@ impl FsWriter {
 
     /// Decides whether a reused commit id already did this exact work.
     ///
-    /// The evidence is the committed change itself, read from the change
-    /// feed at the sequence the conflict reported: its message against the
-    /// one this request asked for, and its content against the bytes just
-    /// staged. Nothing weaker counts: every way of failing to prove the two
-    /// requests are the same — including a comparison this build cannot
-    /// make — leaves the original conflict standing, never agreement.
+    /// The proof is the commit's whole semantic identity, not a selection of
+    /// its parts. The conflict reports the fingerprint the receipt holds;
+    /// this reads the one change that commit id landed, rebuilds this
+    /// request's fingerprint with the committed content reference in place
+    /// of the freshly staged one, and requires the two to be equal. That
+    /// covers the path, the replacement behavior, the expected revision, the
+    /// annotation, and that the original commit was this one put — every
+    /// field a future request gains is covered the day it joins the
+    /// preimage. What the fingerprint cannot speak to is whether the two
+    /// content objects hold the same bytes, so digest evidence answers that
+    /// separately.
+    ///
+    /// Nothing weaker counts: every way of failing to prove the two requests
+    /// are the same — including a comparison this build cannot make — leaves
+    /// the original conflict standing, never agreement.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,
+        absolute_path: &str,
         commit_id: &CommitId,
-        message: Option<&str>,
+        attempt: &PutFileOptions,
         staged: StagedPayload<'_>,
         conflict: RuntimeError,
     ) -> Result<CommitResponse> {
-        let Some(committed_seq) = reported_committed_seq(&conflict) else {
+        let Some((committed_seq, committed_fingerprint)) = reported_commit_receipt(&conflict)
+        else {
             return Err(conflict);
         };
         let Some(committed) = self
@@ -291,19 +307,23 @@ impl FsWriter {
         else {
             return Err(conflict);
         };
-        // The message is part of a commit's identity, so a rerun that
-        // changed it asked for a different mutation and the conflict is the
-        // honest answer. Equality here is the fingerprint's: it serializes
-        // the message as given — absent becomes `null`, an empty message
-        // becomes `""` — so no message and an empty message are different
-        // commits, and this comparison must not fold them together.
-        if committed.message.as_deref() != message {
-            return Err(conflict);
-        }
-        let Some(content_ref) = committed_content_ref(&committed) else {
+        let Some(content_ref) = sole_committed_content_ref(&committed) else {
             return Err(conflict);
         };
-        if content_ref.size_bytes != staged.size_bytes() {
+        let retried = loonfs_core::path::parse_mutation_path(absolute_path)
+            .ok()
+            .and_then(|path| {
+                loonfs_api::put_retry_fingerprint(
+                    namespace_id,
+                    &path,
+                    attempt.behavior,
+                    attempt.expected_revision_no,
+                    attempt.message.as_deref(),
+                    content_ref,
+                )
+                .ok()
+            });
+        if retried.as_deref() != Some(committed_fingerprint.as_str()) {
             return Err(conflict);
         }
         if !staged_matches_committed(&staged, content_ref) {

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -750,6 +750,7 @@ impl NamespacePublisher {
                 return Err(CoreError::CommitIdReuseConflict {
                     commit_id: commit_id.to_string(),
                     committed_seq: None,
+                    committed_fingerprint: None,
                 });
             }
             existing.waiters.push(waiter);

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -620,11 +620,14 @@ async fn publisher_duplicate_active_request_joins_while_conflict_fails() {
         &namespace_id,
         create_directory_request("active", "different-active"),
     );
-    // Both claims are still in flight, so there is no landed sequence.
+    // Both claims are still in flight, so there is no receipt to name.
     assert!(matches!(
         conflict,
-        Err(CoreError::CommitIdReuseConflict { commit_id, committed_seq: None })
-            if commit_id == "active"
+        Err(CoreError::CommitIdReuseConflict {
+            commit_id,
+            committed_seq: None,
+            committed_fingerprint: None,
+        }) if commit_id == "active"
     ));
 
     store.release();
@@ -674,8 +677,11 @@ async fn publisher_pending_batch_full_rejects_distinct_but_allows_duplicate() {
     );
     assert!(matches!(
         conflict,
-        Err(CoreError::CommitIdReuseConflict { commit_id, committed_seq: None })
-            if commit_id == "pending-0"
+        Err(CoreError::CommitIdReuseConflict {
+            commit_id,
+            committed_seq: None,
+            committed_fingerprint: None,
+        }) if commit_id == "pending-0"
     ));
 
     let overflow = try_admit_commit(

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -4,8 +4,9 @@
 //! which necessarily stages a fresh object — is a different commit as far as
 //! the publisher is concerned and it says so. What makes the rerun safe
 //! anyway is the runtime reading back what that commit id actually
-//! committed and comparing it against the bytes just staged. Nothing weaker
-//! counts as agreement.
+//! committed, rebuilding this request's fingerprint around the committed
+//! reference, and requiring the whole value to match before it proves the
+//! bytes agree. Nothing weaker counts as agreement.
 
 use crate::common::{open_runtime_async, store, TestRuntime};
 use bytes::Bytes;
@@ -14,7 +15,7 @@ use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
 use loonfs::{
     ByteStream, ChangeSeq, CommitId, CreateDirectoryOptions, CreateNamespaceOptions,
     DestinationBehavior, ListChangesOptions, MaintenanceStepKind, MaintenanceStepOptions,
-    NamespaceId, PutFileOptions, ReorganizeStepOutcome,
+    NamespaceId, PutFileOptions, ReorganizeStepOutcome, RevisionNo,
 };
 use loonfs_api::ErrorCode;
 use tempfile::tempdir;
@@ -138,6 +139,190 @@ async fn different_bytes_under_a_used_commit_id_still_conflict() {
             .bytes,
         b"stable bytes\n",
         "the refused rerun changed nothing"
+    );
+}
+
+/// The same bytes written somewhere else are a different mutation, and no
+/// amount of matching payload makes them the same one. Content evidence
+/// alone would call this a successful retry and leave `/b.txt` unwritten
+/// forever, which is why the proof is the whole request fingerprint.
+#[tokio::test]
+async fn the_same_bytes_at_a_different_path_still_conflict() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+
+    let first = runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/a.txt",
+            b"stable bytes\n",
+            options(&commit_id),
+        )
+        .await
+        .expect("first put");
+    let error = runtime
+        .put_file_bytes(
+            &namespace_id,
+            "/b.txt",
+            b"stable bytes\n",
+            options(&commit_id),
+        )
+        .await
+        .expect_err("the same bytes at another path are a different commit");
+
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+    assert_eq!(
+        runtime
+            .stat_path(&namespace_id, "/b.txt")
+            .await
+            .expect_err("the refused rerun wrote nothing")
+            .code(),
+        ErrorCode::PathNotFound
+    );
+    let entry = runtime
+        .stat_path(&namespace_id, "/a.txt")
+        .await
+        .expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "the refused rerun published no revision"
+    );
+}
+
+/// The replacement behavior is part of what the caller asked for: the same
+/// bytes at the same path under a changed `behavior` is a different
+/// mutation, and a create-only rerun must not report a replacing commit's
+/// success.
+#[tokio::test]
+async fn a_changed_behavior_under_a_used_commit_id_still_conflicts() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+
+    let first = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
+        .await
+        .expect("first put with replace behavior");
+    let error = runtime
+        .put_file_bytes(
+            &namespace_id,
+            PATH,
+            b"stable bytes\n",
+            PutFileOptions {
+                behavior: DestinationBehavior::NoReplace,
+                ..options(&commit_id)
+            },
+        )
+        .await
+        .expect_err("a changed behavior is a different commit");
+
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+    let entry = runtime
+        .stat_path(&namespace_id, PATH)
+        .await
+        .expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "the refused rerun published no revision"
+    );
+}
+
+/// The expected revision is a race guard, and a rerun that adds one asked a
+/// question the original never asked. Replaying the unguarded commit would
+/// answer it without ever checking it.
+#[tokio::test]
+async fn a_changed_expected_revision_under_a_used_commit_id_still_conflicts() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+
+    let first = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
+        .await
+        .expect("first unguarded put");
+    let error = runtime
+        .put_file_bytes(
+            &namespace_id,
+            PATH,
+            b"stable bytes\n",
+            PutFileOptions {
+                expected_revision_no: Some(RevisionNo(1)),
+                ..options(&commit_id)
+            },
+        )
+        .await
+        .expect_err("a guard the original never carried is a different commit");
+
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+    let entry = runtime
+        .stat_path(&namespace_id, PATH)
+        .await
+        .expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "the refused rerun published no revision"
+    );
+}
+
+/// A commit that did more than one thing is not the commit a single put
+/// makes, however well its put half lines up. The operation list is inside
+/// the fingerprint, so the count alone settles this — no comparison of the
+/// other operations is needed or attempted.
+#[tokio::test]
+async fn a_single_put_does_not_replay_a_multi_operation_commit() {
+    let temp_dir = tempdir().expect("tempdir");
+    let runtime = open_runtime_async(store(temp_dir.path()), "writer-a").await;
+    let namespace_id = namespace(&runtime).await;
+    let commit_id = CommitId::parse("pinned-batch").expect("valid commit id");
+
+    let prepared = runtime
+        .writer
+        .prepare_file_bytes(&namespace_id, b"stable bytes\n")
+        .await
+        .expect("prepare content");
+    let content_ref = prepared.content_ref().clone();
+    let first = runtime
+        .writer
+        .commit_prepared(
+            &namespace_id,
+            CommitRequest {
+                commit_id: commit_id.clone(),
+                message: None,
+                operations: vec![
+                    FilesystemOperation::PutFile {
+                        path: parse_mutation_path(PATH).expect("path"),
+                        content_ref,
+                        behavior: DestinationBehavior::Replace,
+                        expected_revision_no: None,
+                    },
+                    FilesystemOperation::CreateDirectory {
+                        path: parse_mutation_path("/reports").expect("path"),
+                        parents: true,
+                    },
+                ],
+            },
+            vec![prepared],
+        )
+        .await
+        .expect("first two-operation commit");
+
+    let error = runtime
+        .put_file_bytes(&namespace_id, PATH, b"stable bytes\n", options(&commit_id))
+        .await
+        .expect_err("one put is not the two-operation commit that landed");
+
+    assert_eq!(error.code(), ErrorCode::CommitIdReuseConflict);
+    let entry = runtime
+        .stat_path(&namespace_id, PATH)
+        .await
+        .expect("stat path");
+    assert_eq!(
+        entry.head_seq, first.committed_seq,
+        "the refused rerun published no revision"
     );
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -215,7 +215,7 @@ The codes that populate it:
 | --- | --- |
 | `writer_fenced` | `fenced_epoch`, `active_writer_epoch`, plus `active_writer` and `active_acquired_at_ms` when the head recorded a writer block. Writer ids are process labels, so two runs on one machine can share one; the acquisition stamp is what tells them apart |
 | `stale_revision` | `inode_id`, `expected_revision`, `actual_revision` (absent when the inode has no current revision) |
-| `commit_id_reuse_conflict` | `commit_id`, plus `committed_seq` when the conflict was decided against a durable commit receipt — the sequence that `commit_id` already landed at. Absent when nothing has committed under the id yet and two live requests are claiming it at once |
+| `commit_id_reuse_conflict` | `commit_id`, plus `committed_seq` and `committed_fingerprint` when the conflict was decided against a durable commit receipt — the sequence that `commit_id` already landed at, and the semantic identity of what landed there (section 5.1). Both come from the receipt, so both are present or neither is; both are absent when nothing has committed under the id yet and two live requests are claiming it at once |
 | `rebootstrap_required` | `after_seq`, `retention_floor_seq` |
 | `stale_head` | `expected_head_seq`, `actual_head_seq`, when the failure was a caller-supplied `expected_head_seq` precondition rather than a raced head advance. A caller that still means to delete retries against the sequence it found |
 | `not_deleted` | `inode_id`, plus `requested_deletion_seq` and `active_deletion_seq` when a live deletion exists at a different generation |
@@ -448,43 +448,64 @@ answer on its own.
 sequence under one `commit_id` — the shape of a command rerun, where no
 `content_ref` survived the first attempt — is nonetheless safe when the
 request is identical. A client that composes upload and commit must, on
-`commit_id_reuse_conflict`, resolve it as follows before surfacing it:
+`commit_id_reuse_conflict`, resolve it as follows before surfacing it.
+
+The proof is the commit's whole semantic identity, not a selection of its
+parts. The conflict reports `details.committed_fingerprint`, the fingerprint
+the server's receipt holds for what landed. The client recomputes the
+fingerprint its own retry would have had if the only difference were the
+fresh content object, and the two values must be equal. Comparing the whole
+value is what makes the check complete: a path, a `behavior`, an
+`expected_revision_no`, a `message`, or an operation count that differs is
+a different mutation, and every field a future request gains is covered the
+day it joins the preimage.
 
 1. Find what that `commit_id` committed. There is no read keyed by commit
    id, but the error names where it landed: read the change feed once at
    `details.committed_seq` — cursor `after_seq = committed_seq - 1`, limit 1
    — and take the row whose `commit_id` matches. If `details.committed_seq`
-   is absent, or the feed answers `rebootstrap_required` because retention
-   has moved past that sequence, or the row there names some other commit,
-   there is nothing to compare: go straight to rule 5.
-2. Compare the committed change's `message` against the one the request
-   asked for. The message is part of the commit's identity, so a rerun that
-   changed it asked for a different mutation: go to rule 5. Compare the
-   annotations exactly as the server fingerprints them — an absent message
-   and an empty one are different commits, so a client must not fold both
-   into "no message".
-3. Compare the committed content against what was just uploaded: the
-   content's `whole_file_sha256` when it has one, and otherwise its
-   `storage_checksum`, after checking `size_bytes`.
+   or `details.committed_fingerprint` is absent, or the feed answers
+   `rebootstrap_required` because retention has moved past that sequence, or
+   the row there names some other commit, there is nothing to compare: go
+   straight to rule 5.
+2. Take the committed content reference from that row. The row must carry
+   exactly one content-bearing event — a `created` with a `content_ref`, or
+   a `content_changed`. A single put produces exactly one, however many
+   parent directories it also had to create, because directory creations
+   carry no content ref. None, or more than one, means the commit was not
+   this put: go to rule 5.
+3. Recompute the fingerprint of the request just made, with that committed
+   `content_ref` substituted for the freshly uploaded one, and compare it
+   against `details.committed_fingerprint`. Any difference means the two
+   requests are not the same mutation: go to rule 5. The preimage is the
+   one defined in section 5.1, so annotations are compared exactly as the
+   server fingerprints them — an absent message and an empty one are
+   different commits, and a client must not fold both into "no message".
+4. Prove the uploaded bytes are the committed object's bytes: the content's
+   `whole_file_sha256` when it has one, and otherwise its
+   `storage_checksum`. This is the one question the fingerprint cannot
+   answer, because the retry deliberately fingerprints the *committed*
+   object.
 
    A client that still holds its bytes recomputes whichever digest the
    comparison calls for. A client that streamed its payload no longer has
-   the bytes, and compares the length it measured and the digest it folded
-   during that one pass instead — for a `direct_multipart` upload, the
-   `crc64nvme` it claimed at completion, which is also what the reference
-   the server minted carries. Both are evidence about the same bytes; they
-   differ only in which digests they can answer for, and a digest the
-   upload never computed falls to rule 5 rather than being guessed at.
-4. The same message over equal content means the logical operation had
-   already succeeded: report the commit that landed, with its original
+   the bytes, and compares the digest it folded during that one pass
+   instead — for a `direct_multipart` upload, the `crc64nvme` it claimed at
+   completion, which is also what the reference the server minted carries.
+   Both are evidence about the same bytes; they differ only in which digests
+   they can answer for, and a digest the upload never computed falls to rule
+   5 rather than being guessed at.
+
+   Equal fingerprints over provably equal bytes mean the logical operation
+   had already succeeded: report the commit that landed, with its original
    `committed_seq`.
-5. Anything else surfaces a failure. Different content is the
-   `commit_id_reuse_conflict` unchanged, and so are a changed message and a
-   commit the client could not locate — an absent `committed_seq`, or a
-   sequence retention no longer answers for. Content the client *cannot*
-   compare — a checksum algorithm it does not implement — is reported as a
-   failure naming why it could not reconcile. **A comparison that cannot be
-   made is never reported as success.**
+5. Anything else surfaces a failure. A fingerprint that differs is the
+   `commit_id_reuse_conflict` unchanged, and so are different content and a
+   commit the client could not locate — absent receipt fields, or a sequence
+   retention no longer answers for. Content the client *cannot* compare — a
+   checksum algorithm it does not implement — is reported as a failure
+   naming why it could not reconcile. **A comparison that cannot be made is
+   never reported as success.**
 
 The duplicate content object the rerun uploaded is then referenced by
 nothing. That is by design: it is a completed upload whose content no

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1269,9 +1269,10 @@ of every id ever committed, and the durable format does not carry one.
 
 A reused `commit_id` with an equal fingerprint replays the originally
 committed response; an unequal fingerprint is rejected as
-`commit_id_reuse_conflict`. Reference values are pinned by tests in
-`loonfs-core` (`path/write/planner.rs`); those literals must never change
-within scheme `v0`.
+`commit_id_reuse_conflict`, which reports the stored fingerprint so a client
+can prove its retry is the same request (API spec, section 5.2). Reference
+values are pinned by tests in `loonfs-api` (`commit_identity.rs`); those
+literals must never change within scheme `v0`.
 
 ### 3.4 Server authority
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3769,6 +3769,13 @@
               }
             ]
           },
+          "committed_fingerprint": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Semantic identity of the mutation that already landed under that\ncommit id, from the same receipt as `committed_seq` and present\nexactly when it is. A retry recomputes this value from the request it\njust made — see\n[`put_retry_fingerprint`](crate::put_retry_fingerprint) — and equality\nis what proves the two are the same request."
+          },
           "committed_seq": {
             "oneOf": [
               {


### PR DESCRIPTION
This PR fixes a correctness bug: a put retry could report success for the wrong request. The reconciliation that turns `commit_id_reuse_conflict` into "your bytes already landed" compared only the message, size, and digest — never the path, the replacement behavior, the expected revision, or the operation count. Put "hello" at `/a.txt` under commit C, then put "hello" at `/b.txt` under the same C: core correctly conflicted, the helper saw same message and same bytes, and returned the first response as success. `/b.txt` was never written.

The fingerprint machinery moves to loonfs-api: The frozen preimage enum, the domain, and the digest now live beside the operation enum they hash — the only crate both the embedded runtime and the core-less HTTP client share.

The conflict carries the stored fingerprint: The durable receipt has always held `semantic_commit_fingerprint`, and the receipt is what decides the conflict — so the error now carries it, into the wire details as an additive optional field. 

The reconcilers prove the whole claim: Both surfaces run the same short algorithm, every gate leaving the original conflict standing: receipt identity present; one feed read; the committed row must hold exactly one content-bearing change (auto-created parents carry none, so a single put's row always qualifies); the retry's path, behavior, expected revision, and message — with the committed ref substituted for the staged one — must fingerprint to exactly the stored value; and the digest evidence must prove the bytes. The message and size gates are deleted as subsumed.
