### PR TITLE
feat(cache): prepare for optional local block cache

### DIFF
--- a/crates/loonfs-core/Cargo.toml
+++ b/crates/loonfs-core/Cargo.toml
@@ -25,6 +25,9 @@ tracing.workspace = true
 
 [features]
 default = []
+# Test doubles for this crate's public seams, for the test targets of crates
+# that implement or install them. No production build enables it.
+test-support = []
 
 [dev-dependencies]
 loonfs-model = { path = "../loonfs-model" }

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -1,7 +1,12 @@
 //! Shared caches for decoded manifest state: SST blocks keyed by content
 //! digest, validated manifests, and bounded WAL-tail projections.
+//!
+//! The decoded block cache also carries the handle to the optional
+//! node-local cache of the same blocks in their encoded form; see
+//! [`stored_block_cache`](super::stored_block_cache).
 
 use super::runs::MetadataRunManifest;
+use super::stored_block_cache::StoredMetadataBlockCache;
 use crate::metadata::MetadataState;
 use crate::recency::Recency;
 use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
@@ -121,6 +126,12 @@ pub struct MetadataTableCache {
     /// One cell per in-flight block fetch, keyed by the block's cache key,
     /// so concurrent readers share a single ranged GET per block.
     in_flight: Mutex<HashMap<MetadataTableCacheKey, Arc<OnceCell<DecodedMetadataTableBlock>>>>,
+    /// The node-local cache of encoded stored blocks this cache misses
+    /// into, when the runtime was built with one. It lives here so the two
+    /// tiers are available together: a path that carries no table cache —
+    /// maintenance, reorganization, collection, and retention all pass
+    /// none — reaches neither tier, and needs no separate wiring to say so.
+    stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
 }
 
 #[derive(Debug, Default)]
