### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loonfs"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-api"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ciborium",
  "crc32c",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "clap",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-client"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "futures",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-grep"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-model"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "loonfs-api",
  "serde",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-objectstore"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-server"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-sim"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-test-support"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1"
+version = "0.2.0"
 license = "Apache-2.0"
 rust-version = "1.85"
 description = "Spec-locked object-store-backed file service"
@@ -54,6 +54,14 @@ serde_bytes = "0.11"
 serde_json = { version = "1", features = ["raw_value"] }
 sha2 = "0.10"
 hmac = "0.12"
+# Published workspace crates need a registry version as well as a local path.
+# Keep these versions in lockstep with `workspace.package.version`.
+loonfs = { path = "crates/loonfs", version = "0.2.0" }
+loonfs-api = { path = "crates/loonfs-api", version = "0.2.0" }
+loonfs-client = { path = "crates/loonfs-client", version = "0.2.0" }
+loonfs-core = { path = "crates/loonfs-core", version = "0.2.0" }
+loonfs-grep = { path = "crates/loonfs-grep", version = "0.2.0" }
+loonfs-objectstore = { path = "crates/loonfs-objectstore", version = "0.2.0" }
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -19,11 +19,11 @@ futures.workspace = true
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 hostname = "0.4"
 http.workspace = true
-loonfs-api = { path = "../loonfs-api" }
-loonfs-client = { path = "../loonfs-client" }
-loonfs = { path = "../loonfs" }
-loonfs-grep = { path = "../loonfs-grep" }
-loonfs-objectstore = { path = "../loonfs-objectstore" }
+loonfs-api.workspace = true
+loonfs-client.workspace = true
+loonfs.workspace = true
+loonfs-grep.workspace = true
+loonfs-objectstore.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/loonfs-client/Cargo.toml
+++ b/crates/loonfs-client/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 bytes.workspace = true
 futures.workspace = true
 http.workspace = true
-loonfs-api = { path = "../loonfs-api" }
+loonfs-api.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/loonfs-core/Cargo.toml
+++ b/crates/loonfs-core/Cargo.toml
@@ -8,8 +8,8 @@ description = "Core LoonFS engine: namespace metadata, commits, replay, and main
 repository.workspace = true
 
 [dependencies]
-loonfs-api = { path = "../loonfs-api" }
-loonfs-objectstore = { path = "../loonfs-objectstore" }
+loonfs-api.workspace = true
+loonfs-objectstore.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 bytes.workspace = true

--- a/crates/loonfs-grep/Cargo.toml
+++ b/crates/loonfs-grep/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 async-trait.workspace = true
 bytes.workspace = true
 futures.workspace = true
-loonfs = { path = "../loonfs" }
-loonfs-api = { path = "../loonfs-api" }
-loonfs-objectstore = { path = "../loonfs-objectstore" }
+loonfs.workspace = true
+loonfs-api.workspace = true
+loonfs-objectstore.workspace = true
 regex.workspace = true
 regex-syntax.workspace = true
 serde.workspace = true

--- a/crates/loonfs-model/Cargo.toml
+++ b/crates/loonfs-model/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-loonfs-api = { path = "../loonfs-api" }
+loonfs-api.workspace = true
 serde.workspace = true
 
 [lints]

--- a/crates/loonfs-objectstore/Cargo.toml
+++ b/crates/loonfs-objectstore/Cargo.toml
@@ -15,7 +15,7 @@ fs4.workspace = true
 futures.workspace = true
 http.workspace = true
 http-body.workspace = true
-loonfs-api = { path = "../loonfs-api" }
+loonfs-api.workspace = true
 object_store.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -22,10 +22,10 @@ bytes.workspace = true
 clap.workspace = true
 futures.workspace = true
 http.workspace = true
-loonfs-api = { path = "../loonfs-api" }
-loonfs = { path = "../loonfs" }
-loonfs-grep = { path = "../loonfs-grep" }
-loonfs-objectstore = { path = "../loonfs-objectstore" }
+loonfs-api.workspace = true
+loonfs.workspace = true
+loonfs-grep.workspace = true
+loonfs-objectstore.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
 serde.workspace = true
@@ -40,7 +40,7 @@ utoipa = { workspace = true, optional = true }
 
 [dev-dependencies]
 async-trait.workspace = true
-loonfs-client = { path = "../loonfs-client" }
+loonfs-client.workspace = true
 loonfs-test-support = { path = "../loonfs-test-support" }
 rcgen.workspace = true
 tempfile.workspace = true

--- a/crates/loonfs-sim/Cargo.toml
+++ b/crates/loonfs-sim/Cargo.toml
@@ -12,9 +12,9 @@ publish = false
 async-trait.workspace = true
 bytes.workspace = true
 futures.workspace = true
-loonfs-api = { path = "../loonfs-api" }
-loonfs-grep = { path = "../loonfs-grep" }
-loonfs-objectstore = { path = "../loonfs-objectstore" }
+loonfs-api.workspace = true
+loonfs-grep.workspace = true
+loonfs-objectstore.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/loonfs-test-support/Cargo.toml
+++ b/crates/loonfs-test-support/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 futures.workspace = true
-loonfs-api = { path = "../loonfs-api" }
-loonfs-objectstore = { path = "../loonfs-objectstore" }
+loonfs-api.workspace = true
+loonfs-objectstore.workspace = true
 tempfile.workspace = true
 tokio = { version = "1", default-features = false, features = ["macros", "rt", "sync", "time"] }
 ureq.workspace = true

--- a/crates/loonfs/Cargo.toml
+++ b/crates/loonfs/Cargo.toml
@@ -11,9 +11,9 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 futures.workspace = true
-loonfs-api = { path = "../loonfs-api" }
-loonfs-core = { path = "../loonfs-core" }
-loonfs-objectstore = { path = "../loonfs-objectstore" }
+loonfs-api.workspace = true
+loonfs-core.workspace = true
+loonfs-objectstore.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "identifier": "Apache-2.0"
     },
-    "version": "0.1.1"
+    "version": "0.2.0"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
Prepares the workspace for v0.2.0. Updates crate versions and registry dependency metadata, refreshes Cargo.lock, and regenerates the OpenAPI version. Changelog and release notes are unchanged.