### PR TITLE
feat(cache): index and filter reads use the local block cache

### DIFF
--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -1,4 +1,10 @@
 //! Fetching, decoding, and cache publication for SST index and filter blocks.
+//!
+//! A load consults three places in order: the per-view memo, the decoded
+//! block cache, and — for the two sections named here — the node-local cache
+//! of the same blocks in their stored form. Only when all three come up
+//! empty does object storage answer, and what that one GET produced is
+//! offered back to the local tier section by section.
 
 use super::block_load::SessionBlockMemo;
 use super::cache::{
@@ -6,11 +12,15 @@ use super::cache::{
 };
 use super::data_block_load::decoded_data_cache_block;
 use super::error::ManifestLoadError;
+use super::stored_block_cache::{
+    StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind,
+};
+use bytes::Bytes;
 use loonfs_api::wire::hex::hex_decode_bytes;
 use loonfs_api::wire::manifest::MetadataFileRef;
 use loonfs_api::wire::sst_blocks::{
     decode_data_block, decode_filter_block, decode_index_block, BlockHandle, SegmentFilter,
-    SegmentIndexEntry,
+    SegmentIndexEntry, SstBlockCodecError,
 };
 use loonfs_objectstore::{ByteRange, ObjectStore};
 use std::sync::Arc;
@@ -25,6 +35,97 @@ pub(super) fn segment_block_cache_key(
         block_kind,
         block_offset,
     }
+}
+
+/// The local stored-block cache's key for one section of a segment.
+///
+/// The identity is the segment's payload checksum, the same immutable bytes
+/// the decoded cache keys by, and the handle's offset locates the section
+/// inside the object.
+fn stored_block_key(
+    descriptor: &MetadataFileRef,
+    kind: StoredMetadataBlockKind,
+    handle: &BlockHandle,
+) -> StoredMetadataBlockKey {
+    StoredMetadataBlockKey {
+        payload_checksum: descriptor.payload_checksum.clone(),
+        kind,
+        offset: handle.offset,
+    }
+}
+
+/// The local stored-block cache this read may consult, which exists exactly
+/// where the decoded cache does: a path carrying no table cache — every
+/// maintenance path — reaches neither tier.
+fn stored_block_cache(
+    table_cache: Option<&MetadataTableCache>,
+) -> Option<&Arc<dyn StoredMetadataBlockCache>> {
+    table_cache?.stored_block_cache()
+}
+
+/// Answers one section from the local stored-block cache, when it holds
+/// bytes for it that decode.
+///
+/// The bytes go to the same decoder the store's bytes go to, so a hit is
+/// checksummed and structure-checked exactly as a fetch is. A hit that does
+/// not decode says nothing about the segment — object storage still holds
+/// the authority — so the entry is dropped and the caller falls through to
+/// one ordinary fetch, which reports corruption if the store's bytes fail
+/// too. Nothing retries the local tier.
+async fn stored_block_section<T>(
+    table_cache: Option<&MetadataTableCache>,
+    descriptor: &MetadataFileRef,
+    kind: StoredMetadataBlockKind,
+    handle: &BlockHandle,
+    decode: impl FnOnce(&[u8], &BlockHandle) -> Result<T, SstBlockCodecError>,
+) -> Option<T> {
+    let cache = stored_block_cache(table_cache)?;
+    let key = stored_block_key(descriptor, kind, handle);
+    let bytes = cache.get(&key).await?;
+    // The decoder checks the stored length too; checking it first keeps a
+    // truncated entry from reaching the decompressor at all.
+    let decoded = if bytes.len() == handle.stored_len as usize {
+        decode(&bytes, handle).map_err(|error| error.to_string())
+    } else {
+        Err(format!(
+            "entry holds {} bytes, expected {}",
+            bytes.len(),
+            handle.stored_len
+        ))
+    };
+    match decoded {
+        Ok(decoded) => Some(decoded),
+        Err(reason) => {
+            tracing::debug!(
+                object_key = %descriptor.object_key,
+                "local block cache entry rejected, refetching from the store: {reason}"
+            );
+            cache.invalidate(&key);
+            None
+        }
+    }
+}
+
+/// Offers one section's stored bytes to the local stored-block cache.
+///
+/// Every section a fetch produced is offered under its own key, so a later
+/// read of any one of them needs no GET. The bytes are copied rather than
+/// sliced out of the fetch buffer: a slice would keep the whole fetched span
+/// alive for as long as the cache held any one section of it.
+fn offer_stored_block(
+    table_cache: Option<&MetadataTableCache>,
+    descriptor: &MetadataFileRef,
+    kind: StoredMetadataBlockKind,
+    handle: &BlockHandle,
+    stored: &[u8],
+) {
+    let Some(cache) = stored_block_cache(table_cache) else {
+        return;
+    };
+    cache.insert(
+        stored_block_key(descriptor, kind, handle),
+        Bytes::copy_from_slice(stored),
+    );
 }
 
 /// Fetches exactly the byte range a handle names.
