### PR TITLE
fix(api): reject release stamps on active checkpoints

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -136,8 +136,8 @@ pub struct MetadataRootState {
 pub enum CheckpointRecordLifecycle {
     /// Protects the checkpoint basis. The sole state a read may serve from.
     ///
-    /// The empty braces are load-bearing: a unit variant would silently
-    /// accept and discard a `released_at_ms` stamp.
+    /// The braces make serde reject a stray `released_at_ms`; a unit variant
+    /// would silently accept and discard that field.
     Active {},
     /// Terminal: the pin is gone and the record is waiting to be deleted.
     Released {

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -135,7 +135,10 @@ pub struct MetadataRootState {
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CheckpointRecordLifecycle {
     /// Protects the checkpoint basis. The sole state a read may serve from.
-    Active,
+    ///
+    /// The empty braces are load-bearing: a unit variant would silently
+    /// accept and discard a `released_at_ms` stamp.
+    Active {},
     /// Terminal: the pin is gone and the record is waiting to be deleted.
     Released {
         /// Unix-millisecond stamp written by the release compare-and-swap,
@@ -147,7 +150,7 @@ pub enum CheckpointRecordLifecycle {
 impl std::fmt::Display for CheckpointRecordLifecycle {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let state = match self {
-            Self::Active => "active",
+            Self::Active {} => "active",
             Self::Released { .. } => "released",
         };
         formatter.write_str(state)

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -539,7 +539,7 @@ fn control_objects_match_golden_bytes() {
             owner: CheckpointOwner::User {
                 name: "nightly".to_owned(),
             },
-            state: CheckpointRecordLifecycle::Active,
+            state: CheckpointRecordLifecycle::Active {},
         },
     );
     // The fork owner is a durable encoding of its own: the tagged `owner`
@@ -561,7 +561,7 @@ fn control_objects_match_golden_bytes() {
             owner: CheckpointOwner::Fork {
                 target_namespace_id: NamespaceId::parse("clone").expect("valid namespace id"),
             },
-            state: CheckpointRecordLifecycle::Active,
+            state: CheckpointRecordLifecycle::Active {},
         },
     );
     check_control_golden(
@@ -789,6 +789,15 @@ fn checkpoint_records_reject_the_pre_monotonic_lifecycle_encoding() {
         "control_checkpoint_record.v1.json",
         ControlObjectKind::CheckpointRecord,
         |payload| payload["state"]["kind"] = serde_json::Value::from("released"),
+    );
+}
+
+#[test]
+fn active_checkpoint_records_reject_release_stamps() {
+    assert_control_payload_edit_is_corrupt::<CheckpointRecordState>(
+        "control_checkpoint_record.v1.json",
+        ControlObjectKind::CheckpointRecord,
+        |payload| payload["state"]["released_at_ms"] = serde_json::Value::from(9_000),
     );
 }
 

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -76,7 +76,7 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
             created_at_ms: context.now_ms,
             expires_at_ms,
             owner: owner.clone(),
-            state: CheckpointRecordLifecycle::Active,
+            state: CheckpointRecordLifecycle::Active {},
         };
         let verify_started_ms = timer.monotonic_now_ms();
         write_checkpoint_record(store, &record).await?;

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -215,7 +215,7 @@ async fn read_pinning_checkpoint_record<S: ObjectStore + ?Sized>(
             "checkpoint `{checkpoint_id}` does not exist in namespace `{namespace_id}`"
         )));
     };
-    if record.state != CheckpointRecordLifecycle::Active {
+    if record.state != (CheckpointRecordLifecycle::Active {}) {
         return Err(CoreError::CheckpointUnavailable(format!(
             "checkpoint `{checkpoint_id}` is `{}` and no longer pins its basis",
             record.state

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -59,7 +59,7 @@ pub(crate) async fn list_checkpoints<S: ObjectStore + ?Sized>(
         else {
             continue;
         };
-        if loaded.state.state != CheckpointRecordLifecycle::Active {
+        if loaded.state.state != (CheckpointRecordLifecycle::Active {}) {
             continue;
         }
         let record = loaded.state;

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -386,7 +386,7 @@ async fn checkpoint_records_are_standalone_files_one_per_pin() {
     assert_eq!(record.manifest_head_seq, first.checkpoint_seq);
     assert_eq!(
         record.state,
-        loonfs_api::wire::control::CheckpointRecordLifecycle::Active
+        loonfs_api::wire::control::CheckpointRecordLifecycle::Active {}
     );
 
     // A new basis mints a new record; both files exist side by side.

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -504,7 +504,7 @@ async fn each_create_mints_its_own_record_and_carries_its_own_expiry() {
         assert_eq!(record.created_at_ms, 2_000);
         assert_eq!(
             record.state,
-            loonfs_api::wire::control::CheckpointRecordLifecycle::Active
+            loonfs_api::wire::control::CheckpointRecordLifecycle::Active {}
         );
     }
 
@@ -519,7 +519,7 @@ async fn each_create_mints_its_own_record_and_carries_its_own_expiry() {
     assert_eq!(original.expires_at_ms, Some(10_000));
     assert_eq!(
         original.state,
-        loonfs_api::wire::control::CheckpointRecordLifecycle::Active
+        loonfs_api::wire::control::CheckpointRecordLifecycle::Active {}
     );
 }
 
@@ -564,7 +564,7 @@ async fn an_expired_but_unreleased_pin_still_enumerates_its_files() {
             .expect("record exists")
             .state
             .state,
-        loonfs_api::wire::control::CheckpointRecordLifecycle::Active
+        loonfs_api::wire::control::CheckpointRecordLifecycle::Active {}
     );
     assert!(
         !read_checkpoint_files(&store, &namespace_id, &already_expired.checkpoint_id)
@@ -633,7 +633,7 @@ async fn a_pin_without_a_ttl_is_held_until_it_is_released() {
         .state;
     assert_eq!(
         record.state,
-        loonfs_api::wire::control::CheckpointRecordLifecycle::Active
+        loonfs_api::wire::control::CheckpointRecordLifecycle::Active {}
     );
     assert!(
         !read_checkpoint_files(&store, &namespace_id, &pin.checkpoint_id)
@@ -692,7 +692,7 @@ async fn checkpoint_verification_rejects_a_basis_below_the_floor() {
         owner: loonfs_api::wire::control::CheckpointOwner::User {
             name: "test-pin".to_owned(),
         },
-        state: loonfs_api::wire::control::CheckpointRecordLifecycle::Active,
+        state: loonfs_api::wire::control::CheckpointRecordLifecycle::Active {},
     };
     let verified = super::record::verify_checkpoint_basis(&store, &stale)
         .await

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -52,7 +52,7 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
         return Ok(false);
     };
     let record = envelope.state;
-    if record.state != CheckpointRecordLifecycle::Active {
+    if record.state != (CheckpointRecordLifecycle::Active {}) {
         return Ok(false);
     }
     if context.now_ms.saturating_sub(record.created_at_ms) < grace_window_ms {
@@ -96,7 +96,7 @@ pub(super) async fn maybe_release_fork_checkpoint<S: ObjectStore + ?Sized>(
         return Ok(ForkCheckpointSweep::Retained);
     };
     let record = envelope.state;
-    if record.state != CheckpointRecordLifecycle::Active {
+    if record.state != (CheckpointRecordLifecycle::Active {}) {
         return Ok(ForkCheckpointSweep::NotAnActiveFork);
     }
     let CheckpointOwner::Fork {

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -154,7 +154,7 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
                 // Every check here is repeated at decision time; this only
                 // selects candidates.
                 let candidate = match &record.owner {
-                    _ if record.state != CheckpointRecordLifecycle::Active => true,
+                    _ if record.state != (CheckpointRecordLifecycle::Active {}) => true,
                     CheckpointOwner::User { .. } => lease_expired(&record, now_ms),
                     CheckpointOwner::Fork {
                         target_namespace_id,

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -2298,7 +2298,7 @@ async fn gc_never_releases_a_fork_record_while_its_target_lives() {
         assert_eq!(report.released_expired_checkpoints, 0, "at {now_ms}");
         assert_eq!(
             checkpoint_lifecycle(&store, &source, &fork_record.checkpoint_id).await,
-            CheckpointRecordLifecycle::Active,
+            CheckpointRecordLifecycle::Active {},
             "a live target keeps its pin at {now_ms}"
         );
     }
@@ -2375,7 +2375,7 @@ async fn gc_releases_abandoned_fork_checkpoints_once_the_lease_expires() {
         assert_eq!(report.released_fork_checkpoints, 0, "at {now_ms}");
         assert_eq!(
             checkpoint_lifecycle(&store, &source, &abandoned.checkpoint_id).await,
-            CheckpointRecordLifecycle::Active
+            CheckpointRecordLifecycle::Active {}
         );
         assert!(crate::checkpoint::load_namespace_manifest_envelope(
             &store,
@@ -2445,7 +2445,7 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
     assert_eq!(retry, 2, "the retry pins for itself instead of reusing");
     assert_eq!(
         checkpoint_lifecycle(&store, &source, &abandoned.checkpoint_id).await,
-        CheckpointRecordLifecycle::Active,
+        CheckpointRecordLifecycle::Active {},
         "the abandoned record is untouched; its lease ends it"
     );
     load_metadata_view(&store, &clone, ReadLoadContext::latest())

--- a/crates/loonfs-core/src/namespace/fork.rs
+++ b/crates/loonfs-core/src/namespace/fork.rs
@@ -185,7 +185,7 @@ async fn ensure_fork_checkpoint_lease_holds<S: ObjectStore + ?Sized>(
     else {
         return lost("the record is gone".to_owned());
     };
-    if record.state != CheckpointRecordLifecycle::Active {
+    if record.state != (CheckpointRecordLifecycle::Active {}) {
         return lost(format!("the record is `{}`", record.state));
     }
     let holds = record

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -543,7 +543,7 @@ async fn assert_fresh_backfill_attempt(
         .expect("the new attempt's checkpoint record exists");
     assert_eq!(
         record.state,
-        CheckpointRecordLifecycle::Active,
+        CheckpointRecordLifecycle::Active {},
         "a fresh backfill attempt must hold a checkpoint that still pins its basis"
     );
     checkpoint_id.clone()


### PR DESCRIPTION
- spell `CheckpointRecordLifecycle::Active` as a zero-field struct variant
- reject active checkpoint records that also carry `released_at_ms`
- update construction and pattern sites without changing serialized bytes

(Serde's `deny_unknown_fields` does not apply to unit variants of internally tagged enums. As a result, an active checkpoint record could silently discard a release stamp instead of treating the durable control payload as corrupt. The empty braces make serde use a struct-variant visitor, closing that hole while preserving `{"kind":"active"}` )
