### PR TITLE
perf(wal): speed up replay and namespace status

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ allow_remote_without_tls = true
 
 Connect remote clients with an `https://` server URL and the same `LOONFS_AUTH_TOKEN`. If a private CA issued the server certificate, pass its bundle with `--ca-cert-path`.
 
+If you are upgrading a deployment, flush any long WAL tail before you switch builds. This build reads how long a namespace's WAL tail is from the segment pointers its head carries, and heads written by earlier builds carried only the newest 32 of them. A namespace holding more unflushed segments than that answers the namespace status read with a head-coverage error, by design, until the tail is folded — so run `loonfs admin flush` against it (or recreate the namespace) with your current build first.
+
 ## Documentation
 
 Visit loonfs.com/docs to learn more.

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -658,6 +658,7 @@ fn classify_wal_chain_load_error(error: &WalChainLoadError) -> ErrorCode {
         | WalChainLoadError::PointerMismatch { .. }
         | WalChainLoadError::HeadSeqMismatch { .. }
         | WalChainLoadError::CursorNotCovered { .. }
+        | WalChainLoadError::TailNotDescribedByHead { .. }
         | WalChainLoadError::Replay(_) => ErrorCode::NamespaceCorrupt,
     }
 }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -134,7 +134,8 @@ pub mod cache {
         DEFAULT_WAL_TAIL_PROJECTION_ROWS,
     };
     pub use crate::namespace::status::{
-        load_deleted_namespace_head_summary, load_namespace_head_summary, NamespaceHeadSummary,
+        load_deleted_namespace_head_summary, load_namespace_fold_basis,
+        load_namespace_head_summary, NamespaceFoldBasis, NamespaceHeadSummary,
     };
 }
 

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -6,7 +6,7 @@ use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::basis::{read_head_and_metadata_basis, resolve_retention_floor_seq};
 use crate::wal::{count_visible_wal_tail_segments, WalChainLoadRequest};
-use loonfs_api::wire::control::NamespaceState;
+use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
@@ -23,18 +23,37 @@ pub struct NamespaceHeadSummary {
     /// Number of visible WAL segments after the current manifest.
     ///
     /// Counted from the head's chain pointers (`recent_segments`, published
-    /// under the same CAS as the tip); segment bodies are fetched and
-    /// validated only for a tail extending past the hinted window. An
-    /// inspection count for maintenance gating and operators — replay
-    /// consumers load the validated chain instead.
+    /// under the same CAS as the tip and long enough to name every segment a
+    /// legal unflushed tail can hold); no segment body is read. A head that
+    /// under-describes its own tail fails the summary rather than being
+    /// walked. An inspection count for maintenance gating and operators —
+    /// replay consumers load the validated chain instead.
     pub wal_tail_segments: u64,
     pub retention_floor_seq: ChangeSeq,
 }
 
-pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
+/// Whether a namespace carries visible commits its basis manifest does not
+/// cover, and the head sequence they run to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NamespaceFoldBasis {
+    pub head_seq: ChangeSeq,
+    pub has_unflushed_wal_tail: bool,
+}
+
+/// The head-derived half of a status: everything it reports except the WAL
+/// tail count.
+struct LoadedHeadBasis {
+    head: HeadState,
+    current_manifest_id: Option<ManifestId>,
+    /// Sequence the basis manifest covers; the visible tail sits above it.
+    basis_head_seq: ChangeSeq,
+    retention_floor_seq: ChangeSeq,
+}
+
+async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<NamespaceHeadSummary> {
+) -> Result<LoadedHeadBasis> {
     let loaded = read_head_and_metadata_basis(store, expected_namespace_id)
         .await
         .map_err(|error| {
@@ -46,53 +65,85 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
             namespace_id: expected_namespace_id.clone(),
         });
     }
