### PR TITLE
refactor(storage): shard content across two levels

### DIFF
--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -492,19 +492,26 @@ impl ContentId {
         ))
     }
 
-    /// Returns the two-character shard prefix content keys are grouped by.
+    /// Returns the two-character components for both content-key shard levels.
     ///
     /// Every valid id has a 32-character lowercase hex body, so this never
     /// panics.
-    pub fn shard_prefix(&self) -> &str {
-        &self.0[CONTENT_ID_PREFIX_LEN..CONTENT_ID_PREFIX_LEN + CONTENT_ID_SHARD_LEN]
+    pub fn shard_prefixes(&self) -> [&str; CONTENT_ID_SHARD_LEVELS] {
+        let first_start = CONTENT_ID_PREFIX_LEN;
+        let second_start = first_start + CONTENT_ID_SHARD_WIDTH;
+        [
+            &self.0[first_start..second_start],
+            &self.0[second_start..second_start + CONTENT_ID_SHARD_WIDTH],
+        ]
     }
 }
 
 /// Byte length of the `con_` marker that precedes a content id's hex body.
 const CONTENT_ID_PREFIX_LEN: usize = "con_".len();
-/// Number of leading body characters that select a content object's shard.
-const CONTENT_ID_SHARD_LEN: usize = 2;
+/// Number of directory levels used to shard content objects.
+const CONTENT_ID_SHARD_LEVELS: usize = 2;
+/// Number of content-id body characters in each shard directory name.
+const CONTENT_ID_SHARD_WIDTH: usize = 2;
 
 string_id! {
     /// Durable id for one metadata SST table file.
@@ -936,26 +943,33 @@ mod tests {
     #[test]
     fn generated_content_ids_are_unique_and_shard_uniformly() {
         let mut ids = BTreeSet::new();
-        let mut shards = BTreeSet::new();
+        let mut first_level_shards = BTreeSet::new();
+        let mut leaf_shards = BTreeSet::new();
         for _ in 0..512 {
             let id = ContentId::generate();
             assert_generated_id_shape(id.as_str(), "con");
-            assert_eq!(
-                id.shard_prefix(),
-                &id.as_str()["con_".len().."con_".len() + 2]
-            );
-            shards.insert(id.shard_prefix().to_owned());
+            let [first, second] = id.shard_prefixes();
+            assert_eq!(first, &id.as_str()["con_".len().."con_".len() + 2]);
+            assert_eq!(second, &id.as_str()["con_".len() + 2.."con_".len() + 4]);
+            first_level_shards.insert(first.to_owned());
+            leaf_shards.insert(format!("{first}/{second}"));
             assert!(
                 ids.insert(id.clone()),
                 "generated duplicate content id {id}"
             );
         }
-        // 512 draws over 256 shards: a generator with a fixed or clock-derived
-        // prefix would collapse into a handful of shards.
+        // 512 draws over 256 first-level and 65,536 leaf shards: a generator
+        // with a fixed or clock-derived prefix would collapse into a handful
+        // of shards.
         assert!(
-            shards.len() > 128,
-            "content id shard prefixes are not spread: {} distinct",
-            shards.len()
+            first_level_shards.len() > 128,
+            "content id first-level shards are not spread: {} distinct",
+            first_level_shards.len()
+        );
+        assert!(
+            leaf_shards.len() > 480,
+            "content id leaf shards are not spread: {} distinct",
+            leaf_shards.len()
         );
     }
 

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1478,7 +1478,8 @@ fn a_partial_that_does_not_describe_this_file_is_started_over() {
 }
 
 /// The one content object of a given length under a store root. Content
-/// objects live at `content-stores/<store>/objects/<shard>/<id>`, and the
+/// objects live at
+/// `content-stores/<store>/objects/<first-shard>/<second-shard>/<id>`, and the
 /// tests that use this write one file whose length nothing else shares.
 fn content_object_path(store_root: &Path, size_bytes: u64) -> PathBuf {
     let objects = walkdir::WalkDir::new(store_root.join("content-stores"))

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -262,7 +262,8 @@ mod tests {
         let signed = issuer
             .presign_put(
                 PresignedPutRequest {
-                    object_key: "content-stores/cs/objects/01/con_0123456789abcdef0123456789abcdef",
+                    object_key:
+                        "content-stores/cs/objects/01/23/con_0123456789abcdef0123456789abcdef",
                     content_ref: &ContentRef::blob_v1(ContentId::generate(), b"hello"),
                     expires_in: Duration::from_secs(900),
                 },

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -197,6 +197,7 @@ mod tests {
                 .replace("{table_id}", "tbl-1")
                 .replace("{upload_id}", "up-1")
                 .replace("{content_id[4..6]}", &CONTENT_ID[4..6])
+                .replace("{content_id[6..8]}", &CONTENT_ID[6..8])
                 .replace("{content_id}", CONTENT_ID)
         };
 
@@ -278,7 +279,7 @@ mod tests {
         );
         assert_eq!(
             content_blob("cs_00000000000000000000000000000001", &content_id()),
-            "content-stores/cs_00000000000000000000000000000001/objects/ab/con_abcdef0123456789abcdef0123456789"
+            "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
         );
         assert_eq!(
             upload_session("ns-1", "upl_00000000000000000000000000000001"),
@@ -286,12 +287,13 @@ mod tests {
         );
     }
 
-    /// Content keys shard on the id's own leading characters, so the shard a
-    /// key lands in is derivable from the id and nothing else.
+    /// Content keys shard on the id's own leading characters, so both shard
+    /// directories are derivable from the id and nothing else.
     #[test]
     fn content_keys_shard_on_the_content_id_prefix() {
         let id = content_id();
         let key = content_blob("cs-1", &id);
-        assert!(key.ends_with(&format!("/{}/{}", id.shard_prefix(), id.as_str())));
+        let [first_shard, second_shard] = id.shard_prefixes();
+        assert!(key.ends_with(&format!("/{first_shard}/{second_shard}/{}", id.as_str())));
     }
 }

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -158,12 +158,14 @@ impl ObjectLayout {
         format!("namespaces/{namespace}/uploads/")
     }
 
-    /// Content objects shard on the content id's leading characters, which
-    /// are random, so ingest spreads evenly across provider partitions.
+    /// Content objects shard across two directory levels selected by the
+    /// content id's leading characters. Those characters are random, so
+    /// ingest spreads evenly and filesystem-backed stores keep bounded
+    /// directory fanout.
     pub(crate) fn content_blob(&self, content_store: &str, content_id: &ContentId) -> String {
+        let [first_shard, second_shard] = content_id.shard_prefixes();
         format!(
-            "content-stores/{content_store}/objects/{}/{}",
-            content_id.shard_prefix(),
+            "content-stores/{content_store}/objects/{first_shard}/{second_shard}/{}",
             content_id.as_str()
         )
     }
@@ -176,7 +178,7 @@ impl ObjectLayout {
 pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
     let segments: Vec<_> = key.split('/').collect();
     match segments.as_slice() {
-        ["content-stores", _, "objects", _, _] => parsed(DurableObjectFamily::ContentBlob, None),
+        ["content-stores", _, "objects", _, _, _] => parsed(DurableObjectFamily::ContentBlob, None),
         ["namespaces", namespace, "wal", "head.json"] => {
             parsed(DurableObjectFamily::WalHead, Some(namespace))
         }
@@ -279,7 +281,7 @@ mod tests {
             layout
                 .content_blob("cs_00000000000000000000000000000001", &content_id())
                 .as_str(),
-            "content-stores/cs_00000000000000000000000000000001/objects/ab/con_abcdef0123456789abcdef0123456789"
+            "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
         );
     }
 
@@ -390,14 +392,14 @@ mod tests {
         assert!(parse_object_key("namespaces/ns-1/unknown/file").is_none());
     }
 
-    /// One content layout exists. Anything else under `content-stores/`,
-    /// including the deeper digest-partitioned shape this format replaced,
+    /// One content layout exists. Anything else under `content-stores/`
     /// classifies as nothing at all rather than as content.
     #[test]
     fn parser_admits_exactly_one_content_layout() {
         for foreign in [
             "content-stores/cs-1/blobs/ab/cd/deadbeef",
-            "content-stores/cs-1/objects/ab/cd/deadbeef",
+            "content-stores/cs-1/objects/ab/deadbeef",
+            "content-stores/cs-1/objects/ab/cd/ef/deadbeef",
             "content-stores/cs-1/objects/deadbeef",
             "content-stores/cs-1/objects/",
         ] {

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -525,7 +525,8 @@ mod tests {
     use loonfs_api::{ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind, StorageChecksum};
     use std::time::{Duration, UNIX_EPOCH};
 
-    const CONTENT_KEY: &str = "content-stores/cs/objects/01/con_0123456789abcdef0123456789abcdef";
+    const CONTENT_KEY: &str =
+        "content-stores/cs/objects/01/23/con_0123456789abcdef0123456789abcdef";
 
     fn content_ref() -> ContentRef {
         ContentRef::blob_v1(

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -1384,7 +1384,7 @@ mod tests {
     #[tokio::test]
     async fn provider_store_range_semantics_match_blocking_contract() {
         let store = memory_store();
-        let key = "content-stores/cs_0123456789abcdef0123456789abcdef/objects/ab/con_abcdef0123456789abcdef0123456789";
+        let key = "content-stores/cs_0123456789abcdef0123456789abcdef/objects/ab/cd/con_abcdef0123456789abcdef0123456789";
         store
             .put_overwrite(key, Bytes::from_static(b"abcdef"))
             .await
@@ -2124,7 +2124,7 @@ mod tests {
     const MULTIPART_TEST_THRESHOLD: u64 = 1024;
     const MULTIPART_TEST_PART: u64 = 512;
     const MULTIPART_KEY: &str =
-        "content-stores/cs_0123456789abcdef0123456789abcdef/objects/ab/con_abcdef0123456789abcdef0123456789";
+        "content-stores/cs_0123456789abcdef0123456789abcdef/objects/ab/cd/con_abcdef0123456789abcdef0123456789";
 
     /// Retrying store with a test-sized multipart geometry: payloads of
     /// 1024+ bytes go multipart in 512-byte parts.

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -84,14 +84,14 @@ async fn records_get_success_bytes_out() {
 
     store
         .put_overwrite(
-            "content-stores/cs_abc/objects/ab/con_abcdef0123456789abcdef0123456789",
+            "content-stores/cs_abc/objects/ab/cd/con_abcdef0123456789abcdef0123456789",
             bytes(b"abcdef"),
         )
         .await
         .expect("put object");
     let bytes = store
         .get(
-            "content-stores/cs_abc/objects/ab/con_abcdef0123456789abcdef0123456789",
+            "content-stores/cs_abc/objects/ab/cd/con_abcdef0123456789abcdef0123456789",
             Some(ByteRange {
                 start_inclusive: 1,
                 end_exclusive: 4,

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -32,7 +32,7 @@ fn key_builders_cover_locked_object_families() {
             "cs_00000000000000000000000000000001",
             &ContentId::parse("con_abcdef0123456789abcdef0123456789").expect("valid content id"),
         ),
-        "content-stores/cs_00000000000000000000000000000001/objects/ab/con_abcdef0123456789abcdef0123456789"
+        "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
     );
     assert_eq!(
         wal_segment("ns-1", "seg_00000000000000000000000000000001"),

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -65,7 +65,7 @@ The required durable object families and standard key patterns are:
 | **Upload sessions** | Mutable lifecycle | Track one staged-content upload. The lifecycle is monotonic: a session is created `open` under a lease, and moves once to `completed` or `aborted`, both terminal. | `namespaces/{namespace_id}/uploads/{upload_id}.json` |
 | **Metadata root** | Mutable | Cold pointer to the best known materialized metadata root; monotonic CAS. | `namespaces/{namespace_id}/metadata/root.json` |
 | **WAL floor** | Mutable | Cold lower bound of retained WAL/change history; monotonic CAS. | `namespaces/{namespace_id}/wal/floor.json` |
-| **Content objects** | Immutable | Store one file revision's complete bytes. | `content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id}` |
+| **Content objects** | Immutable | Store one file revision's complete bytes. | `content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id[6..8]}/{content_id}` |
 
 These key shapes are part of the interoperable storage contract.
 Implementations may keep additional private control-plane objects — queues,
@@ -573,17 +573,18 @@ This separation is part of the core model.
 The stable immutable content families are:
 
 ```text
-content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id}
+content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id[6..8]}/{content_id}
 ```
 
 The core rules are:
 
 - `content_ref.kind` is `blob_v1` for the current content strategy;
 - `content_id` is `con_` followed by 32 lowercase hex characters — 128 fully
-  random bits, with no time component. The shard directory is the first two
-  characters of that body, so ingest spreads evenly across provider
-  partitions; a clock-derived prefix would put every upload in a window into
-  one shard;
+  random bits, with no time component. Two shard directories use the first
+  four characters of that body in two-character groups. This spreads ingest
+  evenly across provider partitions and bounds directory fanout for
+  filesystem-backed stores; a clock-derived prefix would put every upload in
+  a window into one shard;
 - because the id is random, the final object key is known before the first
   byte is read, and an object that was never published belongs to exactly one
   upload;
@@ -966,7 +967,7 @@ Content must be durable before any metadata change can reference it.
    the final object key exists up front.
 2. Read the namespace head for its `content_store_id`.
 3. Upload the complete byte sequence to
-   `content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id}`
+   `content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id[6..8]}/{content_id}`
    with create-if-absent semantics.
 4. Build a content reference:
 
@@ -1161,7 +1162,7 @@ Given a visible file inode at seq N:
 2. Read the namespace head for its `content_store_id`.
 3. Verify that `content_ref.kind` is supported by the reader.
 4. For `blob_v1`, fetch the object at
-   `content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id}`.
+   `content-stores/{content_store_id}/objects/{content_id[4..6]}/{content_id[6..8]}/{content_id}`.
 5. Verify that the fetched bytes match `content_ref.size_bytes` and the
    reference's `whole_file_sha256`. A reference whose evidence the reader
    cannot recompute fails the read; nothing is served unverified.


### PR DESCRIPTION
Filesystem-backed stores need bounded directory fanout as content grows, so content objects now use two random shard levels. This is a durable-key format change with no compatibility path and namespaces must be manually migrated. 