### PR TITLE
refactor(api): begin-upload response is a tagged union

### DIFF
--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -266,22 +266,83 @@ pub struct ValidatedContentToken {
     pub token: String,
 }
 
-/// Response for starting an upload session.
+/// Response for starting an upload session, tagged by the transport the
+/// server settled on.
+///
+/// Each transport carries what its client needs next and nothing else, so
+/// the combinations a flat response could spell — a proxied session holding
+/// presigned access, a direct put with no capability to write through — are
+/// not values this type can hold. Unlike the request, unknown fields are
+/// accepted: a response reader tolerates what a later server adds.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct BeginUploadResponse {
-    /// Namespace authorized to consume the eventual staged content.
-    pub namespace_id: NamespaceId,
-    /// Durable session identity used by subsequent append and completion calls.
-    pub upload_id: UploadId,
-    /// Transport selected after applying server capability and request validation.
-    pub mode: UploadMode,
-    /// Presigned write details for `DirectPut`, or `None` for `ServiceProxied`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub direct_put: Option<DirectPutUpload>,
-    /// Part geometry for `DirectMultipart`, or `None` for every other mode.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub direct_multipart: Option<DirectMultipartUpload>,
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum BeginUploadResponse {
+    /// The service will receive the bytes and write the content object.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(title = "BeginUploadResponseServiceProxied")
+    )]
+    ServiceProxied {
+        /// Namespace authorized to consume the eventual staged content.
+        namespace_id: NamespaceId,
+        /// Durable session identity used by subsequent append and completion
+        /// calls.
+        upload_id: UploadId,
+    },
+    /// One presigned request writes the whole object.
+    #[cfg_attr(feature = "openapi", schema(title = "BeginUploadResponseDirectPut"))]
+    DirectPut {
+        /// Namespace authorized to consume the eventual staged content.
+        namespace_id: NamespaceId,
+        /// Durable session identity used by subsequent completion calls.
+        upload_id: UploadId,
+        /// The object this session writes, and the capability to write it.
+        direct_put: DirectPutUpload,
+    },
+    /// Presigned part uploads assemble the object.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(title = "BeginUploadResponseDirectMultipart")
+    )]
+    DirectMultipart {
+        /// Namespace authorized to consume the eventual staged content.
+        namespace_id: NamespaceId,
+        /// Durable session identity used by subsequent part-signing and
+        /// completion calls.
+        upload_id: UploadId,
+        /// The geometry the client cuts its payload to.
+        direct_multipart: DirectMultipartUpload,
+    },
+}
+
+impl BeginUploadResponse {
+    /// Namespace that owns the session.
+    pub fn namespace_id(&self) -> &NamespaceId {
+        match self {
+            Self::ServiceProxied { namespace_id, .. }
+            | Self::DirectPut { namespace_id, .. }
+            | Self::DirectMultipart { namespace_id, .. } => namespace_id,
+        }
+    }
+
+    /// Session the later append, part, completion, and abort calls name.
+    pub fn upload_id(&self) -> &UploadId {
+        match self {
+            Self::ServiceProxied { upload_id, .. }
+            | Self::DirectPut { upload_id, .. }
+            | Self::DirectMultipart { upload_id, .. } => upload_id,
+        }
+    }
+
+    /// The transport this session was opened with.
+    pub fn mode(&self) -> UploadMode {
+        match self {
+            Self::ServiceProxied { .. } => UploadMode::ServiceProxied,
+            Self::DirectPut { .. } => UploadMode::DirectPut,
+            Self::DirectMultipart { .. } => UploadMode::DirectMultipart,
+        }
+    }
 }
 
 /// Response after uploading bytes into a session.
@@ -433,8 +494,9 @@ pub struct AbortUploadResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, DirectPutContentClaim,
-        DirectPutUpload, ObjectTransferAccess, UploadMode, UploadSessionStatus,
+        BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, DirectMultipartUpload,
+        DirectPutContentClaim, DirectPutUpload, ObjectTransferAccess, UploadMode,
+        UploadSessionStatus,
     };
     use crate::{ChecksumAlgorithm, ContentId, ContentRef, NamespaceId, StorageChecksum, UploadId};
     use std::collections::BTreeMap;
