### PR TITLE
feat(cache): foyer-backed local block cache 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +209,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +243,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -333,6 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmsketch"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ee2cfacbd29706479902b06d75ad8f1362900836aa32799eabc7e004bfd854"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +401,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -539,6 +574,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastant"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e825441bfb2d831c47c97d05821552db8832479f44c571b97fededbf0099c07"
+dependencies = [
+ "small_ctor",
+ "web-time",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,12 +618,132 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foyer"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0abc0b87814989efa711f9becd9f26969820e2d3905db27d10969c4bd45890"
+dependencies = [
+ "anyhow",
+ "equivalent",
+ "foyer-common",
+ "foyer-memory",
+ "foyer-storage",
+ "foyer-tokio",
+ "futures-util",
+ "mea",
+ "mixtrics",
+ "pin-project",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "foyer-common"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bytes",
+ "cfg-if",
+ "foyer-tokio",
+ "mixtrics",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "twox-hash",
+]
+
+[[package]]
+name = "foyer-intrusive-collections"
+version = "0.10.0-dev"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4fee46bea69e0596130e3210e65d3424e0ac1e6df3bde6636304bdf1ca4a3b"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "foyer-memory"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db907f40a527ca2aa2f40a5f68b32ea58aa70f050cd233518e9ffd402cfba6ce"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "cmsketch",
+ "equivalent",
+ "foyer-common",
+ "foyer-intrusive-collections",
+ "foyer-tokio",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "mea",
+ "mixtrics",
+ "parking_lot",
+ "paste",
+ "pin-project",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "foyer-storage"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
+dependencies = [
+ "allocator-api2",
+ "anyhow",
+ "bytes",
+ "core_affinity",
+ "equivalent",
+ "fastant",
+ "foyer-common",
+ "foyer-memory",
+ "foyer-tokio",
+ "fs4",
+ "futures-core",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "io-uring",
+ "itertools 0.14.0",
+ "libc",
+ "lz4",
+ "mea",
+ "parking_lot",
+ "pin-project",
+ "rand",
+ "serde",
+ "tracing",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "foyer-tokio"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -774,7 +939,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -782,12 +947,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -1079,6 +1255,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1282,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1342,6 +1538,8 @@ dependencies = [
  "base64",
  "bytes",
  "clap",
+ "foyer",
+ "fs4",
  "futures",
  "http",
  "loonfs",
@@ -1350,6 +1548,7 @@ dependencies = [
  "loonfs-grep",
  "loonfs-objectstore",
  "loonfs-test-support",
+ "mixtrics",
  "rcgen",
  "rustls",
  "rustls-pemfile",
@@ -1406,6 +1605,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,10 +1649,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mea"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31fc7d159de0085ab6dd7ff145a9819442cfd3d098f783263120503c3f3e58b0"
+dependencies = [
+ "slab",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1467,6 +1703,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mixtrics"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c46b5adfb7a3ae4996d327a5bdc90e78fec025806dd312bdbe6f07a755e0ec9"
+dependencies = [
+ "itertools 0.15.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1523,6 +1769,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object_store"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1795,7 @@ dependencies = [
  "httparse",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -1610,6 +1866,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1886,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2208,6 +2490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "small_ctor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88414a5ca1f85d82cc34471e975f0f74f6aa54c40f062efa42c0080e7f763f81"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,6 +2897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,6 +3232,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +3255,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,18 @@ categories = ["filesystem", "command-line-utilities"]
 async-trait = "0.1"
 axum = "0.8"
 base64 = "0.22"
-bytes = "1"
+# `serde` because the server's local block cache stores `Bytes` values through
+# foyer, whose `serde` feature encodes values through their serde impls.
+bytes = { version = "1", features = ["serde"] }
 ciborium = "0.2"
 clap = { version = "4.5", features = ["derive", "env"] }
 crc32c = "0.6"
 crc64fast-nvme = "1.2"
 http = "1"
 http-body = "1"
+# The `serde` feature makes foyer encode keys and values through their serde
+# impls, which is how the server's cache key reaches foyer's storage traits.
+foyer = { version = "0.22.3", features = ["serde"] }
 futures = "0.3"
 fs4 = "0.13"
 getrandom = "0.3"
@@ -66,6 +71,11 @@ loonfs-client = { path = "crates/loonfs-client", version = "0.2.0" }
 loonfs-core = { path = "crates/loonfs-core", version = "0.2.0" }
 loonfs-grep = { path = "crates/loonfs-grep", version = "0.2.0" }
 loonfs-objectstore = { path = "crates/loonfs-objectstore", version = "0.2.0" }
+# foyer reports its internal counters through this registry trait and does not
+# re-export it, so a host that wants to read them names the crate itself. The
+# version must stay the one foyer resolves, or the trait this workspace
+# implements is a different trait than the one foyer accepts.
+mixtrics = "0.2"
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }

--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -64,6 +64,25 @@ writer_id = "loonfs-server-local"
 # Decoded-byte budget for the metadata table cache; unlimited by default.
 #metadata_table_cache_max_decoded_bytes = 268435456
 
+# Optional node-local cache of encoded metadata blocks, on this machine's own
+# disk. Omit the table and there is none: every metadata block the decoded
+# cache misses is read from object storage.
+#
+# The directory is this server's alone while it runs — a second server
+# pointed at it fails to start — and it holds nothing durable. Object storage
+# stays the authority for every block, so the directory can be deleted
+# whenever this server is stopped, and it is rebuilt on the next start.
+#
+# `disk_bytes` is claimed up front in 16 MiB files under `path`, each held
+# open, so the value below asks for 6400 files and an open-file limit above
+# that. Nothing else about the tier is configurable: how it is laid out on
+# disk, how many flushers write it, and how large its write buffers are are
+# engine-tuning numbers rather than deployment decisions.
+#[local_cache]
+#path = "/var/lib/loonfs/cache"
+#memory_bytes = 67108864
+#disk_bytes = 107374182400
+
 # Omit the `[grep]` table and this server composes no grep at all: uniform
 # `not_supported` responses, and no `query.grep` feature or limits advertised.
 # A `[grep]` table with no `mode` both serves searches and maintains the index.

--- a/crates/loonfs-core/Cargo.toml
+++ b/crates/loonfs-core/Cargo.toml
@@ -25,6 +25,9 @@ tracing.workspace = true
 
 [features]
 default = []
+# Test doubles for this crate's public seams, for the test targets of crates
+# that implement or install them. No production build enables it.
+test-support = []
 
 [dev-dependencies]
 loonfs-model = { path = "../loonfs-model" }

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -1,7 +1,12 @@
 //! Shared caches for decoded manifest state: SST blocks keyed by content
 //! digest, validated manifests, and bounded WAL-tail projections.
+//!
+//! The decoded block cache also carries the handle to the optional
+//! node-local cache of the same blocks in their encoded form; see
+//! [`stored_block_cache`](super::stored_block_cache).
 
 use super::runs::MetadataRunManifest;
+use super::stored_block_cache::StoredMetadataBlockCache;
 use crate::metadata::MetadataState;
 use crate::recency::Recency;
 use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
@@ -121,6 +126,12 @@ pub struct MetadataTableCache {
     /// One cell per in-flight block fetch, keyed by the block's cache key,
     /// so concurrent readers share a single ranged GET per block.
     in_flight: Mutex<HashMap<MetadataTableCacheKey, Arc<OnceCell<DecodedMetadataTableBlock>>>>,
+    /// The node-local cache of encoded stored blocks this cache misses
+    /// into, when the runtime was built with one. It lives here so the two
+    /// tiers are available together: a path that carries no table cache —
+    /// maintenance, reorganization, collection, and retention all pass
+    /// none — reaches neither tier, and needs no separate wiring to say so.
+    stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
 }
 
 #[derive(Debug, Default)]
@@ -150,12 +161,28 @@ struct MetadataTableCacheStatsInner {
 
 impl MetadataTableCache {
     pub fn new(config: MetadataTableCacheConfig) -> Self {
+        Self::with_stored_block_cache(config, None)
+    }
+
+    /// Sizes a cache that also carries a node-local cache of encoded stored
+    /// blocks beneath it. Passing `None` is exactly [`Self::new`].
+    pub fn with_stored_block_cache(
+        config: MetadataTableCacheConfig,
+        stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
+    ) -> Self {
         Self {
             config,
             inner: Mutex::new(MetadataTableCacheInner::default()),
             stats: MetadataTableCacheStatsInner::default(),
             in_flight: Mutex::new(HashMap::new()),
+            stored_block_cache,
         }
+    }
+
+    /// The node-local stored-block cache this cache misses into, if the
+    /// runtime was built with one.
+    pub fn stored_block_cache(&self) -> Option<&Arc<dyn StoredMetadataBlockCache>> {
+        self.stored_block_cache.as_ref()
     }
 
     /// Resolves one block access through a single-flight cell.

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -22,8 +22,10 @@
 //!   [`row`] handles manifest-row encoding.
 //! - [`reorganize`] compacts bounded family groups into new base runs.
 //! - [`retention`] advances the retention floor behind verified progress.
-//! - [`runs`] models the LSM run layout shared by all of the above, and
-//!   [`cache`] holds decoded SST blocks keyed by content digest.
+//! - [`runs`] models the LSM run layout shared by all of the above,
+//!   [`cache`] holds decoded SST blocks keyed by content digest, and
+//!   [`stored_block_cache`] defines the seam a node-local cache of the same
+//!   blocks in their encoded form plugs into.
 
 mod block_fetch;
 mod block_load;
@@ -44,6 +46,7 @@ mod retention;
 mod row;
 mod runs;
 mod scan;
+mod stored_block_cache;
 #[cfg(test)]
 pub(crate) mod tests;
 mod validate;
@@ -58,6 +61,10 @@ pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
 pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub(crate) use self::runs::MetadataLsmPolicy;
+pub use self::stored_block_cache::{
+    StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
+    StoredMetadataBlockKind,
+};
 
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::files::list_checkpoint_files_page;

--- a/crates/loonfs-core/src/checkpoint/stored_block_cache.rs
+++ b/crates/loonfs-core/src/checkpoint/stored_block_cache.rs
@@ -1,0 +1,140 @@
+//! The seam a node-local cache of encoded metadata SST blocks plugs into.
+//!
+//! This tier sits beneath the decoded [`MetadataTableCache`] and above
+//! object storage. It holds stored section bytes — the same bytes the
+//! segment object holds — so a hit still has to be decoded and verified
+//! before any caller sees a row.
+//!
+//! [`MetadataTableCache`]: super::MetadataTableCache
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use thiserror::Error;
+
+/// Identifies one encoded stored section of one metadata SST segment.
+///
+/// The identity mirrors the decoded cache's. `payload_checksum` is the
+/// segment's `sha256:<hex>` digest, which names immutable bytes, so an entry
+/// can never go stale; `kind` and `offset` locate the section inside that
+/// segment, so sections of one segment cannot collide.
+///
+/// Nothing else belongs in the identity. Stored lengths and CRCs are
+/// validation inputs carried by the segment's block handles, and the decoder
+/// checks them whether the bytes came from this tier or from the store.
+/// There is no version field either: an implementation versions its own
+/// on-disk directory instead.
+///
+/// Namespace manifests are deliberately not representable. The decoded cache
+/// keys them by object key rather than by content digest, and they stay out
+/// of this tier.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct StoredMetadataBlockKey {
+    pub payload_checksum: String,
+    pub kind: StoredMetadataBlockKind,
+    pub offset: u64,
+}
+
+/// Which stored section of a segment a key names.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum StoredMetadataBlockKind {
+    Data,
+    Index,
+    Filter,
+}
+
+/// A cache that failed to shut down cleanly.
+///
+/// Shutdown is the one operation whose failure a caller can observe. The
+/// bytes are a cache, so nothing durable is lost, but a host draining on its
+/// way out should still be able to report why.
+#[derive(Debug, Error)]
+#[error("stored metadata block cache failed to close: {0}")]
+pub struct StoredMetadataBlockCacheCloseError(String);
+
+impl StoredMetadataBlockCacheCloseError {
+    /// Wraps an implementation's shutdown failure message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+/// A node-local cache of encoded, stored metadata SST sections.
+///
+/// Object storage remains the only authority. This tier holds a copy of
+/// bytes the store already holds, addressed by [`StoredMetadataBlockKey`],
+/// and every hit is decoded and verified by the ordinary segment decoder
+/// before a caller sees a row. A hit is therefore evidence that the bytes
+/// were available locally and nothing more.
+///
+/// Lookups and inserts are best effort. An implementation records its own
+/// failures and answers a failed lookup with `None` and a failed insert by
+/// doing nothing, so a full, broken, or unreachable cache degrades to plain
+/// object-store reads.
+///
+/// After [`close`](Self::close) the cache is inert: `get` returns `None`,
+/// and `insert` and `invalidate` do nothing. `close` is idempotent.
+#[async_trait]
+pub trait StoredMetadataBlockCache: Send + Sync + Debug {
+    /// Returns the stored bytes held for `key`, or `None` on a miss.
+    async fn get(&self, key: &StoredMetadataBlockKey) -> Option<Bytes>;
+
+    /// Offers `bytes` as the stored bytes for `key`. Whether the cache keeps
+    /// them, and for how long, is the implementation's decision.
+    fn insert(&self, key: StoredMetadataBlockKey, bytes: Bytes);
+
+    /// Drops whatever is held for `key`.
+    fn invalidate(&self, key: &StoredMetadataBlockKey);
+
+    /// Flushes what the implementation wants to keep and makes the cache
+    /// inert. Calling it more than once is allowed and does nothing further.
+    async fn close(&self) -> Result<(), StoredMetadataBlockCacheCloseError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    const CHECKSUM: &str = "sha256:0f0e0d0c0b0a09080706050403020100";
+    const OTHER_CHECKSUM: &str = "sha256:00112233445566778899aabbccddeeff";
+
+    fn key(
+        payload_checksum: &str,
+        kind: StoredMetadataBlockKind,
+        offset: u64,
+    ) -> StoredMetadataBlockKey {
+        StoredMetadataBlockKey {
+            payload_checksum: payload_checksum.to_owned(),
+            kind,
+            offset,
+        }
+    }
+
+    #[test]
+    fn one_segment_section_has_one_key() {
+        let first = key(CHECKSUM, StoredMetadataBlockKind::Data, 4096);
+        let second = key(CHECKSUM, StoredMetadataBlockKind::Data, 4096);
+        assert_eq!(first, second);
+        // Implementations index by this key, so equality without a matching
+        // hash would still lose the entry.
+        let mut keys = HashSet::new();
+        keys.insert(first);
+        assert!(keys.contains(&second));
+    }
+
+    #[test]
+    fn checksum_kind_and_offset_each_separate_keys() {
+        // Every field varied once against one base key: whichever field
+        // stopped counting, one of these would collide with the base.
+        let keys: HashSet<StoredMetadataBlockKey> = HashSet::from([
+            key(CHECKSUM, StoredMetadataBlockKind::Data, 4096),
+            key(OTHER_CHECKSUM, StoredMetadataBlockKind::Data, 4096),
+            key(CHECKSUM, StoredMetadataBlockKind::Index, 4096),
+            key(CHECKSUM, StoredMetadataBlockKind::Filter, 4096),
+            key(CHECKSUM, StoredMetadataBlockKind::Data, 0),
+        ]);
+        assert_eq!(keys.len(), 5);
+    }
+}

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -106,6 +106,13 @@ pub mod metadata;
 /// Path parsing and current-state resolution. Consumed by `loonfs`'s write
 /// path (`parse_mutation_path`).
 pub mod path;
+/// Test doubles for this crate's public seams, behind the `test-support`
+/// feature. Consumed by the test targets of crates that implement or install
+/// those seams; no production build enables the feature. Doubles live here
+/// rather than in `loonfs-test-support` because that crate is a development
+/// dependency of this one and so cannot depend on these types.
+#[cfg(feature = "test-support")]
+pub mod test_support;
 /// The wall-clock boundary durable timestamps are stamped at. Consumed by
 /// `loonfs`, whose mutation contexts and maintenance clock stamp from the
 /// same boundary this crate's own commits do.
@@ -119,8 +126,9 @@ pub mod cache {
 
     pub use crate::checkpoint::{
         ManifestLoadError, ManifestLoadFailureClass, MetadataTableCache, MetadataTableCacheConfig,
-        MetadataTableCacheStats, WalTailProjectionCache, WalTailProjectionCacheConfig,
-        WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+        MetadataTableCacheStats, StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError,
+        StoredMetadataBlockKey, StoredMetadataBlockKind, WalTailProjectionCache,
+        WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
         DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
         DEFAULT_WAL_TAIL_PROJECTION_ROWS,
     };

--- a/crates/loonfs-core/src/test_support.rs
+++ b/crates/loonfs-core/src/test_support.rs
@@ -1,0 +1,138 @@
+//! Test doubles for this crate's public seams.
+
+use crate::cache::{
+    StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
+};
+use async_trait::async_trait;
+use bytes::Bytes;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// One call made against a [`RecordingStoredMetadataBlockCache`], in the
+/// form that says what the caller asked for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordedStoredMetadataBlockCall {
+    /// A lookup, with whether it was answered from the map.
+    Get {
+        key: StoredMetadataBlockKey,
+        hit: bool,
+    },
+    /// An insert, with the length of the bytes offered.
+    Insert {
+        key: StoredMetadataBlockKey,
+        bytes: usize,
+    },
+    /// An invalidation.
+    Invalidate { key: StoredMetadataBlockKey },
+}
+
+impl RecordedStoredMetadataBlockCall {
+    /// The key the call addressed.
+    pub fn key(&self) -> &StoredMetadataBlockKey {
+        match self {
+            Self::Get { key, .. } | Self::Insert { key, .. } | Self::Invalidate { key } => key,
+        }
+    }
+}
+
+/// A stored-block cache that serves from an in-memory map and records every
+/// call in call order.
+///
+/// Closing flips the cache inert, as the trait requires: later calls are
+/// neither served nor recorded.
+#[derive(Debug, Default)]
+pub struct RecordingStoredMetadataBlockCache {
+    state: Mutex<RecordingState>,
+}
+
+#[derive(Debug, Default)]
+struct RecordingState {
+    entries: HashMap<StoredMetadataBlockKey, Bytes>,
+    calls: Vec<RecordedStoredMetadataBlockCall>,
+    closed: bool,
+}
+
+impl RecordingStoredMetadataBlockCache {
+    /// An empty, open cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every call the cache accepted, in call order.
+    pub fn calls(&self) -> Vec<RecordedStoredMetadataBlockCall> {
+        self.state().calls.clone()
+    }
+
+    /// How many calls the cache accepted.
+    pub fn call_count(&self) -> usize {
+        self.state().calls.len()
+    }
+
+    /// How many entries the cache is holding.
+    pub fn len(&self) -> usize {
+        self.state().entries.len()
+    }
+
+    /// Whether the cache is holding nothing.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Whether [`StoredMetadataBlockCache::close`] has been called.
+    pub fn is_closed(&self) -> bool {
+        self.state().closed
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, RecordingState> {
+        // Poisoning is propagated as a panic: a poisoned lock means a test
+        // thread panicked mid-update, and the recording is no longer a
+        // trustworthy account of what the code under test did.
+        self.state
+            .lock()
+            .expect("recording stored-block cache lock should not be poisoned")
+    }
+}
+
+#[async_trait]
+impl StoredMetadataBlockCache for RecordingStoredMetadataBlockCache {
+    async fn get(&self, key: &StoredMetadataBlockKey) -> Option<Bytes> {
+        let mut state = self.state();
+        if state.closed {
+            return None;
+        }
+        let bytes = state.entries.get(key).cloned();
+        state.calls.push(RecordedStoredMetadataBlockCall::Get {
+            key: key.clone(),
+            hit: bytes.is_some(),
+        });
+        bytes
+    }
+
+    fn insert(&self, key: StoredMetadataBlockKey, bytes: Bytes) {
+        let mut state = self.state();
+        if state.closed {
+            return;
+        }
+        state.calls.push(RecordedStoredMetadataBlockCall::Insert {
+            key: key.clone(),
+            bytes: bytes.len(),
+        });
+        state.entries.insert(key, bytes);
+    }
+
+    fn invalidate(&self, key: &StoredMetadataBlockKey) {
+        let mut state = self.state();
+        if state.closed {
+            return;
+        }
+        state
+            .calls
+            .push(RecordedStoredMetadataBlockCall::Invalidate { key: key.clone() });
+        state.entries.remove(key);
+    }
+
+    async fn close(&self) -> Result<(), StoredMetadataBlockCacheCloseError> {
+        self.state().closed = true;
+        Ok(())
+    }
+}

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -17,15 +17,19 @@ path = "src/bin/loonfs-openapi.rs"
 required-features = ["openapi"]
 
 [dependencies]
+async-trait.workspace = true
 axum.workspace = true
 bytes.workspace = true
 clap.workspace = true
+foyer.workspace = true
+fs4.workspace = true
 futures.workspace = true
 http.workspace = true
 loonfs-api.workspace = true
 loonfs.workspace = true
 loonfs-grep.workspace = true
 loonfs-objectstore.workspace = true
+mixtrics.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
 serde.workspace = true
@@ -39,7 +43,6 @@ tracing-subscriber.workspace = true
 utoipa = { workspace = true, optional = true }
 
 [dev-dependencies]
-async-trait.workspace = true
 base64.workspace = true
 loonfs-client.workspace = true
 loonfs-test-support = { path = "../loonfs-test-support" }

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -41,6 +41,12 @@ pub struct ServerConfig {
     pub writer_id: String,
     #[serde(default)]
     pub runtime_cache: RuntimeCacheConfigOverrides,
+    /// The node-local cache of encoded metadata blocks, if this deployment
+    /// keeps one. Absent means no local cache: every metadata block read
+    /// that misses the decoded cache goes to object storage, which is the
+    /// behavior of a server that never had this table.
+    #[serde(default)]
+    pub local_cache: Option<LocalCacheConfig>,
     /// What this server does about grep, plus the bounded-step budgets its
     /// index maintenance runs under. A config with no `[grep]` table
     /// composes no grep at all; a table that names no `mode` both serves
@@ -161,6 +167,32 @@ fn grep_absent() -> GrepConfig {
         mode: GrepMode::Disabled,
         ..GrepConfig::default()
     }
+}
+
+/// The server's `[local_cache]` table: where the node-local cache of encoded
+/// metadata blocks lives, and how much memory and disk it may use.
+///
+/// The directory is this process's alone while it runs, and it holds nothing
+/// durable. Object storage remains the authority for every block the cache
+/// answers, so the directory can be deleted whenever the process is not
+/// running and the only cost is a cold cache.
+///
+/// Everything else about the tier — its on-disk layout, how many flushers
+/// write it, how large its write buffers are — is fixed in the
+/// implementation. Those are engine-tuning numbers, not deployment
+/// decisions, and they stay out of configuration until measurement says
+/// otherwise.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LocalCacheConfig {
+    /// Directory the cache owns. Created if missing; locked while this
+    /// process runs, so two servers cannot share one.
+    pub path: String,
+    /// Bytes of memory the cache's in-memory tier may hold.
+    pub memory_bytes: u64,
+    /// Bytes of disk the cache's disk tier may hold. The tier claims this
+    /// much space up front, in files under `path`.
+    pub disk_bytes: u64,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -442,6 +474,25 @@ impl ServerConfig {
                          set `maintenance = \"manual\"` to disable scheduling"
                     .to_owned(),
             });
+        }
+        if let Some(local_cache) = &self.local_cache {
+            require_non_empty("local_cache.path", &local_cache.path)?;
+            if local_cache.memory_bytes == 0 {
+                return Err(ServerConfigError::InvalidField {
+                    field: "local_cache.memory_bytes",
+                    reason: "must be greater than zero; \
+                             omit the `[local_cache]` table to run without a local cache"
+                        .to_owned(),
+                });
+            }
+            if local_cache.disk_bytes == 0 {
+                return Err(ServerConfigError::InvalidField {
+                    field: "local_cache.disk_bytes",
+                    reason: "must be greater than zero; \
+                             omit the `[local_cache]` table to run without a local cache"
+                        .to_owned(),
+                });
+            }
         }
         if let Err(error) = self.grep.worker_config().validate() {
             return Err(ServerConfigError::InvalidField {
@@ -1442,6 +1493,128 @@ root = "/tmp/loonfs-server"
             .expect("load config")
             .runtime_cache_config();
         assert_eq!(config, loonfs::RuntimeCacheConfig::disabled());
+    }
+
+    #[test]
+    fn an_omitted_local_cache_table_asks_for_no_local_cache() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let config = load_server_config(&path).expect("valid config");
+        assert!(
+            config.local_cache.is_none(),
+            "a server without the table reads every metadata block from object storage"
+        );
+    }
+
+    #[test]
+    fn load_reads_the_local_cache_table() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[local_cache]
+path = "/var/lib/loonfs/cache"
+memory_bytes = 67108864
+disk_bytes = 107374182400
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let local_cache = load_server_config(&path)
+            .expect("valid config")
+            .local_cache
+            .expect("a local cache table");
+        assert_eq!(local_cache.path, "/var/lib/loonfs/cache");
+        assert_eq!(local_cache.memory_bytes, 67_108_864);
+        assert_eq!(local_cache.disk_bytes, 107_374_182_400);
+    }
+
+    #[test]
+    fn a_local_cache_table_needs_a_path_and_two_sizes() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[local_cache]
+path = "   "
+memory_bytes = 67108864
+disk_bytes = 107374182400
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let error = load_server_config(&path).expect_err("a blank path must be rejected");
+        assert_missing_field(error, "local_cache.path");
+
+        for (field, memory_bytes, disk_bytes) in [
+            ("local_cache.memory_bytes", 0, 107_374_182_400_u64),
+            ("local_cache.disk_bytes", 67_108_864, 0),
+        ] {
+            let path = write_config(&format!(
+                r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[local_cache]
+path = "/var/lib/loonfs/cache"
+memory_bytes = {memory_bytes}
+disk_bytes = {disk_bytes}
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#
+            ));
+            let error = load_server_config(&path).expect_err("a zero size must be rejected");
+            assert_invalid_field(error, field);
+        }
+    }
+
+    #[test]
+    fn the_local_cache_table_takes_no_engine_settings() {
+        // The disk engine's geometry is fixed in the implementation. A
+        // deployment reaching for it fails through strict decoding like any
+        // other unknown key.
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[local_cache]
+path = "/var/lib/loonfs/cache"
+memory_bytes = 67108864
+disk_bytes = 107374182400
+block_bytes = 65536
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+
+        let error = load_server_config(&path).expect_err("an engine key must not load");
+        assert!(error.to_string().contains("block_bytes"), "{error}");
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/metrics.rs
+++ b/crates/loonfs-server/src/http/metrics.rs
@@ -7,6 +7,7 @@
 //! request-level instruments only an HTTP server can report, and renders the
 //! whole snapshot on demand.
 
+use crate::local_cache::FoyerCacheStats;
 use axum::http::{Method, StatusCode};
 use loonfs::metrics::{
     CounterHandle, DefaultMetricsRecorder, HistogramHandle, MetricEntry, MetricValue,
@@ -115,11 +116,18 @@ impl ServerMetrics {
     pub(super) fn render(
         &self,
         cache: &RuntimeCacheStats,
+        local_cache: Option<FoyerCacheStats>,
         upload_permits: usize,
         download_permits: usize,
     ) -> String {
         let mut rendered = render_snapshot(&self.recorder.snapshot());
-        render_scrape_gauges(&mut rendered, cache, upload_permits, download_permits);
+        render_scrape_gauges(
+            &mut rendered,
+            cache,
+            local_cache,
+            upload_permits,
+            download_permits,
+        );
         rendered
     }
 
@@ -302,11 +310,13 @@ fn write_entry(rendered: &mut String, name: &str, entry: &MetricEntry) {
 }
 
 /// Appends the values that are read when a scrape asks rather than
-/// accumulated as work happens: the runtime's cache counters and the
-/// transfer slots this server has free.
+/// accumulated as work happens: the runtime's cache counters, what foyer
+/// says about the local block cache, and the transfer slots this server has
+/// free.
 fn render_scrape_gauges(
     rendered: &mut String,
     cache: &RuntimeCacheStats,
+    local_cache: Option<FoyerCacheStats>,
     upload_permits: usize,
     download_permits: usize,
 ) {
@@ -315,6 +325,16 @@ fn render_scrape_gauges(
         let _ = writeln!(rendered, "# HELP {name} Runtime cache counter `{field}`");
         let _ = writeln!(rendered, "# TYPE {name} gauge");
         let _ = writeln!(rendered, "{name} {value}");
+    }
+    // Absent when this deployment keeps no local cache, so a scrape reports
+    // nothing about a tier that does not exist rather than reporting zeros
+    // that read like an idle one.
+    if let Some(local_cache) = local_cache {
+        for (name, description, value) in local_cache_gauges(&local_cache) {
+            let _ = writeln!(rendered, "# HELP {name} {description}");
+            let _ = writeln!(rendered, "# TYPE {name} gauge");
+            let _ = writeln!(rendered, "{name} {value}");
+        }
     }
     for (name, description, value) in [
         (
@@ -332,6 +352,58 @@ fn render_scrape_gauges(
         let _ = writeln!(rendered, "# TYPE {name} gauge");
         let _ = writeln!(rendered, "{name} {value}");
     }
+}
+
+/// What foyer says about the local block cache, as gauges.
+///
+/// These are foyer's own numbers, read at scrape time; the cache's hits,
+/// misses, and inserts are reported through the runtime's recorder like
+/// every other instrument and are already in the snapshot above.
+///
+/// Destructured without a rest pattern for the same reason the runtime
+/// counters are: a field added to [`FoyerCacheStats`] and not exported here
+/// fails to compile.
+fn local_cache_gauges(stats: &FoyerCacheStats) -> [(&'static str, &'static str, u64); 6] {
+    let FoyerCacheStats {
+        memory_bytes,
+        memory_capacity_bytes,
+        disk_bytes,
+        disk_capacity_bytes,
+        queue_buffer_overflows,
+        queue_channel_overflows,
+    } = *stats;
+    [
+        (
+            "loonfs_local_cache_memory_bytes",
+            "Bytes the local block cache's memory tier is holding",
+            memory_bytes as u64,
+        ),
+        (
+            "loonfs_local_cache_memory_capacity_bytes",
+            "Bytes the local block cache's memory tier may hold",
+            memory_capacity_bytes as u64,
+        ),
+        (
+            "loonfs_local_cache_disk_bytes",
+            "Bytes of the local block cache's disk device claimed as blocks",
+            disk_bytes as u64,
+        ),
+        (
+            "loonfs_local_cache_disk_capacity_bytes",
+            "Bytes of disk the local block cache was opened with",
+            disk_capacity_bytes as u64,
+        ),
+        (
+            "loonfs_local_cache_queue_buffer_overflows",
+            "Inserts the local block cache dropped with a full flush buffer",
+            queue_buffer_overflows,
+        ),
+        (
+            "loonfs_local_cache_queue_channel_overflows",
+            "Inserts the local block cache dropped with a full submit queue",
+            queue_channel_overflows,
+        ),
+    ]
 }
 
 /// The runtime cache counters, named as their fields are.

--- a/crates/loonfs-server/src/http/metrics/tests.rs
+++ b/crates/loonfs-server/src/http/metrics/tests.rs
@@ -140,7 +140,7 @@ fn scrape_time_gauges_carry_every_runtime_cache_counter() {
         metadata_table_cache_hits: 12,
         ..RuntimeCacheStats::default()
     };
-    render_scrape_gauges(&mut rendered, &cache, 4, 2);
+    render_scrape_gauges(&mut rendered, &cache, None, 4, 2);
 
     assert!(rendered.contains("loonfs_cache_metadata_table_cache_hits 12\n"));
     assert!(rendered.contains("loonfs_server_upload_permits_available 4\n"));

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -377,6 +377,10 @@ async fn serve_metrics(
     // level is only true when it is asked for.
     let rendered = state.metrics.render(
         &state.writer.runtime_cache_stats(),
+        state
+            .local_cache
+            .as_ref()
+            .map(|local_cache| local_cache.foyer_stats()),
         state.upload_permits.available_permits(),
         state.download_permits.available_permits(),
     );

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -5,11 +5,13 @@ use super::metrics::ServerMetrics;
 use super::router;
 use super::tls::{self, TlsConfigError, TlsListener};
 use crate::config::{ServerConfig, ServerConfigError};
+use crate::local_cache::FoyerStoredMetadataBlockCache;
 use axum::Router;
 use loonfs::metrics::{JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder};
 use loonfs::{
     FsAdmin, FsReader, FsWriter, MaintenanceHandle, MaintenanceJob, MaintenanceProbe,
-    SharedObjectStore, TraceMode, TraceStoreKind,
+    SharedObjectStore, StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, TraceMode,
+    TraceStoreKind,
 };
 use loonfs_api::NamespaceId;
 use loonfs_grep::{GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker, GREP_INDEX_JOB};
@@ -70,6 +72,12 @@ pub(super) struct AppState {
     /// deployment has to remember to switch on is a metrics surface nobody
     /// has during the incident.
     pub(super) metrics: Arc<ServerMetrics>,
+    /// The node-local block cache this deployment keeps, when `[local_cache]`
+    /// asked for one. The handles reach it through the decoded block cache
+    /// they were built with; it is held here as its concrete type for the
+    /// two things the seam does not offer — reading foyer's own numbers at
+    /// scrape time, and closing the cache at shutdown.
+    pub(super) local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
 }
 
 /// Everything a request path tells the writer's maintenance runner about
@@ -106,19 +114,26 @@ impl GrepMaintenance {
     }
 }
 
-/// Builds the HTTP application: the router that serves requests, and the
-/// writer whose background work its host must settle.
+/// Builds the HTTP application: the router that serves requests, the writer
+/// whose background work its host must settle, and the local block cache
+/// that host must close.
 ///
 /// Everything this app spawns belongs to that writer — publications, and
 /// the maintenance runner that admits the runtime's steps alongside the
 /// grep index's. [`serve`] settles it itself. A host embedding the
 /// [`Router`] on its own HTTP server must call [`FsWriter::shutdown`] after
 /// its listener drains, or publisher tasks and writer maintenance outlive
-/// the listener unobserved. The writer also answers what a deployment's
-/// shape is, so a host that needs to know whether the grep index job is
-/// registered here asks
+/// the listener unobserved, and must then call
+/// [`StoredMetadataBlockCache::close`] on the returned cache, or the blocks
+/// its memory tier still holds never reach disk. The writer also answers
+/// what a deployment's shape is, so a host that needs to know whether the
+/// grep index job is registered here asks
 /// [`FsWriter::maintenance_job`](loonfs::FsWriter::maintenance_job).
-pub async fn app(config: ServerConfig) -> Result<(Router, FsWriter), ServerConfigError> {
+///
+/// The cache is `None` unless the config carried a `[local_cache]` table.
+pub async fn app(
+    config: ServerConfig,
+) -> Result<(Router, FsWriter, Option<Arc<FoyerStoredMetadataBlockCache>>), ServerConfigError> {
     // The one unavoidable validation point: configs that skipped
     // `load_server_config` (direct Rust construction) fail here exactly as
     // file-loaded ones fail at load.
@@ -132,7 +147,7 @@ pub async fn app(config: ServerConfig) -> Result<(Router, FsWriter), ServerConfi
     let store = store.into_shared();
     let (router, state) =
         app_with_store_and_direct_transfers(config, store, direct_transfers).await?;
-    Ok((router, state.writer))
+    Ok((router, state.writer, state.local_cache))
 }
 
 #[cfg(test)]
@@ -166,6 +181,15 @@ pub(super) async fn app_with_store_and_direct_transfers(
     // grep mode maintains the index.
     let maintains_grep_index =
         config.maintenance.registers_automatic_jobs() && config.grep.mode.maintains_index();
+    // Opened before the handles, because the handles are what it is
+    // installed on: a directory that cannot be owned fails startup here
+    // rather than after a runtime is already running on it.
+    let local_cache = match &config.local_cache {
+        Some(local_cache) => Some(Arc::new(
+            FoyerStoredMetadataBlockCache::open(local_cache, metrics.recorder().as_ref()).await?,
+        )),
+        None => None,
+    };
     // Grep reads and checkpoints through the same handles the HTTP planes
     // use, so it is composed after them. Nothing has to be wired back into
     // the writer for its publications to reach the index: the job says on
@@ -176,6 +200,7 @@ pub(super) async fn app_with_store_and_direct_transfers(
         store,
         &metrics,
         std::env::var_os(OBJECT_STORE_METRICS_JSONL_ENV),
+        local_cache.clone(),
     )
     .await?;
     let probe_store = writer.object_store();
@@ -251,6 +276,7 @@ pub(super) async fn app_with_store_and_direct_transfers(
         grep_service,
         grep_maintenance,
         metrics,
+        local_cache,
     };
     Ok((router(state.clone()), state))
 }
@@ -261,7 +287,14 @@ pub(super) async fn build_handles_with_metrics_jsonl_path(
     store: SharedObjectStore,
     metrics_jsonl_path: Option<OsString>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
-    build_handles(config, store, &ServerMetrics::new(), metrics_jsonl_path).await
+    build_handles(
+        config,
+        store,
+        &ServerMetrics::new(),
+        metrics_jsonl_path,
+        None,
+    )
+    .await
 }
 
 /// Opens the process's handles on one store, with the metrics wiring every
@@ -271,11 +304,16 @@ pub(super) async fn build_handles_with_metrics_jsonl_path(
 /// one set of numbers rather than two. The optional JSONL path adds a second
 /// sink for the raw object-store samples; the handle fans one store wrapper
 /// out to both rather than stacking two.
+///
+/// The local block cache is installed on the writer, which is what puts it
+/// under the decoded block cache the reader and the admin share. One
+/// installation covers all three handles.
 async fn build_handles(
     config: &ServerConfig,
     store: SharedObjectStore,
     metrics: &ServerMetrics,
     metrics_jsonl_path: Option<OsString>,
+    local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
 ) -> Result<(FsWriter, FsReader, FsAdmin), ServerConfigError> {
     let trace_store_kind = TraceStoreKind::from(config.store.kind());
     let samples = object_store_metrics_recorder(metrics_jsonl_path)?;
@@ -298,6 +336,9 @@ async fn build_handles(
         .metrics_recorder(metrics.recorder());
     if let Some(samples) = &samples {
         writer_builder = writer_builder.object_store_metrics_recorder(Arc::clone(samples));
+    }
+    if let Some(local_cache) = local_cache {
+        writer_builder = writer_builder.stored_metadata_block_cache(local_cache);
     }
     let writer = writer_builder.build().await.map_err(runtime_error)?;
     let reader = writer.reader();
@@ -356,6 +397,8 @@ pub enum ServeError {
     Serve(#[source] std::io::Error),
     #[error("background work did not settle during shutdown: {0}")]
     Shutdown(#[source] loonfs::RuntimeError),
+    #[error("the local block cache did not close during shutdown: {0}")]
+    LocalCacheClose(#[source] StoredMetadataBlockCacheCloseError),
 }
 
 /// Serves until ctrl-c or SIGTERM, then shuts down gracefully: the listener
@@ -402,7 +445,25 @@ pub(super) async fn serve_on<L>(
 where
     L: axum::serve::Listener<Addr = SocketAddr>,
 {
-    let (router, writer) = app(config).await?;
+    let (router, writer, local_cache) = app(config).await?;
+    serve_and_settle(listener, router, writer, local_cache, shutdown).await
+}
+
+/// Serves until the shutdown trigger fires, then settles what this process
+/// owns, in the order it has to be settled in.
+///
+/// Kept apart from [`serve_on`] so the settling order is a thing a test can
+/// drive with handles it holds.
+pub(super) async fn serve_and_settle<L>(
+    listener: L,
+    router: Router,
+    writer: FsWriter,
+    local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), ServeError>
+where
+    L: axum::serve::Listener<Addr = SocketAddr>,
+{
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown)
         .await
@@ -412,7 +473,22 @@ where
     // work this server accepted. What order the shutdown itself runs in is
     // the writer's business, not this function's. Panicked tasks surface
     // here rather than disappearing with the process.
-    writer.shutdown().await.map_err(ServeError::Shutdown)
+    let settled = writer.shutdown().await.map_err(ServeError::Shutdown);
+    // The cache closes after the writer, and it closes whether or not the
+    // writer settled: a read may outlive the writer by design, and a lookup
+    // after the close is a miss by contract, so nothing is left waiting on
+    // bytes this takes away. Closing is what flushes the memory tier to
+    // disk, so a shutdown that skipped it would throw away the blocks this
+    // process spent the most on. A writer that failed to settle is the
+    // worse news of the two and is what a host is told about.
+    let closed = match local_cache {
+        Some(local_cache) => local_cache
+            .close()
+            .await
+            .map_err(ServeError::LocalCacheClose),
+        None => Ok(()),
+    };
+    settled.and(closed)
 }
 
 /// Resolves on ctrl-c or, on unix, SIGTERM — the stop signal container

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -14,7 +14,7 @@ use futures::stream::{BoxStream, StreamExt};
 use loonfs::{
     CreateNamespaceOptions, DeleteOptions, FsAdmin, FsReader, FsWriter, MaintenanceJob,
     MaintenanceJobId, MaintenanceProbe, MaintenanceStepConclusion, MaintenanceStepResult,
-    PutFileOptions, TraceMode, TraceStoreKind,
+    PutFileOptions, StoredMetadataBlockCache, TraceMode, TraceStoreKind,
 };
 use loonfs_api::ErrorCode;
 use loonfs_api::{
@@ -294,6 +294,103 @@ async fn app_validates_directly_built_configs() {
         }
         Err(other) => panic!("expected invalid field error, got {other:?}"),
         Ok(_) => panic!("app must reject a zero upload bound"),
+    }
+}
+
+/// The `[local_cache]` table is the whole switch: without it nothing is
+/// built, and a scrape says nothing about a tier this deployment does not
+/// have.
+#[tokio::test]
+async fn a_server_without_the_table_builds_no_local_cache() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let config = test_config(temp_dir.path(), "no-local-cache-writer");
+
+    let (_router, state) = app_with_store_and_state(config, store)
+        .await
+        .expect("build app");
+    assert!(state.local_cache.is_none());
+    let rendered = state
+        .metrics
+        .render(&state.writer.runtime_cache_stats(), None, 0, 0);
+    assert!(!rendered.contains("loonfs_local_cache_"));
+}
+
+/// A configured cache is built at startup and reports itself on every
+/// scrape.
+#[tokio::test]
+async fn a_configured_local_cache_is_built_and_scraped() {
+    let temp_dir = tempdir().expect("tempdir");
+    let cache_dir = tempdir().expect("cache tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let mut config = test_config(temp_dir.path(), "local-cache-writer");
+    config.local_cache = Some(test_local_cache_config(cache_dir.path()));
+
+    let (_router, state) = app_with_store_and_state(config, store)
+        .await
+        .expect("build app");
+    let local_cache = state.local_cache.clone().expect("a local cache");
+    let rendered = state.metrics.render(
+        &state.writer.runtime_cache_stats(),
+        Some(local_cache.foyer_stats()),
+        0,
+        0,
+    );
+    assert!(rendered.contains("loonfs_local_cache_memory_capacity_bytes 4194304\n"));
+    assert!(rendered.contains("loonfs_local_cache_disk_capacity_bytes 134217728\n"));
+    assert!(rendered.contains("loonfs_local_cache_queue_buffer_overflows 0\n"));
+    assert!(rendered.contains("loonfs_local_cache_queue_channel_overflows 0\n"));
+
+    local_cache.close().await.expect("close local cache");
+}
+
+/// The graceful path closes the cache, and closes it after the writer has
+/// settled.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graceful_shutdown_closes_the_local_cache() {
+    let temp_dir = tempdir().expect("tempdir");
+    let cache_dir = tempdir().expect("cache tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let mut config = test_config(temp_dir.path(), "shutdown-local-cache-writer");
+    config.local_cache = Some(test_local_cache_config(cache_dir.path()));
+
+    let (router, state) = app_with_store_and_state(config, store)
+        .await
+        .expect("build app");
+    let local_cache = state.local_cache.clone().expect("a local cache");
+    assert!(!local_cache.is_closed());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(super::serve::serve_and_settle(
+        listener,
+        router,
+        state.writer.clone(),
+        state.local_cache.clone(),
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    ));
+
+    shutdown_tx.send(()).expect("trigger shutdown");
+    server
+        .await
+        .expect("join server task")
+        .expect("graceful shutdown settles background work");
+
+    assert!(
+        local_cache.is_closed(),
+        "the graceful path closes the cache before it returns"
+    );
+}
+
+fn test_local_cache_config(root: &Path) -> crate::config::LocalCacheConfig {
+    crate::config::LocalCacheConfig {
+        path: root.display().to_string(),
+        memory_bytes: 4 * 1024 * 1024,
+        disk_bytes: 128 * 1024 * 1024,
     }
 }
 
@@ -1751,7 +1848,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
     // needs to know it is happening, not only that some clients saw 503.
     assert!(state
         .metrics
-        .render(&state.writer.runtime_cache_stats(), 0, 0)
+        .render(&state.writer.runtime_cache_stats(), None, 0, 0)
         .contains("loonfs_server_busy_rejections_total{kind=\"upload\"} 1\n"));
 
     drop(held);
@@ -1866,7 +1963,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     );
     assert!(state
         .metrics
-        .render(&state.writer.runtime_cache_stats(), 0, 0)
+        .render(&state.writer.runtime_cache_stats(), None, 0, 0)
         .contains("loonfs_server_busy_rejections_total{kind=\"download\"} 1\n"));
 
     drop(held);
@@ -2189,6 +2286,7 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         content_token_secret: "test-content-token-secret".into(),
         writer_id: writer_id.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        local_cache: None,
         grep: crate::config::GrepConfig::default(),
         maintenance: crate::config::MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -7,13 +7,15 @@
 
 mod config;
 mod http;
+mod local_cache;
 mod trace;
 
 pub use config::{
-    load_server_config, GrepConfig, GrepMode, MaintenanceMode, RuntimeCacheConfigOverrides,
-    ServerConfig, ServerConfigError, StoreConfig, TlsServerConfig,
+    load_server_config, GrepConfig, GrepMode, LocalCacheConfig, MaintenanceMode,
+    RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig, TlsServerConfig,
 };
 pub use http::{app, serve, serve_with_shutdown, ServeError, TlsConfigError};
 #[cfg(feature = "openapi")]
 pub use http::{openapi_document, openapi_json_pretty};
+pub use local_cache::FoyerStoredMetadataBlockCache;
 pub use trace::{init_tracing_from_env, TraceInitError};

--- a/crates/loonfs-server/src/local_cache.rs
+++ b/crates/loonfs-server/src/local_cache.rs
@@ -1,0 +1,648 @@
+//! The node-local cache of encoded metadata blocks, backed by foyer.
+//!
+//! This module is the only place in the server that names a foyer type.
+//! Everything above it sees [`StoredMetadataBlockCache`], the runtime's seam:
+//! an async lookup that answers `None` on a miss, a fire-and-forget insert,
+//! an invalidation, and a close.
+//!
+//! The tier holds a copy of bytes object storage already holds, so nothing
+//! here is durable. A lookup that fails for any reason is a miss, an insert
+//! that cannot be kept is dropped, and both are counted rather than
+//! surfaced. The one failure a caller can observe is a close that did not
+//! finish cleanly, which a draining host reports on its way out.
+//!
+//! The directory the tier writes is this process's alone while it runs. An
+//! exclusive lock on a file under the configured root is what says so, and a
+//! second process pointed at the same root fails to start rather than
+//! interleaving writes into one device.
+
+use crate::config::{LocalCacheConfig, ServerConfigError};
+use async_trait::async_trait;
+use bytes::Bytes;
+use foyer::{
+    BlockEngineConfig, Compression, DeviceBuilder, FsDeviceBuilder, HybridCache,
+    HybridCacheBuilder, HybridCachePolicy, PsyncIoEngineConfig, RecoverMode,
+};
+use loonfs::metrics::{CounterHandle, MetricsRecorder};
+use loonfs::{
+    StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
+    StoredMetadataBlockKind,
+};
+use mixtrics::metrics::{
+    BoxedCounter, BoxedCounterVec, BoxedGauge, BoxedGaugeVec, BoxedHistogram, BoxedHistogramVec,
+    CounterOps, CounterVecOps, GaugeOps, GaugeVecOps, HistogramOps, HistogramVecOps, RegistryOps,
+};
+use std::borrow::Cow;
+use std::fmt::Debug;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// The directory beneath the configured root that the disk tier writes.
+///
+/// The name carries the layout version. Nothing under it is durable, so a
+/// layout change takes a new name and the old directory is deleted rather
+/// than migrated.
+const CACHE_DIRECTORY: &str = "metadata-blocks-v1";
+
+/// The lock file beneath the configured root, held open and locked for as
+/// long as this process owns the directory.
+const LOCK_FILE: &str = "owner.lock";
+
+/// The name foyer knows this cache by, which is also the label its own
+/// counters carry.
+const CACHE_NAME: &str = "loonfs-metadata-blocks";
+
+// The four disk-engine numbers below are provisional until this tier is
+// qualified against real traffic. They are constants rather than
+// configuration for that reason: a deployment tuning them today would be
+// guessing from the same absence of measurement.
+
+/// Size of one disk block. A block is the disk tier's allocation and
+/// eviction unit and holds many entries, so it is bounded from both sides:
+/// foyer claims the whole capacity as blocks at startup, one file per block
+/// and each one held open, and it refuses an entry larger than a block less
+/// its blob index. This is foyer's own default, which sits between the two.
+const DISK_BLOCK_BYTES: usize = 16 * 1024 * 1024;
+/// Flusher tasks writing the disk tier.
+const DISK_FLUSHERS: usize = 2;
+/// Total flush buffer pool, split evenly among the flushers. Each flusher
+/// holds two buffers of its share, so this is also the tier's steady write
+/// memory.
+const DISK_BUFFER_POOL_BYTES: usize = 64 * 1024 * 1024;
+/// Bytes of queued inserts the disk tier accepts before it drops further
+/// ones. A drop is counted, never surfaced.
+const DISK_SUBMIT_QUEUE_THRESHOLD_BYTES: usize = 256 * 1024 * 1024;
+
+/// Per-entry overhead the memory weigher charges on top of the value's
+/// length: the key's own bytes and foyer's bookkeeping for one entry. It is
+/// a fixed, generous estimate rather than a measurement, because its only
+/// job is to keep small entries from being treated as free.
+const MEMORY_ENTRY_OVERHEAD_BYTES: usize = 256;
+
+/// The block kinds this cache reports separately, in the order its per-kind
+/// counters are indexed by.
+const BLOCK_KINDS: [StoredMetadataBlockKind; 3] = [
+    StoredMetadataBlockKind::Data,
+    StoredMetadataBlockKind::Index,
+    StoredMetadataBlockKind::Filter,
+];
+
+/// One counter per block kind, indexed by [`kind_index`].
+type PerKind = [Arc<dyn CounterHandle>; BLOCK_KINDS.len()];
+
+/// A [`StoredMetadataBlockCache`] over a foyer hybrid cache: a byte-weighted
+/// memory tier in front of a block engine on local disk.
+///
+/// The cache has two states and one transition between them. It opens Open
+/// and [`close`](StoredMetadataBlockCache::close) makes it Closed, after
+/// which a lookup answers `None`, an insert and an invalidation do nothing,
+/// and closing again succeeds without doing anything further.
+pub struct FoyerStoredMetadataBlockCache {
+    cache: HybridCache<StoredMetadataBlockKey, Bytes>,
+    /// The exclusive lock on the configured root, held for the life of this
+    /// cache. Closing the file is what releases it, so the field is kept
+    /// even though nothing reads it.
+    _directory_lock: File,
+    /// The two foyer counters this process keeps, filled by foyer itself
+    /// through the registry installed at construction.
+    overflow: FoyerOverflowCounters,
+    /// False while the cache is Open, true once it is Closed. The one
+    /// transition is the swap in `close`.
+    closed: AtomicBool,
+    /// Whether a lookup failure has already been logged at error level. The
+    /// first one is worth waking someone for; the rest are the same fact
+    /// repeated, so they go to debug.
+    get_failure_logged: AtomicBool,
+    metrics: LocalCacheMetrics,
+}
+
+impl Debug for FoyerStoredMetadataBlockCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FoyerStoredMetadataBlockCache")
+            .field("name", &CACHE_NAME)
+            .field("closed", &self.is_closed())
+            .finish()
+    }
+}
+
+impl FoyerStoredMetadataBlockCache {
+    /// Takes the configured directory and opens the cache in it.
+    ///
+    /// The root is created if it is missing and locked exclusively, so a
+    /// second process pointed at the same root fails here rather than
+    /// writing into a device another process owns. The versioned directory
+    /// beneath it is foyer's, and foyer recovers what it can from it; a
+    /// directory it cannot open at all fails startup, because deleting a
+    /// deployment's files is the operator's decision and not this process's.
+    pub(crate) async fn open(
+        config: &LocalCacheConfig,
+        recorder: &dyn MetricsRecorder,
+    ) -> Result<Self, ServerConfigError> {
+        let root = PathBuf::from(config.path.trim());
+        std::fs::create_dir_all(&root).map_err(|error| {
+            invalid_local_cache(format!(
+                "failed to create `{}`: {error}",
+                display_path(&root)
+            ))
+        })?;
+        let directory_lock = lock_directory(&root)?;
+
+        let directory = root.join(CACHE_DIRECTORY);
+        let capacity = usize::try_from(config.disk_bytes).map_err(|_| {
+            invalid_local_cache(format!(
+                "`disk_bytes` of {} does not fit this platform's address space",
+                config.disk_bytes
+            ))
+        })?;
+        let device = FsDeviceBuilder::new(&directory)
+            .with_capacity(capacity)
+            .build()
+            .map_err(|error| open_failure(&directory, capacity, &error.to_string()))?;
+
+        let overflow = FoyerOverflowCounters::default();
+        let memory_bytes = usize::try_from(config.memory_bytes).map_err(|_| {
+            invalid_local_cache(format!(
+                "`memory_bytes` of {} does not fit this platform's address space",
+                config.memory_bytes
+            ))
+        })?;
+        let cache = HybridCacheBuilder::<StoredMetadataBlockKey, Bytes>::new()
+            .with_name(CACHE_NAME)
+            // Written to disk when an entry is inserted rather than when the
+            // memory tier evicts it: a block this process decoded once is
+            // worth keeping across a restart, and waiting for eviction means
+            // a restart loses whatever the memory tier still held.
+            .with_policy(HybridCachePolicy::WriteOnInsertion)
+            .with_metrics_registry(Box::new(OverflowRegistry::new(overflow.clone())))
+            .memory(memory_bytes)
+            // The memory budget is bytes, so the weight of an entry is its
+            // size. Counting entries instead would let one budget mean
+            // wildly different amounts of memory.
+            .with_weighter(|_key: &StoredMetadataBlockKey, value: &Bytes| {
+                value.len() + MEMORY_ENTRY_OVERHEAD_BYTES
+            })
+            .storage()
+            .with_io_engine_config(PsyncIoEngineConfig::new())
+            .with_engine_config(
+                BlockEngineConfig::new(device)
+                    .with_block_size(DISK_BLOCK_BYTES)
+                    .with_flushers(DISK_FLUSHERS)
+                    .with_buffer_pool_size(DISK_BUFFER_POOL_BYTES)
+                    .with_submit_queue_size_threshold(DISK_SUBMIT_QUEUE_THRESHOLD_BYTES),
+            )
+            // The bytes are already the compressed form the segment object
+            // holds, so compressing them again would spend cpu for nothing.
+            .with_compression(Compression::None)
+            // An entry recovery cannot make sense of is dropped rather than
+            // fatal. Every entry here is a copy of something object storage
+            // still has, so the worst a bad one costs is one miss.
+            .with_recover_mode(RecoverMode::Quiet)
+            .build()
+            .await
+            .map_err(|error| open_failure(&directory, capacity, &error.to_string()))?;
+
+        Ok(Self {
+            cache,
+            _directory_lock: directory_lock,
+            overflow,
+            closed: AtomicBool::new(false),
+            get_failure_logged: AtomicBool::new(false),
+            metrics: LocalCacheMetrics::register(recorder),
+        })
+    }
+
+    /// Whether [`StoredMetadataBlockCache::close`] has run.
+    pub(crate) fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    /// What foyer reports about itself right now.
+    ///
+    /// These are levels and running totals foyer keeps, read when a scrape
+    /// asks rather than accumulated as work happens.
+    pub(crate) fn foyer_stats(&self) -> FoyerCacheStats {
+        FoyerCacheStats {
+            memory_bytes: self.cache.memory().usage(),
+            memory_capacity_bytes: self.cache.memory().capacity(),
+            disk_bytes: self.cache.storage().device().allocated(),
+            disk_capacity_bytes: self.cache.storage().device().capacity(),
+            queue_buffer_overflows: self.overflow.buffer.load(Ordering::Relaxed),
+            queue_channel_overflows: self.overflow.channel.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Records one lookup failure: counted always, logged loudly once.
+    fn record_get_failure(&self, key: &StoredMetadataBlockKey, error: &dyn std::fmt::Display) {
+        self.metrics.get_failures[kind_index(key.kind)].increment(1);
+        if self.get_failure_logged.swap(true, Ordering::Relaxed) {
+            tracing::debug!(
+                cache = CACHE_NAME,
+                "local block cache lookup failed: {error}"
+            );
+        } else {
+            tracing::error!(
+                cache = CACHE_NAME,
+                "local block cache lookup failed, and reads are falling back to object \
+                 storage; further failures are logged at debug: {error}"
+            );
+        }
+    }
+}
+
+#[async_trait]
+impl StoredMetadataBlockCache for FoyerStoredMetadataBlockCache {
+    async fn get(&self, key: &StoredMetadataBlockKey) -> Option<Bytes> {
+        if self.is_closed() {
+            return None;
+        }
+        match self.cache.get(key).await {
+            Ok(Some(entry)) => {
+                self.metrics.hits[kind_index(key.kind)].increment(1);
+                Some(entry.value().clone())
+            }
+            Ok(None) => {
+                self.metrics.misses[kind_index(key.kind)].increment(1);
+                None
+            }
+            Err(error) => {
+                self.record_get_failure(key, &error);
+                None
+            }
+        }
+    }
+
+    fn insert(&self, key: StoredMetadataBlockKey, bytes: Bytes) {
+        if self.is_closed() {
+            return;
+        }
+        self.metrics.inserts[kind_index(key.kind)].increment(1);
+        // foyer takes the entry and decides for itself whether it reaches
+        // disk, so there is nothing here to fail. An insert the disk tier
+        // could not keep shows up in the two overflow counters instead.
+        let _entry = self.cache.insert(key, bytes);
+    }
+
+    fn invalidate(&self, key: &StoredMetadataBlockKey) {
+        if self.is_closed() {
+            return;
+        }
+        self.metrics.invalidations[kind_index(key.kind)].increment(1);
+        self.cache.remove(key);
+    }
+
+    async fn close(&self) -> Result<(), StoredMetadataBlockCacheCloseError> {
+        // The one transition. Whoever flips the flag owns the shutdown; a
+        // second caller has nothing left to do, and every call after the
+        // flip is already answering as a closed cache.
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+        match self.cache.close().await {
+            Ok(()) => {
+                self.metrics.closes_clean.increment(1);
+                Ok(())
+            }
+            Err(error) => {
+                self.metrics.closes_failed.increment(1);
+                Err(StoredMetadataBlockCacheCloseError::new(error.to_string()))
+            }
+        }
+    }
+}
+
+/// What foyer reports about the local cache when a scrape asks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FoyerCacheStats {
+    /// Bytes the memory tier is holding.
+    pub(crate) memory_bytes: usize,
+    /// Bytes the memory tier may hold.
+    pub(crate) memory_capacity_bytes: usize,
+    /// Bytes of the disk device the engine has claimed as blocks. foyer
+    /// exposes claimed space rather than live entry bytes, and the engine
+    /// claims the whole device at startup, so this is a level only in the
+    /// sense that it reports what the device gave up.
+    pub(crate) disk_bytes: usize,
+    /// Bytes of disk the device was opened with.
+    pub(crate) disk_capacity_bytes: usize,
+    /// Inserts the disk tier dropped because a flusher's buffer was full.
+    pub(crate) queue_buffer_overflows: u64,
+    /// Inserts the disk tier dropped because its submit queue was over
+    /// threshold.
+    pub(crate) queue_channel_overflows: u64,
+}
+
+/// Takes the exclusive lock that says this process owns the configured root.
+///
+/// The lock is advisory and process-wide, which is exactly the claim being
+/// made: one server owns one cache directory. The returned file holds the
+/// lock, so it lives as long as the cache does.
+fn lock_directory(root: &Path) -> Result<File, ServerConfigError> {
+    let lock_path = root.join(LOCK_FILE);
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| {
+            invalid_local_cache(format!(
+                "failed to open the lock file `{}`: {error}",
+                display_path(&lock_path)
+            ))
+        })?;
+    fs4::fs_std::FileExt::try_lock_exclusive(&file)
+        .map_err(|error| {
+            invalid_local_cache(format!(
+                "failed to lock `{}`: {error}",
+                display_path(&lock_path)
+            ))
+        })?
+        .then_some(file)
+        .ok_or_else(|| {
+            invalid_local_cache(format!(
+                "`{}` is locked by another process; a local cache directory belongs to \
+                 one server, so give this one a directory of its own",
+                display_path(root)
+            ))
+        })
+}
+
+/// The error a directory foyer could not open produces.
+///
+/// It names the two things an operator can act on: that the directory holds
+/// nothing durable and may be deleted, and how much of the filesystem — and
+/// how many open files — the configured capacity asks for.
+fn open_failure(directory: &Path, capacity: usize, reason: &str) -> ServerConfigError {
+    let blocks = capacity / DISK_BLOCK_BYTES;
+    invalid_local_cache(format!(
+        "failed to open the local cache directory `{}`: {reason}. The directory holds no \
+         durable data and may be deleted while this server is stopped; it is rebuilt on the \
+         next start. `disk_bytes` of {capacity} claims {blocks} files of {DISK_BLOCK_BYTES} \
+         bytes, each held open, so it also needs an open-file limit above that.",
+        display_path(directory)
+    ))
+}
+
+fn invalid_local_cache(reason: String) -> ServerConfigError {
+    ServerConfigError::InvalidField {
+        field: "local_cache.path",
+        reason,
+    }
+}
+
+/// A path as a string, for an error message. A path that is not UTF-8 still
+/// has to be reportable.
+fn display_path(path: &Path) -> String {
+    path.display().to_string()
+}
+
+/// The `kind` label one block kind carries.
+fn kind_label(kind: StoredMetadataBlockKind) -> &'static str {
+    match kind {
+        StoredMetadataBlockKind::Data => "data",
+        StoredMetadataBlockKind::Index => "index",
+        StoredMetadataBlockKind::Filter => "filter",
+    }
+}
+
+/// Where one block kind's counter sits in a [`PerKind`] array.
+fn kind_index(kind: StoredMetadataBlockKind) -> usize {
+    match kind {
+        StoredMetadataBlockKind::Data => 0,
+        StoredMetadataBlockKind::Index => 1,
+        StoredMetadataBlockKind::Filter => 2,
+    }
+}
+
+/// The counters this cache reports, every one registered at construction.
+///
+/// Registering the whole closed set up front is what keeps the label space
+/// closed: the only labels are the three block kinds and the two close
+/// outcomes, all of them `&'static str`, and no call path can add another.
+struct LocalCacheMetrics {
+    hits: PerKind,
+    misses: PerKind,
+    get_failures: PerKind,
+    inserts: PerKind,
+    invalidations: PerKind,
+    closes_clean: Arc<dyn CounterHandle>,
+    closes_failed: Arc<dyn CounterHandle>,
+}
+
+impl LocalCacheMetrics {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        let per_kind = |name: &'static str, description: &'static str, result: &'static str| {
+            BLOCK_KINDS.map(|kind| {
+                recorder.register_counter(
+                    name,
+                    description,
+                    &[("kind", kind_label(kind)), ("result", result)],
+                )
+            })
+        };
+        let closes = |result: &'static str| {
+            recorder.register_counter(
+                "loonfs.local_cache.closes",
+                "Local block cache shutdowns, by outcome",
+                &[("result", result)],
+            )
+        };
+        Self {
+            hits: per_kind(
+                "loonfs.local_cache.gets",
+                "Local block cache lookups, by block kind and outcome",
+                "hit",
+            ),
+            misses: per_kind(
+                "loonfs.local_cache.gets",
+                "Local block cache lookups, by block kind and outcome",
+                "miss",
+            ),
+            get_failures: per_kind(
+                "loonfs.local_cache.gets",
+                "Local block cache lookups, by block kind and outcome",
+                "failed",
+            ),
+            inserts: BLOCK_KINDS.map(|kind| {
+                recorder.register_counter(
+                    "loonfs.local_cache.inserts",
+                    "Blocks offered to the local block cache, by block kind",
+                    &[("kind", kind_label(kind))],
+                )
+            }),
+            invalidations: BLOCK_KINDS.map(|kind| {
+                recorder.register_counter(
+                    "loonfs.local_cache.invalidations",
+                    "Blocks dropped from the local block cache, by block kind",
+                    &[("kind", kind_label(kind))],
+                )
+            }),
+            closes_clean: closes("clean"),
+            closes_failed: closes("failed"),
+        }
+    }
+}
+
+/// The two foyer counters this process keeps.
+///
+/// foyer increments them when the disk tier refuses an insert, which is the
+/// only signal that the tier is behind. It reports them through a metrics
+/// registry and offers no other way to read them, so the registry below
+/// exists to hold these two numbers.
+#[derive(Debug, Clone, Default)]
+struct FoyerOverflowCounters {
+    buffer: Arc<AtomicU64>,
+    channel: Arc<AtomicU64>,
+}
+
+/// The counter vector foyer registers its inner-operation counts under.
+const FOYER_INNER_OP_COUNTER_VEC: &str = "foyer_storage_inner_op_total";
+/// The label value on the counter foyer bumps when a flusher's buffer is
+/// full.
+const FOYER_BUFFER_OVERFLOW_LABEL: &str = "buffer_overflow";
+/// The label value on the counter foyer bumps when the submit queue is over
+/// threshold.
+const FOYER_CHANNEL_OVERFLOW_LABEL: &str = "channel_overflow";
+
+/// A metrics registry that keeps two of foyer's counters and discards the
+/// rest.
+///
+/// foyer's registry is a push interface: it registers instrument vectors at
+/// construction and then only increments handles. Nothing reads back, so a
+/// host that wants a number has to have kept the handle. This registry keeps
+/// the two that matter and answers every other registration with a handle
+/// that drops what it is given.
+#[derive(Debug)]
+struct OverflowRegistry {
+    counters: FoyerOverflowCounters,
+}
+
+impl OverflowRegistry {
+    fn new(counters: FoyerOverflowCounters) -> Self {
+        Self { counters }
+    }
+}
+
+impl RegistryOps for OverflowRegistry {
+    fn register_counter_vec(
+        &self,
+        name: Cow<'static, str>,
+        _desc: Cow<'static, str>,
+        _label_names: &'static [&'static str],
+    ) -> BoxedCounterVec {
+        if name == FOYER_INNER_OP_COUNTER_VEC {
+            Box::new(OverflowCounterVec {
+                counters: self.counters.clone(),
+            })
+        } else {
+            Box::new(DiscardVec)
+        }
+    }
+
+    fn register_gauge_vec(
+        &self,
+        _name: Cow<'static, str>,
+        _desc: Cow<'static, str>,
+        _label_names: &'static [&'static str],
+    ) -> BoxedGaugeVec {
+        Box::new(DiscardVec)
+    }
+
+    fn register_histogram_vec(
+        &self,
+        _name: Cow<'static, str>,
+        _desc: Cow<'static, str>,
+        _label_names: &'static [&'static str],
+    ) -> BoxedHistogramVec {
+        Box::new(DiscardVec)
+    }
+
+    fn register_histogram_vec_with_buckets(
+        &self,
+        _name: Cow<'static, str>,
+        _desc: Cow<'static, str>,
+        _label_names: &'static [&'static str],
+        _buckets: Vec<f64>,
+    ) -> BoxedHistogramVec {
+        Box::new(DiscardVec)
+    }
+}
+
+/// foyer's inner-operation counters, of which two are kept.
+///
+/// The vector is labelled by cache name and operation, and the operation is
+/// the last label. An operation this process does not keep gets a discarding
+/// counter, so a foyer release that adds one costs nothing here.
+#[derive(Debug)]
+struct OverflowCounterVec {
+    counters: FoyerOverflowCounters,
+}
+
+impl CounterVecOps for OverflowCounterVec {
+    fn counter(&self, labels: &[Cow<'static, str>]) -> BoxedCounter {
+        match labels.last().map(Cow::as_ref) {
+            Some(FOYER_BUFFER_OVERFLOW_LABEL) => {
+                Box::new(SharedCounter(Arc::clone(&self.counters.buffer)))
+            }
+            Some(FOYER_CHANNEL_OVERFLOW_LABEL) => {
+                Box::new(SharedCounter(Arc::clone(&self.counters.channel)))
+            }
+            _ => Box::new(Discard),
+        }
+    }
+}
+
+/// A counter foyer increments and this process reads.
+#[derive(Debug)]
+struct SharedCounter(Arc<AtomicU64>);
+
+impl CounterOps for SharedCounter {
+    fn increase(&self, val: u64) {
+        self.0.fetch_add(val, Ordering::Relaxed);
+    }
+}
+
+/// An instrument vector nothing reads, and so nothing keeps.
+#[derive(Debug)]
+struct DiscardVec;
+
+impl CounterVecOps for DiscardVec {
+    fn counter(&self, _labels: &[Cow<'static, str>]) -> BoxedCounter {
+        Box::new(Discard)
+    }
+}
+
+impl GaugeVecOps for DiscardVec {
+    fn gauge(&self, _labels: &[Cow<'static, str>]) -> BoxedGauge {
+        Box::new(Discard)
+    }
+}
+
+impl HistogramVecOps for DiscardVec {
+    fn histogram(&self, _labels: &[Cow<'static, str>]) -> BoxedHistogram {
+        Box::new(Discard)
+    }
+}
+
+/// An instrument that drops what it is given.
+#[derive(Debug)]
+struct Discard;
+
+impl CounterOps for Discard {
+    fn increase(&self, _val: u64) {}
+}
+
+impl GaugeOps for Discard {
+    fn increase(&self, _val: u64) {}
+    fn decrease(&self, _val: u64) {}
+    fn absolute(&self, _val: u64) {}
+}
+
+impl HistogramOps for Discard {
+    fn record(&self, _val: f64) {}
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/loonfs-server/src/local_cache/tests.rs
+++ b/crates/loonfs-server/src/local_cache/tests.rs
@@ -1,0 +1,241 @@
+#![allow(clippy::panic)]
+// Cache tests panic in unexpected match arms for precise diagnostics.
+
+use super::{
+    FoyerOverflowCounters, FoyerStoredMetadataBlockCache, OverflowRegistry, CACHE_DIRECTORY,
+    DISK_BLOCK_BYTES, FOYER_BUFFER_OVERFLOW_LABEL, FOYER_CHANNEL_OVERFLOW_LABEL,
+    FOYER_INNER_OP_COUNTER_VEC,
+};
+use crate::config::{LocalCacheConfig, ServerConfigError};
+use bytes::Bytes;
+use loonfs::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot, NoopMetricsRecorder};
+use loonfs::{StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind};
+use mixtrics::metrics::RegistryOps;
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+/// The smallest disk tier these tests can ask for.
+///
+/// foyer claims the device as whole blocks and warns when the block count is
+/// not comfortably above the flusher count, so the floor is set by
+/// [`DISK_BLOCK_BYTES`] rather than by anything the tests want. Eight blocks
+/// clears it. The block files are sparse, so a test pays for the bytes it
+/// writes and not for the capacity it asked for.
+const TEST_DISK_BYTES: u64 = 8 * DISK_BLOCK_BYTES as u64;
+
+/// A memory tier larger than everything these tests insert.
+const TEST_MEMORY_BYTES: u64 = 4 * 1024 * 1024;
+
+fn test_config(root: &Path) -> LocalCacheConfig {
+    LocalCacheConfig {
+        path: root.display().to_string(),
+        memory_bytes: TEST_MEMORY_BYTES,
+        disk_bytes: TEST_DISK_BYTES,
+    }
+}
+
+async fn open(root: &Path) -> FoyerStoredMetadataBlockCache {
+    FoyerStoredMetadataBlockCache::open(&test_config(root), &NoopMetricsRecorder)
+        .await
+        .expect("open local cache")
+}
+
+fn key(offset: u64) -> StoredMetadataBlockKey {
+    StoredMetadataBlockKey {
+        payload_checksum: "sha256:00112233445566778899aabbccddeeff".to_owned(),
+        kind: StoredMetadataBlockKind::Data,
+        offset,
+    }
+}
+
+/// The cache keeps what it is given and finds it again after a restart.
+///
+/// The reopen is the point. An insert reaches disk, closing flushes what the
+/// memory tier still held, and a fresh cache over the same directory serves
+/// both; without that this would be an in-memory cache with a directory
+/// beside it.
+#[tokio::test]
+async fn a_kept_block_survives_a_reopen() {
+    let temp_dir = tempdir().expect("tempdir");
+    let bytes = Bytes::from_static(b"encoded stored block");
+
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
+    let cache =
+        FoyerStoredMetadataBlockCache::open(&test_config(temp_dir.path()), recorder.as_ref())
+            .await
+            .expect("open local cache");
+    assert_eq!(cache.get(&key(0)).await, None, "an empty cache misses");
+    cache.insert(key(0), bytes.clone());
+    assert_eq!(cache.get(&key(0)).await, Some(bytes.clone()));
+    cache.close().await.expect("close local cache");
+    drop(cache);
+
+    // The instruments are registered at construction and carry a closed
+    // label set, so one hit and one miss are already two named series.
+    let snapshot = recorder.snapshot();
+    assert_eq!(counter(&snapshot, "loonfs.local_cache.gets", "hit"), 1);
+    assert_eq!(counter(&snapshot, "loonfs.local_cache.gets", "miss"), 1);
+    assert_eq!(counter(&snapshot, "loonfs.local_cache.closes", "clean"), 1);
+
+    let reopened = open(temp_dir.path()).await;
+    assert_eq!(
+        reopened.get(&key(0)).await,
+        Some(bytes),
+        "a reopened cache serves what the closed one wrote"
+    );
+    reopened.close().await.expect("close reopened cache");
+}
+
+/// One directory belongs to one server.
+#[tokio::test]
+async fn a_second_open_of_one_directory_is_refused() {
+    let temp_dir = tempdir().expect("tempdir");
+    let held = open(temp_dir.path()).await;
+
+    match FoyerStoredMetadataBlockCache::open(&test_config(temp_dir.path()), &NoopMetricsRecorder)
+        .await
+    {
+        Err(ServerConfigError::InvalidField { field, reason }) => {
+            assert_eq!(field, "local_cache.path");
+            assert!(reason.contains("locked by another process"), "{reason}");
+        }
+        Err(other) => panic!("expected a locked-directory error, got {other:?}"),
+        Ok(_) => panic!("a second server must not open a directory another one owns"),
+    }
+
+    held.close().await.expect("close local cache");
+}
+
+/// A closed cache is inert, and closing it again is not an error.
+#[tokio::test]
+async fn a_closed_cache_answers_nothing_and_keeps_nothing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let cache = open(temp_dir.path()).await;
+    let bytes = Bytes::from_static(b"encoded stored block");
+    cache.insert(key(0), bytes.clone());
+    assert_eq!(cache.get(&key(0)).await, Some(bytes.clone()));
+
+    cache.close().await.expect("close local cache");
+    assert!(cache.is_closed());
+
+    assert_eq!(
+        cache.get(&key(0)).await,
+        None,
+        "a lookup after the close is a miss, whatever the cache still holds"
+    );
+    cache.insert(key(1), bytes);
+    cache.invalidate(&key(0));
+    assert_eq!(cache.get(&key(1)).await, None, "the insert did nothing");
+    cache
+        .close()
+        .await
+        .expect("closing a closed cache does nothing further and succeeds");
+}
+
+/// A root the process cannot make a directory of fails startup.
+#[tokio::test]
+async fn an_unusable_path_fails_startup() {
+    let temp_dir = tempdir().expect("tempdir");
+    let file_path = temp_dir.path().join("not-a-directory");
+    std::fs::write(&file_path, b"").expect("write file");
+
+    match FoyerStoredMetadataBlockCache::open(&test_config(&file_path), &NoopMetricsRecorder).await
+    {
+        Err(ServerConfigError::InvalidField { field, .. }) => {
+            assert_eq!(field, "local_cache.path");
+        }
+        Err(other) => panic!("expected an invalid path error, got {other:?}"),
+        Ok(_) => panic!("a root that is a file must not open"),
+    }
+}
+
+/// The disk tier writes beneath the versioned directory, in one open file
+/// per block.
+///
+/// The file count is what bounds [`DISK_BLOCK_BYTES`] from below: the tier
+/// claims the whole capacity as blocks at startup and holds every block file
+/// open, so a smaller block means proportionally more descriptors for the
+/// same `disk_bytes`. The assertion is here so that relationship cannot
+/// change without someone noticing.
+#[tokio::test]
+async fn the_disk_tier_claims_the_capacity_as_block_files() {
+    let temp_dir = tempdir().expect("tempdir");
+    let cache = open(temp_dir.path()).await;
+    cache.insert(key(0), Bytes::from_static(b"encoded stored block"));
+    cache.close().await.expect("close local cache");
+
+    let directory = temp_dir.path().join(CACHE_DIRECTORY);
+    assert!(
+        directory.is_dir(),
+        "the versioned directory is where the tier's files go"
+    );
+    let files = std::fs::read_dir(&directory)
+        .expect("read the versioned directory")
+        .count();
+    assert_eq!(
+        files,
+        (TEST_DISK_BYTES / DISK_BLOCK_BYTES as u64) as usize,
+        "the tier holds one file per block of the capacity it was given"
+    );
+}
+
+/// foyer's overflow counters reach this process's numbers.
+///
+/// The bridge is one metric name and two label values agreed with foyer, and
+/// nothing in the type system holds the agreement together, so it is
+/// asserted here: the registry hands back the counters foyer increments, and
+/// what foyer increments is what a scrape reads.
+#[test]
+fn the_registry_keeps_foyers_two_overflow_counters() {
+    let counters = FoyerOverflowCounters::default();
+    let registry = OverflowRegistry::new(counters.clone());
+
+    let inner_ops = registry.register_counter_vec(
+        FOYER_INNER_OP_COUNTER_VEC.into(),
+        "foyer disk cache inner operations".into(),
+        &["name", "op"],
+    );
+    inner_ops
+        .counter(&["cache".into(), FOYER_BUFFER_OVERFLOW_LABEL.into()])
+        .increase(3);
+    inner_ops
+        .counter(&["cache".into(), FOYER_CHANNEL_OVERFLOW_LABEL.into()])
+        .increase(5);
+    // An operation this process does not keep is discarded rather than
+    // misfiled onto one of the two.
+    inner_ops
+        .counter(&["cache".into(), "queue_rotate".into()])
+        .increase(7);
+
+    assert_eq!(counters.buffer.load(Ordering::Relaxed), 3);
+    assert_eq!(counters.channel.load(Ordering::Relaxed), 5);
+
+    // Every other vector foyer registers is discarded whole.
+    registry
+        .register_counter_vec("foyer_storage_op_total".into(), "other".into(), &["name"])
+        .counter(&["cache".into()])
+        .increase(11);
+    assert_eq!(counters.buffer.load(Ordering::Relaxed), 3);
+    assert_eq!(counters.channel.load(Ordering::Relaxed), 5);
+}
+
+/// The value of one counter series, found by name and `result` label.
+fn counter(snapshot: &MetricsSnapshot, name: &str, result: &str) -> u64 {
+    snapshot
+        .all()
+        .iter()
+        .filter(|entry| {
+            entry.name == name
+                && entry
+                    .labels
+                    .iter()
+                    .any(|(key, value)| *key == "result" && *value == result)
+        })
+        .map(|entry| match entry.value {
+            MetricValue::Counter(value) => value,
+            _ => panic!("`{name}` should be a counter"),
+        })
+        .sum()
+}

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -38,7 +38,7 @@ pub(crate) async fn start_server(config: ServerConfig) -> TestServer {
     let addr = listener.local_addr().expect("listener addr");
     // The writer is dropped: tests abort the server task instead of shutting
     // it down gracefully.
-    let (router, _writer) = app(config).await.expect("build app");
+    let (router, _writer, _local_cache) = app(config).await.expect("build app");
     let server = tokio::spawn(async move {
         axum::serve(listener, router).await.expect("serve app");
     });
@@ -161,6 +161,7 @@ pub(crate) fn test_config(
         content_token_secret: content_token_secret.into(),
         writer_id: writer_id.to_owned(),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        local_cache: None,
         grep: GrepConfig::default(),
         maintenance: MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -35,7 +35,7 @@ use tower::ServiceExt;
 async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
     let temp_dir = tempdir().expect("store tempdir");
     let (_store, _writer, namespace_id) = seed_namespace(temp_dir.path(), "disabled").await;
-    let (router, server) = app(test_config(temp_dir.path(), GrepMode::Disabled))
+    let (router, server, _local_cache) = app(test_config(temp_dir.path(), GrepMode::Disabled))
         .await
         .expect("build app");
 
@@ -68,9 +68,10 @@ async fn disabled_mode_returns_not_supported_and_omits_grep_capabilities() {
 async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespace() {
     let temp_dir = tempdir().expect("store tempdir");
     let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "both").await;
-    let (router, server) = app(test_config(temp_dir.path(), GrepMode::ServeAndMaintain))
-        .await
-        .expect("build app");
+    let (router, server, _local_cache) =
+        app(test_config(temp_dir.path(), GrepMode::ServeAndMaintain))
+            .await
+            .expect("build app");
     assert!(maintains_grep_index(&server));
     // Before anything is enabled the status route answers honestly rather
     // than inventing a namespace-not-found.
@@ -299,9 +300,10 @@ async fn first_query_after_restart_resumes_stale_and_mid_backfill_namespaces() {
 
     // Nothing has nudged either namespace in this process: the first search
     // is what re-admits the index that trails its head.
-    let (router, server) = app(test_config(temp_dir.path(), GrepMode::ServeAndMaintain))
-        .await
-        .expect("reopen app");
+    let (router, server, _local_cache) =
+        app(test_config(temp_dir.path(), GrepMode::ServeAndMaintain))
+            .await
+            .expect("reopen app");
     let stale_response = grep(&router, &stale, "stale steady needle").await;
     assert_eq!(stale_response.matches.len(), 1);
     settle(&server).await;
@@ -336,7 +338,7 @@ async fn first_query_after_restart_resumes_stale_and_mid_backfill_namespaces() {
 async fn serve_only_answers_searches_over_an_index_it_refuses_to_administer() {
     let temp_dir = tempdir().expect("store tempdir");
     let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "serve-only").await;
-    let (router, server) = app(test_config(temp_dir.path(), GrepMode::ServeOnly))
+    let (router, server, _local_cache) = app(test_config(temp_dir.path(), GrepMode::ServeOnly))
         .await
         .expect("build app");
     assert!(!maintains_grep_index(&server));
@@ -394,7 +396,7 @@ async fn serve_only_answers_searches_over_an_index_it_refuses_to_administer() {
 async fn maintain_only_keeps_the_index_built_without_serving_searches() {
     let temp_dir = tempdir().expect("store tempdir");
     let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "maintain-only").await;
-    let (router, server) = app(test_config(temp_dir.path(), GrepMode::MaintainOnly))
+    let (router, server, _local_cache) = app(test_config(temp_dir.path(), GrepMode::MaintainOnly))
         .await
         .expect("build app");
     assert!(maintains_grep_index(&server));
@@ -456,7 +458,7 @@ async fn maintain_only_keeps_the_index_built_without_serving_searches() {
 async fn manual_maintenance_registers_no_index_job_and_still_administers_one() {
     let temp_dir = tempdir().expect("store tempdir");
     let (store, writer, namespace_id) = seed_namespace(temp_dir.path(), "manual-maintenance").await;
-    let (router, server) = app(ServerConfig {
+    let (router, server, _local_cache) = app(ServerConfig {
         maintenance: MaintenanceMode::Manual,
         ..test_config(temp_dir.path(), GrepMode::ServeAndMaintain)
     })
@@ -531,6 +533,7 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
         content_token_secret: "test-content-token-secret".into(),
         writer_id: format!("grep-mode-{mode:?}"),
         runtime_cache: RuntimeCacheConfigOverrides::default(),
+        local_cache: None,
         grep: GrepConfig {
             mode,
             ..GrepConfig::default()

--- a/crates/loonfs/Cargo.toml
+++ b/crates/loonfs/Cargo.toml
@@ -19,6 +19,10 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+# The stored-block cache double the seam tests install lives behind
+# `loonfs-core`'s `test-support` feature; test targets are the only builds
+# that turn it on.
+loonfs-core = { workspace = true, features = ["test-support"] }
 loonfs-test-support = { path = "../loonfs-test-support" }
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -22,7 +22,8 @@ use loonfs_api::{
     PROTOCOL_VERSION,
 };
 use loonfs_core::cache::{
-    MetadataTableCache, WalTailProjectionCache, WalTailProjectionCacheConfig,
+    MetadataTableCache, StoredMetadataBlockCache, WalTailProjectionCache,
+    WalTailProjectionCacheConfig,
 };
 use loonfs_core::time::current_time_ms;
 use loonfs_core::{MutationContext, NamespaceEngine};
@@ -113,15 +114,23 @@ impl ReadCore {
     /// identities (payload checksums and manifest object keys); the
     /// sharing caller owns the sizing decision, and
     /// `config.runtime_cache.metadata_table_cache` goes unused.
+    ///
+    /// `stored_metadata_block_cache` is the node-local cache of encoded
+    /// blocks the fresh decoded cache carries beneath it. It applies only
+    /// when this core sizes its own cache: a shared cache already carries
+    /// whatever handle it was built with, which is what makes the sharing
+    /// caller's sizing decision cover both tiers together.
     pub(crate) fn open(
         store: SharedObjectStore,
         config: ReadConfig,
         shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
+        stored_metadata_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
         instruments: Arc<RuntimeInstruments>,
     ) -> Self {
         let metadata_table_cache = shared_metadata_table_cache.unwrap_or_else(|| {
-            Arc::new(MetadataTableCache::new(
+            Arc::new(MetadataTableCache::with_stored_block_cache(
                 config.runtime_cache.metadata_table_cache.clone(),
+                stored_metadata_block_cache,
             ))
         });
         let wal_tail_projection_cache =

--- a/crates/loonfs/src/handle/builder_core.rs
+++ b/crates/loonfs/src/handle/builder_core.rs
@@ -10,7 +10,7 @@ use crate::{
     Result, RuntimeCacheConfig, RuntimeError, SharedObjectStore, StoreConfig, TraceMode,
     TraceStoreKind,
 };
-use loonfs_core::cache::MetadataTableCache;
+use loonfs_core::cache::{MetadataTableCache, StoredMetadataBlockCache};
 use loonfs_objectstore::metrics::InstrumentedObjectStore;
 use std::sync::Arc;
 
@@ -32,6 +32,9 @@ pub(super) struct HandleBuilderCore {
     /// An existing decoded-block cache to share instead of sizing a fresh
     /// one from `runtime_cache`; see [`ReadCore::open`].
     pub(super) shared_metadata_table_cache: Option<Arc<MetadataTableCache>>,
+    /// A node-local cache of encoded metadata blocks for the fresh decoded
+    /// cache to carry beneath it; see [`ReadCore::open`].
+    pub(super) stored_metadata_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
     pub(super) trace_mode: TraceMode,
     pub(super) trace_store_kind: Option<TraceStoreKind>,
     pub(super) object_store_metrics_recorder: Option<Arc<dyn ObjectStoreMetricsRecorder>>,
@@ -53,6 +56,7 @@ impl HandleBuilderCore {
             max_read_content_bytes: None,
             runtime_cache: RuntimeCacheConfig::default(),
             shared_metadata_table_cache: None,
+            stored_metadata_block_cache: None,
             trace_mode: TraceMode::Embedded,
             trace_store_kind: None,
             object_store_metrics_recorder: None,
@@ -99,6 +103,7 @@ impl HandleBuilderCore {
                 trace_store_kind,
             },
             self.shared_metadata_table_cache,
+            self.stored_metadata_block_cache,
             instruments,
         ))
     }

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -10,7 +10,7 @@ use crate::{
     MaintenanceJobId, NamespaceId, Result, RuntimeCacheConfig, RuntimeCacheStats, RuntimeError,
     SharedObjectStore, StoreConfig, TraceMode, TraceStoreKind,
 };
-use loonfs_core::cache::MetadataTableCache;
+use loonfs_core::cache::{MetadataTableCache, StoredMetadataBlockCache};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -314,6 +314,27 @@ impl FsWriterBuilder {
         self
     }
 
+    /// Installs a node-local cache of encoded metadata blocks beneath this
+    /// writer's decoded block cache.
+    ///
+    /// The handle rides on the decoded cache, so every handle built from
+    /// this writer's cache reaches the same local cache — the reader this
+    /// writer derives, and an admin handle sharing the cache through
+    /// [`FsAdminBuilder::shared_metadata_table_cache`]. Nothing else
+    /// reaches it: paths that carry no decoded cache carry neither tier.
+    ///
+    /// Unset by default. The host owns the cache and closes it, and object
+    /// storage stays the authority for every read either way.
+    ///
+    /// [`FsAdminBuilder::shared_metadata_table_cache`]: crate::FsAdminBuilder::shared_metadata_table_cache
+    pub fn stored_metadata_block_cache(
+        mut self,
+        stored_metadata_block_cache: Arc<dyn StoredMetadataBlockCache>,
+    ) -> Self {
+        self.core.stored_metadata_block_cache = Some(stored_metadata_block_cache);
+        self
+    }
+
     /// Sets the tracing mode label.
     pub fn trace_mode(mut self, trace_mode: TraceMode) -> Self {
         self.core.trace_mode = trace_mode;
@@ -435,11 +456,50 @@ mod tests {
         CreateNamespaceOptions, ErrorCode, FsBackgroundWork, FsWriter, MaintenanceJobId,
         NamespaceId, PutFileOptions,
     };
+    use loonfs_core::test_support::RecordingStoredMetadataBlockCache;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_test_support::ids::namespace_id;
     use loonfs_test_support::stores::{BlockingStore, KeyPredicate, OperationClass};
     use std::sync::Arc;
     use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn a_writer_carries_no_stored_block_cache_by_default() {
+        let temp_dir = tempdir().expect("tempdir");
+        let writer = FsWriter::builder_with_store(Arc::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        ))
+        .writer_id("no-stored-block-cache-writer")
+        .build()
+        .await
+        .expect("build writer");
+
+        assert!(writer.metadata_table_cache().stored_block_cache().is_none());
+    }
+
+    /// The handle rides on the decoded block cache, which is what puts the
+    /// two tiers in the same places: every handle built from this cache
+    /// reaches the local cache, and every path that carries no decoded cache
+    /// reaches neither tier.
+    #[tokio::test]
+    async fn the_builder_installs_the_stored_block_cache_on_the_decoded_cache() {
+        let temp_dir = tempdir().expect("tempdir");
+        let stored_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+        let writer = FsWriter::builder_with_store(Arc::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        ))
+        .writer_id("stored-block-cache-writer")
+        .stored_metadata_block_cache(stored_blocks.clone())
+        .build()
+        .await
+        .expect("build writer");
+
+        assert!(writer.metadata_table_cache().stored_block_cache().is_some());
+        assert!(Arc::ptr_eq(
+            &writer.metadata_table_cache(),
+            &writer.reader().core.metadata_table_cache()
+        ));
+    }
 
     /// A writer whose store parks the first head compare-and-swap, so a
     /// publication can be held open across a shutdown's first poll.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -68,7 +68,10 @@ pub use loonfs_api::{
     FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
     PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
-pub use loonfs_core::cache::{MetadataTableCacheConfig, Recency};
+pub use loonfs_core::cache::{
+    MetadataTableCacheConfig, Recency, StoredMetadataBlockCache,
+    StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey, StoredMetadataBlockKind,
+};
 pub use loonfs_core::limits::{
     DEFAULT_GC_MAX_OBJECTS, GC_MIN_GRACE_WINDOW_MS, METADATA_PUBLICATION_BUDGET_MS,
 };

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -200,6 +200,7 @@ fn test_read_core(store: SharedStore) -> ReadCore {
             trace_store_kind: TraceStoreKind::LocalFs,
         },
         None,
+        None,
         RuntimeInstruments::new(None),
     )
 }

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -8,6 +8,7 @@ use loonfs::{
     ChangeSeq, CreateDirectoryOptions, CreateNamespaceOptions, ErrorCode, InodeId, InodeKind,
     NamespaceId, PutFileOptions, RuntimeCacheConfig, SharedObjectStore,
 };
+use loonfs_core::test_support::RecordingStoredMetadataBlockCache;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
@@ -656,4 +657,65 @@ fn separate_runtime_instances_share_object_store_state() {
         .get_file_bytes_blocking(&namespace_id, "/docs/shared.txt")
         .expect("read shared file");
     assert_eq!(file.bytes, b"shared");
+}
+
+/// The stored-block cache is a seam and nothing more until a later change
+/// wires the fetch path into it: a runtime built with one installed reads
+/// and writes exactly as it did without one, and never calls it. The
+/// decoded-cache assertion keeps this honest — it fails if the cycle stops
+/// exercising the metadata table path this tier sits under.
+#[test]
+fn an_installed_stored_block_cache_is_never_called() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let stored_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let fs = open_runtime_with(
+        store(temp_dir.path()),
+        "stored-block-seam-test",
+        |builder| builder.stored_metadata_block_cache(stored_blocks.clone()),
+    );
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/file.txt",
+        b"file",
+        PutFileOptions::default(),
+    )
+    .expect("put file");
+    fs.create_checkpoint_blocking(&namespace_id)
+        .expect("checkpoint");
+    // A write after the checkpoint moves the head, so the reads below
+    // resolve against the published manifest and touch its segments.
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/second.txt",
+        b"second",
+        PutFileOptions::default(),
+    )
+    .expect("put second file");
+
+    let file = fs
+        .get_file_bytes_blocking(&namespace_id, "/docs/file.txt")
+        .expect("read file");
+    assert_eq!(file.bytes, b"file");
+    let entries = fs
+        .list_path_blocking(&namespace_id, "/docs")
+        .expect("list docs");
+    assert_eq!(entries.len(), 2);
+
+    assert!(
+        fs.runtime_cache_stats().metadata_table_cache_inserts > 0,
+        "the cycle must reach the decoded block cache for this to prove anything"
+    );
+    assert_eq!(
+        stored_blocks.calls(),
+        Vec::new(),
+        "nothing consults the stored-block cache yet"
+    );
+    assert!(
+        !stored_blocks.is_closed(),
+        "the host owns the cache and closes it"
+    );
 }


### PR DESCRIPTION
Adds the Foyer-backed implementation of the local block cache, behind an optional `[local_cache]` config table (path, memory_bytes, disk_bytes). The server builds it and closes it after writer shutdown. Read traffic does not use it yet; that is the next PR. 

Other notes:
- Disk block size is 16 MiB (Foyer's default), not the planned 64 KiB. Foyer holds one open file per block, so 64 KiB blocks at 100 GiB would need 1.6 million file descriptors.
- The wrapper has two states: after close, get returns None and insert does nothing; a second close is Ok. All cache errors are counted and become misses.
- Foyer's two write-pipeline overflow counters are exported through a small metrics-registry bridge; a test pins the metric name and labels because Foyer has no read-back API for them.
- `app()` now also returns the cache handle so embedding hosts can close it.
- 29 new transitive crates, including lz4-sys (a C build, like the existing zstd-sys). No toolchain change.
