### PR TITLE
feat(gcs): native signed direct transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,7 @@ dependencies = [
  "http-body",
  "loonfs-api",
  "object_store",
+ "ring",
  "serde",
  "serde_json",
  "sha2",
@@ -1338,6 +1339,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
+ "base64",
  "bytes",
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ rcgen = { version = "0.14", default-features = false, features = ["crypto", "rin
 regex = { version = "1.11", default-features = false, features = ["std", "perf"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "stream"] }
 regex-syntax = "0.8"
+# Already in the tree beneath rustls and rcgen. Named directly because the GCS
+# presigner signs `GOOG4-RSA-SHA256` with an RSA key, which the hash and MAC
+# crates this workspace already carries cannot do.
+ring = "0.17"
 # `ring`, not the crate default `aws-lc-rs`: the rustls stack is already in
 # the tree as a transitive dependency built on ring, and the default provider
 # would pull a second, native-toolchain crypto backend in beside it.

--- a/configs/loonfs-server.gcp-gcs.example.toml
+++ b/configs/loonfs-server.gcp-gcs.example.toml
@@ -16,5 +16,10 @@ writer_id = "loonfs-server-gcp"
 [store]
 kind = "gcp-gcs"
 bucket = "your-bucket"
+# The provider client authenticates with this key, and its RSA private key
+# also signs the direct upload and download URLs handed to clients. The
+# service account therefore needs object read and create rights on the
+# bucket, plus the ability to sign — which for a downloaded service-account
+# key it has by holding the key. Startup fails if the file cannot sign.
 service_account_key_path = "/path/to/service-account.json"
 key_prefix = "loonfs-demo"

--- a/crates/loonfs-objectstore/Cargo.toml
+++ b/crates/loonfs-objectstore/Cargo.toml
@@ -17,6 +17,7 @@ http.workspace = true
 http-body.workspace = true
 loonfs-api.workspace = true
 object_store.workspace = true
+ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 hmac.workspace = true

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -6,8 +6,8 @@ use crate::gcs::{GcpGcsStore, GcpGcsStoreConfig};
 use crate::local_fs_store::LocalFsStore;
 use crate::object_store::{Result, SharedObjectStore};
 use crate::presign::{
-    DirectTransferIssuers, S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES,
-    CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
+    DirectTransferIssuers, GcsPresignerConfig, GcsV4Presigner, S3CompatiblePresigner,
+    S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES, CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
 };
 use crate::s3_compatible::{AwsS3StoreConfig, CloudflareR2StoreConfig, S3CompatibleStore};
 use http::Uri;
@@ -146,14 +146,27 @@ impl ConfiguredObjectStore {
         })
     }
 
-    /// Builds a native GCS store without direct-transfer issuance.
+    /// Builds a native GCS store, and the reads and whole-object writes it
+    /// can authorize.
+    ///
+    /// GCS has no S3-style multipart API, so the bundle's multipart slot stays
+    /// empty rather than holding a signer that would fail. It needs no
+    /// endpoint-trust decision either: the configuration carries no endpoint
+    /// override, so every capability is `https` to Google's own host.
     ///
     /// Construction fails when credentials, provider runtime, or key-prefix configuration is invalid.
     pub fn gcp_gcs(config: GcpGcsStoreConfig) -> Result<Self> {
+        let presigner = Arc::new(GcsV4Presigner::new(GcsPresignerConfig {
+            bucket: config.bucket.clone(),
+            service_account_key_path: config.service_account_key_path.clone(),
+            key_prefix: config.key_prefix.clone(),
+        })?);
         let store = GcpGcsStore::new(config)?;
         Ok(Self {
             inner: Arc::new(store),
-            direct_transfers: None,
+            direct_transfers: Some(
+                DirectTransferIssuers::read_only(presigner.clone()).with_put(presigner),
+            ),
         })
     }
 
@@ -244,14 +257,17 @@ mod tests {
     use crate::presign::{
         DirectTransferIssuers, PresignedPutRequest, S3CompatiblePresigner, S3PresignerConfig,
         AWS_S3_MAX_DIRECT_PUT_BYTES, CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
+        GCP_GCS_MAX_DIRECT_PUT_BYTES,
     };
     use crate::s3_compatible::{AwsS3StoreConfig, CloudflareR2StoreConfig};
+    use crate::test_support::gcs_fixture_service_account_key_file;
     use crate::ObjectStore;
     use crate::ObjectStoreError;
     use bytes::Bytes;
     use loonfs_api::ChecksumAlgorithm;
     use loonfs_api::ContentId;
     use loonfs_api::ContentRef;
+    use loonfs_api::StorageChecksum;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -259,7 +275,6 @@ mod tests {
 
     const AZURITE_ACCOUNT_KEY: &str =
         "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
-    const FAKE_GCS_SERVICE_ACCOUNT_KEY: &str = r#"{"private_key":"private_key","private_key_id":"private_key_id","client_email":"client_email","disable_oauth":true}"#;
 
     #[tokio::test]
     async fn configured_local_fs_scopes_optional_key_prefix() {
@@ -287,6 +302,66 @@ mod tests {
                 .expect("list scoped prefix"),
             vec![head_key]
         );
+    }
+
+    /// GCS signs its own scheme, so its bundle carries reads and whole-object
+    /// writes; it has no S3-style multipart API, so that slot stays empty.
+    /// The checksum and the ceiling come from the issuer, which is the only
+    /// thing that knows them.
+    #[test]
+    fn gcs_signs_puts_and_gets_and_offers_no_multipart() {
+        let transfers = gcs_store()
+            .direct_transfers()
+            .expect("gcs signs its native scheme");
+        let put = transfers.put.expect("gcs signs whole-object writes");
+
+        assert!(
+            transfers.multipart.is_none(),
+            "GCS has no S3-style multipart API, which is spelled as an absent signer"
+        );
+        assert_eq!(put.checksum_algorithm(), ChecksumAlgorithm::Crc32c);
+        assert_eq!(put.max_content_bytes(), GCP_GCS_MAX_DIRECT_PUT_BYTES);
+    }
+
+    /// The write GCS authorizes is addressed beneath the configured prefix and
+    /// carries the create-only precondition and the checksum in its
+    /// signature, exactly as the S3-compatible bundle's does.
+    #[test]
+    fn the_gcs_bundle_signs_native_generation_preconditions() {
+        let issuer = gcs_store()
+            .direct_transfers()
+            .and_then(|transfers| transfers.put)
+            .expect("gcs presigner");
+
+        let signed = issuer
+            .presign_put(
+                PresignedPutRequest {
+                    object_key:
+                        "content-stores/cs/objects/01/23/con_0123456789abcdef0123456789abcdef",
+                    content_ref: &crc32c_content_ref(),
+                    expires_in: Duration::from_secs(900),
+                },
+                UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+            )
+            .expect("presign");
+
+        assert!(signed
+            .url
+            .starts_with("https://storage.googleapis.com/bucket/tenant-a/content-stores/"));
+        assert_eq!(
+            signed
+                .headers
+                .get("x-goog-if-generation-match")
+                .map(String::as_str),
+            Some("0")
+        );
+        assert!(signed
+            .headers
+            .get("x-goog-hash")
+            .is_some_and(|value| value.starts_with("crc32c=")));
+        // The S3 family's spellings never appear on a native GCS capability.
+        assert!(!signed.headers.contains_key("if-none-match"));
+        assert!(!signed.url.contains("X-Amz-"));
     }
 
     /// Only a provider that can presign, on an endpoint the live conformance
@@ -318,15 +393,9 @@ mod tests {
             .direct_transfers()
             .is_none());
 
-        let gcs_service_account_key_path =
-            fake_gcs_service_account_key_file("configured-store-gcs-kind");
-        let gcs = ConfiguredObjectStore::gcp_gcs(GcpGcsStoreConfig {
-            bucket: "bucket".to_owned(),
-            service_account_key_path: gcs_service_account_key_path.display().to_string(),
-            key_prefix: Some("tenant-a".to_owned()),
-        })
-        .expect("construct gcs store");
-        assert!(gcs.direct_transfers().is_none());
+        // GCS is proven by construction: its configuration carries no
+        // endpoint override, so there is no unproven endpoint to reach.
+        assert!(gcs_store().direct_transfers().is_some());
 
         let azure = ConfiguredObjectStore::azure_abs(AzureAbsStoreConfig {
             account_name: "devstoreaccount1".to_owned(),
@@ -422,6 +491,26 @@ mod tests {
         .expect("construct s3 store")
     }
 
+    fn gcs_store() -> ConfiguredObjectStore {
+        ConfiguredObjectStore::gcp_gcs(GcpGcsStoreConfig {
+            bucket: "bucket".to_owned(),
+            service_account_key_path: gcs_fixture_service_account_key_file("configured-store-gcs")
+                .display()
+                .to_string(),
+            key_prefix: Some("tenant-a".to_owned()),
+        })
+        .expect("construct gcs store")
+    }
+
+    /// A reference whose storage checksum is the CRC-32C GCS enforces.
+    fn crc32c_content_ref() -> ContentRef {
+        ContentRef {
+            storage_checksum: StorageChecksum::crc32c(b"hello"),
+            whole_file_sha256: None,
+            ..ContentRef::blob_v1(ContentId::generate(), b"hello")
+        }
+    }
+
     fn r2_store(endpoint_url: &str) -> ConfiguredObjectStore {
         ConfiguredObjectStore::cloudflare_r2(CloudflareR2StoreConfig {
             bucket: "bucket".to_owned(),
@@ -512,12 +601,6 @@ mod tests {
             .as_nanos();
         let path = std::env::temp_dir().join(format!("loonfs-objectstore-{label}-{stamp}"));
         fs::create_dir_all(&path).expect("create temp dir");
-        path
-    }
-
-    fn fake_gcs_service_account_key_file(label: &str) -> PathBuf {
-        let path = unique_temp_dir(label).join("service-account.json");
-        fs::write(&path, FAKE_GCS_SERVICE_ACCOUNT_KEY).expect("write fake service account key");
         path
     }
 }

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -2,13 +2,24 @@
 
 use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::object_store::Result;
+use crate::presign::{stored_crc32c, GcsPresignerConfig, GcsV4Presigner, PresignedUrl};
 use crate::store_io_runtime::StoreIoRuntime;
-use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
+use crate::{
+    ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig, StoredObjectChecksum,
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use loonfs_api::StorageChecksum;
+use object_store::client::{HttpClient, HttpConnector, HttpRequestBody};
 use object_store::gcp::GoogleCloudStorageBuilder;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+/// Lifetime of the internally signed request used for checksum readback. It
+/// is issued immediately and never handed out, so it only needs to outlive
+/// one round trip and its clock skew.
+const CHECKSUM_HEAD_TTL: Duration = Duration::from_secs(60);
 
 /// Supplies explicit credentials and key scoping for the native Google Cloud Storage adapter.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,6 +42,14 @@ pub struct GcpGcsStoreConfig {
 #[derive(Debug)]
 pub struct GcpGcsStore {
     inner: ProviderObjectStore,
+    /// Signs the one request the provider client cannot express: the metadata
+    /// read that reports an object's stored CRC-32C back. The V4 signer this
+    /// crate already owns for direct-transfer URLs expresses it, so the store
+    /// needs no second credential path.
+    request_signer: GcsV4Presigner,
+    /// Sends that signed request over the store's own IO runtime and timeout
+    /// scheme, exactly like every provider-client request.
+    http: HttpClient,
     /// Keeps the HTTP IO runtime alive for the provider client's lifetime;
     /// the connector inside the client holds only a handle onto it.
     _io_runtime: StoreIoRuntime,
@@ -53,7 +72,17 @@ impl GcpGcsStore {
             ));
         }
 
+        let request_signer = GcsV4Presigner::new(GcsPresignerConfig {
+            bucket: config.bucket.clone(),
+            service_account_key_path: config.service_account_key_path.clone(),
+            key_prefix: config.key_prefix.clone(),
+        })?;
+
         let io_runtime = StoreIoRuntime::new()?;
+        let http = io_runtime
+            .connector()
+            .connect(&crate::provider_object_store::provider_client_options())
+            .map_err(|err| ObjectStoreError::Configuration(err.to_string()))?;
         let builder = GoogleCloudStorageBuilder::new()
             .with_http_connector(io_runtime.connector())
             .with_client_options(crate::provider_object_store::provider_client_options())
@@ -76,8 +105,44 @@ impl GcpGcsStore {
 
         Ok(Self {
             inner,
+            request_signer,
+            http,
             _io_runtime: io_runtime,
         })
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    fn signing_time() -> SystemTime {
+        // A V4 signature is dated, so this internally issued request enters
+        // wall time here. Nothing durable is derived from it.
+        SystemTime::now()
+    }
+
+    /// Issues one internally signed request and returns its status and headers.
+    ///
+    /// The metadata read this serves carries no body in either direction, so
+    /// it lands on the store's own HTTP client, runtime, and timeouts without
+    /// reading one.
+    async fn execute_signed(&self, key: &str, signed: PresignedUrl) -> Result<http::Response<()>> {
+        let mut builder = http::Request::builder()
+            .method(signed.method.as_str())
+            .uri(&signed.url);
+        for (name, value) in &signed.headers {
+            builder = builder.header(name, value);
+        }
+        let request = builder
+            .body(HttpRequestBody::empty())
+            .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
+        let response = self
+            .http
+            .execute(request)
+            .await
+            .map_err(|err| ObjectStoreError::transport(key, err.to_string()))?;
+
+        let mut parts = http::Response::new(());
+        *parts.status_mut() = response.status();
+        *parts.headers_mut() = response.headers().clone();
+        Ok(parts)
     }
 
     fn generation_as_compare_token(metadata: ObjectMetadata) -> ObjectMetadata {
@@ -105,6 +170,65 @@ impl ObjectStore for GcpGcsStore {
             .head(key)
             .await?
             .map(Self::generation_as_compare_token))
+    }
+
+    /// Reads size and the stored CRC-32C back from one signed metadata
+    /// request.
+    ///
+    /// GCS reports the stored checksum in `x-goog-hash` on an ordinary object
+    /// request, so this is a `HEAD` and nothing more. The provider client
+    /// surfaces neither that header nor any other checksum, which is why the
+    /// request is signed here rather than asked of the client.
+    ///
+    /// An object GCS acknowledges but reports no usable CRC-32C for is an
+    /// error, never a size-only answer: completion compares a stored checksum
+    /// against a promised one, and there is nothing to compare.
+    async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
+        let signed = self.request_signer.presign_head_stored_checksum(
+            key,
+            CHECKSUM_HEAD_TTL,
+            Self::signing_time(),
+        )?;
+        let response = self.execute_signed(key, signed).await?;
+
+        let status = response.status();
+        if status == http::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if status == http::StatusCode::FORBIDDEN || status == http::StatusCode::UNAUTHORIZED {
+            return Err(ObjectStoreError::PermissionDenied {
+                object_key: key.to_owned(),
+                message: format!("provider refused the checksum head with {status}"),
+            });
+        }
+        if !status.is_success() {
+            // A HEAD carries no body to quote, so the status is the whole
+            // diagnostic the provider gives us.
+            return Err(ObjectStoreError::transport(
+                key,
+                format!("checksum head failed with {status}"),
+            ));
+        }
+
+        let headers = response.headers();
+        let storage_checksum = stored_crc32c_from_headers(headers).ok_or_else(|| {
+            ObjectStoreError::transport(
+                key,
+                "provider reported no crc32c for this object".to_owned(),
+            )
+        })?;
+        let size_bytes = headers
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok())
+            .ok_or_else(|| {
+                ObjectStoreError::transport(key, "checksum head reported no content length")
+            })?;
+
+        Ok(Some(StoredObjectChecksum {
+            size_bytes,
+            storage_checksum,
+        }))
     }
 
     async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>> {
@@ -141,20 +265,31 @@ impl ObjectStore for GcpGcsStore {
     }
 }
 
+/// Finds the stored CRC-32C among a metadata response's hash headers.
+///
+/// GCS reports its hashes either as one comma-joined `x-goog-hash` value or
+/// as a header line per algorithm, and promises no order between them. Every
+/// value is searched, so which spelling arrives cannot decide whether the
+/// checksum is found — reading only the first header line would miss a
+/// crc32c that happened to follow an md5.
+fn stored_crc32c_from_headers(headers: &http::HeaderMap) -> Option<StorageChecksum> {
+    headers
+        .get_all("x-goog-hash")
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .find_map(stored_crc32c)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{GcpGcsStore, GcpGcsStoreConfig};
+    use super::{stored_crc32c_from_headers, GcpGcsStore, GcpGcsStoreConfig};
+    use crate::test_support::gcs_fixture_service_account_key_file;
     use crate::{ObjectStore, ObjectStoreError};
     use bytes::Bytes;
-    use std::fs;
-    use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    const FAKE_SERVICE_ACCOUNT_KEY: &str = r#"{"private_key":"private_key","private_key_id":"private_key_id","client_email":"client_email","disable_oauth":true}"#;
 
     #[tokio::test]
     async fn invalid_keys_are_rejected_before_generation_tokens() {
-        let service_account_key_path = fake_service_account_key_file("gcs-invalid-key");
+        let service_account_key_path = gcs_fixture_service_account_key_file("gcs-invalid-key");
         let store = GcpGcsStore::new(GcpGcsStoreConfig {
             bucket: "bucket".to_owned(),
             service_account_key_path: service_account_key_path.display().to_string(),
@@ -182,20 +317,71 @@ mod tests {
         ));
     }
 
-    fn fake_service_account_key_file(label: &str) -> PathBuf {
-        let path = unique_temp_dir(label).join("service-account.json");
-        fs::write(&path, FAKE_SERVICE_ACCOUNT_KEY).expect("write fake service account key");
-        path
+    /// The store signs its own checksum readback, so a key that cannot sign
+    /// stops the store from being built at all rather than surfacing as a
+    /// failure on the first completion.
+    #[test]
+    fn a_service_account_key_that_cannot_sign_stops_the_store_from_being_built() {
+        let dir = gcs_fixture_service_account_key_file("gcs-unsignable")
+            .parent()
+            .expect("fixture dir")
+            .to_path_buf();
+        let unsignable = dir.join("unsignable.json");
+        std::fs::write(
+            &unsignable,
+            br#"{"client_email":"a@b.iam.gserviceaccount.com","private_key":"private_key","disable_oauth":true}"#,
+        )
+        .expect("write unsignable service account key");
+
+        assert!(matches!(
+            GcpGcsStore::new(GcpGcsStoreConfig {
+                bucket: "bucket".to_owned(),
+                service_account_key_path: unsignable.display().to_string(),
+                key_prefix: None,
+            }),
+            Err(ObjectStoreError::Configuration(_))
+        ));
     }
 
-    #[allow(clippy::disallowed_methods)]
-    fn unique_temp_dir(label: &str) -> PathBuf {
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock after epoch")
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!("loonfs-objectstore-{label}-{stamp}"));
-        fs::create_dir_all(&path).expect("create temp dir");
-        path
+    /// GCS spells its hash report two ways and orders it however it likes, so
+    /// the readback finds the crc32c in each of them. Reading only the first
+    /// header line would complete an upload on an md5 it cannot check, or
+    /// fail one whose crc32c was simply second.
+    #[test]
+    fn the_stored_crc32c_is_found_however_gcs_spells_its_hash_header() {
+        let crc32c_of_hello = "9a71bb4c";
+        let md5 = "md5=XUFAKrxLKna5cZ2REBfFkg==";
+        let crc32c = "crc32c=mnG7TA==";
+
+        for values in [
+            vec![crc32c],
+            vec![&format!("{md5},{crc32c}")],
+            vec![&format!("{crc32c},{md5}")],
+            // A header line per algorithm, with the crc32c second.
+            vec![md5, crc32c],
+            vec![crc32c, md5],
+        ] {
+            let mut headers = http::HeaderMap::new();
+            for value in &values {
+                headers.append(
+                    "x-goog-hash",
+                    http::HeaderValue::from_str(value).expect("header value"),
+                );
+            }
+            assert_eq!(
+                stored_crc32c_from_headers(&headers).map(|checksum| checksum.value),
+                Some(crc32c_of_hello.to_owned()),
+                "crc32c not found in {values:?}"
+            );
+        }
+
+        // An object GCS describes without a crc32c is described without one.
+        let mut md5_only = http::HeaderMap::new();
+        md5_only.append(
+            "x-goog-hash",
+            http::HeaderValue::from_static("md5=XUFAKrxLKna5cZ2REBfFkg=="),
+        );
+        assert_eq!(stored_crc32c_from_headers(&md5_only), None);
+        assert_eq!(stored_crc32c_from_headers(&http::HeaderMap::new()), None);
     }
 }

--- a/crates/loonfs-objectstore/src/presign/gcs.rs
+++ b/crates/loonfs-objectstore/src/presign/gcs.rs
@@ -1,0 +1,817 @@
+//! Presigner for Google Cloud Storage's native V4 signed URLs.
+//!
+//! GCS's S3-interoperability surface is not an option here: live conformance
+//! proved it silently ignores preconditions (see [`GcpGcsStore`]). Its native
+//! XML API conditions on object generations and validates CRC-32C, and this
+//! module signs that API directly with `GOOG4-RSA-SHA256`.
+//!
+//! [`GcpGcsStore`]: crate::gcs::GcpGcsStore
+
+use super::{
+    DirectGetIssuer, DirectPutIssuer, PresignedGetRequest, PresignedPutRequest, PresignedUrl,
+};
+use crate::keyspace::scope_object_key;
+use crate::object_store::Result;
+use crate::presign::v4::{
+    canonical_query_string, hex_lower, normalize_header_value, percent_encode_path,
+    percent_encode_segment, signing_dates, unix_ms,
+};
+use crate::ObjectStoreError;
+use base64::Engine as _;
+use loonfs_api::wire::hex::{hex_decode_bytes, hex_encode_bytes};
+use loonfs_api::{ChecksumAlgorithm, ContentRef, ContentRefKind, StorageChecksum};
+use ring::rand::SystemRandom;
+use ring::signature::{RsaKeyPair, RSA_PKCS1_SHA256};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fmt::Write as _;
+use std::time::{Duration, SystemTime};
+
+/// Google's own signed-URL host, and the only one this module addresses.
+///
+/// The GCS store configuration carries no endpoint override, so the endpoint
+/// trust rule that gates the S3-compatible providers has nothing to decide
+/// here: every capability this module issues is `https` to Google.
+const GCS_HOST: &str = "storage.googleapis.com";
+
+/// Create-only precondition. A generation of zero means "only if the object
+/// does not currently exist", which is GCS's spelling of the guarantee the
+/// S3 family gets from `if-none-match: *`.
+const GCS_GENERATION_MATCH_HEADER: &str = "x-goog-if-generation-match";
+const GCS_CREATE_ONLY_GENERATION: &str = "0";
+
+/// Carries a checksum GCS validates the uploaded body against on a write, and
+/// reports the stored one back on a read.
+const GCS_HASH_HEADER: &str = "x-goog-hash";
+
+/// The signing scheme, written into both the algorithm query parameter and
+/// the first line of the string to sign.
+const GCS_SIGNING_ALGORITHM: &str = "GOOG4-RSA-SHA256";
+
+/// The credential scope's location and terminator. GCS accepts `auto` for the
+/// location rather than requiring the bucket's region, which is what Google's
+/// own client libraries write, so a deployment never has to configure one.
+const GCS_CREDENTIAL_SCOPE_SUFFIX: &str = "auto/storage/goog4_request";
+
+/// Google's documented ceiling for a signed URL's lifetime: seven days.
+const MAX_PRESIGN_EXPIRY: u64 = 7 * 24 * 60 * 60;
+
+/// Google Cloud Storage's documented maximum for a single-request upload:
+/// 5 TiB.
+///
+/// Cloud Storage documents one object-size maximum and no separate
+/// single-request one -- Cloud Storage, "Object uploads": you can upload and
+/// store any MIME type of data up to 5 TiB in size, and a single-request
+/// upload is described there as a PUT whose body is the whole object. The
+/// object ceiling is therefore the request ceiling.
+///
+/// This is three orders of magnitude above the S3 family's 5 GiB single-PUT
+/// ceiling, and it is why GCS needs no multipart path to carry a large
+/// object: there is no size at which a whole-object write stops being
+/// expressible.
+pub const GCP_GCS_MAX_DIRECT_PUT_BYTES: u64 = 5 * 1024 * 1024 * 1024 * 1024;
+
+/// Supplies the service-account key and key scoping for native GCS signed URLs.
+///
+/// The key path is the one the GCS store already loads to authenticate its
+/// provider client; signing reads the same file rather than asking an
+/// operator for a second credential.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcsPresignerConfig {
+    /// Bucket incorporated into the signed request target.
+    pub bucket: String,
+    /// Filesystem path to the service-account JSON whose private key signs.
+    pub service_account_key_path: String,
+    /// Logical prefix prepended before the object key is encoded and signed.
+    pub key_prefix: Option<String>,
+}
+
+/// Issues checksum-bound, create-only `GOOG4-RSA-SHA256` capabilities for
+/// Google Cloud Storage.
+pub struct GcsV4Presigner {
+    bucket: String,
+    key_prefix: Option<String>,
+    /// The service account named in the credential parameter, which is also
+    /// the identity GCS resolves the signing key from.
+    client_email: String,
+    signing_key: RsaKeyPair,
+}
+
+/// The two fields of a service-account JSON this module needs. Every other
+/// field is ignored rather than rejected: the file is Google's, and its shape
+/// is theirs to extend.
+#[derive(serde::Deserialize)]
+struct ServiceAccountKey {
+    client_email: String,
+    private_key: String,
+}
+
+impl fmt::Debug for GcsV4Presigner {
+    /// Renders no key material and no service-account identity. A signing key
+    /// is a bearer credential for the whole bucket, so nothing about it
+    /// reaches a log through a `Debug` of the store that holds it.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GcsV4Presigner")
+            .field("bucket", &self.bucket)
+            .field("key_prefix", &self.key_prefix)
+            .field("client_email", &"<redacted>")
+            .field("signing_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl GcsV4Presigner {
+    /// Creates a presigner, reading and parsing the service-account key once.
+    ///
+    /// Construction fails for a blank bucket or key path, an unreadable or
+    /// malformed key file, or a private key that is not an RSA key in PKCS#8
+    /// form. Failing here is deliberate: a GCS deployment whose key cannot
+    /// sign also cannot authenticate its provider client, so the fault
+    /// belongs at startup rather than at the first transfer.
+    pub fn new(config: GcsPresignerConfig) -> Result<Self> {
+        if config.bucket.trim().is_empty() {
+            return Err(ObjectStoreError::Configuration(
+                "bucket must not be empty".to_owned(),
+            ));
+        }
+        if config.service_account_key_path.trim().is_empty() {
+            return Err(ObjectStoreError::Configuration(
+                "service account key path must not be empty".to_owned(),
+            ));
+        }
+
+        let raw = std::fs::read(&config.service_account_key_path).map_err(|err| {
+            ObjectStoreError::Configuration(format!("service account key is unreadable: {err}"))
+        })?;
+        // The parse error is not quoted: a malformed key file's contents are
+        // key material as often as not.
+        let key: ServiceAccountKey = serde_json::from_slice(&raw).map_err(|_| {
+            ObjectStoreError::Configuration(
+                "service account key must be JSON carrying `client_email` and `private_key`"
+                    .to_owned(),
+            )
+        })?;
+        if key.client_email.trim().is_empty() {
+            return Err(ObjectStoreError::Configuration(
+                "service account key must name a client_email".to_owned(),
+            ));
+        }
+
+        let der = pkcs8_der(&key.private_key)?;
+        let signing_key = RsaKeyPair::from_pkcs8(&der).map_err(|_| {
+            ObjectStoreError::Configuration(
+                "service account private key must be an RSA key in PKCS#8 form".to_owned(),
+            )
+        })?;
+
+        Ok(Self {
+            bucket: config.bucket,
+            key_prefix: config.key_prefix,
+            client_email: key.client_email,
+            signing_key,
+        })
+    }
+
+    /// Signs a `HEAD` that reads an object's size and stored checksum back.
+    ///
+    /// GCS reports the stored CRC-32C in the `x-goog-hash` response header of
+    /// an ordinary object request, so no special request header is needed to
+    /// ask for it and the capability signs `host` alone.
+    pub(crate) fn presign_head_stored_checksum(
+        &self,
+        object_key: &str,
+        expires_in: Duration,
+        now: SystemTime,
+    ) -> Result<PresignedUrl> {
+        self.presign("HEAD", object_key, BTreeMap::new(), expires_in, now)
+    }
+
+    fn presign(
+        &self,
+        method: &str,
+        object_key: &str,
+        required_headers: BTreeMap<String, String>,
+        expires_in: Duration,
+        now: SystemTime,
+    ) -> Result<PresignedUrl> {
+        // Expiry comes from deployment configuration, not the transport: a
+        // bad value is a config bug and must not look like network weather.
+        if expires_in.is_zero() {
+            return Err(ObjectStoreError::Configuration(
+                "presigned URL expiry must be greater than zero".to_owned(),
+            ));
+        }
+        if expires_in.as_secs() > MAX_PRESIGN_EXPIRY {
+            return Err(ObjectStoreError::Configuration(format!(
+                "presigned URL expiry must not exceed {MAX_PRESIGN_EXPIRY} seconds"
+            )));
+        }
+
+        let scoped_key = scope_object_key(self.key_prefix.as_deref(), object_key)?;
+        let canonical_uri = format!(
+            "/{}/{}",
+            percent_encode_segment(&self.bucket),
+            percent_encode_path(&scoped_key)
+        );
+        let dates = signing_dates(object_key, now)?;
+        let credential_scope = format!("{}/{GCS_CREDENTIAL_SCOPE_SUFFIX}", dates.short_date);
+
+        let mut headers_to_sign = BTreeMap::from([("host".to_owned(), GCS_HOST.to_owned())]);
+        for (name, value) in &required_headers {
+            headers_to_sign.insert(name.to_ascii_lowercase(), normalize_header_value(value));
+        }
+        let signed_headers = headers_to_sign
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(";");
+        let mut canonical_headers = String::new();
+        for (name, value) in &headers_to_sign {
+            writeln!(&mut canonical_headers, "{name}:{value}")
+                .expect("writing to String cannot fail");
+        }
+
+        let query = BTreeMap::from([
+            (
+                "X-Goog-Algorithm".to_owned(),
+                GCS_SIGNING_ALGORITHM.to_owned(),
+            ),
+            (
+                "X-Goog-Credential".to_owned(),
+                format!("{}/{credential_scope}", self.client_email),
+            ),
+            ("X-Goog-Date".to_owned(), dates.timestamp.clone()),
+            (
+                "X-Goog-Expires".to_owned(),
+                expires_in.as_secs().to_string(),
+            ),
+            ("X-Goog-SignedHeaders".to_owned(), signed_headers.clone()),
+        ]);
+        let canonical_query = canonical_query_string(&query);
+        let canonical_request = format!(
+            "{method}\n{canonical_uri}\n{canonical_query}\n{canonical_headers}\n{signed_headers}\nUNSIGNED-PAYLOAD"
+        );
+        let string_to_sign = format!(
+            "{GCS_SIGNING_ALGORITHM}\n{}\n{credential_scope}\n{}",
+            dates.timestamp,
+            hex_lower(&Sha256::digest(canonical_request.as_bytes()))
+        );
+        let signature = self.sign(object_key, string_to_sign.as_bytes())?;
+        let url = format!(
+            "https://{GCS_HOST}{canonical_uri}?{canonical_query}&X-Goog-Signature={signature}"
+        );
+        let expires_at_ms = unix_ms(object_key, now)? + expires_in.as_millis() as u64;
+
+        Ok(PresignedUrl {
+            method: method.to_owned(),
+            url,
+            headers: required_headers,
+            expires_at_ms,
+        })
+    }
+
+    /// Produces the hex-encoded RSASSA-PKCS1-v1_5 SHA-256 signature GCS
+    /// verifies against the service account's public key.
+    fn sign(&self, object_key: &str, message: &[u8]) -> Result<String> {
+        let mut signature = vec![0u8; self.signing_key.public().modulus_len()];
+        self.signing_key
+            .sign(
+                &RSA_PKCS1_SHA256,
+                &SystemRandom::new(),
+                message,
+                &mut signature,
+            )
+            .map_err(|_| {
+                ObjectStoreError::transport(
+                    object_key,
+                    "service account key could not sign the request".to_owned(),
+                )
+            })?;
+        Ok(hex_lower(&signature))
+    }
+}
+
+impl DirectPutIssuer for GcsV4Presigner {
+    fn checksum_algorithm(&self) -> ChecksumAlgorithm {
+        // The digest the signed `x-goog-hash` header binds a body to. GCS
+        // validates CRC-32C and MD5 and nothing else, and MD5 is not a
+        // checksum this format names.
+        ChecksumAlgorithm::Crc32c
+    }
+
+    fn max_content_bytes(&self) -> u64 {
+        GCP_GCS_MAX_DIRECT_PUT_BYTES
+    }
+
+    fn presign_put(
+        &self,
+        request: PresignedPutRequest<'_>,
+        now: SystemTime,
+    ) -> Result<PresignedUrl> {
+        let required_headers = BTreeMap::from([
+            (
+                GCS_GENERATION_MATCH_HEADER.to_owned(),
+                GCS_CREATE_ONLY_GENERATION.to_owned(),
+            ),
+            (
+                GCS_HASH_HEADER.to_owned(),
+                gcs_hash_header(request.content_ref)?,
+            ),
+        ]);
+        self.presign(
+            "PUT",
+            request.object_key,
+            required_headers,
+            request.expires_in,
+            now,
+        )
+    }
+}
+
+impl DirectGetIssuer for GcsV4Presigner {
+    fn presign_get(
+        &self,
+        request: PresignedGetRequest<'_>,
+        now: SystemTime,
+    ) -> Result<PresignedUrl> {
+        // No required headers, so `host` is the only name in
+        // `X-Goog-SignedHeaders` and the only line in the canonical headers.
+        // A `Range` the client adds is therefore outside the signature
+        // entirely, and one issued URL serves ranged, resumed, and parallel
+        // reads of the object without another round trip to the server.
+        // Adding a required header here would silently cost that.
+        self.presign(
+            "GET",
+            request.object_key,
+            BTreeMap::new(),
+            request.expires_in,
+            now,
+        )
+    }
+}
+
+/// Builds the complete `x-goog-hash` value the write is signed against.
+///
+/// The whole header rides the signature, not just the digest inside it, so a
+/// client can neither drop the checksum nor swap the algorithm it names.
+fn gcs_hash_header(content_ref: &ContentRef) -> Result<String> {
+    if content_ref.kind != ContentRefKind::BlobV1 {
+        return Err(invalid_direct_put_content(
+            "direct_put only supports blob_v1 content refs",
+        ));
+    }
+    if content_ref.storage_checksum.algorithm != ChecksumAlgorithm::Crc32c {
+        return Err(invalid_direct_put_content(
+            "direct_put on GCS requires a crc32c storage checksum",
+        ));
+    }
+    Ok(format!(
+        "crc32c={}",
+        base64_crc32c(&content_ref.storage_checksum)?
+    ))
+}
+
+/// Converts a CRC-32C from the lowercase hex this format stores into the
+/// big-endian base64 GCS reads and writes.
+///
+/// The two spellings meet here and nowhere else: every layer above holds the
+/// hex form, and the provider's is confined to this adapter.
+fn base64_crc32c(checksum: &StorageChecksum) -> Result<String> {
+    let raw = hex_decode_bytes(&checksum.value)
+        .map_err(|_| invalid_direct_put_content("crc32c must be lowercase hex"))?;
+    if raw.len() != ChecksumAlgorithm::Crc32c.value_bytes() {
+        return Err(invalid_direct_put_content(
+            "crc32c must be 8 hex characters",
+        ));
+    }
+    Ok(base64::engine::general_purpose::STANDARD.encode(raw))
+}
+
+/// Reads the stored CRC-32C out of a GCS `x-goog-hash` header value.
+///
+/// The header lists one or more `<algorithm>=<base64>` pairs in an
+/// unspecified order and may carry algorithms this format does not name, so
+/// the CRC-32C is selected rather than positioned. An absent or unusable
+/// crc32c answers `None`, and the caller treats that as a failure: an object
+/// GCS will not describe is never completed on its size alone.
+pub(crate) fn stored_crc32c(header_value: &str) -> Option<StorageChecksum> {
+    for pair in header_value.split(',') {
+        let Some(encoded) = pair.trim().strip_prefix("crc32c=") else {
+            continue;
+        };
+        let Ok(raw) = base64::engine::general_purpose::STANDARD.decode(encoded) else {
+            continue;
+        };
+        if raw.len() != ChecksumAlgorithm::Crc32c.value_bytes() {
+            continue;
+        }
+        return Some(StorageChecksum {
+            algorithm: ChecksumAlgorithm::Crc32c,
+            value: hex_encode_bytes(&raw),
+        });
+    }
+    None
+}
+
+/// Decodes a PEM-wrapped PKCS#8 private key into DER.
+///
+/// Service-account JSON carries the key as a PEM block with escaped
+/// newlines, which JSON decoding has already turned back into real ones.
+fn pkcs8_der(private_key_pem: &str) -> Result<Vec<u8>> {
+    const BEGIN: &str = "-----BEGIN PRIVATE KEY-----";
+    const END: &str = "-----END PRIVATE KEY-----";
+
+    let body = private_key_pem
+        .trim()
+        .strip_prefix(BEGIN)
+        .and_then(|rest| rest.trim_end().strip_suffix(END))
+        .ok_or_else(|| {
+            ObjectStoreError::Configuration(
+                "service account private key must be a PKCS#8 PEM block".to_owned(),
+            )
+        })?;
+    let base64_body: String = body.split_whitespace().collect();
+    base64::engine::general_purpose::STANDARD
+        .decode(base64_body)
+        .map_err(|_| {
+            ObjectStoreError::Configuration(
+                "service account private key is not valid base64".to_owned(),
+            )
+        })
+}
+
+fn invalid_direct_put_content(message: &str) -> ObjectStoreError {
+    ObjectStoreError::InvalidContentRef(message.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{stored_crc32c, GcsPresignerConfig, GcsV4Presigner, GCP_GCS_MAX_DIRECT_PUT_BYTES};
+    use crate::presign::{
+        DirectGetIssuer, DirectPutIssuer, PresignedGetRequest, PresignedPutRequest,
+    };
+    use crate::test_support::{gcs_fixture_service_account_key_file, GCS_FIXTURE_CLIENT_EMAIL};
+    use crate::ObjectStoreError;
+    use loonfs_api::{ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind, StorageChecksum};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    const CONTENT_KEY: &str =
+        "content-stores/cs/objects/01/23/con_0123456789abcdef0123456789abcdef";
+    /// 2023-11-14T22:13:20Z, the instant every expected signature below was
+    /// produced at.
+    const SIGNING_EPOCH_SECS: u64 = 1_700_000_000;
+    const EXPIRES_IN: Duration = Duration::from_secs(900);
+    /// CRC-32C of `b"hello"`, in the lowercase hex this format stores and in
+    /// the big-endian base64 GCS reads.
+    const HELLO_CRC32C_HEX: &str = "9a71bb4c";
+    const HELLO_CRC32C_BASE64: &str = "mnG7TA==";
+
+    /// The query prefix every expected URL shares: the algorithm, the
+    /// credential scope, and the request timestamp.
+    const EXPECTED_CREDENTIAL: &str = "X-Goog-Algorithm=GOOG4-RSA-SHA256\
+         &X-Goog-Credential=loonfs-presign-fixture%40loonfs-tests.iam.gserviceaccount.com\
+         %2F20231114%2Fauto%2Fstorage%2Fgoog4_request\
+         &X-Goog-Date=20231114T221320Z&X-Goog-Expires=900";
+
+    // The expected signatures below were produced by Google's own
+    // `google-cloud-storage` Python client (`generate_signed_url_v4`) against
+    // this fixture key, at a pinned timestamp. They are therefore an
+    // independent implementation's answer, not this module's own output
+    // recorded back: a construction bug here -- a wrong credential scope, a
+    // dropped signed header, a mis-encoded path -- changes the signature and
+    // fails these tests.
+    const PUT_PREFIXED_SIGNATURE: &str = "966829ea3141ec468614f5472381de24f864cd92be0f69d929d53e163dec9d2146f87acfa957f9b9e7e2e598f7ad9b1aaff7a1f456bea1451b487925dbcda72415d38cb40541e964ccd719184d7400b40c268b50ce92ac0c183ade437e0ba4009cff02f683c325f95cccb83ee8836683ce6b7dc473f02e54b928fe63c9b723da8835e414a8d1d14aa235432b1827056f49abf2fde1c927920fd90026b0dc344b0f68198e86acfafa4744708cec4f9899540b7900bfb9e0fb188bedcf8a85f43a7b88d067c2d48cc7f95f8744e84397cc23ec46433fb5e8e9a0bc249f248b92b7a1c6b7797bbccbbd9a4fcb9ee978bef3dd15d215aabf2f8ddc95818a64396f8e";
+    const GET_PREFIXED_SIGNATURE: &str = "0a3a4a24c04a97eafee5fc2038c2a5d774f8246d8a69a1cca83a9c0c3585cd4a0516f2727d4c270112b1a8fd9f7d9c274ba42a27d81898266752233c877a61b7c1e4d47a9126033347382242a8b10e29656e28188492bede3f5108da056d77e572193633e7d28a075282c0b99f96437d13f674532b9a078114130b45789d427d8f5d108efacf07c27ebcbe1a460af18470c8f8289929c4fb60049b6ff0c7ed7cfa95f2b4063980faf342a75a2cead80d4e21d9cd9ee152779c0b549ad16d650a211c938e1febbbbb77d943e77344eb9ed89e0a3971d2ef89075971dae7a3be163fcec135f2036f3d31b15121773fb1f9f2307d0a6b5b4bbdf18d236d7742e89a";
+    const HEAD_PREFIXED_SIGNATURE: &str = "19357d0b1acda281239c83d61e360fad813d2ae5323cc1803d6669f6665062cf6dd639382d1ba37e9ae46f53c166908da32314a1b68c3af9adae8e2bd405af49f5b7e9ea6c096a32a7def051f925bcde9f972470e50398eb4787ec7fef560926c3bf5a1baf7efbf57201a0d2cfb593654680e3122f807e4e7452adc04e142fb8ccd9aa126a28400acca5dbb2f08de129edd1a4608fb116f9ae11efbfed83f762d4d1b9765a8c8c4ebbbe3de3bc8ffffcc370aaaba40ee6f01e6bc59bd053a41e1714f1bbb3ae061847ff6b4c3ece7532cf3b6568024c3705cd568876e3a1c2547958e188146be944915657923614257cb857db1691718efaf16d2b88a0afebdd";
+    const PUT_UNPREFIXED_SIGNATURE: &str = "0f43f56a0e2bd7e41d91240d2d401dd783cd882af218f263fd7083b4b2288e5bbeba3bcb587df6271d91d7e724efa851ee64de8b94d45252c7c2321a54d2c022f8eb493d2b62b8677c631b8507cb8f91fde5f0d51be1773dce672a3102308aa9268cab57ca8862f07ff7aac44b640286f3c839c3ee850b9a8b790577bd0c489d8992a36f4426b04f643bda515b7fedd900ef78f4d60980cf0ac5fea12fa56921beb356c3b153b0f8a437c0444ff3d463dee360e914407302bc813477bd9fc6cecfb340bab4f66e054f1a9d53e0266607b8a0a2b93c4e918587e6c3b88c8a6b554273ace7e82f0d14fac90a748496d2ab8b1ee62c33c9332bb1ffaf7042efbf3c";
+    const GET_ESCAPED_SIGNATURE: &str = "32a9b708f6681f2725b500fd65776c471170a8c52bf912473f69c029264303d07c8e33619300384a175c5390ba89b12aeaa127dac514a19d0d6c53a4d39794b65dd85c0842662be728b9437454767352969a6f588c70525fb5306fc5463663ab364bdcd1a85469e9a7bb8fa5d87073b97f028809836cbac7ebd056104d847cd4c59bf8ea27b7116b8b3116ad93b3ff8b2ef73e0c5b5afc8a19312c5a042b2659fbe991f5ee0b4c7d36af73ed428266c8be2c6766370332afadbfc342a5c4dde67805fa2517cd2ae1eab4e77579fb4e8df3f53b38788de706e28253d55ed47c873c4556691f377c84a613de67ac8f977f743bfdaa7ff61e3ae4227254b9e7d536";
+
+    fn signing_time() -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(SIGNING_EPOCH_SECS)
+    }
+
+    fn presigner(key_prefix: Option<&str>) -> GcsV4Presigner {
+        GcsV4Presigner::new(GcsPresignerConfig {
+            bucket: "bucket".to_owned(),
+            service_account_key_path: gcs_fixture_service_account_key_file("gcs-presign")
+                .display()
+                .to_string(),
+            key_prefix: key_prefix.map(ToOwned::to_owned),
+        })
+        .expect("signer")
+    }
+
+    /// A reference whose storage checksum is the CRC-32C GCS enforces, which
+    /// is what a `direct_put` claim carries on this provider.
+    fn crc32c_content_ref() -> ContentRef {
+        ContentRef {
+            kind: ContentRefKind::BlobV1,
+            content_id: ContentId::parse("con_0123456789abcdef0123456789abcdef")
+                .expect("valid content id"),
+            size_bytes: 5,
+            storage_checksum: StorageChecksum {
+                algorithm: ChecksumAlgorithm::Crc32c,
+                value: HELLO_CRC32C_HEX.to_owned(),
+            },
+            whole_file_sha256: None,
+        }
+    }
+
+    fn presign_put(signer: &GcsV4Presigner) -> crate::presign::PresignedUrl {
+        signer
+            .presign_put(
+                PresignedPutRequest {
+                    object_key: CONTENT_KEY,
+                    content_ref: &crc32c_content_ref(),
+                    expires_in: EXPIRES_IN,
+                },
+                signing_time(),
+            )
+            .expect("presign put")
+    }
+
+    /// The whole write contract in one signature: the scoped object path, the
+    /// create-only precondition, the complete `x-goog-hash` value, and the
+    /// signed-header set that binds both headers to it.
+    #[test]
+    fn presigned_put_binds_the_scoped_path_checksum_and_create_only_precondition() {
+        let signed = presign_put(&presigner(Some("tenant-a")));
+
+        assert_eq!(signed.method, "PUT");
+        assert_eq!(
+            signed
+                .headers
+                .get("x-goog-if-generation-match")
+                .map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            signed.headers.get("x-goog-hash").map(String::as_str),
+            Some(format!("crc32c={HELLO_CRC32C_BASE64}").as_str())
+        );
+        assert_eq!(
+            signed.url,
+            format!(
+                "https://storage.googleapis.com/bucket/tenant-a/{CONTENT_KEY}?{EXPECTED_CREDENTIAL}\
+                 &X-Goog-SignedHeaders=host%3Bx-goog-hash%3Bx-goog-if-generation-match\
+                 &X-Goog-Signature={PUT_PREFIXED_SIGNATURE}"
+            )
+        );
+        assert_eq!(
+            signed.expires_at_ms,
+            SIGNING_EPOCH_SECS * 1_000 + EXPIRES_IN.as_millis() as u64
+        );
+    }
+
+    /// The read capability signs `host` and nothing else, which is what
+    /// leaves `Range` outside the signature: one issued URL serves ranged,
+    /// resumed, and parallel reads without another round trip to the server.
+    #[test]
+    fn presigned_get_signs_only_the_host_so_range_stays_unsigned() {
+        let signed = presigner(Some("tenant-a"))
+            .presign_get(
+                PresignedGetRequest {
+                    object_key: CONTENT_KEY,
+                    expires_in: EXPIRES_IN,
+                },
+                signing_time(),
+            )
+            .expect("presign get");
+
+        assert_eq!(signed.method, "GET");
+        assert!(
+            signed.headers.is_empty(),
+            "a read capability requires the client to send nothing"
+        );
+        assert!(!signed.url.to_ascii_lowercase().contains("range"));
+        assert_eq!(
+            signed.url,
+            format!(
+                "https://storage.googleapis.com/bucket/tenant-a/{CONTENT_KEY}?{EXPECTED_CREDENTIAL}\
+                 &X-Goog-SignedHeaders=host&X-Goog-Signature={GET_PREFIXED_SIGNATURE}"
+            )
+        );
+    }
+
+    /// The checksum readback needs no request header, so it signs the same
+    /// header set a read does and differs only in method.
+    #[test]
+    fn presigned_head_reads_the_object_back_with_host_signed_alone() {
+        let signed = presigner(Some("tenant-a"))
+            .presign_head_stored_checksum(CONTENT_KEY, EXPIRES_IN, signing_time())
+            .expect("presign head");
+
+        assert_eq!(signed.method, "HEAD");
+        assert!(signed.headers.is_empty());
+        assert_eq!(
+            signed.url,
+            format!(
+                "https://storage.googleapis.com/bucket/tenant-a/{CONTENT_KEY}?{EXPECTED_CREDENTIAL}\
+                 &X-Goog-SignedHeaders=host&X-Goog-Signature={HEAD_PREFIXED_SIGNATURE}"
+            )
+        );
+    }
+
+    /// The key prefix is part of what is signed, not decoration on the URL:
+    /// dropping it produces a different signature, so a capability issued for
+    /// one tenant's prefix cannot be replayed against another's.
+    #[test]
+    fn the_key_prefix_is_inside_the_signature() {
+        let unprefixed = presign_put(&presigner(None));
+
+        assert_eq!(
+            unprefixed.url,
+            format!(
+                "https://storage.googleapis.com/bucket/{CONTENT_KEY}?{EXPECTED_CREDENTIAL}\
+                 &X-Goog-SignedHeaders=host%3Bx-goog-hash%3Bx-goog-if-generation-match\
+                 &X-Goog-Signature={PUT_UNPREFIXED_SIGNATURE}"
+            )
+        );
+        assert_ne!(
+            PUT_UNPREFIXED_SIGNATURE, PUT_PREFIXED_SIGNATURE,
+            "the same object key under two prefixes must not sign alike"
+        );
+    }
+
+    /// Path segments are percent-encoded, and the separators between them are
+    /// not. Getting either wrong signs a different object than the one the
+    /// URL addresses.
+    #[test]
+    fn path_segments_are_percent_encoded_and_separators_are_not() {
+        let signed = presigner(Some("tenant-a"))
+            .presign_get(
+                PresignedGetRequest {
+                    object_key: "content-stores/cs/objects/a b/c+d/e~f/con_0123456789abcdef0123456789abcdef",
+                    expires_in: EXPIRES_IN,
+                },
+                signing_time(),
+            )
+            .expect("presign get");
+
+        assert_eq!(
+            signed.url,
+            format!(
+                "https://storage.googleapis.com/bucket/tenant-a/content-stores/cs/objects\
+                 /a%20b/c%2Bd/e~f/con_0123456789abcdef0123456789abcdef?{EXPECTED_CREDENTIAL}\
+                 &X-Goog-SignedHeaders=host&X-Goog-Signature={GET_ESCAPED_SIGNATURE}"
+            )
+        );
+    }
+
+    /// Reads and writes of the same object address the same URL, so a
+    /// deployment cannot sign a write it is unable to sign a read of.
+    #[test]
+    fn presigned_get_addresses_the_same_object_the_write_did() {
+        let signer = presigner(Some("tenant-a"));
+        let written = presign_put(&signer);
+        let read = signer
+            .presign_get(
+                PresignedGetRequest {
+                    object_key: CONTENT_KEY,
+                    expires_in: EXPIRES_IN,
+                },
+                signing_time(),
+            )
+            .expect("presign get");
+
+        let object_of = |url: &str| url.split('?').next().expect("url path").to_owned();
+        assert_eq!(object_of(&read.url), object_of(&written.url));
+    }
+
+    #[test]
+    fn gcs_advertises_crc32c_and_googles_documented_single_request_ceiling() {
+        let signer = presigner(None);
+        assert_eq!(signer.checksum_algorithm(), ChecksumAlgorithm::Crc32c);
+        assert_eq!(signer.max_content_bytes(), GCP_GCS_MAX_DIRECT_PUT_BYTES);
+        assert_eq!(GCP_GCS_MAX_DIRECT_PUT_BYTES, 5 * 1024 * 1024 * 1024 * 1024);
+    }
+
+    /// A checksum GCS cannot enforce is refused at issuance rather than
+    /// signed into a write the provider would accept without checking.
+    #[test]
+    fn presigned_put_rejects_content_refs_it_cannot_bind_to_the_write() {
+        let signer = presigner(None);
+        let unsupported_kind = ContentRef {
+            kind: ContentRefKind::Unsupported("future_kind".to_owned()),
+            ..crc32c_content_ref()
+        };
+        let sha256_only = ContentRef {
+            storage_checksum: StorageChecksum::sha256(b"hello"),
+            whole_file_sha256: Some(StorageChecksum::sha256(b"hello").value),
+            ..crc32c_content_ref()
+        };
+        let malformed_crc = ContentRef {
+            storage_checksum: StorageChecksum {
+                algorithm: ChecksumAlgorithm::Crc32c,
+                value: "nothex!!".to_owned(),
+            },
+            ..crc32c_content_ref()
+        };
+
+        for content_ref in [unsupported_kind, sha256_only, malformed_crc] {
+            let error = signer
+                .presign_put(
+                    PresignedPutRequest {
+                        object_key: CONTENT_KEY,
+                        content_ref: &content_ref,
+                        expires_in: EXPIRES_IN,
+                    },
+                    signing_time(),
+                )
+                .expect_err("unsignable content ref");
+            assert!(matches!(error, ObjectStoreError::InvalidContentRef(_)));
+        }
+    }
+
+    #[test]
+    fn expiry_outside_googles_documented_window_is_a_configuration_error() {
+        let signer = presigner(None);
+        for expires_in in [Duration::ZERO, Duration::from_secs(7 * 24 * 60 * 60 + 1)] {
+            assert!(matches!(
+                signer.presign_get(
+                    PresignedGetRequest {
+                        object_key: CONTENT_KEY,
+                        expires_in,
+                    },
+                    signing_time(),
+                ),
+                Err(ObjectStoreError::Configuration(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn a_key_file_that_cannot_sign_fails_construction() {
+        let dir = gcs_fixture_service_account_key_file("gcs-presign-bad")
+            .parent()
+            .expect("fixture dir")
+            .to_path_buf();
+
+        let not_json = dir.join("not-json.json");
+        std::fs::write(&not_json, b"this is not a service account").expect("write");
+        let no_pem = dir.join("no-pem.json");
+        std::fs::write(
+            &no_pem,
+            br#"{"client_email":"a@b.iam.gserviceaccount.com","private_key":"private_key"}"#,
+        )
+        .expect("write");
+        let missing = dir.join("absent.json");
+
+        for path in [not_json, no_pem, missing] {
+            assert!(
+                matches!(
+                    GcsV4Presigner::new(GcsPresignerConfig {
+                        bucket: "bucket".to_owned(),
+                        service_account_key_path: path.display().to_string(),
+                        key_prefix: None,
+                    }),
+                    Err(ObjectStoreError::Configuration(_))
+                ),
+                "{} should not have produced a signer",
+                path.display()
+            );
+        }
+    }
+
+    /// A signing key is a bearer credential for the whole bucket, so nothing
+    /// about it reaches a log through the store that holds it.
+    #[test]
+    fn presigner_debug_redacts_the_service_account_and_its_key() {
+        let signer = presigner(Some("tenant-a"));
+        let rendered = format!("{signer:?}");
+
+        assert!(!rendered.contains(GCS_FIXTURE_CLIENT_EMAIL));
+        assert!(!rendered.contains("BEGIN PRIVATE KEY"));
+        assert!(!rendered.contains("MIIEv"));
+        assert!(rendered.contains("<redacted>"));
+        assert!(rendered.contains("bucket"));
+    }
+
+    /// GCS lists hashes in an unspecified order and may name algorithms this
+    /// format does not, so the CRC-32C is selected rather than positioned.
+    #[test]
+    fn stored_crc32c_selects_its_algorithm_out_of_the_hash_header() {
+        assert_eq!(
+            stored_crc32c("crc32c=mnG7TA==").map(|checksum| checksum.value),
+            Some(HELLO_CRC32C_HEX.to_owned())
+        );
+        assert_eq!(
+            stored_crc32c("md5=XUFAKrxLKna5cZ2REBfFkg==,crc32c=mnG7TA==")
+                .map(|checksum| checksum.value),
+            Some(HELLO_CRC32C_HEX.to_owned())
+        );
+        assert_eq!(
+            stored_crc32c("crc32c=mnG7TA==, md5=XUFAKrxLKna5cZ2REBfFkg==")
+                .map(|checksum| checksum.algorithm),
+            Some(ChecksumAlgorithm::Crc32c)
+        );
+
+        // An object described without a usable crc32c is described without
+        // one; the caller fails rather than completing on size alone.
+        assert_eq!(stored_crc32c("md5=XUFAKrxLKna5cZ2REBfFkg=="), None);
+        assert_eq!(stored_crc32c(""), None);
+        assert_eq!(stored_crc32c("crc32c=not-base64!"), None);
+        assert_eq!(stored_crc32c("crc32c=bW5HN1RBPT0="), None);
+    }
+}

--- a/crates/loonfs-objectstore/src/presign/mod.rs
+++ b/crates/loonfs-objectstore/src/presign/mod.rs
@@ -1,10 +1,12 @@
 //! Presigned-URL issuing for direct transfers: `direct_put` uploads,
 //! `direct_multipart` part uploads, and `direct_get` downloads.
 
-mod aws_sigv4;
+mod gcs;
 mod issuer;
 mod s3_compatible;
+mod v4;
 
+pub use gcs::{GcsPresignerConfig, GcsV4Presigner, GCP_GCS_MAX_DIRECT_PUT_BYTES};
 pub use issuer::{
     DirectGetIssuer, DirectMultipartIssuer, DirectPutIssuer, DirectTransferIssuers,
     PresignedGetRequest, PresignedPartRequest, PresignedPutRequest, PresignedUrl,
@@ -13,3 +15,5 @@ pub use s3_compatible::{
     S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES,
     CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
 };
+
+pub(crate) use gcs::stored_crc32c;

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -6,9 +6,9 @@ use super::{
 };
 use crate::keyspace::{parse_endpoint_url, scope_object_key};
 use crate::object_store::Result;
-use crate::presign::aws_sigv4::{
-    aws_dates, canonical_query_string, hex_lower, hmac_sha256, normalize_header_value,
-    percent_encode_path, percent_encode_segment,
+use crate::presign::v4::{
+    canonical_query_string, hex_lower, hmac_sha256, normalize_header_value, percent_encode_path,
+    percent_encode_segment, signing_dates, unix_ms,
 };
 use crate::secret::SecretString;
 use crate::ObjectStoreError;
@@ -255,7 +255,7 @@ impl S3CompatiblePresigner {
         }
 
         let endpoint = self.endpoint(object_key)?;
-        let dates = aws_dates(object_key, now)?;
+        let dates = signing_dates(object_key, now)?;
         let credential_scope = format!(
             "{}/{}/s3/aws4_request",
             dates.short_date, self.config.region
@@ -285,7 +285,7 @@ impl S3CompatiblePresigner {
         query.extend([
             ("X-Amz-Algorithm".to_owned(), "AWS4-HMAC-SHA256".to_owned()),
             ("X-Amz-Credential".to_owned(), credential),
-            ("X-Amz-Date".to_owned(), dates.amz_date.clone()),
+            ("X-Amz-Date".to_owned(), dates.timestamp.clone()),
             ("X-Amz-Expires".to_owned(), expires_in.as_secs().to_string()),
             ("X-Amz-SignedHeaders".to_owned(), signed_headers.clone()),
         ]);
@@ -300,7 +300,7 @@ impl S3CompatiblePresigner {
         let hashed_request = hex_lower(&Sha256::digest(canonical_request.as_bytes()));
         let string_to_sign = format!(
             "AWS4-HMAC-SHA256\n{}\n{}\n{}",
-            dates.amz_date, credential_scope, hashed_request
+            dates.timestamp, credential_scope, hashed_request
         );
         let signing_key = signing_key(
             self.config.secret_access_key.expose(),
@@ -533,16 +533,6 @@ struct S3Endpoint {
     scheme: String,
     host: String,
     canonical_uri: String,
-}
-
-fn unix_ms(object_key: &str, time: SystemTime) -> Result<u64> {
-    let duration = time.duration_since(std::time::UNIX_EPOCH).map_err(|err| {
-        ObjectStoreError::transport(
-            object_key,
-            format!("system time is before unix epoch: {err}"),
-        )
-    })?;
-    Ok(duration.as_millis() as u64)
 }
 
 fn signing_key(secret: &str, date: &str, region: &str) -> Vec<u8> {

--- a/crates/loonfs-objectstore/src/presign/v4.rs
+++ b/crates/loonfs-objectstore/src/presign/v4.rs
@@ -1,4 +1,12 @@
-//! AWS Signature Version 4 primitives used to presign S3-compatible URLs.
+//! Version-4 signing primitives, shared by the two schemes this crate signs.
+//!
+//! AWS `AWS4-HMAC-SHA256` and Google `GOOG4-RSA-SHA256` are the same
+//! construction: the same canonical-request shape, the same timestamp
+//! spellings, the same percent-encoding, the same `<date>/<location>/<service>/<terminator>`
+//! credential scope. They differ in the literals each writes into those slots
+//! and in the primitive that produces the signature. Only the parts that are
+//! genuinely identical live here; each scheme's own literals and signature
+//! primitive stay in its own presigner.
 
 use crate::object_store::Result;
 use crate::ObjectStoreError;
@@ -6,13 +14,15 @@ use sha2::Sha256;
 use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// The two date spellings a V4 signature carries: the credential scope's day
+/// and the request's full timestamp, which must agree.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct AwsSigV4Dates {
+pub(crate) struct SigningDates {
     pub(crate) short_date: String,
-    pub(crate) amz_date: String,
+    pub(crate) timestamp: String,
 }
 
-pub(crate) fn aws_dates(object_key: &str, time: SystemTime) -> Result<AwsSigV4Dates> {
+pub(crate) fn signing_dates(object_key: &str, time: SystemTime) -> Result<SigningDates> {
     let seconds = time
         .duration_since(UNIX_EPOCH)
         .map_err(|err| {
@@ -30,10 +40,22 @@ pub(crate) fn aws_dates(object_key: &str, time: SystemTime) -> Result<AwsSigV4Da
     let second = seconds_of_day % 60;
     let short_date = format!("{year:04}{month:02}{day:02}");
 
-    Ok(AwsSigV4Dates {
-        amz_date: format!("{short_date}T{hour:02}{minute:02}{second:02}Z"),
+    Ok(SigningDates {
+        timestamp: format!("{short_date}T{hour:02}{minute:02}{second:02}Z"),
         short_date,
     })
+}
+
+/// Unix milliseconds for a signing instant, used to report when an issued
+/// capability stops working.
+pub(crate) fn unix_ms(object_key: &str, time: SystemTime) -> Result<u64> {
+    let duration = time.duration_since(UNIX_EPOCH).map_err(|err| {
+        ObjectStoreError::transport(
+            object_key,
+            format!("system time is before unix epoch: {err}"),
+        )
+    })?;
+    Ok(duration.as_millis() as u64)
 }
 
 pub(crate) fn canonical_query_string(query: &BTreeMap<String, String>) -> String {

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -903,8 +903,9 @@ mod tests {
             .is_empty());
     }
 
-    /// A store that cannot report stored checksums — GCS and Azure Blob
-    /// Storage are both this case, and it is an answer rather than a fault.
+    /// A store that cannot report stored checksums — Azure Blob Storage and
+    /// the local filesystem's provider-less path are this case, and it is an
+    /// answer rather than a fault.
     #[derive(Debug)]
     struct NoStoredChecksumStore {
         inner: LocalFsStore,

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -108,7 +108,12 @@ pub enum StoreConfig {
     GcpGcs {
         /// GCS bucket that acts as the physical store root.
         bucket: String,
-        /// Filesystem path to the service-account JSON used for authentication.
+        /// Filesystem path to the service-account JSON.
+        ///
+        /// Used twice, from the one file: the provider client authenticates
+        /// with it, and its RSA private key signs the direct-transfer URLs
+        /// this deployment hands to clients. A key that cannot do the second
+        /// fails startup rather than quietly withdrawing direct transfers.
         service_account_key_path: String,
         /// Logical prefix applied inside the bucket, or `None` to expose its root.
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/loonfs-objectstore/src/test_support.rs
+++ b/crates/loonfs-objectstore/src/test_support.rs
@@ -24,3 +24,43 @@ impl MonotonicTimer for SteppingTimer {
         self.now_ms.fetch_add(self.step_ms, Ordering::SeqCst)
     }
 }
+
+/// A service-account JSON whose RSA key is real enough to sign with and
+/// belongs to nobody: it was generated for this repository and names a
+/// project that does not exist.
+///
+/// The GCS adapters parse this file at construction, so a placeholder string
+/// where the private key goes no longer stands in for one. `disable_oauth`
+/// keeps the provider client from reaching for a token it will never need.
+pub(crate) const GCS_FIXTURE_SERVICE_ACCOUNT_KEY: &str = r#"{"type":"service_account","project_id":"loonfs-tests","private_key_id":"0123456789abcdef0123456789abcdef01234567","private_key":"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCqCPHn1DoDzQWc\nQ1RyndwGugUhuWxYV7GhyutLbFVs2+40StJf6UYGJgkKLIaJ5o9X5fSVzHbTnI90\ngA7Hcl3LeVmUBqf3Vzt1ZQaWxWSRrcCnqtvkh3VJ4o4wp/KVRx10o+9MZ5+s5BvB\n9HTnkjzYuz7RwqYPj9oayXWB3Zy4Ba8+yFKc29X77TbdAtUeeaSywi8MOUmUOyzN\nj4/1bniDkj7efPy0nA2m+Rlv+Jgfygs7WLXu3cscCQa2/JMSyfle1tRD+OEVac5y\nzfPu7X6AHNsYPwOjFTtZxAQxcNTjM1Icw+D9001XTe3NiHkTVe1n3L5oVx5VtgsM\nOc3wdLh9AgMBAAECggEADlajw5dvbvuegf9hgyrRr5WHMkFXJBn9BjY84kbX606e\nhzVaCTF8MK+Lapq3m7BgHRrspacwzAZzSHE2DdaUl0B779Ih3ucxweQLirJJmUlM\nKjdrxJkxqFHdCLhY6gKttrTOTKSeX+96ccAiDZcU33fmw7yE0WIhk8mySYm9Gf1p\nasLr2tyxIdAt0rGN6DtlHNGI0gzZU7QZT/rUErLmhsD2dSiACU/mOvJNUB37Prhp\nMhNasQUZMB74duNXliM/NzLg2VEZkXgahXbGkyzMjt5b/lmF7EGR4W9/2AqeWPDl\n4OkVC2GXCXwLgNbNK6UlCSQlAIh1eX3eaENax2QfNwKBgQDi0t1Ok3zzHc69MRCN\nf5fmKsLPd41aJbjEva5a+t/HW9SK4gvKlf5YBb4mmogT5gqDRqhH2A2tD6wh1+Or\nd5y2ffZPkRkr14XWbKlIgnTAJZhMETkzlHQ3VgTaUmQuPQWpu3i/2m2Q9MxkNJQa\nOVnb136/CFKmWhzIM+ymd/3SJwKBgQC/6BG2bwXPCp7OB8k13a5JlK7b3AXx9Cz8\nzJcQ0qzWXjdtnfJbPULem+bWpoBdd7ha4odOgM7bZ08tvjG8EG0ZoYbn3ZvIHWkf\nZREkmuR0iAKVthjQvTHb7CauTgQiAKhT09+YKj8zFQc5X2h//2AR69hlwyAxNGWj\nvrgoG5HauwKBgGHt1lyhctXoLaUjNNlSmDtohNlb7WxZUu+mUUu4ersw24/mzl51\n6e0I9bLnDw9AR5OsAuWZ0zW/yXqHIiWaq89ijOCHbc2u7HrKSUAkCtIWqS1WVlL9\nqjtl6Qx1fAk2kWZZqWVzodBu0HwG81ZrIm+3F2LU7hIiX8DUIj0xGyYLAoGBALcN\nNUAQfLj2B269bIduEh5rrbNYF2+omvT0bjCE1IqSSkrMO24ebFeM3E7peU4usXI3\n3BrcsPQFgjg+0I/0Fy04r0ciUsM6kph4vjZtbPde+SA3F0qc/R8rDeZ70mNgvy9e\nzUwHGEuwhjiKslJNlSTjE4JV8rIcqcrcVCslySWbAoGAcpdodegs1nrDYXgfG/Uc\nG5R+zoAKdoHLtPWyAkVjXMC9qzMhhXcqqtsoKsZs9LbDiwM7+ANjdU9OcPAtw+c6\nSMF4yP4CnQLvdNRiJ7W4VcAYI4fC7Yvlc0cgz8BAMtVJOTuhOwwLs08kJRk6qVLe\nxZ1xhCJtVIW6SUf+s5lL6xE=\n-----END PRIVATE KEY-----\n","client_email":"loonfs-presign-fixture@loonfs-tests.iam.gserviceaccount.com","client_id":"000000000000000000000","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","disable_oauth":true}"#;
+
+/// The service account [`GCS_FIXTURE_SERVICE_ACCOUNT_KEY`] names, which the
+/// signer writes into the credential query parameter.
+pub(crate) const GCS_FIXTURE_CLIENT_EMAIL: &str =
+    "loonfs-presign-fixture@loonfs-tests.iam.gserviceaccount.com";
+
+/// Writes the fixture key to a fresh temporary file and returns its path,
+/// because every GCS constructor takes the key as a path to read.
+///
+/// Each call gets its own directory. A wall-clock stamp alone does not
+/// guarantee that: several tests ask for this fixture under the same label,
+/// the clock's resolution is coarser than the gap between them, and two
+/// callers landing on one directory then truncate and re-write the same file
+/// while the other is reading it. The counter is what actually makes the
+/// path unique within a run; the stamp separates runs.
+#[allow(clippy::disallowed_methods)]
+pub(crate) fn gcs_fixture_service_account_key_file(label: &str) -> std::path::PathBuf {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+
+    // Test-only unique paths are an entropy boundary, not protocol time.
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let ordinal = NEXT.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("loonfs-objectstore-{label}-{stamp}-{ordinal}"));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join("service-account.json");
+    std::fs::write(&path, GCS_FIXTURE_SERVICE_ACCOUNT_KEY).expect("write fixture service account");
+    path
+}

--- a/crates/loonfs-objectstore/tests/provider-conformance.env.example
+++ b/crates/loonfs-objectstore/tests/provider-conformance.env.example
@@ -24,7 +24,11 @@ LOONFS_TEST_R2_ACCESS_KEY_ID=example-r2-access-key-id
 LOONFS_TEST_R2_SECRET_ACCESS_KEY=example-r2-secret-access-key-not-real
 LOONFS_TEST_R2_PREFIX=conformance/r2/manual
 
-# GCP GCS 
+# GCP GCS
+# The key file is used twice: the provider client authenticates with it, and
+# its RSA private key signs the direct-transfer URLs the direct-put suite
+# exercises. A downloaded service-account key does both; a key file without a
+# usable private key fails at startup.
 LOONFS_TEST_GCS_BUCKET=example-loonfs-gcs-bucket
 LOONFS_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH=/path/to/service-account.json
 LOONFS_TEST_GCS_PREFIX=conformance/gcp-gcs/manual

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -40,6 +40,7 @@ utoipa = { workspace = true, optional = true }
 
 [dev-dependencies]
 async-trait.workspace = true
+base64.workspace = true
 loonfs-client.workspace = true
 loonfs-test-support = { path = "../loonfs-test-support" }
 rcgen.workspace = true

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2298,10 +2298,10 @@ mod direct_download {
     use super::*;
     use crate::http::app_with_store_and_direct_transfers;
     use loonfs_api::{
-        ChecksumAlgorithm, RevisionNo, FEATURE_DOWNLOADS_DIRECT_GET,
+        ChecksumAlgorithm, RevisionNo, StorageChecksum, FEATURE_DOWNLOADS_DIRECT_GET,
         FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
-        FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_SHA256, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES,
-        LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES,
+        FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_CRC32C, FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_SHA256,
+        LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES,
     };
     use loonfs_objectstore::presign::{
         DirectGetIssuer, DirectPutIssuer, DirectTransferIssuers, PresignedGetRequest,
@@ -2343,12 +2343,35 @@ mod direct_download {
     #[derive(Debug)]
     struct LoopbackIssuer {
         object_base_url: String,
+        /// The whole-object checksum this stand-in provider enforces.
+        ///
+        /// Providers do not agree on one -- the S3 family verifies SHA-256
+        /// and GCS verifies CRC-32C -- so the shape is a parameter here for
+        /// the same reason it is a trait method in the real issuers: the
+        /// client folds whichever the deployment names.
+        checksum_algorithm: ChecksumAlgorithm,
     }
 
     impl LoopbackIssuer {
+        /// The S3-compatible shape: a whole-object SHA-256.
         fn at(object_base_url: impl Into<String>) -> Arc<Self> {
+            Self::with_checksum(object_base_url, ChecksumAlgorithm::Sha256)
+        }
+
+        /// The GCS shape: a whole-object CRC-32C. Callers pair it with a
+        /// bundle carrying no multipart signer, which is the rest of that
+        /// shape.
+        fn crc32c_at(object_base_url: impl Into<String>) -> Arc<Self> {
+            Self::with_checksum(object_base_url, ChecksumAlgorithm::Crc32c)
+        }
+
+        fn with_checksum(
+            object_base_url: impl Into<String>,
+            checksum_algorithm: ChecksumAlgorithm,
+        ) -> Arc<Self> {
             Arc::new(Self {
                 object_base_url: object_base_url.into(),
+                checksum_algorithm,
             })
         }
     }
@@ -2370,7 +2393,7 @@ mod direct_download {
 
     impl DirectPutIssuer for LoopbackIssuer {
         fn checksum_algorithm(&self) -> ChecksumAlgorithm {
-            ChecksumAlgorithm::Sha256
+            self.checksum_algorithm
         }
 
         fn max_content_bytes(&self) -> u64 {
@@ -2461,8 +2484,26 @@ mod direct_download {
         direct_transfers: Option<DirectTransferIssuers>,
         max_upload_bytes: Option<u64>,
     ) -> Client {
-        let store: SharedObjectStore =
-            Arc::new(LocalFsStore::new(root).expect("construct local store"));
+        start_with_store(
+            Arc::new(LocalFsStore::new(root).expect("construct local store")),
+            root,
+            writer_id,
+            direct_transfers,
+            max_upload_bytes,
+        )
+        .await
+    }
+
+    /// The same deployment over a caller-supplied store, for the cases where
+    /// what the provider reports back about an object is the thing under
+    /// test.
+    async fn start_with_store(
+        store: SharedObjectStore,
+        root: &Path,
+        writer_id: &str,
+        direct_transfers: Option<DirectTransferIssuers>,
+        max_upload_bytes: Option<u64>,
+    ) -> Client {
         let mut config = test_config(root, writer_id);
         config.max_download_bytes = PROXY_CAP_BYTES;
         if let Some(max_upload_bytes) = max_upload_bytes {
@@ -2492,6 +2533,78 @@ mod direct_download {
     /// double. Both see the same objects because both are the same root.
     fn object_store_at(root: &Path) -> SharedObjectStore {
         Arc::new(LocalFsStore::new(root).expect("construct local store for the object double"))
+    }
+
+    /// A store that reports an object's stored checksum as a CRC-32C, the way
+    /// a GCS provider answers.
+    ///
+    /// The reference local store reports SHA-256, which is the readback that
+    /// pairs with an S3-compatible issuer. A provider's readback algorithm
+    /// and its `direct_put` issuer's algorithm have to be the same one, or
+    /// completion compares two digests of different kinds and refuses every
+    /// upload — so a CRC-32C issuer needs a CRC-32C readback beneath it, and
+    /// this double supplies one.
+    #[derive(Debug)]
+    struct Crc32cReadbackStore {
+        inner: LocalFsStore,
+    }
+
+    #[async_trait::async_trait]
+    impl loonfs_objectstore::ObjectStore for Crc32cReadbackStore {
+        async fn head(
+            &self,
+            key: &str,
+        ) -> Result<Option<loonfs_objectstore::ObjectMetadata>, ObjectStoreError> {
+            self.inner.head(key).await
+        }
+
+        async fn head_stored_checksum(
+            &self,
+            key: &str,
+        ) -> Result<Option<loonfs_objectstore::StoredObjectChecksum>, ObjectStoreError> {
+            let Some(bytes) = self.inner.get(key, None).await? else {
+                return Ok(None);
+            };
+            Ok(Some(loonfs_objectstore::StoredObjectChecksum {
+                size_bytes: bytes.len() as u64,
+                storage_checksum: StorageChecksum::crc32c(&bytes),
+            }))
+        }
+
+        async fn get_with_metadata(
+            &self,
+            key: &str,
+        ) -> Result<Option<loonfs_objectstore::ObjectBody>, ObjectStoreError> {
+            self.inner.get_with_metadata(key).await
+        }
+
+        async fn get(
+            &self,
+            key: &str,
+            range: Option<loonfs_objectstore::ByteRange>,
+        ) -> Result<Option<bytes::Bytes>, ObjectStoreError> {
+            self.inner.get(key, range).await
+        }
+
+        async fn put(
+            &self,
+            key: &str,
+            bytes: bytes::Bytes,
+            mode: loonfs_objectstore::PutMode,
+        ) -> Result<loonfs_objectstore::ObjectMetadata, ObjectStoreError> {
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(
+            &self,
+            prefix: &str,
+        ) -> futures::stream::BoxStream<'static, Result<String, ObjectStoreError>> {
+            self.inner.list_prefix_stream(prefix)
+        }
     }
 
     /// The audit's case in miniature: a file this deployment will not
@@ -2685,6 +2798,91 @@ mod direct_download {
             Some(&PROXY_CAP_BYTES),
             "the proxy cap stays advertised: it is what tells a client which reads need a grant"
         );
+    }
+
+    /// The GCS shape, end to end, with no GCS-specific code anywhere above
+    /// the object-store adapter.
+    ///
+    /// A bundle that signs reads and CRC-32C whole-object writes and has no
+    /// multipart API is served by the same handler, carried by the same
+    /// client ladder, and completed by the same rule as the S3-compatible
+    /// one. The client learns `crc32c` from the capability document, folds
+    /// exactly that digest over the payload in its one measuring pass, and
+    /// the ref the commit records says so — with no `whole_file_sha256`,
+    /// because nobody computed a SHA-256 over these bytes and the format does
+    /// not let one be conjured.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_crc32c_provider_without_multipart_carries_a_file_end_to_end() {
+        let temp_dir = tempdir().expect("tempdir");
+        let object_base_url = serve_objects(object_store_at(temp_dir.path())).await;
+        let issuer = LoopbackIssuer::crc32c_at(object_base_url);
+        let transfers = DirectTransferIssuers::read_only(issuer.clone()).with_put(issuer);
+        let store: SharedObjectStore = Arc::new(Crc32cReadbackStore {
+            inner: LocalFsStore::new(temp_dir.path()).expect("construct local store"),
+        });
+        let client = start_with_store(
+            store,
+            temp_dir.path(),
+            "ladder-crc32c-put",
+            Some(transfers),
+            Some(PROXY_CAP_BYTES),
+        )
+        .await;
+
+        // The deployment names crc32c, and names only crc32c.
+        let advertised = client.capabilities().await.expect("capabilities");
+        assert!(advertised.supports(FEATURE_UPLOADS_DIRECT_PUT));
+        assert!(advertised.supports(FEATURE_DOWNLOADS_DIRECT_GET));
+        assert!(advertised.supports(FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_CRC32C));
+        assert!(!advertised.supports(FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_SHA256));
+        assert!(
+            !advertised.supports(FEATURE_UPLOADS_DIRECT_MULTIPART),
+            "GCS has no S3-style multipart API to advertise"
+        );
+        assert_eq!(
+            advertised.direct_put_checksum_algorithm(),
+            Some(ChecksumAlgorithm::Crc32c)
+        );
+
+        let namespace = namespace_id("ladder-crc32c-put");
+        client
+            .create_namespace(&namespace)
+            .await
+            .expect("create namespace");
+        let target = NamespacePath::parse(namespace.as_str(), "/large.bin").expect("target");
+        // Large enough that the client looks for a direct transport at all,
+        // and far past the proxy cap, so nothing else could carry it.
+        let payload: Vec<u8> = (0..loonfs_client::STREAMING_PUT_MIN_BYTES as usize)
+            .map(|index| (index % 251) as u8)
+            .collect();
+
+        client
+            .put_file_bytes(&target, &payload, &replace_file_options())
+            .await
+            .expect("a large file goes straight to object storage under a crc32c claim");
+
+        let grant = client
+            .begin_download(&target, None)
+            .await
+            .expect("download grant");
+        assert_eq!(
+            grant.content_ref.storage_checksum,
+            StorageChecksum::crc32c(&payload),
+            "the recorded ref carries the digest the provider was made to enforce"
+        );
+        assert_eq!(
+            grant.content_ref.whole_file_sha256, None,
+            "no trustworthy party hashed these bytes with SHA-256, so the ref claims none"
+        );
+
+        // And it comes home byte for byte through the read half of the same
+        // bundle, which is the symmetry the bundle type exists to guarantee.
+        let mut received = Vec::new();
+        client
+            .download_via_presigned_url(&grant, &mut received)
+            .await
+            .expect("stream the granted object");
+        assert_eq!(received, payload);
     }
 
     /// A store that authorizes nothing directly advertises none of the three.

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -1,6 +1,7 @@
 // Ignored real-provider tests exercise the full server/client/direct-object-store path.
 
 use crate::common::{start_server, test_config};
+use base64::Engine as _;
 use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::{
@@ -9,8 +10,8 @@ use loonfs_api::{
         DirectPutContentClaim, ObjectTransferAccess, UploadPartChecksumClaim,
         ValidatedContentToken,
     },
-    ChangeSeq, CommitId, CommitRequest, CommitResponse, DestinationBehavior, FilesystemOperation,
-    NamespaceId, StorageChecksum,
+    ChangeSeq, ChecksumAlgorithm, CommitId, CommitRequest, CommitResponse, DestinationBehavior,
+    FilesystemOperation, NamespaceId, StorageChecksum,
 };
 use loonfs_client::{Client, ClientError, NamespacePath, PayloadSource};
 use loonfs_objectstore::ObjectStore;
@@ -21,17 +22,54 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const AUTH_TOKEN: &str = "test-token";
 const CONTENT_TOKEN_SECRET: &str = "test-content-token-secret";
-const SIGNED_CHECKSUM_HEADER: &str = "x-amz-checksum-sha256";
 /// The part size the reference server hands out. A live payload is cut to
 /// this so it lands on a known part count; the assertions check the server
 /// still says so.
 const MULTIPART_PART_SIZE: usize = 8 * 1024 * 1024;
 
-/// What a direct-put client declares about bytes it is holding.
-fn direct_put_claim(bytes: &[u8]) -> DirectPutContentClaim {
+/// The proxy caps the GCS capability suite narrows its deployment to.
+///
+/// Small on purpose: what makes an object one this deployment will not proxy
+/// is the cap rather than the byte count, so the behavior is identical at a
+/// megabyte and at 256 MiB and this suite does not push the larger figure
+/// through a real provider on every run.
+const PROXY_CAP_BYTES: u64 = 1024 * 1024;
+
+/// The provider-specific spellings a signed write carries.
+///
+/// Every provider binds the same two things into the signature — the digest
+/// the body must hash to and a create-only precondition — under its own
+/// header names. The proofs below tamper with those headers by name, so the
+/// name is a parameter rather than a constant.
+#[derive(Debug, Clone, Copy)]
+struct SignedWriteHeaders {
+    checksum: &'static str,
+    create_only: &'static str,
+    /// The whole-object digest this provider validates.
+    checksum_algorithm: ChecksumAlgorithm,
+}
+
+/// AWS S3 and Cloudflare R2: a signed SHA-256 and `if-none-match: *`.
+const S3_SIGNED_WRITE: SignedWriteHeaders = SignedWriteHeaders {
+    checksum: "x-amz-checksum-sha256",
+    create_only: "if-none-match",
+    checksum_algorithm: ChecksumAlgorithm::Sha256,
+};
+
+/// Google Cloud Storage's native API: a signed `x-goog-hash` carrying a
+/// CRC-32C, and a zero object generation for create-only.
+const GCS_SIGNED_WRITE: SignedWriteHeaders = SignedWriteHeaders {
+    checksum: "x-goog-hash",
+    create_only: "x-goog-if-generation-match",
+    checksum_algorithm: ChecksumAlgorithm::Crc32c,
+};
+
+/// What a direct-put client declares about bytes it is holding, in the
+/// algorithm this deployment advertised.
+fn direct_put_claim(bytes: &[u8], algorithm: ChecksumAlgorithm) -> DirectPutContentClaim {
     DirectPutContentClaim {
         size_bytes: bytes.len() as u64,
-        storage_checksum: StorageChecksum::sha256(bytes),
+        storage_checksum: StorageChecksum::compute(algorithm, bytes),
     }
 }
 
@@ -39,21 +77,24 @@ fn direct_put_claim(bytes: &[u8]) -> DirectPutContentClaim {
 #[ignore = "requires real AWS S3 credentials"]
 async fn aws_s3_direct_put_real_provider_round_trip() {
     let config = AwsS3DirectPutConfig::from_env().expect("load AWS S3 direct-put environment");
-    direct_put_round_trip(test_config(
-        StoreConfig::AwsS3 {
-            bucket: config.bucket,
-            region: config.region,
-            endpoint_url: config.endpoint,
-            access_key_id: config.access_key_id.into(),
-            secret_access_key: config.secret_access_key.into(),
-            session_token: config.session_token.map(Into::into),
-            key_prefix: Some(config.prefix),
-            force_path_style: false,
-        },
-        AUTH_TOKEN,
-        CONTENT_TOKEN_SECRET,
-        "direct-put-aws-s3",
-    ))
+    direct_put_round_trip(
+        S3_SIGNED_WRITE,
+        test_config(
+            StoreConfig::AwsS3 {
+                bucket: config.bucket,
+                region: config.region,
+                endpoint_url: config.endpoint,
+                access_key_id: config.access_key_id.into(),
+                secret_access_key: config.secret_access_key.into(),
+                session_token: config.session_token.map(Into::into),
+                key_prefix: Some(config.prefix),
+                force_path_style: false,
+            },
+            AUTH_TOKEN,
+            CONTENT_TOKEN_SECRET,
+            "direct-put-aws-s3",
+        ),
+    )
     .await;
 }
 
@@ -62,23 +103,26 @@ async fn aws_s3_direct_put_real_provider_round_trip() {
 async fn cloudflare_r2_direct_put_real_provider_round_trip() {
     let config =
         CloudflareR2DirectPutConfig::from_env().expect("load Cloudflare R2 direct-put environment");
-    direct_put_round_trip(test_config(
-        StoreConfig::CloudflareR2 {
-            bucket: config.bucket,
-            account_id: config.account_id,
-            endpoint_url: config.endpoint,
-            access_key_id: config.access_key_id.into(),
-            secret_access_key: config.secret_access_key.into(),
-            key_prefix: Some(config.prefix),
-        },
-        AUTH_TOKEN,
-        CONTENT_TOKEN_SECRET,
-        "direct-put-r2",
-    ))
+    direct_put_round_trip(
+        S3_SIGNED_WRITE,
+        test_config(
+            StoreConfig::CloudflareR2 {
+                bucket: config.bucket,
+                account_id: config.account_id,
+                endpoint_url: config.endpoint,
+                access_key_id: config.access_key_id.into(),
+                secret_access_key: config.secret_access_key.into(),
+                key_prefix: Some(config.prefix),
+            },
+            AUTH_TOKEN,
+            CONTENT_TOKEN_SECRET,
+            "direct-put-r2",
+        ),
+    )
     .await;
 }
 
-async fn direct_put_round_trip(config: ServerConfig) {
+async fn direct_put_round_trip(signed_write: SignedWriteHeaders, config: ServerConfig) {
     let harness = start_server(config).await;
 
     let namespace = "direct-put-e2e";
@@ -93,6 +137,12 @@ async fn direct_put_round_trip(config: ServerConfig) {
         .await
         .expect("fetch capabilities");
     assert!(capabilities.supports("core.uploads.direct_put"));
+    // The deployment names the digest its provider enforces, and it is the
+    // one this provider's signed write actually carries.
+    assert_eq!(
+        capabilities.direct_put_checksum_algorithm(),
+        Some(signed_write.checksum_algorithm)
+    );
 
     harness
         .client
@@ -100,13 +150,17 @@ async fn direct_put_round_trip(config: ServerConfig) {
         .await
         .expect("create namespace");
 
-    assert_wrong_direct_put_bytes_rejected(&harness.client, &namespace_id).await;
-    assert_direct_put_requires_signed_checksum_header(&harness.client, &namespace_id).await;
-    assert_direct_put_is_no_replace(&harness.client, &namespace_id).await;
+    assert_wrong_direct_put_bytes_rejected(&harness.client, &namespace_id, signed_write).await;
+    assert_direct_put_requires_its_signed_headers(&harness.client, &namespace_id, signed_write)
+        .await;
+    assert_direct_put_is_no_replace(&harness.client, &namespace_id, signed_write).await;
 
     let begin = harness
         .client
-        .begin_direct_put(&namespace_id, direct_put_claim(bytes))
+        .begin_direct_put(
+            &namespace_id,
+            direct_put_claim(bytes, signed_write.checksum_algorithm),
+        )
         .await
         .expect("begin direct put");
     let direct_put = begin.direct_put.expect("direct-put access");
@@ -115,9 +169,15 @@ async fn direct_put_round_trip(config: ServerConfig) {
     let content_ref = direct_put.content_ref.clone();
     assert_eq!(content_ref.size_bytes, bytes.len() as u64);
     assert_eq!(
-        content_ref.whole_file_sha256.as_deref(),
-        Some(content_ref.storage_checksum.value.as_str())
+        content_ref.storage_checksum.algorithm,
+        signed_write.checksum_algorithm
     );
+    // A trusted whole-file SHA-256 exists only where the provider validated
+    // one. On a CRC-32C provider nobody hashed these bytes with SHA-256, and
+    // the ref says so rather than repeating the CRC under a second name.
+    let expected_sha256 = (signed_write.checksum_algorithm == ChecksumAlgorithm::Sha256)
+        .then(|| content_ref.storage_checksum.value.clone());
+    assert_eq!(content_ref.whole_file_sha256, expected_sha256);
 
     harness
         .client
@@ -254,11 +314,18 @@ fn fetch_range(url: &str, first: usize, last: usize) -> Vec<u8> {
     bytes
 }
 
-async fn assert_wrong_direct_put_bytes_rejected(client: &Client, namespace_id: &NamespaceId) {
+async fn assert_wrong_direct_put_bytes_rejected(
+    client: &Client,
+    namespace_id: &NamespaceId,
+    signed_write: SignedWriteHeaders,
+) {
     let bytes = b"expected direct put bytes\n";
     let wrong_bytes = b"wrong direct put bytes\n";
     let begin = client
-        .begin_direct_put(namespace_id, direct_put_claim(bytes))
+        .begin_direct_put(
+            namespace_id,
+            direct_put_claim(bytes, signed_write.checksum_algorithm),
+        )
         .await
         .expect("begin wrong-bytes direct put");
     let direct_put = begin.direct_put.expect("wrong-bytes direct-put access");
@@ -282,44 +349,89 @@ async fn assert_wrong_direct_put_bytes_rejected(client: &Client, namespace_id: &
     );
 }
 
-async fn assert_direct_put_requires_signed_checksum_header(
+/// Both signed headers are load-bearing, and neither can be dropped or
+/// rewritten in flight.
+///
+/// The provider recomputes the signature over what it received, so a request
+/// missing a signed header — or carrying a different value for one — is not
+/// the request that was signed. Omission and tampering are checked
+/// separately: a provider could plausibly reject the first as malformed
+/// while quietly accepting the second, and only the second is what an
+/// attacker holding a capability would actually try.
+async fn assert_direct_put_requires_its_signed_headers(
     client: &Client,
     namespace_id: &NamespaceId,
+    signed_write: SignedWriteHeaders,
 ) {
-    let bytes = b"direct put bytes without checksum header\n";
-    let begin = client
-        .begin_direct_put(namespace_id, direct_put_claim(bytes))
-        .await
-        .expect("begin missing-checksum direct put");
-    let direct_put = begin
-        .direct_put
-        .expect("missing-checksum direct-put access");
-    let content_ref = direct_put.content_ref.clone();
-    let access_without_checksum =
-        presigned_access_without_header(&direct_put.access, SIGNED_CHECKSUM_HEADER);
+    let bytes = b"direct put bytes with the signed headers meddled with\n";
+    let other_bytes = b"some other object entirely\n";
+    let other_checksum = StorageChecksum::compute(signed_write.checksum_algorithm, other_bytes);
 
-    expect_client_rejection(
-        client
-            .upload_via_presigned_url(&access_without_checksum, bytes)
-            .await,
-        "missing-checksum direct put",
-    );
-    expect_client_rejection(
-        client
-            .complete_upload(
+    for (label, meddle) in [
+        (
+            "checksum header omitted",
+            Meddle::Remove(signed_write.checksum),
+        ),
+        (
+            "create-only header omitted",
+            Meddle::Remove(signed_write.create_only),
+        ),
+        (
+            "checksum header rewritten to another object's digest",
+            Meddle::Replace(
+                signed_write.checksum,
+                provider_checksum_header_value(signed_write, &other_checksum),
+            ),
+        ),
+        (
+            "create-only precondition rewritten to allow replacement",
+            Meddle::Replace(signed_write.create_only, relaxed_precondition(signed_write)),
+        ),
+    ] {
+        let begin = client
+            .begin_direct_put(
                 namespace_id,
-                &begin.upload_id,
-                &CompleteUploadRequest::for_content_ref(content_ref),
+                direct_put_claim(bytes, signed_write.checksum_algorithm),
             )
-            .await,
-        "complete missing-checksum direct put",
-    );
+            .await
+            .expect("begin meddled direct put");
+        let direct_put = begin.direct_put.expect("meddled direct-put access");
+        let content_ref = direct_put.content_ref.clone();
+
+        expect_client_rejection(
+            client
+                .upload_via_presigned_url(&meddle.apply(&direct_put.access), bytes)
+                .await,
+            label,
+        );
+        // And the object was never created, so completion has nothing to
+        // find and hands out no token.
+        expect_client_rejection(
+            client
+                .complete_upload(
+                    namespace_id,
+                    &begin.upload_id,
+                    &CompleteUploadRequest::for_content_ref(content_ref),
+                )
+                .await,
+            &format!("complete after {label}"),
+        );
+    }
 }
 
-async fn assert_direct_put_is_no_replace(client: &Client, namespace_id: &NamespaceId) {
+/// The create-only precondition holds against a replay of the very same
+/// capability, and the object the first write created is untouched.
+async fn assert_direct_put_is_no_replace(
+    client: &Client,
+    namespace_id: &NamespaceId,
+    signed_write: SignedWriteHeaders,
+) {
     let bytes = b"duplicate direct put bytes\n";
     let begin = client
-        .begin_direct_put(namespace_id, direct_put_claim(bytes))
+        .begin_direct_put(
+            namespace_id,
+            direct_put_claim(bytes, signed_write.checksum_algorithm),
+        )
         .await
         .expect("begin duplicate direct put");
     let direct_put = begin.direct_put.expect("duplicate direct-put access");
@@ -344,31 +456,80 @@ async fn assert_direct_put_is_no_replace(client: &Client, namespace_id: &Namespa
         )
         .await
         .expect("complete first direct put");
-    assert!(complete.validated_content_token.is_some());
+    assert!(
+        complete.validated_content_token.is_some(),
+        "the refused replay left the first object exactly as it was written"
+    );
 }
 
-fn presigned_access_without_header(
-    access: &ObjectTransferAccess,
-    header: &str,
-) -> ObjectTransferAccess {
-    match access {
-        ObjectTransferAccess::PresignedUrl {
+/// The complete header value this provider expects for a given digest.
+///
+/// GCS names the algorithm inside the value and spells the digest in base64;
+/// the S3 family names the algorithm in the header and spells the digest in
+/// base64 too. Both are produced here so a tampering proof can offer a
+/// well-formed value for the wrong object rather than a malformed one.
+fn provider_checksum_header_value(
+    signed_write: SignedWriteHeaders,
+    checksum: &StorageChecksum,
+) -> String {
+    let raw = loonfs_api::wire::hex::hex_decode_bytes(&checksum.value).expect("checksum is hex");
+    let encoded = base64::engine::general_purpose::STANDARD.encode(raw);
+    if signed_write.checksum.starts_with("x-goog") {
+        // GCS names the algorithm inside the value; the S3 family names it in
+        // the header.
+        format!("{}={encoded}", checksum.algorithm.as_str())
+    } else {
+        encoded
+    }
+}
+
+/// A precondition value that would let the write replace an existing object,
+/// which is exactly what the signature must stop.
+fn relaxed_precondition(signed_write: SignedWriteHeaders) -> String {
+    if signed_write.create_only.starts_with("x-goog") {
+        // Any live generation, rather than "must not exist".
+        "1".to_owned()
+    } else {
+        // An etag no object has, rather than "must not exist".
+        "\"never-matches-any-etag\"".to_owned()
+    }
+}
+
+/// One edit to a signed header set, applied to an issued capability.
+enum Meddle {
+    Remove(&'static str),
+    Replace(&'static str, String),
+}
+
+impl Meddle {
+    fn apply(&self, access: &ObjectTransferAccess) -> ObjectTransferAccess {
+        let ObjectTransferAccess::PresignedUrl {
             method,
             url,
             headers,
             expires_at_ms,
-        } => {
-            let mut headers = headers.clone();
-            assert!(
-                headers.remove(header).is_some(),
-                "presigned access did not include expected header `{header}`"
-            );
-            ObjectTransferAccess::PresignedUrl {
-                method: method.clone(),
-                url: url.clone(),
-                headers,
-                expires_at_ms: *expires_at_ms,
+        } = access;
+        let mut headers = headers.clone();
+        match self {
+            Self::Remove(header) => {
+                assert!(
+                    headers.remove(*header).is_some(),
+                    "presigned access did not include expected header `{header}`"
+                );
             }
+            Self::Replace(header, value) => {
+                let previous = headers.insert((*header).to_owned(), value.clone());
+                assert!(
+                    previous.is_some_and(|previous| &previous != value),
+                    "presigned access did not include a different `{header}` to replace"
+                );
+            }
+        }
+        ObjectTransferAccess::PresignedUrl {
+            method: method.clone(),
+            url: url.clone(),
+            headers,
+            expires_at_ms: *expires_at_ms,
         }
     }
 }
@@ -441,6 +602,31 @@ impl CloudflareR2DirectPutConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct GcpGcsDirectPutConfig {
+    bucket: String,
+    service_account_key_path: String,
+    prefix: String,
+}
+
+impl GcpGcsDirectPutConfig {
+    fn from_env() -> Result<Self, ProviderEnvError> {
+        Ok(Self {
+            bucket: required_env("LOONFS_TEST_GCS_BUCKET")?,
+            service_account_key_path: required_env("LOONFS_TEST_GCS_SERVICE_ACCOUNT_KEY_PATH")?,
+            prefix: direct_put_prefix("gcp-gcs", optional_env("LOONFS_TEST_GCS_PREFIX")),
+        })
+    }
+
+    fn store(self) -> StoreConfig {
+        StoreConfig::GcpGcs {
+            bucket: self.bucket,
+            service_account_key_path: self.service_account_key_path,
+            key_prefix: Some(self.prefix),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ProviderEnvError {
     Missing { name: &'static str },
     Empty { name: &'static str },
@@ -490,6 +676,328 @@ fn direct_put_prefix(provider: &str, base_prefix: Option<String>) -> String {
         std::process::id(),
         provider
     )
+}
+
+/// The same round trip on Google Cloud Storage, through its native V4 signed
+/// URLs rather than the banned S3-interoperability surface.
+///
+/// Everything above the object-store adapter is the same code path the S3
+/// providers take: the client learns `crc32c` from the capability document,
+/// the begin handler refuses any other algorithm, and completion compares a
+/// stored checksum to a promised one. Only the header spellings differ, and
+/// those are the parameter.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires real GCP GCS credentials"]
+async fn gcp_gcs_direct_put_real_provider_round_trip() {
+    let config = GcpGcsDirectPutConfig::from_env().expect("load GCP GCS direct-put environment");
+    direct_put_round_trip(
+        GCS_SIGNED_WRITE,
+        test_config(
+            config.store(),
+            AUTH_TOKEN,
+            CONTENT_TOKEN_SECRET,
+            "direct-put-gcp-gcs",
+        ),
+    )
+    .await;
+}
+
+/// The GCS proofs the shared round trip does not reach: what the provider
+/// does with capabilities that are scoped, replayed, expired, or ranged.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires real GCP GCS credentials"]
+async fn gcp_gcs_signed_capabilities_are_scoped_bounded_and_single_use() {
+    let config = GcpGcsDirectPutConfig::from_env().expect("load GCP GCS direct-put environment");
+    let store_config = config.clone().store();
+    let mut server_config = test_config(
+        config.store(),
+        AUTH_TOKEN,
+        CONTENT_TOKEN_SECRET,
+        "gcs-signed-capabilities",
+    );
+    // Narrow both proxy caps so a modest payload is genuinely past them.
+    // What makes an object "too big to proxy" is the cap, not the byte
+    // count, so this suite proves the behavior without moving a gigabyte
+    // through a real provider on every run.
+    server_config.max_upload_bytes = PROXY_CAP_BYTES;
+    server_config.max_download_bytes = PROXY_CAP_BYTES;
+    let harness = start_server(server_config).await;
+
+    let namespace = "gcs-capabilities";
+    let namespace_id = NamespaceId::parse(namespace).expect("valid namespace id");
+    harness
+        .client
+        .create_namespace(&namespace_id)
+        .await
+        .expect("create namespace");
+
+    let capabilities = harness
+        .client
+        .capabilities()
+        .await
+        .expect("fetch capabilities");
+    assert!(capabilities.supports("core.uploads.direct_put"));
+    assert!(capabilities.supports("core.downloads.direct_get"));
+    assert!(capabilities.supports("core.uploads.direct_put.checksum.crc32c"));
+    assert!(
+        !capabilities.supports("core.uploads.direct_multipart"),
+        "GCS has no S3-style multipart API to advertise"
+    );
+
+    assert_gcs_completion_judges_the_object_that_is_there(&harness.client, &namespace_id).await;
+    assert_gcs_signed_writes_land_under_the_configured_prefix(&harness, &store_config).await;
+    assert_gcs_read_capability_serves_ranges_and_resumes(&harness, namespace).await;
+    assert_gcs_expired_capability_is_refused(&harness.client, &namespace_id).await;
+    assert_gcs_cap_bound_object_moves_only_directly(&harness, namespace).await;
+
+    delete_everything_under_the_run_prefix(&store_config).await;
+    harness.server.abort();
+}
+
+/// Completion reads the object back and judges it. A promise that does not
+/// describe what is actually stored fails, and a failed completion hands out
+/// no content token — so nothing unproven can reach a commit.
+async fn assert_gcs_completion_judges_the_object_that_is_there(
+    client: &Client,
+    namespace_id: &NamespaceId,
+) {
+    let bytes = b"gcs completion reads the object back\n";
+    let begin = client
+        .begin_direct_put(
+            namespace_id,
+            direct_put_claim(bytes, ChecksumAlgorithm::Crc32c),
+        )
+        .await
+        .expect("begin direct put");
+    let direct_put = begin.direct_put.expect("direct-put access");
+    let content_ref = direct_put.content_ref.clone();
+    client
+        .upload_via_presigned_url(&direct_put.access, bytes)
+        .await
+        .expect("upload the promised bytes");
+
+    // A ref claiming the wrong length, and one claiming the wrong digest,
+    // each describe an object that is not the one stored.
+    let wrong_size = loonfs_api::ContentRef {
+        size_bytes: content_ref.size_bytes + 1,
+        ..content_ref.clone()
+    };
+    let wrong_checksum = loonfs_api::ContentRef {
+        storage_checksum: StorageChecksum::crc32c(b"some other object entirely\n"),
+        ..content_ref.clone()
+    };
+    for (label, claimed) in [
+        ("wrong size", wrong_size),
+        ("wrong checksum", wrong_checksum),
+    ] {
+        let refused = client
+            .complete_upload(
+                namespace_id,
+                &begin.upload_id,
+                &CompleteUploadRequest::for_content_ref(claimed),
+            )
+            .await;
+        expect_client_rejection(refused, &format!("complete with a {label}"));
+    }
+
+    // The honest promise completes, against the very same stored object.
+    let complete = client
+        .complete_upload(
+            namespace_id,
+            &begin.upload_id,
+            &CompleteUploadRequest::for_content_ref(content_ref.clone()),
+        )
+        .await
+        .expect("complete the honest promise");
+    assert_eq!(complete.content_ref, content_ref);
+    assert!(complete.validated_content_token.is_some());
+    assert_eq!(
+        content_ref.storage_checksum,
+        StorageChecksum::crc32c(bytes),
+        "the readback and the promise met on the crc32c GCS actually stored"
+    );
+    assert_eq!(
+        content_ref.whole_file_sha256, None,
+        "no trustworthy party hashed these bytes with SHA-256"
+    );
+}
+
+/// Every object a signed write creates lands beneath the deployment's
+/// configured key prefix, so a capability cannot address the bucket outside
+/// this deployment's scope.
+async fn assert_gcs_signed_writes_land_under_the_configured_prefix(
+    harness: &crate::common::TestServer,
+    store_config: &StoreConfig,
+) {
+    let namespace_id = NamespaceId::parse("gcs-capabilities").expect("valid namespace id");
+    let bytes = b"gcs prefix scoping\n";
+    let begin = harness
+        .client
+        .begin_direct_put(
+            &namespace_id,
+            direct_put_claim(bytes, ChecksumAlgorithm::Crc32c),
+        )
+        .await
+        .expect("begin direct put");
+    let direct_put = begin.direct_put.expect("direct-put access");
+    let ObjectTransferAccess::PresignedUrl { url, .. } = &direct_put.access;
+    let StoreConfig::GcpGcs {
+        bucket, key_prefix, ..
+    } = store_config
+    else {
+        unreachable!("this proof runs on GCS")
+    };
+    let prefix = key_prefix.as_deref().expect("this run configures a prefix");
+    assert!(
+        url.starts_with(&format!(
+            "https://storage.googleapis.com/{bucket}/{prefix}/"
+        )),
+        "a signed write addressed something outside the deployment's prefix: {url}"
+    );
+
+    harness
+        .client
+        .upload_via_presigned_url(&direct_put.access, bytes)
+        .await
+        .expect("upload under the prefix");
+
+    // The store scopes every key beneath the same prefix, so listing its
+    // root is exactly this run's objects — and the new one is among them.
+    let store = store_config
+        .configured_object_store()
+        .expect("build a store")
+        .into_shared();
+    let keys = store.list_prefix("").await.expect("list the run prefix");
+    assert!(
+        keys.iter()
+            .any(|key| key.contains(direct_put.content_ref.content_id.as_str())),
+        "the object a signed write created is not under the run prefix"
+    );
+}
+
+/// One read capability serves the whole object, arbitrary windows of it, and
+/// a resumption that stitches a prefix already in hand to the rest.
+async fn assert_gcs_read_capability_serves_ranges_and_resumes(
+    harness: &crate::common::TestServer,
+    namespace: &str,
+) {
+    let payload: Vec<u8> = (0..96 * 1024).map(|offset| (offset % 251) as u8).collect();
+    let target = NamespacePath::parse(namespace, "/ranged.bin").expect("ranged target");
+    harness
+        .client
+        .put_file_bytes(&target, &payload, &put_options("gcs-ranged"))
+        .await
+        .expect("stage an object to read back");
+
+    let grant = harness
+        .client
+        .begin_download(&target, None)
+        .await
+        .expect("begin download");
+    let ObjectTransferAccess::PresignedUrl { url, headers, .. } = &grant.access;
+    assert!(
+        headers.is_empty(),
+        "a read capability requires the client to send nothing, which is what leaves \
+         `Range` free"
+    );
+
+    // The whole object, then three disjoint windows off the one URL that
+    // reassemble into it exactly.
+    let mut received = Vec::new();
+    harness
+        .client
+        .download_via_presigned_url(&grant, &mut received)
+        .await
+        .expect("read the whole object");
+    assert_eq!(received, payload);
+
+    let cuts = [0, 12_345, 60_000, payload.len()];
+    let mut reassembled = Vec::new();
+    for window in cuts.windows(2) {
+        reassembled.extend_from_slice(&fetch_range(url, window[0], window[1] - 1));
+    }
+    assert_eq!(
+        reassembled, payload,
+        "three windows off one capability did not reassemble the object"
+    );
+
+    // A resumption: a prefix already in hand, and the remainder fetched with
+    // a `Range` the signature never covered.
+    let already_have = 40_000;
+    let mut resumed = payload[..already_have].to_vec();
+    resumed.extend_from_slice(&fetch_range(url, already_have, payload.len() - 1));
+    assert_eq!(
+        resumed, payload,
+        "a resumed read did not fold to the object"
+    );
+}
+
+/// A capability stops working when it expires, which is what bounds the
+/// damage of one leaking.
+async fn assert_gcs_expired_capability_is_refused(client: &Client, namespace_id: &NamespaceId) {
+    let bytes = b"gcs expiry\n";
+    let begin = client
+        .begin_direct_put(
+            namespace_id,
+            direct_put_claim(bytes, ChecksumAlgorithm::Crc32c),
+        )
+        .await
+        .expect("begin direct put");
+    let direct_put = begin.direct_put.expect("direct-put access");
+    let ObjectTransferAccess::PresignedUrl { url, .. } = &direct_put.access;
+
+    // Rewrite the capability's own lifetime to one already spent. The
+    // signature covered the original, so this is refused twice over — which
+    // is the point: neither the expiry nor the signature can be edited in
+    // flight.
+    let expired = url.replace("X-Goog-Expires=900", "X-Goog-Expires=1");
+    assert_ne!(&expired, url, "the capability did not carry an expiry");
+    let response = ureq::put(&expired).send_bytes(bytes);
+    assert!(
+        response.is_err(),
+        "a capability with an edited lifetime was accepted"
+    );
+}
+
+/// An object past the deployment's proxy caps moves only directly, in both
+/// directions, and the proxy still refuses it.
+async fn assert_gcs_cap_bound_object_moves_only_directly(
+    harness: &crate::common::TestServer,
+    namespace: &str,
+) {
+    let payload: Vec<u8> = (0..4 * PROXY_CAP_BYTES as usize)
+        .map(|offset| (offset % 251) as u8)
+        .collect();
+    let target = NamespacePath::parse(namespace, "/cap-bound.bin").expect("cap-bound target");
+
+    // GCS signs no multipart, so this whole-object write is the only
+    // direct transport there is — and the proxy will not take it.
+    harness
+        .client
+        .put_file_bytes(&target, &payload, &put_options("gcs-cap-bound"))
+        .await
+        .expect("an object past the proxy cap takes the whole-object direct write");
+
+    let grant = harness
+        .client
+        .begin_download(&target, None)
+        .await
+        .expect("an object past the read cap is served by grant");
+    let mut received = Vec::new();
+    harness
+        .client
+        .download_via_presigned_url(&grant, &mut received)
+        .await
+        .expect("read the granted object");
+    assert_eq!(received, payload);
+
+    // And the proxy still says no, which is what made the grant necessary.
+    // `get_file_bytes` is the plain proxied read with no fallback, so this
+    // asks the proxy directly rather than re-running the ladder.
+    expect_client_rejection(
+        harness.client.get_file_bytes(&target).await,
+        "proxied read of an object past the read cap",
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -934,15 +934,27 @@ available and is the default.
 The reference server offers `direct_put` only where its adapter can presign the
 required create-only, checksum-bound request *and* the configured endpoint is a
 first-party provider domain family the live conformance suite has run against.
-Custom S3-compatible endpoints, Google Cloud Storage, Azure Blob Storage, and
-the local filesystem are not offered `direct_put`, and there is no
-configuration override. Other implementations may use different headers or
-decline `direct_put` support.
+AWS S3 and Cloudflare R2 qualify through SigV4, and Google Cloud Storage
+through its native `GOOG4-RSA-SHA256` signed URLs — not through GCS's
+S3-interoperability surface, which conformance proved ignores preconditions.
+Custom S3-compatible endpoints, Azure Blob Storage, and the local filesystem
+are not offered `direct_put`, and there is no configuration override. Other
+implementations may use different headers or decline `direct_put` support.
+
+The signed request's shape is the provider's, not a fixed one, and the
+deployment names the digest it binds in
+`core.uploads.direct_put.checksum.<algorithm>`. A client folds that algorithm
+over its payload and never infers one from the backend.
 
 `direct_put` and `direct_multipart` are separate offers. A provider that can
 sign a whole-object write but has no S3-style multipart API advertises the
-first and not the second, and a client's transport ladder falls from parts to
-one whole-object write before it falls back to the proxy.
+first and not the second — Google Cloud Storage is exactly this case — and a
+client's transport ladder falls from parts to one whole-object write before it
+falls back to the proxy.
+
+A browser calling a presigned URL is talking to the provider, not to LoonFS,
+so cross-origin access is governed by the bucket's or container's own CORS
+configuration rather than by anything this API sets.
 
 After the client uploads bytes to the presigned URL, it calls complete with the
 `content_ref` the server returned at begin. Completion **verifies rather than

--- a/docs/specs/object-storage-providers.md
+++ b/docs/specs/object-storage-providers.md
@@ -37,17 +37,28 @@ the bundle *is* the decision, so nothing above the object-store crate asks
 configuration the question a second time:
 
 1. **The adapter can presign a request that binds the content ref's digest.**
-   Only the S3-compatible adapters (AWS S3 and Cloudflare R2) issue one
-   today: a presigned PUT carrying a signed `x-amz-checksum-sha256` and
-   `if-none-match: *`. GCS and Azure Blob can presign and enforce create-only
-   but validate only CRC32C/MD5, neither of which the claim could name until
-   now; the local filesystem has no signing surface at all.
+   The S3-compatible adapters (AWS S3 and Cloudflare R2) issue a presigned
+   PUT carrying a signed `x-amz-checksum-sha256` and `if-none-match: *`.
+   Google Cloud Storage issues the same guarantee in its own spellings: a
+   native `GOOG4-RSA-SHA256` signed URL carrying a signed
+   `x-goog-hash: crc32c=<base64>` and `x-goog-if-generation-match: 0`, which
+   is create-only. Azure Blob can presign and enforce create-only but
+   validates only MD5, which this format does not name; the local filesystem
+   has no signing surface at all.
+
+   GCS's *S3-interoperability* surface is banned outright and is not the
+   route here. Live conformance proved it accepts the signature and then
+   silently ignores HTTP preconditions — it overwrites where it should fail —
+   so the native API is the only correct backend, and the native V4 signer is
+   the only thing that signs GCS transfers.
 2. **The endpoint is one the live conformance suite has actually run against,
    reached over TLS.** An AWS S3 endpoint with no override, an override in
    the `amazonaws.com` or `amazonaws.com.cn` domain family, and an R2
    endpoint in the `r2.cloudflarestorage.com` family qualify. Any other
    endpoint URL is some other implementation of the S3 API, is not covered by
-   those runs, and does not qualify.
+   those runs, and does not qualify. GCS has nothing to decide here: its
+   configuration carries no endpoint override, so every capability it issues
+   is `https` to `storage.googleapis.com`.
 
    The scheme is part of the test because a presigned URL is a bearer
    capability to read or write one object: issued over `http`, it and its
@@ -69,9 +80,23 @@ enforce the preconditions.
 The digest a provider binds is its own, not a fixed one. The deployment names
 it in `core.uploads.direct_put.checksum.<algorithm>`, and the client folds
 that digest while staging; a claim in any other algorithm is refused at
-begin. The provider's single-request ceiling is advertised the same way, as
-`upload.direct_put_max_content_bytes` — 5 GiB on AWS S3, and 5 MiB less than
-that on R2, which documents the smaller single-part maximum of the two.
+begin. That is what lets GCS join at all: it validates CRC-32C, the S3 family
+validates SHA-256, and the client learns which from the capability document
+rather than from the backend kind. The provider's single-request ceiling is
+advertised the same way, as `upload.direct_put_max_content_bytes` — 5 GiB on
+AWS S3, 5 MiB less than that on R2, which documents the smaller single-part
+maximum of the two, and 5 TiB on GCS, which documents one object-size
+maximum and no separate single-request one.[^1]
+
+A deployment's `direct_put` issuer and its stored-checksum readback have to
+name the same algorithm, because completion compares one against the other.
+That is not a rule anyone remembers: a provider adapter that signs CRC-32C
+reads CRC-32C back, from the same adapter, and a provider that cannot report
+a stored checksum at all cannot offer `direct_put` either.
+
+Browser callers reading or writing through these URLs need CORS configured on
+the bucket or container itself; LoonFS issues the capability and the provider
+serves the request, so the provider's CORS rules are the ones that apply.
 
 This never weakens ordinary uploads. The server-mediated upload path is
 available on every supported store and is the default wherever direct-put is
@@ -89,21 +114,24 @@ than it will proxy can be created through it. A presigned read binds nothing
 beyond the object key; a client checks the arriving bytes against the content
 reference the grant carried.
 
-| Provider | `direct_get` | `direct_put` | `direct_multipart` | Proven endpoints |
-| --- | --- | --- | --- | --- |
-| AWS S3 | Yes | Yes | Yes | Default endpoint, `amazonaws.com`, `amazonaws.com.cn` |
-| Cloudflare R2 | Yes | Yes | Yes | `r2.cloudflarestorage.com` |
-| Other S3-compatible endpoints | No | No | No | None — unproven |
-| Google Cloud Storage | No | No | No | n/a |
-| Azure Blob Storage | No | No | No | n/a |
-| Local filesystem | No | No | No | n/a |
+| Provider | `direct_get` | `direct_put` | `direct_multipart` | Signed write | Proven endpoints |
+| --- | --- | --- | --- | --- | --- |
+| AWS S3 | Yes | Yes | Yes | SigV4, SHA-256, `if-none-match: *` | Default endpoint, `amazonaws.com`, `amazonaws.com.cn` |
+| Cloudflare R2 | Yes | Yes | Yes | SigV4, SHA-256, `if-none-match: *` | `r2.cloudflarestorage.com` |
+| Other S3-compatible endpoints | No | No | No | n/a | None — unproven |
+| Google Cloud Storage | Yes | Yes | No | GOOG4-RSA-SHA256, CRC-32C, generation 0 | `storage.googleapis.com` (no override exists) |
+| Azure Blob Storage | No | No | No | n/a | n/a |
+| Local filesystem | No | No | No | n/a | n/a |
 
-The three are separate columns because they are separate offers. `direct_get`
-comes with the bundle existing at all, and the two write directions are
-independent of each other: a provider that can sign a whole-object write but
-has no S3-style multipart API to open advertises `direct_put` and not
-`direct_multipart`. A client's upload ladder falls from parts, to one
-whole-object write, to the proxy, and refuses a payload none of them can
+The three transfer columns are separate because they are separate offers.
+`direct_get` comes with the bundle existing at all, and the two write
+directions are independent of each other: GCS is the case that makes this
+concrete, signing whole-object writes and reads while having no S3-style
+multipart API to open, so it advertises `direct_put` and not
+`direct_multipart`. Nothing is lost by that — GCS's single-request ceiling is
+1000x the S3 family's, so there is no object size at which a whole-object
+write stops being expressible. A client's upload ladder falls from parts, to
+one whole-object write, to the proxy, and refuses a payload none of them can
 carry rather than pushing it into the capped proxy.
 
 ## 4. Incremental writes and where they are real


### PR DESCRIPTION
IN this PR, GCS gets direct upload and download through Google's native V4 signed URLs. A signed request can only perform the exact write approved by the server: create-only, checksum-bound, one object. GCS offers direct PUT and GET but not multipart, and the client needed zero GCS-specific changes.

other notes:

- The advertised size limit is GCS's 5 TiB object maximum
- `x-goog-hash` can arrive as several headers in any order
- Signature test vectors came from Google's own client library against a throwaway fixture key (test-only, but scanners will flag the PEM)
- `presign/aws_sigv4.rs` became `presign/v4.rs` so both signing schemes share date and encoding helpers
