### PR TITLE
test(model): the differential compares deleted bindings

### DIFF
--- a/crates/loonfs-core/tests/it/differential.rs
+++ b/crates/loonfs-core/tests/it/differential.rs
@@ -1,22 +1,58 @@
 //! Differential checks between core metadata and the `loonfs-model` oracle.
 
+use loonfs_api::wire::manifest::{DeletedDirentry, TombstoneGeneration};
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
     ChangeSeq, ContentId, ContentRef, DisplayName, InodeId, InodeKind, NameKey, RevisionNo,
 };
-use loonfs_core::metadata::MetadataState as CoreMetadataState;
-use loonfs_model::metadata::MetadataState as ModelMetadataState;
+use loonfs_core::metadata::{
+    MetadataState as CoreMetadataState, SubtreeTombstoneAction as CoreTombstoneAction,
+};
+use loonfs_model::metadata::{
+    MetadataState as ModelMetadataState, SubtreeTombstoneAction as ModelTombstoneAction,
+};
 
 type NormalizedInodes = Vec<(u64, &'static str, u64)>;
 type NormalizedDirentryBinds = Vec<(u64, String, u64, u64, u32)>;
 type NormalizedRevisions = Vec<(u64, u64, u64, u32, ContentId)>;
-type NormalizedTombstones = Vec<(u64, u64, u32)>;
+type NormalizedTombstones = Vec<NormalizedTombstone>;
 type NormalizedMetadata = (
     NormalizedInodes,
     NormalizedDirentryBinds,
     NormalizedRevisions,
     NormalizedTombstones,
 );
+
+/// One tombstone event, whole: the generation, what the event did, and the
+/// binding a delete recorded. Comparing only the generation would let a
+/// dropped or mangled deleted binding through, so both sides reduce to
+/// every field; the fields are named rather than positional so a divergence
+/// prints which one differs.
+#[derive(Debug, PartialEq, Eq)]
+struct NormalizedTombstone {
+    root_inode_id: u64,
+    tombstone_seq: u64,
+    tombstone_delta_index: u32,
+    action: NormalizedTombstoneAction,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum NormalizedTombstoneAction {
+    Set {
+        deleted_binding: Option<NormalizedBinding>,
+    },
+    Revoke {
+        target_seq: u64,
+        target_delta_index: u32,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct NormalizedBinding {
+    parent_inode_id: u64,
+    name_key: String,
+    display_name: String,
+}
 
 fn content_ref(seed: &str) -> ContentRef {
     ContentRef::blob_v1(ContentId::generate(), seed.as_bytes())
@@ -105,12 +141,55 @@ fn bind(
     }]
 }
 
-fn tombstone(delta_index: u32, root_inode_id: InodeId) -> Vec<WalDelta> {
+/// A delete by path, which records the binding it removed.
+fn tombstone(
+    delta_index: u32,
+    root_inode_id: InodeId,
+    parent_inode_id: InodeId,
+    display_name: &str,
+) -> Vec<WalDelta> {
+    vec![WalDelta::TombstoneSubtree {
+        delta_index,
+        root_inode_id,
+        deleted_direntry: Some(DeletedDirentry {
+            parent_inode_id,
+            name_key: NameKey::parse(loonfs_api::name_key_for_display_name(display_name))
+                .expect("derived name key"),
+            display_name: DisplayName::parse(display_name).expect("valid display name"),
+        }),
+    }]
+}
+
+/// A delete addressed by inode, which had no name to record.
+fn tombstone_without_binding(delta_index: u32, root_inode_id: InodeId) -> Vec<WalDelta> {
     vec![WalDelta::TombstoneSubtree {
         delta_index,
         root_inode_id,
         deleted_direntry: None,
     }]
+}
+
+/// Undelete as the commit path materializes it: revoke the exact deletion
+/// generation, then re-bind the recovered inode.
+fn undelete(
+    delta_index: u32,
+    inode_id: InodeId,
+    parent_inode_id: InodeId,
+    display_name: &str,
+    target: TombstoneGeneration,
+) -> Vec<WalDelta> {
+    let mut deltas = vec![WalDelta::RevokeSubtreeTombstone {
+        delta_index,
+        root_inode_id: inode_id,
+        target,
+    }];
+    deltas.extend(bind(
+        delta_index.saturating_add(1),
+        inode_id,
+        parent_inode_id,
+        display_name,
+    ));
+    deltas
 }
 
 #[test]
@@ -174,8 +253,36 @@ fn metadata_apply_matches_model_for_restore_revision_of_current_head() {
     ]);
 }
 
+// The deleted names below are spelled with capitals on purpose: their
+// derived key case-folds, so a tombstone that lost the user-facing spelling
+// and fell back to the key would differ here.
+
 #[test]
 fn metadata_apply_matches_model_for_delete_file() {
+    assert_states_match(&[
+        create_directory(0, InodeId(2), InodeId(1), "docs"),
+        create_file(
+            0,
+            InodeId(3),
+            InodeId(2),
+            "Readme.TXT",
+            content_ref("content-1"),
+        ),
+        tombstone(0, InodeId(3), InodeId(2), "Readme.TXT"),
+    ]);
+}
+
+#[test]
+fn metadata_apply_matches_model_for_delete_subtree() {
+    assert_states_match(&[
+        create_directory(0, InodeId(2), InodeId(1), "Docs"),
+        create_directory(0, InodeId(3), InodeId(2), "nested"),
+        tombstone(0, InodeId(2), InodeId(1), "Docs"),
+    ]);
+}
+
+#[test]
+fn metadata_apply_matches_model_for_delete_addressed_by_inode() {
     assert_states_match(&[
         create_directory(0, InodeId(2), InodeId(1), "docs"),
         create_file(
@@ -185,16 +292,34 @@ fn metadata_apply_matches_model_for_delete_file() {
             "readme.txt",
             content_ref("content-1"),
         ),
-        tombstone(0, InodeId(3)),
+        tombstone_without_binding(0, InodeId(3)),
     ]);
 }
 
 #[test]
-fn metadata_apply_matches_model_for_delete_subtree() {
+fn metadata_apply_matches_model_for_undelete() {
     assert_states_match(&[
         create_directory(0, InodeId(2), InodeId(1), "docs"),
-        create_directory(0, InodeId(3), InodeId(2), "nested"),
-        tombstone(0, InodeId(2)),
+        create_file(
+            0,
+            InodeId(3),
+            InodeId(2),
+            "Readme.TXT",
+            content_ref("content-1"),
+        ),
+        tombstone(1, InodeId(3), InodeId(2), "Readme.TXT"),
+        // The revoke names the delete's own generation — the third commit,
+        // second delta — which differs from where the revoke itself lands.
+        undelete(
+            0,
+            InodeId(3),
+            InodeId(2),
+            "Readme.TXT",
+            TombstoneGeneration {
+                seq: ChangeSeq(3),
+                delta_index: 1,
+            },
+        ),
     ]);
 }
 
@@ -263,12 +388,27 @@ fn normalize_core(state: &CoreMetadataState) -> NormalizedMetadata {
         state
             .subtree_tombstones()
             .iter()
-            .map(|tombstone| {
-                (
-                    tombstone.root_inode_id.0,
-                    tombstone.generation.seq.0,
-                    tombstone.generation.delta_index,
-                )
+            .map(|tombstone| NormalizedTombstone {
+                root_inode_id: tombstone.root_inode_id.0,
+                tombstone_seq: tombstone.generation.seq.0,
+                tombstone_delta_index: tombstone.generation.delta_index,
+                action: match &tombstone.action {
+                    CoreTombstoneAction::Set { deleted_direntry } => {
+                        NormalizedTombstoneAction::Set {
+                            deleted_binding: deleted_direntry.as_ref().map(|direntry| {
+                                NormalizedBinding {
+                                    parent_inode_id: direntry.parent_inode_id.0,
+                                    name_key: direntry.name_key.as_str().to_owned(),
+                                    display_name: direntry.display_name.as_str().to_owned(),
+                                }
+                            }),
+                        }
+                    }
+                    CoreTombstoneAction::Revoke { target } => NormalizedTombstoneAction::Revoke {
+                        target_seq: target.seq.0,
+                        target_delta_index: target.delta_index,
+                    },
+                },
             })
             .collect(),
     )
@@ -313,12 +453,27 @@ fn normalize_model(state: &ModelMetadataState) -> NormalizedMetadata {
             .collect(),
         subtree_tombstones
             .iter()
-            .map(|tombstone| {
-                (
-                    tombstone.root_inode_id.0,
-                    tombstone.tombstone_seq.0,
-                    tombstone.tombstone_delta_index,
-                )
+            .map(|tombstone| NormalizedTombstone {
+                root_inode_id: tombstone.root_inode_id.0,
+                tombstone_seq: tombstone.tombstone_seq.0,
+                tombstone_delta_index: tombstone.tombstone_delta_index,
+                action: match &tombstone.action {
+                    ModelTombstoneAction::Set { deleted_binding } => {
+                        NormalizedTombstoneAction::Set {
+                            deleted_binding: deleted_binding.as_ref().map(|binding| {
+                                NormalizedBinding {
+                                    parent_inode_id: binding.parent_inode_id.0,
+                                    name_key: binding.name_key.clone(),
+                                    display_name: binding.display_name.clone(),
+                                }
+                            }),
+                        }
+                    }
+                    ModelTombstoneAction::Revoke { target } => NormalizedTombstoneAction::Revoke {
+                        target_seq: target.seq.0,
+                        target_delta_index: target.delta_index,
+                    },
+                },
             })
             .collect(),
     )

--- a/crates/loonfs-model/src/metadata.rs
+++ b/crates/loonfs-model/src/metadata.rs
@@ -73,22 +73,40 @@ pub struct SubtreeTombstoneRecord {
     pub tombstone_seq: ChangeSeq,
     pub tombstone_delta_index: u32,
     pub deleted_at_ms: u64,
-    pub parent_inode_id: Option<InodeId>,
-    pub name_key: Option<String>,
-    pub display_name: Option<String>,
     /// What this event did, mirroring the core row semantics: the newest
     /// event per root wins, and a revoke as the newest means no active
     /// tombstone.
     pub action: SubtreeTombstoneAction,
 }
 
+/// Where one deletion event committed. A revoke names its target this way,
+/// so the two events it takes to cancel a deletion stay tied together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeletionGeneration {
+    pub seq: ChangeSeq,
+    pub delta_index: u32,
+}
+
+/// The binding a path delete removed, restated in this crate's own plain
+/// spelling. The three fields describe one binding, so they travel as one:
+/// an event either recorded a binding or it did not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeletedBinding {
+    pub parent_inode_id: InodeId,
+    pub name_key: String,
+    pub display_name: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SubtreeTombstoneAction {
-    Set,
-    Revoke {
-        target_seq: ChangeSeq,
-        target_delta_index: u32,
+    /// Deletes the subtree rooted at the record's inode. Only a delete has
+    /// a binding to remove, so this is the one action that can carry one —
+    /// absent when the delete was addressed by inode.
+    Set {
+        deleted_binding: Option<DeletedBinding>,
     },
+    /// Cancels exactly the deletion recorded at `target`.
+    Revoke { target: DeletionGeneration },
 }
 
 impl MetadataState {
@@ -175,16 +193,15 @@ impl MetadataState {
                             tombstone_seq: committed_seq,
                             tombstone_delta_index: *delta_index,
                             deleted_at_ms: committed_at_ms,
-                            parent_inode_id: deleted_direntry
-                                .as_ref()
-                                .map(|direntry| direntry.parent_inode_id),
-                            name_key: deleted_direntry
-                                .as_ref()
-                                .map(|direntry| direntry.name_key.as_str().to_owned()),
-                            display_name: deleted_direntry
-                                .as_ref()
-                                .map(|direntry| direntry.display_name.as_str().to_owned()),
-                            action: SubtreeTombstoneAction::Set,
+                            action: SubtreeTombstoneAction::Set {
+                                deleted_binding: deleted_direntry.as_ref().map(|direntry| {
+                                    DeletedBinding {
+                                        parent_inode_id: direntry.parent_inode_id,
+                                        name_key: direntry.name_key.as_str().to_owned(),
+                                        display_name: direntry.display_name.as_str().to_owned(),
+                                    }
+                                }),
+                            },
                         });
                 }
                 WalDelta::RevokeSubtreeTombstone {
@@ -199,12 +216,11 @@ impl MetadataState {
                             tombstone_seq: committed_seq,
                             tombstone_delta_index: *delta_index,
                             deleted_at_ms: committed_at_ms,
-                            parent_inode_id: None,
-                            name_key: None,
-                            display_name: None,
                             action: SubtreeTombstoneAction::Revoke {
-                                target_seq: target.seq,
-                                target_delta_index: target.delta_index,
+                                target: DeletionGeneration {
+                                    seq: target.seq,
+                                    delta_index: target.delta_index,
+                                },
                             },
                         });
                 }
@@ -218,6 +234,7 @@ impl MetadataState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use loonfs_api::wire::manifest::{DeletedDirentry, TombstoneGeneration};
     use loonfs_api::NameKey;
 
     #[test]
@@ -237,5 +254,56 @@ mod tests {
 
         assert_eq!(applied.direntry_binds.len(), 1);
         assert_eq!(applied.direntry_binds[0].name_key, "persisted-key");
+    }
+
+    #[test]
+    fn tombstone_replay_restates_the_deleted_binding_and_the_revoked_generation() {
+        let applied = MetadataState::default().apply_committed_wal_deltas(
+            ChangeSeq(9),
+            4_200,
+            &[
+                WalDelta::TombstoneSubtree {
+                    delta_index: 1,
+                    root_inode_id: InodeId(2),
+                    deleted_direntry: Some(DeletedDirentry {
+                        parent_inode_id: InodeId(1),
+                        name_key: NameKey::parse("report.txt").expect("valid name key"),
+                        display_name: loonfs_api::DisplayName::parse("Report.TXT")
+                            .expect("valid display name"),
+                    }),
+                },
+                WalDelta::RevokeSubtreeTombstone {
+                    delta_index: 2,
+                    root_inode_id: InodeId(2),
+                    target: TombstoneGeneration {
+                        seq: ChangeSeq(4),
+                        delta_index: 3,
+                    },
+                },
+            ],
+        );
+
+        assert_eq!(
+            applied
+                .subtree_tombstones
+                .iter()
+                .map(|tombstone| tombstone.action.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                SubtreeTombstoneAction::Set {
+                    deleted_binding: Some(DeletedBinding {
+                        parent_inode_id: InodeId(1),
+                        name_key: "report.txt".to_owned(),
+                        display_name: "Report.TXT".to_owned(),
+                    }),
+                },
+                SubtreeTombstoneAction::Revoke {
+                    target: DeletionGeneration {
+                        seq: ChangeSeq(4),
+                        delta_index: 3,
+                    },
+                },
+            ]
+        );
     }
 }


### PR DESCRIPTION
The model-vs-core differential never compared the deleted binding. The whole enriched-tombstone feature sat outside the suite. 

