### PR TITLE
fix(gc): the budget applies to the whole GC pass

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -642,12 +642,22 @@ pub struct GcResponse {
     /// True when ambiguous roots suppressed manifest/table deletion.
     pub degraded_retention: bool,
     /// True when the pass skipped completed-content reclamation because
-    /// the reference collection it needs did not fit in `max_objects`.
-    /// Nothing was ever decided from a partial collection and the rest of
-    /// the sweep ran normally; a later pass with room for the whole scan
-    /// reclaims what this one left behind.
+    /// what it needs — the namespace's live roots, then the reference
+    /// collection over them — did not fit in `max_objects`. Nothing was
+    /// ever decided from a partial collection; a later pass with room for
+    /// the whole scan reclaims what this one left behind. A pass that had
+    /// room for the roots swept every other candidate normally around the
+    /// skip, and one that did not also reports `budget_exhausted`.
     #[serde(default)]
     pub content_reclamation_deferred: bool,
+    /// True when the pass stopped because `max_objects` ran out before it
+    /// finished. Whatever it did before that is reported here and stands;
+    /// rerun with the returned cursor, or with a larger budget, to
+    /// continue. A budget too small for the namespace's own roots stops a
+    /// pass before it decides anything at all, which is what this says and
+    /// an empty report on its own does not.
+    #[serde(default)]
+    pub budget_exhausted: bool,
     /// Opaque resume token when more candidates remain. Resuming rebuilds
     /// every safety proof; the token carries enumeration position only and
     /// is valid only against the same namespace.
@@ -693,6 +703,7 @@ impl GcResponse {
             retained: RetainedCandidates::default(),
             degraded_retention: false,
             content_reclamation_deferred: false,
+            budget_exhausted: false,
             next_cursor: None,
             next_reclamation_at_ms: None,
         }

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -125,7 +125,10 @@ async fn run_admin_gc(
             Some(total) => accumulate_gc_response(total, pass),
             None => response = Some(pass),
         }
-        if single_pass || next_cursor.is_none() {
+        // A pass that hands back the cursor it was given ran out of budget
+        // before deciding anything, and would again; the summary's
+        // budget-exhausted line says why the drain stopped short.
+        if single_pass || next_cursor.is_none() || next_cursor == request.cursor {
             break;
         }
         request.cursor = next_cursor;
@@ -221,6 +224,7 @@ fn accumulate_gc_response(total: &mut loonfs_api::GcResponse, pass: loonfs_api::
     total.retained.add(&pass.retained);
     total.degraded_retention |= pass.degraded_retention;
     total.content_reclamation_deferred |= pass.content_reclamation_deferred;
+    total.budget_exhausted |= pass.budget_exhausted;
     // The summary keeps the soonest obligation any pass reported — the same
     // soonest-wake rule the maintenance runner applies. A later pass with
     // nothing deferred does not erase an earlier pass's pending horizon.

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -152,6 +152,9 @@ fn gc_summary(report: &GcResponse) -> String {
             "; content reclamation deferred: the reference scan did not fit in --max-objects",
         );
     }
+    if report.budget_exhausted {
+        summary.push_str("; stopped on --max-objects before the pass finished");
+    }
     if let Some(cursor) = &report.next_cursor {
         summary.push_str(&format!("; next_cursor: {cursor}"));
     }

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -4915,14 +4915,33 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_success(&quiet_gc);
         assert!(!stderr_string(&quiet_gc).contains("pass 1:"));
 
-        // Supplying a candidate budget requests exactly one pass and exposes
-        // the opaque cursor instead of the CLI's default completion loop.
-        let bounded_gc = harness.run(&[
+        // The budget covers marking too, so one object buys the head and
+        // the root beside it and nothing else. That pass says it ran out
+        // rather than reporting a clean sweep, and hands back no position
+        // it never reached.
+        let starved_gc = harness.run(&[
             "--json",
             "admin",
             "gc",
             "--max-objects",
             "1",
+            "--profile",
+            profile,
+        ]);
+        assert_success(&starved_gc);
+        let starved_data = json_data(&starved_gc);
+        assert_eq!(starved_data["budget_exhausted"], true);
+        assert!(starved_data.get("next_cursor").is_none());
+
+        // Supplying a budget with room for the roots and some candidates
+        // requests exactly one pass and exposes the opaque cursor instead
+        // of the CLI's default completion loop.
+        let bounded_gc = harness.run(&[
+            "--json",
+            "admin",
+            "gc",
+            "--max-objects",
+            "8",
             "--profile",
             profile,
         ]);

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -2,16 +2,25 @@
 
 use super::config::GcConfig;
 
-/// The work one garbage-collection pass is allowed to do.
+/// The work one garbage-collection pass is allowed to do, from its first
+/// read to its last. Marking is inside the bound, not before it.
 ///
 /// One unit is one object the pass reads or decides on a candidate's
 /// behalf:
 ///
-/// * one enumerated candidate key, decided — the original meaning of
-///   `max_objects`;
-/// * one manifest opened by the content reference scan;
+/// * the head and the metadata root together — one unit for the pair,
+///   because they are read concurrently and neither is a root without the
+///   other;
+/// * the retention floor;
+/// * one checkpoint record read while marking, plus one more for the fork
+///   target head that decides whether that record's target is gone;
+/// * one manifest opened, whether to mark its tables or by the content
+///   reference scan;
 /// * one page of revision rows read out of an opened manifest;
-/// * one retained WAL segment fetched by the scan.
+/// * the retained WAL chain, charged as one block of one unit per segment
+///   once the chain validates;
+/// * one enumerated candidate key, decided — the original meaning of
+///   `max_objects`.
 ///
 /// Prefix listing is the one thing not metered: it is how a family finds
 /// candidates at all, and the cursor is what resumes it. Everything else a
@@ -55,6 +64,14 @@ impl PassBudget {
         self.spent = self.spent.saturating_add(1);
     }
 
+    /// What has been charged so far. Tests price a namespace's roots with
+    /// this, so a bounded case can ask for a budget in candidates rather
+    /// than in a number that has to be kept true by hand.
+    #[cfg(test)]
+    pub(super) fn spent(&self) -> u64 {
+        self.spent
+    }
+
     /// Charges one unit for work about to be done. `false` means the
     /// budget is spent and the caller must not do it.
     pub(super) fn try_charge(&mut self) -> bool {
@@ -63,5 +80,18 @@ impl PassBudget {
         }
         self.charge();
         true
+    }
+
+    /// Charges `units` for one block of work that could not be stopped
+    /// partway — the retained WAL chain, loaded whole by a loader that is
+    /// shared with foreground reads and takes no budget of its own. The
+    /// charge always lands, because the reads happened; `false` says the
+    /// block overdrew what was left and the pass stops having paid for it.
+    pub(super) fn charge_block(&mut self, units: u64) -> bool {
+        let within_budget = self
+            .max_objects
+            .is_none_or(|max_objects| self.spent.saturating_add(units) <= max_objects);
+        self.spent = self.spent.saturating_add(units);
+        within_budget
     }
 }

--- a/crates/loonfs-core/src/gc/config.rs
+++ b/crates/loonfs-core/src/gc/config.rs
@@ -16,13 +16,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GcConfig {
     pub grace_window_ms: u64,
-    /// Maximum objects this invocation may read or decide. `None` keeps the
-    /// run-to-completion behavior. What one unit buys is spelled out on
-    /// `gc::budget::PassBudget`; the short version is that the content
-    /// reference scan pays out of the same purse as candidate enumeration,
-    /// so a budget smaller than that scan defers content reclamation
-    /// instead of finishing it, pass after pass, while the rest of the
-    /// sweep proceeds normally.
+    /// Maximum objects this invocation may read or decide, marking
+    /// included. `None` keeps the run-to-completion behavior. What one unit
+    /// buys is spelled out on `gc::budget::PassBudget`; the short version
+    /// is that everything pays out of one purse, and the pass spends it in
+    /// the order it needs things.
+    ///
+    /// Two budgets are therefore worth naming. One below the namespace's
+    /// roots — the head, the floor, the checkpoint records, the live
+    /// manifests, and the retained WAL chain — buys nothing at all: the
+    /// pass reports `budget_exhausted`, deletes nothing, and hands back the
+    /// position it came in with. One above the roots but below the content
+    /// reference scan on top of them sweeps normally and defers content
+    /// reclamation, pass after pass, until a budget with room for the scan
+    /// runs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_objects: Option<u64>,
     /// Opaque enumeration cursor returned by an earlier invocation.

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -1,19 +1,23 @@
 //! Collects the live set: every object the current namespace state
 //! can still reach, re-verified in chunks as the sweep advances.
 
+use super::budget::PassBudget;
 use super::fork_checkpoints::fork_target_proven_gone;
 use super::reap::lease_expired;
 use crate::checkpoint::load_namespace_manifest_envelope_if_present;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
-use crate::namespace::basis::{read_head_and_metadata_basis, resolve_retention_floor_seq};
+use crate::namespace::basis::{
+    read_head_and_metadata_basis, resolve_retention_floor_seq, LoadedNamespaceBasis,
+};
 use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
 use futures::StreamExt;
 use loonfs_api::wire::control::{
     decode_control_object, CheckpointOwner, CheckpointRecordLifecycle, CheckpointRecordState,
     ControlObjectKind, NamespaceState,
 };
-use loonfs_api::{ManifestObjectId, NamespaceId};
+use loonfs_api::wire::wal::WalDelta;
+use loonfs_api::{ContentId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::{checkpoint_prefix, metadata_manifest_object};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
@@ -24,6 +28,12 @@ pub(super) struct LiveSet {
     pub(super) manifests: BTreeSet<ManifestObjectId>,
     pub(super) tables: BTreeSet<String>,
     pub(super) wal_segments: BTreeSet<String>,
+    /// Content the retained chain's commits append, harvested from the same
+    /// decoded bodies the chain walk validated. These are the references
+    /// that protect bytes a durable commit named but no manifest has
+    /// materialized yet, and reading them here is why no later scan fetches
+    /// a segment a second time.
+    pub(super) wal_content_ids: BTreeSet<ContentId>,
     pub(super) checkpoint_keys: BTreeSet<String>,
     /// Still-active records whose basis manifest is verifiably absent —
     /// the crash window between record write and verification. The pass
@@ -34,6 +44,32 @@ pub(super) struct LiveSet {
     pub(super) degraded: bool,
     /// The inspected namespace head is the terminal, absorbing tombstone.
     pub(super) namespace_deleted: bool,
+}
+
+/// What one collection produced. Marking is all or nothing: a partial root
+/// set is not a smaller answer, it is no answer, and deciding a deletion
+/// against one would delete something live.
+pub(super) enum LiveSetCollection {
+    Complete(LiveSet),
+    BudgetExhausted,
+}
+
+impl LiveSetCollection {
+    /// The roots, when the collection got all of them.
+    #[cfg(test)]
+    pub(super) fn complete(self) -> Option<LiveSet> {
+        match self {
+            Self::Complete(live) => Some(live),
+            Self::BudgetExhausted => None,
+        }
+    }
+}
+
+/// Whether the pass may go on from here, or stopped because its budget did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SweepStep {
+    Continue,
+    BudgetExhausted,
 }
 
 /// Delete-time re-verification state (rule 3): deletion decisions consult a
@@ -60,28 +96,56 @@ impl SweepVerifier {
         &mut self,
         store: &S,
         namespace_id: &NamespaceId,
+        budget: &mut PassBudget,
         context: &MutationContext,
-    ) -> Result<()> {
+    ) -> Result<SweepStep> {
         if self.decided_since_collect >= self.reverify_chunk {
-            self.live = Arc::new(collect_live_set(store, namespace_id, context).await?);
-            self.degraded |= self.live.degraded;
-            self.decided_since_collect = 0;
+            match recollect_live_set(store, namespace_id, budget, context).await? {
+                LiveSetCollection::Complete(live) => {
+                    self.live = Arc::new(live);
+                    self.degraded |= self.live.degraded;
+                    self.decided_since_collect = 0;
+                }
+                // Rule 3 does not bend for a budget: a decision needs a
+                // live set no staler than the chunk, so a pass that cannot
+                // pay for a fresh one stops sweeping rather than deciding
+                // against the stale one.
+                LiveSetCollection::BudgetExhausted => return Ok(SweepStep::BudgetExhausted),
+            }
         }
         self.decided_since_collect += 1;
-        Ok(())
+        Ok(SweepStep::Continue)
     }
 }
 
-pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
+/// Collects against a freshly read head and basis. Re-collecting is what a
+/// mid-sweep refresh is for, so it pays for the pair like the pass's own
+/// first read did.
+pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    budget: &mut PassBudget,
     context: &MutationContext,
-) -> Result<LiveSet> {
-    let now_ms = context.now_ms;
+) -> Result<LiveSetCollection> {
+    if !budget.try_charge() {
+        return Ok(LiveSetCollection::BudgetExhausted);
+    }
     let loaded = read_head_and_metadata_basis(store, namespace_id)
         .await
         .map_err(CoreError::load_head)?;
-    let head = loaded.head.envelope.state;
+    collect_live_set(store, namespace_id, &loaded, budget, context).await
+}
+
+/// Collects from the head and basis the pass already read and charged for.
+pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    loaded: &LoadedNamespaceBasis,
+    budget: &mut PassBudget,
+    context: &MutationContext,
+) -> Result<LiveSetCollection> {
+    let now_ms = context.now_ms;
+    let head = &loaded.head.envelope.state;
     // A namespace with no root of its own roots no manifest here: the
     // genesis basis has none, and a fork target's basis is a source-prefix
     // object that the source's own pass protects through the fork-owned
@@ -96,7 +160,10 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     });
     // A missing floor means retain from the namespace's birth sequence
     // (format spec, "WAL floor").
-    let floor_seq = resolve_retention_floor_seq(store, &head)
+    if !budget.try_charge() {
+        return Ok(LiveSetCollection::BudgetExhausted);
+    }
+    let floor_seq = resolve_retention_floor_seq(store, head)
         .await
         .map_err(CoreError::load_head)?;
 
@@ -105,6 +172,7 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
         manifests: BTreeSet::new(),
         tables: BTreeSet::new(),
         wal_segments: BTreeSet::new(),
+        wal_content_ids: BTreeSet::new(),
         checkpoint_keys: BTreeSet::new(),
         missing_basis_records: BTreeSet::new(),
         degraded: false,
@@ -133,6 +201,9 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     let mut checkpoint_keys = store.list_prefix_stream(&checkpoints_prefix);
     while let Some(item) = checkpoint_keys.next().await {
         let key = item.map_err(|error| CoreError::store(&checkpoints_prefix, &error))?;
+        if !budget.try_charge() {
+            return Ok(LiveSetCollection::BudgetExhausted);
+        }
         let Some(body) = store
             .get_with_metadata(&key)
             .await
@@ -159,6 +230,9 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
                     CheckpointOwner::Fork {
                         target_namespace_id,
                     } => {
+                        if !budget.try_charge() {
+                            return Ok(LiveSetCollection::BudgetExhausted);
+                        }
                         fork_target_proven_gone(store, target_namespace_id, &record, context)
                             .await?
                     }
@@ -204,6 +278,9 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     // are trusted to protect data — the envelope loader checks the payload
     // checksum).
     for manifest_object_id in live.manifests.clone() {
+        if !budget.try_charge() {
+            return Ok(LiveSetCollection::BudgetExhausted);
+        }
         let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
         match load_namespace_manifest_envelope_if_present(
             store,
@@ -242,6 +319,13 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     // root-to-head replay (rule 7). A terminal namespace has no replay
     // future: its chain ages out.
     if !namespace_deleted && head.seq > floor_seq {
+        // The loader is shared with foreground reads and the changefeed, so
+        // it carries no budget and cannot stop partway. What the pass can
+        // do is refuse to start a load it has nothing left to pay for, and
+        // charge the whole chain as one block once it validates.
+        if budget.exhausted() {
+            return Ok(LiveSetCollection::BudgetExhausted);
+        }
         let chain = load_validated_wal_chain(
             store,
             WalChainLoadRequest {
@@ -257,10 +341,24 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
         })?;
-        for segment in chain.segments() {
+        let segments = chain.segments();
+        if !budget.charge_block(u64::try_from(segments.len()).unwrap_or(u64::MAX)) {
+            return Ok(LiveSetCollection::BudgetExhausted);
+        }
+        for segment in segments {
             live.wal_segments.insert(segment.object_key().to_owned());
+            // The bodies are decoded and validated right here, so the
+            // content these commits name is read off them now rather than
+            // by a second pass over the same objects.
+            for record in segment.records() {
+                for delta in &record.deltas {
+                    if let WalDelta::AppendFileRevision { content_ref, .. } = &delta.delta {
+                        live.wal_content_ids.insert(content_ref.content_id.clone());
+                    }
+                }
+            }
         }
     }
 
-    Ok(live)
+    Ok(LiveSetCollection::Complete(live))
 }

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -7,14 +7,15 @@ use super::cursor::{CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
     maybe_release_fork_checkpoint, release_missing_basis_checkpoint, ForkCheckpointSweep,
 };
-use super::live_set::{collect_live_set, LiveSet, SweepVerifier};
+use super::live_set::{collect_live_set, LiveSet, LiveSetCollection, SweepStep, SweepVerifier};
 use super::reap::{
     delete_if_aged, manifest_object_id_of, sweep_checkpoint_record, CheckpointSweep,
 };
 use super::uploads::{sweep_upload_session, ContentReferences, UploadSessionSweep};
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
-use crate::namespace::control::{read_head_object, ControlObjectLoadError};
+use crate::namespace::basis::read_head_and_metadata_basis;
+use crate::namespace::control::ControlObjectLoadError;
 use futures::StreamExt;
 use loonfs_api::v0::GcResponse;
 use loonfs_api::{ContentStoreId, NamespaceId, RetainedReason, UploadId};
@@ -44,39 +45,58 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     reverify_chunk: usize,
 ) -> Result<GcResponse> {
     config.validate()?;
-    // The head is the namespace: without one there is nothing to collect,
-    // and nothing could have been written under the prefix either, because
-    // the head is every installation's first and only write. It also names
-    // the content store a session's object lives in.
-    let content_store_id = match read_head_object(store, namespace_id).await {
-        Ok(head) => head.envelope.state.content_store_id,
-        Err(ControlObjectLoadError::MissingObject { .. }) => {
-            return Ok(GcResponse::empty(namespace_id.clone()))
-        }
-        Err(error) => return Err(CoreError::load_head(error)),
-    };
-
     let resume = match config.cursor.as_deref() {
         Some(token) => GcCursor::decode(token, namespace_id)?,
         None => GcCursor::initial(namespace_id),
     };
+    let mut report = GcResponse::empty(namespace_id.clone());
+    // The budget opens before the first read, so marking is inside it. A
+    // pass that cannot afford its own roots has to say so, rather than
+    // reading the whole retained chain for free and metering only what
+    // comes after.
+    let mut budget = PassBudget::of(config);
+
+    // The head is the namespace: without one there is nothing to collect,
+    // and nothing could have been written under the prefix either, because
+    // the head is every installation's first and only write. It also names
+    // the content store a session's object lives in. The metadata root is
+    // read alongside it and charged with it as one unit.
+    budget.charge();
+    let loaded = match read_head_and_metadata_basis(store, namespace_id).await {
+        Ok(loaded) => loaded,
+        Err(ControlObjectLoadError::MissingObject { .. }) => return Ok(report),
+        Err(error) => return Err(CoreError::load_head(error)),
+    };
+    let content_store_id = loaded.head.envelope.state.content_store_id.clone();
 
     // Every invocation rebuilds all roots before interpreting the cursor.
     // The cursor can skip enumeration only; it never carries safety state.
-    let mark = Arc::new(collect_live_set(store, namespace_id, context).await?);
+    let mark = match collect_live_set(store, namespace_id, &loaded, &mut budget, context).await? {
+        LiveSetCollection::Complete(live) => Arc::new(live),
+        // Nothing was marked, so nothing may be decided: the pass deletes
+        // nothing, hands back the position it came in with rather than
+        // inventing progress, and says why. Content reclamation is skipped
+        // for the same reason the scan itself skips it — the collection it
+        // needs did not fit.
+        LiveSetCollection::BudgetExhausted => {
+            report.budget_exhausted = true;
+            report.content_reclamation_deferred = true;
+            report.next_cursor.clone_from(&config.cursor);
+            return Ok(report);
+        }
+    };
     let mut sweep = SweepVerifier::seeded(Arc::clone(&mark), reverify_chunk);
     // Content references are collected from this same root set, lazily and
     // at most once per invocation. The derived reclamation grace is what
     // lets one collection stand for every candidate that follows it: past
     // it, no receipt survives that could add a reference. The scan is
-    // charged against the budget below like everything else, and an
-    // invocation that cannot afford it skips content reclamation instead
-    // of overrunning — the sessions waiting on it are retained and the
-    // sweep continues.
+    // charged against the budget like everything else, and an invocation
+    // that cannot afford it skips content reclamation instead of
+    // overrunning — the sessions waiting on it are retained and the sweep
+    // continues.
     let mut references = ContentReferences::over(&mark);
-    let mut report = GcResponse::empty(namespace_id.clone());
-    let mut budget = PassBudget::of(config);
     let mut position = resume.clone();
+    let mut decided = 0_u64;
 
     // Data precedes mutable records. A crash or bounded return can therefore
     // leave data protected for an extra pass, never a readable record whose
@@ -94,16 +114,19 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
             {
                 continue;
             }
-            if budget.exhausted() {
-                // This one-key lookahead proves work remains. It performs no
-                // candidate reads or mutations; the key is reconsidered from
-                // the exclusive last-examined position on resume.
-                report.next_cursor = Some(position.encode()?);
-                report.degraded_retention = sweep.degraded;
-                return Ok(report);
+            // The first candidate of a pass is decided whatever is left,
+            // because marking spends out of this same budget: a namespace
+            // whose roots cost the whole of `max_objects` would otherwise
+            // hand back the cursor it came in with forever, marking each
+            // time and walking nowhere. Past that first key the lookahead
+            // is the ordinary one — it proves work remains, performs no
+            // candidate reads or mutations, and leaves the key to be
+            // reconsidered from the exclusive last-examined position.
+            if decided > 0 && budget.exhausted() {
+                return stopped_on_budget(report, &position, &sweep);
             }
 
-            process_candidate(
+            let step = process_candidate(
                 store,
                 namespace_id,
                 &content_store_id,
@@ -118,18 +141,38 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
                 &mut report,
             )
             .await?;
-            // Every candidate this loop hands to `process_candidate` comes
-            // back decided one way or the other, so the cursor always
-            // advances past it. The one thing a pass can run out of budget
-            // to answer — whether a completed session's content is still
+            if step == SweepStep::BudgetExhausted {
+                // The re-verification this candidate's decision needs could
+                // not be paid for, so the candidate stays undecided and is
+                // reconsidered from the same exclusive position on resume.
+                return stopped_on_budget(report, &position, &sweep);
+            }
+            // Every candidate that gets past the check above comes back
+            // decided one way or the other, so the cursor always advances
+            // past it. The one thing a pass can run out of budget to
+            // answer — whether a completed session's content is still
             // referenced — is answered by retaining the session, never by
             // leaving it undecided and stopping: a budget below that scan's
             // cost would otherwise pin the walk to one key forever.
             budget.charge();
+            decided += 1;
             position = GcCursor::after(namespace_id, family, key);
         }
     }
 
+    report.degraded_retention = sweep.degraded;
+    Ok(report)
+}
+
+/// Closes a pass that stopped mid-enumeration on its budget, reporting the
+/// work it did do and where a rerun picks the walk back up.
+fn stopped_on_budget(
+    mut report: GcResponse,
+    position: &GcCursor,
+    sweep: &SweepVerifier,
+) -> Result<GcResponse> {
+    report.budget_exhausted = true;
+    report.next_cursor = Some(position.encode()?);
     report.degraded_retention = sweep.degraded;
     Ok(report)
 }
@@ -148,9 +191,9 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     references: &mut ContentReferences<'_>,
     budget: &mut PassBudget,
     report: &mut GcResponse,
-) -> Result<()> {
+) -> Result<SweepStep> {
     if family == CandidateFamily::UploadSessions {
-        return process_upload_session(
+        process_upload_session(
             store,
             namespace_id,
             content_store_id,
@@ -161,7 +204,8 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
             budget,
             report,
         )
-        .await;
+        .await?;
+        return Ok(SweepStep::Continue);
     }
 
     if family == CandidateFamily::Checkpoints && mark.missing_basis_records.contains(key) {
@@ -178,7 +222,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         } else {
             report.retain(RetainedReason::CheckpointNotReleasable);
         }
-        return Ok(());
+        return Ok(SweepStep::Continue);
     }
 
     // Preserve the existing mark selection exactly: objects reachable from
@@ -195,10 +239,16 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         CandidateFamily::UploadSessions => false,
     };
     if !selected {
-        return Ok(());
+        return Ok(SweepStep::Continue);
     }
 
-    sweep.refresh_if_due(store, namespace_id, context).await?;
+    if sweep
+        .refresh_if_due(store, namespace_id, budget, context)
+        .await?
+        == SweepStep::BudgetExhausted
+    {
+        return Ok(SweepStep::BudgetExhausted);
+    }
     // Each arm names the one reason it kept a candidate. The decisions are
     // exactly the ones they always were — the `||` conditions below are
     // split only so a retention can say which half of the condition held.
@@ -245,7 +295,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         }
         CandidateFamily::UploadSessions => {}
     }