@@ -496,12 +558,11 @@ mod tests {
 
     #[test]
     fn direct_put_response_exposes_only_presigned_access() {
-        let response = BeginUploadResponse {
+        let response = BeginUploadResponse::DirectPut {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
             upload_id: UploadId::parse("upl_00000000000000000000000000000001")
                 .expect("valid upload id"),
-            mode: UploadMode::DirectPut,
-            direct_put: Some(DirectPutUpload {
+            direct_put: DirectPutUpload {
                 content_ref: ContentRef::blob_v1(ContentId::generate(), b"hello"),
                 access: ObjectTransferAccess::PresignedUrl {
                     method: "PUT".to_owned(),
@@ -515,13 +576,111 @@ mod tests {
                     ]),
                     expires_at_ms: 1,
                 },
-            }),
-            direct_multipart: None,
+            },
         };
 
         let json = serde_json::to_string(&response).expect("serialize response");
         assert!(json.contains(r#""kind":"presigned_url""#));
         assert!(!json.contains("object_key"));
+    }
+
+    /// The bytes each transport answers with, pinned. A response names its
+    /// transport in `mode` and carries that transport's field and no other's,
+    /// which is the same wire the flat shape spelled by convention.
+    #[test]
+    fn a_begin_response_carries_only_its_transports_field() {
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let upload_id =
+            UploadId::parse("upl_00000000000000000000000000000001").expect("valid upload id");
+        let sha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
+        assert_eq!(
+            serde_json::to_value(BeginUploadResponse::ServiceProxied {
+                namespace_id: namespace_id.clone(),
+                upload_id: upload_id.clone(),
+            })
+            .expect("serialize proxied response"),
+            serde_json::json!({
+                "mode": "service_proxied",
+                "namespace_id": "demo",
+                "upload_id": "upl_00000000000000000000000000000001"
+            })
+        );
+
+        assert_eq!(
+            serde_json::to_value(BeginUploadResponse::DirectPut {
+                namespace_id: namespace_id.clone(),
+                upload_id: upload_id.clone(),
+                direct_put: DirectPutUpload {
+                    content_ref: ContentRef::blob_v1(
+                        ContentId::parse("con_0123456789abcdef0123456789abcdef")
+                            .expect("content id"),
+                        b"hello",
+                    ),
+                    access: ObjectTransferAccess::PresignedUrl {
+                        method: "PUT".to_owned(),
+                        url: "https://bucket.example/object".to_owned(),
+                        headers: BTreeMap::new(),
+                        expires_at_ms: 1,
+                    },
+                },
+            })
+            .expect("serialize direct-put response"),
+            serde_json::json!({
+                "mode": "direct_put",
+                "namespace_id": "demo",
+                "upload_id": "upl_00000000000000000000000000000001",
+                "direct_put": {
+                    "content_ref": {
+                        "kind": "blob_v1",
+                        "content_id": "con_0123456789abcdef0123456789abcdef",
+                        "size_bytes": 5,
+                        "storage_checksum": { "algorithm": "sha256", "value": sha256 },
+                        "whole_file_sha256": sha256
+                    },
+                    "access": {
+                        "kind": "presigned_url",
+                        "method": "PUT",
+                        "url": "https://bucket.example/object",
+                        "expires_at_ms": 1
+                    }
+                }
+            })
+        );
+
+        assert_eq!(
+            serde_json::to_value(BeginUploadResponse::DirectMultipart {
+                namespace_id,
+                upload_id,
+                direct_multipart: DirectMultipartUpload {
+                    part_size_bytes: 8 * 1024 * 1024,
+                },
+            })
+            .expect("serialize multipart response"),
+            serde_json::json!({
+                "mode": "direct_multipart",
+                "namespace_id": "demo",
+                "upload_id": "upl_00000000000000000000000000000001",
+                "direct_multipart": { "part_size_bytes": 8 * 1024 * 1024 }
+            })
+        );
+    }
+
+    /// The request refuses fields it does not know; the response must not.
+    /// A reader that rejected them could not talk to a later server.
+    #[test]
+    fn a_begin_response_carrying_a_later_servers_field_still_decodes() {
+        assert_eq!(
+            serde_json::from_str::<BeginUploadResponse>(
+                r#"{"mode":"service_proxied","namespace_id":"demo","upload_id":"upl_00000000000000000000000000000001","invented_later":true}"#
+            )
+            .expect("decode a proxied response carrying an unknown field"),
+            BeginUploadResponse::ServiceProxied {
+                namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+                upload_id: UploadId::parse("upl_00000000000000000000000000000001")
+                    .expect("valid upload id"),
+            }
+        );
     }
 
     /// A direct-put client declares what it is about to write; it cannot

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -505,6 +505,15 @@ fn signed_access(signed: &[SignedUploadPart], part_number: u32) -> Result<Object
         })
 }
 
+/// A begin-upload response that is not the transport the request asked for.
+///
+/// Which transport carries a payload is settled before the request goes
+/// out, from what the deployment advertises, so a different mode coming
+/// back is a broken server rather than something to fall back from.
+fn negotiated_a_different_upload_mode() -> ClientError {
+    ClientError::Http("the server answered with a different upload mode than negotiated".to_owned())
+}
+
 /// A path qualified by namespace.
 ///
 /// Both parts are validated at construction — [`NamespacePath::parse`] for
@@ -1659,10 +1668,13 @@ impl Client {
                 },
             )
             .await?;
