### PR TITLE
fix(cache): disk geometry is enforced across restarts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,9 @@ http = "1"
 http-body = "1"
 # The `serde` feature makes foyer encode keys and values through their serde
 # impls, which is how the server's cache key reaches foyer's storage traits.
-foyer = { version = "0.22.3", features = ["serde"] }
+# Pinned exactly: the cache-directory geometry code reads foyer's block-file
+# naming, so a version bump is a deliberate change with its own review.
+foyer = { version = "=0.22.3", features = ["serde"] }
 futures = "0.3"
 fs4 = "0.13"
 getrandom = "0.3"

--- a/configs/loonfs-server.local-fs.example.toml
+++ b/configs/loonfs-server.local-fs.example.toml
@@ -75,9 +75,13 @@ writer_id = "loonfs-server-local"
 #
 # `disk_bytes` is claimed up front in 16 MiB files under `path`, each held
 # open, so the value below asks for 6400 files and an open-file limit above
-# that. Nothing else about the tier is configurable: how it is laid out on
-# disk, how many flushers write it, and how large its write buffers are are
-# engine-tuning numbers rather than deployment decisions.
+# that. Six files is the smallest tier that may be configured; anything
+# under 100663296 is refused. Raising the value across a restart keeps what
+# the directory already holds, and lowering it starts the directory empty
+# rather than leaving the files it no longer claims behind. Nothing else
+# about the tier is configurable: how it is laid out on disk, how many
+# flushers write it, and how large its write buffers are are engine-tuning
+# numbers rather than deployment decisions.
 #[local_cache]
 #path = "/var/lib/loonfs/cache"
 #memory_bytes = 67108864

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -1,6 +1,7 @@
 //! Server configuration: strict TOML decoding of the listen address,
 //! store, and runtime cache overrides.
 
+use crate::local_cache::{DISK_BLOCK_BYTES, MIN_DISK_BYTES};
 use loonfs::RuntimeCacheConfig;
 use loonfs_grep::GrepWorkerConfig;
 use loonfs_objectstore::{ConfiguredObjectStore, SecretString, StoreConfigError};
@@ -191,7 +192,11 @@ pub struct LocalCacheConfig {
     /// Bytes of memory the cache's in-memory tier may hold.
     pub memory_bytes: u64,
     /// Bytes of disk the cache's disk tier may hold. The tier claims this
-    /// much space up front, in files under `path`.
+    /// much space up front, in whole blocks, one file per block under
+    /// `path`; six blocks is the smallest tier that may be configured.
+    /// Raising this across a restart keeps what the directory holds, and
+    /// lowering it starts the directory empty rather than leaving the
+    /// blocks it no longer claims behind.
     pub disk_bytes: u64,
 }
 
@@ -485,12 +490,19 @@ impl ServerConfig {
                         .to_owned(),
                 });
             }
-            if local_cache.disk_bytes == 0 {
+            // The disk tier allocates whole blocks and never a partial one,
+            // so a capacity under the floor is a cache that starts, holds
+            // nothing on disk, and says nothing about it. Refuse it here
+            // instead.
+            if local_cache.disk_bytes < MIN_DISK_BYTES {
                 return Err(ServerConfigError::InvalidField {
                     field: "local_cache.disk_bytes",
-                    reason: "must be greater than zero; \
-                             omit the `[local_cache]` table to run without a local cache"
-                        .to_owned(),
+                    reason: format!(
+                        "must be at least {MIN_DISK_BYTES}; the disk tier allocates whole \
+                         blocks of {DISK_BLOCK_BYTES} bytes, and six blocks is the floor \
+                         for stable operation. Omit the `[local_cache]` table to run \
+                         without a local cache"
+                    ),
                 });
             }
         }
@@ -574,7 +586,7 @@ mod tests {
     #![allow(clippy::panic)]
     // Config tests use panic in unexpected match arms for precise diagnostics.
 
-    use super::{load_server_config, ServerConfigError};
+    use super::{load_server_config, ServerConfigError, DISK_BLOCK_BYTES, MIN_DISK_BYTES};
     use std::fs;
     use tempfile::tempdir;
 
@@ -1588,6 +1600,50 @@ root = "/tmp/loonfs-server"
             let error = load_server_config(&path).expect_err("a zero size must be rejected");
             assert_invalid_field(error, field);
         }
