### PR TITLE
fix(gc): the pass never reads past its budget

### DIFF
--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -18,7 +18,8 @@ use super::config::GcConfig;
 ///   reference scan;
 /// * one page of revision rows read out of an opened manifest;
 /// * the retained WAL chain, charged as one block of one unit per segment
-///   once the chain validates;
+///   body read. The pass caps that load at what it has left, so the chain
+///   cannot read past the bound either;
 /// * one enumerated candidate key, decided — the original meaning of
 ///   `max_objects`.
 ///
@@ -55,8 +56,17 @@ impl PassBudget {
     /// stands. The sweep returns its cursor; the content reference scan
     /// gives up on collecting and the pass defers that reclamation.
     pub fn exhausted(&self) -> bool {
-        self.max_objects
-            .is_some_and(|max_objects| self.spent >= max_objects)
+        self.remaining() == 0
+    }
+
+    /// How many units are left to spend. An unmetered pass reports the
+    /// largest count there is, so a caller that sizes work by what remains
+    /// puts no cap on it.
+    pub(super) fn remaining(&self) -> u64 {
+        match self.max_objects {
+            Some(max_objects) => max_objects.saturating_sub(self.spent),
+            None => u64::MAX,
+        }
     }
 
     /// Charges one unit for work already done.
@@ -82,16 +92,11 @@ impl PassBudget {
         true
     }
 
-    /// Charges `units` for one block of work that could not be stopped
-    /// partway — the retained WAL chain, loaded whole by a loader that is
-    /// shared with foreground reads and takes no budget of its own. The
-    /// charge always lands, because the reads happened; `false` says the
-    /// block overdrew what was left and the pass stops having paid for it.
-    pub(super) fn charge_block(&mut self, units: u64) -> bool {
-        let within_budget = self
-            .max_objects
-            .is_none_or(|max_objects| self.spent.saturating_add(units) <= max_objects);
+    /// Charges `units` for one block of work already done — the segment
+    /// bodies one chain load read. The caller sizes that load by what
+    /// [`PassBudget::remaining`] reports, so a block never charges more
+    /// than the budget had left.
+    pub(super) fn charge_block(&mut self, units: u64) {
         self.spent = self.spent.saturating_add(units);
-        within_budget
     }
 }

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -10,7 +10,7 @@ use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::basis::{
     read_head_and_metadata_basis, resolve_retention_floor_seq, LoadedNamespaceBasis,
 };
-use crate::wal::{load_validated_wal_chain, WalChainLoadRequest};
+use crate::wal::{load_wal_chain_within, WalChainLoad, WalChainLoadRequest};
 use futures::StreamExt;
 use loonfs_api::wire::control::{
     decode_control_object, CheckpointOwner, CheckpointRecordLifecycle, CheckpointRecordState,
@@ -319,14 +319,16 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     // root-to-head replay (rule 7). A terminal namespace has no replay
     // future: its chain ages out.
     if !namespace_deleted && head.seq > floor_seq {
-        // The loader is shared with foreground reads and the changefeed, so
-        // it carries no budget and cannot stop partway. What the pass can
-        // do is refuse to start a load it has nothing left to pay for, and
-        // charge the whole chain as one block once it validates.
-        if budget.exhausted() {
+        // The loader keeps no budget of its own, because foreground reads
+        // and the changefeed share it. The pass caps the load at what it
+        // has left to spend instead. The loader then reads no more segment
+        // bodies than the pass can pay for, and the charge below can never
+        // go past the bound.
+        let remaining = budget.remaining();
+        if remaining == 0 {
             return Ok(LiveSetCollection::BudgetExhausted);
         }
-        let chain = load_validated_wal_chain(
+        let load = load_wal_chain_within(
             store,
             WalChainLoadRequest {
                 namespace_id,
@@ -336,15 +338,24 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
                 stop_after_seq: None,
                 recent_segments: &head.recent_segments,
             },
+            usize::try_from(remaining).unwrap_or(usize::MAX),
         )
         .await
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
         })?;
+        let chain = match load {
+            WalChainLoad::Complete(chain) => chain,
+            // The load stopped where the budget did. The pass pays for the
+            // bodies it read and then stops, because a partial chain roots
+            // nothing.
+            WalChainLoad::LimitReached { segments_fetched } => {
+                budget.charge_block(u64::try_from(segments_fetched).unwrap_or(u64::MAX));
+                return Ok(LiveSetCollection::BudgetExhausted);
+            }
+        };
         let segments = chain.segments();
-        if !budget.charge_block(u64::try_from(segments.len()).unwrap_or(u64::MAX)) {
-            return Ok(LiveSetCollection::BudgetExhausted);
-        }
+        budget.charge_block(u64::try_from(segments.len()).unwrap_or(u64::MAX));
         for segment in segments {
             live.wal_segments.insert(segment.object_key().to_owned());
             // The bodies are decoded and validated right here, so the

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -50,9 +50,9 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
         None => GcCursor::initial(namespace_id),
     };
     let mut report = GcResponse::empty(namespace_id.clone());
-    // The budget opens before the first read, so marking is inside it. A
-    // pass that cannot afford its own roots has to say so, rather than
-    // reading the whole retained chain for free and metering only what
+    // The budget opens before the first read, so marking spends out of it
+    // too. A pass that cannot afford its own roots reports that. It does
+    // not read the whole retained chain for free and then meter only what
     // comes after.
     let mut budget = PassBudget::of(config);
 
@@ -73,11 +73,11 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     // The cursor can skip enumeration only; it never carries safety state.
     let mark = match collect_live_set(store, namespace_id, &loaded, &mut budget, context).await? {
         LiveSetCollection::Complete(live) => Arc::new(live),
-        // Nothing was marked, so nothing may be decided: the pass deletes
-        // nothing, hands back the position it came in with rather than
-        // inventing progress, and says why. Content reclamation is skipped
-        // for the same reason the scan itself skips it — the collection it
-        // needs did not fit.
+        // The pass has no root set, so it may not decide any candidate. It
+        // deletes nothing and hands back the token it was given, because it
+        // made no progress to report. It also skips content reclamation for
+        // the same reason the scan skips it. The collection that decision
+        // needs did not fit in the budget.
         LiveSetCollection::BudgetExhausted => {
             report.budget_exhausted = true;
             report.content_reclamation_deferred = true;
@@ -114,16 +114,11 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
             {
                 continue;
             }
-            // The first candidate of a pass is decided whatever is left,
-            // because marking spends out of this same budget: a namespace
-            // whose roots cost the whole of `max_objects` would otherwise
-            // hand back the cursor it came in with forever, marking each
-            // time and walking nowhere. Past that first key the lookahead
-            // is the ordinary one — it proves work remains, performs no
-            // candidate reads or mutations, and leaves the key to be
-            // reconsidered from the exclusive last-examined position.
-            if decided > 0 && budget.exhausted() {
-                return stopped_on_budget(report, &position, &sweep);
+            // This one-key lookahead proves work remains. It performs no
+            // candidate reads or mutations, and the key is reconsidered
+            // from the exclusive last-examined position on resume.
+            if budget.exhausted() {
+                return stopped_on_budget(report, config, &position, decided, &sweep);
             }
 
             let step = process_candidate(
@@ -145,15 +140,15 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
                 // The re-verification this candidate's decision needs could
                 // not be paid for, so the candidate stays undecided and is
                 // reconsidered from the same exclusive position on resume.
-                return stopped_on_budget(report, &position, &sweep);
+                return stopped_on_budget(report, config, &position, decided, &sweep);
             }
             // Every candidate that gets past the check above comes back
             // decided one way or the other, so the cursor always advances
             // past it. The one thing a pass can run out of budget to
-            // answer — whether a completed session's content is still
-            // referenced — is answered by retaining the session, never by
-            // leaving it undecided and stopping: a budget below that scan's
-            // cost would otherwise pin the walk to one key forever.
+            // answer is whether a completed session's content is still
+            // referenced. The sweep answers that by retaining the session
+            // rather than by leaving the key undecided. A budget below that
+            // scan's cost would otherwise pin the walk to one key forever.
             budget.charge();
             decided += 1;
             position = GcCursor::after(namespace_id, family, key);
@@ -164,15 +159,28 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     Ok(report)
 }
 
-/// Closes a pass that stopped mid-enumeration on its budget, reporting the
-/// work it did do and where a rerun picks the walk back up.
+/// Closes a pass that stopped on its budget partway through the sweep. The
+/// pass reports the work it did.
+///
+/// A pass that decided at least one candidate returns the position it
+/// walked to. A pass that decided none returns the token it was given, byte
+/// for byte, because it made no progress to report. The runner compares
+/// that token against the one it submitted to tell a pass that walked from
+/// a pass that did not, so re-encoding the position here would have to rely
+/// on decode-then-encode producing the same bytes.
 fn stopped_on_budget(
     mut report: GcResponse,
+    config: &GcConfig,
     position: &GcCursor,
+    decided: u64,
     sweep: &SweepVerifier,
 ) -> Result<GcResponse> {
     report.budget_exhausted = true;
-    report.next_cursor = Some(position.encode()?);
+    if decided == 0 {
+        report.next_cursor.clone_from(&config.cursor);
+    } else {
+        report.next_cursor = Some(position.encode()?);
+    }
     report.degraded_retention = sweep.degraded;
     Ok(report)
 }

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1309,11 +1309,10 @@ async fn a_budget_below_the_roots_reads_no_chain_and_says_it_ran_out() {
     );
 }
 
-/// The chain loader is shared with foreground reads and cannot stop
-/// partway, so the pass refuses to start a load it has nothing left to pay
-/// for. A budget sized to everything before the chain therefore stops at
-/// that gate: no segment is fetched, no candidate is decided, and a rerun
-/// with room does the whole job.
+/// A pass with nothing left does not start a chain load at all. A budget
+/// sized to everything before the chain stops at that gate. It fetches no
+/// segment and decides no candidate, and a rerun with room does the whole
+/// job.
 #[tokio::test]
 async fn a_budget_that_dies_at_the_chain_gate_sweeps_nothing() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1346,7 +1345,7 @@ async fn a_budget_that_dies_at_the_chain_gate_sweeps_nothing() {
         "the gate holds before the chain is fetched, not after"
     );
 
-    // The same namespace, unbounded: the work the gate deferred is exactly
+    // The same namespace, unbounded. The work the gate deferred is exactly
     // the work that gets done.
     let resumed = gc_namespace(&store, &namespace_id, &config(), &past)
         .await
@@ -1356,6 +1355,157 @@ async fn a_budget_that_dies_at_the_chain_gate_sweeps_nothing() {
     assert!(read_upload_session(&store, &namespace_id, &upload_id)
         .await
         .is_none());
+}
+
+/// The chain can be longer than the budget has room for. The pass caps the
+/// load at what it has left, so the loader reads no more segment bodies
+/// than the pass may pay for. The pass then decides nothing and reports
+/// that it ran out.
+#[tokio::test]
+async fn a_chain_longer_than_the_budget_is_not_read_past_the_budget() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
+    let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
+    let (live, marking) = marked(&inner, &namespace_id, &aged).await;
+    let chain_units = u64::try_from(live.wal_segments.len()).expect("segment count fits");
+    assert!(
+        chain_units > 2,
+        "the fixture must retain a chain longer than the budget below"
+    );
+    // Two units are left when the pass reaches the chain, and the chain
+    // wants more than two.
+    let at_the_gate = 2;
+
+    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str()));
+    let store = RecordingStore::new(inner, segment_reads);
+    let mut bounded = config();
+    bounded.max_objects = Some(marking - chain_units + at_the_gate);
+    let report = gc_namespace(&store, &namespace_id, &bounded, &aged)
+        .await
+        .expect("pass over a chain it cannot afford");
+
+    let fetched = store.take_get_keys().len();
+    assert!(
+        u64::try_from(fetched).expect("fetch count fits") <= at_the_gate,
+        "the pass read {fetched} segment bodies with {at_the_gate} units left"
+    );
+    assert!(report.budget_exhausted);
+    assert_eq!(
+        report.next_cursor, None,
+        "the pass echoes the cursor it was given, and it was given none"
+    );
+    assert_eq!(report.retained_candidates, 0);
+    assert_eq!(
+        (
+            report.deleted_wal_segments,
+            report.deleted_metadata_tables,
+            report.deleted_manifests,
+            report.deleted_checkpoint_records,
+            report.deleted_upload_sessions,
+            report.deleted_content_objects,
+        ),
+        (0, 0, 0, 0, 0, 0)
+    );
+}
+
+/// A budget that covers the roots exactly reads the whole chain. The cap on
+/// the load is what the budget has left, and that is the chain's own size,
+/// so nothing is truncated. One more unit than that lets the walk begin.
+#[tokio::test]
+async fn a_budget_that_covers_the_roots_exactly_finishes_marking() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
+    let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
+    let (live, marking) = marked(&inner, &namespace_id, &aged).await;
+    let retained = live.wal_segments;
+    assert!(!retained.is_empty(), "the fixture must retain a chain");
+
+    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str()));
+    let store = RecordingStore::new(inner, segment_reads);
+    let mut exact = config();
+    exact.max_objects = Some(marking);
+    let report = gc_namespace(&store, &namespace_id, &exact, &aged)
+        .await
+        .expect("pass with a budget for the roots");
+
+    assert_eq!(
+        store.take_get_keys().into_iter().collect::<BTreeSet<_>>(),
+        retained,
+        "marking read every retained segment"
+    );
+    assert!(report.budget_exhausted);
+    assert!(
+        !report.content_reclamation_deferred,
+        "this pass did finish marking, so it has a root set and a reference set"
+    );
+
+    // One more unit, and the pass walks: it decides a candidate and hands
+    // back a position instead of the cursor it came in with.
+    let mut one_more = config();
+    one_more.max_objects = Some(marking + 1);
+    let walked = gc_namespace(&store, &namespace_id, &one_more, &aged)
+        .await
+        .expect("pass with one candidate of room");
+    assert!(walked.budget_exhausted);
+    assert!(
+        walked.next_cursor.is_some(),
+        "a pass that decided a candidate reports where it walked to"
+    );
+}
+
+/// A pass whose roots cost the whole budget decides nothing. It returns the
+/// token it was given, byte for byte, so the runner can tell that the pass
+/// made no progress and park it.
+#[tokio::test]
+async fn a_pass_that_decides_nothing_echoes_its_cursor_verbatim() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&store, &namespace_id, &setup).await;
+    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    let marking = marking_units(&store, &namespace_id, &aged).await;
+
+    let mut walking = config();
+    walking.max_objects = Some(marking + 2);
+    let first = gc_namespace(&store, &namespace_id, &walking, &aged)
+        .await
+        .expect("pass with two candidates of room");
+    let submitted = first
+        .next_cursor
+        .expect("two candidates leave more to walk");
+
+    let mut starved = config();
+    starved.max_objects = Some(marking);
+    starved.cursor = Some(submitted.clone());
+    let parked = gc_namespace(&store, &namespace_id, &starved, &aged)
+        .await
+        .expect("pass with no candidate of room");
+
+    assert!(parked.budget_exhausted);
+    assert_eq!(
+        parked.next_cursor,
+        Some(submitted),
+        "the token comes back unchanged, not re-encoded from the position"
+    );
+    assert_eq!(parked.retained_candidates, 0);
+    assert_eq!(
+        (
+            parked.deleted_wal_segments,
+            parked.deleted_metadata_tables,
+            parked.deleted_manifests,
+            parked.deleted_checkpoint_records,
+            parked.deleted_upload_sessions,
+            parked.deleted_content_objects,
+        ),
+        (0, 0, 0, 0, 0, 0)
+    );
 }
 
 /// Marking decodes and validates every retained segment already, so the