-    Ok(())
+    Ok(SweepStep::Continue)
 }
 
 /// Ages one unreferenced key out, recording the reason when it stays.

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1,7 +1,8 @@
 //! Behavior tests for namespace GC.
 
+use super::budget::PassBudget;
 use super::config::GcConfig;
-use super::live_set::collect_live_set;
+use super::live_set::{recollect_live_set, LiveSet};
 use super::run::{gc_namespace, gc_namespace_with_reverify_chunk};
 use crate::checkpoint::advance_retention_floor;
 use crate::checkpoint::record::release_checkpoint_record;
@@ -21,11 +22,11 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::{ContentRef, ContentStoreId, NamespaceId, UploadId};
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_manifest_object, metadata_manifest_prefix, metadata_table,
-    metadata_table_prefix, wal_segment, wal_segment_prefix,
+    checkpoint_prefix, metadata_manifest_object, metadata_manifest_prefix, metadata_root,
+    metadata_table, metadata_table_prefix, wal_head, wal_segment, wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroUsize;
 
 use crate::commit_engine::delete_namespace;
@@ -38,7 +39,8 @@ use futures::stream::BoxStream;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
 use loonfs_test_support::stores::{
-    BlockingStore, CountingStore, KeyPredicate, MetadataMapStore, OperationContext, OperationKind,
+    BlockingStore, CountingStore, KeyPredicate, MetadataMapStore, OperationClass, OperationContext,
+    OperationKind, RecordingStore,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::tempdir;
@@ -55,6 +57,41 @@ fn config() -> GcConfig {
 
 fn context(now_ms: u64) -> MutationContext {
     mutation_context("gc-test", now_ms)
+}
+
+/// The roots one unbounded collection finds, for tests that assert against
+/// the same set a pass marks.
+async fn live_set<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> LiveSet {
+    marked(store, namespace_id, context).await.0
+}
+
+/// What marking this namespace costs, in budget units. Marking is inside
+/// `max_objects`, so a bounded test asks for the roots plus the candidates
+/// it means to buy rather than for a number kept true by hand.
+async fn marking_units<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> u64 {
+    marked(store, namespace_id, context).await.1
+}
+
+async fn marked<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> (LiveSet, u64) {
+    let mut budget = PassBudget::new(None);
+    let live = recollect_live_set(store, namespace_id, &mut budget, context)
+        .await
+        .expect("collect live set")
+        .complete()
+        .expect("an unbounded collection cannot run out");
+    (live, budget.spent())
 }
 
 /// The durable lifecycle of one checkpoint record, stamp included.
@@ -1134,13 +1171,13 @@ async fn namespace_with_a_scan_worth_bounding(
     }
 }
 
-/// The reference scan is the one place a bounded pass used to do unbounded
-/// work. A one-object budget cannot finish it, and the honest response to
-/// that is to reclaim nothing and say so: the session and its content stay
-/// exactly where they were, `content_reclamation_deferred` reports the
-/// skip, and the walk keeps moving past the session rather than pinning
-/// itself to it. A later pass with room for the scan reaches the verdict an
-/// unbounded pass would have reached.
+/// A budget with room for the roots and one candidate a pass has nothing
+/// left for the reference scan, and the honest response to that is to
+/// reclaim nothing and say so: the session and its content stay exactly
+/// where they were, `content_reclamation_deferred` reports the skip, and
+/// the walk keeps moving past the session rather than pinning itself to it.
+/// A later pass with room for the scan reaches the verdict an unbounded
+/// pass would have reached.
 #[tokio::test]
 async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1152,20 +1189,18 @@ async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
         complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
     let content_key =
         loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
-    let live = collect_live_set(&store, &namespace_id, &setup)
-        .await
-        .expect("collect live set");
+    let live = live_set(&store, &namespace_id, &setup).await;
     assert!(
         !live.manifests.is_empty() && !live.wal_segments.is_empty(),
         "the fixture must give the scan more than one object to read"
     );
 
-    // One object per pass: the sweep advances a key at a time until it
-    // reaches the session, and the scan behind that session never fits in
-    // one object. The walk has to get past it anyway.
+    // One candidate a pass: the sweep advances a key at a time until it
+    // reaches the session, and nothing is left over for the scan behind
+    // that session. The walk has to get past it anyway.
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
     let mut tiny = config();
-    tiny.max_objects = Some(1);
+    tiny.max_objects = Some(marking_units(&store, &namespace_id, &past).await + 1);
     let mut cursor: Option<String> = None;
     let mut deferred = false;
     let mut passes = 0;
@@ -1173,7 +1208,7 @@ async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
         passes += 1;
         assert!(
             passes <= 64,
-            "a one-object budget must still walk the namespace to the end"
+            "a one-candidate budget must still walk the namespace to the end"
         );
         tiny.cursor.clone_from(&cursor);
         let pass = gc_namespace(&store, &namespace_id, &tiny, &past)
@@ -1197,7 +1232,7 @@ async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
     }
     assert!(
         deferred,
-        "a one-object budget cannot afford the scan, and the pass must say so"
+        "a budget spent on the roots cannot afford the scan, and the pass must say so"
     );
     assert!(
         store.head(&content_key).await.expect("head").is_some(),
@@ -1223,6 +1258,214 @@ async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
     assert!(read_upload_session(&store, &namespace_id, &upload_id)
         .await
         .is_none());
+}
+
+/// Marking spends out of the same budget as everything else, and it spends
+/// first. One unit buys the head and the metadata root beside it and
+/// nothing more: no floor, no manifest, and above all no retained WAL
+/// chain, which is where the unmetered reading used to be. The pass says it
+/// ran out rather than reporting an empty pass, which is what an operator
+/// would otherwise read as a clean namespace.
+#[tokio::test]
+async fn a_budget_below_the_roots_reads_no_chain_and_says_it_ran_out() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
+    let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
+    assert!(
+        live_set(&inner, &namespace_id, &aged)
+            .await
+            .wal_segments
+            .len()
+            > 1,
+        "the fixture must retain a chain worth more than one unit"
+    );
+
+    let store = RecordingStore::new(inner, KeyPredicate::any());
+    let mut tiny = config();
+    tiny.max_objects = Some(1);
+    let report = gc_namespace(&store, &namespace_id, &tiny, &aged)
+        .await
+        .expect("one-unit pass");
+
+    let mut exhausted_before_marking = GcResponse::empty(namespace_id.clone());
+    exhausted_before_marking.budget_exhausted = true;
+    exhausted_before_marking.content_reclamation_deferred = true;
+    assert_eq!(
+        report, exhausted_before_marking,
+        "a pass that never marked decides nothing and invents no cursor"
+    );
+    let mut read = store.take_get_keys();
+    read.sort();
+    assert_eq!(
+        read,
+        vec![
+            metadata_root(namespace_id.as_str()),
+            wal_head(namespace_id.as_str())
+        ],
+        "the pair the pass charged itself for is all it read"
+    );
+}
+
+/// The chain loader is shared with foreground reads and cannot stop
+/// partway, so the pass refuses to start a load it has nothing left to pay
+/// for. A budget sized to everything before the chain therefore stops at
+/// that gate: no segment is fetched, no candidate is decided, and a rerun
+/// with room does the whole job.
+#[tokio::test]
+async fn a_budget_that_dies_at_the_chain_gate_sweeps_nothing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
+    let (upload_id, ..) =
+        complete_upload_for_gc(&inner, &namespace_id, b"unpublished\n", &setup).await;
+    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+    let (live, marking) = marked(&inner, &namespace_id, &past).await;
+    let chain_units = u64::try_from(live.wal_segments.len()).expect("segment count fits");
+    assert!(chain_units > 0, "the fixture must retain a chain");
+
+    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str()));
+    let store = CountingStore::new(inner, segment_reads);
+    let mut at_the_gate = config();
+    at_the_gate.max_objects = Some(marking - chain_units);
+    let report = gc_namespace(&store, &namespace_id, &at_the_gate, &past)
+        .await
+        .expect("pass stopped at the chain gate");
+
+    assert!(report.budget_exhausted);
+    assert_eq!(report.next_cursor, None);
+    assert_eq!(report.retained_candidates, 0, "no candidate was examined");
+    assert_eq!(report.deleted_upload_sessions, 0);
+    assert_eq!(
+        store.count(OperationClass::Read),
+        0,
+        "the gate holds before the chain is fetched, not after"
+    );
+
+    // The same namespace, unbounded: the work the gate deferred is exactly
+    // the work that gets done.
+    let resumed = gc_namespace(&store, &namespace_id, &config(), &past)
+        .await
+        .expect("unbounded rerun");
+    assert!(!resumed.budget_exhausted);
+    assert_eq!(resumed.deleted_upload_sessions, 1);
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_none());
+}
+
+/// Marking decodes and validates every retained segment already, so the
+/// content those commits name is read off the same bodies rather than by a
+/// second pass over the same objects. One complete pass, one fetch per
+/// segment — and the reference that only exists in a retained WAL record
+/// still protects its bytes, because that harvest is where it comes from.
+#[tokio::test]
+async fn a_complete_pass_fetches_each_retained_segment_once() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
+    let (upload_id, content_ref, content_store_id, prepared) =
+        complete_upload_for_gc(&inner, &namespace_id, b"wal-only\n", &setup).await;
+    // Nothing has been flushed since this publish, so the newest WAL
+    // segment is the only place the reference lives.
+    publish_completed_content(
+        &inner,
+        &namespace_id,
+        "/docs/wal-only.txt",
+        content_ref.clone(),
+        prepared,
+        &setup,
+    )
+    .await;
+    let content_key =
+        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+    let retained = live_set(&inner, &namespace_id, &past).await.wal_segments;
+    assert!(!retained.is_empty(), "the fixture must retain a chain");
+
+    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str()));
+    let store = RecordingStore::new(inner, segment_reads);
+    let report = gc_namespace(&store, &namespace_id, &config(), &past)
+        .await
+        .expect("unbounded pass");
+
+    let mut fetches: BTreeMap<String, usize> = BTreeMap::new();
+    for key in store.take_get_keys() {
+        *fetches.entry(key).or_default() += 1;
+    }
+    assert_eq!(
+        fetches.keys().cloned().collect::<BTreeSet<_>>(),
+        retained,
+        "a pass reads the retained chain and nothing else under the segment prefix"
+    );
+    for (key, count) in &fetches {
+        assert_eq!(*count, 1, "segment `{key}` was fetched {count} times");
+    }
+    assert_eq!(
+        report.deleted_content_objects, 0,
+        "a reference that only a retained WAL record carries still protects its bytes"
+    );
+    assert!(store.head(&content_key).await.expect("head").is_some());
+    assert_eq!(
+        report.deleted_upload_sessions, 1,
+        "the session itself has said everything it will say"
+    );
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_none());
+}
+
+/// Checkpoint records are read one at a time while marking, and each one
+/// costs a unit like everything else. A budget that covers the head-and-root
+/// pair, the floor, and exactly one of six records stops inside that loop:
+/// one record read, nothing marked, nothing decided.
+#[tokio::test]
+async fn a_budget_that_dies_among_the_checkpoint_records_decides_nothing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    add_bounded_gc_fixture(&inner, &namespace_id, &setup).await;
+    let aged = context(
+        now_after_newest_object(
+            &inner,
+            &namespace_id,
+            UPLOAD_SESSION_LEASE_MS + 2 * GRACE_MS + 1,
+        )
+        .await,
+    );
+
+    let record_reads = KeyPredicate::prefix(checkpoint_prefix(namespace_id.as_str()));
+    let store = CountingStore::new(inner, record_reads);
+    let mut bounded = config();
+    bounded.max_objects = Some(3);
+    let report = gc_namespace(&store, &namespace_id, &bounded, &aged)
+        .await
+        .expect("pass stopped among the records");
+
+    assert!(report.budget_exhausted);
+    assert_eq!(report.next_cursor, None);
+    assert_eq!(report.retained_candidates, 0);
+    assert_eq!(
+        (
+            report.deleted_wal_segments,
+            report.deleted_metadata_tables,
+            report.deleted_manifests,
+            report.deleted_checkpoint_records,
+        ),
+        (0, 0, 0, 0)
+    );
+    assert_eq!(
+        store.count(OperationClass::Read),
+        1,
+        "the third unit bought exactly one record read"
+    );
 }
 
 /// The only reference keeping this content alive lives in the newest WAL