+    }
+
+    /// A disk tier smaller than one block holds nothing on disk, and foyer
+    /// says so in a warning rather than an error. The config check is what
+    /// makes it a startup failure with a number in it.
+    #[test]
+    fn a_local_cache_disk_tier_has_a_floor() {
+        let with_disk_bytes = |disk_bytes: u64| {
+            write_config(&format!(
+                r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[local_cache]
+path = "/var/lib/loonfs/cache"
+memory_bytes = 67108864
+disk_bytes = {disk_bytes}
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#
+            ))
+        };
+
+        // Eight megabytes is a plausible value that would have started a
+        // server whose disk tier holds nothing at all.
+        let error = load_server_config(with_disk_bytes(8 * 1024 * 1024))
+            .expect_err("a disk tier under one block must be rejected");
+        let message = error.to_string();
+        assert!(message.contains(&MIN_DISK_BYTES.to_string()), "{message}");
+        assert!(message.contains(&DISK_BLOCK_BYTES.to_string()), "{message}");
+        assert_invalid_field(error, "local_cache.disk_bytes");
+
+        let error = load_server_config(with_disk_bytes(MIN_DISK_BYTES - 1))
+            .expect_err("one byte under the floor is still under it");
+        assert_invalid_field(error, "local_cache.disk_bytes");
+
+        let local_cache = load_server_config(with_disk_bytes(MIN_DISK_BYTES))
+            .expect("the floor itself is a valid disk tier")
+            .local_cache
+            .expect("a local cache table");
+        assert_eq!(local_cache.disk_bytes, MIN_DISK_BYTES);
     }
 
     #[test]

--- a/crates/loonfs-server/src/local_cache.rs
+++ b/crates/loonfs-server/src/local_cache.rs
@@ -32,6 +32,7 @@ use mixtrics::metrics::{
     BoxedCounter, BoxedCounterVec, BoxedGauge, BoxedGaugeVec, BoxedHistogram, BoxedHistogramVec,
     CounterOps, CounterVecOps, GaugeOps, GaugeVecOps, HistogramOps, HistogramVecOps, RegistryOps,
 };
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::fs::File;
@@ -50,6 +51,13 @@ const CACHE_DIRECTORY: &str = "metadata-blocks-v1";
 /// long as this process owns the directory.
 const LOCK_FILE: &str = "owner.lock";
 
+/// The geometry marker inside the versioned directory, which records the
+/// disk geometry that directory was last built for. See [`DiskGeometry`].
+///
+/// The name cannot collide with a block file: foyer names those from a
+/// fixed prefix and a number.
+const GEOMETRY_MARKER: &str = "geometry.json";
+
 /// The name foyer knows this cache by, which is also the label its own
 /// counters carry.
 const CACHE_NAME: &str = "loonfs-metadata-blocks";
@@ -64,7 +72,7 @@ const CACHE_NAME: &str = "loonfs-metadata-blocks";
 /// foyer claims the whole capacity as blocks at startup, one file per block
 /// and each one held open, and it refuses an entry larger than a block less
 /// its blob index. This is foyer's own default, which sits between the two.
-const DISK_BLOCK_BYTES: usize = 16 * 1024 * 1024;
+pub(crate) const DISK_BLOCK_BYTES: usize = 16 * 1024 * 1024;
 /// Flusher tasks writing the disk tier.
 const DISK_FLUSHERS: usize = 2;
 /// Total flush buffer pool, split evenly among the flushers. Each flusher
@@ -74,6 +82,16 @@ const DISK_BUFFER_POOL_BYTES: usize = 64 * 1024 * 1024;
 /// Bytes of queued inserts the disk tier accepts before it drops further
 /// ones. A drop is counted, never surfaced.
 const DISK_SUBMIT_QUEUE_THRESHOLD_BYTES: usize = 256 * 1024 * 1024;
+
+/// The smallest disk tier a deployment may configure, which the config
+/// check enforces so a too-small one is refused rather than run.
+///
+/// The tier allocates whole blocks, so a capacity under one block allocates
+/// none: the cache opens, holds nothing on disk, and a restart is cold with
+/// nothing said about it. Six blocks is the floor because it is also the
+/// smallest count foyer itself calls stable, which wants the flusher count
+/// plus the clean-block threshold to be at most half the block count.
+pub(crate) const MIN_DISK_BYTES: u64 = 6 * DISK_BLOCK_BYTES as u64;
 
 /// Per-entry overhead the memory weigher charges on top of the value's
 /// length: the key's own bytes and foyer's bookkeeping for one entry. It is