-    // The tail is counted from the basis manifest's coverage, whoever owns
-    // it: a fork target that has not flushed counts from its fork point.
-    let (current_manifest_id, basis_head_seq) = match loaded.basis.manifest() {
-        Some(basis) => {
-            let manifest = load_namespace_manifest_envelope(
-                store,
-                &basis.owner_namespace_id,
-                &basis.manifest_object_id,
-            )
-            .await
-            .map_err(|error| {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-            })?;
-            let own_manifest_id = loaded
-                .basis
-                .is_owned_by(expected_namespace_id)
-                .then_some(basis.manifest_id);
-            (own_manifest_id, manifest.payload.head_seq)
-        }
-        None => (None, ChangeSeq(0)),
-    };
-    let wal_tail_segments = count_visible_wal_tail_segments(
-        store,
-        WalChainLoadRequest {
-            namespace_id: expected_namespace_id,
-            chain_base_seq: basis_head_seq,
-            head_seq: head.seq,
-            visible_tip: head.visible_wal_tip.clone(),
-            stop_after_seq: None,
-            recent_segments: &head.recent_segments,
+    // The floor object is addressed by the head alone, so it is read beside
+    // the basis manifest rather than after it. The tail is measured from the
+    // basis manifest's coverage, whoever owns it: a fork target that has not
+    // flushed measures from its fork point.
+    let (basis, retention_floor_seq) = futures::join!(
+        async {
+            match loaded.basis.manifest() {
+                Some(basis) => load_namespace_manifest_envelope(
+                    store,
+                    &basis.owner_namespace_id,
+                    &basis.manifest_object_id,
+                )
+                .await
+                .map(|manifest| {
+                    let own_manifest_id = loaded
+                        .basis
+                        .is_owned_by(expected_namespace_id)
+                        .then_some(basis.manifest_id);
+                    (own_manifest_id, manifest.payload.head_seq)
+                }),
+                None => Ok((None, ChangeSeq(0))),
+            }
         },
-    )
-    .await
+        resolve_retention_floor_seq(store, &head)
+    );
+    let (current_manifest_id, basis_head_seq) = basis.map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+    })?;
+    let retention_floor_seq = retention_floor_seq.map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+    })?;
+    Ok(LoadedHeadBasis {
+        head,
+        current_manifest_id,
+        basis_head_seq,
+        retention_floor_seq,
+    })
+}
+
+pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace_id: &NamespaceId,
+) -> Result<NamespaceHeadSummary> {
+    let loaded = load_namespace_head_basis(store, expected_namespace_id).await?;
+    let wal_tail_segments = count_visible_wal_tail_segments(WalChainLoadRequest {
+        namespace_id: expected_namespace_id,
+        chain_base_seq: loaded.basis_head_seq,
+        head_seq: loaded.head.seq,
+        visible_tip: loaded.head.visible_wal_tip.clone(),
+        stop_after_seq: None,
+        recent_segments: &loaded.head.recent_segments,
+    })
     .map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
-    let retention_floor_seq = resolve_retention_floor_seq(store, &head)
-        .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-        })?;
     Ok(NamespaceHeadSummary {
-        namespace_id: head.namespace_id,
-        head_seq: head.seq,
-        current_manifest_id,
+        namespace_id: loaded.head.namespace_id,
+        head_seq: loaded.head.seq,
+        current_manifest_id: loaded.current_manifest_id,
         wal_tail_segments,
-        retention_floor_seq,
+        retention_floor_seq: loaded.retention_floor_seq,
+    })
+}
+
+/// Answers the one question a WAL fold decides on — is there anything to
+/// fold — without sizing the tail.
+///
+/// [`load_namespace_head_summary`] answers it too, but only alongside a
+/// segment count the head must be able to describe. A head that
+/// under-describes its own tail is exactly the state an explicit fold
+/// repairs, so the fold must not be gated on the count it cannot produce.
+pub async fn load_namespace_fold_basis<S: ObjectStore + ?Sized>(
+    store: &S,
+    expected_namespace_id: &NamespaceId,
+) -> Result<NamespaceFoldBasis> {
+    let loaded = load_namespace_head_basis(store, expected_namespace_id).await?;
+    Ok(NamespaceFoldBasis {
+        head_seq: loaded.head.seq,
+        has_unflushed_wal_tail: loaded.basis_head_seq < loaded.head.seq,
     })
 }
 

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -178,6 +178,16 @@ pub enum WalChainLoadError {
     },
     #[error("WAL chain suffix does not cover requested cursor `{after_seq}`")]
     CursorNotCovered { after_seq: ChangeSeq },
+    #[error(
+        "namespace head describes `{described_segments}` visible WAL tail segments reaching down \
+         to seq `{described_from_seq}`, which does not reach the tail boundary at seq \
+         `{boundary_seq}`"
+    )]
+    TailNotDescribedByHead {
+        boundary_seq: ChangeSeq,
+        described_segments: u64,
+        described_from_seq: ChangeSeq,
+    },
     #[error("wal replay validation failed: {0}")]
     Replay(#[from] WalReplayError),
 }

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -10,7 +10,10 @@ use loonfs_api::ChangeSeq;
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
 
-const RECENT_SEGMENT_PREFETCH_CONCURRENCY: usize = 8;
+/// Hinted segments fetched at once. The head names every segment a legal
+/// unflushed tail can hold, so a replay's whole gap is usually hinted and
+/// this is what decides how many round trips it costs.
+pub(super) const RECENT_SEGMENT_PREFETCH_CONCURRENCY: usize = 32;
 
 /// Fetches the hinted segments covering the replay gap concurrently.
 ///
@@ -184,22 +187,29 @@ fn validate_pointer_matches_envelope(
     Ok(())
 }
 
-/// Counts the visible WAL tail segments above `chain_base_seq` without
-/// loading bodies the head already describes.
+/// Counts the visible WAL tail segments above `chain_base_seq` from the
+/// head's chain pointers alone.
 ///
 /// Every head publish prepends its tip pointer to `recent_segments` under
 /// the same compare-and-swap that installs `visible_wal_tip`, so a hint run
 /// that is contiguous from the tip carries the same authority as the tip
-/// itself: those segments are counted from pointer seq ranges alone. Only
-/// a tail extending past the hinted window (or an unusable hint list) walks
-/// chain links, fetching and pointer-validating one body per unresolved
-/// segment.
+/// itself. The list holds every segment a legal unflushed tail can reach
+/// (see [`crate::limits::RECENT_SEGMENTS_LIMIT`]), so that run describes
+/// the whole tail and this takes no store parameter: the signature is the
+/// guarantee.
 ///
-/// Unlike [`load_validated_wal_chain`], hint-covered bodies are neither
-/// fetched nor checksum-verified, and the manifest boundary is accepted at
-/// `base <= chain_base_seq` rather than exact equality: this serves
-/// inspection surfaces (status, maintenance gating) whose callers do not
-/// replay the tail. Replay consumers keep loading the validated chain.
+/// A head that under-describes its own tail is corrupted or predates that
+/// coverage, and either way is reported as
+/// [`WalChainLoadError::TailNotDescribedByHead`] rather than walked. This
+/// serves inspection surfaces (status, maintenance gating), and a serial
+/// chain walk of an unbounded tail is not something a foreground call
+/// should pay for silently. Replay consumers keep loading the validated
+/// chain, which does walk.
+///
+/// Unlike [`load_validated_wal_chain`], bodies are never fetched or
+/// checksum-verified, and the manifest boundary is accepted at
+/// `base <= chain_base_seq` rather than exact equality: callers here do not
+/// replay the tail.
 #[tracing::instrument(
     level = "info",
     name = "loonfs.phase",
@@ -207,8 +217,7 @@ fn validate_pointer_matches_envelope(
     skip_all,
     fields(phase = "count_wal_tail_segments", key_class = "wal_segment")
 )]