@@ -1471,10 +1621,14 @@ async fn a_budget_that_dies_among_the_checkpoint_records_decides_nothing() {
 /// The only reference keeping this content alive lives in the newest WAL
 /// segment, the very last root the scan reads. A pass that stopped short
 /// and answered from what it had collected would call the content
-/// unreferenced and delete it. Running every budget from one up past the
-/// whole scan's cost, each to the end of its walk, leaves no interleaving
-/// where a partial reference set decides anything — and the budgets that
-/// can afford the scan still reach the right verdict.
+/// unreferenced and delete it. The budgets below run from one candidate a
+/// pass up to sixteen, each walk to its end, which leaves no interleaving
+/// where a partial reference set decides anything. The budgets that can
+/// afford the scan still reach the right verdict.
+///
+/// Every budget is priced from what marking this namespace costs, because
+/// marking spends out of the same purse. A budget below that cost buys no
+/// walk at all, which would prove nothing here.
 #[tokio::test]
 async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1499,11 +1653,13 @@ async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
     let content_key =
         loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+    let marking = marking_units(&seed, &namespace_id, &past).await;
     let mut some_budget_reached_the_verdict = false;
     let mut some_budget_deferred_instead = false;
 
-    for max_objects in 1..=16 {
-        let trial_root = temp_dir.path().join(format!("trial-{max_objects}"));
+    for candidates in 1..=16 {
+        let max_objects = marking + candidates;
+        let trial_root = temp_dir.path().join(format!("trial-{candidates}"));
         copy_tree(&seed_root, &trial_root);
         let store = LocalFsStore::new(&trial_root).expect("trial store");
         let mut bounded = config();

--- a/crates/loonfs-core/src/wal/mod.rs
+++ b/crates/loonfs-core/src/wal/mod.rs
@@ -10,7 +10,9 @@ pub(crate) use self::frame::{
     DecodedWalRecord, PreparedWalSegment, ReplayedWalTail, ValidatedWalChain, ValidatedWalSegment,
     WalBuildError, WalChainLoadError, WalChainLoadRequest, WalReplayError,
 };
-pub(crate) use self::reader::{count_visible_wal_tail_segments, load_validated_wal_chain};
+pub(crate) use self::reader::{
+    count_visible_wal_tail_segments, load_validated_wal_chain, load_wal_chain_within, WalChainLoad,
+};
 pub(crate) use self::replay::project_validated_wal_tail;
 pub(crate) use self::writer::prepare_wal_segment;
 

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -15,21 +15,27 @@ use std::collections::HashMap;
 /// this is what decides how many round trips it costs.
 pub(super) const RECENT_SEGMENT_PREFETCH_CONCURRENCY: usize = 32;
 
+/// The hinted segment keys that cover the replay gap, newest first.
+fn hints_in_gap(
+    hints: &[WalSegmentPointer],
+    stop_after_seq: ChangeSeq,
+    head_seq: ChangeSeq,
+) -> Vec<String> {
+    hints
+        .iter()
+        .filter(|pointer| pointer.end_seq > stop_after_seq && pointer.end_seq <= head_seq)
+        .map(|pointer| pointer.object_key.clone())
+        .collect()
+}
+
 /// Fetches the hinted segments covering the replay gap concurrently.
 ///
 /// Failures and misses are silently dropped: the chain walk re-fetches
 /// anything the prefetch did not deliver, so hints can only save latency.
 async fn prefetch_recent_segments<S: ObjectStore + ?Sized>(
     store: &S,
-    hints: &[WalSegmentPointer],
-    stop_after_seq: ChangeSeq,
-    head_seq: ChangeSeq,
+    in_gap: &[String],
 ) -> HashMap<String, Bytes> {
-    let in_gap: Vec<String> = hints
-        .iter()
-        .filter(|pointer| pointer.end_seq > stop_after_seq && pointer.end_seq <= head_seq)
-        .map(|pointer| pointer.object_key.clone())
-        .collect();
     let mut prefetched = HashMap::new();
     for chunk in in_gap.chunks(RECENT_SEGMENT_PREFETCH_CONCURRENCY) {
         let fetches = chunk.iter().map(|object_key| async move {
@@ -46,6 +52,77 @@ async fn prefetch_recent_segments<S: ObjectStore + ?Sized>(
     prefetched
 }
 
+/// One walk down the chain links, from the visible tip towards the base.
+struct WalkedChain {
+    /// The segments the walk found, oldest first.
+    segments: Vec<ValidatedWalSegment>,
+    /// How many segment bodies the walk read from the store. Every read
+    /// counts, including a prefetch that missed and a hint the walk never
+    /// used.
+    fetches: usize,
+    /// `true` when the walk stopped at its fetch limit instead of reaching
+    /// the base. `segments` is then a partial chain. Nothing may replay
+    /// from it, and [`finish_chain`] rejects it.
+    stopped_at_limit: bool,
+}
+
+impl WalkedChain {
+    fn reached(segments: Vec<ValidatedWalSegment>, fetches: usize) -> Self {
+        Self {
+            segments,
+            fetches,
+            stopped_at_limit: false,
+        }
+    }
+
+    fn stopped_at_limit(fetches: usize) -> Self {
+        Self {
+            segments: Vec::new(),
+            fetches,
+            stopped_at_limit: true,
+        }
+    }
+}
+
+/// What a bounded chain load produced.
+pub(crate) enum WalChainLoad {
+    /// The whole chain was read inside the fetch limit.
+    Complete(ValidatedWalChain),
+    /// The load stopped at the fetch limit. `segments_fetched` is how many
+    /// segment bodies it read before it stopped, and it is never more than
+    /// the limit the caller gave.
+    LimitReached { segments_fetched: usize },
+}
+
+/// Loads the chain, reading at most `max_segment_fetches` segment bodies.
+///
+/// A caller that meters its own reads uses this so that the loader cannot
+/// read past what the caller may pay for. The loader itself keeps no
+/// budget, because foreground reads and the changefeed share it.
+#[tracing::instrument(
+    level = "info",
+    name = "loonfs.phase",
+    err,
+    skip_all,
+    fields(phase = "load_wal_chain_within", key_class = "wal_segment")
+)]
+pub(crate) async fn load_wal_chain_within<S: ObjectStore + ?Sized>(
+    store: &S,
+    request: WalChainLoadRequest<'_>,
+    max_segment_fetches: usize,
+) -> Result<WalChainLoad, WalChainLoadError> {
+    let walked = walk_chain(store, &request, max_segment_fetches).await?;
+    if walked.stopped_at_limit {
+        return Ok(WalChainLoad::LimitReached {
+            segments_fetched: walked.fetches,
+        });
+    }
+    Ok(WalChainLoad::Complete(finish_chain(
+        &request,
+        walked.segments,
+    )?))
+}
+
 #[tracing::instrument(
     level = "info",
     name = "loonfs.phase",
@@ -57,6 +134,21 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
     store: &S,
     request: WalChainLoadRequest<'_>,
 ) -> Result<ValidatedWalChain, WalChainLoadError> {
+    // No caller here meters its own reads, so the walk runs to the base.
+    // A namespace cannot hold `usize::MAX` segments, so the walk never
+    // stops at this limit. If it somehow did, `finish_chain` would reject
+    // the partial chain rather than return it.
+    let walked = walk_chain(store, &request, usize::MAX).await?;
+    finish_chain(&request, walked.segments)
+}
+
+/// Walks the chain links from the visible tip down to the base, reading at
+/// most `max_segment_fetches` segment bodies.
+async fn walk_chain<S: ObjectStore + ?Sized>(
+    store: &S,
+    request: &WalChainLoadRequest<'_>,
+    max_segment_fetches: usize,
+) -> Result<WalkedChain, WalChainLoadError> {
     if request.chain_base_seq > request.head_seq {
         return Err(WalChainLoadError::InvalidSeqRange {
             chain_base_seq: request.chain_base_seq,
@@ -64,7 +156,7 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
         });
     }
     if request.chain_base_seq == request.head_seq {
-        return Ok(ValidatedWalChain::empty());
+        return Ok(WalkedChain::reached(Vec::new(), 0));
     }
 
     let mut pointer = request
@@ -82,16 +174,18 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
     }
 
     let stop_after_seq = request.stop_after_seq.unwrap_or(request.chain_base_seq);
-    let mut prefetched = if request.recent_segments.is_empty() {
+    let in_gap = hints_in_gap(request.recent_segments, stop_after_seq, request.head_seq);
+    // The prefetch issues one request per hint, and it issues them before
+    // the walk can decide it has read enough. The walk stops here instead,
+    // having read nothing at all.
+    if in_gap.len() > max_segment_fetches {
+        return Ok(WalkedChain::stopped_at_limit(0));
+    }
+    let mut fetches = in_gap.len();
+    let mut prefetched = if in_gap.is_empty() {
         HashMap::new()
     } else {
-        prefetch_recent_segments(
-            store,
-            request.recent_segments,
-            stop_after_seq,
-            request.head_seq,
-        )
-        .await
+        prefetch_recent_segments(store, &in_gap).await
     };
     let mut reversed = Vec::new();
     loop {
@@ -102,16 +196,22 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
         let object_key = pointer.object_key.clone();
         let encoded_bytes = match prefetched.remove(&object_key) {
             Some(bytes) => bytes,
-            None => store
-                .get(&object_key, None)
-                .await
-                .map_err(|err| WalChainLoadError::ReadWal {
-                    object_key: object_key.clone(),
-                    message: err.to_string(),
-                })?
-                .ok_or_else(|| WalChainLoadError::MissingWalObject {
-                    object_key: object_key.clone(),
-                })?,
+            None => {
+                if fetches >= max_segment_fetches {
+                    return Ok(WalkedChain::stopped_at_limit(fetches));
+                }
+                fetches += 1;
+                store
+                    .get(&object_key, None)
+                    .await
+                    .map_err(|err| WalChainLoadError::ReadWal {
+                        object_key: object_key.clone(),
+                        message: err.to_string(),
+                    })?
+                    .ok_or_else(|| WalChainLoadError::MissingWalObject {
+                        object_key: object_key.clone(),
+                    })?
+            }
         };
         let envelope = decode_wal_segment_envelope_zstd(&encoded_bytes)
             .map_err(|err| WalReplayError::Codec(err.to_string()))?;
@@ -135,8 +235,18 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
     }
 
     reversed.reverse();
+    Ok(WalkedChain::reached(reversed, fetches))
+}
 
-    let Some(first_segment) = reversed.first() else {
+/// Validates one walked chain as a replayable run and hands it back.
+///
+/// A partial chain does not survive this: its oldest segment does not sit
+/// at the requested base, so the base check below rejects it.
+fn finish_chain(
+    request: &WalChainLoadRequest<'_>,
+    segments: Vec<ValidatedWalSegment>,
+) -> Result<ValidatedWalChain, WalChainLoadError> {
+    let Some(first_segment) = segments.first() else {
         return Ok(ValidatedWalChain::empty());
     };
     if let Some(after_seq) = request.stop_after_seq {
@@ -154,7 +264,7 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
             actual: expected_base_seq,
         });
     }
-    for segment in &reversed {
+    for segment in &segments {
         validate_wal_segment_for_replay(
             request.namespace_id,
             expected_base_seq,
@@ -171,7 +281,7 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
         });
     }
 
-    Ok(ValidatedWalChain::new(reversed))
+    Ok(ValidatedWalChain::new(segments))
 }
 
 fn validate_pointer_matches_envelope(

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -1,5 +1,7 @@
 //! Behavior tests for WAL segment preparation and validated chain loading.
 
+#![allow(clippy::panic)]
+
 use super::reader::RECENT_SEGMENT_PREFETCH_CONCURRENCY;
 use super::*;
 use crate::commit::{
@@ -13,7 +15,9 @@ use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey, NamespaceId, WalSegmentI
 use loonfs_objectstore::keys::{wal_segment, wal_segment_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
-use loonfs_test_support::stores::{ConcurrencyWatchStore, KeyPredicate, RecordingStore};
+use loonfs_test_support::stores::{
+    ConcurrencyWatchStore, CountingStore, KeyPredicate, OperationClass, RecordingStore,
+};
 use std::borrow::Cow;
 use tempfile::tempdir;
 
@@ -593,6 +597,133 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
     .await
     .expect("chain despite garbage hints");
     assert_eq!(survived.segments(), unhinted.segments());
+}
+
+/// Writes a chain of `length` linked segments and returns their pointers,
+/// oldest first.
+async fn write_linked_chain(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    length: u64,
+) -> Vec<WalSegmentPointer> {
+    let mut pointers: Vec<WalSegmentPointer> = Vec::new();
+    for index in 0..length {
+        let segment = write_create_directory_segment(
+            store,
+            namespace_id,
+            pointers.last().cloned(),
+            &format!("c_wal_bounded_{index:02}"),
+            &format!("dir-{index:02}"),
+            ChangeSeq(index),
+            ChangeSeq(index + 1),
+        )
+        .await;
+        pointers.push(segment.envelope.pointer(segment.object_key.clone()));
+    }
+    pointers
+}
+
+/// A caller that meters its own reads caps the load, and the loader stops
+/// once it has read that many segment bodies. It reports how many it read
+/// so the caller can charge for exactly those.
+#[tokio::test]
+async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::any(),
+    );
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let pointers = write_linked_chain(store.inner(), &namespace_id, 5).await;
+    let tip = pointers.last().expect("a chain was written").clone();
+
+    // No hints, so every body comes from the serial walk down the links.
+    store.reset();
+    let bounded = load_wal_chain_within(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(5),
+            visible_tip: Some(tip.clone()),
+            stop_after_seq: None,
+            recent_segments: &[],
+        },
+        2,
+    )
+    .await
+    .expect("bounded chain load");
+    match bounded {
+        WalChainLoad::Complete(_) => panic!("a five-segment chain does not fit in two fetches"),
+        WalChainLoad::LimitReached { segments_fetched } => assert_eq!(segments_fetched, 2),
+    }
+    assert_eq!(
+        store.count(OperationClass::Get),
+        2,
+        "the walk reads no more bodies than the limit allows"
+    );
+
+    // The hinted gap is known before the prefetch issues anything, so a
+    // hint list longer than the limit costs no read at all.
+    let mut newest_first = pointers.clone();
+    newest_first.reverse();
+    store.reset();
+    let hinted = load_wal_chain_within(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(5),
+            visible_tip: Some(tip.clone()),
+            stop_after_seq: None,
+            recent_segments: &newest_first,
+        },
+        2,
+    )
+    .await
+    .expect("bounded hinted load");
+    match hinted {
+        WalChainLoad::Complete(_) => panic!("five hints do not fit in two fetches"),
+        WalChainLoad::LimitReached { segments_fetched } => assert_eq!(segments_fetched, 0),
+    }
+    assert_eq!(store.count(OperationClass::Get), 0);
+}
+
+/// A limit that covers the chain exactly does not truncate it. The load
+/// completes and matches what an unbounded load returns.
+#[tokio::test]
+async fn a_limit_that_covers_the_chain_loads_all_of_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::any(),
+    );
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let pointers = write_linked_chain(store.inner(), &namespace_id, 5).await;
+    let tip = pointers.last().expect("a chain was written").clone();
+    let request = |recent: &'static [WalSegmentPointer]| WalChainLoadRequest {
+        namespace_id: &namespace_id,
+        chain_base_seq: ChangeSeq(0),
+        head_seq: ChangeSeq(5),
+        visible_tip: Some(tip.clone()),
+        stop_after_seq: None,
+        recent_segments: recent,
+    };
+    let unbounded = load_validated_wal_chain(&store, request(&[]))
+        .await
+        .expect("unbounded chain");
+
+    store.reset();
+    let bounded = load_wal_chain_within(&store, request(&[]), 5)
+        .await
+        .expect("bounded chain load");
+    match bounded {
+        WalChainLoad::Complete(chain) => assert_eq!(chain.segments(), unbounded.segments()),
+        WalChainLoad::LimitReached { segments_fetched } => {
+            panic!("a five-segment chain fits in five fetches, not {segments_fetched}")
+        }
+    }
+    assert_eq!(store.count(OperationClass::Get), 5);
 }
 
 async fn write_create_directory_segment(

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -539,8 +539,8 @@ mod tests {
             MaintenanceStepConclusion::Blocked
         );
 
-        // The same pass on a resumed step: it echoes the cursor it came in
-        // with rather than inventing progress, which parks it too.
+        // The same pass on a resumed step returns the token it was given,
+        // byte for byte, because it made no progress. That parks it too.
         let mut echoed = GcResponse::empty(namespace.clone());
         echoed.budget_exhausted = true;
         echoed.next_cursor = Some("page-2".to_owned());

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -681,13 +681,16 @@ completed-content reclamation for the rest of the invocation: the session is
 retained, `content_reclamation_deferred` is set, and the sweep goes on
 through every other candidate under the usual budget. Deletion only ever
 follows a complete collection, so a partial one decides nothing. A budget
-too small for the roots themselves does nothing at all: it reports
+too small for the roots themselves does nothing at all. It reports
 `budget_exhausted` alongside `content_reclamation_deferred`, deletes
-nothing, and hands back the cursor it was given rather than a new one. A
-pass that did have room for the roots decides at least one candidate
-whatever is left over, so a bounded walk always advances. A budget above
-the roots but below the scan on top of them keeps completed content rather
-than reclaiming it — a pass with room for the whole scan collects it later.
+nothing, and returns the cursor it was given byte for byte. A budget that
+covers the roots and no more behaves the same way, except that it did
+finish marking, so it does not set `content_reclamation_deferred`. Any pass
+that stops without deciding a candidate returns its submitted cursor
+unchanged, and a caller that loops on `next_cursor` should stop when the
+token it gets back is the token it sent. A budget above the roots but below
+the reference scan on top of them keeps completed content rather than
+reclaiming it, and a pass with room for the whole scan collects it later.
 Step-driven GC defaults `max_objects` to 1024 and returns any `next_cursor`
 for a later step rather than looping internally. Nothing sweeps unless `gc`
 is present.


### PR DESCRIPTION
1. The chain load now stops at the budget. GC passes its remaining budget to a new bounded loader entry point (`load_wal_chain_within`). The loader reads at most that many segment bodies and reports how many it read. GC charges that count and returns the exhausted response with no deletions. Before this change, GC checked for one remaining unit and then loaded the whole chain.
2. The first sweep candidate no longer bypasses an exhausted budget. The loop checks the budget before every candidate. A pass that decides no candidate returns the cursor token it was given, unchanged, so the runner's no-progress check does not depend on re-encoding a token.
