### PR TITLE
fix(gcs): review findings from the native direct-transfer PR

### DIFF
--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -1562,10 +1562,18 @@ impl Client {
             return Ok(UploadTransport::Multipart);
         }
         let direct_put_algorithm = capabilities.direct_put_checksum_algorithm();
-        // A length nobody knows cannot be checked against a cap, and cannot
-        // be declared to a provider that wants the digest before the write.
+        // A length nobody knows cannot be checked against a cap. Where a
+        // whole-object write is on offer that is no reason to give up on
+        // it: the transport's first pass measures the payload without
+        // sending a byte, and that measurement re-decides the transport
+        // before anything moves. Falling straight to the service here would
+        // stream an unmeasured payload at a cap it may not fit, and where the
+        // deployment signs no multipart it would be discarding the only rung
+        // that could have carried it.
         let Some(size_bytes) = size_bytes else {
-            return Ok(UploadTransport::Proxied);
+            return Ok(
+                direct_put_algorithm.map_or(UploadTransport::Proxied, UploadTransport::DirectPut)
+            );
         };
         let proxy_cap = capabilities
             .limits

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -14,8 +14,8 @@ use crate::transport::test_transport::{self, Outcome};
 use futures::stream::StreamExt;
 use loonfs_api::v0::{DirectMultipartUpload, DirectPutUpload, UploadMode};
 use loonfs_api::{
-    CapabilityDocument, ContentId, ContentRef, FEATURE_UPLOADS_DIRECT_PUT,
-    FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_SHA256, PROFILE_CORE_V0, PROTOCOL_VERSION,
+    direct_put_checksum_feature, CapabilityDocument, ContentId, ContentRef,
+    FEATURE_UPLOADS_DIRECT_PUT, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -184,9 +184,14 @@ fn capabilities(direct_multipart: bool) -> Outcome {
 #[derive(Default, Clone, Copy)]
 struct Advertised {
     direct_multipart: bool,
-    /// Advertises `direct_put` with a SHA-256 claim, the algorithm the
-    /// S3-compatible providers enforce.
-    direct_put: bool,
+    /// The whole-object checksum this deployment says its provider
+    /// enforces, or `None` to advertise no `direct_put` at all.
+    ///
+    /// Providers do not agree on one -- the S3 family enforces SHA-256 and
+    /// GCS enforces CRC-32C -- so the shape is a parameter here for the same
+    /// reason it is a capability key on the wire: the client folds whichever
+    /// the deployment names.
+    direct_put: Option<ChecksumAlgorithm>,
     /// The service's own buffering cap, when the deployment advertises one.
     proxy_max_bytes: Option<u64>,
     /// The provider's single-request ceiling, when it advertises one.
@@ -198,9 +203,9 @@ fn capabilities_for(advertised: Advertised) -> Outcome {
         FEATURE_UPLOADS_DIRECT_MULTIPART.to_owned(),
         advertised.direct_multipart,
     )]);
-    if advertised.direct_put {
+    if let Some(algorithm) = advertised.direct_put {
         features.insert(FEATURE_UPLOADS_DIRECT_PUT.to_owned(), true);
-        features.insert(FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_SHA256.to_owned(), true);
+        features.insert(direct_put_checksum_feature(algorithm).to_owned(), true);
     }
     let mut limits = std::collections::BTreeMap::new();
     if let Some(cap) = advertised.proxy_max_bytes {
@@ -611,7 +616,7 @@ async fn a_small_payload_past_the_proxy_cap_takes_direct_put() {
     let (source, _) = watched_source(&payload, 512);
     let transport = test_transport::script(vec![
         capabilities_for(Advertised {
-            direct_put: true,
+            direct_put: Some(ChecksumAlgorithm::Sha256),
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()
@@ -635,6 +640,108 @@ async fn a_small_payload_past_the_proxy_cap_takes_direct_put() {
     assert_eq!(object_write.body_bytes(), payload.len());
 }
 
+/// The reviewer's case: a payload nobody measured, on a deployment that
+/// signs no multipart — which is what the GCS adapter is.
+///
+/// A length nobody knows is not a reason to fall to the service. The
+/// whole-object write's own first pass measures the payload without sending
+/// a byte, and that measurement is what routes it. Falling straight to the
+/// proxy here would stream an unmeasured payload — a pipe, a `tar` on
+/// stdin — at a cap it does not fit, and fail at the far end after moving
+/// every byte, with the one transport that could have carried it never
+/// asked.
+#[tokio::test]
+async fn an_unknown_length_payload_past_the_proxy_cap_takes_direct_put() {
+    let payload = payload(64 * 1024);
+    let uploaded = content_ref(&payload);
+    let (sized, retention) = watched_source(&payload, 4 * 1024);
+    let (stream, _) = sized.into_stream();
+    // The pipe's view of the same bytes: no length to route on.
+    let source = PayloadSource::stream(stream);
+    assert_eq!(source.size_bytes(), None);
+
+    let transport = test_transport::script(vec![
+        // A GCS-shaped deployment: crc32c whole-object writes, no multipart
+        // API, and a proxy that would refuse this payload.
+        capabilities_for(Advertised {
+            direct_put: Some(ChecksumAlgorithm::Crc32c),
+            direct_multipart: false,
+            proxy_max_bytes: Some(1_024),
+            direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024 * 1024),
+        }),
+        begin_direct_put(uploaded.clone()),
+        Outcome::Success(Vec::new()),
+        completed(uploaded),
+        commit_landed(),
+    ]);
+
+    client()
+        .put_file_stream(&spec(), source, &PutFileOptions::default())
+        .await
+        .expect("an unmeasured payload past the proxy cap should take the direct write");
+
+    let object_write = transport
+        .sent()
+        .into_iter()
+        .find(|sent| sent.url.starts_with("http://object.invalid/"))
+        .expect("the payload went straight to object storage");
+    assert_eq!(object_write.body_bytes(), payload.len());
+    // And the measuring pass still never held it: it folded and spooled.
+    assert_eq!(retention.total_bytes(), payload.len() as u64);
+    assert!(
+        retention.peak_live_bytes() <= 8 * 1024,
+        "the measuring pass accumulated the payload; peak was {}",
+        retention.peak_live_bytes()
+    );
+}
+
+/// The other half of the same rule: measuring first does not push small
+/// payloads onto the direct write.
+///
+/// The pass decides nothing by itself — it produces a length, and the
+/// ordinary ladder routes on it. A payload the service will take goes
+/// through the service, exactly as it would have with its length known up
+/// front.
+#[tokio::test]
+async fn a_small_unknown_length_payload_still_proxies() {
+    let payload = payload(1_000);
+    let uploaded = content_ref(&payload);
+    let (sized, _) = watched_source(&payload, 512);
+    let (stream, _) = sized.into_stream();
+    let source = PayloadSource::stream(stream);
+    assert_eq!(source.size_bytes(), None);
+
+    let transport = test_transport::script(vec![
+        capabilities_for(Advertised {
+            direct_put: Some(ChecksumAlgorithm::Crc32c),
+            direct_multipart: false,
+            proxy_max_bytes: Some(4_096),
+            direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024 * 1024),
+        }),
+        begin_proxied(),
+        json(&UploadContentResponse {
+            namespace_id: namespace_id(),
+            upload_id: upload_id(),
+            content_ref: uploaded.clone(),
+        }),
+        completed(uploaded),
+        commit_landed(),
+    ]);
+
+    client()
+        .put_file_stream(&spec(), source, &PutFileOptions::default())
+        .await
+        .expect("a small unmeasured payload should still proxy");
+
+    assert!(
+        transport
+            .sent()
+            .into_iter()
+            .all(|sent| !sent.url.starts_with("http://object.invalid/")),
+        "a payload the service would take was sent straight to object storage"
+    );
+}
+
 /// A direct-put payload crosses the network in bounded pieces: the first
 /// pass measures it without holding it, and the second streams it from
 /// where that pass left it. Nothing on either side of the digest ever holds
@@ -646,7 +753,7 @@ async fn a_direct_put_streams_its_payload_without_ever_holding_it() {
     let (source, retention) = watched_source(&payload, TEST_PART_BYTES as usize);
     let transport = test_transport::script(vec![
         capabilities_for(Advertised {
-            direct_put: true,
+            direct_put: Some(ChecksumAlgorithm::Sha256),
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()
@@ -701,7 +808,7 @@ async fn a_wrong_size_hint_does_not_refuse_an_upload_that_actually_fits() {
     let source = source_declaring(&payload, 100_000, 512);
     let _transport = test_transport::script(vec![
         capabilities_for(Advertised {
-            direct_put: true,
+            direct_put: Some(ChecksumAlgorithm::Sha256),
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(4_096),
             ..Advertised::default()
@@ -725,7 +832,7 @@ async fn a_refusal_reports_the_measured_length_not_the_declared_one() {
     let payload = payload(50_000);
     let source = source_declaring(&payload, 100_000, 512);
     let _transport = test_transport::script(vec![capabilities_for(Advertised {
-        direct_put: true,
+        direct_put: Some(ChecksumAlgorithm::Sha256),
         proxy_max_bytes: Some(1_024),
         direct_put_max_bytes: Some(4_096),
         ..Advertised::default()
@@ -762,7 +869,7 @@ async fn a_file_backed_direct_put_re_reads_the_file_rather_than_spooling_it() {
 
     let transport = test_transport::script(vec![
         capabilities_for(Advertised {
-            direct_put: true,
+            direct_put: Some(ChecksumAlgorithm::Sha256),
             proxy_max_bytes: Some(1_024),
             direct_put_max_bytes: Some(5 * 1024 * 1024 * 1024),
             ..Advertised::default()

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -26,6 +26,29 @@ use std::sync::Arc;
 pub(crate) const AWS_S3_PROVEN_DOMAINS: &[&str] = &["amazonaws.com", "amazonaws.com.cn"];
 pub(crate) const CLOUDFLARE_R2_PROVEN_DOMAINS: &[&str] = &["r2.cloudflarestorage.com"];
 
+/// Whether GCS's direct transfers have been proven against a live bucket.
+///
+/// The two S3-compatible providers earned their place in the lists above by
+/// a credentialed run of the conformance suite; this is the same bar,
+/// spelled as one flag because GCS has no endpoint override to key it on.
+/// It is `false` because that run has not happened yet: the signer, the
+/// readback, and the whole path are implemented and covered by unit tests,
+/// but no test has yet watched Google itself refuse a tampered checksum or a
+/// replayed create-only write, and the trust direct transfers rest on is
+/// exactly that refusal.
+///
+/// Flipping this to `true` belongs to the change that records a passing
+/// live run — nothing else in the build needs to move, and until then GCS
+/// deployments advertise no direct transfer and proxy every byte.
+///
+/// The run comes first and the flip second, which means doing it in that
+/// order locally: the ignored GCS suite in
+/// `crates/loonfs-server/tests/it/direct_put_real_provider.rs` asks a
+/// deployment for capabilities it does not yet advertise, so flip this,
+/// run the suite against a real bucket, and commit the flip with what the
+/// run showed.
+const GCS_DIRECT_TRANSFERS_PROVEN: bool = false;
+
 /// Identifies the concrete provider backing a [`ConfiguredObjectStore`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfiguredObjectStoreKind {
@@ -147,15 +170,29 @@ impl ConfiguredObjectStore {
     }
 
     /// Builds a native GCS store, and the reads and whole-object writes it
-    /// can authorize.
+    /// can authorize once [`GCS_DIRECT_TRANSFERS_PROVEN`] says a live run
+    /// has watched the provider enforce them.
     ///
-    /// GCS has no S3-style multipart API, so the bundle's multipart slot stays
-    /// empty rather than holding a signer that would fail. It needs no
-    /// endpoint-trust decision either: the configuration carries no endpoint
-    /// override, so every capability is `https` to Google's own host.
+    /// This adapter implements no multipart signing for GCS, so the bundle's
+    /// multipart slot stays empty rather than holding a signer that would
+    /// fail. It needs no endpoint-trust decision either: the configuration
+    /// carries no endpoint override, so every capability is `https` to
+    /// Google's own host.
     ///
     /// Construction fails when credentials, provider runtime, or key-prefix configuration is invalid.
     pub fn gcp_gcs(config: GcpGcsStoreConfig) -> Result<Self> {
+        Self::gcp_gcs_proven(config, GCS_DIRECT_TRANSFERS_PROVEN)
+    }
+
+    /// The same store with the live-conformance verdict passed in, so a test
+    /// can show what the flip turns on without waiting for it.
+    ///
+    /// The signer is built either way. It is the credential path the store's
+    /// own checksum readback needs, and building it is what makes an
+    /// unusable service-account key a startup failure rather than a surprise
+    /// at the first transfer — so `proven` decides only whether the bundle is
+    /// handed out, never whether it exists.
+    fn gcp_gcs_proven(config: GcpGcsStoreConfig, proven: bool) -> Result<Self> {
         let presigner = Arc::new(GcsV4Presigner::new(GcsPresignerConfig {
             bucket: config.bucket.clone(),
             service_account_key_path: config.service_account_key_path.clone(),
@@ -164,9 +201,8 @@ impl ConfiguredObjectStore {
         let store = GcpGcsStore::new(config)?;
         Ok(Self {
             inner: Arc::new(store),
-            direct_transfers: Some(
-                DirectTransferIssuers::read_only(presigner.clone()).with_put(presigner),
-            ),
+            direct_transfers: proven
+                .then(|| DirectTransferIssuers::read_only(presigner.clone()).with_put(presigner)),
         })
     }
 
@@ -304,20 +340,39 @@ mod tests {
         );
     }
 
-    /// GCS signs its own scheme, so its bundle carries reads and whole-object
-    /// writes; it has no S3-style multipart API, so that slot stays empty.
+    /// GCS advertises no direct transfer until a credentialed conformance
+    /// run has proven the provider enforces what the signatures bind.
+    ///
+    /// This is the same bar the S3-compatible providers cleared before their
+    /// domains went into the allowlists above. Trusting a signed precondition
+    /// that nothing has watched the provider honour is exactly the failure
+    /// the whole gate exists to prevent, and an implementation passing its
+    /// own unit tests is not that evidence.
+    ///
+    /// Flipping [`GCS_DIRECT_TRANSFERS_PROVEN`] fails this test, which is the
+    /// point: the flip and the run that justifies it land together.
+    #[test]
+    fn gcs_advertises_no_direct_transfer_until_a_live_run_proves_it() {
+        assert!(
+            gcs_store().direct_transfers().is_none(),
+            "an unproven provider must hand out no capability at all"
+        );
+    }
+
+    /// What the live-conformance flip turns on: reads and whole-object
+    /// writes, and no multipart, because this adapter signs none for GCS.
     /// The checksum and the ceiling come from the issuer, which is the only
     /// thing that knows them.
     #[test]
-    fn gcs_signs_puts_and_gets_and_offers_no_multipart() {
-        let transfers = gcs_store()
+    fn a_proven_gcs_deployment_signs_puts_and_gets_and_offers_no_multipart() {
+        let transfers = proven_gcs_store()
             .direct_transfers()
             .expect("gcs signs its native scheme");
         let put = transfers.put.expect("gcs signs whole-object writes");
 
         assert!(
             transfers.multipart.is_none(),
-            "GCS has no S3-style multipart API, which is spelled as an absent signer"
+            "this adapter signs no multipart for GCS, which is spelled as an absent signer"
         );
         assert_eq!(put.checksum_algorithm(), ChecksumAlgorithm::Crc32c);
         assert_eq!(put.max_content_bytes(), GCP_GCS_MAX_DIRECT_PUT_BYTES);
@@ -328,7 +383,7 @@ mod tests {
     /// signature, exactly as the S3-compatible bundle's does.
     #[test]
     fn the_gcs_bundle_signs_native_generation_preconditions() {
-        let issuer = gcs_store()
+        let issuer = proven_gcs_store()
             .direct_transfers()
             .and_then(|transfers| transfers.put)
             .expect("gcs presigner");
@@ -393,9 +448,9 @@ mod tests {
             .direct_transfers()
             .is_none());
 
-        // GCS is proven by construction: its configuration carries no
-        // endpoint override, so there is no unproven endpoint to reach.
-        assert!(gcs_store().direct_transfers().is_some());
+        // GCS has no endpoint override to judge, so what gates it is the
+        // live-conformance flag instead — and that run has not happened.
+        assert!(gcs_store().direct_transfers().is_none());
 
         let azure = ConfiguredObjectStore::azure_abs(AzureAbsStoreConfig {
             account_name: "devstoreaccount1".to_owned(),
@@ -492,14 +547,23 @@ mod tests {
     }
 
     fn gcs_store() -> ConfiguredObjectStore {
-        ConfiguredObjectStore::gcp_gcs(GcpGcsStoreConfig {
+        ConfiguredObjectStore::gcp_gcs(gcs_config()).expect("construct gcs store")
+    }
+
+    /// The same deployment as it will be once a credentialed conformance run
+    /// has flipped [`GCS_DIRECT_TRANSFERS_PROVEN`].
+    fn proven_gcs_store() -> ConfiguredObjectStore {
+        ConfiguredObjectStore::gcp_gcs_proven(gcs_config(), true).expect("construct gcs store")
+    }
+
+    fn gcs_config() -> GcpGcsStoreConfig {
+        GcpGcsStoreConfig {
             bucket: "bucket".to_owned(),
             service_account_key_path: gcs_fixture_service_account_key_file("configured-store-gcs")
                 .display()
                 .to_string(),
             key_prefix: Some("tenant-a".to_owned()),
-        })
-        .expect("construct gcs store")
+        }
     }
 
     /// A reference whose storage checksum is the CRC-32C GCS enforces.

--- a/crates/loonfs-objectstore/src/presign/gcs.rs
+++ b/crates/loonfs-objectstore/src/presign/gcs.rs
@@ -10,7 +10,7 @@
 use super::{
     DirectGetIssuer, DirectPutIssuer, PresignedGetRequest, PresignedPutRequest, PresignedUrl,
 };
-use crate::keyspace::scope_object_key;
+use crate::keyspace::{normalize_key_prefix, scope_object_key};
 use crate::object_store::Result;
 use crate::presign::v4::{
     canonical_query_string, hex_lower, normalize_header_value, percent_encode_path,
@@ -67,9 +67,13 @@ const MAX_PRESIGN_EXPIRY: u64 = 7 * 24 * 60 * 60;
 /// object ceiling is therefore the request ceiling.
 ///
 /// This is three orders of magnitude above the S3 family's 5 GiB single-PUT
-/// ceiling, and it is why GCS needs no multipart path to carry a large
-/// object: there is no size at which a whole-object write stops being
-/// expressible.
+/// ceiling, which is what lets this adapter carry large objects without
+/// signing multipart at all: there is no size at which the whole-object
+/// write stops being expressible. Google does document an XML API multipart
+/// upload, and documents it as S3-compatible; this adapter does not
+/// implement it, because it belongs to the same interoperability surface
+/// whose precondition handling conformance found unsound, and because the
+/// large-object path GCS is headed for is the native resumable upload.
 pub const GCP_GCS_MAX_DIRECT_PUT_BYTES: u64 = 5 * 1024 * 1024 * 1024 * 1024;
 
 /// Supplies the service-account key and key scoping for native GCS signed URLs.
@@ -124,11 +128,18 @@ impl fmt::Debug for GcsV4Presigner {
 impl GcsV4Presigner {
     /// Creates a presigner, reading and parsing the service-account key once.
     ///
-    /// Construction fails for a blank bucket or key path, an unreadable or
-    /// malformed key file, or a private key that is not an RSA key in PKCS#8
-    /// form. Failing here is deliberate: a GCS deployment whose key cannot
-    /// sign also cannot authenticate its provider client, so the fault
-    /// belongs at startup rather than at the first transfer.
+    /// The key prefix is normalized here, through the same helper the
+    /// provider client uses. That is not tidiness: the two have to resolve
+    /// an object key to the same string or a signed write lands somewhere
+    /// the store's own reads, listings, and collection never look — an
+    /// object committed, invisible, and unreclaimable.
+    ///
+    /// Construction fails for a blank bucket or key path, an unusable key
+    /// prefix, an unreadable or malformed key file, or a private key that is
+    /// not an RSA key in PKCS#8 form. Failing here is deliberate: a GCS
+    /// deployment whose key cannot sign also cannot authenticate its
+    /// provider client, so the fault belongs at startup rather than at the
+    /// first transfer.
     pub fn new(config: GcsPresignerConfig) -> Result<Self> {
         if config.bucket.trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
@@ -167,7 +178,7 @@ impl GcsV4Presigner {
 
         Ok(Self {
             bucket: config.bucket,
-            key_prefix: config.key_prefix,
+            key_prefix: normalize_key_prefix(config.key_prefix.as_deref())?,
             client_email: key.client_email,
             signing_key,
         })
@@ -448,6 +459,7 @@ fn invalid_direct_put_content(message: &str) -> ObjectStoreError {
 #[cfg(test)]
 mod tests {
     use super::{stored_crc32c, GcsPresignerConfig, GcsV4Presigner, GCP_GCS_MAX_DIRECT_PUT_BYTES};
+    use crate::keyspace::{normalize_key_prefix, scope_object_key};
     use crate::presign::{
         DirectGetIssuer, DirectPutIssuer, PresignedGetRequest, PresignedPutRequest,
     };
@@ -632,6 +644,66 @@ mod tests {
             PUT_UNPREFIXED_SIGNATURE, PUT_PREFIXED_SIGNATURE,
             "the same object key under two prefixes must not sign alike"
         );
+    }
+
+    /// The signer and the provider client resolve an object key to the same
+    /// string, whatever spelling of a prefix the deployment configured.
+    ///
+    /// A whitespace-only prefix is the case that used to split them: the
+    /// store normalizes it away and works in the unprefixed keyspace, while
+    /// the signer kept it raw and addressed `%20%20%20/...`. An object
+    /// written through such a capability is committed and then invisible to
+    /// every read, listing, and collection the store performs — durable
+    /// nowhere anything looks.
+    #[test]
+    fn the_signer_and_the_store_resolve_a_key_to_the_same_string() {
+        for raw_prefix in [None, Some("   "), Some(""), Some("tenant-a")] {
+            let signed = presigner(raw_prefix)
+                .presign_get(
+                    PresignedGetRequest {
+                        object_key: CONTENT_KEY,
+                        expires_in: EXPIRES_IN,
+                    },
+                    signing_time(),
+                )
+                .expect("presign get");
+
+            // Exactly what `ProviderObjectStore` does with the same value.
+            let store_key = scope_object_key(
+                normalize_key_prefix(raw_prefix)
+                    .expect("store normalizes the prefix")
+                    .as_deref(),
+                CONTENT_KEY,
+            )
+            .expect("store scopes the key");
+
+            let signed_path = signed.url.split('?').next().expect("url path");
+            assert_eq!(
+                signed_path,
+                format!("https://storage.googleapis.com/bucket/{store_key}"),
+                "signer and store disagree about the key under prefix {raw_prefix:?}"
+            );
+        }
+    }
+
+    /// A prefix the store would refuse is refused here too, at construction,
+    /// rather than producing capabilities the store cannot address.
+    #[test]
+    fn an_unusable_key_prefix_fails_construction() {
+        for raw_prefix in ["tenant-a//bad", "../escape"] {
+            assert!(matches!(
+                GcsV4Presigner::new(GcsPresignerConfig {
+                    bucket: "bucket".to_owned(),
+                    service_account_key_path: gcs_fixture_service_account_key_file(
+                        "gcs-presign-prefix"
+                    )
+                    .display()
+                    .to_string(),
+                    key_prefix: Some(raw_prefix.to_owned()),
+                }),
+                Err(ObjectStoreError::InvalidKey { .. })
+            ));
+        }
     }
 
     /// Path segments are percent-encoded, and the separators between them are

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -4,7 +4,7 @@ use super::{
     DirectGetIssuer, DirectMultipartIssuer, DirectPutIssuer, PresignedGetRequest,
     PresignedPartRequest, PresignedPutRequest, PresignedUrl,
 };
-use crate::keyspace::{parse_endpoint_url, scope_object_key};
+use crate::keyspace::{normalize_key_prefix, parse_endpoint_url, scope_object_key};
 use crate::object_store::Result;
 use crate::presign::v4::{
     canonical_query_string, hex_lower, hmac_sha256, normalize_header_value, percent_encode_path,
@@ -88,9 +88,16 @@ pub struct S3CompatiblePresigner {
 impl S3CompatiblePresigner {
     /// Creates a presigner after validating required bucket, region, and credential values.
     ///
-    /// Blank required values fail immediately; endpoint, key-prefix, content,
-    /// expiry, and signing-time failures surface when [`DirectPutIssuer::presign_put`] runs.
-    pub fn new(config: S3PresignerConfig) -> Result<Self> {
+    /// The key prefix is normalized here, through the same helper the
+    /// provider client uses, so the two resolve an object key to the same
+    /// string. They must: a signed write that lands outside the keyspace the
+    /// store reads, lists, and collects creates an object that is committed,
+    /// invisible, and unreclaimable.
+    ///
+    /// Blank required values and an unusable key prefix fail immediately;
+    /// endpoint, content, expiry, and signing-time failures surface when
+    /// [`DirectPutIssuer::presign_put`] runs.
+    pub fn new(mut config: S3PresignerConfig) -> Result<Self> {
         if config.bucket.trim().is_empty() {
             return Err(ObjectStoreError::Configuration(
                 "bucket must not be empty".to_owned(),
@@ -111,6 +118,7 @@ impl S3CompatiblePresigner {
                 "secret access key must not be empty".to_owned(),
             ));
         }
+        config.key_prefix = normalize_key_prefix(config.key_prefix.as_deref())?;
         Ok(Self { config })
     }
 
@@ -545,6 +553,7 @@ fn signing_key(secret: &str, date: &str, region: &str) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::{S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES};
+    use crate::keyspace::{normalize_key_prefix, scope_object_key};
     use crate::presign::{
         DirectGetIssuer, DirectPutIssuer, PresignedGetRequest, PresignedPutRequest,
     };
@@ -701,6 +710,67 @@ mod tests {
 
         let object_of = |url: &str| url.split('?').next().expect("url path").to_owned();
         assert_eq!(object_of(&read.url), object_of(&written.url));
+    }
+
+    /// The signer and the provider client resolve an object key to the same
+    /// string, whatever spelling of a prefix the deployment configured.
+    ///
+    /// A whitespace-only prefix is the case that used to split them: the
+    /// store normalizes it away and works in the unprefixed keyspace, while
+    /// the signer kept it raw and addressed `%20%20%20/...`. An object
+    /// written through such a capability is committed and then invisible to
+    /// every read, listing, and collection the store performs.
+    #[test]
+    fn the_signer_and_the_store_resolve_a_key_to_the_same_string() {
+        for raw_prefix in [None, Some("   "), Some(""), Some("tenant-a")] {
+            let signed = presigner(raw_prefix, None)
+                .presign_get(
+                    PresignedGetRequest {
+                        object_key: CONTENT_KEY,
+                        expires_in: Duration::from_secs(900),
+                    },
+                    UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+                )
+                .expect("presign get");
+
+            // Exactly what `ProviderObjectStore` does with the same value.
+            let store_key = scope_object_key(
+                normalize_key_prefix(raw_prefix)
+                    .expect("store normalizes the prefix")
+                    .as_deref(),
+                CONTENT_KEY,
+            )
+            .expect("store scopes the key");
+
+            let signed_path = signed.url.split('?').next().expect("url path");
+            assert_eq!(
+                signed_path,
+                format!("https://bucket.s3.us-east-1.amazonaws.com/{store_key}"),
+                "signer and store disagree about the key under prefix {raw_prefix:?}"
+            );
+        }
+    }
+
+    /// A prefix the store would refuse is refused here too, at construction,
+    /// rather than producing capabilities the store cannot address.
+    #[test]
+    fn an_unusable_key_prefix_fails_construction() {
+        for raw_prefix in ["tenant-a//bad", "../escape"] {
+            assert!(matches!(
+                S3CompatiblePresigner::new(S3PresignerConfig {
+                    bucket: "bucket".to_owned(),
+                    region: "us-east-1".to_owned(),
+                    endpoint_url: None,
+                    access_key_id: "access".into(),
+                    secret_access_key: "secret".into(),
+                    session_token: None,
+                    key_prefix: Some(raw_prefix.to_owned()),
+                    force_path_style: false,
+                    direct_put_max_content_bytes: AWS_S3_MAX_DIRECT_PUT_BYTES,
+                }),
+                Err(ObjectStoreError::InvalidKey { .. })
+            ));
+        }
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2803,10 +2803,9 @@ mod direct_download {
     /// The GCS shape, end to end, with no GCS-specific code anywhere above
     /// the object-store adapter.
     ///
-    /// A bundle that signs reads and CRC-32C whole-object writes and has no
-    /// multipart API is served by the same handler, carried by the same
-    /// client ladder, and completed by the same rule as the S3-compatible
-    /// one. The client learns `crc32c` from the capability document, folds
+    /// A bundle that signs reads and CRC-32C whole-object writes and no
+    /// multipart is served by the same handler, carried by the same client
+    /// ladder, and completed by the same rule as the S3-compatible one. The client learns `crc32c` from the capability document, folds
     /// exactly that digest over the payload in its one measuring pass, and
     /// the ref the commit records says so — with no `whole_file_sha256`,
     /// because nobody computed a SHA-256 over these bytes and the format does
@@ -2837,7 +2836,7 @@ mod direct_download {
         assert!(!advertised.supports(FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_SHA256));
         assert!(
             !advertised.supports(FEATURE_UPLOADS_DIRECT_MULTIPART),
-            "GCS has no S3-style multipart API to advertise"
+            "this adapter signs no multipart for GCS, so the key must be absent"
         );
         assert_eq!(
             advertised.direct_put_checksum_algorithm(),

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -686,6 +686,13 @@ fn direct_put_prefix(provider: &str, base_prefix: Option<String>) -> String {
 /// the begin handler refuses any other algorithm, and completion compares a
 /// stored checksum to a promised one. Only the header spellings differ, and
 /// those are the parameter.
+///
+/// This suite and its sibling below are what earns GCS its capabilities, so
+/// they run before the deployment advertises any: set
+/// `GCS_DIRECT_TRANSFERS_PROVEN` in `loonfs-objectstore`'s `configured.rs`
+/// to `true`, run these against a real bucket, and commit the flip with what
+/// they showed. Against the default build they fail at the capability
+/// assertion, which is the gate working.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires real GCP GCS credentials"]
 async fn gcp_gcs_direct_put_real_provider_round_trip() {
@@ -741,7 +748,7 @@ async fn gcp_gcs_signed_capabilities_are_scoped_bounded_and_single_use() {
     assert!(capabilities.supports("core.uploads.direct_put.checksum.crc32c"));
     assert!(
         !capabilities.supports("core.uploads.direct_multipart"),
-        "GCS has no S3-style multipart API to advertise"
+        "this adapter signs no multipart for GCS, so the key must be absent"
     );
 
     assert_gcs_completion_judges_the_object_that_is_there(&harness.client, &namespace_id).await;
@@ -970,8 +977,8 @@ async fn assert_gcs_cap_bound_object_moves_only_directly(
         .collect();
     let target = NamespacePath::parse(namespace, "/cap-bound.bin").expect("cap-bound target");
 
-    // GCS signs no multipart, so this whole-object write is the only
-    // direct transport there is — and the proxy will not take it.
+    // This adapter signs no multipart for GCS, so the whole-object write is
+    // the only direct transport on offer — and the proxy will not take it.
     harness
         .client
         .put_file_bytes(&target, &payload, &put_options("gcs-cap-bound"))

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -932,25 +932,30 @@ Without an explicit opt-in, the feature key is absent and beginning
 available and is the default.
 
 The reference server offers `direct_put` only where its adapter can presign the
-required create-only, checksum-bound request *and* the configured endpoint is a
-first-party provider domain family the live conformance suite has run against.
-AWS S3 and Cloudflare R2 qualify through SigV4, and Google Cloud Storage
-through its native `GOOG4-RSA-SHA256` signed URLs — not through GCS's
-S3-interoperability surface, which conformance proved ignores preconditions.
-Custom S3-compatible endpoints, Azure Blob Storage, and the local filesystem
-are not offered `direct_put`, and there is no configuration override. Other
-implementations may use different headers or decline `direct_put` support.
+required create-only, checksum-bound request *and* the live conformance suite
+has been run against that provider. AWS S3 and Cloudflare R2 qualify today,
+through SigV4 on their own domain families. The Google Cloud Storage adapter
+signs the same guarantees natively with `GOOG4-RSA-SHA256` — not through GCS's
+S3-interoperability surface, which conformance proved ignores preconditions —
+but withholds the capability until a run against a live bucket is recorded, so
+a GCS deployment currently advertises no direct transfer. Custom S3-compatible
+endpoints, Azure Blob Storage, and the local filesystem are not offered
+`direct_put`, and there is no configuration override. Other implementations may
+use different headers or decline `direct_put` support.
 
 The signed request's shape is the provider's, not a fixed one, and the
 deployment names the digest it binds in
 `core.uploads.direct_put.checksum.<algorithm>`. A client folds that algorithm
 over its payload and never infers one from the backend.
 
-`direct_put` and `direct_multipart` are separate offers. A provider that can
-sign a whole-object write but has no S3-style multipart API advertises the
-first and not the second — Google Cloud Storage is exactly this case — and a
-client's transport ladder falls from parts to one whole-object write before it
-falls back to the proxy.
+`direct_put` and `direct_multipart` are separate offers, and a deployment may
+advertise the first and not the second — the reference server's Google Cloud
+Storage adapter is built that way, signing whole-object writes and reads while
+implementing no multipart signing. A client's transport ladder falls
+from parts to one whole-object write before it falls back to the proxy, and a
+source whose length is unknown takes the whole-object write wherever one is
+offered: that transport measures the payload before sending a byte, and the
+measurement is what routes it.
 
 A browser calling a presigned URL is talking to the provider, not to LoonFS,
 so cross-origin access is governed by the bucket's or container's own CORS

--- a/docs/specs/object-storage-providers.md
+++ b/docs/specs/object-storage-providers.md
@@ -56,9 +56,11 @@ configuration the question a second time:
    the `amazonaws.com` or `amazonaws.com.cn` domain family, and an R2
    endpoint in the `r2.cloudflarestorage.com` family qualify. Any other
    endpoint URL is some other implementation of the S3 API, is not covered by
-   those runs, and does not qualify. GCS has nothing to decide here: its
-   configuration carries no endpoint override, so every capability it issues
-   is `https` to `storage.googleapis.com`.
+   those runs, and does not qualify. GCS has no endpoint to judge — its
+   configuration carries no override, so every capability it issues is
+   `https` to `storage.googleapis.com` — so it clears this bar the same way,
+   through a single flag that a credentialed run flips. Until that run is
+   recorded, GCS advertises no direct transfer and proxies every byte.
 
    The scheme is part of the test because a presigned URL is a bearer
    capability to read or write one object: issued over `http`, it and its
@@ -73,9 +75,10 @@ configuration the question a second time:
 Where both hold, the server advertises `core.uploads.direct_put` in its
 capability document and accepts the mode. Everywhere else the feature key is
 absent and beginning that mode answers `not_supported`. There is no override:
-an endpoint that has not been proven does not get the capability, because the
+a provider that has not been proven does not get the capability, because the
 whole point of the gate is that the provider — not LoonFS — is being trusted to
-enforce the preconditions.
+enforce the preconditions. An implementation passing its own unit tests is
+not that evidence; only a run against the live provider is.
 
 The digest a provider binds is its own, not a fixed one. The deployment names
 it in `core.uploads.direct_put.checksum.<algorithm>`, and the client folds
@@ -119,19 +122,35 @@ reference the grant carried.
 | AWS S3 | Yes | Yes | Yes | SigV4, SHA-256, `if-none-match: *` | Default endpoint, `amazonaws.com`, `amazonaws.com.cn` |
 | Cloudflare R2 | Yes | Yes | Yes | SigV4, SHA-256, `if-none-match: *` | `r2.cloudflarestorage.com` |
 | Other S3-compatible endpoints | No | No | No | n/a | None — unproven |
-| Google Cloud Storage | Yes | Yes | No | GOOG4-RSA-SHA256, CRC-32C, generation 0 | `storage.googleapis.com` (no override exists) |
+| Google Cloud Storage | Built, withheld[^47] | Built, withheld[^47] | No | GOOG4-RSA-SHA256, CRC-32C, generation 0 | `storage.googleapis.com` (no override exists) |
 | Azure Blob Storage | No | No | No | n/a | n/a |
 | Local filesystem | No | No | No | n/a | n/a |
 
 The three transfer columns are separate because they are separate offers.
 `direct_get` comes with the bundle existing at all, and the two write
 directions are independent of each other: GCS is the case that makes this
-concrete, signing whole-object writes and reads while having no S3-style
-multipart API to open, so it advertises `direct_put` and not
-`direct_multipart`. Nothing is lost by that — GCS's single-request ceiling is
-1000x the S3 family's, so there is no object size at which a whole-object
-write stops being expressible. A client's upload ladder falls from parts, to
-one whole-object write, to the proxy, and refuses a payload none of them can
+concrete, signing whole-object writes and reads while advertising
+`direct_put` and not `direct_multipart`.
+
+That is a decision about this adapter, not a gap in the provider. Google
+does document an XML API multipart upload, and documents it as compatible
+with the S3 multipart API.[^46] This adapter does not implement it, for two
+reasons:
+
+- It is part of the same S3-interoperability surface whose precondition
+  handling conformance found unsound. Nothing has been run to show that
+  *this* corner of it behaves, and the create-only and checksum guarantees
+  direct transfers rest on are exactly what was wrong on the surface next to
+  it. It would need its own conformance run to earn the same trust the
+  native path is earning.
+- The large-object path GCS is headed for is the native resumable upload,
+  not S3-style parts. Implementing the interop multipart now would be
+  building the transport we intend to replace.
+
+Nothing is stranded meanwhile: GCS's single-request ceiling is 1000x the S3
+family's, so there is no object size at which the whole-object write stops
+being expressible. A client's upload ladder falls from parts, to one
+whole-object write, to the proxy, and refuses a payload none of them can
 carry rather than pushing it into the capped proxy.
 
 ## 4. Incremental writes and where they are real
@@ -245,3 +264,7 @@ The local provider is a development and test provider supported on Unix-family p
 [^44]: Microsoft Learn, "Scalability and performance targets for standard storage accounts": [https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account](https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account)
 
 [^45]: Microsoft Learn, "Performance checklist for Blob Storage": [https://learn.microsoft.com/en-us/azure/storage/blobs/storage-performance-checklist](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-performance-checklist)
+
+[^46]: Google Cloud Storage, "XML API multipart uploads": [https://cloud.google.com/storage/docs/multipart-uploads](https://cloud.google.com/storage/docs/multipart-uploads)
+
+[^47]: The signer, the readback, and the whole path are implemented and unit-covered, but a GCS deployment advertises neither key today: the capability is withheld until a credentialed conformance run against a live bucket has been recorded. See `GCS_DIRECT_TRANSFERS_PROVEN` in `crates/loonfs-objectstore/src/configured.rs`.


### PR DESCRIPTION
Four review fixes. The important two: unknown-length uploads (stdin pipes) now measure and take direct PUT instead of dying at the proxy cap, and GCS direct transfers are switched off until a live conformance run proves them.

Other notes:
- Unknown-length sources on S3/R2 also take the measuring pass now
- The whitespace-prefix split (signed URLs addressing a different keyspace than reads and GC) existed in both presigners; both now normalize like the store, and a bad prefix fails at construction instead of first use