-pub(crate) async fn count_visible_wal_tail_segments<S: ObjectStore + ?Sized>(
-    store: &S,
+pub(crate) fn count_visible_wal_tail_segments(
     request: WalChainLoadRequest<'_>,
 ) -> Result<u64, WalChainLoadError> {
     if request.chain_base_seq > request.head_seq {
@@ -239,17 +248,17 @@ pub(crate) async fn count_visible_wal_tail_segments<S: ObjectStore + ?Sized>(
     }
 
     let mut count: u64 = 1;
-    // Newest pointer whose tail membership is decided but whose predecessor
-    // is not; the body walk resumes here when pointer math runs out.
-    let mut newest_unresolved = tip.clone();
-    if pointer_reaches_base(&newest_unresolved, stop_after_seq) {
+    // Oldest pointer counted so far: the run has to keep descending from
+    // here, contiguously, until it crosses the boundary.
+    let mut oldest_counted = &tip;
+    if pointer_reaches_base(oldest_counted, stop_after_seq) {
         return Ok(count);
     }
 
     if request.recent_segments.first() == Some(&tip) {
         for pointer in &request.recent_segments[1..] {
-            if pointer.end_seq.0 + 1 != newest_unresolved.start_seq.0 {
-                // Contiguity break: chain links resume authority below.
+            if pointer.end_seq.0 + 1 != oldest_counted.start_seq.0 {
+                // Contiguity break: nothing below is described.
                 break;
             }
             if pointer.end_seq <= stop_after_seq {
@@ -257,43 +266,18 @@ pub(crate) async fn count_visible_wal_tail_segments<S: ObjectStore + ?Sized>(
                 return Ok(count);
             }
             count += 1;
-            newest_unresolved = pointer.clone();
-            if pointer_reaches_base(&newest_unresolved, stop_after_seq) {
+            oldest_counted = pointer;
+            if pointer_reaches_base(oldest_counted, stop_after_seq) {
                 return Ok(count);
             }
         }
     }
 
-    loop {
-        let object_key = newest_unresolved.object_key.clone();
-        let encoded_bytes = store
-            .get(&object_key, None)
-            .await
-            .map_err(|err| WalChainLoadError::ReadWal {
-                object_key: object_key.clone(),
-                message: err.to_string(),
-            })?
-            .ok_or_else(|| WalChainLoadError::MissingWalObject {
-                object_key: object_key.clone(),
-            })?;
-        let envelope = decode_wal_segment_envelope_zstd(&encoded_bytes)
-            .map_err(|err| WalReplayError::Codec(err.to_string()))?;
-        validate_pointer_matches_envelope(&newest_unresolved, &object_key, &envelope)?;
-        let prev = envelope.payload.prev_visible_segment.clone().ok_or(
-            WalReplayError::BrokenChainLink {
-                object_key,
-                required_seq: stop_after_seq,
-            },
-        )?;
-        if prev.end_seq <= stop_after_seq {
-            return Ok(count);
-        }
-        count += 1;
-        newest_unresolved = prev;
-        if pointer_reaches_base(&newest_unresolved, stop_after_seq) {
-            return Ok(count);
-        }
-    }
+    Err(WalChainLoadError::TailNotDescribedByHead {
+        boundary_seq: stop_after_seq,
+        described_segments: count,
+        described_from_seq: oldest_counted.start_seq,
+    })
 }
 
 /// True when the pointer's base (the seq before its first commit) sits at

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -1,5 +1,6 @@
 //! Behavior tests for WAL segment preparation and validated chain loading.
 
+use super::reader::RECENT_SEGMENT_PREFETCH_CONCURRENCY;
 use super::*;
 use crate::commit::{
     materialize_commit, wal_payload_from_materialized_commit, CommitFingerprint, CommitIr,
@@ -9,9 +10,10 @@ use bytes::Bytes;
 use loonfs_api::wire::control::WalSegmentPointer;
 use loonfs_api::wire::wal::{encode_wal_segment_envelope_zstd, WalSegmentEnvelope};
 use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey, NamespaceId, WalSegmentId, WriterEpoch};
-use loonfs_objectstore::keys::wal_segment;
+use loonfs_objectstore::keys::{wal_segment, wal_segment_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
+use loonfs_test_support::stores::{ConcurrencyWatchStore, KeyPredicate, RecordingStore};
 use std::borrow::Cow;
 use tempfile::tempdir;
 
@@ -681,85 +683,186 @@ fn newest_first_pointers(chain: &[PreparedWalSegment]) -> Vec<WalSegmentPointer>
         .collect()
 }
 
-#[tokio::test]
-async fn tail_count_from_contiguous_hints_reads_no_bodies() {
-    // The store stays empty on purpose: any body fetch would fail with
-    // `MissingWalObject`, so a successful count came from pointers alone.
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+async fn store_chain<S: ObjectStore + ?Sized>(store: &S, chain: &[PreparedWalSegment]) {
+    for segment in chain {
+        store
+            .put_if_absent(
+                &segment.object_key,
+                Bytes::copy_from_slice(&segment.encoded_bytes),
+            )
+            .await
+            .expect("write wal segment");
+    }
+}
+
+fn tail_count_request<'a>(
+    namespace_id: &'a NamespaceId,
+    chain_base_seq: ChangeSeq,
+    head_seq: ChangeSeq,
+    hints: &'a [WalSegmentPointer],
+) -> WalChainLoadRequest<'a> {
+    WalChainLoadRequest {
+        namespace_id,
+        chain_base_seq,
+        head_seq,
+        visible_tip: hints.first().cloned(),
+        stop_after_seq: None,
+        recent_segments: hints,
+    }
+}
+
+/// The count takes no store at all, so "reads no bodies" is the signature
+/// rather than an assertion — and it holds at the longest tail a landed
+/// publish can leave behind, which is what the head is sized to describe.
+#[test]
+fn tail_count_from_contiguous_hints_covers_the_longest_legal_tail() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let chain = prepared_unstored_chain(&namespace_id, 3);
+    let boundary = crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS;
+    let chain = prepared_unstored_chain(&namespace_id, boundary);
     let hints = newest_first_pointers(&chain);
 
-    let count = count_visible_wal_tail_segments(
-        &store,
-        WalChainLoadRequest {
-            namespace_id: &namespace_id,
-            chain_base_seq: ChangeSeq(0),
-            head_seq: ChangeSeq(3),
-            visible_tip: Some(hints[0].clone()),
-            stop_after_seq: None,
-            recent_segments: &hints,
-        },
-    )
-    .await
+    let count = count_visible_wal_tail_segments(tail_count_request(
+        &namespace_id,
+        ChangeSeq(0),
+        ChangeSeq(boundary),
+        &hints,
+    ))
     .expect("count from pointers");
-    assert_eq!(count, 3);
+    assert_eq!(count, boundary);
 
     // A manifest boundary inside the hinted window is honored: only the
     // segments above it are tail.
-    let count = count_visible_wal_tail_segments(
-        &store,
-        WalChainLoadRequest {
-            namespace_id: &namespace_id,
-            chain_base_seq: ChangeSeq(2),
-            head_seq: ChangeSeq(3),
-            visible_tip: Some(hints[0].clone()),
-            stop_after_seq: None,
-            recent_segments: &hints,
-        },
-    )
-    .await
+    let count = count_visible_wal_tail_segments(tail_count_request(
+        &namespace_id,
+        ChangeSeq(boundary - 1),
+        ChangeSeq(boundary),
+        &hints,
+    ))
     .expect("count above interior boundary");
     assert_eq!(count, 1);
 
     // An empty tail costs nothing and consults nothing.
-    let count = count_visible_wal_tail_segments(
-        &store,
-        WalChainLoadRequest {
-            namespace_id: &namespace_id,
-            chain_base_seq: ChangeSeq(3),
-            head_seq: ChangeSeq(3),
-            visible_tip: Some(hints[0].clone()),
-            stop_after_seq: None,
-            recent_segments: &hints,
-        },
-    )
-    .await
+    let count = count_visible_wal_tail_segments(tail_count_request(
+        &namespace_id,
+        ChangeSeq(boundary),
+        ChangeSeq(boundary),
+        &hints,
+    ))
     .expect("count of empty tail");
     assert_eq!(count, 0);
 }
 
+/// A head that does not name its whole tail is corrupted or predates the
+/// coverage guarantee. Either way the count says so instead of walking
+/// chain links one round trip at a time on an inspection call.
+#[test]
+fn tail_count_rejects_a_head_that_does_not_describe_its_tail() {
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let chain = prepared_unstored_chain(&namespace_id, 4);
+    let pointers = newest_first_pointers(&chain);
+    let head_seq = ChangeSeq(4);
+
+    // A run that stops short of the basis boundary.
+    let error = count_visible_wal_tail_segments(tail_count_request(
+        &namespace_id,
+        ChangeSeq(0),
+        head_seq,
+        &pointers[..2],
+    ))
+    .expect_err("a short run must not be walked");
+    assert_eq!(
+        error,
+        WalChainLoadError::TailNotDescribedByHead {
+            boundary_seq: ChangeSeq(0),
+            described_segments: 2,
+            described_from_seq: ChangeSeq(3),
+        }
+    );
+
+    // A run with a hole in it: nothing below the hole is described.
+    let discontiguous = [
+        pointers[0].clone(),
+        pointers[2].clone(),
+        pointers[3].clone(),
+    ];
+    let error = count_visible_wal_tail_segments(tail_count_request(
+        &namespace_id,
+        ChangeSeq(0),
+        head_seq,
+        &discontiguous,
+    ))
+    .expect_err("a discontiguous run must not be walked");
+    assert!(matches!(
+        error,
+        WalChainLoadError::TailNotDescribedByHead {
+            described_segments: 1,
+            ..
+        }
+    ));
+
+    // A run whose newest entry is not the tip carries no authority at all.
+    let error = count_visible_wal_tail_segments(WalChainLoadRequest {
+        namespace_id: &namespace_id,
+        chain_base_seq: ChangeSeq(0),
+        head_seq,
+        visible_tip: Some(pointers[0].clone()),
+        stop_after_seq: None,
+        recent_segments: &pointers[1..],
+    })
+    .expect_err("a run that does not start at the tip must not be walked");
+    assert!(matches!(
+        error,
+        WalChainLoadError::TailNotDescribedByHead {
+            described_segments: 1,
+            ..
+        }
+    ));
+}
+
+/// The two readers diverge on purpose: replay walks chain links for history
+/// the head no longer names, and the count refuses to.
 #[tokio::test]
-async fn tail_count_walks_only_past_the_hinted_window() {
+async fn tail_count_and_chain_load_agree_where_the_head_describes_the_tail() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let chain = prepared_unstored_chain(&namespace_id, 3);
-    // Store only the middle segment: the tip is hint-covered and the
-    // oldest is resolved through the middle segment's chain link, so
-    // neither body may be touched.
-    store
-        .put_if_absent(
-            &chain[1].object_key,
-            Bytes::copy_from_slice(&chain[1].encoded_bytes),
-        )
+    store_chain(&store, &chain).await;
+    let pointers = newest_first_pointers(&chain);
+
+    let request = tail_count_request(&namespace_id, ChangeSeq(0), ChangeSeq(3), &pointers);
+    let count = count_visible_wal_tail_segments(request.clone()).expect("count tail");
+    let loaded = load_validated_wal_chain(&store, request)
         .await
-        .expect("write middle wal segment");
+        .expect("load chain");
+    assert_eq!(count as usize, loaded.segments().len());
+    assert_eq!(count, 3);
+
+    let unhinted = WalChainLoadRequest {
+        recent_segments: &[],
+        ..tail_count_request(&namespace_id, ChangeSeq(0), ChangeSeq(3), &pointers)
+    };
+    count_visible_wal_tail_segments(unhinted.clone())
+        .expect_err("an unhinted head describes no tail to count");
+    let loaded = load_validated_wal_chain(&store, unhinted)
+        .await
+        .expect("replay still walks the links");
+    assert_eq!(loaded.segments().len(), 3);
+}
+
+/// The change feed reads history below the accelerator window, so the chain
+/// loader keeps its predecessor walk.
+#[tokio::test]
+async fn chain_load_walks_predecessor_links_past_the_hinted_window() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let chain = prepared_unstored_chain(&namespace_id, 3);
+    store_chain(&store, &chain).await;
     let pointers = newest_first_pointers(&chain);
     let short_window = &pointers[..2];
 
-    let count = count_visible_wal_tail_segments(
+    let loaded = load_validated_wal_chain(
         &store,
         WalChainLoadRequest {
             namespace_id: &namespace_id,
@@ -771,122 +874,147 @@ async fn tail_count_walks_only_past_the_hinted_window() {
         },
     )
     .await
-    .expect("count past hinted window");
-    assert_eq!(count, 3);
+    .expect("load past the hinted window");
+
+    assert_eq!(loaded.segments().len(), 3);
+    assert_eq!(loaded.segments()[0].records()[0].seq, ChangeSeq(1));
 }
 
+/// A boundary-length replay is one wave shape: every segment arrives from
+/// the hints, none is fetched twice, and the width is the prefetch bound.
 #[tokio::test]
-async fn tail_count_matches_loaded_chain_length() {
+async fn boundary_length_replay_fetches_every_segment_once_in_bounded_waves() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = ConcurrencyWatchStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+    );
+    let segments =
+        usize::try_from(crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS).expect("a segment count");
+    assert!(
+        segments > RECENT_SEGMENT_PREFETCH_CONCURRENCY,
+        "a tail inside one wave would not pin the wave's width"
+    );
+    let chain = prepared_unstored_chain(&namespace_id, crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS);
+    store_chain(&store, &chain).await;
+    let hints = newest_first_pointers(&chain);
+
+    let loaded = load_validated_wal_chain(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS),
+            visible_tip: Some(hints[0].clone()),
+            stop_after_seq: None,
+            recent_segments: &hints,
+        },
+    )
+    .await
+    .expect("load the whole legal tail");
+
+    assert_eq!(loaded.segments().len(), segments);
+    let reads = store.reads();
+    assert_eq!(
+        reads.total, segments,
+        "every segment came from the prefetch; the walk re-fetched none"
+    );
+    assert_eq!(reads.peak_in_flight, RECENT_SEGMENT_PREFETCH_CONCURRENCY);
+}
+
+/// The prefetch fetches only the segments the replay gap intersects.
+#[tokio::test]
+async fn prefetch_fetches_only_the_segments_the_gap_intersects() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+    );
+    let chain = prepared_unstored_chain(&namespace_id, 5);
+    store_chain(&store, &chain).await;
+    let hints = newest_first_pointers(&chain);
+    store.reset();
+
+    let loaded = load_validated_wal_chain(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(5),
+            visible_tip: Some(hints[0].clone()),
+            stop_after_seq: Some(ChangeSeq(3)),
+            recent_segments: &hints,
+        },
+    )
+    .await
+    .expect("load the newest two segments");
+
+    assert_eq!(loaded.segments().len(), 2);
+    let mut fetched = store.take_get_keys();
+    fetched.sort();
+    let mut expected = vec![chain[3].object_key.clone(), chain[4].object_key.clone()];
+    expected.sort();
+    assert_eq!(fetched, expected);
+}
+
+/// Prefetching moves where the bytes come from, not what is checked: every
+/// chain validation runs in the sequential pass either way.
+#[tokio::test]
+async fn a_corrupt_segment_inside_the_hinted_set_is_still_rejected() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let chain = prepared_unstored_chain(&namespace_id, 3);
-    for segment in &chain {
-        store
-            .put_if_absent(
-                &segment.object_key,
-                Bytes::copy_from_slice(&segment.encoded_bytes),
-            )
-            .await
-            .expect("write wal segment");
-    }
-    let pointers = newest_first_pointers(&chain);
+    store_chain(&store, &chain).await;
+    // Rewrite the middle segment's body at its own key: it decodes, but its
+    // payload no longer matches the checksum its successor's chain link
+    // recorded.
+    let mut tampered = chain[1].envelope.clone();
+    tampered.payload.records[0].committed_at_ms += 1;
+    rewrap_envelope(&mut tampered);
+    store
+        .put_overwrite(
+            &chain[1].object_key,
+            Bytes::from(encode_wal_segment_envelope_zstd(&tampered).expect("encode tampered")),
+        )
+        .await
+        .expect("overwrite middle wal segment");
+    let hints = newest_first_pointers(&chain);
 
