### PR TITLE
fix(wal): the head describes every legal unflushed segment

### DIFF
--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -923,8 +923,8 @@ mod tests {
     use crate::resolve::EmbeddedTarget;
     use loonfs::{
         BootstrapNamespaceError, CoreError, CreateNamespaceOptions, FsBackgroundWork, FsWriter,
-        MaintenanceJobId, MaintenanceStepConclusion, PutFileOptions, RuntimeError,
-        SharedObjectStore,
+        MaintenanceJobId, MaintenanceStepConclusion, MetadataMaintenanceOptions, PutFileOptions,
+        RuntimeError, SharedObjectStore,
     };
     use loonfs_api::{
         ChangeSeq, CreateCheckpointRequest, DestinationBehavior, ErrorCode, InodeId, NamespaceId,
@@ -935,6 +935,14 @@ mod tests {
 
     fn namespace_id(value: &str) -> NamespaceId {
         NamespaceId::parse(value).expect("valid namespace id")
+    }
+
+    /// WAL-tail length at which the metadata job checkpoints — what a
+    /// drained namespace must be back under.
+    fn checkpoint_threshold() -> u64 {
+        MetadataMaintenanceOptions::default()
+            .max_wal_tail_segments
+            .get()
     }
 
     /// The three jobs `admin run` hosts by default, in the order it drives
@@ -1055,7 +1063,7 @@ mod tests {
                 .await
                 .expect("status after the drain");
             assert!(
-                status.wal_tail_segments < 32,
+                status.wal_tail_segments < checkpoint_threshold(),
                 "`{namespace_id}` kept a WAL tail of {} segments past the checkpoint threshold",
                 status.wal_tail_segments
             );
@@ -1173,7 +1181,7 @@ mod tests {
             .await
             .expect("status after hosting");
         assert!(
-            status.wal_tail_segments < 32,
+            status.wal_tail_segments < checkpoint_threshold(),
             "the hosted runner left a WAL tail of {} segments",
             status.wal_tail_segments
         );

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1,6 +1,7 @@
 //! Checkpoint retention, reorganization, compaction, and publication budgets.
 
 use super::*;
+use loonfs_objectstore::keys::wal_segment_prefix;
 
 async fn current_manifest_id<S: ObjectStore + ?Sized>(
     store: &S,
@@ -700,8 +701,16 @@ async fn checkpoint_verification_rejects_a_basis_below_the_floor() {
     assert!(!verified, "sub-floor basis must not verify");
 }
 
+async fn wal_segment_count(store: &LocalFsStore, namespace_id: &NamespaceId) -> usize {
+    store
+        .list_prefix(&wal_segment_prefix(namespace_id.as_str()))
+        .await
+        .expect("list wal segments")
+        .len()
+}
+
 #[tokio::test]
-async fn publish_backpressure_rejects_when_wal_tail_outruns_maintenance() {
+async fn publish_backpressure_rejects_at_the_longest_tail_the_head_describes() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -709,10 +718,12 @@ async fn publish_backpressure_rejects_when_wal_tail_outruns_maintenance() {
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
         .expect("bootstrap");
-    let limit =
-        u32::try_from(crate::commit_engine::WalTailPolicy::DEFAULT.reject_writes_at_segments)
-            .expect("limit");
-    for round in 0..=limit {
+    let boundary =
+        usize::try_from(crate::commit_engine::WalTailPolicy::DEFAULT.reject_writes_at_segments)
+            .expect("the write-stop bound fits a segment count");
+
+    // Stop one short, so the next publish is the one that reaches the bound.
+    for round in 0..boundary - 1 {
         write_file_bytes(
             &store,
             &namespace_id,
@@ -724,6 +735,19 @@ async fn publish_backpressure_rejects_when_wal_tail_outruns_maintenance() {
         .await
         .expect("write within backpressure window");
     }
+    assert_eq!(wal_segment_count(&store, &namespace_id).await, boundary - 1);
+
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/at-the-boundary.txt",
+        b"body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("the publish that lands exactly at the bound is still admitted");
+    assert_eq!(wal_segment_count(&store, &namespace_id).await, boundary);
 
     let error = write_file_bytes(
         &store,
@@ -734,8 +758,33 @@ async fn publish_backpressure_rejects_when_wal_tail_outruns_maintenance() {
         None,
     )
     .await
-    .expect_err("publish past the backpressure limit must be rejected");
+    .expect_err("a publish against a tail at the bound must be rejected");
     assert_eq!(error.code(), ErrorCode::MaintenanceRequired);
+    assert_eq!(
+        wal_segment_count(&store, &namespace_id).await,
+        boundary,
+        "the rejection lands before the segment PUT, so nothing new is written"
+    );
+
+    // The whole legal tail is named by the head, so no reader has to walk
+    // predecessor links to reach any of it.
+    let head = read_head_object(&store, &namespace_id)
+        .await
+        .expect("read head")
+        .envelope
+        .state;
+    assert_eq!(head.recent_segments.len(), boundary);
+    assert_eq!(head.recent_segments.first(), head.visible_wal_tip.as_ref());
+    for pair in head.recent_segments.windows(2) {
+        let [newer, older] = pair else {
+            unreachable!("windows(2) yields pairs")
+        };
+        assert_eq!(
+            older.end_seq.0 + 1,
+            newer.start_seq.0,
+            "hints must be newest-first and gap-free"
+        );
+    }
 
     // Reads never gate: the change feed still serves the whole tail.
     let changes = list_changes_after(
@@ -746,7 +795,10 @@ async fn publish_backpressure_rejects_when_wal_tail_outruns_maintenance() {
     )
     .await
     .expect("list changes");
-    assert_eq!(changes.through_seq, ChangeSeq(129));
+    assert_eq!(
+        changes.through_seq,
+        ChangeSeq(u64::try_from(boundary).expect("one commit per segment"))
+    );
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -2,6 +2,7 @@
 //! compare-and-swap that makes its commits visible.
 
 use super::{CommitHeadPublishError, CommitPlan};
+use crate::limits::RECENT_SEGMENTS_LIMIT;
 use crate::wal::PreparedWalSegment;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
@@ -121,13 +122,9 @@ pub fn prepare_commit_head_publish(
     })
 }
 
-/// How many segment pointers the head carries as a replay accelerator.
-///
-/// Newest first, tip included. The bound keeps the head one small object at
-/// any commit rate; readers needing older history walk the chain links,
-/// which remain the only authority.
-const RECENT_SEGMENTS_LIMIT: usize = 32;
-
+/// Rebuilds the head's replay accelerator: newest first, tip included,
+/// capped at [`RECENT_SEGMENTS_LIMIT`]. Readers reaching past it walk the
+/// chain links, which remain the only history authority.
 fn next_recent_segments(
     current_head: &HeadState,
     new_tip: WalSegmentPointer,
@@ -214,7 +211,7 @@ mod tests {
     }
     use loonfs_api::wire::control::WriterBlock;
     use loonfs_api::wire::wal::{WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload};
-    use loonfs_api::{CommitId, InodeId, NamespaceId, WalSegmentId, WriterEpoch};
+    use loonfs_api::{CommitId, InodeId, NamespaceId, WalSegmentId, WriterEpoch, MAX_ID_BYTES};
 
     fn head(namespace_id: NamespaceId, seq: ChangeSeq) -> HeadState {
         HeadState {
@@ -342,7 +339,8 @@ mod tests {
     #[test]
     fn head_publish_prepends_the_tip_and_truncates_recent_segments() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let mut current_head = head(namespace_id.clone(), ChangeSeq(100));
+        let limit = u64::try_from(RECENT_SEGMENTS_LIMIT).expect("limit fits a sequence");
+        let mut current_head = head(namespace_id.clone(), ChangeSeq(limit));
         let filler = |index: u64| {
             let segment = wal_segment(
                 namespace_id.clone(),
@@ -353,18 +351,19 @@ mod tests {
             );
             segment.envelope.pointer(segment.object_key.clone())
         };
-        current_head.recent_segments = (0..32).rev().map(filler).collect();
+        // A list already at the cap: the tip has to displace something.
+        current_head.recent_segments = (0..limit).rev().map(filler).collect();
         let oldest = current_head
             .recent_segments
             .last()
             .cloned()
             .expect("oldest");
-        let plan = plan(namespace_id.clone(), ChangeSeq(101));
+        let plan = plan(namespace_id.clone(), ChangeSeq(limit + 1));
         let wal = wal_segment(
             namespace_id,
-            ChangeSeq(100),
-            ChangeSeq(101),
-            ChangeSeq(101),
+            ChangeSeq(limit),
+            ChangeSeq(limit + 1),
+            ChangeSeq(limit + 1),
             1,
         );
 
@@ -372,7 +371,7 @@ mod tests {
             prepare_commit_head_publish(&current_head, &plan, &wal).expect("prepare head publish");
 
         let recent = &prepared.resulting_head.recent_segments;
-        assert_eq!(recent.len(), 32);
+        assert_eq!(recent.len(), RECENT_SEGMENTS_LIMIT);
         assert_eq!(recent[0], wal.envelope.pointer(wal.object_key.clone()));
         assert!(!recent.contains(&oldest), "oldest hint must fall off");
     }
@@ -477,5 +476,52 @@ mod tests {
             Err(CommitHeadPublishError::WalSegmentNamespaceMismatch { head, wal })
                 if head == NamespaceId::parse("demo").expect("valid namespace id") && wal == NamespaceId::parse("other").expect("valid namespace id")
         ));
+    }
+
+    /// Encodes a full accelerator through the real codec, so the numbers
+    /// the cap is justified by are measured rather than estimated.
+    fn encoded_head_bytes(namespace: &str, newest_seq: u64) -> usize {
+        let namespace_id = NamespaceId::parse(namespace).expect("valid namespace id");
+        let segments: Vec<WalSegmentPointer> = (0..RECENT_SEGMENTS_LIMIT)
+            .map(|index| {
+                let offset = u64::try_from(index).expect("test index");
+                let seq = ChangeSeq(newest_seq - offset);
+                let segment_id = WalSegmentId::parse(format!("{:020}-{offset:016x}", seq.0))
+                    .expect("valid segment id");
+                WalSegmentPointer {
+                    object_key: wal_segment_key(namespace_id.as_str(), segment_id.as_str()),
+                    segment_id,
+                    start_seq: seq,
+                    end_seq: seq,
+                    payload_checksum: format!("sha256:{}", "b".repeat(64)),
+                }
+            })
+            .collect();
+        let mut state = head(namespace_id, ChangeSeq(newest_seq));
+        state.visible_wal_tip = segments.first().cloned();
+        state.recent_segments = segments;
+
+        let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, state)
+            .expect("head envelope");
+        encode_control_object(&envelope).expect("encode head").len()
+    }
+
+    /// The head is the one control object whose size grows with the tail it
+    /// describes, so raising the accelerator's cap is a claim about how big
+    /// the head gets. This measures it at the cap, from both ends of what
+    /// the identifier grammars allow.
+    #[test]
+    fn a_head_at_the_accelerator_cap_stays_a_small_object() {
+        const CEILING_BYTES: usize = 256 * 1024;
+
+        let realistic = encoded_head_bytes("demo", 4_200);
+        let worst_case = encoded_head_bytes(&"n".repeat(MAX_ID_BYTES), u64::MAX);
+
+        assert!(
+            worst_case < CEILING_BYTES,
+            "a full head encodes to {worst_case} bytes at the longest namespace id and \
+             sequence numbers the grammars allow, and {realistic} bytes at realistic ones; \
+             the ceiling is {CEILING_BYTES}"
+        );
     }
 }

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -164,16 +164,18 @@ pub struct WalTailPolicy {
     /// Visible WAL-tail length, in segments, at which a maintenance step
     /// publishes a checkpoint. The step fires at or past this length.
     pub checkpoint_at_segments: u64,
-    /// Visible WAL-tail length past which (strictly greater than) every
-    /// publish surface rejects with `maintenance_required`.
+    /// Visible WAL-tail length at which (at or past) every publish surface
+    /// rejects with `maintenance_required`, so a landed publication never
+    /// leaves a longer tail behind.
     pub reject_writes_at_segments: u64,
 }
 
 impl WalTailPolicy {
-    /// The workspace policy: checkpoint at 32 segments, reject past 128.
+    /// The workspace policy: checkpoint at 32 segments, reject at the
+    /// longest tail the format admits.
     pub const DEFAULT: Self = Self {
         checkpoint_at_segments: 32,
-        reject_writes_at_segments: 128,
+        reject_writes_at_segments: crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS,
     };
 }
 
@@ -431,7 +433,9 @@ impl NamespaceCommitEngine {
         };
 
         let reject_writes_at_segments = WalTailPolicy::DEFAULT.reject_writes_at_segments;
-        if projection.wal_tail_segments > reject_writes_at_segments {
+        // `wal_tail_segments` is the tail this publish would extend, so
+        // rejecting at the bound is what keeps the landed tail inside it.
+        if projection.wal_tail_segments >= reject_writes_at_segments {
             let wal_tail_segments = projection.wal_tail_segments;
             self.publish_tail_projection = Some(projection);
             let error = MetadataViewError::MaintenanceRequired {
@@ -512,6 +516,11 @@ impl NamespaceCommitEngine {
             } => {
                 projection.wal_tail_segments = projection.wal_tail_segments.saturating_add(1);
                 let wal_tail_segments = projection.wal_tail_segments;
+                debug_assert!(
+                    wal_tail_segments <= crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS,
+                    "a landed publish left {wal_tail_segments} unflushed segments, \
+                     more than the head can describe"
+                );
                 // The head advanced, but without the etag its
                 // compare-and-swap acknowledged there is nothing to re-anchor
                 // the projection to.

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -35,6 +35,35 @@ pub const MAX_COMMIT_MESSAGE_BYTES: usize = 4096;
 /// Maximum attempts for a bounded compare-and-swap or allocation contention loop.
 pub const CONTENTION_RETRY_LIMIT: usize = 8;
 
+/// Longest visible WAL tail, in segments, a namespace may carry unflushed.
+/// Every publish surface rejects at this length with `maintenance_required`,
+/// so a landed publication never leaves more than this behind.
+pub const MAX_UNFLUSHED_WAL_SEGMENTS: u64 = 128;
+
+/// Segment pointers the head carries as a replay accelerator, newest first
+/// and always including the tip. Sized so the head describes the whole
+/// legal unflushed tail rather than to keep the head small: a full list
+/// encodes to roughly 68 KiB at realistic identifier lengths and 107 KiB at
+/// the worst case the grammars allow.
+pub(crate) const RECENT_SEGMENTS_LIMIT: usize = 256;
+
+/// The head-coverage inequality, shared by the compile-time assertion below
+/// and the test that proves the assertion has teeth.
+const fn covers_every_unflushed_segment(pointers: usize) -> bool {
+    pointers >= MAX_UNFLUSHED_WAL_SEGMENTS as usize
+}
+
+// A reader that wants a segment the head does not name walks predecessor
+// links to reach it, one round trip per segment, so an accelerator shorter
+// than the tail the rejection bound admits is a latency cliff the write
+// path can legally produce. The two constants have to move together, and
+// that is an inequality rather than a judgement call, so it is checked
+// where a broken derivation is a compile error instead of a test failure.
+const _: () = assert!(
+    covers_every_unflushed_segment(RECENT_SEGMENTS_LIMIT),
+    "the head must describe every legal unflushed WAL segment"
+);
+
 /// Provider operation deadline, in milliseconds (`loonfs-objectstore`
 /// consumes it across every retry of one single-request operation).
 /// Multipart transfers of large immutable payloads carry no
@@ -232,6 +261,20 @@ mod tests {
         // 7 days of re-minting + 1 hour of receipt life + 20.5 minutes of
         // publication.
         assert_eq!(CONTENT_RECLAMATION_GRACE_MS, 608_400_000 + 1_230_000);
+    }
+
+    /// Same bargain as above: the head-coverage assertion is only worth
+    /// having if its predicate can fail, so one pointer short of the legal
+    /// tail is exercised too.
+    #[test]
+    fn the_head_coverage_floor_rejects_a_list_one_segment_short() {
+        assert!(covers_every_unflushed_segment(RECENT_SEGMENTS_LIMIT));
+        assert!(covers_every_unflushed_segment(
+            MAX_UNFLUSHED_WAL_SEGMENTS as usize
+        ));
+        assert!(!covers_every_unflushed_segment(
+            MAX_UNFLUSHED_WAL_SEGMENTS as usize - 1
+        ));
     }
 
     #[test]

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -70,10 +70,12 @@ async fn fill_wal_tail_past_threshold(writer: &FsWriter, namespace_id: &Namespac
     }
 }
 
-async fn fill_wal_tail_through_write_stop(writer: &FsWriter, namespace_id: &NamespaceId) {
+/// Leaves the tail exactly at the write-stop bound: every write here is
+/// admitted, and the next one is not.
+async fn fill_wal_tail_to_write_stop(writer: &FsWriter, namespace_id: &NamespaceId) {
     let writes =
-        u32::try_from(loonfs_core::publish::WalTailPolicy::DEFAULT.reject_writes_at_segments + 1)
-            .expect("WAL write-stop limit plus one should fit in u32");
+        u32::try_from(loonfs_core::publish::WalTailPolicy::DEFAULT.reject_writes_at_segments)
+            .expect("the WAL write-stop bound should fit in u32");
     for round in 0..writes {
         writer
             .put_file_bytes(
@@ -83,7 +85,7 @@ async fn fill_wal_tail_through_write_stop(writer: &FsWriter, namespace_id: &Name
                 PutFileOptions::default(),
             )
             .await
-            .expect("put file through the write-stop boundary");
+            .expect("put file up to the write-stop boundary");
     }
 }
 
@@ -258,7 +260,7 @@ fn a_write_stopped_namespace_queued_at_the_global_cap_unblocks_itself() {
         blocking.block_next();
         fill_wal_tail_past_threshold(&writer, &active_namespace).await;
         blocking.wait_until_blocked().await;
-        fill_wal_tail_through_write_stop(&writer, &write_stopped_namespace).await;
+        fill_wal_tail_to_write_stop(&writer, &write_stopped_namespace).await;
         let error = writer
             .put_file_bytes(
                 &write_stopped_namespace,
@@ -267,7 +269,7 @@ fn a_write_stopped_namespace_queued_at_the_global_cap_unblocks_itself() {
                 PutFileOptions::default(),
             )
             .await
-            .expect_err("writes past the hard limit must reject");
+            .expect_err("writes against a tail at the hard limit must reject");
         assert_eq!(error.code(), ErrorCode::MaintenanceRequired);
 
         blocking.release();

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1940,7 +1940,7 @@ deployment's read costs bounded regardless of scheduling: the reference
 implementation nudges its maintenance runner after any runtime publish that
 observes the WAL tail at or past the WAL-tail policy's checkpoint threshold
 (32 segments at defaults), and every publish surface rejects with
-`maintenance_required` once the tail exceeds the same policy's
+`maintenance_required` once the tail reaches the same policy's
 write-rejection threshold (128 at defaults). Reads never gate on tail
 length. Bounded reads are the
 automatic half only: the retention floor never advances on its own, so


### PR DESCRIPTION
This fixes two WAL-tail boundary problems:
- A publish now stops when the current tail already contains 128 segments. A tail of 127 may accept one final segment; a tail of 128 is rejected before a WAL object is written.
- Namespace heads now retain 256 recent segment pointers instead of 32. That is enough to describe every legal unflushed tail, with additional room for recently flushed history, without walking serially. 

The old write gate used `>` against the pre-publication tail length, so it could admit a 129th segment. Separately, the 32-pointer head window was shorter than the 128-segment tail limit, which forced readers to follow older predecessor links one request at a time.

Details:
- Centralize the tail limit and pointer-window constants in `limits.rs`.
- Add a compile-time assertion that the pointer window covers the maximum unflushed tail.
- Update the publication boundary check.
- Update the format wording and remove CLI tests that depended on a literal threshold.