-        let Some(direct_put) = begin.direct_put else {
-            return Err(ClientError::Http(
-                "server accepted direct_put without a write capability".to_owned(),
-            ));
+        let BeginUploadResponse::DirectPut {
+            upload_id,
+            direct_put,
+            ..
+        } = begin
+        else {
+            return Err(negotiated_a_different_upload_mode());
         };
         let written = match body {
             DirectPutBody::Held(bytes) => {
@@ -1675,13 +1687,13 @@ impl Client {
             }
         };
         if let Err(error) = written {
-            let _ = self.abort_upload(namespace_id, &begin.upload_id).await;
+            let _ = self.abort_upload(namespace_id, &upload_id).await;
             return Err(error);
         }
         let response = self
             .complete_upload(
                 namespace_id,
-                &begin.upload_id,
+                &upload_id,
                 &CompleteUploadRequest::for_content_ref(direct_put.content_ref),
             )
             .await?;
@@ -1715,15 +1727,18 @@ impl Client {
                 let begin = self
                     .begin_direct_multipart(namespace_id, DirectMultipartUploadOptions::default())
                     .await?;
-                let Some(multipart) = begin.direct_multipart else {
-                    return Err(ClientError::Http(
-                        "server accepted direct_multipart without part geometry".to_owned(),
-                    ));
+                let BeginUploadResponse::DirectMultipart {
+                    upload_id,
+                    direct_multipart,
+                    ..
+                } = begin
+                else {
+                    return Err(negotiated_a_different_upload_mode());
                 };
                 if let Some(journal) = continuity.journal {
-                    journal.began(&begin.upload_id, multipart.part_size_bytes);
+                    journal.began(&upload_id, direct_multipart.part_size_bytes);
                 }
-                (begin.upload_id, multipart.part_size_bytes)
+                (upload_id, direct_multipart.part_size_bytes)
             }
         };
         let uploaded = self
@@ -1935,9 +1950,9 @@ impl Client {
             .begin_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await?;
         let staged = self
-            .upload_content(namespace_id, &upload.upload_id, bytes)
+            .upload_content(namespace_id, upload.upload_id(), bytes)
             .await?;
-        self.complete_staged(namespace_id, &upload.upload_id, staged)
+        self.complete_staged(namespace_id, upload.upload_id(), staged)
             .await
     }
 
@@ -1955,16 +1970,16 @@ impl Client {
             .begin_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await?;
         let staged = self
-            .upload_streamed_content(namespace_id, &upload.upload_id, source)
+            .upload_streamed_content(namespace_id, upload.upload_id(), source)
             .await;
         let staged = match staged {
             Ok(staged) => staged,
             Err(error) => {
-                let _ = self.abort_upload(namespace_id, &upload.upload_id).await;
+                let _ = self.abort_upload(namespace_id, upload.upload_id()).await;
                 return Err(error);
             }
         };
-        self.complete_staged(namespace_id, &upload.upload_id, staged)
+        self.complete_staged(namespace_id, upload.upload_id(), staged)
             .await
     }
 

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -12,7 +12,7 @@
 use super::*;
 use crate::transport::test_transport::{self, Outcome};
 use futures::stream::StreamExt;
-use loonfs_api::v0::{DirectMultipartUpload, DirectPutUpload, UploadMode};
+use loonfs_api::v0::{DirectMultipartUpload, DirectPutUpload};
 use loonfs_api::{
     direct_put_checksum_feature, CapabilityDocument, ContentId, ContentRef,
     FEATURE_UPLOADS_DIRECT_PUT, PROFILE_CORE_V0, PROTOCOL_VERSION,
@@ -223,11 +223,10 @@ fn capabilities_for(advertised: Advertised) -> Outcome {
 }
 
 fn begin_direct_put(content_ref: ContentRef) -> Outcome {
-    json(&BeginUploadResponse {
+    json(&BeginUploadResponse::DirectPut {
         namespace_id: namespace_id(),
         upload_id: upload_id(),
-        mode: UploadMode::DirectPut,
-        direct_put: Some(DirectPutUpload {
+        direct_put: DirectPutUpload {
             content_ref,
             access: ObjectTransferAccess::PresignedUrl {
                 method: "PUT".to_owned(),
@@ -235,30 +234,24 @@ fn begin_direct_put(content_ref: ContentRef) -> Outcome {
                 headers: std::collections::BTreeMap::new(),
                 expires_at_ms: u64::MAX,
             },
-        }),
-        direct_multipart: None,
+        },
     })
 }
 
 fn begin_multipart() -> Outcome {
-    json(&BeginUploadResponse {
+    json(&BeginUploadResponse::DirectMultipart {
         namespace_id: namespace_id(),
         upload_id: upload_id(),
-        mode: UploadMode::DirectMultipart,
-        direct_put: None,
-        direct_multipart: Some(DirectMultipartUpload {
+        direct_multipart: DirectMultipartUpload {
             part_size_bytes: TEST_PART_BYTES,
-        }),
+        },
     })
 }
 
 fn begin_proxied() -> Outcome {
-    json(&BeginUploadResponse {
+    json(&BeginUploadResponse::ServiceProxied {
         namespace_id: namespace_id(),
         upload_id: upload_id(),
-        mode: UploadMode::ServiceProxied,
-        direct_put: None,
-        direct_multipart: None,
     })
 }
 

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -321,14 +321,18 @@ async fn stage_upload<S: ObjectStore + ?Sized>(
     .await
     .expect("begin upload");
     let staged =
-        crate::protocol::upload_content(store, namespace_id, &begin.upload_id, b"racing upload\n")
+        crate::protocol::upload_content(store, namespace_id, begin.upload_id(), b"racing upload\n")
             .await
             .expect("stage upload");
     let content_store_id =
         crate::namespace::catalog::load_namespace_content_store_id(store, namespace_id)
             .await
             .expect("content store id");
-    (begin.upload_id, staged.content_ref, content_store_id)
+    (
+        begin.upload_id().clone(),
+        staged.content_ref,
+        content_store_id,
+    )
 }
 
 async fn read_upload_session<S: ObjectStore + ?Sized>(
@@ -907,7 +911,7 @@ async fn complete_upload_for_gc<S: ObjectStore + ?Sized>(
     )
     .await
     .expect("begin upload");
-    let staged = crate::protocol::upload_content(store, namespace_id, &begin.upload_id, bytes)
+    let staged = crate::protocol::upload_content(store, namespace_id, begin.upload_id(), bytes)
         .await
         .expect("stage upload");
     let content_store_id =
@@ -918,14 +922,14 @@ async fn complete_upload_for_gc<S: ObjectStore + ?Sized>(
         store,
         namespace_id,
         &content_store_id,
-        &begin.upload_id,
+        begin.upload_id(),
         &loonfs_api::v0::CompleteUploadRequest::for_content_ref(staged.content_ref.clone()),
         context,
     )
     .await
     .expect("complete upload");
     (
-        begin.upload_id,
+        begin.upload_id().clone(),
         staged.content_ref,
         content_store_id,
         completed.prepared,

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -83,12 +83,9 @@ pub(crate) async fn begin_upload<S: ObjectStore + ?Sized>(
         context,
     )
     .await?;
-    Ok(BeginUploadResponse {
+    Ok(BeginUploadResponse::ServiceProxied {
         namespace_id: namespace_id.clone(),
         upload_id,
-        mode: UploadMode::ServiceProxied,
-        direct_put: None,
-        direct_multipart: None,
     })
 }
 
@@ -1500,7 +1497,7 @@ mod tests {
         )
         .await
         .expect("begin upload");
-        let staged = upload_content(store, &namespace_id, &begin.upload_id, BYTES)
+        let staged = upload_content(store, &namespace_id, begin.upload_id(), BYTES)
             .await
             .expect("stage upload");
         let content_store_id = load_namespace_content_store_id(store, &namespace_id)
@@ -1510,7 +1507,7 @@ mod tests {
         (
             namespace_id,
             content_store_id,
-            begin.upload_id,
+            begin.upload_id().clone(),
             staged.content_ref,
             content_key,
         )
@@ -1687,12 +1684,12 @@ mod tests {
             &store,
             &namespace_id,
             &content_store_id,
-            &aborted.upload_id,
+            aborted.upload_id(),
             &context(3_000),
         )
         .await
         .expect("abort");
-        let error = upload_content(&store, &namespace_id, &aborted.upload_id, BYTES)
+        let error = upload_content(&store, &namespace_id, aborted.upload_id(), BYTES)
             .await
             .expect_err("an aborted session takes no more bytes");
         assert!(matches!(error, CoreError::UploadNotFound { .. }));
@@ -1751,7 +1748,7 @@ mod tests {
             &store,
             &namespace_id,
             &content_store_id,
-            &begin.upload_id,
+            begin.upload_id(),
             &context(3_000),
         )
         .await
@@ -1760,7 +1757,7 @@ mod tests {
             &store,
             &namespace_id,
             &content_store_id,
-            &begin.upload_id,
+            begin.upload_id(),
             3_500,
         )
         .await

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -239,12 +239,12 @@ async fn valid_content_admission_skips_durable_content_validation() {
         .await
         .expect("begin upload");
     let staged = engine
-        .upload_content(&upload.upload_id, b"admitted")
+        .upload_content(upload.upload_id(), b"admitted")
         .await
         .expect("stage content");
     let completed = engine
         .complete_upload_prepared(
-            &upload.upload_id,
+            upload.upload_id(),
             &loonfs_api::v0::CompleteUploadRequest::for_content_ref(staged.content_ref.clone()),
         )
         .await
@@ -950,12 +950,12 @@ async fn a_re_minted_receipt_publishes_after_the_first_one_expired() {
         .await
         .expect("begin upload");
     let staged = engine
-        .upload_content(&upload.upload_id, b"re-minted")
+        .upload_content(upload.upload_id(), b"re-minted")
         .await
         .expect("stage content");
     let completed = engine
         .complete_upload_prepared(
-            &upload.upload_id,
+            upload.upload_id(),
             &loonfs_api::v0::CompleteUploadRequest::for_content_ref(staged.content_ref.clone()),
         )
         .await
@@ -985,7 +985,7 @@ async fn a_re_minted_receipt_publishes_after_the_first_one_expired() {
 
     // Reading the session mints another one for the same durable bytes.
     let (status, receipt) = engine
-        .read_upload_status(&upload.upload_id)
+        .read_upload_status(upload.upload_id())
         .await
         .expect("read upload status");
     match status.status {

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -97,12 +97,12 @@ async fn reads_commits_and_change_feed_never_list() {
         .await
         .expect("begin upload");
     let uploaded = engine
-        .upload_content(&staged.upload_id, b"uploaded\n")
+        .upload_content(staged.upload_id(), b"uploaded\n")
         .await
         .expect("upload content");
     engine
         .complete_upload(
-            &staged.upload_id,
+            staged.upload_id(),
             &loonfs_api::v0::CompleteUploadRequest::for_content_ref(uploaded.content_ref),
         )
         .await
@@ -196,12 +196,12 @@ async fn maintenance_never_touches_the_wal_head() {
         .await
         .expect("second upload");
     let uploaded = engine
-        .upload_content(&staged.upload_id, b"more\n")
+        .upload_content(staged.upload_id(), b"more\n")
         .await
         .expect("second upload content");
     engine
         .complete_upload(
-            &staged.upload_id,
+            staged.upload_id(),
             &loonfs_api::v0::CompleteUploadRequest::for_content_ref(uploaded.content_ref),
         )
         .await

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -246,7 +246,7 @@ async fn begin_upload_does_not_read_manifest_or_wal_replay_objects() {
     let begin = begin_upload(&guarded_store, &namespace_id, &context)
         .await
         .expect("begin upload");
-    assert_eq!(begin.namespace_id, namespace_id);
+    assert_eq!(begin.namespace_id(), &namespace_id);
     assert_eq!(guarded_store.attempts(), 0);
 }
 
@@ -263,7 +263,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     let begin = begin_upload(&store, &namespace_id, &context)
         .await
         .expect("begin upload");
-    let uploaded = upload_content(&store, &namespace_id, &begin.upload_id, b"hello", &context)
+    let uploaded = upload_content(&store, &namespace_id, begin.upload_id(), b"hello", &context)
         .await
         .expect("upload content");
 
@@ -271,7 +271,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     let completed = complete_upload(
         &store,
         &namespace_id,
-        &begin.upload_id,
+        begin.upload_id(),
         &CompleteUploadRequest::for_content_ref(uploaded.content_ref.clone()),
         &context,
     )
@@ -284,7 +284,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     let completed_again = complete_upload(
         &store,
         &namespace_id,
-        &begin.upload_id,
+        begin.upload_id(),
         &CompleteUploadRequest::for_content_ref(uploaded.content_ref),
         &context,
     )
@@ -299,7 +299,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     let mismatch_uploaded = upload_content(
         &store,
         &namespace_id,
-        &mismatch_begin.upload_id,
+        mismatch_begin.upload_id(),
         b"staged",
         &context,
     )
@@ -312,7 +312,7 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
     let mismatch = complete_upload(
         &store,
         &namespace_id,
-        &mismatch_begin.upload_id,
+        mismatch_begin.upload_id(),
         &CompleteUploadRequest::for_content_ref(wrong_ref),
         &context,
     )
@@ -403,7 +403,7 @@ mod streamed_content {
         let begin = begin_upload(&store, &namespace_id, &context)
             .await
             .expect("begin upload");
-        let staged = upload_streamed(&store, &namespace_id, &begin.upload_id, &bytes, &context)
+        let staged = upload_streamed(&store, &namespace_id, begin.upload_id(), &bytes, &context)
             .await
             .expect("stream a multi-part payload into the session");
 
@@ -423,7 +423,7 @@ mod streamed_content {
         let completed = complete_upload(
             &store,
             &namespace_id,
-            &begin.upload_id,
+            begin.upload_id(),
             &CompleteUploadRequest::for_content_ref(staged.content_ref.clone()),
             &context,
         )
@@ -450,10 +450,10 @@ mod streamed_content {
         let begin = begin_upload(&store, &namespace_id, &context)
             .await
             .expect("begin upload");
-        let first = upload_streamed(&store, &namespace_id, &begin.upload_id, &bytes, &context)
+        let first = upload_streamed(&store, &namespace_id, begin.upload_id(), &bytes, &context)
             .await
             .expect("first streamed upload");
-        let repeated = upload_streamed(&store, &namespace_id, &begin.upload_id, &bytes, &context)
+        let repeated = upload_streamed(&store, &namespace_id, begin.upload_id(), &bytes, &context)
             .await
             .expect("the same bytes again is the same upload");
         assert_eq!(first, repeated);
@@ -463,7 +463,7 @@ mod streamed_content {
         let error = upload_streamed(
             &store,
             &namespace_id,
-            &begin.upload_id,
+            begin.upload_id(),
             &different,
             &context,
         )
@@ -974,7 +974,7 @@ mod direct_multipart {
         upload_content(
             &store,
             &session.namespace_id,
-            &begin.upload_id,
+            begin.upload_id(),
             PART,
             &context,
         )
@@ -983,7 +983,7 @@ mod direct_multipart {
         let error = complete_upload(
             &store,
             &session.namespace_id,
-            &begin.upload_id,
+            begin.upload_id(),
             &CompleteUploadRequest::for_multipart(
                 session.claim.clone(),
                 upload_every_part(&store, &session),

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -19,8 +19,8 @@ use loonfs_api::{
         AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest,
         CompleteUploadResponse, DirectMultipartUpload, DirectMultipartUploadOptions,
         DirectPutContentClaim, DirectPutUpload, ObjectTransferAccess, SignUploadPartsRequest,
-        SignUploadPartsResponse, SignedUploadPart, UploadContentResponse, UploadMode,
-        UploadSessionStatus, UploadStatusResponse, ValidatedContentToken,
+        SignUploadPartsResponse, SignedUploadPart, UploadContentResponse, UploadSessionStatus,
+        UploadStatusResponse, ValidatedContentToken,
     },
     ContentRef, NamespaceId, UploadId, FEATURE_UPLOADS_DIRECT_MULTIPART,
     FEATURE_UPLOADS_DIRECT_PUT, LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES,
@@ -161,11 +161,10 @@ async fn begin_direct_put_upload(
         )
         .map_err(presign_issuer_error)?;
 
-    Ok(Json(BeginUploadResponse {
+    Ok(Json(BeginUploadResponse::DirectPut {
         namespace_id: prepared.namespace_id,
         upload_id: prepared.upload_id,
-        mode: UploadMode::DirectPut,
-        direct_put: Some(DirectPutUpload {
+        direct_put: DirectPutUpload {
             content_ref,
             access: ObjectTransferAccess::PresignedUrl {
                 method: signed.method,
@@ -173,8 +172,7 @@ async fn begin_direct_put_upload(
                 headers: signed.headers,
                 expires_at_ms: signed.expires_at_ms,
             },
-        }),
-        direct_multipart: None,
+        },
     }))
 }
 
@@ -205,14 +203,12 @@ async fn begin_direct_multipart_upload(
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
 
-    Ok(Json(BeginUploadResponse {
+    Ok(Json(BeginUploadResponse::DirectMultipart {
         namespace_id: prepared.namespace_id,
         upload_id: prepared.upload_id,
-        mode: UploadMode::DirectMultipart,
-        direct_put: None,
-        direct_multipart: Some(DirectMultipartUpload {
+        direct_multipart: DirectMultipartUpload {
             part_size_bytes: prepared.target.part_size_bytes,
-        }),
+        },
     }))
 }
 

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1350,7 +1350,7 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
         .expect("begin a proxied upload session");
     assert_api_error(
         client
-            .upload_content(&namespace, &session.upload_id, &[0u8; 4096])
+            .upload_content(&namespace, session.upload_id(), &[0u8; 4096])
             .await,
         413,
         "content_too_large",

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -249,16 +249,16 @@ pub(crate) mod http_split_support {
             .await
             .expect("begin upload");
         let staged = client
-            .upload_content(namespace_id, &begin.upload_id, file_bytes)
+            .upload_content(namespace_id, begin.upload_id(), file_bytes)
             .await
             .expect("upload content");
         let complete_request = CompleteUploadRequest::for_content_ref(staged.content_ref);
         let complete = client
-            .complete_upload(namespace_id, &begin.upload_id, &complete_request)
+            .complete_upload(namespace_id, begin.upload_id(), &complete_request)
             .await
             .expect("complete upload");
         let repeated = client
-            .complete_upload(namespace_id, &begin.upload_id, &complete_request)
+            .complete_upload(namespace_id, begin.upload_id(), &complete_request)
             .await
             .expect("repeat complete upload");
         assert_eq!(repeated.namespace_id, complete.namespace_id);

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -6,9 +6,9 @@ use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::{
     v0::{
-        CompleteUploadRequest, DirectMultipartContentClaim, DirectMultipartUploadOptions,
-        DirectPutContentClaim, ObjectTransferAccess, UploadPartChecksumClaim,
-        ValidatedContentToken,
+        BeginUploadResponse, CompleteUploadRequest, DirectMultipartContentClaim,
+        DirectMultipartUpload, DirectMultipartUploadOptions, DirectPutContentClaim,
+        DirectPutUpload, ObjectTransferAccess, UploadPartChecksumClaim, ValidatedContentToken,
     },
     ChangeSeq, ChecksumAlgorithm, CommitId, CommitRequest, CommitResponse, DestinationBehavior,
     FilesystemOperation, NamespaceId, StorageChecksum,
@@ -70,6 +70,24 @@ fn direct_put_claim(bytes: &[u8], algorithm: ChecksumAlgorithm) -> DirectPutCont
     DirectPutContentClaim {
         size_bytes: bytes.len() as u64,
         storage_checksum: StorageChecksum::compute(algorithm, bytes),
+    }
+}
+
+/// The presigned write a `direct_put` begin answered with.
+fn direct_put_of(begin: &BeginUploadResponse) -> &DirectPutUpload {
+    match begin {
+        BeginUploadResponse::DirectPut { direct_put, .. } => direct_put,
+        other => unreachable!("a direct_put begin answered as {:?}", other.mode()),
+    }
+}
+
+/// The part geometry a `direct_multipart` begin answered with.
+fn direct_multipart_of(begin: &BeginUploadResponse) -> DirectMultipartUpload {
+    match begin {
+        BeginUploadResponse::DirectMultipart {
+            direct_multipart, ..
+        } => *direct_multipart,
+        other => unreachable!("a direct_multipart begin answered as {:?}", other.mode()),
     }
 }
 
@@ -163,7 +181,7 @@ async fn direct_put_round_trip(signed_write: SignedWriteHeaders, config: ServerC
         )
         .await
         .expect("begin direct put");
-    let direct_put = begin.direct_put.expect("direct-put access");
+    let direct_put = direct_put_of(&begin);
     // The server minted the identity; the client learns it here and names it
     // everywhere afterwards.
     let content_ref = direct_put.content_ref.clone();
@@ -189,7 +207,7 @@ async fn direct_put_round_trip(signed_write: SignedWriteHeaders, config: ServerC
         .client
         .complete_upload(
             &namespace_id,
-            &begin.upload_id,
+            begin.upload_id(),
             &CompleteUploadRequest::for_content_ref(content_ref.clone()),
         )
         .await
@@ -328,7 +346,7 @@ async fn assert_wrong_direct_put_bytes_rejected(
         )
         .await
         .expect("begin wrong-bytes direct put");
-    let direct_put = begin.direct_put.expect("wrong-bytes direct-put access");
+    let direct_put = direct_put_of(&begin);
     let content_ref = direct_put.content_ref.clone();
 
     expect_client_rejection(
@@ -341,7 +359,7 @@ async fn assert_wrong_direct_put_bytes_rejected(
         client
             .complete_upload(
                 namespace_id,
-                &begin.upload_id,
+                begin.upload_id(),
                 &CompleteUploadRequest::for_content_ref(content_ref),
             )
             .await,
@@ -395,7 +413,7 @@ async fn assert_direct_put_requires_its_signed_headers(
             )
             .await
             .expect("begin meddled direct put");
-        let direct_put = begin.direct_put.expect("meddled direct-put access");
+        let direct_put = direct_put_of(&begin);
         let content_ref = direct_put.content_ref.clone();
 
         expect_client_rejection(
@@ -410,7 +428,7 @@ async fn assert_direct_put_requires_its_signed_headers(
             client
                 .complete_upload(
                     namespace_id,
-                    &begin.upload_id,
+                    begin.upload_id(),
                     &CompleteUploadRequest::for_content_ref(content_ref),
                 )
                 .await,
@@ -434,7 +452,7 @@ async fn assert_direct_put_is_no_replace(
         )
         .await
         .expect("begin duplicate direct put");
-    let direct_put = begin.direct_put.expect("duplicate direct-put access");
+    let direct_put = direct_put_of(&begin);
     let content_ref = direct_put.content_ref.clone();
 
     client
@@ -451,7 +469,7 @@ async fn assert_direct_put_is_no_replace(
     let complete = client
         .complete_upload(
             namespace_id,
-            &begin.upload_id,
+            begin.upload_id(),
             &CompleteUploadRequest::for_content_ref(content_ref),
         )
         .await
@@ -776,7 +794,7 @@ async fn assert_gcs_completion_judges_the_object_that_is_there(
         )
         .await
         .expect("begin direct put");
-    let direct_put = begin.direct_put.expect("direct-put access");
+    let direct_put = direct_put_of(&begin);
     let content_ref = direct_put.content_ref.clone();
     client
         .upload_via_presigned_url(&direct_put.access, bytes)
@@ -800,7 +818,7 @@ async fn assert_gcs_completion_judges_the_object_that_is_there(
         let refused = client
             .complete_upload(
                 namespace_id,
-                &begin.upload_id,
+                begin.upload_id(),
                 &CompleteUploadRequest::for_content_ref(claimed),
             )
             .await;
@@ -811,7 +829,7 @@ async fn assert_gcs_completion_judges_the_object_that_is_there(
     let complete = client
         .complete_upload(
             namespace_id,
-            &begin.upload_id,
+            begin.upload_id(),
             &CompleteUploadRequest::for_content_ref(content_ref.clone()),
         )
         .await
@@ -846,7 +864,7 @@ async fn assert_gcs_signed_writes_land_under_the_configured_prefix(
         )
         .await
         .expect("begin direct put");
-    let direct_put = begin.direct_put.expect("direct-put access");
+    let direct_put = direct_put_of(&begin);
     let ObjectTransferAccess::PresignedUrl { url, .. } = &direct_put.access;
     let StoreConfig::GcpGcs {
         bucket, key_prefix, ..
@@ -950,7 +968,7 @@ async fn assert_gcs_expired_capability_is_refused(client: &Client, namespace_id:
         )
         .await
         .expect("begin direct put");
-    let direct_put = begin.direct_put.expect("direct-put access");
+    let direct_put = direct_put_of(&begin);
     let ObjectTransferAccess::PresignedUrl { url, .. } = &direct_put.access;
 
     // Rewrite the capability's own lifetime to one already spent. The
@@ -1099,8 +1117,8 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
         .begin_direct_multipart(&namespace_id, DirectMultipartUploadOptions::default())
         .await
         .expect("begin direct multipart");
-    let upload_id = begin.upload_id.clone();
-    let multipart = begin.direct_multipart.expect("multipart geometry");
+    let upload_id = begin.upload_id().clone();
+    let multipart = direct_multipart_of(&begin);
     assert_eq!(
         multipart.part_size_bytes as usize, part_size,
         "the deployment's part geometry is the one this payload was cut to"

--- a/crates/loonfs-server/tests/it/http_auth.rs
+++ b/crates/loonfs-server/tests/it/http_auth.rs
@@ -434,7 +434,7 @@ async fn every_upload_session_route_requires_the_bearer_token() {
         .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
-    let upload_id = begin.upload_id;
+    let upload_id = begin.upload_id().clone();
     let base = format!(
         "{}/v0/namespaces/{namespace}/uploads/{upload_id}",
         harness.server_url

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -131,18 +131,18 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         .expect("begin upload");
     let first_content = harness
         .client
-        .upload_content(&namespace, &begin.upload_id, file_bytes)
+        .upload_content(&namespace, begin.upload_id(), file_bytes)
         .await
         .expect("upload content");
     let repeated_content = harness
         .client
-        .upload_content(&namespace, &begin.upload_id, file_bytes)
+        .upload_content(&namespace, begin.upload_id(), file_bytes)
         .await
         .expect("repeat upload content");
     assert_eq!(first_content, repeated_content);
     match harness
         .client
-        .upload_content(&namespace, &begin.upload_id, b"different bytes")
+        .upload_content(&namespace, begin.upload_id(), b"different bytes")
         .await
     {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "upload_content_conflict"),
@@ -156,7 +156,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         .expect("begin mismatch upload");
     let staged = harness
         .client
-        .upload_content(&namespace, &mismatch_upload.upload_id, file_bytes)
+        .upload_content(&namespace, mismatch_upload.upload_id(), file_bytes)
         .await
         .expect("stage mismatch upload content");
     assert_ne!(
@@ -167,7 +167,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
         .client
         .complete_upload(
             &namespace,
-            &mismatch_upload.upload_id,
+            mismatch_upload.upload_id(),
             &CompleteUploadRequest::for_content_ref(ContentRef::blob_v1(
                 ContentId::generate(),
                 b"other bytes",
@@ -289,14 +289,14 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
         .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
-    let status = read_upload_status(&harness.server_url, &open.upload_id);
+    let status = read_upload_status(&harness.server_url, open.upload_id());
     assert!(matches!(status.status, UploadSessionStatus::Open { .. }));
 
     // Aborting it is terminal, repeatable, and observable.
-    let aborted = abort_upload(&harness.server_url, &open.upload_id).expect("abort");
-    let repeated = abort_upload(&harness.server_url, &open.upload_id).expect("repeated abort");
+    let aborted = abort_upload(&harness.server_url, open.upload_id()).expect("abort");
+    let repeated = abort_upload(&harness.server_url, open.upload_id()).expect("repeated abort");
     assert_eq!(repeated, aborted);
-    let status = read_upload_status(&harness.server_url, &open.upload_id);
+    let status = read_upload_status(&harness.server_url, open.upload_id());
     let UploadSessionStatus::Aborted { aborted_at_ms } = status.status else {
         unreachable!("an aborted session reports itself aborted");
     };
@@ -308,7 +308,7 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
         .client
         .complete_upload(
             &namespace,
-            &open.upload_id,
+            open.upload_id(),
             &CompleteUploadRequest::for_content_ref(ContentRef::blob_v1(
                 ContentId::generate(),
                 b"never staged",
@@ -458,19 +458,19 @@ async fn complete_upload_session(
         .expect("begin upload");
     let staged = harness
         .client
-        .upload_content(namespace, &begin.upload_id, bytes)
+        .upload_content(namespace, begin.upload_id(), bytes)
         .await
         .expect("upload content");
     let completed = harness
         .client
         .complete_upload(
             namespace,
-            &begin.upload_id,
+            begin.upload_id(),
             &CompleteUploadRequest::for_content_ref(staged.content_ref),
         )
         .await
         .expect("complete upload");
-    (begin.upload_id, completed.content_ref)
+    (begin.upload_id().clone(), completed.content_ref)
 }
 
 fn read_upload_status(server_url: &str, upload_id: &loonfs_api::UploadId) -> UploadStatusResponse {

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -871,13 +871,13 @@ async fn upload_paths_plant_the_collection_deadlines_they_create() {
     );
 
     let uploaded = writer
-        .upload_content(&namespace_id, &begun.upload_id, b"body")
+        .upload_content(&namespace_id, begun.upload_id(), b"body")
         .await
         .expect("upload content");
     writer
         .complete_upload(
             &namespace_id,
-            &begun.upload_id,
+            begun.upload_id(),
             &CompleteUploadRequest::for_content_ref(uploaded.content_ref),
         )
         .await

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -1203,7 +1203,7 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
         .await
         .expect("begin upload");
     let staged = writer
-        .upload_content(&namespace_id, &upload.upload_id, b"hello")
+        .upload_content(&namespace_id, upload.upload_id(), b"hello")
         .await
         .expect("stage content");
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&shared, &namespace_id)

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -495,7 +495,7 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
 
     let staged = harness
         .writer
-        .upload_content(&harness.namespace_id, &begin.upload_id, bytes)
+        .upload_content(&harness.namespace_id, begin.upload_id(), bytes)
         .await
         .expect("upload content");
     let upload_counts = harness.recording.snapshot();
@@ -515,7 +515,7 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
         .writer
         .complete_upload_prepared(
             &harness.namespace_id,
-            &begin.upload_id,
+            begin.upload_id(),
             &CompleteUploadRequest::for_content_ref(staged.content_ref),
         )
         .await

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -66,19 +66,19 @@ fn upload_flow_is_available_from_runtime() {
         .begin_upload_blocking(&namespace_id)
         .expect("begin upload");
     let staged = fs
-        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, begin.upload_id(), b"uploaded")
         .expect("upload content");
     let staged_again = fs
-        .upload_content_blocking(&namespace_id, &begin.upload_id, b"uploaded")
+        .upload_content_blocking(&namespace_id, begin.upload_id(), b"uploaded")
         .expect("repeat upload content");
     assert_eq!(staged.content_ref, staged_again.content_ref);
 
     let request = CompleteUploadRequest::for_content_ref(staged.content_ref);
     let completed = fs
-        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
+        .complete_upload_blocking(&namespace_id, begin.upload_id(), &request)
         .expect("complete upload");
     let completed_again = fs
-        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
+        .complete_upload_blocking(&namespace_id, begin.upload_id(), &request)
         .expect("repeat complete upload");
     assert_eq!(completed.content_ref, completed_again.content_ref);
 }
@@ -461,14 +461,14 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
                 .expect("begin upload");
             let staged = fs
                 .writer
-                .upload_content(&namespace_id, &begin.upload_id, bytes)
+                .upload_content(&namespace_id, begin.upload_id(), bytes)
                 .await
                 .expect("upload content");
             let completed = fs
                 .writer
                 .complete_upload(
                     &namespace_id,
-                    &begin.upload_id,
+                    begin.upload_id(),
                     &CompleteUploadRequest::for_content_ref(staged.content_ref),
                 )
                 .await

--- a/crates/loonfs/tests/it/publication.rs
+++ b/crates/loonfs/tests/it/publication.rs
@@ -68,7 +68,7 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
         .await
         .expect("begin upload");
     let staged = writer
-        .upload_content(&namespace_id, &upload.upload_id, b"b")
+        .upload_content(&namespace_id, upload.upload_id(), b"b")
         .await
         .expect("stage second put content");
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1616,6 +1616,12 @@ the server knows which transport a session was opened with; completing a
 session with the other shape is `invalid_request` too, reported after the
 record is read.
 
+The begin-upload *response* is tagged the same way, in the same `mode`, and
+carries its transport's field and no other's: `service_proxied` carries
+neither `direct_put` nor `direct_multipart`, and each direct mode carries
+only its own. Unlike the request bodies it does not reject unknown fields,
+because a response reader must tolerate what a later server adds.
+
 An upload session allocates its content object when it begins, so repeating
 `PUT /content` with the same bytes for the same upload id writes the same
 object and is idempotent. Repeating it with different bytes is a conflict.

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2977,49 +2977,97 @@
         "description": "Request for starting an upload session, tagged by the transport it asks\nfor.\n\nEach transport carries only what it needs, so the combinations a flat\nrequest could spell — a proxied begin carrying multipart geometry, a\ndirect put with no claim to sign — are refused when the body is decoded\nrather than by a handler reading them back. `mode` is required: a\nrequest that does not say how it intends to move its bytes is not a\nrequest this API can answer."
       },
       "BeginUploadResponse": {
-        "type": "object",
-        "description": "Response for starting an upload session.",
-        "required": [
-          "namespace_id",
-          "upload_id",
-          "mode"
-        ],
-        "properties": {
-          "direct_multipart": {
-            "oneOf": [
-              {
-                "type": "null"
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "BeginUploadResponseServiceProxied",
+            "description": "The service will receive the bytes and write the content object.",
+            "required": [
+              "namespace_id",
+              "upload_id",
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "service_proxied"
+                ]
               },
-              {
-                "$ref": "#/components/schemas/DirectMultipartUpload",
-                "description": "Part geometry for `DirectMultipart`, or `None` for every other mode."
+              "namespace_id": {
+                "$ref": "#/components/schemas/NamespaceId",
+                "description": "Namespace authorized to consume the eventual staged content."
+              },
+              "upload_id": {
+                "$ref": "#/components/schemas/UploadId",
+                "description": "Durable session identity used by subsequent append and completion\ncalls."
               }
-            ]
+            }
           },
-          "direct_put": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
+          {
+            "type": "object",
+            "title": "BeginUploadResponseDirectPut",
+            "description": "One presigned request writes the whole object.",
+            "required": [
+              "namespace_id",
+              "upload_id",
+              "direct_put",
+              "mode"
+            ],
+            "properties": {
+              "direct_put": {
                 "$ref": "#/components/schemas/DirectPutUpload",
-                "description": "Presigned write details for `DirectPut`, or `None` for `ServiceProxied`."
+                "description": "The object this session writes, and the capability to write it."
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "direct_put"
+                ]
+              },
+              "namespace_id": {
+                "$ref": "#/components/schemas/NamespaceId",
+                "description": "Namespace authorized to consume the eventual staged content."
+              },
+              "upload_id": {
+                "$ref": "#/components/schemas/UploadId",
+                "description": "Durable session identity used by subsequent completion calls."
               }
-            ]
+            }
           },
-          "mode": {
-            "$ref": "#/components/schemas/UploadMode",
-            "description": "Transport selected after applying server capability and request validation."
-          },
-          "namespace_id": {
-            "$ref": "#/components/schemas/NamespaceId",
-            "description": "Namespace authorized to consume the eventual staged content."
-          },
-          "upload_id": {
-            "$ref": "#/components/schemas/UploadId",
-            "description": "Durable session identity used by subsequent append and completion calls."
+          {
+            "type": "object",
+            "title": "BeginUploadResponseDirectMultipart",
+            "description": "Presigned part uploads assemble the object.",
+            "required": [
+              "namespace_id",
+              "upload_id",
+              "direct_multipart",
+              "mode"
+            ],
+            "properties": {
+              "direct_multipart": {
+                "$ref": "#/components/schemas/DirectMultipartUpload",
+                "description": "The geometry the client cuts its payload to."
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "direct_multipart"
+                ]
+              },
+              "namespace_id": {
+                "$ref": "#/components/schemas/NamespaceId",
+                "description": "Namespace authorized to consume the eventual staged content."
+              },
+              "upload_id": {
+                "$ref": "#/components/schemas/UploadId",
+                "description": "Durable session identity used by subsequent part-signing and\ncompletion calls."
+              }
+            }
           }
-        }
+        ],
+        "description": "Response for starting an upload session, tagged by the transport the\nserver settled on.\n\nEach transport carries what its client needs next and nothing else, so\nthe combinations a flat response could spell — a proxied session holding\npresigned access, a direct put with no capability to write through — are\nnot values this type can hold. Unlike the request, unknown fields are\naccepted: a response reader tolerates what a later server adds."
       },
       "CapabilityDocument": {
         "type": "object",


### PR DESCRIPTION
The "begin-upload" response was a flat struct — a mode field beside two optional payloads — so the server could construct an answer whose mode disagreed with its payloads, and the client checked payload presence by hand. It is now the same tagged union the request uses: each mode carries exactly its own payload, and a mismatch cannot be built. The durable upload record made this move earlier so this brings the HTTP response in line.

Notes:
- Valid responses keep the same JSON keys and values; only key order shifts (the mode tag now serializes first)
- The response deliberately accepts unknown fields — a reader must tolerate what a later server adds — and a test pins that, alongside a test pinning each variant's full serialized JSON
- `UploadMode`'s schema is now unreferenced in openapi.json (the tags are inline); it stays registered like the existing `ContentStoreId` orphan — say the word to drop it
- The client's two hand-written "accepted X without Y" errors collapse into one "answered with a different upload mode than negotiated"