-    for hints in [&pointers[..], &[]] {
-        let request = WalChainLoadRequest {
+    let hinted = load_validated_wal_chain(
+        &store,
+        WalChainLoadRequest {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
             head_seq: ChangeSeq(3),
-            visible_tip: Some(pointers[0].clone()),
+            visible_tip: Some(hints[0].clone()),
             stop_after_seq: None,
-            recent_segments: hints,
-        };
-        let count = count_visible_wal_tail_segments(&store, request.clone())
-            .await
-            .expect("count tail");
-        let loaded = load_validated_wal_chain(&store, request)
-            .await
-            .expect("load chain");
-        assert_eq!(count as usize, loaded.segments().len());
-        assert_eq!(count, 3);
-    }
-}
-
-#[tokio::test]
-async fn tail_count_ignores_hints_that_do_not_start_at_the_tip() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let chain = prepared_unstored_chain(&namespace_id, 2);
-    for segment in &chain {
-        store
-            .put_if_absent(
-                &segment.object_key,
-                Bytes::copy_from_slice(&segment.encoded_bytes),
-            )
-            .await
-            .expect("write wal segment");
-    }
-    let pointers = newest_first_pointers(&chain);
-    let mut lying_tip = pointers[0].clone();
-    lying_tip.end_seq = ChangeSeq(999);
-    let garbage = [lying_tip, pointers[1].clone()];
-
-    let count = count_visible_wal_tail_segments(
-        &store,
-        WalChainLoadRequest {
-            namespace_id: &namespace_id,
-            chain_base_seq: ChangeSeq(0),
-            head_seq: ChangeSeq(2),
-            visible_tip: Some(pointers[0].clone()),
-            stop_after_seq: None,
-            recent_segments: &garbage,
+            recent_segments: &hints,
         },
     )
     .await
-    .expect("count despite garbage hints");
-    assert_eq!(count, 2);
-}
-
-#[tokio::test]
-async fn tail_count_reports_broken_chains_truthfully() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    // A segment claiming seqs (1, 2] with no predecessor link cannot reach
-    // a chain base of 0.
-    let orphan = prepared_create_directory_segment(
-        &namespace_id,
-        None,
-        "c_count_orphan",
-        "orphan",
-        ChangeSeq(1),
-        ChangeSeq(2),
-    );
-    store
-        .put_if_absent(
-            &orphan.object_key,
-            Bytes::copy_from_slice(&orphan.encoded_bytes),
-        )
-        .await
-        .expect("write wal segment");
-    let tip = orphan.envelope.pointer(orphan.object_key.clone());
-
-    let error = count_visible_wal_tail_segments(
+    .expect_err("a prefetched corrupt segment must be rejected");
+    let serial = load_validated_wal_chain(
         &store,
         WalChainLoadRequest {
             namespace_id: &namespace_id,
             chain_base_seq: ChangeSeq(0),
-            head_seq: ChangeSeq(2),
-            visible_tip: Some(tip),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(hints[0].clone()),
             stop_after_seq: None,
             recent_segments: &[],
         },
     )
     .await
-    .expect_err("broken chain must not count");
-    assert!(matches!(
-        error,
-        WalChainLoadError::Replay(WalReplayError::BrokenChainLink { .. })
-    ));
+    .expect_err("the serial path rejects it too");
+
+    assert_eq!(
+        hinted,
+        WalChainLoadError::PointerMismatch {
+            object_key: chain[1].object_key.clone(),
+        }
+    );
+    assert_eq!(hinted, serial);
 }

