### PR TITLE
Keep pre-release format versions at v1

### DIFF
--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -14,12 +14,10 @@ const GREP_MANIFEST_ID_BODY_LEN: usize = 32;
 
 /// Version of the grep index state nested inside a v1 manifest.
 ///
-/// Version 2 moved the phase-only watermark fields out of the index-wide
-/// bookkeeping and into the lifecycle variant that owns them. A version-1
-/// root is rejected outright: it spelled a backfill's target and a steady
-/// index's real progress with the same field, and nothing can tell those
-/// apart after the fact.
-pub const GREP_INDEX_FORMAT_VERSION: u32 = 2;
+/// Before the first stable release this schema evolves in place at version 1;
+/// compatibility starts with the released format, not intermediate
+/// pre-release encodings.
+pub const GREP_INDEX_FORMAT_VERSION: u32 = 1;
 
 /// Durable object id for one immutable grep manifest candidate.
 ///

--- a/crates/loonfs-grep/tests/it/root_format.rs
+++ b/crates/loonfs-grep/tests/it/root_format.rs
@@ -17,12 +17,12 @@ use loonfs_test_support::ids::namespace_id;
 // field names, ordering, enum tags, or omission rules must change them
 // deliberately. Together they represent every lifecycle state.
 //
-// The envelope is version 1; what index version 2 changed is the index state
-// nested inside it, which moved each phase's own watermark into the phase.
-const BACKFILLING_V2: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:5002cd1db3aef16bdc6cc413185add75a3d392f66f80f51a54e37278d413bbdf","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","target_seq":7,"cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":2,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const STEADY_V2: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"next_event_index":5},"index":{"format_version":2,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const DISABLED_V2: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":2,"next_run_ordinal":4},"segments":[]}}"#;
-const ADDITIVE_V2: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:f015075bf0949612b508d5d3a765028264cdbbcb01be060bd997c4d1904621b2","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"future_lifecycle":"ignored"},"index":{"format_version":2,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
+// Every pre-release grep format stays at version 1. These current bytes pin
+// the schema where each phase owns its own watermark.
+const BACKFILLING_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:de7c0a92722040ae68768f4bbe7250a85ac6dc4eb06dd1485e481d1a6eaae66b","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","target_seq":7,"cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":1,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const STEADY_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:a4b785b27bfd68a5bbd9db2b1d0cc8f7992696b424523f4d225837e4c0d91ea4","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"next_event_index":5},"index":{"format_version":1,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
+const DISABLED_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:dd73bacf797be51a706ba8737ba11eef2097fd8d547f8024461184ef4a4927c6","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"next_run_ordinal":4},"segments":[]}}"#;
+const ADDITIVE_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:4cce429174eabcf92d1fc36e468700a260c5357ad629bc2e5448a4610bac50f3","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady","built_through_seq":11,"future_lifecycle":"ignored"},"index":{"format_version":1,"next_run_ordinal":2,"future_index":17},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789","future_segment":"ignored"}],"future_root":true},"future_envelope":{"retained":true}}"#;
 
 // Pointer ids are minted, not derived, so each fixture names an arbitrary
 // id and carries the digest of the manifest it points at. That pairing is
@@ -31,28 +31,21 @@ const BACKFILLING_MANIFEST_ID: &str = "gmf_1a2b3c4d5e6f70819a2b3c4d5e6f7081";
 const STEADY_MANIFEST_ID: &str = "gmf_2b3c4d5e6f70819a2b3c4d5e6f708192";
 const DISABLED_MANIFEST_ID: &str = "gmf_3c4d5e6f70819a2b3c4d5e6f70819a2b";
 
