### PR TITLE
fix(api): decode enforces checkpoint and upload record invariants

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -187,8 +187,7 @@ pub enum CheckpointOwner {
 /// record is written `active`, then the basis manifest is re-verified
 /// against the floor, and a failed verification flips the record to
 /// `released`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CheckpointRecordState {
     /// Freshly generated record identity, one per logical pin. Nothing
     /// derives it, and no caller supplies it, so a new pin can never land on
@@ -220,6 +219,59 @@ pub struct CheckpointRecordState {
     pub owner: CheckpointOwner,
     /// Current lifecycle, advanced only by the one-way release compare-and-swap.
     pub state: CheckpointRecordLifecycle,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictCheckpointRecordState {
+    checkpoint_id: CheckpointId,
+    namespace_id: NamespaceId,
+    manifest_id: ManifestId,
+    manifest_object_id: ManifestObjectId,
+    manifest_head_seq: ChangeSeq,
+    manifest_payload_checksum: String,
+    head_commit_id: CommitId,
+    created_at_ms: u64,
+    #[serde(default)]
+    expires_at_ms: Option<u64>,
+    owner: CheckpointOwner,
+    state: CheckpointRecordLifecycle,
+}
+
+impl<'de> Deserialize<'de> for CheckpointRecordState {
+    /// Reads one checkpoint record and proves the one relationship its shape
+    /// cannot: that a fork-owned pin carries the lease bounding it.
+    ///
+    /// The lease is the only thing that ever releases an attempt whose
+    /// target head was never installed — nothing else can tell that attempt
+    /// from one still running — so a fork record without one pins its basis
+    /// forever, and no pass can decide otherwise. It is refused at load like
+    /// any other corruption.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let record = StrictCheckpointRecordState::deserialize(deserializer)?;
+        if matches!(record.owner, CheckpointOwner::Fork { .. }) && record.expires_at_ms.is_none() {
+            return Err(serde::de::Error::custom(format!(
+                "checkpoint record `{}` is fork-owned but has no lease expiry",
+                record.checkpoint_id
+            )));
+        }
+        Ok(Self {
+            checkpoint_id: record.checkpoint_id,
+            namespace_id: record.namespace_id,
+            manifest_id: record.manifest_id,
+            manifest_object_id: record.manifest_object_id,
+            manifest_head_seq: record.manifest_head_seq,
+            manifest_payload_checksum: record.manifest_payload_checksum,
+            head_commit_id: record.head_commit_id,
+            created_at_ms: record.created_at_ms,
+            expires_at_ms: record.expires_at_ms,
+            owner: record.owner,
+            state: record.state,
+        })
+    }
 }
 
 /// Links one accepted WAL segment to its immutable object and verified sequence range.
@@ -671,7 +723,7 @@ pub struct UploadSessionState {
     ///
     /// The identity exists before any byte is read, so the final object key
     /// is known up front and belongs to exactly this session. Every
-    /// reference the record holds names this object; see the decoder below,
+    /// reference the record holds names this object; see `validate` below,
     /// which refuses a record that disagrees with itself.
     pub content_id: ContentId,
     /// Unix-millisecond creation stamp.
@@ -681,6 +733,61 @@ pub struct UploadSessionState {
     /// The session's lifecycle, and the field every upload operation
     /// compare-and-swaps against.
     pub state: UploadSessionLifecycle,
+}
+
+impl UploadSessionState {
+    /// Proves the relationships this record's shape cannot express but every
+    /// reader of one depends on.
+    ///
+    /// Every reference the record holds is about the same content object,
+    /// whose identity the session allocated before any byte moved. A record
+    /// whose references disagree with its own `content_id` describes two
+    /// objects and cannot be acted on — a completion would verify one key
+    /// and publish another.
+    ///
+    /// The transport and the state must also agree on how the bytes got
+    /// there. Only a service-proxied session stages, because every other
+    /// transport writes past this server; and a direct-put session settles
+    /// on exactly the reference its write was signed against, because that
+    /// reference is what the provider enforced and what completion read
+    /// back. A record that says otherwise describes an upload that did not
+    /// happen.
+    fn validate(&self) -> Result<(), String> {
+        for content_ref in self
+            .transport
+            .promised_content()
+            .into_iter()
+            .chain(self.state.content_ref())
+        {
+            if content_ref.content_id != self.content_id {
+                return Err(format!(
+                    "upload session `{}` owns content `{}` but holds a reference to `{}`",
+                    self.upload_id, self.content_id, content_ref.content_id
+                ));
+            }
+        }
+        match (&self.transport, &self.state) {
+            (
+                UploadSessionTransport::DirectPut { .. }
+                | UploadSessionTransport::DirectMultipart { .. },
+                UploadSessionLifecycle::Open {
+                    staged_content: Some(_),
+                    ..
+                },
+            ) => Err(format!(
+                "upload session `{}` writes past the service but holds staged content",
+                self.upload_id
+            )),
+            (
+                UploadSessionTransport::DirectPut { promised_content },
+                UploadSessionLifecycle::Completed { content_ref, .. },
+            ) if content_ref != promised_content => Err(format!(
+                "upload session `{}` completed on content its direct write never promised",
+                self.upload_id
+            )),
+            _ => Ok(()),
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -820,43 +927,24 @@ impl From<StrictContentRef> for ContentRef {
 }
 
 impl<'de> Deserialize<'de> for UploadSessionState {
-    /// Reads one session record and proves the one relationship its shape
-    /// cannot: that every reference it holds names the object it owns.
-    ///
-    /// The transport promise and the staged or completed reference are all
-    /// about the same content object, whose identity the session allocated
-    /// before any byte moved. A record whose references disagree with its
-    /// own `content_id` describes two objects and cannot be acted on — a
-    /// completion would verify one key and publish another — so it is
-    /// refused at load like any other corruption, with no shim and no
-    /// salvage.
+    /// Reads one session record and refuses one that `validate` finds
+    /// disagreeing with itself, like any other corruption and with no shim
+    /// or salvage.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let state = StrictUploadSessionState::deserialize(deserializer)?;
-        let transport = UploadSessionTransport::from(state.transport);
-        let lifecycle = UploadSessionLifecycle::from(state.state);
-        for content_ref in transport
-            .promised_content()
-            .into_iter()
-            .chain(lifecycle.content_ref())
-        {
-            if content_ref.content_id != state.content_id {
-                return Err(serde::de::Error::custom(format!(
-                    "upload session `{}` owns content `{}` but holds a reference to `{}`",
-                    state.upload_id, state.content_id, content_ref.content_id
-                )));
-            }
-        }
-        Ok(Self {
+        let session = Self {
             namespace_id: state.namespace_id,
             upload_id: state.upload_id,
             content_id: state.content_id,
             created_at_ms: state.created_at_ms,
-            transport,
-            state: lifecycle,
-        })
+            transport: state.transport.into(),
+            state: state.state.into(),
+        };
+        session.validate().map_err(serde::de::Error::custom)?;
+        Ok(session)
     }
 }
 

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -443,20 +443,24 @@ fn control_document_with_payload_edit(
     .into_bytes()
 }
 
+/// Returns the refusal an edited payload must produce. Every schema
+/// rejection and every hand-checked invariant shares one error variant, so a
+/// caller that cares which rule fired reads it out of the message.
 fn assert_control_payload_edit_is_corrupt<T>(
     fixture: &str,
     kind: ControlObjectKind,
     edit: impl FnOnce(&mut serde_json::Value),
-) where
+) -> String
+where
     T: DeserializeOwned + Debug,
 {
     let edited = control_document_with_payload_edit(fixture, edit);
     let error = decode_control_object::<T>(&edited, kind)
         .expect_err("unknown mutable payload field must be rejected");
-    assert!(
-        matches!(error, EnvelopeCodecError::PayloadDecode(_)),
-        "unexpected error for {kind:?}: {error}"
-    );
+    match error {
+        EnvelopeCodecError::PayloadDecode(message) => message,
+        other => panic!("unexpected error for {kind:?}: {other}"),
+    }
 }
 
 #[test]
@@ -801,6 +805,29 @@ fn active_checkpoint_records_reject_release_stamps() {
     );
 }
 
+/// A fork-owned record is the lease over one fork attempt, and letting the
+/// lease pass is the only way an attempt that never installed its target
+/// head becomes collectable. Without an expiry the pin is immortal, so it is
+/// not a record that decodes — while a user pin without one is ordinary,
+/// held until someone releases it.
+#[test]
+fn fork_checkpoint_records_reject_a_missing_lease_expiry() {
+    let message = assert_control_payload_edit_is_corrupt::<CheckpointRecordState>(
+        "control_checkpoint_record_fork.v1.json",
+        ControlObjectKind::CheckpointRecord,
+        |payload| {
+            payload
+                .as_object_mut()
+                .expect("payload object")
+                .remove("expires_at_ms");
+        },
+    );
+    assert!(
+        message.contains("fork-owned but has no lease expiry"),
+        "unexpected refusal: {message}"
+    );
+}
+
 /// The monotonic upload lifecycle is a hard cutover too. The pre-cutover
 /// encoding wrote `state` as a bare string over `active` and `condemned`;
 /// the current decoder takes a tagged object over three states, each
@@ -933,6 +960,89 @@ fn upload_sessions_reject_a_reference_to_another_content_object() {
         ControlObjectKind::UploadSession,
         |payload| payload["transport"]["promised_content"]["content_id"] = other.clone(),
     );
+}
+
+/// Staging is the service-proxied flow. A direct session's bytes never pass
+/// through this server, so nothing here could have validated them, and a
+/// staged reference under one claims a write that did not happen.
+#[test]
+fn direct_upload_sessions_reject_staged_content() {
+    for fixture in [
+        "control_upload_session_direct_put.v1.json",
+        "control_upload_session_direct_multipart.v1.json",
+    ] {
+        let message = assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+            fixture,
+            ControlObjectKind::UploadSession,
+            |payload| {
+                // The session's own content, so the reference is refused for
+                // being staged and not for naming another object.
+                let mut staged =
+                    serde_json::to_value(sample_content_ref()).expect("encode content ref");
+                staged["content_id"] = payload["content_id"].clone();
+                payload["state"]["staged_content"] = staged;
+            },
+        );
+        assert!(
+            message.contains("holds staged content"),
+            "unexpected refusal for {fixture}: {message}"
+        );
+    }
+}
+
+/// A direct-put session settles on exactly the reference its write was
+/// signed against: the provider enforced that digest over those bytes, and
+/// completion read that object back against the same reference. A completed
+/// reference that drifts from the promise names content nobody proved.
+#[test]
+fn direct_put_sessions_reject_a_completion_that_drifts_from_the_promise() {
+    let fixture = "control_upload_session_direct_put.v1.json";
+    // Completing the open fixture on its own promise is a record that
+    // decodes, so the two edits below are refused for the drift alone.
+    decode_control_object::<UploadSessionState>(
+        &control_document_with_payload_edit(fixture, complete_on_the_promise(|_| {})),
+        ControlObjectKind::UploadSession,
+    )
+    .expect("a direct_put session completed on its own promise");
+
+    for message in [
+        assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+            fixture,
+            ControlObjectKind::UploadSession,
+            complete_on_the_promise(|content_ref| {
+                content_ref["size_bytes"] = serde_json::Value::from(11);
+            }),
+        ),
+        assert_control_payload_edit_is_corrupt::<UploadSessionState>(
+            fixture,
+            ControlObjectKind::UploadSession,
+            complete_on_the_promise(|content_ref| {
+                content_ref["storage_checksum"]["value"] = serde_json::Value::from("0".repeat(64));
+            }),
+        ),
+    ] {
+        assert!(
+            message.contains("never promised"),
+            "unexpected refusal: {message}"
+        );
+    }
+}
+
+/// Edits an open `direct_put` payload into a completed one carrying the
+/// transport's own promise, then lets the caller drift the reference it
+/// settled on.
+fn complete_on_the_promise(
+    drift: impl FnOnce(&mut serde_json::Value),
+) -> impl FnOnce(&mut serde_json::Value) {
+    move |payload| {
+        let promised = payload["transport"]["promised_content"].clone();
+        payload["state"] = serde_json::json!({
+            "kind": "completed",
+            "completed_at_ms": 2_000,
+            "content_ref": promised,
+        });
+        drift(&mut payload["state"]["content_ref"]);
+    }
 }
 
 /// Each transport carries its own details, and carries all of them. A

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1629,7 +1629,7 @@ The `state` carries what its own phase of the lifecycle needs. `open` carries
 exactly one place — the `completed` state — so no reader has to decide which
 of two copies is authoritative, and no writer can leave them disagreeing.
 