@@ -92,6 +193,10 @@ fn segment_object_len(descriptor: &MetadataFileRef) -> u64 {
 /// filter that is the filter plus the index that directly follows it
 /// (manifest loading rejects any other layout), and for an index exactly the
 /// index, which ends the object. Returns the requested block.
+///
+/// Every section the span covers is also offered to the local stored-block
+/// cache in its stored form, so what one GET produced is what a later read
+/// finds there.
 async fn load_and_publish_segment_sections<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -128,6 +233,13 @@ async fn load_and_publish_segment_sections<S: ObjectStore + ?Sized>(
 
     let index_entries = match section(&index_handle) {
         Some(stored) => {
+            offer_stored_block(
+                table_cache,
+                descriptor,
+                StoredMetadataBlockKind::Index,
+                &index_handle,
+                stored,
+            );
             let entries = Arc::new(
                 decode_index_block(stored, &index_handle)
                     .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,
@@ -152,6 +264,13 @@ async fn load_and_publish_segment_sections<S: ObjectStore + ?Sized>(
     };
     let filter_block = match section(&filter_handle) {
         Some(stored) => {
+            offer_stored_block(
+                table_cache,
+                descriptor,
+                StoredMetadataBlockKind::Filter,
+                &filter_handle,
+                stored,
+            );
             let filter = decode_filter_block(stored, &filter_handle)
                 .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
             let block = DecodedMetadataTableBlock::Filter {
@@ -181,6 +300,13 @@ async fn load_and_publish_segment_sections<S: ObjectStore + ?Sized>(
                         "data block outside the segment object bounds",
                     ));
                 };
+                offer_stored_block(
+                    table_cache,
+                    descriptor,
+                    StoredMetadataBlockKind::Data,
+                    &entry.block,
+                    stored,
+                );
                 let decoded = decode_data_block(stored, &entry.block)
                     .map_err(|err| segment_codec_error(&descriptor.object_key, err))?;
                 let block = decoded_data_cache_block(descriptor.family, decoded);
@@ -257,6 +383,24 @@ async fn load_segment_index_inner<S: ObjectStore + ?Sized>(
         return Ok(entries);
     }
     let fetch = || async {
+        // Between the decoded cache above and the store below: a local copy
+        // of the same stored bytes. A hit answers this section and nothing
+        // else, so the sibling sections a fetch would have published are
+        // published only when a fetch happens.
+        if let Some(entries) = stored_block_section(
+            table_cache,
+            descriptor,
+            StoredMetadataBlockKind::Index,
+            &handle,
+            decode_index_block,
+        )
+        .await
+        {
+            return Ok(DecodedMetadataTableBlock::Index {
+                decoded_byte_len: handle.decoded_len as usize,
+                entries: Arc::new(entries),
+            });
+        }
         if load_small_segment_whole {
             load_and_publish_segment_sections(
                 store,
@@ -300,10 +444,11 @@ async fn load_segment_index_inner<S: ObjectStore + ?Sized>(
 
 /// Loads a segment's bloom filter block: the cheap pre-index check a lookup
 /// consults to skip the segment entirely. A copy inlined in the manifest
-/// descriptor answers without any object fetch; otherwise one ranged GET
-/// covers the filter together with the adjacent index block (and the whole
-/// object when it is small), so an admitted lookup does not pay a second
-/// round-trip for the index.
+/// descriptor answers without any object fetch; otherwise the local
+/// stored-block cache answers if it holds the section, and only failing that
+/// does one ranged GET cover the filter together with the adjacent index
+/// block (and the whole object when it is small), so an admitted lookup does
+/// not pay a second round-trip for the index.
 pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -334,6 +479,22 @@ pub(super) async fn load_segment_filter<S: ObjectStore + ?Sized>(
         return Ok(filter);
     }
     let fetch = || async {
+        // Reached only when the descriptor carried no inline copy: an
+        // inlined filter is answered above and never touches this tier.
+        if let Some(filter) = stored_block_section(
+            table_cache,
+            descriptor,
+            StoredMetadataBlockKind::Filter,
+            &handle,
+            decode_filter_block,
+        )
+        .await
+        {
+            return Ok(DecodedMetadataTableBlock::Filter {
+                decoded_byte_len: handle.decoded_len as usize,
+                filter: Arc::new(filter),
+            });
+        }
         load_and_publish_segment_sections(
             store,
             table_cache,

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -784,6 +784,277 @@ async fn corrupt_inline_filter_fails_the_lookup() {
     );
 }
 
+/// One checkpointed direntry segment, with the inline filter copy stripped
+/// from its descriptor so both the filter and the index have to come from
+/// somewhere other than the manifest — the shape a base segment, whose
+/// filter is too big to inline, already has.
+async fn checkpointed_direntry_segment() -> (
+    tempfile::TempDir,
+    CountingStore<LocalFsStore>,
+    MetadataFileRef,
+) {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..4 {
+        let path = format!("/docs/file-{index}.txt");
+        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
+            .await
+            .expect("write file");
+    }
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let tables = load_verified_manifest_tables(&store, &namespace_id, &manifest_object_id)
+        .await
+        .expect("load tables");
+    let mut descriptor = tables
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .find(|descriptor| descriptor.family == ApiMetadataTableFamily::DirentryBinds)
+        .expect("a direntry segment")
+        .clone();
+    descriptor.filter_inline = None;
+    (temp_dir, store, descriptor)
+}
+
+/// A decoded block cache with `blocks` beneath it, which is what a runtime
+/// built with a local cache hands the read paths. A fresh one stands for a
+/// fresh process: only the local tier carries anything over.
+fn table_cache_over(blocks: &Arc<RecordingStoredMetadataBlockCache>) -> MetadataTableCache {
+    MetadataTableCache::with_stored_block_cache(
+        MetadataTableCacheConfig::default(),
+        Some(Arc::clone(blocks) as Arc<dyn StoredMetadataBlockCache>),
+    )
+}
+
+fn stored_key(
+    descriptor: &MetadataFileRef,
+    kind: StoredMetadataBlockKind,
+    offset: u64,
+) -> StoredMetadataBlockKey {
+    StoredMetadataBlockKey {
+        payload_checksum: descriptor.payload_checksum.clone(),
+        kind,
+        offset,
+    }
+}
+
+/// Fills `blocks` the way one cold read fills it, and returns the index that
+/// read decoded.
+async fn warm_local_block_cache(
+    store: &CountingStore<LocalFsStore>,
+    descriptor: &MetadataFileRef,
+    blocks: &Arc<RecordingStoredMetadataBlockCache>,
+) -> Arc<Vec<SegmentIndexEntry>> {
+    let cache = table_cache_over(blocks);
+    let memo = load::SessionBlockMemo::default();
+    load::load_segment_filter(store, Some(&cache), &memo, descriptor)
+        .await
+        .expect("warm the filter");
+    block_fetch::load_segment_index(store, Some(&cache), &memo, descriptor)
+        .await
+        .expect("warm the index")
+}
+
+/// A cold local cache is probed, answers nothing, and is then offered every
+/// section the one fetch produced: the filter that was asked for, the index
+/// beside it, and the data blocks a small segment brings along.
+#[tokio::test]
+async fn a_cold_local_block_cache_takes_every_section_one_fetch_produced() {
+    let (_temp_dir, store, descriptor) = checkpointed_direntry_segment().await;
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let cache = table_cache_over(&blocks);
+    let memo = load::SessionBlockMemo::default();
+
+    store.reset();
+    load::load_segment_filter(&store, Some(&cache), &memo, &descriptor)
+        .await
+        .expect("load filter");
+
+    assert_eq!(
+        blocks.calls().first(),
+        Some(&RecordedStoredMetadataBlockCall::Get {
+            key: stored_key(
+                &descriptor,
+                StoredMetadataBlockKind::Filter,
+                descriptor.filter_block.offset
+            ),
+            hit: false,
+        }),
+        "a filter load probes the local cache before it asks the store"
+    );
+    assert_eq!(
+        store.count(OperationClass::Read),
+        1,
+        "a cold filter load pays exactly one fetch"
+    );
+
+    // That fetch published the index into the view memo, so asking for it
+    // costs nothing and tells this test which data blocks the segment holds.
+    let index = block_fetch::load_segment_index(&store, Some(&cache), &memo, &descriptor)
+        .await
+        .expect("load index");
+    assert_eq!(store.count(OperationClass::Read), 1);
+    assert!(!index.is_empty(), "a segment holds at least one data block");
+
+    let offered: Vec<_> = blocks
+        .calls()
+        .into_iter()
+        .filter_map(|call| match call {
+            RecordedStoredMetadataBlockCall::Insert { key, .. } => Some(key),
+            RecordedStoredMetadataBlockCall::Get { .. }
+            | RecordedStoredMetadataBlockCall::Invalidate { .. } => None,
+        })
+        .collect();
+    let mut expected = vec![
+        stored_key(
+            &descriptor,
+            StoredMetadataBlockKind::Index,
+            descriptor.index_block.offset,
+        ),
+        stored_key(
+            &descriptor,
+            StoredMetadataBlockKind::Filter,
+            descriptor.filter_block.offset,
+        ),
+    ];
+    expected.extend(index.iter().map(|entry| {
+        stored_key(
+            &descriptor,
+            StoredMetadataBlockKind::Data,
+            entry.block.offset,
+        )
+    }));
+    for key in expected {
+        assert!(
+            offered.contains(&key),
+            "the fetch did not offer {key:?} to the local cache"
+        );
+    }
+}
+
+/// A warm local cache answers both sections with no segment bytes read: the
+/// decoded cache and the view memo are fresh, as a restarted process's are,
+/// so only the local tier can be answering.
+#[tokio::test]
+async fn a_warm_local_block_cache_answers_index_and_filter_without_the_store() {
+    let (_temp_dir, store, descriptor) = checkpointed_direntry_segment().await;
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let cold_index = warm_local_block_cache(&store, &descriptor, &blocks).await;
+
+    let cache = table_cache_over(&blocks);
+    let memo = load::SessionBlockMemo::default();
+    store.reset();
+    let warm_index = block_fetch::load_segment_index(&store, Some(&cache), &memo, &descriptor)
+        .await
+        .expect("index from the local cache");
+    load::load_segment_filter(&store, Some(&cache), &memo, &descriptor)
+        .await
+        .expect("filter from the local cache");
+
+    assert_eq!(warm_index, cold_index);
+    assert_eq!(
+        store.count(OperationClass::Read),
+        0,
+        "a warm index and filter should read no segment bytes"
+    );
+    for (kind, offset) in [
+        (
+            StoredMetadataBlockKind::Index,
+            descriptor.index_block.offset,
+        ),
+        (
+            StoredMetadataBlockKind::Filter,
+            descriptor.filter_block.offset,
+        ),
+    ] {
+        assert!(
+            blocks
+                .calls()
+                .contains(&RecordedStoredMetadataBlockCall::Get {
+                    key: stored_key(&descriptor, kind, offset),
+                    hit: true,
+                }),
+            "the {kind:?} section should have been served by the local cache"
+        );
+    }
+}
+
+/// A local entry that no longer decodes is dropped and refetched exactly
+/// once. What it held was a copy; object storage still holds the authority,
+/// so the read succeeds rather than reporting a corrupt segment.
+#[tokio::test]
+async fn a_local_block_cache_entry_that_does_not_decode_is_dropped_and_refetched() {
+    let (_temp_dir, store, descriptor) = checkpointed_direntry_segment().await;
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let cold_index = warm_local_block_cache(&store, &descriptor, &blocks).await;
+    let index_key = stored_key(
+        &descriptor,
+        StoredMetadataBlockKind::Index,
+        descriptor.index_block.offset,
+    );
+    blocks.corrupt(&index_key);
+
+    let cache = table_cache_over(&blocks);
+    let memo = load::SessionBlockMemo::default();
+    store.reset();
+    let repaired = block_fetch::load_segment_index(&store, Some(&cache), &memo, &descriptor)
+        .await
+        .expect("a local entry that does not decode must not fail the read");
+
+    assert_eq!(repaired, cold_index);
+    assert_eq!(
+        store.count(OperationClass::Read),
+        1,
+        "the bad entry costs one refetch and no retry loop"
+    );
+    assert_eq!(
+        blocks
+            .calls()
+            .iter()
+            .filter(|call| **call
+                == RecordedStoredMetadataBlockCall::Invalidate {
+                    key: index_key.clone()
+                })
+            .count(),
+        1,
+        "the entry that did not decode should have been dropped once"
+    );
+}
+
+/// A closed cache is a miss, and a miss is only ever a fetch.
+#[tokio::test]
+async fn a_closed_local_block_cache_reads_as_a_miss() {
+    let (_temp_dir, store, descriptor) = checkpointed_direntry_segment().await;
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let cold_index = warm_local_block_cache(&store, &descriptor, &blocks).await;
+    blocks.close().await.expect("close the local cache");
+    let calls_before = blocks.call_count();
+
+    let cache = table_cache_over(&blocks);
+    let memo = load::SessionBlockMemo::default();
+    store.reset();
+    let index = block_fetch::load_segment_index(&store, Some(&cache), &memo, &descriptor)
+        .await
+        .expect("a closed local cache must not fail the read");
+
+    assert_eq!(index, cold_index);
+    assert_eq!(store.count(OperationClass::Read), 1);
+    assert_eq!(
+        blocks.call_count(),
+        calls_before,
+        "a closed cache neither serves nor records"
+    );
+}
+
 #[tokio::test]
 async fn checkpoint_l0_update_does_not_read_existing_metadata_ssts() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -32,8 +32,11 @@ use super::runs::{
     MetadataRunManifest, CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
     CHECKPOINT_TABLE_FAMILIES, DEFAULT_MAX_CHECKPOINT_L0_RUNS,
 };
+use super::stored_block_cache::{
+    StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind,
+};
 use super::{
-    create, flush, load, record, reorganize, reorganize_metadata_step, row, scan,
+    block_fetch, create, flush, load, record, reorganize, reorganize_metadata_step, row, scan,
     MetadataReorganizeOutcome,
 };
 use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
@@ -52,6 +55,7 @@ use crate::publish::{
     CommitCandidate, CommitRequest, FilesystemOperation, NamespaceCommitEngine, PublishTailOptions,
 };
 use crate::storage::content::{prepare_stored_content, store_bytes_as_content};
+use crate::test_support::{RecordedStoredMetadataBlockCall, RecordingStoredMetadataBlockCache};
 use crate::MutationContext;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -62,7 +66,9 @@ use loonfs_api::wire::manifest::{
     MetadataRow, MetadataTableFamily as ApiMetadataTableFamily, NamespaceManifestEnvelope,
     NamespaceManifestPayload,
 };
-use loonfs_api::wire::sst_blocks::{string_prefix_upper_bound, SegmentBlocksBuilder};
+use loonfs_api::wire::sst_blocks::{
+    string_prefix_upper_bound, SegmentBlocksBuilder, SegmentIndexEntry,
+};
 use loonfs_api::{
     AbsolutePath, ChangeSeq, CheckpointId, CommitId, DestinationBehavior, EffectiveLimit, InodeId,
     ManifestId, ManifestObjectId, NameKey, NamespaceId, RevisionNo,

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -108,10 +108,11 @@ pub mod metadata;
 pub mod path;
 /// Test doubles for this crate's public seams, behind the `test-support`
 /// feature. Consumed by the test targets of crates that implement or install
-/// those seams; no production build enables the feature. Doubles live here
-/// rather than in `loonfs-test-support` because that crate is a development
-/// dependency of this one and so cannot depend on these types.
-#[cfg(feature = "test-support")]
+/// those seams, and by this crate's own tests; no production build enables
+/// the feature. Doubles live here rather than in `loonfs-test-support`
+/// because that crate is a development dependency of this one and so cannot
+/// depend on these types.
+#[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 /// The wall-clock boundary durable timestamps are stamped at. Consumed by
 /// `loonfs`, whose mutation contexts and maintenance clock stamp from the

--- a/crates/loonfs-core/src/test_support.rs
+++ b/crates/loonfs-core/src/test_support.rs
@@ -83,6 +83,19 @@ impl RecordingStoredMetadataBlockCache {
         self.state().closed
     }
 
+    /// Replaces what is held for `key` with the same number of bytes that no
+    /// longer checksum, the way a lost write or a bad sector leaves an
+    /// entry. Does nothing for a key the cache is not holding.
+    ///
+    /// The replacement is not recorded: it is the test arranging the world,
+    /// not a call the code under test made.
+    pub fn corrupt(&self, key: &StoredMetadataBlockKey) {
+        let mut state = self.state();
+        if let Some(held) = state.entries.get_mut(key) {
+            *held = held.iter().map(|byte| !byte).collect::<Vec<_>>().into();
+        }
+    }
+
     fn state(&self) -> std::sync::MutexGuard<'_, RecordingState> {
         // Poisoning is propagated as a panic: a poisoned lock means a test
         // thread panicked mid-update, and the recording is no longer a

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -7,9 +7,56 @@ use loonfs_server::{
     app, serve_with_shutdown, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServeError,
     ServerConfig, StoreConfig, TlsServerConfig,
 };
+use loonfs_test_support::http::raw_agent;
+use std::collections::BTreeMap;
+use std::io::Read as _;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
+
+/// The exposition lines of one scrape, keyed by everything left of the
+/// value. Comment lines are dropped; a value that does not parse as a number
+/// is a rendering bug and fails here.
+pub(crate) fn scrape(server_url: &str, token: Option<&str>) -> Result<BTreeMap<String, f64>, u16> {
+    let request = raw_agent().get(&format!("{server_url}/metrics"));
+    let request = match token {
+        Some(token) => request.set("authorization", &format!("Bearer {token}")),
+        None => request,
+    };
+    let response = match request.call() {
+        Ok(response) => response,
+        Err(ureq::Error::Status(status, _)) => return Err(status),
+        Err(error) => unreachable!("metrics scrape failed: {error}"),
+    };
+    assert_eq!(
+        response.header("content-type"),
+        Some("text/plain; version=0.0.4")
+    );
+    let mut body = String::new();
+    response
+        .into_reader()
+        .read_to_string(&mut body)
+        .expect("read scrape body");
+    Ok(body
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.is_empty())
+        .map(|line| {
+            let (series, value) = line
+                .rsplit_once(' ')
+                .unwrap_or_else(|| unreachable!("exposition line without a value: {line}"));
+            let value: f64 = value
+                .parse()
+                .unwrap_or_else(|_| unreachable!("unparsable value in `{line}`"));
+            (series.to_owned(), value)
+        })
+        .collect())
+}
+
+pub(crate) fn series(scrape: &BTreeMap<String, f64>, name: &str) -> f64 {
+    *scrape
+        .get(name)
+        .unwrap_or_else(|| unreachable!("no series `{name}` in the scrape"))
+}
 
 pub(crate) struct TestServer {
     pub(crate) client: Client,
@@ -124,6 +171,68 @@ pub(crate) async fn start_tls_server(mut config: ServerConfig) -> TlsTestServer 
         shutdown,
         server,
         _identity_dir: identity_dir,
+    }
+}
+
+/// A plaintext server started and stopped through the deployed entry point.
+///
+/// Unlike [`start_server`], which aborts its task, this shuts down the way a
+/// host does: the listener drains, the writer settles, and the local block
+/// cache is closed and released. That is what lets a test stop one server
+/// and start another on the same directories.
+pub(crate) struct GracefulTestServer {
+    pub(crate) client: Client,
+    pub(crate) server_url: String,
+    shutdown: tokio::sync::oneshot::Sender<()>,
+    server: tokio::task::JoinHandle<Result<(), ServeError>>,
+}
+
+pub(crate) async fn start_graceful_server(mut config: ServerConfig) -> GracefulTestServer {
+    let addr = reserve_loopback_addr().await;
+    config.bind = addr.to_string();
+    let auth_token = config
+        .auth_token
+        .as_ref()
+        .map(|token| token.expose().to_owned());
+
+    let (shutdown, shutdown_signal) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(serve_with_shutdown(config, async move {
+        let _ = shutdown_signal.await;
+    }));
+    wait_until_listening(addr).await;
+
+    let server_url = format!("http://{addr}");
+    GracefulTestServer {
+        client: Client::new(ClientConfig {
+            server_url: server_url.clone(),
+            auth_token,
+            request_timeout_ms: None,
+            disable_transient_retry: false,
+            ca_cert_path: None,
+        })
+        .expect("valid client config"),
+        server_url,
+        shutdown,
+        server,
+    }
+}
+
+impl GracefulTestServer {
+    /// Stops the server and reports what settling found. The client goes
+    /// first so its idle connections do not hold the listener open.
+    pub(crate) async fn shut_down(self) {
+        let Self {
+            client,
+            shutdown,
+            server,
+            ..
+        } = self;
+        drop(client);
+        shutdown.send(()).expect("signal shutdown");
+        server
+            .await
+            .expect("server task")
+            .expect("graceful shutdown settles");
     }
 }
 

--- a/crates/loonfs-server/tests/it/http_metrics.rs
+++ b/crates/loonfs-server/tests/it/http_metrics.rs
@@ -1,57 +1,12 @@
 //! What a scrape of a running server actually returns.
 
 use crate::common::http_split_support::*;
-use crate::common::start_server;
+use crate::common::{scrape, series, start_server};
 use loonfs_client::NamespacePath;
 use loonfs_test_support::http::raw_agent;
 use loonfs_test_support::ids::namespace_id;
 use std::collections::BTreeMap;
-use std::io::Read as _;
 use tempfile::tempdir;
-
-/// The exposition lines of one scrape, keyed by everything left of the
-/// value. Comment lines are dropped; a value that does not parse as a number
-/// is a rendering bug and fails here.
-fn scrape(server_url: &str, token: Option<&str>) -> Result<BTreeMap<String, f64>, u16> {
-    let request = raw_agent().get(&format!("{server_url}/metrics"));
-    let request = match token {
-        Some(token) => request.set("authorization", &format!("Bearer {token}")),
-        None => request,
-    };
-    let response = match request.call() {
-        Ok(response) => response,
-        Err(ureq::Error::Status(status, _)) => return Err(status),
-        Err(error) => unreachable!("metrics scrape failed: {error}"),
-    };
-    assert_eq!(
-        response.header("content-type"),
-        Some("text/plain; version=0.0.4")
-    );
-    let mut body = String::new();
-    response
-        .into_reader()
-        .read_to_string(&mut body)
-        .expect("read scrape body");
-    Ok(body
-        .lines()
-        .filter(|line| !line.starts_with('#') && !line.is_empty())
-        .map(|line| {
-            let (series, value) = line
-                .rsplit_once(' ')
-                .unwrap_or_else(|| unreachable!("exposition line without a value: {line}"));
-            let value: f64 = value
-                .parse()
-                .unwrap_or_else(|_| unreachable!("unparsable value in `{line}`"));
-            (series.to_owned(), value)
-        })
-        .collect())
-}
-
-fn series(scrape: &BTreeMap<String, f64>, name: &str) -> f64 {
-    *scrape
-        .get(name)
-        .unwrap_or_else(|| unreachable!("no series `{name}` in the scrape"))
-}
 
 /// Object-store calls of every operation and outcome, summed.
 fn object_store_calls(scrape: &BTreeMap<String, f64>) -> f64 {

--- a/crates/loonfs-server/tests/it/local_cache.rs
+++ b/crates/loonfs-server/tests/it/local_cache.rs
@@ -1,0 +1,139 @@
+//! What the node-local block cache carries from one server to the next.
+
+use crate::common::http_split_support::*;
+use crate::common::{scrape, series, start_graceful_server};
+use loonfs_api::CreateCheckpointRequest;
+use loonfs_client::NamespacePath;
+use loonfs_server::{LocalCacheConfig, MaintenanceMode, ServerConfig};
+use loonfs_test_support::ids::namespace_id;
+use std::path::Path;
+use tempfile::tempdir;
+
+/// The `loonfs.local_cache.gets` series for one block kind and outcome.
+fn gets(kind: &str, result: &str) -> String {
+    format!("loonfs_local_cache_gets_total{{kind=\"{kind}\",result=\"{result}\"}}")
+}
+
+/// A server holding its cache in `cache_root` and its objects in
+/// `store_root`.
+///
+/// Maintenance is manual so the two servers read the same manifest: an
+/// automatic flush between them would publish segments the first server
+/// never saw, and a miss on those would say nothing about the cache.
+fn test_config_with_local_cache(
+    store_root: &Path,
+    cache_root: &Path,
+    writer_id: &str,
+) -> ServerConfig {
+    ServerConfig {
+        maintenance: MaintenanceMode::Manual,
+        local_cache: Some(LocalCacheConfig {
+            path: cache_root.display().to_string(),
+            memory_bytes: 4 * 1024 * 1024,
+            disk_bytes: 128 * 1024 * 1024,
+        }),
+        ..test_config(store_root.to_path_buf(), writer_id, "local-cache")
+    }
+}
+
+/// A restarted server reads its metadata index sections out of the local
+/// cache instead of the store.
+///
+/// The second server starts with empty in-memory caches, so the only thing
+/// carried over is the cache directory the first one closed. Every index
+/// lookup it makes is one the first server made and filled, so a single miss
+/// would mean a section did not survive the restart.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_restarted_server_reads_index_sections_from_its_local_cache() {
+    let store_dir = tempdir().expect("store tempdir");
+    let cache_dir = tempdir().expect("cache tempdir");
+    let namespace = namespace_id("warm");
+    let listing = NamespacePath::parse("warm", "/docs").expect("parse path");
+
+    let first = start_graceful_server(test_config_with_local_cache(
+        &store_dir.path().join("store"),
+        cache_dir.path(),
+        "local-cache-first",
+    ))
+    .await;
+    first
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    for index in 0..4 {
+        let path = format!("/docs/file-{index}.txt");
+        let target = NamespacePath::parse("warm", &path).expect("parse path");
+        first
+            .client
+            .put_file_bytes(&target, b"file", &replace_file_options())
+            .await
+            .expect("put file");
+    }
+    first
+        .client
+        .create_checkpoint(
+            &namespace,
+            &CreateCheckpointRequest {
+                name: "warm".to_owned(),
+                ttl_ms: None,
+            },
+        )
+        .await
+        .expect("create checkpoint");
+    // One write after the checkpoint moves the head, so reads resolve
+    // against the published manifest and touch its segments.
+    let extra = NamespacePath::parse("warm", "/docs/after.txt").expect("parse path");
+    first
+        .client
+        .put_file_bytes(&extra, b"after", &replace_file_options())
+        .await
+        .expect("put file after the checkpoint");
+
+    let warmed = first
+        .client
+        .list_path_entries_all(&listing)
+        .await
+        .expect("warm the cache");
+    assert_eq!(warmed.entries.len(), 5);
+    let filled = scrape(&first.server_url, Some("test-token")).expect("scrape the first server");
+    assert!(
+        series(&filled, &gets("index", "miss")) >= 1.0,
+        "a cold server misses on the sections it then fills"
+    );
+    assert!(series(&filled, "loonfs_local_cache_inserts_total{kind=\"index\"}") >= 1.0);
+    first.shut_down().await;
+
+    let second = start_graceful_server(test_config_with_local_cache(
+        &store_dir.path().join("store"),
+        cache_dir.path(),
+        "local-cache-second",
+    ))
+    .await;
+    let served = second
+        .client
+        .list_path_entries_all(&listing)
+        .await
+        .expect("list from the restarted server");
+    assert_eq!(served.entries, warmed.entries);
+
+    let restarted = scrape(&second.server_url, Some("test-token")).expect("scrape the second");
+    assert!(
+        series(&restarted, &gets("index", "hit")) >= 1.0,
+        "the restarted server should read index sections from the cache"
+    );
+    assert_eq!(
+        series(&restarted, &gets("index", "miss")),
+        0.0,
+        "every index section the restarted server wanted should have survived"
+    );
+    assert_eq!(
+        series(
+            &restarted,
+            "loonfs_local_cache_inserts_total{kind=\"index\"}"
+        ),
+        0.0,
+        "a section served from the cache is not fetched, so it is not reinserted"
+    );
+    second.shut_down().await;
+}

--- a/crates/loonfs-server/tests/it/main.rs
+++ b/crates/loonfs-server/tests/it/main.rs
@@ -16,6 +16,7 @@ mod http_retry;
 mod http_smoke;
 mod http_tls;
 mod http_uploads;
+mod local_cache;
 
 // The OpenAPI document only exists behind the feature that generates it.
 #[cfg(feature = "openapi")]

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -6,9 +6,11 @@
 use crate::common::*;
 use loonfs::{
     ChangeSeq, CreateDirectoryOptions, CreateNamespaceOptions, ErrorCode, InodeId, InodeKind,
-    NamespaceId, PutFileOptions, RuntimeCacheConfig, SharedObjectStore,
+    NamespaceId, PutFileOptions, RuntimeCacheConfig, SharedObjectStore, StoredMetadataBlockKind,
 };
-use loonfs_core::test_support::RecordingStoredMetadataBlockCache;
+use loonfs_core::test_support::{
+    RecordedStoredMetadataBlockCall, RecordingStoredMetadataBlockCache,
+};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
@@ -659,21 +661,20 @@ fn separate_runtime_instances_share_object_store_state() {
     assert_eq!(file.bytes, b"shared");
 }
 
-/// The stored-block cache is a seam and nothing more until a later change
-/// wires the fetch path into it: a runtime built with one installed reads
-/// and writes exactly as it did without one, and never calls it. The
-/// decoded-cache assertion keeps this honest — it fails if the cycle stops
-/// exercising the metadata table path this tier sits under.
+/// A runtime built with a stored-block cache fills it from the reads that go
+/// through it, and a second runtime on the same store — whose decoded caches
+/// are empty, as a restarted process's are — reads a segment section back
+/// out of it. The decoded-cache assertion keeps this honest: it fails if the
+/// cycle stops exercising the metadata table path this tier sits under.
 #[test]
-fn an_installed_stored_block_cache_is_never_called() {
+fn an_installed_stored_block_cache_is_filled_and_then_serves_a_later_runtime() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     let stored_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
-    let fs = open_runtime_with(
-        store(temp_dir.path()),
-        "stored-block-seam-test",
-        |builder| builder.stored_metadata_block_cache(stored_blocks.clone()),
-    );
+    let shared_store = store(temp_dir.path());
+    let fs = open_runtime_with(shared_store.clone(), "stored-block-writer", |builder| {
+        builder.stored_metadata_block_cache(stored_blocks.clone())
+    });
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
@@ -709,10 +710,39 @@ fn an_installed_stored_block_cache_is_never_called() {
         fs.runtime_cache_stats().metadata_table_cache_inserts > 0,
         "the cycle must reach the decoded block cache for this to prove anything"
     );
-    assert_eq!(
-        stored_blocks.calls(),
-        Vec::new(),
-        "nothing consults the stored-block cache yet"
+    let offered: Vec<StoredMetadataBlockKind> = stored_blocks
+        .calls()
+        .into_iter()
+        .filter_map(|call| match call {
+            RecordedStoredMetadataBlockCall::Insert { key, .. } => Some(key.kind),
+            RecordedStoredMetadataBlockCall::Get { .. }
+            | RecordedStoredMetadataBlockCall::Invalidate { .. } => None,
+        })
+        .collect();
+    for kind in [
+        StoredMetadataBlockKind::Index,
+        StoredMetadataBlockKind::Filter,
+        StoredMetadataBlockKind::Data,
+    ] {
+        assert!(
+            offered.contains(&kind),
+            "the fetched segment's {kind:?} section was not offered to the cache"
+        );
+    }
+
+    let calls_before = stored_blocks.call_count();
+    let reader = open_runtime_with(shared_store, "stored-block-reader", |builder| {
+        builder.stored_metadata_block_cache(stored_blocks.clone())
+    });
+    let entries = reader
+        .list_path_blocking(&namespace_id, "/docs")
+        .expect("list docs from a second runtime");
+    assert_eq!(entries.len(), 2);
+    assert!(
+        stored_blocks.calls()[calls_before..]
+            .iter()
+            .any(|call| matches!(call, RecordedStoredMetadataBlockCall::Get { hit: true, .. })),
+        "the second runtime should have been served a section by the cache"
     );
     assert!(
         !stored_blocks.is_closed(),


### PR DESCRIPTION
Index and filter reads now consult the local block cache between the RAM cache and object storage. A hit is decoded and validated exactly like store bytes; a corrupt entry is dropped and fetched once from the store; cache errors read as misses. Every section a fetch produces (index, filter, and each data block on whole-segment loads) is inserted under its own key.

**DEtails:**

- Small segments see no GET reduction yet: cold loads fetch the whole object either way, and a warm read still pays one data-block GET until the next PR routes data blocks. Large segments stop refetching filter and index.
- Filters under 1 KiB are inlined in the manifest and never reach this tier, so the precise probe tests live in core, where the inline copy can be stripped.
- The warm-restart test asserts through cache counters (index hits at least 1, misses 0, inserts 0) because the store-op metric does not separate section GETs.
- Reorganization reads stay cold (no table cache yet).