@@ -2775,7 +3018,10 @@ async fn bounded_passes_delete_exactly_the_unbounded_pass_set() {
     )
     .await;
     let mut bounded_config = config();
-    bounded_config.max_objects = Some(3);
+    // Three candidates a pass, on top of what marking this namespace's
+    // roots costs every time the pass rebuilds them.
+    bounded_config.max_objects =
+        Some(marking_units(&bounded_store, &namespace_id, &context(bounded_now)).await + 3);
     let mut bounded_report = GcResponse::empty(namespace_id.clone());
     let mut passes = 0;
     loop {
@@ -2847,7 +3093,9 @@ async fn budget_caps_candidate_operations_and_cursor_resumes_mid_family() {
     let wal_prefix = wal_segment_prefix(namespace_id.as_str());
     let store = CountingStore::new(inner, KeyPredicate::prefix(wal_prefix));
     let mut bounded = config();
-    bounded.max_objects = Some(2);
+    // Two candidates a pass, plus the roots the pass marks before it walks.
+    bounded.max_objects = Some(marking_units(&store, &namespace_id, &aged).await + 2);
+    store.reset();
 
     let first = gc_namespace(&store, &namespace_id, &bounded, &aged)
         .await
@@ -2917,7 +3165,8 @@ async fn stale_cursor_rebuilds_roots_before_resuming() {
     }
     let first_now = now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await;
     let mut bounded = config();
-    bounded.max_objects = Some(1);
+    // One candidate a pass, on top of the roots the pass marks first.
+    bounded.max_objects = Some(marking_units(&store, &namespace_id, &context(first_now)).await + 1);
     let first = gc_namespace(&store, &namespace_id, &bounded, &context(first_now))
         .await
         .expect("first bounded pass");
@@ -2936,9 +3185,7 @@ async fn stale_cursor_rebuilds_roots_before_resuming() {
         .expect("new checkpoint");
     let resume_now = now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await;
     let resume_context = context(resume_now);
-    let live = collect_live_set(&store, &namespace_id, &resume_context)
-        .await
-        .expect("collect advanced live set");
+    let live = live_set(&store, &namespace_id, &resume_context).await;
 
     let mut resume = config();
     resume.cursor = Some(cursor);

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -30,7 +30,6 @@ use crate::storage::content::delete_unpublished_content_object;
 use loonfs_api::wire::control::{UploadSessionLifecycle, UploadSessionState};
 use loonfs_api::wire::manifest::{lookup_keys, MetadataRow, MetadataTableFamily};
 use loonfs_api::wire::sst_blocks::string_prefix_upper_bound;
-use loonfs_api::wire::wal::{decode_wal_segment_envelope_zstd, WalDelta};
 use loonfs_api::{ContentId, ContentStoreId, NamespaceId, UploadId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
@@ -349,23 +348,26 @@ impl<'a> ContentReferences<'a> {
 ///
 /// The roots are the same ones the rest of the pass uses: every manifest the
 /// live set protects, which includes each fork basis a fork-owned checkpoint
-/// record pins, plus every retained WAL segment for commits that are durable
+/// record pins, plus the retained WAL chain for commits that are durable
 /// but not yet materialized. A fork target can only carry forward references
 /// that were in the basis it forked from, and a commit in any other
 /// namespace can only name content minted by that namespace's own sessions,
 /// so those two sources are the whole reachable set.
 ///
-/// Every root read costs a budget unit — one per manifest opened, one per
-/// page of revision rows, one per WAL segment fetched — so this scan is
-/// part of the pass's bound rather than an exception to it. Running out
-/// stops the scan where it stands and reports
-/// [`ScanOutcome::BudgetExhausted`]; the caller retains the session that
-/// triggered it, marks the pass as having deferred content reclamation,
-/// and carries on. A namespace whose scan never fits therefore keeps its
-/// completed content — `max_objects` has to be at least the scan's size
-/// for content reclamation to happen at all — but the sweep around it
-/// still advances, which is the difference between leaking content for a
-/// while and not collecting anything ever.
+/// Only the manifest half is read here. The chain's references were
+/// harvested off the bodies marking already decoded, so this half is a set
+/// union rather than a second pass over the same objects.
+///
+/// Every manifest root read costs a budget unit — one per manifest opened,
+/// one per page of revision rows — so this scan is part of the pass's bound
+/// rather than an exception to it. Running out stops the scan where it
+/// stands and reports [`ScanOutcome::BudgetExhausted`]; the caller retains
+/// the session that triggered it, marks the pass as having deferred content
+/// reclamation, and carries on. A namespace whose scan never fits therefore
+/// keeps its completed content — `max_objects` has to be at least the
+/// scan's size for content reclamation to happen at all — but the sweep
+/// around it still advances, which is the difference between leaking
+/// content for a while and not collecting anything ever.
 async fn collect_referenced_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -415,30 +417,10 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
         }
     }
 
-    for segment_key in &live.wal_segments {
-        if !budget.try_charge() {
-            return Ok(ScanOutcome::BudgetExhausted);
-        }
-        let Some(bytes) = store
-            .get(segment_key, None)
-            .await
-            .map_err(|error| CoreError::store(segment_key, &error))?
-        else {
-            // A retained segment that vanished mid-pass is exactly the
-            // ambiguity rule 5 is about.
-            return Ok(ScanOutcome::Unavailable);
-        };
-        let Ok(envelope) = decode_wal_segment_envelope_zstd(&bytes) else {
-            return Ok(ScanOutcome::Unavailable);
-        };
-        for record in &envelope.payload.records {
-            for delta in &record.deltas {
-                if let WalDelta::AppendFileRevision { content_ref, .. } = &delta.delta {
-                    referenced.insert(content_ref.content_id.clone());
-                }
-            }
-        }
-    }
+    // The retained chain's own references came back with the marking that
+    // validated it, already paid for there, so no segment is fetched twice
+    // in one pass.
+    referenced.extend(live.wal_content_ids.iter().cloned());
 
     Ok(ScanOutcome::Complete(referenced))
 }

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -286,18 +286,20 @@ async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
     post_checkpoint(&server_url, namespace.as_str()).expect("checkpoint");
 
     // A bounded pass returns an opaque cursor, and the route accepts it
-    // on the next invocation without carrying any safety state.
+    // on the next invocation without carrying any safety state. The budget
+    // covers the roots this namespace marks before it walks, so what is
+    // left over is what bounds the walk.
     let bounded = post_gc_with(
         &server_url,
         namespace.as_str(),
-        serde_json::json!({ "max_objects": 1 }),
+        serde_json::json!({ "max_objects": 6 }),
     )
     .expect("bounded gc pass");
     let cursor = bounded.next_cursor.expect("more candidate families remain");
     let resumed = post_gc_with(
         &server_url,
         namespace.as_str(),
-        serde_json::json!({ "max_objects": 1, "cursor": cursor }),
+        serde_json::json!({ "max_objects": 6, "cursor": cursor }),
     )
     .expect("resumed gc pass");
     assert!(resumed.next_cursor.is_some());

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -336,17 +336,23 @@ fn gc_step_result(gc: GcResponse, submitted_cursor: Option<&str>) -> Maintenance
 /// Progress is where the enumeration got to, never what the counters say. A
 /// pass that hands back a cursor past the one it was given walked keyspace
 /// and has more to walk, so it runs again. A pass that hands back the very
-/// cursor it started from decided nothing at all — its budget died inside
-/// the content-reference scan, which every pass has to redo before it may
-/// delete anything — and repeating it immediately would repeat that exact
-/// result forever, so it parks like any other zero-progress step and waits
-/// for something to change.
+/// cursor it started from decided nothing at all — its budget died in the
+/// marking or the content-reference scan, both of which every pass redoes
+/// before it may delete anything — and repeating it immediately would
+/// repeat that exact result forever, so it parks like any other
+/// zero-progress step and waits for something to change.
 ///
 /// A pass that walked the whole keyspace is finished: idle when it freed
 /// nothing, eligible again when it did, because reclamation cascades — a
 /// deleted manifest can leave tables unreferenced. Ambiguous roots that
 /// suppressed deletion are the one clean-pass case with work provably left
 /// undone, so they park distinctly rather than reading as idle.
+///
+/// A pass with no cursor at all can still have run out: a namespace whose
+/// roots cost more than `max_objects` never gets as far as the keyspace,
+/// and says so outright. That parks too, and pointedly not as idle — idle
+/// clears the stored continuation, and this pass freed nothing and walked
+/// nowhere.
 fn gc_conclusion(gc: &GcResponse, submitted_cursor: Option<&str>) -> MaintenanceStepConclusion {
     match gc.next_cursor.as_deref() {
         Some(next_cursor) if Some(next_cursor) == submitted_cursor => {
@@ -354,6 +360,7 @@ fn gc_conclusion(gc: &GcResponse, submitted_cursor: Option<&str>) -> Maintenance
         }
         Some(_) => MaintenanceStepConclusion::Progressed,
         None if reclaimed_anything(gc) => MaintenanceStepConclusion::Progressed,
+        None if gc.budget_exhausted => MaintenanceStepConclusion::Blocked,
         None if gc.degraded_retention => MaintenanceStepConclusion::Blocked,
         None => MaintenanceStepConclusion::Idle,
     }
@@ -516,6 +523,48 @@ mod tests {
             gc_conclusion(&parked, Some("first")),
             MaintenanceStepConclusion::Blocked,
             "a pass whose budget died before it decided anything must not requeue hot"
+        );
+    }
+
+    /// A budget that ran out before the pass finished is a park, not an
+    /// idle: idle clears the stored continuation, and a pass that never got
+    /// to the keyspace has nothing to show for itself but that.
+    #[test]
+    fn a_pass_that_ran_out_of_budget_parks_unless_it_got_somewhere_first() {
+        let namespace = namespace_id("demo");
+        let mut marked_nothing = GcResponse::empty(namespace.clone());
+        marked_nothing.budget_exhausted = true;
+        assert_eq!(
+            gc_conclusion(&marked_nothing, None),
+            MaintenanceStepConclusion::Blocked
+        );
+
+        // The same pass on a resumed step: it echoes the cursor it came in
+        // with rather than inventing progress, which parks it too.
+        let mut echoed = GcResponse::empty(namespace.clone());
+        echoed.budget_exhausted = true;
+        echoed.next_cursor = Some("page-2".to_owned());
+        assert_eq!(
+            gc_conclusion(&echoed, Some("page-2")),
+            MaintenanceStepConclusion::Blocked
+        );
+
+        let mut swept_then_stopped = GcResponse::empty(namespace.clone());
+        swept_then_stopped.budget_exhausted = true;
+        swept_then_stopped.next_cursor = Some("page-3".to_owned());
+        assert_eq!(
+            gc_conclusion(&swept_then_stopped, Some("page-2")),
+            MaintenanceStepConclusion::Progressed,
+            "a pass that walked keyspace before running out has more to walk"
+        );
+
+        let mut reclaimed_then_stopped = GcResponse::empty(namespace);
+        reclaimed_then_stopped.budget_exhausted = true;
+        reclaimed_then_stopped.deleted_wal_segments = 2;
+        assert_eq!(
+            gc_conclusion(&reclaimed_then_stopped, None),
+            MaintenanceStepConclusion::Progressed,
+            "reclamation cascades whether or not the budget lasted"
         );
     }
 

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -797,6 +797,7 @@ mod tests {
             },
             degraded_retention: false,
             content_reclamation_deferred: false,
+            budget_exhausted: false,
             next_cursor: None,
             next_reclamation_at_ms: None,
         };

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -670,19 +670,27 @@ below the derived safety floor or a zero budget is rejected as
 behind are not under `grace_window_ms` alone: a session carries its own
 lease, and how long a completed session's content is protected is derived
 rather than configured (format spec, "Garbage collection", rule 11).
-`max_objects` bounds every object the pass reads, not only the candidates it
-enumerates: deciding whether a completed session's content is still
-referenced means reading each live manifest and each retained WAL segment,
-and each of those reads spends the same budget. A pass that runs out partway
-through that reading skips completed-content reclamation for the rest of the
-invocation: the session is retained, `content_reclamation_deferred` is set,
-and the sweep goes on through every other candidate under the usual budget.
-Deletion only ever follows a complete collection, so a partial one decides
-nothing. A budget smaller than the namespace's live manifests plus retained
-segments therefore keeps that content rather than reclaiming it — a pass with
-room for the whole scan collects it later. Step-driven GC defaults
-`max_objects` to 1024 and returns any `next_cursor` for a later step rather
-than looping internally. Nothing sweeps unless `gc` is present.
+`max_objects` bounds the whole pass, from its first read to its last, and
+not only the candidates it enumerates. Building the live root set spends it
+too: the head and metadata root together, the retention floor, each
+checkpoint record, each live manifest, and each retained WAL segment, read
+once, while marking. Deciding whether a completed session's content is still
+referenced then spends it again on each live manifest and the revision rows
+inside it. A pass that runs out partway through that scan skips
+completed-content reclamation for the rest of the invocation: the session is
+retained, `content_reclamation_deferred` is set, and the sweep goes on
+through every other candidate under the usual budget. Deletion only ever
+follows a complete collection, so a partial one decides nothing. A budget
+too small for the roots themselves does nothing at all: it reports
+`budget_exhausted` alongside `content_reclamation_deferred`, deletes
+nothing, and hands back the cursor it was given rather than a new one. A
+pass that did have room for the roots decides at least one candidate
+whatever is left over, so a bounded walk always advances. A budget above
+the roots but below the scan on top of them keeps completed content rather
+than reclaiming it — a pass with room for the whole scan collects it later.
+Step-driven GC defaults `max_objects` to 1024 and returns any `next_cursor`
+for a later step rather than looping internally. Nothing sweeps unless `gc`
+is present.
 
 The retention floor bounds incremental replay only. File revision history
 is never pruned: a revisions listing is always complete, however far the

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4502,9 +4502,13 @@
           "degraded_retention"
         ],
         "properties": {
+          "budget_exhausted": {
+            "type": "boolean",
+            "description": "True when the pass stopped because `max_objects` ran out before it\nfinished. Whatever it did before that is reported here and stands;\nrerun with the returned cursor, or with a larger budget, to\ncontinue. A budget too small for the namespace's own roots stops a\npass before it decides anything at all, which is what this says and\nan empty report on its own does not."
+          },
           "content_reclamation_deferred": {
             "type": "boolean",
-            "description": "True when the pass skipped completed-content reclamation because\nthe reference collection it needs did not fit in `max_objects`.\nNothing was ever decided from a partial collection and the rest of\nthe sweep ran normally; a later pass with room for the whole scan\nreclaims what this one left behind."
+            "description": "True when the pass skipped completed-content reclamation because\nwhat it needs — the namespace's live roots, then the reference\ncollection over them — did not fit in `max_objects`. Nothing was\never decided from a partial collection; a later pass with room for\nthe whole scan reclaims what this one left behind. A pass that had\nroom for the roots swept every other candidate normally around the\nskip, and one that did not also reports `budget_exhausted`."
           },
           "degraded_retention": {
             "type": "boolean",


### PR DESCRIPTION
GC has a `max_objects` setting that is supposed to limit how much work one run can do. Before this change, that limit did not start until after GC had read the namespace head and found every object that must be kept. On the namespace that exposed the problem, `max_objects = 1` still caused about 187 reads.

This PR starts counting work before the first read. Reading the namespace head and metadata root counts as one step because those reads happen together. Reads for the retention floor, checkpoints, fork targets, manifests, and WAL segments also count toward the same limit.

The PR also removes duplicate WAL reads. GC already reads and validates each WAL segment while finding objects that must be kept. It now records the referenced content IDs during that read instead of fetching every WAL segment again later.

If the limit is reached before GC finishes finding the objects that must be kept, GC deletes nothing. It sets `budget_exhausted` and returns the same resume cursor it received. The maintenance runner waits instead of immediately repeating the same work, and the CLI drain command stops instead of looping forever.

Tests cover limits reached before WAL reads, limits reached while reading checkpoints, unchanged resume cursors, resuming a partial run, reading each retained WAL segment once, and protecting content that is referenced only by an unflushed WAL record. All CI checks pass.
