### PR TITLE
feat(content): add support for crc32c checksum type

### DIFF
--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -288,7 +288,7 @@ pub fn put_retry_fingerprint(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ContentId;
+    use crate::{ContentId, ContentRefKind, StorageChecksum};
 
     /// Pins the exact stored fingerprint for a fixed one-operation request.
     ///
@@ -419,6 +419,54 @@ mod tests {
             fingerprint,
             "v0:sha256:3febc279ebb36c013f734095bebdba3c0a59bf8cbd82d205b53adbf00c112d59"
         );
+    }
+
+    /// The retry leg, over the pinned value above: whatever algorithm the
+    /// original commit's reference landed with, a retry reading it back
+    /// recomputes the same fingerprint.
+    ///
+    /// This is what lets a retry prove sameness in two independent steps —
+    /// the fingerprint says the two requests are the same mutation, and the
+    /// digest evidence says the two payloads are the same bytes. A checksum
+    /// inside the preimage would collapse them into one weaker check and
+    /// make a CRC-only commit unreplayable.
+    #[test]
+    fn a_put_retry_reaches_the_pinned_fingerprint_under_every_checksum_algorithm() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let content_id =
+            ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id");
+        let bytes = b"pinned put bytes";
+
+        for content_ref in [
+            ContentRef::blob_v1(content_id.clone(), bytes),
+            ContentRef {
+                kind: ContentRefKind::BlobV1,
+                content_id: content_id.clone(),
+                size_bytes: bytes.len() as u64,
+                storage_checksum: StorageChecksum::crc32c(bytes),
+                whole_file_sha256: None,
+            },
+            ContentRef {
+                kind: ContentRefKind::BlobV1,
+                content_id: content_id.clone(),
+                size_bytes: bytes.len() as u64,
+                storage_checksum: StorageChecksum::crc64nvme(bytes),
+                whole_file_sha256: None,
+            },
+        ] {
+            assert_eq!(
+                put_retry_fingerprint(
+                    &namespace_id,
+                    &AbsolutePath::parse("/docs/report.txt").expect("path"),
+                    DestinationBehavior::NoReplace,
+                    None,
+                    None,
+                    &content_ref,
+                )
+                .expect("retry fingerprint"),
+                "v0:sha256:3febc279ebb36c013f734095bebdba3c0a59bf8cbd82d205b53adbf00c112d59"
+            );
+        }
     }
 
     fn create_dir(path: &str) -> FilesystemOperation {

--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -72,11 +72,12 @@ impl<'de> Deserialize<'de> for ContentRefKind {
 /// provider. (Cloudflare R2 never reports `x-amz-checksum-type` at all, so a
 /// type read back would be unavailable exactly where it would matter.)
 ///
-/// [`ChecksumAlgorithm::Sha256`] and [`ChecksumAlgorithm::Crc64nvme`] both
-/// have producers: every path that moves bytes through LoonFS hashes them,
-/// and direct multipart upload carries the CRC-64/NVME the S3-compatible
-/// providers compute over the assembled object. `Crc32c` decodes and
-/// round-trips without a producer.
+/// Every algorithm here is producible by this build, and the vocabulary is
+/// closed: an algorithm spelling this build does not know fails to decode
+/// rather than decoding into a value nothing can recompute. So a
+/// `ChecksumAlgorithm` in hand always names evidence that can be checked,
+/// and the read, retry, and resume paths never have to carry a "cannot
+/// tell" answer. Adding a variant is therefore adding a producer for it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
@@ -130,59 +131,62 @@ pub struct StorageChecksum {
 }
 
 impl StorageChecksum {
-    /// Builds the SHA-256 storage checksum for these complete bytes.
-    pub fn sha256(bytes: &[u8]) -> Self {
-        Self {
-            algorithm: ChecksumAlgorithm::Sha256,
-            value: hex_encode_bytes(&Sha2Sha256::digest(bytes)),
-        }
-    }
-
-    /// Builds the CRC-64/NVME storage checksum for these complete bytes.
-    pub fn crc64nvme(bytes: &[u8]) -> Self {
-        let mut digest = Crc64Nvme::new();
+    /// Builds the `algorithm` checksum for these complete bytes.
+    ///
+    /// The one-shot forms below are this with the algorithm spelled out, so
+    /// a payload held whole and one delivered in pieces cannot drift: both
+    /// close the same digest.
+    pub fn compute(algorithm: ChecksumAlgorithm, bytes: &[u8]) -> Self {
+        let mut digest = StreamingChecksum::for_algorithm(algorithm);
         digest.update(bytes);
         digest.finish()
     }
 
+    /// Builds the SHA-256 storage checksum for these complete bytes.
+    pub fn sha256(bytes: &[u8]) -> Self {
+        Self::compute(ChecksumAlgorithm::Sha256, bytes)
+    }
+
+    /// Builds the CRC-64/NVME storage checksum for these complete bytes.
+    pub fn crc64nvme(bytes: &[u8]) -> Self {
+        Self::compute(ChecksumAlgorithm::Crc64nvme, bytes)
+    }
+
+    /// Builds the CRC-32C storage checksum for these complete bytes.
+    pub fn crc32c(bytes: &[u8]) -> Self {
+        Self::compute(ChecksumAlgorithm::Crc32c, bytes)
+    }
+
     /// Reports whether these bytes produce this exact checksum.
-    ///
-    /// `None` means the algorithm has no implementation here, which is a
-    /// refusal to verify rather than a verification: a caller must never
-    /// read it as agreement.
-    pub fn matches(&self, bytes: &[u8]) -> Option<bool> {
-        let recomputed = match self.algorithm {
-            ChecksumAlgorithm::Sha256 => Self::sha256(bytes),
-            ChecksumAlgorithm::Crc64nvme => Self::crc64nvme(bytes),
-            ChecksumAlgorithm::Crc32c => return None,
-        };
-        Some(recomputed.value == self.value)
+    pub fn matches(&self, bytes: &[u8]) -> bool {
+        Self::compute(self.algorithm, bytes).value == self.value
     }
 }
 
 /// One full-object checksum folded over a payload delivered in pieces.
 ///
 /// This is the streaming form of [`StorageChecksum::matches`], for a reader
-/// that verifies an object it never holds whole. The two agree about what
-/// this build can recompute: [`StreamingChecksum::for_algorithm`] answers
-/// `None` for exactly the algorithms `matches` refuses to judge, so an
-/// unverifiable checksum is refused before any bytes move rather than after.
+/// that verifies an object it never holds whole. Both cover the whole
+/// vocabulary, so a checksum a buffered read would judge is one a streaming
+/// read can fold — the two can never disagree about whether an object is
+/// checkable, only about what it hashes to.
 #[derive(Debug)]
 pub enum StreamingChecksum {
     /// SHA-256 folded over the payload.
     Sha256(Sha256),
     /// CRC-64/NVME folded over the payload.
     Crc64nvme(Crc64Nvme),
+    /// CRC-32C folded over the payload.
+    Crc32c(Crc32c),
 }
 
 impl StreamingChecksum {
-    /// Starts an empty digest for `algorithm`, or `None` when this build
-    /// cannot recompute that algorithm.
-    pub fn for_algorithm(algorithm: ChecksumAlgorithm) -> Option<Self> {
+    /// Starts an empty digest for `algorithm`.
+    pub fn for_algorithm(algorithm: ChecksumAlgorithm) -> Self {
         match algorithm {
-            ChecksumAlgorithm::Sha256 => Some(Self::Sha256(Sha256::new())),
-            ChecksumAlgorithm::Crc64nvme => Some(Self::Crc64nvme(Crc64Nvme::new())),
-            ChecksumAlgorithm::Crc32c => None,
+            ChecksumAlgorithm::Sha256 => Self::Sha256(Sha256::new()),
+            ChecksumAlgorithm::Crc64nvme => Self::Crc64nvme(Crc64Nvme::new()),
+            ChecksumAlgorithm::Crc32c => Self::Crc32c(Crc32c::new()),
         }
     }
 
@@ -191,6 +195,7 @@ impl StreamingChecksum {
         match self {
             Self::Sha256(digest) => digest.update(bytes),
             Self::Crc64nvme(digest) => digest.update(bytes),
+            Self::Crc32c(digest) => digest.update(bytes),
         }
     }
 
@@ -199,6 +204,7 @@ impl StreamingChecksum {
         match self {
             Self::Sha256(digest) => digest.finish(),
             Self::Crc64nvme(digest) => digest.finish(),
+            Self::Crc32c(digest) => digest.finish(),
         }
     }
 }
@@ -243,6 +249,49 @@ impl Crc64Nvme {
 impl fmt::Debug for Crc64Nvme {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Crc64Nvme").finish_non_exhaustive()
+    }
+}
+
+/// CRC-32C (Castagnoli) over a payload delivered in pieces.
+///
+/// This is the full-object checksum Google Cloud Storage computes and
+/// reports, so a transfer that never passes through LoonFS is described by
+/// it and nothing else. A CRC folds forward from a running value, so the
+/// same digest serves a whole-object read and a resumed one: the prefix
+/// already on disk goes in first, the fetched remainder after it, and the
+/// closed value covers the object either way.
+#[derive(Default)]
+pub struct Crc32c {
+    crc: u32,
+}
+
+impl Crc32c {
+    /// Starts an empty digest.
+    pub fn new() -> Self {
+        Self { crc: 0 }
+    }
+
+    /// Folds the next piece of the payload in, in order.
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.crc = crc32c::crc32c_append(self.crc, bytes);
+    }
+
+    /// Closes the digest over everything fed so far.
+    ///
+    /// The value is the big-endian spelling of the 32-bit result, which is
+    /// what the raw checksum bytes are on the wire and therefore what the
+    /// hex here has to be.
+    pub fn finish(self) -> StorageChecksum {
+        StorageChecksum {
+            algorithm: ChecksumAlgorithm::Crc32c,
+            value: hex_encode_bytes(&self.crc.to_be_bytes()),
+        }
+    }
+}
+
+impl fmt::Debug for Crc32c {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Crc32c").finish_non_exhaustive()
     }
 }
 
@@ -372,6 +421,43 @@ impl ContentRef {
         }
     }
 
+    /// The checksum this reference holds its bytes to.
+    ///
+    /// The trusted whole-file digest when one exists, and otherwise the
+    /// reference's own storage checksum — which for an object a provider
+    /// assembled or a client wrote directly is the only full-object evidence
+    /// there is. Reads, resumed reads, and retry reconciliation all judge
+    /// against this one answer, so no two of them can hold the same
+    /// reference to different evidence.
+    pub fn verifiable_checksum(&self) -> StorageChecksum {
+        match &self.whole_file_sha256 {
+            Some(digest) => StorageChecksum {
+                algorithm: ChecksumAlgorithm::Sha256,
+                value: digest.clone(),
+            },
+            None => self.storage_checksum.clone(),
+        }
+    }
+
+    /// The digest this reference carries under `algorithm`, when it carries
+    /// one at all.
+    ///
+    /// A reference describes its object with the checksum whoever wrote it
+    /// produced, plus a whole-file SHA-256 when the write path hashed the
+    /// bytes itself. Asking for anything else answers `None`: a digest
+    /// nobody computed over these bytes cannot be conjured from the ones
+    /// that were, and a retry comparing against it must refuse rather than
+    /// guess.
+    pub fn digest_under(&self, algorithm: ChecksumAlgorithm) -> Option<&str> {
+        if self.storage_checksum.algorithm == algorithm {
+            return Some(&self.storage_checksum.value);
+        }
+        match algorithm {
+            ChecksumAlgorithm::Sha256 => self.whole_file_sha256.as_deref(),
+            ChecksumAlgorithm::Crc64nvme | ChecksumAlgorithm::Crc32c => None,
+        }
+    }
+
     /// Reports whether the reference is well formed enough to publish.
     ///
     /// This is a shape check on the reference itself; proving that the
@@ -427,8 +513,8 @@ fn validate_checksum_value(
 #[cfg(test)]
 mod tests {
     use super::{
-        ChecksumAlgorithm, ContentRef, ContentRefKind, ContentRefValidationError, Crc64Nvme,
-        StorageChecksum, StreamingChecksum,
+        ChecksumAlgorithm, ContentRef, ContentRefKind, ContentRefValidationError, Crc32c,
+        Crc64Nvme, StorageChecksum, StreamingChecksum,
     };
     use crate::ids::ContentId;
 
@@ -469,6 +555,30 @@ mod tests {
                 serde_json::from_str(&encoded).expect("decode algorithm");
             assert_eq!(decoded, algorithm);
         }
+    }
+
+    /// An algorithm spelling this build does not know is rejected at decode
+    /// rather than kept as an unknown value, unlike
+    /// [`ContentRefKind::Unsupported`], which exists so a relaying reader
+    /// cannot destroy a newer kind.
+    ///
+    /// The asymmetry is deliberate and load-bearing: nothing here relays a
+    /// checksum it did not verify, so an algorithm that survived decoding
+    /// would be evidence nothing could check. Rejecting at the boundary is
+    /// what makes every `ChecksumAlgorithm` value in memory recomputable,
+    /// and therefore what lets reads, retries, and resumes have no "cannot
+    /// tell" answer to carry.
+    #[test]
+    fn an_unknown_checksum_algorithm_fails_to_decode() {
+        assert!(serde_json::from_str::<ChecksumAlgorithm>("\"md5\"").is_err());
+
+        let json = r#"{
+            "kind": "blob_v1",
+            "content_id": "con_0123456789abcdef0123456789abcdef",
+            "size_bytes": 5,
+            "storage_checksum": {"algorithm": "md5", "value": "00000000000000000000000000000000"}
+        }"#;
+        assert!(serde_json::from_str::<ContentRef>(json).is_err());
     }
 
     #[test]
@@ -544,6 +654,22 @@ mod tests {
         );
     }
 
+    /// The catalog check value for CRC-32C (Castagnoli), the one the RFC
+    /// 3720 iSCSI CRC and Google Cloud Storage both mean by "crc32c". Like
+    /// the CRC-64/NVME vector above it is an external anchor: it fixes the
+    /// polynomial and the big-endian byte order of the canonical hex against
+    /// a published value rather than against whatever this build happens to
+    /// compute, so a GCS-minted reference and one produced here agree.
+    #[test]
+    fn crc32c_matches_its_catalog_check_value() {
+        assert_eq!(StorageChecksum::crc32c(b"123456789").value, "e3069283");
+        assert_eq!(
+            StorageChecksum::crc32c(b"").value,
+            "00000000",
+            "the empty payload is the identity"
+        );
+    }
+
     /// The streaming form exists so parts can be hashed on the way past
     /// without the whole object ever being held, so it must agree with the
     /// one-shot form over the same bytes.
@@ -558,8 +684,21 @@ mod tests {
         assert_eq!(streamed.finish(), StorageChecksum::crc64nvme(&payload));
     }
 
+    /// A resumed read folds a prefix it already holds and then the bytes it
+    /// fetches, so a CRC has to close over the two halves exactly as it
+    /// closes over the whole.
+    #[test]
+    fn a_crc32c_folded_over_a_prefix_and_the_rest_equals_the_whole_payload() {
+        let payload: Vec<u8> = (0..4096u32).map(|byte| byte as u8).collect();
+        let mut streamed = Crc32c::new();
+        streamed.update(&payload[..1500]);
+        streamed.update(&payload[1500..]);
+
+        assert_eq!(streamed.finish(), StorageChecksum::crc32c(&payload));
+    }
+
     /// A verifying reader folds the same checksum the one-shot check
-    /// computes, and refuses the same algorithms it refuses — a reader that
+    /// computes, for every algorithm the vocabulary has — a reader that
     /// disagreed with [`StorageChecksum::matches`] would accept or reject
     /// objects the buffered read would not.
     #[test]
@@ -568,40 +707,51 @@ mod tests {
         for expected in [
             StorageChecksum::sha256(&payload),
             StorageChecksum::crc64nvme(&payload),
+            StorageChecksum::crc32c(&payload),
         ] {
-            let mut streaming = StreamingChecksum::for_algorithm(expected.algorithm)
-                .expect("a producing algorithm folds");
+            let mut streaming = StreamingChecksum::for_algorithm(expected.algorithm);
             for chunk in payload.chunks(97) {
                 streaming.update(chunk);
             }
             assert_eq!(streaming.finish(), expected);
         }
-        assert!(StreamingChecksum::for_algorithm(ChecksumAlgorithm::Crc32c).is_none());
     }
 
-    /// A checksum this build cannot recompute must answer "cannot tell",
-    /// never "matches".
+    /// Every algorithm in the vocabulary is comparable, so a checksum in
+    /// hand is always a question with an answer.
     #[test]
-    fn checksum_matching_refuses_rather_than_agrees_when_it_cannot_recompute() {
+    fn every_algorithm_compares_bytes_against_the_checksum_they_produce() {
+        for algorithm in [
+            ChecksumAlgorithm::Sha256,
+            ChecksumAlgorithm::Crc64nvme,
+            ChecksumAlgorithm::Crc32c,
+        ] {
+            let expected = StorageChecksum::compute(algorithm, b"hello");
+            assert_eq!(expected.algorithm, algorithm);
+            assert!(expected.matches(b"hello"));
+            assert!(!expected.matches(b"other"));
+        }
+    }
+
+    /// The evidence a read holds an object to is one answer, whichever
+    /// surface asks: the trusted whole-file digest when there is one, and
+    /// the reference's own checksum when it is all there is.
+    #[test]
+    fn a_reference_names_the_whole_file_digest_as_its_evidence_when_it_has_one() {
+        let hashed = ContentRef::blob_v1(content_id(), b"hello");
         assert_eq!(
-            StorageChecksum::sha256(b"hello").matches(b"hello"),
-            Some(true)
+            hashed.verifiable_checksum(),
+            StorageChecksum::sha256(b"hello")
         );
+
+        let crc_only = ContentRef {
+            storage_checksum: StorageChecksum::crc32c(b"hello"),
+            whole_file_sha256: None,
+            ..hashed
+        };
         assert_eq!(
-            StorageChecksum::sha256(b"hello").matches(b"other"),
-            Some(false)
-        );
-        assert_eq!(
-            StorageChecksum::crc64nvme(b"hello").matches(b"hello"),
-            Some(true)
-        );
-        assert_eq!(
-            StorageChecksum {
-                algorithm: ChecksumAlgorithm::Crc32c,
-                value: "00000000".to_owned(),
-            }
-            .matches(b"hello"),
-            None
+            crc_only.verifiable_checksum(),
+            StorageChecksum::crc32c(b"hello")
         );
     }
 

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -106,8 +106,8 @@ pub use commit_identity::{
     put_retry_fingerprint, semantic_commit_fingerprint, SemanticFingerprintError,
 };
 pub use content::{
-    ChecksumAlgorithm, ContentRef, ContentRefKind, ContentRefValidationError, Crc64Nvme, Sha256,
-    StorageChecksum, StreamingChecksum,
+    ChecksumAlgorithm, ContentRef, ContentRefKind, ContentRefValidationError, Crc32c, Crc64Nvme,
+    Sha256, StorageChecksum, StreamingChecksum,
 };
 pub use digest::sha256_digest;
 pub use error::{ErrorCode, ErrorKind};

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -148,10 +148,10 @@ fn sample_crc_content_ref() -> ContentRef {
 /// Pins the durable JSON of a content reference for every checksum algorithm
 /// the format defines.
 ///
-/// Only `sha256` has a producer today. The CRC variants are pinned anyway:
-/// direct multipart will write full-object CRC-64/NVME, and this fixture is
-/// what proves that arriving producer needs no format change — and what fails
-/// if someone reshapes the reference in the meantime.
+/// One reference per algorithm in the vocabulary, so the durable bytes of
+/// each are pinned independently of which write path happens to mint it: a
+/// producer arriving for one of them must need no format change, and this
+/// fixture is what fails if someone reshapes the reference on the way.
 #[test]
 fn content_ref_matches_golden_bytes_for_every_checksum_algorithm() {
     let references = [

--- a/crates/loonfs-cli/src/commands/partial.rs
+++ b/crates/loonfs-cli/src/commands/partial.rs
@@ -10,7 +10,7 @@
 
 use crate::backend::FileDownload;
 use crate::error::CliError;
-use loonfs_api::{ContentRef, RevisionNo};
+use loonfs_api::{ContentRef, RevisionNo, StorageChecksum};
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
@@ -32,11 +32,18 @@ const FOLD_CHUNK_BYTES: usize = 1024 * 1024;
 /// is a different file. The rest is recorded because a partial disagreeing
 /// with any of it is not worth resuming either, and because a note this
 /// build cannot read at all is the same answer — start over.
+///
+/// The storage checksum is the reference's own evidence whatever produced
+/// it, which is the only thing an object nobody hashed for us carries. The
+/// whole-file SHA-256 is recorded beside it when there is one rather than
+/// instead of it, because the two are different claims about the same
+/// bytes and a note that dropped either would be a weaker match.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct PartialMeta {
     content_id: String,
     size_bytes: u64,
+    storage_checksum: StorageChecksum,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     whole_file_sha256: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -49,6 +56,7 @@ impl PartialMeta {
         Self {
             content_id: content_ref.content_id.to_string(),
             size_bytes: content_ref.size_bytes,
+            storage_checksum: content_ref.storage_checksum.clone(),
             whole_file_sha256: content_ref.whole_file_sha256.clone(),
             revision_no: revision_no.map(|revision_no| revision_no.0),
         }
@@ -219,10 +227,22 @@ fn unreadable_note(error: serde_json::Error) -> CliError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_api::{ContentId, ContentRef};
+    use loonfs_api::{ContentId, ContentRef, ContentRefKind};
 
     fn meta_for(bytes: &[u8]) -> PartialMeta {
         PartialMeta::describe(&ContentRef::blob_v1(ContentId::generate(), bytes), None)
+    }
+
+    /// A reference whose only full-object evidence is a CRC-32C, as a direct
+    /// transfer to Google Cloud Storage leaves behind.
+    fn crc32c_content_ref(bytes: &[u8]) -> ContentRef {
+        ContentRef {
+            kind: ContentRefKind::BlobV1,
+            content_id: ContentId::generate(),
+            size_bytes: bytes.len() as u64,
+            storage_checksum: StorageChecksum::crc32c(bytes),
+            whole_file_sha256: None,
+        }
     }
 
     /// A partial whose note matches the content being fetched is picked up
@@ -283,5 +303,49 @@ mod tests {
         // Bytes with no note beside them say nothing about themselves.
         std::fs::remove_file(&meta_path).expect("remove note");
         assert_eq!(resumable_bytes(&destination, &meta), 0);
+    }
+
+    /// A file whose only evidence is a CRC-32C is described and resumed like
+    /// any other: the note carries the reference's own checksum, so content
+    /// nobody hashed for us is still identified on disk rather than being
+    /// content a rerun has to start over on.
+    #[test]
+    fn a_crc32c_only_note_describes_and_resumes_its_partial() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let destination = dir.path().join("file.bin");
+        let content_ref = crc32c_content_ref(b"0123456789");
+        let meta = PartialMeta::describe(&content_ref, None);
+
+        let encoded = serde_json::to_vec(&meta).expect("encode the note");
+        let document: serde_json::Value =
+            serde_json::from_slice(&encoded).expect("decode the note as a document");
+        assert_eq!(document["storage_checksum"]["algorithm"], "crc32c");
+        assert!(
+            document.get("whole_file_sha256").is_none(),
+            "a digest nobody computed is absent, not null: {document}"
+        );
+
+        std::fs::write(
+            sibling(&destination, PARTIAL_SUFFIX).expect("partial path"),
+            b"0123",
+        )
+        .expect("write partial");
+        std::fs::write(
+            sibling(&destination, META_SUFFIX).expect("meta path"),
+            &encoded,
+        )
+        .expect("write note");
+        assert_eq!(resumable_bytes(&destination, &meta), 4);
+
+        // The checksum is part of the match: the same id and length under a
+        // different digest is not the content this run resolved.
+        let other = PartialMeta::describe(
+            &ContentRef {
+                storage_checksum: StorageChecksum::crc32c(b"9876543210"),
+                ..content_ref
+            },
+            None,
+        );
+        assert_eq!(resumable_bytes(&destination, &other), 0);
     }
 }

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1373,6 +1373,7 @@ fn leave_a_partial_download(
     let mut note = serde_json::json!({
         "content_id": content_ref["content_id"],
         "size_bytes": content_ref["size_bytes"],
+        "storage_checksum": content_ref["storage_checksum"],
     });
     if let Some(sha256) = content_ref.get("whole_file_sha256") {
         note["whole_file_sha256"] = sha256.clone();

--- a/crates/loonfs-client/src/download_tests.rs
+++ b/crates/loonfs-client/src/download_tests.rs
@@ -123,6 +123,105 @@ async fn a_streamed_read_is_refused_when_the_bytes_are_not_what_the_grant_named(
     );
 }
 
+/// A reference whose only full-object evidence is a CRC-32C, as a direct
+/// transfer to Google Cloud Storage leaves behind.
+fn crc32c_content_ref(bytes: &[u8]) -> ContentRef {
+    ContentRef {
+        kind: loonfs_api::ContentRefKind::BlobV1,
+        content_id: ContentId::generate(),
+        size_bytes: bytes.len() as u64,
+        storage_checksum: loonfs_api::StorageChecksum::crc32c(bytes),
+        whole_file_sha256: None,
+    }
+}
+
+/// An object nobody hashed for us is described only by the provider's own
+/// CRC, and that is what the download checks it against. A grant carrying
+/// one is not a grant whose bytes go unchecked.
+#[tokio::test]
+async fn a_crc32c_only_grant_verifies_the_bytes_it_receives() {
+    let payload = b"transferred straight to the provider".to_vec();
+    let content_ref = crc32c_content_ref(&payload);
+    let client = client();
+
+    // Same length, different bytes: only the CRC can tell the two apart.
+    let served = b"transferred straight to the PROVIDER".to_vec();
+    assert_eq!(served.len(), payload.len());
+    let _guard =
+        test_transport::script([Outcome::Success(payload.clone()), Outcome::Success(served)]);
+
+    let mut sink = Vec::new();
+    let written = client
+        .download_via_presigned_url(
+            &grant(content_ref.clone(), "http://example.invalid/object"),
+            &mut sink,
+        )
+        .await
+        .expect("granted object");
+    assert_eq!(written, payload.len() as u64);
+    assert_eq!(sink, payload);
+
+    let mut sink = Vec::new();
+    let error = client
+        .download_via_presigned_url(
+            &grant(content_ref, "http://example.invalid/object"),
+            &mut sink,
+        )
+        .await
+        .expect_err("bytes that are not the granted object");
+    assert!(
+        matches!(&error, ClientError::Http(message) if message.contains("grant named")),
+        "unexpected error: {error}"
+    );
+}
+
+/// A CRC folds forward from a running value, so a resumed download of a
+/// CRC-32C-only grant closes over the prefix it never received exactly as a
+/// hashed one does.
+#[tokio::test]
+async fn a_resumed_crc32c_download_folds_the_prefix_into_the_same_verdict() {
+    let payload = b"the first half and then the second half".to_vec();
+    let held = 10;
+    let content_ref = crc32c_content_ref(&payload);
+    let client = client();
+
+    let _guard = test_transport::script([
+        Outcome::Success(payload[held..].to_vec()),
+        Outcome::Success(payload[held..].to_vec()),
+    ]);
+    let mut download = client
+        .open_direct_download_at(
+            &grant(content_ref.clone(), "http://example.invalid/object"),
+            held as u64,
+        )
+        .await
+        .expect("resumed grant");
+    download.fold_resumed_prefix(&payload[..held]);
+    while download.next_chunk().await.expect("chunk").is_some() {}
+
+    // A prefix that is not the object's fails the whole download.
+    let mut download = client
+        .open_direct_download_at(
+            &grant(content_ref, "http://example.invalid/object"),
+            held as u64,
+        )
+        .await
+        .expect("resumed grant");
+    download.fold_resumed_prefix(&vec![0u8; held]);
+    let error = loop {
+        match download.next_chunk().await {
+            Ok(Some(_)) => continue,
+            #[allow(clippy::panic, reason = "the failure this test exists to catch")]
+            Ok(None) => panic!("a prefix that is not the object's verified"),
+            Err(error) => break error,
+        }
+    };
+    assert!(
+        matches!(&error, ClientError::Http(message) if message.contains("grant named")),
+        "unexpected error: {error}"
+    );
+}
+
 /// The happy path over the same seam: the declared length and digest both
 /// hold, every byte reaches the sink, and the count comes back.
 #[tokio::test]

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -31,13 +31,13 @@ use loonfs_api::{
         UploadContentResponse, UploadPartChecksumClaim, UploadStatusResponse,
         ValidatedContentToken,
     },
-    AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId,
-    ChecksumAlgorithm, CommitId, CommitRequest, ContentRef, Crc64Nvme, CreateCheckpointRequest,
-    CreateCheckpointResponse, CreateNamespaceRequest, DeleteNamespaceResponse, ErrorCode,
-    FilesystemOperation, ForkNamespaceRequest, GrepRequest, GrepResponse, InodeId,
-    ListCheckpointsResponse, ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse,
-    MaintenanceStepRequest, MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse,
-    NamespaceSummary, ReleaseCheckpointResponse, RevisionNo, Sha256, StorageChecksum, UploadId,
+    AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId, CommitId,
+    CommitRequest, ContentRef, Crc64Nvme, CreateCheckpointRequest, CreateCheckpointResponse,
+    CreateNamespaceRequest, DeleteNamespaceResponse, ErrorCode, FilesystemOperation,
+    ForkNamespaceRequest, GrepRequest, GrepResponse, InodeId, ListCheckpointsResponse,
+    ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest,
+    MaintenanceStepResponse, NamespaceId, NamespaceStatusResponse, NamespaceSummary,
+    ReleaseCheckpointResponse, RevisionNo, StorageChecksum, StreamingChecksum, UploadId,
     FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_UPLOADS_DIRECT_MULTIPART,
     LIMIT_DOWNLOAD_MAX_CONTENT_BYTES,
 };
@@ -83,49 +83,29 @@ enum UploadedContent<'a> {
 impl UploadedContent<'_> {
     /// Whether the upload's bytes produce this checksum.
     ///
-    /// `None` is a refusal to answer — the algorithm is one this build
-    /// cannot recompute, or one nobody computed over the streamed payload —
-    /// and a caller must never read it as agreement.
+    /// `None` is a refusal to answer, and a caller must never read it as
+    /// agreement. Held bytes never refuse — every algorithm in the
+    /// vocabulary is one this client can recompute — so the only refusal
+    /// left is a streamed payload being asked for a digest nobody folded
+    /// over it.
     fn matches(&self, expected: &StorageChecksum) -> Option<bool> {
         match self {
-            Self::Bytes(bytes) => expected.matches(bytes),
+            Self::Bytes(bytes) => Some(expected.matches(bytes)),
             Self::Streamed(content_ref) => {
-                let observed = digest_of(content_ref, expected.algorithm)?;
-                Some(observed == expected.value)
+                Some(content_ref.digest_under(expected.algorithm)? == expected.value)
             }
         }
     }
 }
 
-/// The digest a reference carries under one algorithm, if it carries one.
-fn digest_of(content_ref: &ContentRef, algorithm: ChecksumAlgorithm) -> Option<&str> {
-    if content_ref.storage_checksum.algorithm == algorithm {
-        return Some(&content_ref.storage_checksum.value);
-    }
-    match algorithm {
-        ChecksumAlgorithm::Sha256 => content_ref.whole_file_sha256.as_deref(),
-        _ => None,
-    }
-}
-
 /// Whether the committed reference provably holds the bytes just uploaded.
 ///
-/// The evidence is the trusted whole-file digest when the server has one,
-/// and otherwise the reference's own storage checksum — which for a
-/// provider-assembled multipart object is the only full-object evidence
-/// that exists. Only a digest this client can recompute, over bytes that
-/// agree, proves anything: a digest that disagrees and a digest this client
-/// cannot recompute are both unproven, and both leave the conflict
-/// standing.
+/// The evidence is whatever the reference holds its own bytes to. Only that
+/// digest, over an upload that can answer for it and agrees, proves
+/// anything: a digest that disagrees and a digest the upload cannot answer
+/// for are both unproven, and both leave the conflict standing.
 fn uploaded_matches_committed(uploaded: &UploadedContent<'_>, content_ref: &ContentRef) -> bool {
-    let evidence = match &content_ref.whole_file_sha256 {
-        Some(digest) => StorageChecksum {
-            algorithm: ChecksumAlgorithm::Sha256,
-            value: digest.clone(),
-        },
-        None => content_ref.storage_checksum.clone(),
-    };
-    uploaded.matches(&evidence) == Some(true)
+    uploaded.matches(&content_ref.verifiable_checksum()) == Some(true)
 }
 
 /// What a reuse conflict says the commit id already landed as: where, and
@@ -209,7 +189,12 @@ pub struct DirectDownloadStream {
     body: payload::PayloadStream,
     expected: ContentRef,
     path: AbsolutePath,
-    sha256: Option<Sha256>,
+    /// The checksum the complete object must produce, folded so far. The
+    /// grant's reference names it, so an object nobody hashed for us — a
+    /// provider-assembled multipart, or a direct transfer described only by
+    /// the provider's own CRC — is checked on the way past rather than
+    /// taken on trust.
+    digest: StreamingChecksum,
     size_bytes: u64,
     /// Offset this stream was opened at: zero for the whole object, and the
     /// length of what the caller already holds for a resumed download.
@@ -226,14 +211,12 @@ impl DirectDownloadStream {
     /// from the object's first byte.
     ///
     /// A resumed download still checks the whole object's digest, so the
-    /// bytes it will never receive have to be folded into the same hash as
+    /// bytes it will never receive have to be folded into the same digest as
     /// the ones it does. Feeding the wrong bytes fails the download at its
     /// end, which is right: the grant's reference is the authority on what
     /// the object holds, not the partial copy on the caller's disk.
     pub fn fold_resumed_prefix(&mut self, bytes: &[u8]) {
-        if let Some(sha256) = self.sha256.as_mut() {
-            sha256.update(bytes);
-        }
+        self.digest.update(bytes);
         self.prefix_folded = self.prefix_folded.saturating_add(bytes.len() as u64);
     }
 
@@ -261,9 +244,7 @@ impl DirectDownloadStream {
                         self.path, self.expected.size_bytes
                     )));
                 }
-                if let Some(sha256) = self.sha256.as_mut() {
-                    sha256.update(&chunk);
-                }
+                self.digest.update(&chunk);
                 Ok(Some(chunk))
             }
             Some(Err(error)) => {
@@ -281,18 +262,23 @@ impl DirectDownloadStream {
                         self.path, self.size_bytes, self.expected.size_bytes
                     )));
                 }
