### PR TITLE
fix(release): harden artifact packaging

### DIFF
--- a/.github/workflows/release-loonfs.yml
+++ b/.github/workflows/release-loonfs.yml
@@ -1,11 +1,15 @@
-name: Release Loon CLI
+name: Release LoonFS CLI
 
 on:
   release:
     types: [published]
 
+concurrency:
+  group: release-loonfs-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,6 +23,8 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -56,6 +62,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -81,14 +89,16 @@ jobs:
         shell: bash
         run: |
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           tar -xzf "dist/loonfs-${{ matrix.target }}.tar.gz" -C "$tmpdir"
-          if [ ! -f "$tmpdir/LICENSE" ]; then
-            echo "expected LICENSE in release archive" >&2
-            exit 1
-          fi
+          test -x "$tmpdir/loonfs"
+          test -f "$tmpdir/README.md"
+          test -f "$tmpdir/LICENSE"
+          test "$(cat "$tmpdir/VERSION")" = "$VERSION"
           actual="$("$tmpdir/loonfs" version)"
-          if [ "$actual" != "$VERSION" ]; then
-            echo "expected loonfs version $VERSION, got $actual" >&2
+          actual_version="${actual%% *}"
+          if [ "$actual_version" != "$VERSION" ]; then
+            echo "expected loonfs version $VERSION, got: $actual" >&2
             exit 1
           fi
 
@@ -98,6 +108,7 @@ jobs:
           name: loonfs-${{ matrix.target }}
           path: dist/loonfs-${{ matrix.target }}.tar.gz
           if-no-files-found: error
+          retention-days: 1
 
   publish:
     name: Publish release assets
@@ -105,6 +116,8 @@ jobs:
     # failed target can never ship a release with missing artifacts.
     needs: [prepare, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -112,20 +125,31 @@ jobs:
           pattern: loonfs-*
           merge-multiple: true
 
-      - name: Verify release artifacts exist
+      - name: Verify release artifacts and generate checksums
         shell: bash
         working-directory: dist
         run: |
+          expected=(
+            loonfs-aarch64-apple-darwin.tar.gz
+            loonfs-x86_64-apple-darwin.tar.gz
+            loonfs-aarch64-unknown-linux-gnu.tar.gz
+            loonfs-x86_64-unknown-linux-gnu.tar.gz
+          )
+          for file in "${expected[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "missing release artifact: $file" >&2
+              exit 1
+            fi
+          done
+
           shopt -s nullglob
-          files=(loonfs-*.tar.gz)
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "no release artifacts were produced" >&2
+          actual=(loonfs-*.tar.gz)
+          if [ "${#actual[@]}" -ne "${#expected[@]}" ]; then
+            echo "expected ${#expected[@]} release artifacts, found ${#actual[@]}" >&2
+            printf 'found: %s\n' "${actual[@]}" >&2
             exit 1
           fi
-
-      - name: Generate checksums
-        working-directory: dist
-        run: sha256sum loonfs-*.tar.gz > SHA256SUMS
+          sha256sum "${expected[@]}" > SHA256SUMS
 
       - name: Upload assets to GitHub release
         uses: softprops/action-gh-release@v2

--- a/scripts/package-loonfs-release.sh
+++ b/scripts/package-loonfs-release.sh
@@ -8,22 +8,44 @@ Usage: package-loonfs-release.sh --target <target> --version <version> --artifac
 EOF
 }
 
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
 target=""
 version=""
 artifact_dir=""
+stage_dir=""
+archive_tmp=""
+
+cleanup() {
+    if [ -n "$stage_dir" ] && [ -d "$stage_dir" ]; then
+        rm -rf "$stage_dir"
+    fi
+    if [ -n "$archive_tmp" ] && [ -f "$archive_tmp" ]; then
+        rm -f "$archive_tmp"
+    fi
+}
+
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --target)
-            target="${2:-}"
+            [ "$#" -ge 2 ] || die "--target requires a value"
+            target="$2"
             shift 2
             ;;
         --version)
-            version="${2:-}"
+            [ "$#" -ge 2 ] || die "--version requires a value"
+            version="$2"
             shift 2
             ;;
         --artifact-dir)
-            artifact_dir="${2:-}"
+            [ "$#" -ge 2 ] || die "--artifact-dir requires a value"
+            artifact_dir="$2"
             shift 2
             ;;
         -h|--help)
@@ -31,9 +53,8 @@ while [ "$#" -gt 0 ]; do
             exit 0
             ;;
         *)
-            echo "unknown argument: $1" >&2
             usage >&2
-            exit 1
+            die "unknown argument: $1"
             ;;
     esac
 done
@@ -43,25 +64,41 @@ if [ -z "$target" ] || [ -z "$version" ] || [ -z "$artifact_dir" ]; then
     exit 1
 fi
 
+case "$target" in
+    aarch64-apple-darwin | x86_64-apple-darwin | aarch64-unknown-linux-gnu | x86_64-unknown-linux-gnu)
+        ;;
+    *)
+        die "unsupported release target: $target"
+        ;;
+esac
+
 repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 binary_path="$repo_root/target/$target/release/loonfs"
 archive_name="loonfs-$target.tar.gz"
-stage_dir="$artifact_dir/package/$target"
 
 if [ ! -x "$binary_path" ]; then
-    echo "missing compiled loonfs binary at $binary_path" >&2
-    exit 1
+    die "missing compiled loonfs binary at $binary_path"
 fi
 