-const BACKFILLING_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:00bc51efa86c740e2cef630738b44bbef5a831f81bb10e3e49efbf34225ea6b9","payload":{"namespace_id":"docs","manifest_id":"gmf_1a2b3c4d5e6f70819a2b3c4d5e6f7081","manifest_payload_checksum":"sha256:5002cd1db3aef16bdc6cc413185add75a3d392f66f80f51a54e37278d413bbdf"}}"#;
-const STEADY_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:9ca8910922c6d336cc40c90230b93b3dbea8d1d68b09d7960e9793904124741a","payload":{"namespace_id":"docs","manifest_id":"gmf_2b3c4d5e6f70819a2b3c4d5e6f708192","manifest_payload_checksum":"sha256:b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff"}}"#;
-const DISABLED_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:9f7642267b421acefb82ecf9447d44a0cc775fa18f33391f3767e12f50eeba0c","payload":{"namespace_id":"docs","manifest_id":"gmf_3c4d5e6f70819a2b3c4d5e6f70819a2b","manifest_payload_checksum":"sha256:cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc"}}"#;
-const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:b09014e32fe81501ef34ca037c33ad6b3cbdf4424a16bd376462f84dd2d1b4bc","payload":{"namespace_id":"docs","manifest_id":"gmf_4d5e6f70819a2b3c4d5e6f70819a2b3c","manifest_payload_checksum":"sha256:b1890700a91365f8f7663705f662387f913ab9e05571640cd2eff792da8cacff","future_pointer":true},"future_envelope":{"retained":true}}"#;
+const BACKFILLING_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:0606a247e11f23e938081a0ff717d018b27f563ea8f59f9a1b09bfd2f6135563","payload":{"namespace_id":"docs","manifest_id":"gmf_1a2b3c4d5e6f70819a2b3c4d5e6f7081","manifest_payload_checksum":"sha256:de7c0a92722040ae68768f4bbe7250a85ac6dc4eb06dd1485e481d1a6eaae66b"}}"#;
+const STEADY_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:b4a84a9b2c21d72a7c3a6c274ec593fdfeead9a45c3fd8bfe74cd9ed686309d3","payload":{"namespace_id":"docs","manifest_id":"gmf_2b3c4d5e6f70819a2b3c4d5e6f708192","manifest_payload_checksum":"sha256:a4b785b27bfd68a5bbd9db2b1d0cc8f7992696b424523f4d225837e4c0d91ea4"}}"#;
+const DISABLED_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:3aa5e6a5f1be03c8f70581f6d5992c4b350188b55af2c7c03544935031cb850d","payload":{"namespace_id":"docs","manifest_id":"gmf_3c4d5e6f70819a2b3c4d5e6f70819a2b","manifest_payload_checksum":"sha256:dd73bacf797be51a706ba8737ba11eef2097fd8d547f8024461184ef4a4927c6"}}"#;
+const ADDITIVE_POINTER_V1: &str = r#"{"kind":"grep_root","format_version":1,"payload_checksum":"sha256:29c9e928317b08a1a42e282f134f5ef31e29a897510c574fd989184c0e850008","payload":{"namespace_id":"docs","manifest_id":"gmf_4d5e6f70819a2b3c4d5e6f70819a2b3c","manifest_payload_checksum":"sha256:a4b785b27bfd68a5bbd9db2b1d0cc8f7992696b424523f4d225837e4c0d91ea4","future_pointer":true},"future_envelope":{"retained":true}}"#;
 
 // The string spelling every grep envelope carried before the version became
 // a number, kept only to prove it is refused.