@@ -150,12 +161,28 @@ struct MetadataTableCacheStatsInner {
 
 impl MetadataTableCache {
     pub fn new(config: MetadataTableCacheConfig) -> Self {
+        Self::with_stored_block_cache(config, None)
+    }
+
+    /// Sizes a cache that also carries a node-local cache of encoded stored
+    /// blocks beneath it. Passing `None` is exactly [`Self::new`].
+    pub fn with_stored_block_cache(
+        config: MetadataTableCacheConfig,
+        stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
+    ) -> Self {
         Self {
             config,
             inner: Mutex::new(MetadataTableCacheInner::default()),
             stats: MetadataTableCacheStatsInner::default(),
             in_flight: Mutex::new(HashMap::new()),
+            stored_block_cache,
         }
+    }
+
+    /// The node-local stored-block cache this cache misses into, if the
+    /// runtime was built with one.
+    pub fn stored_block_cache(&self) -> Option<&Arc<dyn StoredMetadataBlockCache>> {
+        self.stored_block_cache.as_ref()
     }
 
     /// Resolves one block access through a single-flight cell.

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -22,8 +22,10 @@
 //!   [`row`] handles manifest-row encoding.
 //! - [`reorganize`] compacts bounded family groups into new base runs.
 //! - [`retention`] advances the retention floor behind verified progress.
-//! - [`runs`] models the LSM run layout shared by all of the above, and
-//!   [`cache`] holds decoded SST blocks keyed by content digest.
+//! - [`runs`] models the LSM run layout shared by all of the above,
+//!   [`cache`] holds decoded SST blocks keyed by content digest, and
+//!   [`stored_block_cache`] defines the seam a node-local cache of the same
+//!   blocks in their encoded form plugs into.
 
 mod block_fetch;
 mod block_load;
@@ -44,6 +46,7 @@ mod retention;
 mod row;
 mod runs;
 mod scan;
+mod stored_block_cache;
 #[cfg(test)]
 pub(crate) mod tests;
 mod validate;
@@ -58,6 +61,10 @@ pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
 pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub(crate) use self::runs::MetadataLsmPolicy;
+pub use self::stored_block_cache::{
+    StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
+    StoredMetadataBlockKind,
+};
 
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::files::list_checkpoint_files_page;

--- a/crates/loonfs-core/src/checkpoint/stored_block_cache.rs
+++ b/crates/loonfs-core/src/checkpoint/stored_block_cache.rs
@@ -1,0 +1,140 @@
+//! The seam a node-local cache of encoded metadata SST blocks plugs into.
+//!
+//! This tier sits beneath the decoded [`MetadataTableCache`] and above
+//! object storage. It holds stored section bytes — the same bytes the
+//! segment object holds — so a hit still has to be decoded and verified
+//! before any caller sees a row.
+//!
+//! [`MetadataTableCache`]: super::MetadataTableCache
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use thiserror::Error;
+
+/// Identifies one encoded stored section of one metadata SST segment.
+///
+/// The identity mirrors the decoded cache's. `payload_checksum` is the
+/// segment's `sha256:<hex>` digest, which names immutable bytes, so an entry
+/// can never go stale; `kind` and `offset` locate the section inside that
+/// segment, so sections of one segment cannot collide.
+///
+/// Nothing else belongs in the identity. Stored lengths and CRCs are
+/// validation inputs carried by the segment's block handles, and the decoder
+/// checks them whether the bytes came from this tier or from the store.
+/// There is no version field either: an implementation versions its own
+/// on-disk directory instead.
+///
+/// Namespace manifests are deliberately not representable. The decoded cache
+/// keys them by object key rather than by content digest, and they stay out
+/// of this tier.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct StoredMetadataBlockKey {
+    pub payload_checksum: String,
+    pub kind: StoredMetadataBlockKind,
+    pub offset: u64,
+}
+
+/// Which stored section of a segment a key names.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum StoredMetadataBlockKind {
+    Data,
+    Index,
+    Filter,
+}
+
+/// A cache that failed to shut down cleanly.
+///
+/// Shutdown is the one operation whose failure a caller can observe. The
+/// bytes are a cache, so nothing durable is lost, but a host draining on its
+/// way out should still be able to report why.
+#[derive(Debug, Error)]
+#[error("stored metadata block cache failed to close: {0}")]
+pub struct StoredMetadataBlockCacheCloseError(String);
+
+impl StoredMetadataBlockCacheCloseError {
+    /// Wraps an implementation's shutdown failure message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+/// A node-local cache of encoded, stored metadata SST sections.
+///
+/// Object storage remains the only authority. This tier holds a copy of
+/// bytes the store already holds, addressed by [`StoredMetadataBlockKey`],
+/// and every hit is decoded and verified by the ordinary segment decoder
+/// before a caller sees a row. A hit is therefore evidence that the bytes
+/// were available locally and nothing more.
+///
+/// Lookups and inserts are best effort. An implementation records its own
+/// failures and answers a failed lookup with `None` and a failed insert by
+/// doing nothing, so a full, broken, or unreachable cache degrades to plain
+/// object-store reads.
+///
+/// After [`close`](Self::close) the cache is inert: `get` returns `None`,
+/// and `insert` and `invalidate` do nothing. `close` is idempotent.
+#[async_trait]
+pub trait StoredMetadataBlockCache: Send + Sync + Debug {
+    /// Returns the stored bytes held for `key`, or `None` on a miss.
+    async fn get(&self, key: &StoredMetadataBlockKey) -> Option<Bytes>;
+
+    /// Offers `bytes` as the stored bytes for `key`. Whether the cache keeps
+    /// them, and for how long, is the implementation's decision.
+    fn insert(&self, key: StoredMetadataBlockKey, bytes: Bytes);
+
+    /// Drops whatever is held for `key`.
+    fn invalidate(&self, key: &StoredMetadataBlockKey);
+
+    /// Flushes what the implementation wants to keep and makes the cache
+    /// inert. Calling it more than once is allowed and does nothing further.
+    async fn close(&self) -> Result<(), StoredMetadataBlockCacheCloseError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    const CHECKSUM: &str = "sha256:0f0e0d0c0b0a09080706050403020100";
+    const OTHER_CHECKSUM: &str = "sha256:00112233445566778899aabbccddeeff";
+
+    fn key(
+        payload_checksum: &str,
+        kind: StoredMetadataBlockKind,
+        offset: u64,
+    ) -> StoredMetadataBlockKey {
+        StoredMetadataBlockKey {
+            payload_checksum: payload_checksum.to_owned(),
+            kind,
+            offset,
+        }
+    }
+
+    #[test]
+    fn one_segment_section_has_one_key() {
+        let first = key(CHECKSUM, StoredMetadataBlockKind::Data, 4096);
+        let second = key(CHECKSUM, StoredMetadataBlockKind::Data, 4096);
+        assert_eq!(first, second);
+        // Implementations index by this key, so equality without a matching
+        // hash would still lose the entry.
+        let mut keys = HashSet::new();
+        keys.insert(first);
+        assert!(keys.contains(&second));
+    }
+
+    #[test]
+    fn checksum_kind_and_offset_each_separate_keys() {
+        // Every field varied once against one base key: whichever field
+        // stopped counting, one of these would collide with the base.
+        let keys: HashSet<StoredMetadataBlockKey> = HashSet::from([
+            key(CHECKSUM, StoredMetadataBlockKind::Data, 4096),
+            key(OTHER_CHECKSUM, StoredMetadataBlockKind::Data, 4096),
+            key(CHECKSUM, StoredMetadataBlockKind::Index, 4096),
+            key(CHECKSUM, StoredMetadataBlockKind::Filter, 4096),
+            key(CHECKSUM, StoredMetadataBlockKind::Data, 0),
+        ]);
+        assert_eq!(keys.len(), 5);
+    }
+}

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -106,6 +106,13 @@ pub mod metadata;
 /// Path parsing and current-state resolution. Consumed by `loonfs`'s write
 /// path (`parse_mutation_path`).
 pub mod path;
+/// Test doubles for this crate's public seams, behind the `test-support`
+/// feature. Consumed by the test targets of crates that implement or install
+/// those seams; no production build enables the feature. Doubles live here
+/// rather than in `loonfs-test-support` because that crate is a development
+/// dependency of this one and so cannot depend on these types.
+#[cfg(feature = "test-support")]
+pub mod test_support;
 /// The wall-clock boundary durable timestamps are stamped at. Consumed by
 /// `loonfs`, whose mutation contexts and maintenance clock stamp from the
 /// same boundary this crate's own commits do.
@@ -119,8 +126,9 @@ pub mod cache {
 
     pub use crate::checkpoint::{
         ManifestLoadError, ManifestLoadFailureClass, MetadataTableCache, MetadataTableCacheConfig,
-        MetadataTableCacheStats, WalTailProjectionCache, WalTailProjectionCacheConfig,
-        WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+        MetadataTableCacheStats, StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError,
+        StoredMetadataBlockKey, StoredMetadataBlockKind, WalTailProjectionCache,
+        WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
         DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
         DEFAULT_WAL_TAIL_PROJECTION_ROWS,
     };

--- a/crates/loonfs-core/src/test_support.rs
+++ b/crates/loonfs-core/src/test_support.rs
@@ -1,0 +1,138 @@
+//! Test doubles for this crate's public seams.
+
+use crate::cache::{
+    StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
+};
+use async_trait::async_trait;
+use bytes::Bytes;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// One call made against a [`RecordingStoredMetadataBlockCache`], in the
+/// form that says what the caller asked for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordedStoredMetadataBlockCall {
+    /// A lookup, with whether it was answered from the map.
+    Get {
+        key: StoredMetadataBlockKey,
+        hit: bool,
+    },
+    /// An insert, with the length of the bytes offered.
+    Insert {
+        key: StoredMetadataBlockKey,
+        bytes: usize,
+    },
+    /// An invalidation.
+    Invalidate { key: StoredMetadataBlockKey },
+}
+
+impl RecordedStoredMetadataBlockCall {
+    /// The key the call addressed.
+    pub fn key(&self) -> &StoredMetadataBlockKey {
+        match self {
+            Self::Get { key, .. } | Self::Insert { key, .. } | Self::Invalidate { key } => key,
+        }
+    }
+}
+
+/// A stored-block cache that serves from an in-memory map and records every
+/// call in call order.
+///
+/// Closing flips the cache inert, as the trait requires: later calls are
+/// neither served nor recorded.
+#[derive(Debug, Default)]
+pub struct RecordingStoredMetadataBlockCache {
+    state: Mutex<RecordingState>,
+}
+
+#[derive(Debug, Default)]
+struct RecordingState {
+    entries: HashMap<StoredMetadataBlockKey, Bytes>,
+    calls: Vec<RecordedStoredMetadataBlockCall>,
+    closed: bool,
+}
+
+impl RecordingStoredMetadataBlockCache {
+    /// An empty, open cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every call the cache accepted, in call order.
+    pub fn calls(&self) -> Vec<RecordedStoredMetadataBlockCall> {
+        self.state().calls.clone()
+    }
+
+    /// How many calls the cache accepted.
+    pub fn call_count(&self) -> usize {
+        self.state().calls.len()
+    }
+
+    /// How many entries the cache is holding.
+    pub fn len(&self) -> usize {
+        self.state().entries.len()
+    }
+
+    /// Whether the cache is holding nothing.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Whether [`StoredMetadataBlockCache::close`] has been called.
+    pub fn is_closed(&self) -> bool {
+        self.state().closed
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, RecordingState> {
+        // Poisoning is propagated as a panic: a poisoned lock means a test
+        // thread panicked mid-update, and the recording is no longer a
+        // trustworthy account of what the code under test did.
+        self.state
+            .lock()
+            .expect("recording stored-block cache lock should not be poisoned")
+    }
+}
+
+#[async_trait]
+impl StoredMetadataBlockCache for RecordingStoredMetadataBlockCache {
+    async fn get(&self, key: &StoredMetadataBlockKey) -> Option<Bytes> {
+        let mut state = self.state();
+        if state.closed {
+            return None;
+        }
+        let bytes = state.entries.get(key).cloned();
+        state.calls.push(RecordedStoredMetadataBlockCall::Get {
+            key: key.clone(),
+            hit: bytes.is_some(),
+        });
+        bytes
+    }
+
+    fn insert(&self, key: StoredMetadataBlockKey, bytes: Bytes) {
+        let mut state = self.state();
+        if state.closed {
+            return;
+        }
+        state.calls.push(RecordedStoredMetadataBlockCall::Insert {
+            key: key.clone(),
+            bytes: bytes.len(),
+        });
+        state.entries.insert(key, bytes);
+    }
+
+    fn invalidate(&self, key: &StoredMetadataBlockKey) {
+        let mut state = self.state();
+        if state.closed {
+            return;
+        }
+        state
+            .calls
+            .push(RecordedStoredMetadataBlockCall::Invalidate { key: key.clone() });
+        state.entries.remove(key);
+    }
+
+    async fn close(&self) -> Result<(), StoredMetadataBlockCacheCloseError> {
+        self.state().closed = true;
+        Ok(())
+    }
+}

--- a/crates/loonfs/Cargo.toml
+++ b/crates/loonfs/Cargo.toml
@@ -19,6 +19,10 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+# The stored-block cache double the seam tests install lives behind
+# `loonfs-core`'s `test-support` feature; test targets are the only builds
+# that turn it on.
+loonfs-core = { workspace = true, features = ["test-support"] }
 loonfs-test-support = { path = "../loonfs-test-support" }
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -22,7 +22,8 @@ use loonfs_api::{
     PROTOCOL_VERSION,
 };
 use loonfs_core::cache::{
-    MetadataTableCache, WalTailProjectionCache, WalTailProjectionCacheConfig,
+    MetadataTableCache, StoredMetadataBlockCache, WalTailProjectionCache,
+    WalTailProjectionCacheConfig,
 };
 use loonfs_core::time::current_time_ms;
 use loonfs_core::{MutationContext, NamespaceEngine};
@@ -113,15 +114,23 @@ impl ReadCore {
     /// identities (payload checksums and manifest object keys); the
     /// sharing caller owns the sizing decision, and
     /// `config.runtime_cache.metadata_table_cache` goes unused.
+    ///
+    /// `stored_metadata_block_cache` is the node-local cache of encoded
+    /// blocks the fresh decoded cache carries beneath it. It applies only
+    /// when this core sizes its own cache: a shared cache already carries
+    /// whatever handle it was built with, which is what makes the sharing
+    /// caller's sizing decision cover both tiers together.
     pub(crate) fn open(
         store: SharedObjectStore,
         config: ReadConfig,
         shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
+        stored_metadata_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
         instruments: Arc<RuntimeInstruments>,
     ) -> Self {
         let metadata_table_cache = shared_metadata_table_cache.unwrap_or_else(|| {
-            Arc::new(MetadataTableCache::new(
+            Arc::new(MetadataTableCache::with_stored_block_cache(
                 config.runtime_cache.metadata_table_cache.clone(),
+                stored_metadata_block_cache,
             ))
         });
         let wal_tail_projection_cache =

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -10,7 +10,7 @@ use crate::{
     Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
     TraceStoreKind,
 };
-use loonfs_core::cache::MetadataTableCache;
+use loonfs_core::cache::{MetadataTableCache, StoredMetadataBlockCache};
 use loonfs_objectstore::metrics::InstrumentedObjectStore;
 use std::sync::Arc;
 
@@ -32,6 +32,9 @@ pub(super) struct HandleBuilderCore {
     /// An existing decoded-block cache to share instead of sizing a fresh
     /// one from `runtime_cache`; see [`ReadCore::open`].
     pub(super) shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
+    /// A node-local cache of encoded metadata blocks for the fresh decoded
+    /// cache to carry beneath it; see [`ReadCore::open`].
+    pub(super) stored_metadata_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
     pub(super) trace_mode: TraceMode,
     pub(super) trace_store_kind: Option<TraceStoreKind>,
     pub(super) object_store_metrics_recorder: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
@@ -53,6 +56,7 @@ impl HandleBuilderCore {
             max_read_content_bytes: None,
             runtime_cache: RuntimeCacheConfig::default(),
             shared_metadata_table_cache: None,
+            stored_metadata_block_cache: None,
             trace_mode: TraceMode::Embedded,
             trace_store_kind: None,
             object_store_metrics_recorder: None,
@@ -99,6 +103,7 @@ impl HandleBuilderCore {
                 trace_store_kind,
             },
             self.shared_metadata_table_cache,
+            self.stored_metadata_block_cache,
             instruments,
         ))
     }

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -10,7 +10,7 @@ use crate::{
     MaintenanceJobId, NamespaceId, Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError,
     SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
-use loonfs_core::cache::MetadataTableCache;
+use loonfs_core::cache::{MetadataTableCache, StoredMetadataBlockCache};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -314,6 +314,27 @@ impl FsWriterBuilder {
         self
     }
 
+    /// Installs a node-local cache of encoded metadata blocks beneath this
+    /// writer's decoded block cache.
+    ///
+    /// The handle rides on the decoded cache, so every handle built from
+    /// this writer's cache reaches the same local cache — the reader this
+    /// writer derives, and an admin handle sharing the cache through
+    /// [`FsAdminBuilder::shared_metadata_table_cache`]. Nothing else
+    /// reaches it: paths that carry no decoded cache carry neither tier.
+    ///
+    /// Unset by default. The host owns the cache and closes it, and object
+    /// storage stays the authority for every read either way.
+    ///
+    /// [`FsAdminBuilder::shared_metadata_table_cache`]: crate::FsAdminBuilder::shared_metadata_table_cache
+    pub fn stored_metadata_block_cache(
+        mut self,
+        stored_metadata_block_cache: Arc<dyn StoredMetadataBlockCache>,
+    ) -> Self {
+        self.core.stored_metadata_block_cache = Some(stored_metadata_block_cache);
+        self
+    }
+
     /// Sets the tracing mode label.
     pub fn trace_mode(mut self, trace_mode: TraceMode) -> Self {
         self.core.trace_mode = trace_mode;
@@ -435,11 +456,50 @@ mod tests {
         CreateNamespaceOptions, ErrorCode, FsBackgroundWork, FsWriter, MaintenanceJobId,
         NamespaceId, PutFileOptions,
     };
+    use loonfs_core::test_support::RecordingStoredMetadataBlockCache;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_test_support::ids::namespace_id;
     use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
     use std::sync::Arc;
     use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn a_writer_carries_no_stored_block_cache_by_default() {
+        let temp_dir = tempdir().expect("tempdir");
+        let writer = FsWriter::builder_with_store(Arc::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        ))
+        .writer_id("no-stored-block-cache-writer")
+        .build()
+        .await
+        .expect("build writer");
+
+        assert!(writer.metadata_table_cache().stored_block_cache().is_none());
+    }
+
+    /// The handle rides on the decoded block cache, which is what puts the
+    /// two tiers in the same places: every handle built from this cache
+    /// reaches the local cache, and every path that carries no decoded cache
+    /// reaches neither tier.
+    #[tokio::test]
+    async fn the_builder_installs_the_stored_block_cache_on_the_decoded_cache() {
+        let temp_dir = tempdir().expect("tempdir");
+        let stored_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+        let writer = FsWriter::builder_with_store(Arc::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        ))
+        .writer_id("stored-block-cache-writer")
+        .stored_metadata_block_cache(stored_blocks.clone())
+        .build()
+        .await
+        .expect("build writer");
+
+        assert!(writer.metadata_table_cache().stored_block_cache().is_some());
+        assert!(Arc::ptr_eq(
+            &writer.metadata_table_cache(),
+            &writer.reader().core.metadata_table_cache()
+        ));
+    }
 
     /// A writer whose store parks the first head compare-and-swap, so a
     /// publication can be held open across a shutdown's first poll.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -68,7 +68,10 @@ pub use loonfs_api::{
     FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
     PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
-pub use loonfs_core::cache::{MetadataTableCacheConfig, Recency};
+pub use loonfs_core::cache::{
+    MetadataTableCacheConfig, Recency, StoredMetadataBlockCache,
+    StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey, StoredMetadataBlockKind,
+};
 pub use loonfs_core::limits::{
     DEFAULT_GC_MAX_OBJECTS, GC_MIN_GRACE_WINDOW_MS, METADATA_PUBLICATION_BUDGET_MS,
 };

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -200,6 +200,7 @@ fn test_read_core(store: SharedStore) -> ReadCore {
             trace_store_kind: TraceStoreKind::LocalFs,
         },
         None,
+        None,
         RuntimeInstruments::new(None),
     )
 }

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -8,6 +8,7 @@ use loonfs::{
     ChangeSeq, CreateDirectoryOptions, CreateNamespaceOptions, ErrorCode, InodeId, InodeKind,
     NamespaceId, PutFileOptions, RuntimeCacheConfig, SharedObjectStore,
 };
+use loonfs_core::test_support::RecordingStoredMetadataBlockCache;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
@@ -656,4 +657,65 @@ fn separate_runtime_instances_share_object_store_state() {
         .get_file_bytes_blocking(&namespace_id, "/docs/shared.txt")
         .expect("read shared file");
     assert_eq!(file.bytes, b"shared");
+}
+
+/// The stored-block cache is a seam and nothing more until a later change
+/// wires the fetch path into it: a runtime built with one installed reads
+/// and writes exactly as it did without one, and never calls it. The
+/// decoded-cache assertion keeps this honest — it fails if the cycle stops
+/// exercising the metadata table path this tier sits under.
+#[test]
+fn an_installed_stored_block_cache_is_never_called() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let stored_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let fs = open_runtime_with(
+        store(temp_dir.path()),
+        "stored-block-seam-test",
+        |builder| builder.stored_metadata_block_cache(stored_blocks.clone()),
+    );
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/file.txt",
+        b"file",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
+    // A write after the checkpoint moves the head, so the reads below
+    // resolve against the published manifest and touch its segments.
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/second.txt",
+        b"second",
+        PutFileOptions::default(),
+    )
+    .expect("put second file");
+
+    let file = fs
+        .get_file_bytes_blocking(&namespace_id, "/docs/file.txt")
+        .expect("read file");
+    assert_eq!(file.bytes, b"file");
+    let entries = fs
+        .list_path_blocking(&namespace_id, "/docs")
+        .expect("list docs");
+    assert_eq!(entries.len(), 2);
+
+    assert!(
+        fs.runtime_cache_stats().metadata_table_cache_inserts > 0,
+        "the cycle must reach the decoded block cache for this to prove anything"
+    );
+    assert_eq!(
+        stored_blocks.calls(),
+        Vec::new(),
+        "nothing consults the stored-block cache yet"
+    );
+    assert!(
+        !stored_blocks.is_closed(),
+        "the host owns the cache and closes it"
+    );
 }


### PR DESCRIPTION
Adds the outline for an optional local SSD cache of encoded metadata SST blocks. This PR only defines the types and threads an optional handle. Nothing reads or writes the cache yet, and behavior is unchanged.
