### PR TITLE
refactor(publisher): structural state for session, admission, and publish effects

### DIFF
--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -13,6 +13,7 @@ use crate::options::DeleteNamespaceOptions;
 use crate::path::write::{commit_fingerprint, CommitRequest, FilesystemOperation};
 use crate::protocol::{
     load_publish_metadata_view, PublishTailOptions, PublishTailProjection, PublishTailWeight,
+    PublishViewEffect,
 };
 use crate::storage::content_admission::{ContentAdmission, ContentTokenError, PreparedContent};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
@@ -215,8 +216,8 @@ pub struct ResultingReadState {
     pub tail_rows: Arc<MetadataState>,
 }
 
-/// Writer-session state for one namespace: the epoch this session acquired
-/// and its terminal fencing record.
+/// Writer-session state for one namespace: never acquired, holding the epoch
+/// this session acquired, or terminally fenced.
 ///
 /// This is authoritative session state, not a cache of durable state —
 /// nothing in the store can rebuild "this session was fenced". Runtimes keep
@@ -227,15 +228,18 @@ pub struct ResultingReadState {
 /// documented one-shot semantics: each one-shot commit is its own
 /// acquisition decision.
 #[derive(Debug, Default)]
-pub struct WriterSessionState {
+pub enum WriterSessionState {
+    /// No epoch yet: the session's first publish acquires one.
+    #[default]
+    Unacquired,
     /// Epoch acquired lazily on this session's first publish and reused for
     /// its lifetime; no per-publish acquisition CAS.
-    acquired_writer: Option<AcquiredWriter>,
+    Acquired(AcquiredWriter),
     /// Terminal fencing record. Once another session supersedes our epoch,
     /// every later publish fails with `writer_fenced` without touching the
     /// store; the session never reacquires on its own. Reacquisition is an
     /// explicit caller decision, left to a future takeover API.
-    fenced: Option<WriterFence>,
+    Fenced(WriterFence),
 }
 
 /// Shared handle to one namespace's [`WriterSessionState`].
@@ -294,11 +298,11 @@ impl NamespaceCommitEngine {
         self
     }
 
-    pub fn invalidate(&mut self) {
-        // Drops only the tail projection. The acquired epoch and fencing
-        // are session state, not cached state: the epoch's validity is
-        // re-checked against the head on every publish view load, and a
-        // fenced session stays fenced.
+    /// Drops the rebuildable tail projection and nothing else. The acquired
+    /// epoch and fencing are session state, not cached state: the epoch's
+    /// validity is re-checked against the head on every publish view load,
+    /// and a fenced session stays fenced.
+    pub fn invalidate_projection(&mut self) {
         self.publish_tail_projection = None;
     }
 
@@ -324,12 +328,12 @@ impl NamespaceCommitEngine {
         store: &S,
         context: &MutationContext,
     ) -> Result<AcquiredWriter> {
-        let already_acquired = {
-            let session = self.lock_session();
-            if let Some(fence) = &session.fenced {
-                return Err(CoreError::WriterFenced(fence.clone()));
+        let already_acquired = match &*self.lock_session() {
+            WriterSessionState::Fenced(fence) => {
+                return Err(CoreError::WriterFenced(fence.clone()))
             }
-            session.acquired_writer.clone()
+            WriterSessionState::Acquired(acquired_writer) => Some(acquired_writer.clone()),
+            WriterSessionState::Unacquired => None,
         };
         if let Some(acquired_writer) = already_acquired {
             return Ok(acquired_writer);
@@ -338,12 +342,12 @@ impl NamespaceCommitEngine {
             .await
             .map_err(CoreError::WriterEpoch)?;
         let mut session = self.lock_session();
-        if let Some(fence) = session.fenced.clone() {
+        if let WriterSessionState::Fenced(fence) = &*session {
             // Another engine sharing this session observed fencing while we
             // were acquiring; the session stays fenced.
-            return Err(CoreError::WriterFenced(fence));
+            return Err(CoreError::WriterFenced(fence.clone()));
         }
-        session.acquired_writer = Some(acquired_writer.clone());
+        *session = WriterSessionState::Acquired(acquired_writer.clone());
         Ok(acquired_writer)
     }
 
@@ -370,9 +374,7 @@ impl NamespaceCommitEngine {
         )
         .await;
         if let Err(CoreError::WriterFenced(fence)) = &deleted {
-            let mut session = self.lock_session();
-            session.fenced = Some(fence.clone());
-            session.acquired_writer = None;
+            *self.lock_session() = WriterSessionState::Fenced(fence.clone());
         }
         deleted
     }
@@ -416,11 +418,9 @@ impl NamespaceCommitEngine {
         {
             Ok(value) => value,
             Err(error) => {
-                self.invalidate();
+                self.invalidate_projection();
                 if let CoreError::WriterFenced(fence) = &error {
-                    let mut session = self.lock_session();
-                    session.fenced = Some(fence.clone());
-                    session.acquired_writer = None;
+                    *self.lock_session() = WriterSessionState::Fenced(fence.clone());
                 }
                 return NamespaceCommitEnginePublishResult {
                     results: repeated_error(candidate_count, error),
@@ -456,9 +456,12 @@ impl NamespaceCommitEngine {
             self.timer.as_ref(),
         )
         .await;
-        let resulting_head = published.resulting_head.clone();
+        let resulting_head = match &published.effect {
+            PublishViewEffect::Advanced { head, .. } => Some(head.clone()),
+            PublishViewEffect::Unchanged | PublishViewEffect::Invalidated => None,
+        };
         let wal_tail_segments =
-            self.update_publish_tail_projection(projection, &published, tail_options);
+            self.update_publish_tail_projection(projection, published.effect, tail_options);
         // Seedable only when the CAS landed unambiguously and the updated
         // projection survived (it carries the post-publish tail and etag).
         let resulting_read_state = match (resulting_head, self.publish_tail_projection.as_ref()) {
@@ -481,39 +484,54 @@ impl NamespaceCommitEngine {
         }
     }
 
+    /// Folds one batch's effect into the retained tail projection, and
+    /// reports the WAL-tail length the caller schedules maintenance on.
     fn update_publish_tail_projection(
         &mut self,
         mut projection: PublishTailProjection,
-        published: &crate::protocol::PublishBatchAgainstViewResult,
+        effect: PublishViewEffect,
         tail_options: &PublishTailOptions,
     ) -> u64 {
-        if !published.published_records.is_empty() {
-            projection.wal_tail_segments = projection.wal_tail_segments.saturating_add(1);
-        }
-        let wal_tail_segments = projection.wal_tail_segments;
-        let Some(resulting_head) = published.resulting_head.clone() else {
-            if published.can_reuse_loaded_projection {
+        match effect {
+            // Nothing landed, so the loaded projection still describes the
+            // tail exactly.
+            PublishViewEffect::Unchanged => {
+                let wal_tail_segments = projection.wal_tail_segments;
                 self.publish_tail_projection = Some(projection);
-            } else {
-                self.invalidate();
+                wal_tail_segments
             }
-            return wal_tail_segments;
-        };
-        let Some(resulting_head_etag) = published.resulting_head_etag.clone() else {
-            self.invalidate();
-            return wal_tail_segments;
-        };
-        for record in &published.published_records {
-            projection.tail_state.apply_committed_wal_record_mut(record);
+            PublishViewEffect::Invalidated => {
+                self.invalidate_projection();
+                projection.wal_tail_segments
+            }
+            // A landed batch is exactly one new WAL segment.
+            PublishViewEffect::Advanced {
+                records,
+                head,
+                head_etag,
+            } => {
+                projection.wal_tail_segments = projection.wal_tail_segments.saturating_add(1);
+                let wal_tail_segments = projection.wal_tail_segments;
+                // The head advanced, but without the etag its
+                // compare-and-swap acknowledged there is nothing to re-anchor
+                // the projection to.
+                let Some(head_etag) = head_etag else {
+                    self.invalidate_projection();
+                    return wal_tail_segments;
+                };
+                for record in &records {
+                    projection.tail_state.apply_committed_wal_record_mut(record);
+                }
+                projection.head_seq = head.seq;
+                projection.head_etag = head_etag;
+                if projection.within_limits(tail_options) {
+                    self.publish_tail_projection = Some(projection);
+                } else {
+                    self.invalidate_projection();
+                }
+                wal_tail_segments
+            }
         }
-        projection.head_seq = resulting_head.seq;
-        projection.head_etag = resulting_head_etag;
-        if projection.within_limits(tail_options) {
-            self.publish_tail_projection = Some(projection);
-        } else {
-            self.invalidate();
-        }
-        wal_tail_segments
     }
 }
 
@@ -825,7 +843,7 @@ mod tests {
             .as_ref()
             .expect("writer a first commit");
         // Force a fresh manifest load on the next publish.
-        engine_a.invalidate();
+        engine_a.invalidate_projection();
 
         store.block_next();
         let blocked_store = StdArc::clone(&store);

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -29,45 +29,37 @@ use tracing::Instrument;
 #[derive(Debug, Clone)]
 pub(crate) struct PublishBatchAgainstViewResult {
     pub(crate) results: Vec<Result<ApiCommitResponse>>,
-    pub(crate) published_records: Vec<WalCommitPayload>,
-    pub(crate) resulting_head: Option<HeadState>,
-    pub(crate) resulting_head_etag: Option<String>,
-    pub(crate) can_reuse_loaded_projection: bool,
+    pub(crate) effect: PublishViewEffect,
+}
+
+/// What one batch did to the publish view it ran against — the whole of what
+/// a caller needs to decide the fate of the projection it loaded.
+#[derive(Debug, Clone)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "one value per published batch, moved once: indirection would buy an allocation and save nothing"
+)]
+pub(crate) enum PublishViewEffect {
+    /// Nothing was written: the loaded projection still describes the tail.
+    Unchanged,
+    /// The batch may have left durable state the loaded projection does not
+    /// account for, so that projection must be dropped.
+    Invalidated,
+    /// The head advanced past one new WAL segment. `head_etag` is absent
+    /// when the store's compare-and-swap acknowledgement carried none: the
+    /// head still advanced, but the projection cannot be re-anchored to it.
+    Advanced {
+        records: Vec<WalCommitPayload>,
+        head: HeadState,
+        head_etag: Option<String>,
+    },
 }
 
 impl PublishBatchAgainstViewResult {
-    fn new(results: Vec<Result<ApiCommitResponse>>) -> Self {
+    fn unchanged(results: Vec<Result<ApiCommitResponse>>) -> Self {
         Self {
             results,
-            published_records: Vec::new(),
-            resulting_head: None,
-            resulting_head_etag: None,
-            can_reuse_loaded_projection: true,
-        }
-    }
-
-    fn invalidate_projection(results: Vec<Result<ApiCommitResponse>>) -> Self {
-        Self {
-            results,
-            published_records: Vec::new(),
-            resulting_head: None,
-            resulting_head_etag: None,
-            can_reuse_loaded_projection: false,
-        }
-    }
-
-    fn published(
-        results: Vec<Result<ApiCommitResponse>>,
-        published_records: Vec<WalCommitPayload>,
-        resulting_head: HeadState,
-        resulting_head_etag: Option<String>,
-    ) -> Self {
-        Self {
-            results,
-            published_records,
-            resulting_head: Some(resulting_head),
-            resulting_head_etag,
-            can_reuse_loaded_projection: false,
+            effect: PublishViewEffect::Unchanged,
         }
     }
 }
@@ -83,11 +75,11 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     timer: &dyn MonotonicTimer,
 ) -> PublishBatchAgainstViewResult {
     if candidates.is_empty() {
-        return PublishBatchAgainstViewResult::new(Vec::new());
+        return PublishBatchAgainstViewResult::unchanged(Vec::new());
     }
     let batch_size = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
     if view.head.namespace_id != *namespace_id {
-        return PublishBatchAgainstViewResult::new(
+        return PublishBatchAgainstViewResult::unchanged(
             (0..candidates.len())
                 .map(|_| {
                     Err(CoreError::Internal(
@@ -226,7 +218,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     drop(prepare_span);
 
     if accepted.is_empty() {
-        return PublishBatchAgainstViewResult::new(dedup.finish(outcomes));
+        return PublishBatchAgainstViewResult::unchanged(dedup.finish(outcomes));
     }
     let records = accepted
         .iter()
@@ -269,7 +261,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         });
         return abort_batch(outcomes, &dedup, &accepted, &error);
     }
-    let resulting_head_etag = match cas_batch_head(
+    let head_etag = match cas_batch_head(
         store,
         &view.head_etag,
         &head_publish,
@@ -282,21 +274,22 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         Err(error) => return abort_batch(outcomes, &dedup, &accepted, &error),
     };
 
-    let published_records = wal.envelope.payload.records.clone();
+    let records = wal.envelope.payload.records.clone();
     for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
         outcomes[outcome_index] = Some(Ok(ApiCommitResponse {
             namespace_id: namespace_id.clone(),
             commit_id: record.prepared.request.commit_id,
-            committed_seq: published_records[accepted_index].seq,
+            committed_seq: records[accepted_index].seq,
         }));
     }
-    let results = dedup.finish(outcomes);
-    PublishBatchAgainstViewResult::published(
-        results,
-        published_records,
-        head_publish.resulting_head,
-        resulting_head_etag,
-    )
+    PublishBatchAgainstViewResult {
+        results: dedup.finish(outcomes),
+        effect: PublishViewEffect::Advanced {
+            records,
+            head: head_publish.resulting_head,
+            head_etag,
+        },
+    }
 }
 
 /// Aborts a batch whose accepted candidates never became durable.
@@ -310,7 +303,10 @@ fn abort_batch(
     error: &CoreError,
 ) -> PublishBatchAgainstViewResult {
     fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, accepted, error);
-    PublishBatchAgainstViewResult::invalidate_projection(dedup.finish(outcomes))
+    PublishBatchAgainstViewResult {
+        results: dedup.finish(outcomes),
+        effect: PublishViewEffect::Invalidated,
+    }
 }
 
 /// Writes the accepted records as one durable WAL segment.

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -28,7 +28,7 @@ mod publish_view;
 mod uploads;
 
 pub(crate) use self::batch::{
-    publish_namespace_commits_batch_against_publish_view, PublishBatchAgainstViewResult,
+    publish_namespace_commits_batch_against_publish_view, PublishViewEffect,
 };
 pub(crate) use self::changes::list_changes_after;
 pub(crate) use self::publish_view::{load_publish_metadata_view, PublishTailProjection};

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -31,7 +31,7 @@ impl FsAdmin {
     fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
         self.core.invalidate_namespace_read_cache(namespace_id);
         if let Some(publisher) = &self.publisher {
-            publisher.invalidate_engine(namespace_id);
+            publisher.invalidate_projection(namespace_id);
         }
     }
 

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -109,7 +109,7 @@ impl FsWriter {
     /// caches, and the rebuildable half of its publisher's publish state.
     pub(crate) fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
         self.core.invalidate_namespace_read_cache(namespace_id);
-        self.publisher.invalidate_engine(namespace_id);
+        self.publisher.invalidate_projection(namespace_id);
     }
 
     pub(crate) fn finish_namespace_mutation<T>(
@@ -826,7 +826,7 @@ pub(crate) async fn publish_batch_with_engine(
         // Diagnostic mode: the publisher's engine outlives the publish
         // even with caches off, so drop the tail projection it just
         // built. Every publish then reads what a cold engine reads.
-        engine.invalidate();
+        engine.invalidate_projection();
     }
     {
         let _span = tracing::info_span!(

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -23,9 +23,8 @@ use std::sync::Arc;
 pub struct FsAdmin {
     pub(crate) core: ReadCore,
     pub(crate) actor: WriterIdentity,
-    /// `invalidate_engine` matters only where a publisher exists for the
-    /// namespace, so a standalone admin holds `None` — its
-    /// engines-to-invalidate do not exist — and an admin built over a
+    /// A tail projection to invalidate exists only where a publisher does,
+    /// so a standalone admin holds `None`, and an admin built over a
     /// writer's runtime for background maintenance holds that writer's
     /// registry.
     pub(crate) publisher: Option<PublisherRegistry>,

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -197,7 +197,7 @@ impl RegistryShared {
                 // that namespace either way.
                 publisher
                     .as_ref()
-                    .is_none_or(NamespacePublisher::invalidate_engine)
+                    .is_none_or(NamespacePublisher::invalidate_projection)
             })
             .map(|(victim, _)| victim)
             .collect::<Vec<_>>();
@@ -432,7 +432,7 @@ impl PublisherRegistry {
     ///
     /// A held engine means a publication or delete is in flight; that unit
     /// revalidates against the live head itself, so skipping it is safe.
-    pub(crate) fn invalidate_engine(&self, namespace_id: &NamespaceId) {
+    pub(crate) fn invalidate_projection(&self, namespace_id: &NamespaceId) {
         let publisher = self
             .shared
             .lock_state()
@@ -442,7 +442,7 @@ impl PublisherRegistry {
         let Some(publisher) = publisher else {
             return;
         };
-        if publisher.invalidate_engine() {
+        if publisher.invalidate_projection() {
             let totals = self.shared.forget_projection(namespace_id);
             self.read_core
                 .instruments()
@@ -534,7 +534,7 @@ struct NamespacePublisher {
     writer: Weak<WriterBits>,
     state: Arc<Mutex<NamespacePublisherState>>,
     /// Locked only by the worker, across one publication or delete, and by
-    /// [`Self::invalidate_engine`], which never waits for it.
+    /// [`Self::invalidate_projection`], which never waits for it.
     engine: Arc<AsyncMutex<EngineSlot>>,
     /// Weak: the registry map owns its publishers, and a strong reference
     /// back would cycle the whole structure into a leak. A publisher whose
@@ -565,17 +565,28 @@ struct EngineSlot {
     session: SharedWriterSessionState,
 }
 
+/// Whether the publisher still admits work, and if not, what it owes the
+/// caller.
+///
+/// One state rather than two flags, so the precedence holds by construction:
+/// a namespace whose delete landed is gone, not shutting down, and closing
+/// admission afterwards cannot demote it.
+enum PublisherAdmissionState {
+    Open,
+    /// Set by the registry's admission close. Later admissions fail with
+    /// `shutting_down`; everything already queued keeps publishing.
+    Closed,
+    /// Terminal: set once a delete succeeds. Admissions fail fast from then
+    /// on without touching the store.
+    Deleted,
+}
+
 struct NamespacePublisherState {
     /// Admitted work in admission order. Commits coalesce into the tail
     /// batch, so a delete queued between them keeps its barrier position.
     queue: VecDeque<WorkItem>,
     in_flight: HashMap<CommitId, InFlightRequest>,
-    /// Terminal: set once a delete succeeds. Admissions fail fast from then
-    /// on without touching the store.
-    deleted: bool,
-    /// Set by the registry's admission close. Later admissions fail with
-    /// `shutting_down`; everything already queued keeps publishing.
-    closed: bool,
+    admission: PublisherAdmissionState,
     /// The worker draining `queue`, while one is running. A live entry is
     /// what makes the loop single-flight: a worker installs itself under
     /// the admission lock and releases the slot under the same lock that
@@ -640,8 +651,7 @@ impl NamespacePublisher {
             state: Arc::new(Mutex::new(NamespacePublisherState {
                 queue: VecDeque::new(),
                 in_flight: HashMap::new(),
-                deleted: false,
-                closed: false,
+                admission: PublisherAdmissionState::Open,
                 worker: None,
                 next_allowed_cas_at: None,
             })),
@@ -666,19 +676,34 @@ impl NamespacePublisher {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
+    /// Open becomes closed; a delete that already landed is terminal and
+    /// stays terminal.
     fn close_admission(&self) {
-        self.lock_state().closed = true;
+        let mut state = self.lock_state();
+        if matches!(state.admission, PublisherAdmissionState::Open) {
+            state.admission = PublisherAdmissionState::Closed;
+        }
+    }
+
+    /// What an admission owes its caller right now, or `Ok(())` while the
+    /// publisher is open.
+    fn check_admission(&self, state: &NamespacePublisherState) -> Result<(), CoreError> {
+        match state.admission {
+            PublisherAdmissionState::Open => Ok(()),
+            PublisherAdmissionState::Closed => Err(CoreError::ShuttingDown),
+            PublisherAdmissionState::Deleted => Err(self.namespace_deleted()),
+        }
     }
 
     /// Drops the engine's tail projection, reporting whether it took the
     /// engine to do so. A `false` return means a publication or delete holds
     /// the engine, and that unit's own settlement reports what it retains.
-    fn invalidate_engine(&self) -> bool {
+    fn invalidate_projection(&self) -> bool {
         let Ok(mut slot) = self.engine.try_lock() else {
             return false;
         };
         if let Some(engine) = slot.engine.as_mut() {
-            engine.invalidate();
+            engine.invalidate_projection();
         }
         true
     }
@@ -736,14 +761,7 @@ impl NamespacePublisher {
         enqueued_at: Instant,
     ) -> Result<(), CoreError> {
         let mut state = self.lock_state();
-        if state.deleted {
-            return Err(CoreError::NamespaceDeleted {
-                namespace_id: self.namespace_id.clone(),
-            });
-        }
-        if state.closed {
-            return Err(CoreError::ShuttingDown);
-        }
+        self.check_admission(&state)?;
         if let Some(existing) = state.in_flight.get_mut(&commit_id) {
             if existing.semantic_identity != semantic_identity {
                 // Both claims are still in flight, so nothing has landed
@@ -799,14 +817,7 @@ impl NamespacePublisher {
         let (sender, receiver) = oneshot::channel();
         {
             let mut state = self.lock_state();
-            if state.deleted {
-                return Err(CoreError::NamespaceDeleted {
-                    namespace_id: self.namespace_id.clone(),
-                });
-            }
-            if state.closed {
-                return Err(CoreError::ShuttingDown);
-            }
+            self.check_admission(&state)?;
             match state.queue.back_mut() {
                 // A delete queued with the same options is the same request:
                 // both callers share its outcome. Different options ask for
@@ -903,7 +914,7 @@ impl NamespacePublisher {
         let mut state = self.lock_state();
         // Terminal: a successful delete emptied the queue and set this
         // before its worker returned, so nothing may be taken afterwards.
-        if state.deleted || state.queue.is_empty() {
+        if matches!(state.admission, PublisherAdmissionState::Deleted) || state.queue.is_empty() {
             state.worker = None;
             return None;
         }
@@ -1073,12 +1084,12 @@ impl NamespacePublisher {
                 // the delete; admissions from here on fail fast.
                 let queued = {
                     let mut state = self.lock_state();
-                    state.deleted = true;
+                    state.admission = PublisherAdmissionState::Deleted;
                     take_queued_waiters(&mut state)
                 };
                 // The publisher is terminal; drop it from the registry map
                 // so the map stays bounded by live namespaces. Clones still
-                // in flight fail fast on `deleted`, and a later submission
+                // in flight fail fast on `Deleted`, and a later submission
                 // gets a fresh publisher whose publish fails on the durable
                 // tombstone.
                 if let Some(shared) = self.shared.upgrade() {

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -808,9 +808,12 @@ impl NamespacePublisher {
                 return Err(CoreError::ShuttingDown);
             }
             match state.queue.back_mut() {
-                // A delete already queued at the tail is the same barrier:
-                // both callers get its outcome.
-                Some(WorkItem::Delete(pending)) => pending.waiters.push(sender),
+                // A delete queued with the same options is the same request:
+                // both callers share its outcome. Different options ask for
+                // different operations and settle separately, in order.
+                Some(WorkItem::Delete(pending)) if pending.options == options => {
+                    pending.waiters.push(sender);
+                }
                 _ => state.queue.push_back(WorkItem::Delete(PendingDelete {
                     options,
                     waiters: vec![sender],

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -1716,6 +1716,75 @@ async fn close_admission_refuses_without_creating_publishers() {
     registry.drain().await.expect("nothing to drain");
 }
 
+/// A delete admitted before the shutdown sweep is the worker's to finish, so
+/// it still lands after admission closes — and it lands terminally. Deleted
+/// outranks closed: the publisher answers later work with the namespace's
+/// tombstone, not with the shutdown that raced it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_delete_admitted_before_close_admission_lands_terminal() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
+    let shared = store.clone() as SharedStore;
+    let writer = test_writer(shared.clone()).await;
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("bootstrap");
+    let registry = writer.publisher();
+
+    // A publication parks at its head CAS, so the delete deterministically
+    // queues behind it instead of being taken first.
+    store.block_next();
+    let active = {
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        tokio::spawn(async move {
+            registry
+                .submit_commit(namespace_id, create_directory_request("active", "active"))
+                .await
+        })
+    };
+    store.wait_until_blocked().await;
+    let publisher = registry
+        .shared
+        .lock_state()
+        .publishers
+        .get(&namespace_id)
+        .cloned()
+        .expect("publisher exists once a publish is in flight");
+    let delete = spawn_delete(&publisher, DeleteNamespaceOptions::default());
+    wait_for_queued_delete(&publisher).await;
+
+    // Admission closes with the delete already admitted; releasing the gate
+    // lets the batch and then the delete publish.
+    registry.close_admission();
+    store.release();
+
+    let response = active
+        .await
+        .expect("submit task")
+        .expect("admitted commit publishes");
+    assert_eq!(response.committed_seq, ChangeSeq(1));
+    let deleted = settle_delete(delete, "delete admitted before close_admission")
+        .await
+        .expect("an admitted delete lands after admission closes");
+    assert_eq!(deleted.head_seq, ChangeSeq(1));
+
+    assert!(matches!(
+        publisher_state(&publisher).admission,
+        PublisherAdmissionState::Deleted
+    ));
+    let late = try_admit_commit(
+        &publisher,
+        &namespace_id,
+        create_directory_request("late", "late"),
+    )
+    .expect_err("submission after the delete lands");
+    assert_eq!(late.code(), ErrorCode::NamespaceDeleted);
+    registry.drain().await.expect("drain settles the delete");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn delete_queued_mid_publish_waits_behind_admitted_work() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1788,7 +1857,7 @@ async fn delete_queued_mid_publish_waits_behind_admitted_work() {
     let (deleted_while_blocked, delete_queued_while_blocked) = {
         let state = publisher_state(&publisher);
         (
-            state.deleted,
+            matches!(state.admission, PublisherAdmissionState::Deleted),
             matches!(state.queue.back(), Some(WorkItem::Delete(_))),
         )
     };

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -376,6 +376,41 @@ async fn wait_for_queued_delete(publisher: &NamespacePublisher) {
     }
 }
 
+/// Queued delete items and the waiters they hold, worker-untaken.
+fn queued_delete_shape(state: &NamespacePublisherState) -> (usize, usize) {
+    state
+        .queue
+        .iter()
+        .fold((0, 0), |(items, waiters), item| match item {
+            WorkItem::Delete(pending) => (items + 1, waiters + pending.waiters.len()),
+            _ => (items, waiters),
+        })
+}
+
+/// Yields until the queued deletes hold at least `expected` waiters.
+async fn wait_for_queued_delete_waiters(publisher: &NamespacePublisher, expected: usize) {
+    while queued_delete_shape(&publisher_state(publisher)).1 < expected {
+        tokio::task::yield_now().await;
+    }
+}
+
+fn spawn_delete(
+    publisher: &NamespacePublisher,
+    options: DeleteNamespaceOptions,
+) -> tokio::task::JoinHandle<DeleteResult> {
+    let publisher = publisher.clone();
+    tokio::spawn(async move { publisher.submit_delete(options).await })
+}
+
+/// Bounded: a stranded delete waiter is a hang, and a hang must fail
+/// the test.
+async fn settle_delete(handle: tokio::task::JoinHandle<DeleteResult>, label: &str) -> DeleteResult {
+    timeout(Duration::from_secs(10), handle)
+        .await
+        .unwrap_or_else(|_| panic!("{label} must settle, not hang"))
+        .unwrap_or_else(|err| panic!("{label} task failed: {err}"))
+}
+
 /// A publisher with no owning registry, exercising the unowned-task
 /// fallback the production paths reserve for a dropped registry. The
 /// caller keeps `runtime` alive; the publisher holds its bits weakly.
@@ -1050,6 +1085,177 @@ async fn second_delete_during_inflight_delete_settles_both() {
         .expect("orphan waiter answered")
         .expect_err("admitted behind the delete");
     assert_eq!(orphan_error.code(), ErrorCode::NamespaceDeleted);
+}
+
+/// Two deletes pending at the queue tail with equal options are one
+/// request: one queue item, and both callers share its outcome.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn identical_pending_deletes_coalesce_into_one_outcome() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
+    let shared = store.clone() as SharedStore;
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
+
+    recv_commit(
+        admit_commit(
+            &publisher,
+            &namespace_id,
+            create_directory_request("seed", "seed"),
+        ),
+        "seed",
+    )
+    .await;
+
+    // A blocked publication holds the worker, so both deletes stay
+    // pending at the tail together.
+    store.block_next();
+    let gate = admit_commit(
+        &publisher,
+        &namespace_id,
+        create_directory_request("gate", "gate"),
+    );
+    store.wait_until_blocked().await;
+
+    let options = DeleteNamespaceOptions {
+        expected_head_seq: Some(ChangeSeq(2)),
+    };
+    let first = spawn_delete(&publisher, options);
+    wait_for_queued_delete_waiters(&publisher, 1).await;
+    let second = spawn_delete(&publisher, options);
+    wait_for_queued_delete_waiters(&publisher, 2).await;
+    assert_eq!(
+        queued_delete_shape(&publisher_state(&publisher)),
+        (1, 2),
+        "equal options coalesce into one pending delete"
+    );
+
+    store.release();
+    recv_commit(gate, "gate").await;
+    let first = settle_delete(first, "first delete")
+        .await
+        .expect("first delete succeeds");
+    let second = settle_delete(second, "second delete")
+        .await
+        .expect("second delete succeeds");
+    assert_eq!(first.head_seq, ChangeSeq(2));
+    assert_eq!(second.head_seq, ChangeSeq(2));
+}
+
+/// Deletes with different preconditions are different requests: each is
+/// its own queue item, and each settles against its own options.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pending_deletes_with_different_preconditions_settle_separately() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
+    let shared = store.clone() as SharedStore;
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
+
+    recv_commit(
+        admit_commit(
+            &publisher,
+            &namespace_id,
+            create_directory_request("seed", "seed"),
+        ),
+        "seed",
+    )
+    .await;
+
+    store.block_next();
+    let gate = admit_commit(
+        &publisher,
+        &namespace_id,
+        create_directory_request("gate", "gate"),
+    );
+    store.wait_until_blocked().await;
+
+    let stale = spawn_delete(
+        &publisher,
+        DeleteNamespaceOptions {
+            expected_head_seq: Some(ChangeSeq(1)),
+        },
+    );
+    wait_for_queued_delete_waiters(&publisher, 1).await;
+    let unconditional = spawn_delete(&publisher, DeleteNamespaceOptions::default());
+    wait_for_queued_delete_waiters(&publisher, 2).await;
+    assert_eq!(
+        queued_delete_shape(&publisher_state(&publisher)),
+        (2, 2),
+        "different options stay separate pending deletes"
+    );
+
+    store.release();
+    recv_commit(gate, "gate").await;
+    let stale_error = settle_delete(stale, "stale delete")
+        .await
+        .expect_err("the gate publication moved the head past its precondition");
+    assert_eq!(stale_error.code(), ErrorCode::StaleHead);
+    let deleted = settle_delete(unconditional, "unconditional delete")
+        .await
+        .expect("the unconditional delete lands after the stale one fails");
+    assert_eq!(deleted.head_seq, ChangeSeq(2));
+}
+
+/// A stale delete queued behind a valid one settles as
+/// `namespace_deleted` — it never inherits the other delete's success.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_stale_pending_delete_does_not_share_the_first_deletes_success() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = Arc::new(blocking_head_cas_store(temp_dir.path(), &namespace_id));
+    let shared = store.clone() as SharedStore;
+    let runtime = test_runtime(shared.clone());
+    create_namespace(&runtime, &namespace_id).await;
+    let publisher = standalone_publisher(&namespace_id, &runtime);
+
+    recv_commit(
+        admit_commit(
+            &publisher,
+            &namespace_id,
+            create_directory_request("seed", "seed"),
+        ),
+        "seed",
+    )
+    .await;
+
+    store.block_next();
+    let gate = admit_commit(
+        &publisher,
+        &namespace_id,
+        create_directory_request("gate", "gate"),
+    );
+    store.wait_until_blocked().await;
+
+    let valid = spawn_delete(
+        &publisher,
+        DeleteNamespaceOptions {
+            expected_head_seq: Some(ChangeSeq(2)),
+        },
+    );
+    wait_for_queued_delete_waiters(&publisher, 1).await;
+    let stale = spawn_delete(
+        &publisher,
+        DeleteNamespaceOptions {
+            expected_head_seq: Some(ChangeSeq(1)),
+        },
+    );
+    wait_for_queued_delete_waiters(&publisher, 2).await;
+
+    store.release();
+    recv_commit(gate, "gate").await;
+    let landed = settle_delete(valid, "valid delete")
+        .await
+        .expect("the delete whose precondition holds lands");
+    assert_eq!(landed.head_seq, ChangeSeq(2));
+    let stale_error = settle_delete(stale, "stale delete")
+        .await
+        .expect_err("a precondition the tombstone outran");
+    assert_eq!(stale_error.code(), ErrorCode::NamespaceDeleted);
 }
 
 /// Commit admission races a delete already queued behind an in-flight


### PR DESCRIPTION
Three publisher states were spread across correlated fields with the rules held by convention. The writer session is now a three-phase enum (unacquired / acquired / terminally fenced) instead of two options whose illegal both-set combination was avoided by hand.

Notes:
- A new test pins the previously untested transition: a delete admitted before `close_admission` still lands afterward, and the publisher ends deleted, not shutting down
- `close_admission` now moves Open to Closed only — the old unconditional flag write was harmless behind the deleted-first check; with one state the guard is what preserves behavior
- `Advanced` keeps its etag optional: a compare-and-swap acknowledgement without one advanced the head but cannot re-anchor the projection, and the consumer still invalidates there
- One `allow(clippy::large_enum_variant)` with a stated reason — the old struct held the same head state inline, so boxing would be pure lint appeasement