-mkdir -p "$stage_dir"
-rm -rf "$stage_dir"/*
+binary_output=$("$binary_path" version)
+binary_version=${binary_output%% *}
+if [ "$binary_version" != "$version" ]; then
+    die "compiled loonfs reports version $binary_version, expected $version"
+fi
+
+mkdir -p "$artifact_dir"
+artifact_dir=$(CDPATH= cd -- "$artifact_dir" && pwd)
+stage_dir=$(mktemp -d "${TMPDIR:-/tmp}/loonfs-release.XXXXXX")
+archive_tmp=$(mktemp "$artifact_dir/.${archive_name}.XXXXXX")
+archive_path="$artifact_dir/$archive_name"
 
 cp "$binary_path" "$stage_dir/loonfs"
 cp "$repo_root/README.md" "$stage_dir/README.md"
 cp "$repo_root/LICENSE" "$stage_dir/LICENSE"
 printf '%s\n' "$version" > "$stage_dir/VERSION"
 
-mkdir -p "$artifact_dir"
-tar -C "$stage_dir" -czf "$artifact_dir/$archive_name" .
+COPYFILE_DISABLE=1 tar -C "$stage_dir" -czf "$archive_tmp" loonfs README.md LICENSE VERSION
+mv "$archive_tmp" "$archive_path"
+archive_tmp=""
 
-printf '%s\n' "$artifact_dir/$archive_name"
+printf '%s\n' "$archive_path"

--- a/scripts/test-install-loonfs.sh
+++ b/scripts/test-install-loonfs.sh
@@ -3,7 +3,7 @@
 set -eu
 
 repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
-version=$(cargo pkgid -p loonfs-cli | sed 's/.*#//')
+version=$(cargo pkgid --manifest-path "$repo_root/Cargo.toml" -p loonfs-cli | sed 's/.*#//')
 target="${LOONFS_TEST_TARGET:-$(rustc -vV | sed -n 's/^host: //p')}"
 expected_version="$version ($(git -C "$repo_root" rev-parse --short=12 HEAD) $(git -C "$repo_root" show -s --format=%cs HEAD))"
 
@@ -11,7 +11,8 @@ tmpdir=$(mktemp -d)
 cleanup() {
     rm -rf "$tmpdir"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
 
 expect_failure() {
     description="$1"
@@ -28,23 +29,55 @@ expect_failure() {
     fi
 }
 
+write_checksum() {
+    archive_path="$1"
+    sums_path="$2"
+    archive_dir=$(dirname "$archive_path")
+    archive_name=$(basename "$archive_path")
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        (cd "$archive_dir" && sha256sum "$archive_name") > "$sums_path"
+    elif command -v shasum >/dev/null 2>&1; then
+        (cd "$archive_dir" && shasum -a 256 "$archive_name") > "$sums_path"
+    else
+        echo "test requires sha256sum or shasum" >&2
+        exit 1
+    fi
+}
+
 artifact_dir="$tmpdir/artifacts"
 latest_dir="$tmpdir/releases/latest/download"
 pinned_dir="$tmpdir/releases/download/v$version"
 
-cargo build --release -p loonfs-cli --target "$target"
+cargo build --manifest-path "$repo_root/Cargo.toml" --release -p loonfs-cli --target "$target"
+
+expect_failure "an unsupported release target" \
+    "$repo_root/scripts/package-loonfs-release.sh" \
+    --target "../escape" --version "$version" --artifact-dir "$artifact_dir"
+expect_failure "a mismatched package version" \
+    "$repo_root/scripts/package-loonfs-release.sh" \
+    --target "$target" --version "0.0.0-mismatch" --artifact-dir "$artifact_dir"
+
 "$repo_root/scripts/package-loonfs-release.sh" --target "$target" --version "$version" --artifact-dir "$artifact_dir"
 
-tar -tzf "$artifact_dir/loonfs-$target.tar.gz" | grep -Fx "./LICENSE" >/dev/null
+archive_contents=$(tar -tzf "$artifact_dir/loonfs-$target.tar.gz" | sort)
+expected_contents=$(printf '%s\n' LICENSE README.md VERSION loonfs | sort)
+if [ "$archive_contents" != "$expected_contents" ]; then
+    echo "release archive contained unexpected files:" >&2
+    printf '%s\n' "$archive_contents" >&2
+    exit 1
+fi
+archive_version=$(tar -xOf "$artifact_dir/loonfs-$target.tar.gz" VERSION)
+if [ "$archive_version" != "$version" ]; then
+    echo "release archive reported version $archive_version, expected $version" >&2
+    exit 1
+fi
 
 mkdir -p "$latest_dir" "$pinned_dir"
 cp "$artifact_dir/loonfs-$target.tar.gz" "$latest_dir/"
 cp "$artifact_dir/loonfs-$target.tar.gz" "$pinned_dir/"
 
-(
-    cd "$artifact_dir"
-    sha256sum "loonfs-$target.tar.gz" > SHA256SUMS
-)
+write_checksum "$artifact_dir/loonfs-$target.tar.gz" "$artifact_dir/SHA256SUMS"
 
 cp "$artifact_dir/SHA256SUMS" "$latest_dir/"
 cp "$artifact_dir/SHA256SUMS" "$pinned_dir/"


### PR DESCRIPTION
The release check assumed loonfs version returned only semver, but it also includes commit metadata. This fixes that check and hardens packaging and artifact validation. Tested with the full installer test and syntax checks.