@@ -133,9 +151,12 @@ impl FoyerStoredMetadataBlockCache {
     /// The root is created if it is missing and locked exclusively, so a
     /// second process pointed at the same root fails here rather than
     /// writing into a device another process owns. The versioned directory
-    /// beneath it is foyer's, and foyer recovers what it can from it; a
-    /// directory it cannot open at all fails startup, because deleting a
-    /// deployment's files is the operator's decision and not this process's.
+    /// beneath it is foyer's, and foyer recovers what it can from it, but
+    /// only once [`prepare_directory`] has agreed the directory holds the
+    /// geometry this start is about to claim. A directory foyer then cannot
+    /// open at all fails startup rather than being deleted: an open failure
+    /// says something about the machine, and what to do about it is the
+    /// operator's decision and not this process's.
     pub(crate) async fn open(
         config: &LocalCacheConfig,
         recorder: &dyn MetricsRecorder,
@@ -156,6 +177,7 @@ impl FoyerStoredMetadataBlockCache {
                 config.disk_bytes
             ))
         })?;
+        prepare_directory(&directory, capacity)?;
         let device = FsDeviceBuilder::new(&directory)
             .with_capacity(capacity)
             .build()
@@ -331,6 +353,125 @@ pub(crate) struct FoyerCacheStats {
     /// Inserts the disk tier dropped because its submit queue was over
     /// threshold.
     pub(crate) queue_channel_overflows: u64,
+}
+
+/// The disk geometry the versioned directory was built to hold, as its
+/// marker records it.
+///
+/// foyer names one file per disk block from an in-memory counter and never
+/// looks at the directory it was pointed at. A start that claims fewer
+/// blocks than the last one therefore reopens files `0..blocks` and leaves
+/// every higher-numbered file exactly where it is: cached bytes on disk
+/// that no metric counts, that nothing reclaims, and that put the tier over
+/// the size its configuration asked for. The marker is the only record of
+/// how many files could be down there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DiskGeometry {
+    /// Bytes in one disk block, which is [`DISK_BLOCK_BYTES`] for a
+    /// directory this build wrote.
+    block_bytes: usize,
+    /// Blocks the directory was built to hold, which is an upper bound on
+    /// the block files it holds.
+    blocks: usize,
+}
+
+/// Makes the versioned directory one that can hold the configured geometry,
+/// discarding it when it cannot.
+///
+/// A directory built for the same block size and no more blocks than this
+/// start claims is kept: foyer reopens the files that are there and creates
+/// the rest, so growing the tier keeps everything it had cached. A shrunk
+/// block count, a different block size, and a directory that says nothing
+/// about itself are all discarded, because each of them would leave files
+/// behind that nothing would ever open again. The tier holds nothing
+/// durable, so discarding costs one cold start.
+///
+/// The marker is written before the device is built, which is what makes it
+/// an upper bound: a build that dies partway can leave fewer block files
+/// than the marker names, never more. The directory lock is already held,
+/// and the lock file sits beside the versioned directory rather than inside
+/// it, so nothing here races and nothing here removes the lock.
+fn prepare_directory(directory: &Path, capacity: usize) -> Result<(), ServerConfigError> {
+    let wanted = DiskGeometry {
+        block_bytes: DISK_BLOCK_BYTES,
+        blocks: capacity / DISK_BLOCK_BYTES,
+    };
+    let found = read_geometry(directory);
+    let keep = found.is_some_and(|found| {
+        found.block_bytes == wanted.block_bytes && found.blocks <= wanted.blocks
+    });
+
+    if !keep && directory.exists() {
+        let reason = match found {
+            None => "it records no geometry of its own".to_owned(),
+            Some(found) if found.block_bytes != wanted.block_bytes => format!(
+                "it was built for blocks of {} bytes and this start uses {}",
+                found.block_bytes, wanted.block_bytes
+            ),
+            Some(found) => format!(
+                "it was built for {} blocks and this start claims only {}",
+                found.blocks, wanted.blocks
+            ),
+        };
+        tracing::info!(
+            cache = CACHE_NAME,
+            "discarding the local cache directory `{}` and starting it empty because {reason}; \
+             it holds nothing durable, and keeping it would leave block files behind that \
+             nothing reads and nothing reclaims",
+            display_path(directory)
+        );
+        std::fs::remove_dir_all(directory).map_err(|error| {
+            invalid_local_cache(format!(
+                "failed to remove `{}`: {error}",
+                display_path(directory)
+            ))
+        })?;
+    }
+
+    std::fs::create_dir_all(directory).map_err(|error| {
+        invalid_local_cache(format!(
+            "failed to create `{}`: {error}",
+            display_path(directory)
+        ))
+    })?;
+    // A marker that already says exactly this is left alone. Every other
+    // case — a discarded directory, and a kept one this start grows — needs
+    // the new geometry on disk before any block file is.
+    if found != Some(wanted) {
+        write_geometry(directory, wanted)?;
+    }
+    Ok(())
+}
+
+/// The geometry the versioned directory records, or `None` when it records
+/// none this process can make sense of.
+///
+/// A marker that cannot be read or cannot be parsed says nothing about the
+/// directory, and a directory that says nothing about itself is discarded.
+/// There is no repair path, because the marker is smaller than one write.
+fn read_geometry(directory: &Path) -> Option<DiskGeometry> {
+    let bytes = std::fs::read(directory.join(GEOMETRY_MARKER)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Records the geometry this start claims.
+///
+/// A marker that cannot be written fails startup. The directory is about to
+/// be filled with block files, so a process that cannot write a few bytes
+/// beside them has a problem the next start would inherit as orphaned
+/// blocks.
+fn write_geometry(directory: &Path, geometry: DiskGeometry) -> Result<(), ServerConfigError> {
+    let path = directory.join(GEOMETRY_MARKER);
+    let bytes = serde_json::to_vec(&geometry).map_err(|error| {
+        invalid_local_cache(format!("failed to encode `{geometry:?}`: {error}"))
+    })?;
+    std::fs::write(&path, bytes).map_err(|error| {
+        invalid_local_cache(format!(
+            "failed to write `{}`: {error}",
+            display_path(&path)
+        ))
+    })
 }
 
 /// Takes the exclusive lock that says this process owns the configured root.

--- a/crates/loonfs-server/src/local_cache/tests.rs
+++ b/crates/loonfs-server/src/local_cache/tests.rs
@@ -2,9 +2,9 @@
 // Cache tests panic in unexpected match arms for precise diagnostics.
 
 use super::{
-    FoyerOverflowCounters, FoyerStoredMetadataBlockCache, OverflowRegistry, CACHE_DIRECTORY,
-    DISK_BLOCK_BYTES, FOYER_BUFFER_OVERFLOW_LABEL, FOYER_CHANNEL_OVERFLOW_LABEL,
-    FOYER_INNER_OP_COUNTER_VEC,
+    DiskGeometry, FoyerOverflowCounters, FoyerStoredMetadataBlockCache, OverflowRegistry,
+    CACHE_DIRECTORY, DISK_BLOCK_BYTES, FOYER_BUFFER_OVERFLOW_LABEL, FOYER_CHANNEL_OVERFLOW_LABEL,
+    FOYER_INNER_OP_COUNTER_VEC, GEOMETRY_MARKER, MIN_DISK_BYTES,
 };
 use crate::config::{LocalCacheConfig, ServerConfigError};
 use bytes::Bytes;
@@ -16,30 +16,70 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tempfile::tempdir;
 
-/// The smallest disk tier these tests can ask for.
+/// The disk tier these tests ask for by default.
 ///
 /// foyer claims the device as whole blocks and warns when the block count is
 /// not comfortably above the flusher count, so the floor is set by
 /// [`DISK_BLOCK_BYTES`] rather than by anything the tests want. Eight blocks
-/// clears it. The block files are sparse, so a test pays for the bytes it
-/// writes and not for the capacity it asked for.
+/// clears it with room to shrink toward [`MIN_DISK_BYTES`]. The block files
+/// are sparse, so a test pays for the bytes it writes and not for the
+/// capacity it asked for.
 const TEST_DISK_BYTES: u64 = 8 * DISK_BLOCK_BYTES as u64;
 
 /// A memory tier larger than everything these tests insert.
 const TEST_MEMORY_BYTES: u64 = 4 * 1024 * 1024;
 
+/// The prefix foyer names one block file by, followed by the block's index.
+///
+/// Nothing in foyer's api reports this, so the geometry marker's whole job
+/// rests on a naming convention read out of foyer's source. The workspace
+/// resolves one foyer version, and a release that renames these files
+/// should break the tests below rather than start quietly orphaning them.
+const BLOCK_FILE_PREFIX: &str = "foyer-storage-direct-fs-";
+
 fn test_config(root: &Path) -> LocalCacheConfig {
+    sized_config(root, TEST_DISK_BYTES)
+}
+
+fn sized_config(root: &Path, disk_bytes: u64) -> LocalCacheConfig {
     LocalCacheConfig {
         path: root.display().to_string(),
         memory_bytes: TEST_MEMORY_BYTES,
-        disk_bytes: TEST_DISK_BYTES,
+        disk_bytes,
     }
 }
 
 async fn open(root: &Path) -> FoyerStoredMetadataBlockCache {
-    FoyerStoredMetadataBlockCache::open(&test_config(root), &NoopMetricsRecorder)
+    open_sized(root, TEST_DISK_BYTES).await
+}
+
+async fn open_sized(root: &Path, disk_bytes: u64) -> FoyerStoredMetadataBlockCache {
+    FoyerStoredMetadataBlockCache::open(&sized_config(root, disk_bytes), &NoopMetricsRecorder)
         .await
         .expect("open local cache")
+}
+
+/// The block files under the versioned directory, which is every file in it
+/// but the geometry marker.
+fn block_files(root: &Path) -> usize {
+    std::fs::read_dir(root.join(CACHE_DIRECTORY))
+        .expect("read the versioned directory")
+        .filter(|entry| {
+            entry
+                .as_ref()
+                .expect("read a directory entry")
+                .file_name()
+                .to_string_lossy()
+                .starts_with(BLOCK_FILE_PREFIX)
+        })
+        .count()
+}
+
+/// The geometry the versioned directory records.
+fn geometry(root: &Path) -> DiskGeometry {
+    let bytes = std::fs::read(root.join(CACHE_DIRECTORY).join(GEOMETRY_MARKER))
+        .expect("read the geometry marker");
+    serde_json::from_slice(&bytes).expect("parse the geometry marker")
 }
 
 fn key(offset: u64) -> StoredMetadataBlockKey {
@@ -171,14 +211,145 @@ async fn the_disk_tier_claims_the_capacity_as_block_files() {
         directory.is_dir(),
         "the versioned directory is where the tier's files go"
     );
-    let files = std::fs::read_dir(&directory)
-        .expect("read the versioned directory")
-        .count();
     assert_eq!(
-        files,
+        block_files(temp_dir.path()),
         (TEST_DISK_BYTES / DISK_BLOCK_BYTES as u64) as usize,
         "the tier holds one file per block of the capacity it was given"
     );
+    assert_eq!(
+        geometry(temp_dir.path()),
+        DiskGeometry {
+            block_bytes: DISK_BLOCK_BYTES,
+            blocks: (TEST_DISK_BYTES / DISK_BLOCK_BYTES as u64) as usize,
+        },
+        "the directory records the geometry it was built for"
+    );
+}
+
+/// A tier that shrinks starts over rather than leaving blocks behind.
+///
+/// foyer names block files from a counter and never reads the directory, so
+/// a smaller capacity would reopen the low-numbered files and abandon the
+/// rest: cached bytes on disk that nothing opens, nothing counts, and
+/// nothing reclaims, holding the tier above the size it was configured for.
+/// The file count is the assertion because it is the thing that leaks.
+#[tokio::test]
+async fn a_shrunk_disk_tier_starts_over() {
+    let temp_dir = tempdir().expect("tempdir");
+    let bytes = Bytes::from_static(b"encoded stored block");
+
+    let cache = open_sized(temp_dir.path(), TEST_DISK_BYTES).await;
+    cache.insert(key(0), bytes.clone());
+    assert_eq!(cache.get(&key(0)).await, Some(bytes));
+    cache.close().await.expect("close local cache");
+    drop(cache);
+    assert_eq!(block_files(temp_dir.path()), 8);
+
+    let shrunk_blocks = (MIN_DISK_BYTES / DISK_BLOCK_BYTES as u64) as usize;
+    let reopened = open_sized(temp_dir.path(), MIN_DISK_BYTES).await;
+    assert_eq!(
+        block_files(temp_dir.path()),
+        shrunk_blocks,
+        "the directory holds the blocks this start claims and no others"
+    );
+    assert_eq!(
+        geometry(temp_dir.path()),
+        DiskGeometry {
+            block_bytes: DISK_BLOCK_BYTES,
+            blocks: shrunk_blocks,
+        },
+        "the marker records the smaller geometry"
+    );
+    assert_eq!(
+        reopened.get(&key(0)).await,
+        None,
+        "the discarded directory took what it held with it"
+    );
+    reopened.close().await.expect("close reopened cache");
+}
+
+/// A tier that grows keeps what it had.
+///
+/// The files foyer already wrote are the ones it reopens, so a bigger
+/// capacity is the one geometry change that costs nothing: it adds files
+/// above the ones that are there. Discarding here would throw away a warm
+/// cache for no reason.
+#[tokio::test]
+async fn a_grown_disk_tier_keeps_what_it_had() {
+    let temp_dir = tempdir().expect("tempdir");
+    let bytes = Bytes::from_static(b"encoded stored block");
+
+    let cache = open_sized(temp_dir.path(), MIN_DISK_BYTES).await;
+    cache.insert(key(0), bytes.clone());
+    cache.close().await.expect("close local cache");
+    drop(cache);
+
+    let grown_blocks = (TEST_DISK_BYTES / DISK_BLOCK_BYTES as u64) as usize;
+    let reopened = open_sized(temp_dir.path(), TEST_DISK_BYTES).await;
+    assert_eq!(
+        reopened.get(&key(0)).await,
+        Some(bytes),
+        "a grown tier still serves what the smaller one wrote"
+    );
+    assert_eq!(
+        block_files(temp_dir.path()),
+        grown_blocks,
+        "the directory holds one file per block of the larger capacity"
+    );
+    assert_eq!(
+        geometry(temp_dir.path()),
+        DiskGeometry {
+            block_bytes: DISK_BLOCK_BYTES,
+            blocks: grown_blocks,
+        },
+        "the marker records the geometry this start claimed"
+    );
+    reopened.close().await.expect("close reopened cache");
+}
+
+/// A directory whose marker says nothing readable is discarded.
+///
+/// The marker is the only account of how many block files are down there.
+/// One this process cannot parse is no account at all, and a directory of
+/// unknown geometry is exactly the one that leaks, so it is treated like a
+/// shrink rather than trusted.
+#[tokio::test]
+async fn an_unreadable_geometry_marker_starts_over() {
+    let temp_dir = tempdir().expect("tempdir");
+    let bytes = Bytes::from_static(b"encoded stored block");
+
+    let cache = open(temp_dir.path()).await;
+    cache.insert(key(0), bytes);
+    cache.close().await.expect("close local cache");
+    drop(cache);
+
+    std::fs::write(
+        temp_dir.path().join(CACHE_DIRECTORY).join(GEOMETRY_MARKER),
+        b"not json",
+    )
+    .expect("overwrite the geometry marker");
+
+    let blocks = (TEST_DISK_BYTES / DISK_BLOCK_BYTES as u64) as usize;
+    let reopened = open(temp_dir.path()).await;
+    assert_eq!(
+        reopened.get(&key(0)).await,
+        None,
+        "the discarded directory took what it held with it"
+    );
+    assert_eq!(
+        block_files(temp_dir.path()),
+        blocks,
+        "the directory was rebuilt from nothing"
+    );
+    assert_eq!(
+        geometry(temp_dir.path()),
+        DiskGeometry {
+            block_bytes: DISK_BLOCK_BYTES,
+            blocks,
+        },
+        "the rebuilt directory records a marker again"
+    );
+    reopened.close().await.expect("close reopened cache");
 }
 
 /// foyer's overflow counters reach this process's numbers.


### PR DESCRIPTION
The disk cache uses one 16 MiB file per block. When `disk_bytes` was reduced and the server restarted, Foyer reopened only the lower-numbered files needed for the new capacity. It did not delete the remaining files from the old, larger cache.

Those unused files stayed on disk indefinitely. As a result, the cache could consume more space than configured, while its metrics reported only the files it had reopened.

- The cache directory now contains a small `geometry.json` marker recording its block size and block count.
- Restarting with the same or a larger capacity keeps the existing cache contents.
- Restarting with a smaller capacity recreates the cache directory, removing the surplus files.
- A missing, unreadable, or incompatible marker also recreates the directory because its previous size cannot be determined safely.
- `disk_bytes` must now be at least 96 MiB: six 16 MiB blocks, which is the minimum that satisfies the current Foyer configuration.