--- a/crates/loonfs-test-support/src/stores/concurrency_watch_store.rs
+++ b/crates/loonfs-test-support/src/stores/concurrency_watch_store.rs
@@ -1,0 +1,161 @@
+//! Watches how many reads a path keeps in flight at once.
+//!
+//! A batched fetch's whole promise is that its round trips overlap, and the
+//! only place that is visible is the store boundary: request counts and
+//! call order both look identical whether a path fetched its objects one at
+//! a time or all at once. This wrapper counts matching reads as they enter
+//! and leave, and records the high-water mark, so a test can pin the width
+//! of a fetch wave rather than only its size.
+//!
+//! Each watched read yields once before it delegates. That is what makes the
+//! mark a measurement rather than a race: a batch polled onto the same task
+//! has all of its members inside the wrapper before the first of them can
+//! finish, whatever the wrapped store does.
+
+use super::KeyPredicate;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use loonfs_objectstore::{
+    ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+    StoredObjectChecksum,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// What one read path was observed to overlap.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReadConcurrency {
+    /// Most matching reads in flight at any instant.
+    pub peak_in_flight: usize,
+    /// Matching reads issued in total.
+    pub total: usize,
+}
+
+#[derive(Debug, Default)]
+struct InFlight {
+    current: AtomicUsize,
+    peak: AtomicUsize,
+    total: AtomicUsize,
+}
+
+/// Decrements on drop, so a cancelled or failed read leaves no phantom.
+struct InFlightGuard<'a>(&'a InFlight);
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.0.current.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Wraps a store and records the reads it is asked for concurrently.
+#[derive(Debug)]
+pub struct ConcurrencyWatchStore<S> {
+    inner: S,
+    keys: KeyPredicate,
+    reads: InFlight,
+}
+
+impl<S> ConcurrencyWatchStore<S> {
+    /// Watches reads of keys `keys` selects.
+    pub fn new(inner: S, keys: KeyPredicate) -> Self {
+        Self {
+            inner,
+            keys,
+            reads: InFlight::default(),
+        }
+    }
+
+    /// What has been observed so far.
+    pub fn reads(&self) -> ReadConcurrency {
+        ReadConcurrency {
+            peak_in_flight: self.reads.peak.load(Ordering::SeqCst),
+            total: self.reads.total.load(Ordering::SeqCst),
+        }
+    }
+
+    /// Returns a reference to the wrapped store.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    /// Counts one read in, and holds the count up until the guard drops.
+    async fn enter(&self, key: &str) -> Option<InFlightGuard<'_>> {
+        if !self.keys.matches(key) {
+            return None;
+        }
+        self.reads.total.fetch_add(1, Ordering::SeqCst);
+        let current = self.reads.current.fetch_add(1, Ordering::SeqCst) + 1;
+        self.reads.peak.fetch_max(current, Ordering::SeqCst);
+        let guard = InFlightGuard(&self.reads);
+        tokio::task::yield_now().await;
+        Some(guard)
+    }
+}
+
+#[async_trait]
+impl<S: ObjectStore> ObjectStore for ConcurrencyWatchStore<S> {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        let _in_flight = self.enter(key).await;
+        self.inner.head(key).await
+    }
+
+    async fn head_stored_checksum(
+        &self,
+        key: &str,
+    ) -> Result<Option<StoredObjectChecksum>, ObjectStoreError> {
+        let _in_flight = self.enter(key).await;
+        self.inner.head_stored_checksum(key).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let _in_flight = self.enter(key).await;
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let _in_flight = self.enter(key).await;
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn put_streamed(
+        &self,
+        key: &str,
+        body: ByteStream,
+        mode: PutMode,
+    ) -> Result<u64, ObjectStoreError> {
+        self.inner.put_streamed(key, body, mode).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected_etag: &str,
+        bytes: Bytes,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.compare_and_swap(key, expected_etag, bytes).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}

--- a/crates/loonfs-test-support/src/stores/mod.rs
+++ b/crates/loonfs-test-support/src/stores/mod.rs
@@ -2,6 +2,7 @@
 
 mod blocking_store;
 mod buffer_watch_store;
+mod concurrency_watch_store;
 mod counting_store;
 mod fail_store;
 mod key_predicate;
@@ -12,6 +13,7 @@ mod recording_store;
 
 pub use blocking_store::BlockingStore;
 pub use buffer_watch_store::{BufferPeaks, BufferWatchStore};
+pub use concurrency_watch_store::{ConcurrencyWatchStore, ReadConcurrency};
 pub use counting_store::{CountingStore, StoreCounts};
 pub use fail_store::{FailStore, FailureMode, InjectedError};
 pub use key_predicate::KeyPredicate;

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -13,9 +13,8 @@ use crate::{
     MaintenanceStepResponse, MetadataMaintenanceOptions, MetadataMaintenanceResponse, NamespaceId,
     ReleaseCheckpointResponse, ReorganizeStepOutcome, SharedObjectStore, WalFlushStepOutcome,
 };
-use crate::{Result, RuntimeError};
-use loonfs_core::cache::load_namespace_head_summary;
-use std::num::NonZeroU64;
+use crate::{ChangeSeq, Result, RuntimeError};
+use loonfs_core::cache::{load_namespace_fold_basis, load_namespace_head_summary};
 
 impl FsAdmin {
     /// A mutating engine under this handle's actor identity.
@@ -172,7 +171,21 @@ impl FsAdmin {
         options: MetadataMaintenanceOptions,
         status_before: &NamespaceStatusResponse,
     ) -> Result<MetadataMaintenanceResponse> {
-        let wal_flush = if status_before.wal_tail_segments >= options.max_wal_tail_segments.get() {
+        let fold = status_before.wal_tail_segments >= options.max_wal_tail_segments.get();
+        self.fold_then_reorganize(namespace_id, fold, status_before.head_seq)
+            .await
+    }
+
+    /// Folds the tail when asked, then merges one reorganization unit,
+    /// reporting both. `observed_head_seq` is what the caller saw before the
+    /// fold, and is only reported when another publisher wins the head race.
+    async fn fold_then_reorganize(
+        &self,
+        namespace_id: &NamespaceId,
+        fold: bool,
+        observed_head_seq: ChangeSeq,
+    ) -> Result<MetadataMaintenanceResponse> {
+        let wal_flush = if fold {
             match self.run_wal_flush(namespace_id).await {
                 Ok(flush) => match flush.outcome {
                     FlushWalOutcome::Published => WalFlushStepOutcome::Flushed {
@@ -186,9 +199,7 @@ impl FsAdmin {
                     }
                 },
                 Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => {
-                    WalFlushStepOutcome::RaceLost {
-                        observed_head_seq: status_before.head_seq,
-                    }
+                    WalFlushStepOutcome::RaceLost { observed_head_seq }
                 }
                 Err(error) => return Err(error),
             }
@@ -353,35 +364,28 @@ impl FsAdmin {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    /// Runs one metadata-upkeep pass at a threshold of one segment, so any
-    /// visible WAL tail is folded.
+    /// Folds any visible WAL tail, then merges one reorganization unit.
     ///
-    /// One name over the one step path: exactly
-    /// [`Self::maintenance_step_namespace`] with a metadata-only plan. The
-    /// reorganization unit rides along and is reported beside the fold —
-    /// upkeep is one action, and folding a tail is what creates the delta
-    /// runs a merge consumes. A namespace with an empty tail has nothing to
-    /// fold and reports [`WalFlushStepOutcome::NotNeeded`]: this is the
-    /// flush an operator asks for, not a way to publish a manifest for a
-    /// namespace that has never been written to.
+    /// The same upkeep [`Self::maintenance_step_namespace`] runs for a
+    /// metadata plan, at a threshold of one segment. The reorganization unit
+    /// rides along and is reported beside the fold — upkeep is one action,
+    /// and folding a tail is what creates the delta runs a merge consumes. A
+    /// namespace with an empty tail has nothing to fold and reports
+    /// [`WalFlushStepOutcome::NotNeeded`]: this is the flush an operator
+    /// asks for, not a way to publish a manifest for a namespace that has
+    /// never been written to.
+    ///
+    /// It asks whether there is a tail rather than how long one is, so it
+    /// does not read the namespace status. That matters for the one
+    /// namespace shape status refuses to answer for — a head that does not
+    /// describe its own WAL tail — because folding the tail is the repair.
     pub async fn flush_wal(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<MetadataMaintenanceResponse> {
-        let step = self
-            .maintenance_step_namespace(
-                namespace_id,
-                MaintenancePlan {
-                    metadata: Some(MetadataMaintenanceOptions {
-                        max_wal_tail_segments: NonZeroU64::MIN,
-                    }),
-                    ..MaintenancePlan::default()
-                },
-            )
-            .await?;
-        Ok(step
-            .metadata
-            .expect("a plan selecting metadata upkeep reports it"))
+        let basis = load_namespace_fold_basis(self.core.store(), namespace_id).await?;
+        self.fold_then_reorganize(namespace_id, basis.has_unflushed_wal_tail, basis.head_seq)
+            .await
     }
 
     /// Advances the namespace retention floor when a verified checkpoint

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -7,7 +7,12 @@ use crate::common::*;
 use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
 use loonfs::{
     ChangeSeq, CommitId, CreateNamespaceOptions, ErrorCode, MaintenancePlan, ManifestId,
-    PutFileOptions, ReorganizeStepOutcome, RuntimeError, SharedObjectStore, WalFlushStepOutcome,
+    NamespaceId, PutFileOptions, ReorganizeStepOutcome, RuntimeError, SharedObjectStore,
+    WalFlushStepOutcome,
+};
+use loonfs_api::wire::control::{
+    decode_control_object, encode_control_object, ControlObjectEnvelope, ControlObjectKind,
+    HeadState, HeadStateEnvelope,
 };
 use loonfs_api::wire::manifest::decode_namespace_manifest_json;
 use loonfs_objectstore::keys::{metadata_manifest_object, wal_head, wal_segment_prefix};
@@ -91,6 +96,93 @@ fn namespace_status_counts_wal_tail_without_reading_segments() {
         .expect("status with populated tail");
     assert_eq!(status.wal_tail_segments, 3);
     assert_eq!(store.count(OperationClass::Read), 0);
+}
+
+/// Pointers a head published before the accelerator was sized to cover the
+/// whole legal WAL tail.
+const LEGACY_RECENT_SEGMENTS: usize = 32;
+
+/// Rewrites a head's replay accelerator to its newest `keep` pointers,
+/// which is the shape a head published by an older build carries.
+fn truncate_recent_segments(store: &SharedObjectStore, namespace_id: &NamespaceId, keep: usize) {
+    let key = wal_head(namespace_id.as_str());
+    let bytes = block_on(store.get(&key, None))
+        .expect("read head")
+        .expect("head exists");
+    let envelope: ControlObjectEnvelope<HeadState> =
+        decode_control_object(&bytes, ControlObjectKind::WalHead).expect("decode head");
+    let mut state = envelope.state;
+    assert!(
+        state.recent_segments.len() > keep,
+        "the fixture must publish more pointers than the legacy window held"
+    );
+    state.recent_segments.truncate(keep);
+    let truncated =
+        HeadStateEnvelope::from_state(ControlObjectKind::WalHead, state).expect("head envelope");
+    let encoded = encode_control_object(&truncated).expect("encode head");
+    block_on(store.put_overwrite(&key, bytes::Bytes::from(encoded))).expect("rewrite head");
+}
+
+/// The documented escape for a namespace whose WAL tail already outran the
+/// pointer window the head was published with: status refuses to answer,
+/// and an explicit flush is what repairs it.
+#[test]
+fn a_head_that_under_describes_its_tail_is_repaired_by_an_explicit_flush() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let fs = open_runtime(store.clone(), "legacy-head-test");
+    let namespace_id = namespace_id("demo");
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for revision in 0..LEGACY_RECENT_SEGMENTS + 4 {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            &format!("/docs/hello-{revision}.txt"),
+            format!("rev {revision}").as_bytes(),
+            PutFileOptions::default(),
+        )
+        .expect("put file");
+    }
+    truncate_recent_segments(&store, &namespace_id, LEGACY_RECENT_SEGMENTS);
+
+    let error = fs
+        .namespace_status_blocking(&namespace_id)
+        .expect_err("a head that does not describe its tail cannot be counted");
+    assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+    assert!(
+        error
+            .to_string()
+            .contains("does not reach the tail boundary"),
+        "unexpected message: {error}"
+    );
+
+    let flushed = fs
+        .flush_wal_blocking(&namespace_id)
+        .expect("an explicit flush does not read the status it cannot get");
+    assert!(
+        matches!(flushed.wal_flush, WalFlushStepOutcome::Flushed { .. }),
+        "unexpected flush outcome: {:?}",
+        flushed.wal_flush
+    );
+
+    let status = fs
+        .namespace_status_blocking(&namespace_id)
+        .expect("status after the flush");
+    assert_eq!(status.wal_tail_segments, 0);
+
+    // And the pointer count answers again for the tail written after it.
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/after-the-flush.txt",
+        b"after",
+        PutFileOptions::default(),
+    )
+    .expect("put file after the flush");
+    let status = fs
+        .namespace_status_blocking(&namespace_id)
+        .expect("status after the flush");
+    assert_eq!(status.wal_tail_segments, 1);
 }
 
 #[test]

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -149,7 +149,8 @@ The load-bearing invariants of this layout, in one place:
 
 > **Throughput is group commit; deadlines are local monotonic budgets a
 > writer applies to itself.** No validator ever compares clocks, and
-> accelerators (`recent_segments`, WAL indexes) prefetch but never decide.
+> accelerators (`recent_segments`, WAL indexes) prefetch but never decide
+> what the history is.
 
 ### 1.4 Head update authority
 


### PR DESCRIPTION
This PR makes two WAL read paths faster. The WAL tail is the set of segment files containing commits that have not yet been moved into the current manifest.

When LoonFS needs to replay those commits, it now reads up to 32 segment files at the same time instead of 8. Reading the maximum 128-segment tail therefore takes four groups of requests instead of sixteen.

Namespace status no longer downloads WAL segment files just to count them. The namespace head already stores a reference to every segment in a valid unflushed tail, so status counts those references instead.

This does not weaken validation when LoonFS uses the commits. Replay still downloads, decodes, and validates every WAL segment before using its records. Only the status count avoids those reads.

For status to count safely, the references in the head must form an unbroken list from the newest segment back to the current manifest. If they do not, status returns the existing `namespace_corrupt` error instead of following segment links one request at a time.

Older LoonFS builds stored only 32 segment references in the head. After upgrading, status will return that error for an existing namespace with more than 32 unflushed segments. An explicit `flush_wal` call can repair it by moving the pending WAL changes into a manifest. `flush_wal` no longer calls namespace status first, so it still works when status cannot count the old tail. The README tells operators to flush long tails before upgrading.

The tests cover a 128-segment replay with 32 reads happening at once, partial replay ranges, corrupt segment data, incomplete or broken reference lists, and repairing an older head with an explicit flush.