-Two invariants are checked when the record is read, because the shape cannot
+Four invariants are checked when the record is read, because the shape cannot
 express them:
 
 - Every content reference the record holds — the transport's promise, the
@@ -1638,14 +1638,20 @@ express them:
   could verify one while publishing the other.
 - The record carries a `transport` and a `state`. Neither has a default and
   neither may be omitted.
+- Only a `service_proxied` session holds `staged_content`: the other
+  transports write past the service, so nothing here validated their bytes.
+- A `direct_put` session's `completed` reference equals its
+  `promised_content` in full, which is the reference the provider enforced
+  and completion read back.
 
-A record that fails either is rejected outright, like any other corruption.
-This schema evolves in place at control-object version 1 before the first
-stable release; the implementation carries no compatibility shim for
-intermediate pre-release encodings, and in particular the earlier encoding
-that spelled the transport as a bare `mode` beside independent optional
-`claimed_checksum`, `direct_put_content_ref`, `provider_multipart_upload_id`,
-`multipart_part_size_bytes`, and `staged_content_ref` fields does not decode.
+A record that fails any of them is rejected outright, like any other
+corruption. This schema evolves in place at control-object version 1 before
+the first stable release; the implementation carries no compatibility shim
+for intermediate pre-release encodings, and in particular the earlier
+encoding that spelled the transport as a bare `mode` beside independent
+optional `claimed_checksum`, `direct_put_content_ref`,
+`provider_multipart_upload_id`, `multipart_part_size_bytes`, and
+`staged_content_ref` fields does not decode.
 
 Three rules apply:
 


### PR DESCRIPTION
Two invariants were checked when a record was written but not when one was read back: a fork-owned checkpoint record could decode without the lease expiry that makes an abandoned fork attempt collectable, and an upload session could decode claiming staged bytes on a direct transport, or a direct-put completion that drifted from its signed promise. All of these are now refused at load, like any other corruption.

Notes:
- Checkpoint records get the same strict-shadow custom decode the upload session already had; the fork rule's refusal names the record
- The upload session's rules (existing content-id one included) consolidate into one `validate` the decoder calls
- New negative golden tests prove which rule fired; the drift tests first decode a completion on its own promise, so the rejections are about the drift alone
- No fixture bytes changed; valid records encode and decode exactly as before

