### PR TITLE
feat(cache): data blocks and wide reads use the local block cache

### DIFF
--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -1,10 +1,11 @@
 //! Fetching, decoding, and cache publication for SST index and filter blocks.
 //!
 //! A load consults three places in order: the per-view memo, the decoded
-//! block cache, and — for the two sections named here — the node-local cache
-//! of the same blocks in their stored form. Only when all three come up
-//! empty does object storage answer, and what that one GET produced is
-//! offered back to the local tier section by section.
+//! block cache, and the node-local cache of the same blocks in their stored
+//! form. Only when all three come up empty does object storage answer, and
+//! what that one GET produced is offered back to the local tier section by
+//! section. The data-block loads in [`super::data_block_load`] reach the
+//! local tier through the same two helpers.
 
 use super::block_load::SessionBlockMemo;
 use super::cache::{
@@ -72,7 +73,7 @@ fn stored_block_cache(
 /// the authority — so the entry is dropped and the caller falls through to
 /// one ordinary fetch, which reports corruption if the store's bytes fail
 /// too. Nothing retries the local tier.
-async fn stored_block_section<T>(
+pub(super) async fn stored_block_section<T>(
     table_cache: Option<&MetadataTableCache>,
     descriptor: &MetadataFileRef,
     kind: StoredMetadataBlockKind,
@@ -112,7 +113,7 @@ async fn stored_block_section<T>(
 /// read of any one of them needs no GET. The bytes are copied rather than
 /// sliced out of the fetch buffer: a slice would keep the whole fetched span
 /// alive for as long as the cache held any one section of it.
-fn offer_stored_block(
+pub(super) fn offer_stored_block(
     table_cache: Option<&MetadataTableCache>,
     descriptor: &MetadataFileRef,
     kind: StoredMetadataBlockKind,

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -1,9 +1,18 @@
 //! Fetching, decoding, coalescing, and cache publication for SST data blocks.
+//!
+//! Both loads below consult the same three places [`super::block_fetch`]
+//! describes — the per-view memo, the decoded block cache, and the
+//! node-local cache of stored bytes — before object storage answers, and
+//! offer every block a fetch produced back to the local tier.
 
-use super::block_fetch::{load_section_bytes, segment_block_cache_key, segment_codec_error};
+use super::block_fetch::{
+    load_section_bytes, offer_stored_block, publish_segment_block, segment_block_cache_key,
+    segment_codec_error, stored_block_section,
+};
 use super::block_load::SessionBlockMemo;
 use super::cache::{DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache};
 use super::error::ManifestLoadError;
+use super::stored_block_cache::StoredMetadataBlockKind;
 use crate::metadata::content_ref_evidence_bytes;
 use loonfs_api::wire::manifest::{
     ActiveDeletionRowAction, MetadataFileRef, MetadataRow, MetadataTableFamily,
@@ -16,7 +25,7 @@ use std::sync::Arc;
 /// spans split into consecutive requests.
 const MAX_BULK_LOAD_BYTES: u64 = 4 * 1024 * 1024;
 
-async fn load_segment_data_block<S: ObjectStore + ?Sized>(
+pub(super) async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
@@ -31,6 +40,19 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
         return Ok(block);
     }
     let fetch = || async {
+        // Between the decoded cache above and the store below: a local copy
+        // of the same stored bytes.
+        if let Some(decoded) = stored_block_section(
+            table_cache,
+            descriptor,
+            StoredMetadataBlockKind::Data,
+            &handle,
+            decode_data_block,
+        )
+        .await
+        {
+            return Ok(decoded_data_cache_block(family, decoded));
+        }
         let bytes = load_section_bytes(
             store,
             &descriptor.object_key,
@@ -38,6 +60,13 @@ async fn load_segment_data_block<S: ObjectStore + ?Sized>(
             handle.stored_len as u64,
         )
         .await?;
+        offer_stored_block(
+            table_cache,
+            descriptor,
+            StoredMetadataBlockKind::Data,
+            &handle,
+            &bytes,
+        );
         Ok(decoded_data_cache_block(
             family,
             decode_data_block(&bytes, &handle)
@@ -70,11 +99,12 @@ pub(super) fn decoded_data_cache_block(
     }
 }
 
-/// Bulk path for wide selections: consult the cache per block, group the
-/// misses into consecutive spans, and fetch each span with coalesced ranged
-/// GETs instead of one request per block. Duplicate concurrent span fetches
-/// are possible and benign; the narrow path keeps single-flight for the hot
-/// point lookups.
+/// Bulk path for wide selections: resolve each block against the caches in
+/// turn, group the blocks none of them answered into consecutive spans, and
+/// fetch each span with coalesced ranged GETs instead of one request per
+/// block. Duplicate concurrent span fetches are possible and benign — two
+/// fetches of one block offer the same bytes under the same key; the narrow
+/// path keeps single-flight for the hot point lookups.
 pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -88,7 +118,8 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
     // clone the segment checksum once per block on every warm scan.
     let mut probe_key = segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, 0);
     for (position, entry) in entries.iter().enumerate() {
-        probe_key.block_offset = entry.block.offset;
+        let handle = entry.block;
+        probe_key.block_offset = handle.offset;
         if let Some(DecodedMetadataTableBlock::Data { block, .. }) = memo.get(&probe_key) {
             blocks[position] = Some(block);
             continue;
@@ -96,7 +127,33 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
         if let Some(cache) = table_cache {
             if let Some(DecodedMetadataTableBlock::Data { block, .. }) = cache.get(&probe_key) {
                 blocks[position] = Some(block);
+                continue;
             }
+        }
+        // The local stored-block cache, one tier below the two above. A hit
+        // is decoded and published exactly as a fetched block is; a miss —
+        // including an entry that did not decode, which drops itself — is a
+        // true miss the span grouping below covers.
+        if let Some(decoded) = stored_block_section(
+            table_cache,
+            descriptor,
+            StoredMetadataBlockKind::Data,
+            &handle,
+            decode_data_block,
+        )
+        .await
+        {
+            let block = Arc::new(decoded);
+            publish_segment_block(
+                table_cache,
+                memo,
+                probe_key.clone(),
+                &DecodedMetadataTableBlock::Data {
+                    decoded_byte_len: decoded_manifest_block_weight(family, &block.rows),
+                    block: Arc::clone(&block),
+                },
+            );
+            blocks[position] = Some(block);
         }
     }
 
@@ -170,8 +227,9 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
 
 /// Fetches one contiguous span with a single ranged GET, decodes every
 /// block, and publishes them to the per-view memo and (when populating) the
-/// shared cache. Returns the first block's cache entry for the
-/// single-flight cell.
+/// shared cache. Every block the GET covered is also offered to the local
+/// stored-block cache under its own key. Returns the first block's cache
+/// entry for the single-flight cell.
 async fn load_and_publish_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -189,6 +247,15 @@ async fn load_and_publish_span<S: ObjectStore + ?Sized>(
         let handle = entry.block;
         let begin = (handle.offset - first.offset) as usize;
         let stored = &bytes[begin..begin + handle.stored_len as usize];
+        // Every block the span GET produced is offered under its own key, so
+        // a later read of any one of them needs no fetch.
+        offer_stored_block(
+            table_cache,
+            descriptor,
+            StoredMetadataBlockKind::Data,
+            &handle,
+            stored,
+        );
         let decoded = Arc::new(
             decode_data_block(stored, &handle)
                 .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -1055,6 +1055,446 @@ async fn a_closed_local_block_cache_reads_as_a_miss() {
     );
 }
 
+/// One checkpointed direntry segment rebuilt with a one-byte block target,
+/// so every row lands in its own data block. A handful of test rows would
+/// otherwise fit in one block, and the coalescing span path only says
+/// anything with several. Returns the segment's index, read with no caches,
+/// so a test can drive the span path without an index load filling either
+/// cache first.
+async fn multi_block_direntry_segment() -> (
+    tempfile::TempDir,
+    CountingStore<LocalFsStore>,
+    MetadataFileRef,
+    Arc<Vec<SegmentIndexEntry>>,
+) {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = CountingStore::metadata_tables(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..12 {
+        let path = format!("/docs/file-{index:02}.txt");
+        write_file_bytes(&store, &namespace_id, &path, b"file\n", &context, None)
+            .await
+            .expect("write file");
+    }
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("create checkpoint");
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let tables = load_verified_manifest_tables(&store, &namespace_id, &manifest_object_id)
+        .await
+        .expect("load tables");
+    let mut descriptor = tables
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .find(|descriptor| descriptor.family == ApiMetadataTableFamily::DirentryBinds)
+        .expect("a direntry segment")
+        .clone();
+    descriptor.filter_inline = None;
+
+    let rows = segment_rows(&store, &descriptor).await;
+    let mut builder = SegmentBlocksBuilder::new(NonZeroUsize::MIN);
+    for row in &rows {
+        builder
+            .push(
+                &row.row_key_for_family(descriptor.family),
+                &row.filter_key_for_family(descriptor.family),
+                row,
+            )
+            .expect("rebuilt rows should encode");
+    }
+    let built = builder.finish().expect("rebuilt segment");
+    store
+        .put_overwrite(&descriptor.object_key, Bytes::from(built.bytes.clone()))
+        .await
+        .expect("overwrite segment");
+    descriptor.row_count = built.row_count;
+    descriptor.min_key = built.min_key;
+    descriptor.max_key = built.max_key;
+    descriptor.index_block = built.index;
+    descriptor.filter_block = built.filter;
+    descriptor.payload_checksum = loonfs_api::sha256_digest(&built.bytes);
+
+    let index = block_fetch::load_segment_index(
+        &store,
+        None,
+        &load::SessionBlockMemo::default(),
+        &descriptor,
+    )
+    .await
+    .expect("rebuilt segment index");
+    assert!(
+        index.len() >= 9,
+        "the span tests need several data blocks, got {}",
+        index.len()
+    );
+    (temp_dir, store, descriptor, index)
+}
+
+/// Every row of one segment, in row-key order, read straight through with
+/// no caches of either kind.
+async fn segment_rows(
+    store: &CountingStore<LocalFsStore>,
+    descriptor: &MetadataFileRef,
+) -> Vec<MetadataRow> {
+    let memo = load::SessionBlockMemo::default();
+    let index = block_fetch::load_segment_index(store, None, &memo, descriptor)
+        .await
+        .expect("segment index");
+    data_block_load::load_segment_data_block_span(
+        store,
+        None,
+        &memo,
+        descriptor.family,
+        descriptor,
+        &index,
+    )
+    .await
+    .expect("segment data blocks")
+    .iter()
+    .flat_map(|block| block.rows.iter().cloned())
+    .collect()
+}
+
+/// One segment object's whole body, which the seeding helpers slice.
+async fn segment_object_bytes(
+    store: &CountingStore<LocalFsStore>,
+    descriptor: &MetadataFileRef,
+) -> Bytes {
+    store
+        .get(&descriptor.object_key, None)
+        .await
+        .expect("read segment object")
+        .expect("segment object present")
+}
+
+fn stored_block_bytes(object: &Bytes, handle: &BlockHandle) -> Bytes {
+    let start = handle.offset as usize;
+    object.slice(start..start + handle.stored_len as usize)
+}
+
+/// Puts the named blocks into the decoded cache, as an earlier read through
+/// this process would have left them.
+fn seed_decoded_blocks(
+    cache: &MetadataTableCache,
+    object: &Bytes,
+    descriptor: &MetadataFileRef,
+    index: &[SegmentIndexEntry],
+    positions: &[usize],
+) {
+    for position in positions {
+        let handle = index[*position].block;
+        let decoded = decode_data_block(&stored_block_bytes(object, &handle), &handle)
+            .expect("seeded block decodes");
+        cache.insert(
+            block_fetch::segment_block_cache_key(
+                descriptor,
+                MetadataTableBlockKind::Data,
+                handle.offset,
+            ),
+            data_block_load::decoded_data_cache_block(descriptor.family, decoded),
+        );
+    }
+}
+
+/// Puts the named blocks into the local stored-block cache, as an earlier
+/// process's reads would have left them.
+fn seed_local_blocks(
+    blocks: &RecordingStoredMetadataBlockCache,
+    object: &Bytes,
+    descriptor: &MetadataFileRef,
+    index: &[SegmentIndexEntry],
+    positions: &[usize],
+) {
+    for position in positions {
+        let handle = index[*position].block;
+        blocks.insert(
+            stored_key(descriptor, StoredMetadataBlockKind::Data, handle.offset),
+            stored_block_bytes(object, &handle),
+        );
+    }
+}
+
+/// The block offsets one recorded slice inserted, in ascending order. Spans
+/// are fetched concurrently, so the order they are offered in is not fixed.
+fn offered_offsets(calls: &[RecordedStoredMetadataBlockCall]) -> Vec<u64> {
+    let mut offsets: Vec<u64> = calls
+        .iter()
+        .filter_map(|call| match call {
+            RecordedStoredMetadataBlockCall::Insert { key, .. } => Some(key.offset),
+            RecordedStoredMetadataBlockCall::Get { .. }
+            | RecordedStoredMetadataBlockCall::Invalidate { .. } => None,
+        })
+        .collect();
+    offsets.sort_unstable();
+    offsets
+}
+
+fn block_offsets(index: &[SegmentIndexEntry], positions: &[usize]) -> Vec<u64> {
+    let mut offsets: Vec<u64> = positions
+        .iter()
+        .map(|position| index[*position].block.offset)
+        .collect();
+    offsets.sort_unstable();
+    offsets
+}
+
+/// One wide read over a whole segment through `cache`, with the per-view
+/// memo a fresh request would carry, and the segment fetches it paid.
+async fn wide_read(
+    store: &CountingStore<LocalFsStore>,
+    cache: Option<&MetadataTableCache>,
+    descriptor: &MetadataFileRef,
+    index: &[SegmentIndexEntry],
+) -> (Vec<Arc<DecodedDataBlock>>, usize) {
+    let memo = load::SessionBlockMemo::default();
+    store.reset();
+    let blocks = data_block_load::load_segment_data_block_span(
+        store,
+        cache,
+        &memo,
+        descriptor.family,
+        descriptor,
+        index,
+    )
+    .await
+    .expect("wide read");
+    (blocks, store.count(OperationClass::Read))
+}
+
+/// A narrow data-block load probes the local cache, misses, pays one fetch,
+/// and offers what it fetched. A second load whose decoded caches are fresh
+/// — a restarted process's shape — is answered without reading the store.
+#[tokio::test]
+async fn a_narrow_data_block_load_fills_the_local_cache_and_then_reads_from_it() {
+    let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let entry = &index[0];
+    let data_key = stored_key(
+        &descriptor,
+        StoredMetadataBlockKind::Data,
+        entry.block.offset,
+    );
+
+    let cold_cache = table_cache_over(&blocks);
+    store.reset();
+    let cold = data_block_load::load_segment_data_block(
+        &store,
+        Some(&cold_cache),
+        &load::SessionBlockMemo::default(),
+        descriptor.family,
+        &descriptor,
+        entry,
+    )
+    .await
+    .expect("cold data block load");
+
+    assert_eq!(
+        store.count(OperationClass::Read),
+        1,
+        "a cold data block costs exactly one fetch"
+    );
+    assert_eq!(
+        blocks.calls(),
+        vec![
+            RecordedStoredMetadataBlockCall::Get {
+                key: data_key.clone(),
+                hit: false,
+            },
+            RecordedStoredMetadataBlockCall::Insert {
+                key: data_key.clone(),
+                bytes: entry.block.stored_len as usize,
+            },
+        ],
+        "a cold load probes the local cache, misses, and offers what it fetched"
+    );
+
+    let warm_cache = table_cache_over(&blocks);
+    store.reset();
+    let warm = data_block_load::load_segment_data_block(
+        &store,
+        Some(&warm_cache),
+        &load::SessionBlockMemo::default(),
+        descriptor.family,
+        &descriptor,
+        entry,
+    )
+    .await
+    .expect("warm data block load");
+
+    assert_eq!(warm, cold);
+    assert_eq!(
+        store.count(OperationClass::Read),
+        0,
+        "a warm data block reads no segment bytes"
+    );
+    assert_eq!(
+        blocks.calls().last(),
+        Some(&RecordedStoredMetadataBlockCall::Get {
+            key: data_key,
+            hit: true,
+        }),
+        "the warm load was served by the local cache"
+    );
+}
+
+/// A wide read over a mixed segment: two blocks already decoded, two held
+/// locally in their stored form, the rest nowhere. Only the blocks nothing
+/// answered are fetched, in one ranged GET per run of consecutive ones, and
+/// exactly those blocks are offered back.
+#[tokio::test]
+async fn a_wide_read_fetches_and_offers_only_the_blocks_no_cache_answered() {
+    let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
+    let (expected, _) = wide_read(&store, None, &descriptor, &index).await;
+
+    // Positions 0 and 1 are decoded, 3 and 7 are held locally; the rest are
+    // nowhere. That leaves three runs of consecutive misses — {2}, {4, 5, 6},
+    // and {8..} — so three ranged GETs.
+    let decoded = [0usize, 1];
+    let local = [3usize, 7];
+    let missing: Vec<usize> = (0..index.len())
+        .filter(|position| !decoded.contains(position) && !local.contains(position))
+        .collect();
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let cache = table_cache_over(&blocks);
+    let object = segment_object_bytes(&store, &descriptor).await;
+    seed_decoded_blocks(&cache, &object, &descriptor, &index, &decoded);
+    seed_local_blocks(&blocks, &object, &descriptor, &index, &local);
+
+    let calls_before = blocks.call_count();
+    let (read, gets) = wide_read(&store, Some(&cache), &descriptor, &index).await;
+    let calls = blocks.calls();
+    let during = &calls[calls_before..];
+
+    assert_eq!(read, expected);
+    assert_eq!(
+        gets, 3,
+        "one ranged GET per run of consecutive blocks nothing answered"
+    );
+    assert_eq!(
+        offered_offsets(during),
+        block_offsets(&index, &missing),
+        "exactly the fetched blocks are offered to the local cache"
+    );
+    let probed: Vec<u64> = during
+        .iter()
+        .filter_map(|call| match call {
+            RecordedStoredMetadataBlockCall::Get { key, .. } => Some(key.offset),
+            RecordedStoredMetadataBlockCall::Insert { .. }
+            | RecordedStoredMetadataBlockCall::Invalidate { .. } => None,
+        })
+        .collect();
+    assert_eq!(
+        probed,
+        (0..index.len())
+            .filter(|position| !decoded.contains(position))
+            .map(|position| index[position].block.offset)
+            .collect::<Vec<_>>(),
+        "a decoded block short-circuits the probe; every other block is probed once, in order"
+    );
+}
+
+/// A cold local cache changes nothing about how a wide read groups its
+/// fetches: it is one more tier consulted per block, and the blocks nothing
+/// answered coalesce exactly as they do without it.
+#[tokio::test]
+async fn a_cold_local_block_cache_does_not_change_how_a_wide_read_groups_its_fetches() {
+    let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
+    let plain = MetadataTableCache::new(MetadataTableCacheConfig::default());
+    let (plain_read, plain_gets) = wide_read(&store, Some(&plain), &descriptor, &index).await;
+
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let cold = table_cache_over(&blocks);
+    let (cold_read, cold_gets) = wide_read(&store, Some(&cold), &descriptor, &index).await;
+
+    assert_eq!(cold_read, plain_read);
+    assert_eq!(plain_gets, 1, "a selection nothing answered is one span");
+    assert_eq!(cold_gets, plain_gets);
+    assert_eq!(
+        blocks
+            .calls()
+            .iter()
+            .filter(|call| matches!(
+                call,
+                RecordedStoredMetadataBlockCall::Get { hit: false, .. }
+            ))
+            .count(),
+        index.len(),
+        "the cold tier was consulted for every block"
+    );
+
+    // The same comparison where the grouping is not trivial: two decoded
+    // blocks split the selection into two spans on both sides.
+    let object = segment_object_bytes(&store, &descriptor).await;
+    let split_plain = MetadataTableCache::new(MetadataTableCacheConfig::default());
+    seed_decoded_blocks(&split_plain, &object, &descriptor, &index, &[0, 4]);
+    let (_, split_plain_gets) = wide_read(&store, Some(&split_plain), &descriptor, &index).await;
+    let split_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let split_cold = table_cache_over(&split_blocks);
+    seed_decoded_blocks(&split_cold, &object, &descriptor, &index, &[0, 4]);
+    let (_, split_cold_gets) = wide_read(&store, Some(&split_cold), &descriptor, &index).await;
+
+    assert_eq!(
+        split_plain_gets, 2,
+        "a decoded block in the middle splits the selection into two spans"
+    );
+    assert_eq!(split_cold_gets, split_plain_gets);
+}
+
+/// One local entry inside a span that no longer decodes is dropped, refetched
+/// with the span it falls in, and the read succeeds. What it held was a copy;
+/// object storage still holds the authority.
+#[tokio::test]
+async fn a_corrupt_local_entry_inside_a_span_is_dropped_and_refetched() {
+    let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
+    let (expected, _) = wide_read(&store, None, &descriptor, &index).await;
+
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let object = segment_object_bytes(&store, &descriptor).await;
+    let every_block: Vec<usize> = (0..index.len()).collect();
+    seed_local_blocks(&blocks, &object, &descriptor, &index, &every_block);
+    let corrupt = 5usize;
+    let corrupt_key = stored_key(
+        &descriptor,
+        StoredMetadataBlockKind::Data,
+        index[corrupt].block.offset,
+    );
+    blocks.corrupt(&corrupt_key);
+
+    let cache = table_cache_over(&blocks);
+    let calls_before = blocks.call_count();
+    let (read, gets) = wide_read(&store, Some(&cache), &descriptor, &index).await;
+    let calls = blocks.calls();
+    let during = &calls[calls_before..];
+
+    assert_eq!(read, expected);
+    assert_eq!(
+        gets, 1,
+        "the bad entry costs one span fetch and no retry loop"
+    );
+    assert_eq!(
+        during
+            .iter()
+            .filter(|call| **call
+                == RecordedStoredMetadataBlockCall::Invalidate {
+                    key: corrupt_key.clone()
+                })
+            .count(),
+        1,
+        "the entry that did not decode should have been dropped once"
+    );
+    assert_eq!(
+        offered_offsets(during),
+        block_offsets(&index, &[corrupt]),
+        "only the refetched block is offered back"
+    );
+}
+
 #[tokio::test]
 async fn checkpoint_l0_update_does_not_read_existing_metadata_ssts() {
     let temp_dir = tempdir().expect("tempdir");

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -15,7 +15,7 @@ mod retention;
 use super::build::{
     build_manifest_tables, build_manifest_tables_from_rows, MetadataTableSegmentation,
 };
-use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
+use super::cache::{MetadataTableBlockKind, MetadataTableCache, MetadataTableCacheConfig};
 use super::create::load_checkpoint_projection_metadata_state;
 use super::error::ManifestLoadError;
 use super::load::load_verified_manifest_tables_with_cache;
@@ -36,8 +36,8 @@ use super::stored_block_cache::{
     StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind,
 };
 use super::{
-    block_fetch, create, flush, load, record, reorganize, reorganize_metadata_step, row, scan,
-    MetadataReorganizeOutcome,
+    block_fetch, create, data_block_load, flush, load, record, reorganize,
+    reorganize_metadata_step, row, scan, MetadataReorganizeOutcome,
 };
 use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
@@ -67,7 +67,8 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestPayload,
 };
 use loonfs_api::wire::sst_blocks::{
-    string_prefix_upper_bound, SegmentBlocksBuilder, SegmentIndexEntry,
+    decode_data_block, string_prefix_upper_bound, BlockHandle, DecodedDataBlock,
+    SegmentBlocksBuilder, SegmentIndexEntry,
 };
 use loonfs_api::{
     AbsolutePath, ChangeSeq, CheckpointId, CommitId, DestinationBehavior, EffectiveLimit, InodeId,

--- a/crates/loonfs-server/tests/it/local_cache.rs
+++ b/crates/loonfs-server/tests/it/local_cache.rs
@@ -9,9 +9,17 @@ use loonfs_test_support::ids::namespace_id;
 use std::path::Path;
 use tempfile::tempdir;
 
+/// Every block kind a segment read can ask this cache for.
+const BLOCK_KINDS: [&str; 3] = ["index", "filter", "data"];
+
 /// The `loonfs.local_cache.gets` series for one block kind and outcome.
 fn gets(kind: &str, result: &str) -> String {
     format!("loonfs_local_cache_gets_total{{kind=\"{kind}\",result=\"{result}\"}}")
+}
+
+/// The `loonfs.local_cache.inserts` series for one block kind.
+fn inserts(kind: &str) -> String {
+    format!("loonfs_local_cache_inserts_total{{kind=\"{kind}\"}}")
 }
 
 /// A server holding its cache in `cache_root` and its objects in
@@ -36,15 +44,17 @@ fn test_config_with_local_cache(
     }
 }
 
-/// A restarted server reads its metadata index sections out of the local
-/// cache instead of the store.
+/// A restarted server reads every metadata segment section — index, filter,
+/// and data — out of the local cache instead of the store.
 ///
 /// The second server starts with empty in-memory caches, so the only thing
-/// carried over is the cache directory the first one closed. Every index
-/// lookup it makes is one the first server made and filled, so a single miss
-/// would mean a section did not survive the restart.
+/// carried over is the cache directory the first one closed. Every section it
+/// wants is one the first server fetched and filled, and a section it had to
+/// fetch would show up here twice over: as a miss on the way in and as an
+/// insert on the way back. Zero of both is what makes this a full read with
+/// no segment bytes read at all.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_restarted_server_reads_index_sections_from_its_local_cache() {
+async fn a_restarted_server_reads_every_segment_section_from_its_local_cache() {
     let store_dir = tempdir().expect("store tempdir");
     let cache_dir = tempdir().expect("cache tempdir");
     let namespace = namespace_id("warm");
@@ -101,7 +111,12 @@ async fn a_restarted_server_reads_index_sections_from_its_local_cache() {
         series(&filled, &gets("index", "miss")) >= 1.0,
         "a cold server misses on the sections it then fills"
     );
-    assert!(series(&filled, "loonfs_local_cache_inserts_total{kind=\"index\"}") >= 1.0);
+    for kind in BLOCK_KINDS {
+        assert!(
+            series(&filled, &inserts(kind)) >= 1.0,
+            "a cold server should have filled its {kind} sections"
+        );
+    }
     first.shut_down().await;
 
     let second = start_graceful_server(test_config_with_local_cache(
@@ -118,22 +133,23 @@ async fn a_restarted_server_reads_index_sections_from_its_local_cache() {
     assert_eq!(served.entries, warmed.entries);
 
     let restarted = scrape(&second.server_url, Some("test-token")).expect("scrape the second");
-    assert!(
-        series(&restarted, &gets("index", "hit")) >= 1.0,
-        "the restarted server should read index sections from the cache"
-    );
-    assert_eq!(
-        series(&restarted, &gets("index", "miss")),
-        0.0,
-        "every index section the restarted server wanted should have survived"
-    );
-    assert_eq!(
-        series(
-            &restarted,
-            "loonfs_local_cache_inserts_total{kind=\"index\"}"
-        ),
-        0.0,
-        "a section served from the cache is not fetched, so it is not reinserted"
-    );
+    for kind in ["index", "data"] {
+        assert!(
+            series(&restarted, &gets(kind, "hit")) >= 1.0,
+            "the restarted server should read {kind} sections from the cache"
+        );
+    }
+    for kind in BLOCK_KINDS {
+        assert_eq!(
+            series(&restarted, &gets(kind, "miss")),
+            0.0,
+            "every {kind} section the restarted server wanted should have survived"
+        );
+        assert_eq!(
+            series(&restarted, &inserts(kind)),
+            0.0,
+            "a {kind} section served from the cache is not fetched, so it is not reinserted"
+        );
+    }
     second.shut_down().await;
 }

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -6,7 +6,8 @@
 use crate::common::*;
 use loonfs::{
     ChangeSeq, CreateDirectoryOptions, CreateNamespaceOptions, ErrorCode, InodeId, InodeKind,
-    NamespaceId, PutFileOptions, RuntimeCacheConfig, SharedObjectStore, StoredMetadataBlockKind,
+    NamespaceId, PutFileOptions, ReorganizeStepOutcome, RuntimeCacheConfig, SharedObjectStore,
+    StoredMetadataBlockKind,
 };
 use loonfs_core::test_support::{
     RecordedStoredMetadataBlockCall, RecordingStoredMetadataBlockCache,
@@ -747,5 +748,59 @@ fn an_installed_stored_block_cache_is_filled_and_then_serves_a_later_runtime() {
     assert!(
         !stored_blocks.is_closed(),
         "the host owns the cache and closes it"
+    );
+}
+
+/// Maintenance reads through no metadata table cache, so the local tier
+/// beneath it never sees a maintenance read. Reorganization is the widest
+/// read maintenance has — it decodes every row of the runs it folds — and
+/// this pins the structural argument end to end: not one block offered, and
+/// not one probe either.
+#[test]
+fn metadata_maintenance_offers_nothing_to_the_local_block_cache() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let stored_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let fs = open_runtime_with(store(temp_dir.path()), "maintenance-cold", |builder| {
+        builder.stored_metadata_block_cache(stored_blocks.clone())
+    });
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+
+    // Each step folds the tail into one more L0 run, and the default policy
+    // admits a reorganization unit once enough of them have piled up. Reads
+    // the writes make on the way are outside every measured window.
+    let mut reorganized = false;
+    for index in 0..16 {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            &format!("/docs/file-{index:02}.txt"),
+            b"file",
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+        let calls_before = stored_blocks.call_count();
+        let step = fs
+            .maintenance_step_namespace_blocking(&namespace_id, metadata_plan(1))
+            .expect("maintenance step");
+        assert_eq!(
+            stored_blocks.call_count(),
+            calls_before,
+            "a maintenance step carries no table cache, so it reaches neither cache tier"
+        );
+        if upkeep(&step).reorganize == ReorganizeStepOutcome::UnitPublished {
+            reorganized = true;
+            break;
+        }
+    }
+
+    assert!(
+        reorganized,
+        "the steps above should have folded one reorganization unit"
+    );
+    assert!(
+        stored_blocks.call_count() > 0,
+        "the reads around the steps must reach the cache for this to prove anything"
     );
 }


### PR DESCRIPTION
Data-block reads now consult the local block cache. 

Notes:

- A corrupt local entry inside a span is dropped and refetched as part of the span; one invalidate, one reinsert, (no retry loop).
- The restart test now covers all three block kinds: after a graceful restart, reads hit with zero misses and zero inserts.
- Maintenance stays cold, pinned end to end: a reorganization run makes zero cache calls, with a tail assertion so the test cannot pass vacuously.