-const STRING_VERSION_MANIFEST: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:cad95bd09384a8d651c38a9070dfc30cb94276edb752c5438d5646a687c9bbdc","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":2,"next_run_ordinal":4},"segments":[]}}"#;
-
-// Version-1 index states, kept only to prove they are refused. Each spelled
-// a backfill's target and a steady index's progress with one field, so a
-// decoder that accepted them could not tell which meaning it had read.
-const BACKFILLING_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:a629f619356fda3c1d5789df1082221494bdec8ae182b6883748c73346a0fae9","payload":{"namespace_id":"docs","lifecycle":{"kind":"backfilling","backfill_cursor":7,"checkpoint_id":"chk_00000000000000000000000000000009"},"index":{"format_version":1,"built_through_seq":7,"reorganize":{"snapshot_segment_ids":["idx_00000000000000000000000000000001","idx_00000000000000000000000000000002"],"output_segment_ids":["idx_00000000000000000000000000000003"],"row_key_cursor":"gram-6d6e6f-00000000000000000042","output_level":1,"run_ordinal":3},"next_run_ordinal":4},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000002","run_seq":9,"run_ordinal":2,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},{"segment_id":"idx_00000000000000000000000000000003","run_seq":10,"run_ordinal":3,"level":1,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const STEADY_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:c7d26cf67191665af1c6985ad742fa9ef36cfe635a6577b4e02d79e112fe02cf","payload":{"namespace_id":"docs","lifecycle":{"kind":"steady"},"index":{"format_version":1,"built_through_seq":11,"next_event_index":5,"next_run_ordinal":2},"segments":[{"segment_id":"idx_00000000000000000000000000000001","run_seq":8,"run_ordinal":1,"level":0,"segment_index":0,"min_row_key":"gram-616263-00000000000000000001","max_row_key":"gram-7a7a7a-00000000000000000099","index_block":{"offset":128,"stored_len":48,"decoded_len":96,"crc32c":305419896},"filter_block":{"offset":176,"stored_len":16,"decoded_len":16,"crc32c":2591069104},"filter_inline":"00112233445566778899aabbccddeeff","payload_checksum":"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}}"#;
-const DISABLED_INDEX_V1: &str = r#"{"kind":"grep_manifest","format_version":1,"payload_checksum":"sha256:70b4ba748d1ddffcb28baa05e0874993a4650007e09bf32c85c215ee298baf6c","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"built_through_seq":15,"next_run_ordinal":4},"segments":[]}}"#;
+const STRING_VERSION_MANIFEST: &str = r#"{"kind":"grep_manifest","format_version":"v1","payload_checksum":"sha256:dd73bacf797be51a706ba8737ba11eef2097fd8d547f8024461184ef4a4927c6","payload":{"namespace_id":"docs","lifecycle":{"kind":"disabled"},"index":{"format_version":1,"next_run_ordinal":4},"segments":[]}}"#;
 
 #[test]
 fn encoded_manifests_and_pointers_match_frozen_bytes() {
     let cases = [
-        (sample_backfilling_root(), BACKFILLING_V2),
-        (sample_steady_root(ChangeSeq(11), 5), STEADY_V2),
-        (sample_disabled_root(), DISABLED_V2),
+        (sample_backfilling_root(), BACKFILLING_V1),
+        (sample_steady_root(ChangeSeq(11), 5), STEADY_V1),
+        (sample_disabled_root(), DISABLED_V1),
     ];
 
     for (state, expected) in cases {
@@ -126,7 +119,7 @@ fn every_lifecycle_phase_round_trips_carrying_only_its_own_position() {
 #[test]
 fn immutable_manifest_decoder_reads_frozen_bytes_with_additive_fields() {
     let decoded =
-        decode_grep_manifest(ADDITIVE_V2.as_bytes()).expect("decode additive manifest fixture");
+        decode_grep_manifest(ADDITIVE_V1.as_bytes()).expect("decode additive manifest fixture");
 
     assert_eq!(
         decoded.manifest_state(),
@@ -188,40 +181,33 @@ fn decoder_rejects_the_string_format_version_without_a_shim() {
     ));
 }
 
-/// Version 1 is refused outright, with no shim and no salvage.
-///
-/// Its `built_through_seq` meant the backfill's target in one phase and real
-/// indexed progress in another, and nothing in the bytes says which. A
-/// disabled root — whose lifecycle happens to still parse — proves the
-/// version guard itself does the refusing, not just the changed field
-/// shapes.
 #[test]
-fn decoder_rejects_version_one_index_state_without_a_shim() {
+fn decoder_rejects_unknown_index_version_without_fallback() {
+    let mut document: serde_json::Value =
+        serde_json::from_str(DISABLED_V1).expect("decode manifest fixture");
+    document["payload"]["index"]["format_version"] = serde_json::Value::from(7);
+    let payload = serde_json::to_string(&document["payload"]).expect("encode edited payload");
+    document["payload_checksum"] =
+        serde_json::Value::from(loonfs_api::sha256_digest(payload.as_bytes()));
+    let edited = format!(
+        "{{\"kind\":{},\"format_version\":{},\"payload_checksum\":{},\"payload\":{}}}",
+        document["kind"], document["format_version"], document["payload_checksum"], payload,
+    );
+
     assert!(matches!(
-        decode_grep_manifest(DISABLED_INDEX_V1.as_bytes()),
+        decode_grep_manifest(edited.as_bytes()),
         Err(GrepEnvelopeCodecError::InvalidState(
             GrepManifestStateError::UnsupportedIndexFormatVersion {
-                found: 1,
-                supported: 2
+                found: 7,
+                supported: 1
             }
         ))
     ));
-
-    // The other two cannot even be read into the current shape: their
-    // phases no longer carry the fields version 1 put beside them.
-    for fixture in [BACKFILLING_INDEX_V1, STEADY_INDEX_V1] {
-        assert!(matches!(
-            decode_grep_manifest(fixture.as_bytes()),
-            Err(GrepEnvelopeCodecError::Envelope(
-                EnvelopeCodecError::PayloadDecode(_)
-            ))
-        ));
-    }
 }
 
 #[test]
 fn decoder_rejects_unknown_version_without_fallback() {
-    let wrong_version = STEADY_V2.replacen("\"format_version\":1", "\"format_version\":7", 1);
+    let wrong_version = STEADY_V1.replacen("\"format_version\":1", "\"format_version\":7", 1);
 
     assert!(matches!(
         decode_grep_manifest(wrong_version.as_bytes()),
@@ -233,7 +219,7 @@ fn decoder_rejects_unknown_version_without_fallback() {
 
 #[test]
 fn decoder_rejects_corrupted_checksum() {
-    let corrupted = STEADY_V2.replacen("\"steady\"", "\"disabled\"", 1);
+    let corrupted = STEADY_V1.replacen("\"steady\"", "\"disabled\"", 1);
 
     assert!(matches!(
         decode_grep_manifest(corrupted.as_bytes()),
@@ -245,7 +231,7 @@ fn decoder_rejects_corrupted_checksum() {
 
 #[test]
 fn decoder_rejects_truncated_payload() {
-    let truncated = &STEADY_V2.as_bytes()[..STEADY_V2.len() - 8];
+    let truncated = &STEADY_V1.as_bytes()[..STEADY_V1.len() - 8];
 
     assert!(matches!(
         decode_grep_manifest(truncated),

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1752,7 +1752,7 @@ over its namespace manifest. The mutable
 root-pointer decoder rejects unknown envelope and payload fields; the
 immutable manifest decoder tolerates additive fields.
 
-The nested `index` object carries its own `format_version`, currently `2`.
+The nested `index` object carries its own `format_version`, currently `1`.
 It holds what every phase has — the in-progress `reorganize` state and the
 `next_run_ordinal` allocator — while each phase's own position lives in the
 `lifecycle` tag beside it:
@@ -1763,11 +1763,11 @@ It holds what every phase has — the in-progress `reorganize` state and the
 - `steady`: `built_through_seq` and an optional `next_event_index`;
 - `disabled`: no fields, no segments, and no reorganization.
 
-A phase carrying another phase's sequence is not representable. Version 1
-put one `built_through_seq` in the index object for every phase, where it
-meant the backfill's target in one phase and real indexed progress in
-another; the decoder rejects that version outright, with no shim, and the
-namespace rebuilds its index from a fresh checkpoint.
+A phase carrying another phase's sequence is not representable. Before the
+first stable release, this nested schema evolves in place at version 1; the
+implementation carries no compatibility shim for intermediate pre-release
+encodings, and a namespace can rebuild its derived index from a fresh
+checkpoint.
 
 A gram-index segment uses the section 4.2.1 block grammar unchanged —
 prefix-compressed data blocks, one bloom filter block, one index block,


### PR DESCRIPTION
- keep the nested grep index format at version 1 while LoonFS is pre-release
- refresh the frozen manifest and root-pointer fixtures and their checksums
- document that intermediate pre-release schema changes evolve in place

The current grep index schema was assigned version 2 when lifecycle-specific watermarks were introduced. The schema change is retained, but there is no released v1 compatibility boundary yet, so the durable format should remain version 1.