-                if let (Some(sha256), Some(expected_sha256)) = (
-                    self.sha256.take(),
-                    self.expected.whole_file_sha256.as_deref(),
-                ) {
-                    let observed = sha256.finish().value;
-                    if observed != expected_sha256 {
-                        return Err(ClientError::Http(format!(
-                            "direct download of `{}` hashed to {observed}, not the \
-                             {expected_sha256} the grant named",
-                            self.path
-                        )));
-                    }
+                let expected = self.expected.verifiable_checksum();
+                // Closing consumes the digest; `finished` is what keeps this
+                // from running a second time over an empty one.
+                let observed = std::mem::replace(
+                    &mut self.digest,
+                    StreamingChecksum::for_algorithm(expected.algorithm),
+                )
+                .finish();
+                if observed != expected {
+                    return Err(ClientError::Http(format!(
+                        "direct download of `{}` produced {}:{}, not the {}:{} the grant named",
+                        self.path,
+                        observed.algorithm,
+                        observed.value,
+                        expected.algorithm,
+                        expected.value
+                    )));
                 }
                 Ok(None)
             }
@@ -755,11 +741,9 @@ impl Client {
             body,
             expected: download.content_ref.clone(),
             path: download.absolute_path.clone(),
-            sha256: download
-                .content_ref
-                .whole_file_sha256
-                .as_ref()
-                .map(|_| Sha256::new()),
+            digest: StreamingChecksum::for_algorithm(
+                download.content_ref.verifiable_checksum().algorithm,
+            ),
             // The counter measures the whole object, not this response, so
             // the length check at the end lands where it always did.
             size_bytes: start_offset,
@@ -1676,9 +1660,8 @@ impl Client {
     /// available: it reads back what the commit id actually committed and
     /// compares it against the request just made. The same content under
     /// the same message means the operation had already succeeded and the
-    /// original answer is returned; anything else — different bytes, a
-    /// different message, or content this build cannot compare — surfaces
-    /// the conflict.
+    /// original answer is returned; anything else — different bytes or a
+    /// different message — surfaces the conflict.
     ///
     /// The freshly uploaded duplicate object is then referenced by nothing.
     /// That is by design, not a leak: content garbage collection reclaims an
@@ -1860,8 +1843,8 @@ impl Client {
     /// separately.
     ///
     /// Nothing weaker counts: every way of failing to prove the two requests
-    /// are the same — including a comparison this client cannot make —
-    /// leaves the original conflict standing, never agreement.
+    /// are the same — including the upload having no answer to give — leaves
+    /// the original conflict standing, never agreement.
     async fn reconcile_commit_id_reuse(
         &self,
         spec: &NamespacePath,
@@ -2178,28 +2161,46 @@ mod tests {
         }
     }
 
-    /// A reference whose only full-object evidence is a digest this client
-    /// has no implementation for. No server mints one today, which is
-    /// exactly why the reconciliation has to say what it does when one
-    /// arrives.
+    /// A reference whose only full-object evidence is a CRC-32C, as a direct
+    /// transfer to Google Cloud Storage leaves behind.
     fn crc32c_content_ref(bytes: &[u8]) -> ContentRef {
         ContentRef {
             kind: loonfs_api::ContentRefKind::BlobV1,
             content_id: ContentId::generate(),
             size_bytes: bytes.len() as u64,
-            storage_checksum: StorageChecksum {
-                algorithm: ChecksumAlgorithm::Crc32c,
-                value: "0f5c0a1e".to_owned(),
-            },
+            storage_checksum: StorageChecksum::crc32c(bytes),
             whole_file_sha256: None,
         }
     }
 
+    /// A CRC-32C-only commit is reconciled like any other: the uploaded
+    /// bytes recompute it, so a retry over the same payload proves it did
+    /// this work and a retry over different bytes does not.
     #[test]
-    fn a_digest_this_client_cannot_compare_leaves_the_reuse_conflict_standing() {
+    fn a_crc32c_committed_reference_is_compared_against_the_uploaded_bytes() {
         let bytes = b"retried payload";
         let committed = crc32c_content_ref(bytes);
-        let uploaded = UploadedContent::Bytes(bytes);
+
+        assert!(uploaded_matches_committed(
+            &UploadedContent::Bytes(bytes),
+            &committed
+        ));
+        assert!(!uploaded_matches_committed(
+            &UploadedContent::Bytes(b"some other payload"),
+            &committed
+        ));
+    }
+
+    /// A one-pass payload is gone by the time the retry asks, so it answers
+    /// only for the digests that were folded over it. Being asked for one
+    /// nobody computed is a refusal, and a refusal leaves the conflict
+    /// standing.
+    #[test]
+    fn a_digest_nobody_folded_over_the_streamed_payload_leaves_the_conflict_standing() {
+        let bytes = b"retried payload";
+        let committed = crc32c_content_ref(bytes);
+        let hashed = test_content_ref(bytes);
+        let uploaded = UploadedContent::Streamed(&hashed);
 
         assert_eq!(
             uploaded.matches(&committed.storage_checksum),
@@ -2207,6 +2208,9 @@ mod tests {
             "the fixture must reach the refusal, not a comparison"
         );
         assert!(!uploaded_matches_committed(&uploaded, &committed));
+
+        // The same one-pass payload does answer for the digest it folded.
+        assert!(uploaded_matches_committed(&uploaded, &hashed));
     }
 
     #[test]

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -628,7 +628,7 @@ fn streamed_evidence_answers_only_the_digests_it_has() {
     assert_eq!(streamed.matches(&StorageChecksum::sha256(bytes)), None);
 }
 
-/// Held bytes can answer any digest this build knows, which is why the
+/// Held bytes can answer any digest in the vocabulary, which is why the
 /// buffered path never has to refuse.
 #[test]
 fn held_evidence_recomputes_whatever_it_is_asked() {
@@ -636,8 +636,13 @@ fn held_evidence_recomputes_whatever_it_is_asked() {
     let held = UploadedContent::Bytes(bytes);
     assert_eq!(held.matches(&StorageChecksum::sha256(bytes)), Some(true));
     assert_eq!(held.matches(&StorageChecksum::crc64nvme(bytes)), Some(true));
+    assert_eq!(held.matches(&StorageChecksum::crc32c(bytes)), Some(true));
     assert_eq!(
         held.matches(&StorageChecksum::sha256(b"something else")),
+        Some(false)
+    );
+    assert_eq!(
+        held.matches(&StorageChecksum::crc32c(b"something else")),
         Some(false)
     );
 }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -675,7 +675,6 @@ fn classify_durable_content_error(error: &DurableContentValidationError) -> Erro
         | DurableContentValidationError::MissingContentObject { .. }
         | DurableContentValidationError::ContentLengthMismatch { .. }
         | DurableContentValidationError::ContentChecksumMismatch { .. }
-        | DurableContentValidationError::ContentChecksumUnverifiable { .. }
         | DurableContentValidationError::ContentStoreMismatch { .. } => ErrorCode::NamespaceCorrupt,
         DurableContentValidationError::Store { .. } => ErrorCode::ServerError,
     }

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -7,8 +7,8 @@ use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::{
-    AuthoritativePathEntry, ChecksumAlgorithm, ContentId, ContentRef, ContentRefValidationError,
-    ContentStoreId, NamespaceId, Sha256, StorageChecksum, StreamingChecksum,
+    AuthoritativePathEntry, ContentId, ContentRef, ContentRefValidationError, ContentStoreId,
+    NamespaceId, Sha256, StorageChecksum, StreamingChecksum,
 };
 use loonfs_objectstore::keys::content_blob;
 use loonfs_objectstore::{ByteRange, ByteStream, ObjectStore, ObjectStoreError, PutMode};
@@ -62,13 +62,6 @@ pub enum DurableContentValidationError {
         object_key: String,
         expected: String,
         actual: String,
-    },
-    #[error(
-        "content checksum for `{object_key}` uses `{algorithm}`, which this build cannot recompute"
-    )]
-    ContentChecksumUnverifiable {
-        object_key: String,
-        algorithm: ChecksumAlgorithm,
     },
     #[error(
         "stored content belongs to content store `{actual}`, not namespace-bound store `{expected}`"
@@ -247,10 +240,9 @@ pub const CONTENT_READ_CHUNK_BYTES: u64 = 8 * 1024 * 1024;
 /// the verifying digest is folded as they go, so a 50 GiB object costs one
 /// chunk of memory rather than 50 GiB. It verifies exactly what the buffered
 /// read verifies — the declared size, and the reference's trusted whole-file
-/// SHA-256 when it has one, otherwise its own storage checksum, which for a
-/// provider-assembled object is the only full-object evidence there is. A
-/// reference whose checksum this build cannot recompute is refused when the
-/// stream is opened, before any byte is fetched, rather than after.
+/// SHA-256 when it has one, otherwise its own storage checksum, which for an
+/// object this deployment did not hash itself is the only full-object
+/// evidence there is.
 ///
 /// The object is immutable and named by a random content id, so nothing can
 /// rewrite it under a reader: chunk *n* and chunk *n+1* are always from the
@@ -293,8 +285,7 @@ impl<S: ObjectStore> FileContentStream<S> {
     /// One `HeadObject` proves the object exists and is exactly as long as
     /// the reference claims before any payload moves, which is what lets a
     /// wrong-sized object fail without a partial answer having been handed
-    /// out. The reference's checksum algorithm is resolved here for the same
-    /// reason.
+    /// out.
     /// `start_offset` is where the caller already is: bytes below it are
     /// never fetched, and [`Self::fold_resumed_prefix`] is how they still
     /// reach the digest.
@@ -308,13 +299,8 @@ impl<S: ObjectStore> FileContentStream<S> {
     ) -> Result<Self, DurableContentValidationError> {
         let object_key = content_object_key_for_ref(content_store_id, &content_ref)?;
         validate_content_size(&store, &object_key, &content_ref).await?;
-        let expected = verifiable_checksum(&content_ref);
-        let digest = StreamingChecksum::for_algorithm(expected.algorithm).ok_or({
-            DurableContentValidationError::ContentChecksumUnverifiable {
-                object_key: object_key.clone(),
-                algorithm: content_ref.storage_checksum.algorithm,
-            }
-        })?;
+        let expected = content_ref.verifiable_checksum();
+        let digest = StreamingChecksum::for_algorithm(expected.algorithm);
         Ok(Self {
             store,
             entry,
@@ -448,8 +434,7 @@ impl<S: ObjectStore> FileContentStream<S> {
         // Closing consumes the digest, which is why this runs exactly once.
         let digest = std::mem::replace(
             &mut self.digest,
-            StreamingChecksum::for_algorithm(self.expected.algorithm)
-                .expect("an algorithm this stream already folded stays recomputable"),
+            StreamingChecksum::for_algorithm(self.expected.algorithm),
         );
         let actual = digest.finish();
         if actual != self.expected {
@@ -501,11 +486,9 @@ pub(crate) fn content_object_key_for_ref(
 /// Checks fetched bytes against everything the reference claims about them.
 ///
 /// The whole-file SHA-256 is the check whenever it is present; a reference
-/// that carries only a CRC — which direct multipart produces, because a
-/// provider-assembled object is never hashed by us — is verified by that
-/// CRC instead. A reference whose checksum this build cannot recompute is
-/// refused rather than waved through: an unverifiable read is not a
-/// verified one.
+/// that carries only a CRC — which a direct transfer produces, because an
+/// object assembled by the provider or written by the client is never hashed
+/// by us — is verified by that CRC instead.
 fn validate_loaded_content_bytes(
     object_key: String,
     content_ref: &ContentRef,
@@ -520,26 +503,14 @@ fn validate_loaded_content_bytes(
         });
     }
 
-    let expected = verifiable_checksum(content_ref);
-    match expected.matches(bytes) {
-        Some(true) => {}
-        Some(false) => {
-            let actual = match expected.algorithm {
-                ChecksumAlgorithm::Sha256 => StorageChecksum::sha256(bytes),
-                _ => StorageChecksum::crc64nvme(bytes),
-            };
-            return Err(DurableContentValidationError::ContentChecksumMismatch {
-                object_key,
-                expected: describe_checksum(&expected),
-                actual: describe_checksum(&actual),
-            });
-        }
-        None => {
-            return Err(DurableContentValidationError::ContentChecksumUnverifiable {
-                object_key,
-                algorithm: content_ref.storage_checksum.algorithm,
-            })
-        }
+    let expected = content_ref.verifiable_checksum();
+    if !expected.matches(bytes) {
+        let actual = StorageChecksum::compute(expected.algorithm, bytes);
+        return Err(DurableContentValidationError::ContentChecksumMismatch {
+            object_key,
+            expected: describe_checksum(&expected),
+            actual: describe_checksum(&actual),
+        });
     }
 
     Ok(ValidatedDurableContent {
@@ -547,19 +518,6 @@ fn validate_loaded_content_bytes(
         object_key,
         file_size_bytes: actual_size,
     })
-}
-
-/// The checksum a read holds these bytes to: the trusted whole-file digest
-/// when one exists, and otherwise the reference's own storage checksum,
-/// which for a provider-assembled object is the only evidence there is.
-fn verifiable_checksum(content_ref: &ContentRef) -> StorageChecksum {
-    match &content_ref.whole_file_sha256 {
-        Some(digest) => StorageChecksum {
-            algorithm: ChecksumAlgorithm::Sha256,
-            value: digest.clone(),
-        },
-        None => content_ref.storage_checksum.clone(),
-    }
 }
 
 fn describe_checksum(checksum: &StorageChecksum) -> String {
@@ -800,8 +758,8 @@ mod tests {
     };
     use bytes::Bytes;
     use loonfs_api::{
-        AuthoritativePathEntry, ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind,
-        ContentStoreId, StorageChecksum,
+        AuthoritativePathEntry, ContentId, ContentRef, ContentRefKind, ContentStoreId,
+        StorageChecksum,
     };
     use loonfs_objectstore::keys::content_blob;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -904,26 +862,39 @@ mod tests {
         ));
     }
 
-    /// A reference whose only evidence is a CRC this build cannot recompute
-    /// must fail the read rather than be waved through unverified.
+    /// A direct transfer to Google Cloud Storage produces a reference whose
+    /// only evidence is the CRC-32C that provider computed. Reads verify it
+    /// like any other full-object evidence, and a wrong object fails on it.
     #[tokio::test]
-    async fn read_refuses_a_reference_it_cannot_verify() {
+    async fn read_verifies_a_reference_whose_only_evidence_is_a_crc32c() {
         let (_temp_dir, store, content_store_id) = test_store();
-        let bytes = b"crc only";
-        let mut content_ref = content_ref(bytes);
-        content_ref.whole_file_sha256 = None;
-        content_ref.storage_checksum = StorageChecksum {
-            algorithm: ChecksumAlgorithm::Crc32c,
-            value: "00000000".to_owned(),
+        let bytes = b"transferred straight to the provider";
+        let content_ref = ContentRef {
+            kind: ContentRefKind::BlobV1,
+            content_id: ContentId::generate(),
+            size_bytes: bytes.len() as u64,
+            storage_checksum: StorageChecksum::crc32c(bytes),
+            whole_file_sha256: None,
         };
         put_content_object(&store, &content_store_id, &content_ref, bytes).await;
 
-        let err = read_durable_content_bytes(&store, &content_store_id, &content_ref)
+        let read = read_durable_content_bytes(&store, &content_store_id, &content_ref)
             .await
-            .expect_err("unverifiable checksum");
+            .expect("a crc32c-only reference verifies by its crc");
+        assert_eq!(read.bytes, bytes);
+
+        // Same length, different bytes: only the checksum can tell.
+        let (_temp_dir, store, content_store_id) = test_store();
+        let planted = ContentRef {
+            storage_checksum: StorageChecksum::crc32c(b"transferred straight to the PROVIDER"),
+            ..content_ref
+        };
+        put_content_object(&store, &content_store_id, &planted, bytes).await;
         assert!(matches!(
-            err,
-            DurableContentValidationError::ContentChecksumUnverifiable { .. }
+            read_durable_content_bytes(&store, &content_store_id, &planted)
+                .await
+                .expect_err("crc mismatch"),
+            DurableContentValidationError::ContentChecksumMismatch { .. }
         ));
     }
 
@@ -1280,32 +1251,117 @@ mod tests {
         );
     }
 
-    /// A reference whose only evidence is a checksum this build cannot
-    /// recompute is refused before any byte moves, not after — a streamed
-    /// read that discovered this at the end would already have handed
-    /// unverifiable bytes to its caller.
+    /// A CRC-32C-only reference is what a direct transfer to Google Cloud
+    /// Storage leaves behind, and a streamed read of one is verified like any
+    /// other: folded chunk by chunk, closed at the end, and failed when the
+    /// object is not what the reference says.
     #[tokio::test]
-    async fn a_streamed_read_refuses_a_reference_it_cannot_verify_before_reading() {
+    async fn a_streamed_read_verifies_a_reference_whose_only_evidence_is_a_crc32c() {
+        let (_temp_dir, store, content_store_id) = test_store();
+        let bytes = payload(2 * TEST_CHUNK_BYTES as usize + 5);
+        let content_ref = ContentRef {
+            kind: ContentRefKind::BlobV1,
+            content_id: ContentId::generate(),
+            size_bytes: bytes.len() as u64,
+            storage_checksum: StorageChecksum::crc32c(&bytes),
+            whole_file_sha256: None,
+        };
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+
+        let mut stream = open_stream(&store, &content_store_id, &content_ref)
+            .await
+            .expect("open stream");
+        let mut fetched = Vec::new();
+        while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
+            fetched.extend_from_slice(&chunk);
+        }
+        assert_eq!(fetched, bytes);
+
+        let (_temp_dir, store, content_store_id) = test_store();
+        let planted = ContentRef {
+            storage_checksum: StorageChecksum::crc32c(&payload(bytes.len() + 1)),
+            ..content_ref
+        };
+        put_content_object(&store, &content_store_id, &planted, &bytes).await;
+        let mut stream = open_stream(&store, &content_store_id, &planted)
+            .await
+            .expect("open stream");
+        let verdict = loop {
+            match stream.next_chunk().await {
+                Ok(Some(_)) => continue,
+                #[allow(clippy::panic, reason = "the failure this test exists to catch")]
+                Ok(None) => panic!("an object that is not the reference's verified"),
+                Err(error) => break error,
+            }
+        };
+        assert!(
+            matches!(
+                verdict,
+                CoreError::DurableContent(
+                    DurableContentValidationError::ContentChecksumMismatch { .. }
+                )
+            ),
+            "unexpected verdict: {verdict}"
+        );
+    }
+
+    /// A CRC folds forward from a running value, so a resumed read of a
+    /// CRC-32C-only reference closes over the prefix it never fetched
+    /// exactly as a hashed one does.
+    #[tokio::test]
+    async fn a_resumed_crc32c_read_folds_the_prefix_into_the_same_verdict() {
         let (_temp_dir, inner, content_store_id) = test_store();
         let store = CountingStore::new(inner, KeyPredicate::content_blob());
-        let bytes = b"crc only";
-        let mut content_ref = content_ref(bytes);
-        content_ref.whole_file_sha256 = None;
-        content_ref.storage_checksum = StorageChecksum {
-            algorithm: ChecksumAlgorithm::Crc32c,
-            value: "00000000".to_owned(),
+        let bytes = payload(2 * TEST_CHUNK_BYTES as usize);
+        let content_ref = ContentRef {
+            kind: ContentRefKind::BlobV1,
+            content_id: ContentId::generate(),
+            size_bytes: bytes.len() as u64,
+            storage_checksum: StorageChecksum::crc32c(&bytes),
+            whole_file_sha256: None,
         };
-        put_content_object(&store, &content_store_id, &content_ref, bytes).await;
+        put_content_object(&store, &content_store_id, &content_ref, &bytes).await;
+        let held = TEST_CHUNK_BYTES as usize;
 
         store.reset();
-        let err = open_stream(&store, &content_store_id, &content_ref)
+        let mut stream = open_stream_at(&store, &content_store_id, &content_ref, held as u64)
             .await
-            .expect_err("unverifiable checksum");
-        assert!(matches!(
-            err,
-            DurableContentValidationError::ContentChecksumUnverifiable { .. }
-        ));
-        assert_eq!(store.count(OperationClass::Read), 0);
+            .expect("open stream");
+        stream.fold_resumed_prefix(&bytes[..held]);
+        let mut fetched = Vec::new();
+        while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
+            fetched.extend_from_slice(&chunk);
+        }
+        assert_eq!(fetched, bytes[held..]);
+        assert_eq!(
+            store.count(OperationClass::Read),
+            1,
+            "one chunk was left to fetch, so one ranged read happened"
+        );
+
+        // The prefix is part of the verdict here too: wrong bytes below the
+        // resume point fail the whole read.
+        let mut wrong = open_stream_at(&store, &content_store_id, &content_ref, held as u64)
+            .await
+            .expect("open stream");
+        wrong.fold_resumed_prefix(&vec![0u8; held]);
+        let verdict = loop {
+            match wrong.next_chunk().await {
+                Ok(Some(_)) => continue,
+                #[allow(clippy::panic, reason = "the failure this test exists to catch")]
+                Ok(None) => panic!("a prefix that is not the object's verified"),
+                Err(error) => break error,
+            }
+        };
+        assert!(
+            matches!(
+                verdict,
+                CoreError::DurableContent(
+                    DurableContentValidationError::ContentChecksumMismatch { .. }
+                )
+            ),
+            "unexpected verdict: {verdict}"
+        );
     }
 
     /// The same evidence the buffered read holds bytes to, folded chunk by

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -9,7 +9,7 @@ use crate::{
     CreateDirectoryOptions, DeleteOptions, InodeId, MaintenanceJobId, MaintenanceStepOptions,
     MoveOptions, NamespaceId, PutFileOptions, RestoreRevisionOptions, RevisionNo, UndeleteOptions,
 };
-use crate::{ChecksumAlgorithm, CommittedChange, FilesystemChange};
+use crate::{CommittedChange, FilesystemChange};
 use crate::{Result, RuntimeError};
 use loonfs_api::{EffectiveLimit, ErrorCode, StorageChecksum};
 use loonfs_core::NamespaceEngine;
@@ -33,20 +33,17 @@ enum StagedPayload<'a> {
 }
 
 impl StagedPayload<'_> {
-    /// Whether the staged bytes produce this checksum. `None` is a refusal
-    /// to answer, never agreement.
+    /// Whether the staged bytes produce this checksum.
+    ///
+    /// `None` is a refusal to answer, never agreement. Held bytes never
+    /// refuse — every algorithm in the vocabulary is one this build can
+    /// recompute — so the only refusal left is a streamed payload being
+    /// asked for a digest nobody folded over it.
     fn matches(&self, expected: &StorageChecksum) -> Option<bool> {
         match self {
-            Self::Bytes(bytes) => expected.matches(bytes),
+            Self::Bytes(bytes) => Some(expected.matches(bytes)),
             Self::Streamed(content_ref) => {
-                let observed = if content_ref.storage_checksum.algorithm == expected.algorithm {
-                    Some(content_ref.storage_checksum.value.as_str())
-                } else if expected.algorithm == ChecksumAlgorithm::Sha256 {
-                    content_ref.whole_file_sha256.as_deref()
-                } else {
-                    None
-                };
-                Some(observed? == expected.value)
+                Some(content_ref.digest_under(expected.algorithm)? == expected.value)
             }
         }
     }
@@ -91,21 +88,12 @@ fn sole_committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
 
 /// Whether the committed reference provably holds the bytes just staged.
 ///
-/// The evidence is the trusted whole-file digest when one exists, and
-/// otherwise the reference's own storage checksum — which for a
-/// provider-assembled multipart object is the only full-object evidence
-/// there is. Only a digest this build can recompute, over bytes that agree,
-/// proves anything: a digest that disagrees and a digest this build cannot
-/// recompute are both unproven, and both leave the conflict standing.
+/// The evidence is whatever the reference holds its own bytes to. Only that
+/// digest, over a staged payload that can answer for it and agrees, proves
+/// anything: a digest that disagrees and a digest the staged payload cannot
+/// answer for are both unproven, and both leave the conflict standing.
 fn staged_matches_committed(staged: &StagedPayload<'_>, content_ref: &ContentRef) -> bool {
-    let evidence = match &content_ref.whole_file_sha256 {
-        Some(digest) => StorageChecksum {
-            algorithm: ChecksumAlgorithm::Sha256,
-            value: digest.clone(),
-        },
-        None => content_ref.storage_checksum.clone(),
-    };
-    staged.matches(&evidence) == Some(true)
+    staged.matches(&content_ref.verifiable_checksum()) == Some(true)
 }
 
 impl FsWriter {
@@ -160,8 +148,8 @@ impl FsWriter {
     /// the commit id actually committed and rebuilding this request's
     /// fingerprint around it: an identical value plus bytes that provably
     /// agree means the operation had already succeeded. Anything else —
-    /// a different path, behavior, guard, message, or payload, or content
-    /// this build cannot compare — surfaces the conflict.
+    /// a different path, behavior, guard, message, or payload — surfaces
+    /// the conflict.
     ///
     /// The freshly staged duplicate object is then referenced by nothing.
     /// That is by design, not a leak: it is a completed upload session's
@@ -286,8 +274,8 @@ impl FsWriter {
     /// separately.
     ///
     /// Nothing weaker counts: every way of failing to prove the two requests
-    /// are the same — including a comparison this build cannot make — leaves
-    /// the original conflict standing, never agreement.
+    /// are the same — including the staged payload having no answer to give
+    /// — leaves the original conflict standing, never agreement.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,
@@ -924,30 +912,49 @@ fn maybe_auto_step_after_publish(
 #[cfg(test)]
 mod tests {
     use super::{staged_matches_committed, StagedPayload};
-    use crate::{ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind};
+    use crate::{ContentId, ContentRef, ContentRefKind};
     use loonfs_api::StorageChecksum;
 
-    /// A reference whose only full-object evidence is a digest this build
-    /// has no implementation for. Nothing mints one today, which is exactly
-    /// why the reconciliation has to say what it does when one arrives.
+    /// A reference whose only full-object evidence is a CRC-32C, as a direct
+    /// transfer to Google Cloud Storage leaves behind.
     fn crc32c_ref(bytes: &[u8]) -> ContentRef {
         ContentRef {
             kind: ContentRefKind::BlobV1,
             content_id: ContentId::generate(),
             size_bytes: bytes.len() as u64,
-            storage_checksum: StorageChecksum {
-                algorithm: ChecksumAlgorithm::Crc32c,
-                value: "0f5c0a1e".to_owned(),
-            },
+            storage_checksum: StorageChecksum::crc32c(bytes),
             whole_file_sha256: None,
         }
     }
 
+    /// A CRC-32C-only commit is reconciled like any other: the staged bytes
+    /// recompute it, so a retry over the same payload proves it did this
+    /// work and a retry over different bytes does not.
     #[test]
-    fn a_digest_this_build_cannot_compare_leaves_the_reuse_conflict_standing() {
+    fn a_crc32c_committed_reference_is_compared_against_the_staged_bytes() {
         let bytes = b"retried payload";
         let committed = crc32c_ref(bytes);
-        let staged = StagedPayload::Bytes(bytes);
+
+        assert!(staged_matches_committed(
+            &StagedPayload::Bytes(bytes),
+            &committed
+        ));
+        assert!(!staged_matches_committed(
+            &StagedPayload::Bytes(b"some other payload"),
+            &committed
+        ));
+    }
+
+    /// A streamed payload is gone by the time the retry asks, so it answers
+    /// only for the digests that were folded over it. Being asked for one
+    /// nobody computed is a refusal, and a refusal leaves the conflict
+    /// standing.
+    #[test]
+    fn a_digest_nobody_folded_over_the_streamed_payload_leaves_the_conflict_standing() {
+        let bytes = b"retried payload";
+        let committed = crc32c_ref(bytes);
+        let hashed = ContentRef::blob_v1(ContentId::generate(), bytes);
+        let staged = StagedPayload::Streamed(&hashed);
 
         assert_eq!(
             staged.matches(&committed.storage_checksum),
@@ -955,6 +962,9 @@ mod tests {
             "the fixture must reach the refusal, not a comparison"
         );
         assert!(!staged_matches_committed(&staged, &committed));
+
+        // The same streamed payload does answer for the digest it folded.
+        assert!(staged_matches_committed(&staged, &hashed));
     }
 
     #[test]

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -240,16 +240,19 @@ field as a decision rather than a hint.
 algorithm is its own field, so the value carries no prefix; provider APIs that
 report base64 are converted at the adapter).
 
-`sha256` and `crc64nvme` both have producers. Every path that moves bytes
+Every algorithm in that list is producible, and the list is closed: an
+algorithm spelling a reader does not know fails to decode rather than
+decoding into a value nothing can recompute. Every path that moves bytes
 through LoonFS hashes them and produces `sha256`. Direct multipart upload
 produces `crc64nvme`: an S3-compatible provider assembles a multipart object
 without any party hashing the whole stream, and the CRC-64/NVME it computes
 over the assembly is the only full-object evidence that will ever exist for
-those bytes. Such a reference therefore carries no `whole_file_sha256`, by
-the provenance rule above, and reads verify it by recomputing that CRC.
-`crc32c` decodes and round-trips with no producer; a reference carrying a
-checksum an implementation cannot recompute must fail its reads rather than
-pass them unverified.
+those bytes. `crc32c` is the full-object checksum Google Cloud Storage
+computes and reports, and is likewise the only evidence for an object
+transferred straight to it. A reference produced either way carries no
+`whole_file_sha256`, by the provenance rule above, and reads verify it by
+recomputing that CRC. A reference carrying a checksum an implementation
+cannot recompute must fail its reads rather than pass them unverified.
 
 Metadata materialization tables include canonical metadata families and
 validated derived families. The canonical families are `inodes`,

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3209,7 +3209,7 @@
       },
       "ChecksumAlgorithm": {
         "type": "string",
-        "description": "Algorithm of a stored full-object checksum.\n\nEvery algorithm here covers the complete object. There is deliberately no\nchecksum-*type* field: full-object coverage is an invariant of this\nformat, established when the object is written, never read back from a\nprovider. (Cloudflare R2 never reports `x-amz-checksum-type` at all, so a\ntype read back would be unavailable exactly where it would matter.)\n\n[`ChecksumAlgorithm::Sha256`] and [`ChecksumAlgorithm::Crc64nvme`] both\nhave producers: every path that moves bytes through LoonFS hashes them,\nand direct multipart upload carries the CRC-64/NVME the S3-compatible\nproviders compute over the assembled object. `Crc32c` decodes and\nround-trips without a producer.",
+        "description": "Algorithm of a stored full-object checksum.\n\nEvery algorithm here covers the complete object. There is deliberately no\nchecksum-*type* field: full-object coverage is an invariant of this\nformat, established when the object is written, never read back from a\nprovider. (Cloudflare R2 never reports `x-amz-checksum-type` at all, so a\ntype read back would be unavailable exactly where it would matter.)\n\nEvery algorithm here is producible by this build, and the vocabulary is\nclosed: an algorithm spelling this build does not know fails to decode\nrather than decoding into a value nothing can recompute. So a\n`ChecksumAlgorithm` in hand always names evidence that can be checked,\nand the read, retry, and resume paths never have to carry a \"cannot\ntell\" answer. Adding a variant is therefore adding a producer for it.",
         "enum": [
           "sha256",
           "crc64nvme",


### PR DESCRIPTION
This PR is part 1 of 3 of the GCS direct-transfer project.

Adds `StorageChecksum::crc32c`, a streaming `Crc32c` option, cross-checked against an independent implementation before pinning. Zero new dependencies: the crc32c crate was already a direct dependency of the api crate for durable block checksums, and the lockfile is unchanged.

