### PR TITLE
feat(server): official container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,37 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-msrv-
       - run: cargo +1.85 check --workspace --all-targets --all-features --locked
 
+  # Builds the server image and proves it works: the probes answer, the
+  # process is not root, the bearer token is enforced, durable state survives
+  # a restart, and SIGTERM exits zero. The script asserts all of that, so this
+  # job is the script's exit code.
+  #
+  # The job runs on every change, the way every other job here does. A path
+  # filter would be wrong for this one in any case: the image carries the
+  # whole workspace's code, so a change to any crate can change it.
+  container:
+    name: container
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/loonfs-server/Dockerfile
+          tags: loonfs-server:ci
+          # Into the runner's own image store, so the test below runs the
+          # image this step built.
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      # LOONFS_IMAGE is what tells the script to test an existing image
+      # instead of building its own, so the cached build above is the one
+      # under test.
+      - run: crates/loonfs-server/scripts/test-image.sh
+        env:
+          LOONFS_IMAGE: loonfs-server:ci
+
   dist:
     name: dist
     runs-on: ubuntu-latest

--- a/crates/loonfs-server/Dockerfile
+++ b/crates/loonfs-server/Dockerfile
@@ -1,0 +1,56 @@
+# The LoonFS server image.
+#
+# Build it with the repository root as the context, because the build needs
+# the whole workspace:
+#
+#   docker build -f crates/loonfs-server/Dockerfile -t loonfs-server:dev .
+#
+# The image carries the server binary and nothing else. Mount a config file
+# and, for a local-fs store, the directory that store writes to.
+
+# The tag names no version on purpose. `rust-toolchain.toml` pins
+# `channel = "stable"`, and the rustup in this image honors that file, so the
+# toolchain file picks the compiler whatever version the tag installed. The
+# CI `msrv` job is what enforces the 1.85 floor.
+FROM rust:bookworm AS builder
+
+WORKDIR /src
+
+# The whole workspace, because the members depend on each other and the lock
+# file resolves all of them together.
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+
+# One package, default features. `--all-features` would also build
+# `loonfs-openapi`, the crate's second binary, which rides the non-default
+# `openapi` feature. That binary regenerates the API spec during development
+# and does not belong in a deployment.
+RUN cargo build --locked --release -p loonfs-server
+
+FROM debian:bookworm-slim
+
+# The server reaches object storage over HTTPS and verifies those endpoints
+# against the public root certificates. Nothing else is installed.
+RUN apt-get update \
+    && apt-get install --no-install-recommends --assume-yes ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# The server runs as a normal user. It writes only where a deployment mounts
+# a volume, so it owns no path inside the image.
+RUN groupadd --system --gid 10001 loonfs \
+    && useradd --system --uid 10001 --gid loonfs --no-create-home \
+        --shell /usr/sbin/nologin loonfs
+
+COPY --from=builder /src/target/release/loonfs-server /usr/local/bin/loonfs-server
+
+USER loonfs
+
+# A convention, not a server default. The config's `bind` decides the address
+# and the port; this line documents the port the examples use.
+EXPOSE 9400
+
+# Exec form, so the server is PID 1 and receives SIGTERM itself. A shell
+# wrapper would hold PID 1 instead, and the server would never see the signal
+# it shuts down on.
+ENTRYPOINT ["/usr/local/bin/loonfs-server"]
+CMD ["--config", "/etc/loonfs/config.toml"]

--- a/crates/loonfs-server/Dockerfile.dockerignore
+++ b/crates/loonfs-server/Dockerfile.dockerignore
@@ -1,0 +1,17 @@
+# BuildKit reads this file because it sits beside the Dockerfile it names, so
+# a build with the repository root as its context still ships only what this
+# image needs: the workspace manifests, the lock file, the toolchain file,
+# and the whole `crates/` tree.
+#
+# `*.md` excludes the Markdown files at the context root. A pattern without a
+# slash matches one path component, so the READMEs inside `crates/` stay.
+target/
+.git/
+.github/
+.claude/
+.codex/
+.lab/
+scripts/
+docs/
+assets/
+*.md

--- a/crates/loonfs-server/README.md
+++ b/crates/loonfs-server/README.md
@@ -23,6 +23,18 @@ LOONFS_AUTH_TOKEN=dev-token loonfs init default --no-input \
   --server-url http://127.0.0.1:9400
 ```
 
+## Run it in a container
+
+```bash
+docker build -f crates/loonfs-server/Dockerfile -t loonfs-server:dev .
+docker run --rm -p 9400:9400 \
+  -v /etc/loonfs/server.toml:/etc/loonfs/config.toml:ro loonfs-server:dev
+```
+
+The image reads `/etc/loonfs/config.toml` and runs as uid 10001.
+[docs/self-hosting.md](docs/self-hosting.md#running-it-in-a-container)
+covers the secrets, the mounts, and the shutdown timeout.
+
 ## Configuration
 
 `config/` holds one example per object store: `local-fs`, `aws-s3`,

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -93,6 +93,65 @@ The crate's [`config/`](../config) directory holds one worked example per
 object store, each documenting its provider credentials and the optional
 settings this guide leaves out.
 
+## Running it in a container
+
+The crate carries a [`Dockerfile`](../Dockerfile). Build it with the
+repository root as the context, because the build needs the whole workspace:
+
+```bash
+docker build -f crates/loonfs-server/Dockerfile -t loonfs-server:dev .
+```
+
+The image holds the server binary and the public root certificates. It runs
+as uid 10001, and it reads `/etc/loonfs/config.toml` unless you pass another
+`--config`. Mount your config at that path:
+
+```bash
+docker run --rm \
+  --env LOONFS_AUTH_TOKEN={auth_token} \
+  --env LOONFS_CONTENT_TOKEN_SECRET={content_token_secret} \
+  --volume /etc/loonfs/server.toml:/etc/loonfs/config.toml:ro \
+  --volume /var/lib/loonfs/store:/var/lib/loonfs/store \
+  --publish 9400:9400 \
+  loonfs-server:dev
+```
+
+The second mount is the `local-fs` store from the config above, and it has to
+be writable by uid 10001, because that is the user the process runs as. A
+cloud store needs no mount at all: the config names the bucket and the
+credentials arrive through the environment.
+
+The image declares port 9400, which is the port the examples use. The
+config's `bind` decides the port the process actually listens on, so a config
+that binds another port needs another `--publish`.
+
+The first log line reports that the config loaded and that the process holds
+the port:
+
+```json
+{"timestamp":"2026-08-07T01:32:23.285509Z","level":"INFO","fields":{"message":"loonfs-server is listening","bind":"0.0.0.0:9400","store":"local-fs"},"target":"loonfs_server::http::serve"}
+```
+
+Arguments after the image name replace the default command, so the same image
+validates a config without serving:
+
+```bash
+docker run --rm \
+  --volume /etc/loonfs/server.toml:/etc/loonfs/config.toml:ro \
+  loonfs-server:dev --config /etc/loonfs/config.toml --check-config
+```
+
+The server is PID 1 and shuts down on SIGTERM, which is what `docker stop`
+and a Kubernetes pod deletion send. It stops accepting, drains the requests
+in flight, settles its background work, and exits zero. Allow enough time for
+that: pass `--timeout 120` to `docker stop`, or set
+`terminationGracePeriodSeconds: 120` on the pod. A process killed before it
+settles may lose work it had already accepted.
+
+[`scripts/test-image.sh`](../scripts/test-image.sh) builds the image and runs
+this whole path against it, down to the restart. CI runs the same script on
+every change.
+
 ## Probes and metrics
 
 Three routes report on the process. Each one answers a narrow question, and

--- a/crates/loonfs-server/scripts/test-image.sh
+++ b/crates/loonfs-server/scripts/test-image.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Proves the server image works: it starts under its own config, answers the
+# probes, runs as a normal user, enforces the bearer token, writes durable
+# state, shuts down cleanly on SIGTERM, and finds that state again on the
+# next start.
+#
+#   crates/loonfs-server/scripts/test-image.sh
+#
+# The script builds the image itself. Set LOONFS_IMAGE to test one that is
+# already built, which is what CI does with the image its cached build
+# produced.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+IMAGE="${LOONFS_IMAGE:-loonfs-server:test-$$}"
+BUILT_IMAGE=""
+FIRST_CONTAINER="loonfs-server-test-$$-1"
+SECOND_CONTAINER="loonfs-server-test-$$-2"
+WORK_DIR=""
+NAMESPACE="container-check"
+# The startup line the server logs once it holds the port. Step 5 asserts
+# the container's first log line is this one, which proves both that logging
+# is on by default and that the line exists.
+STARTUP_MESSAGE="loonfs-server is listening"
+
+# The server wrote the store as the image's own user, so under a runtime
+# that maps container ids onto host ids the files there belong to that user
+# and this script cannot remove them. A root container removes those, and
+# then the directory itself, which this script does own, goes.
+remove_work_dir() {
+  [[ -n "$WORK_DIR" ]] || return 0
+  if ! rm -rf "$WORK_DIR" 2>/dev/null; then
+    docker run --rm --user 0:0 --volume "$WORK_DIR:/work" \
+      --entrypoint /bin/rm "$IMAGE" -rf /work/store /work/config.toml \
+      >/dev/null 2>&1 || true
+    rm -rf "$WORK_DIR" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  local status=$?
+  docker rm --force "$FIRST_CONTAINER" "$SECOND_CONTAINER" >/dev/null 2>&1 || true
+  # Before the image goes, because removing the store runs a container from it.
+  remove_work_dir
+  if [[ -n "$BUILT_IMAGE" ]]; then
+    docker image rm --force "$BUILT_IMAGE" >/dev/null 2>&1 || true
+  fi
+  return "$status"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "ok: $*"
+}
+
+# A hex string from the kernel's random source, for the two secrets. They
+# live for one run and are never written anywhere but this run's config.
+random_hex() {
+  od -An -tx1 -N16 /dev/urandom | tr -d ' \n'
+}
+
+status_code() {
+  curl --silent --output /dev/null --write-out '%{http_code}' "$@" || true
+}
+
+# Publishes the container port on a loopback port the kernel picks, then
+# reports the address curl should use. Two runs on one machine never collide.
+#
+# `docker port` may report one mapping per address family, and the first
+# line is taken. Trimming it here rather than piping through `head` keeps
+# `pipefail` from seeing the broken pipe `head` leaves behind.
+container_base_url() {
+  local container="$1" mapping
+  mapping="$(docker port "$container" 9400/tcp)"
+  mapping="${mapping%%$'\n'*}"
+  [[ -n "$mapping" ]] || fail "container $container published no port"
+  echo "http://127.0.0.1:${mapping##*:}"
+}
+
+# The container's first log line, trimmed off the whole log for the same
+# reason.
+first_log_line() {
+  local logs
+  logs="$(docker logs "$1" 2>&1)"
+  echo "${logs%%$'\n'*}"
+}
+
+# Waits for the process to answer its liveness probe. A container that has
+# already exited is never going to answer, so that is reported at once
+# instead of after the whole budget.
+wait_for_health() {
+  local container="$1" base="$2" attempt
+  for attempt in $(seq 1 60); do
+    if [[ "$(status_code "$base/health")" == "200" ]]; then
+      return 0
+    fi
+    if [[ "$(docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null || echo false)" != "true" ]]; then
+      docker logs "$container" >&2 || true
+      fail "container $container exited before it answered /health"
+    fi
+    sleep 1
+  done
+  docker logs "$container" >&2 || true
+  fail "container $container did not answer /health within 60 seconds"
+}
+
+command -v docker >/dev/null 2>&1 || fail "docker is not on PATH"
+
+# 1. Build the image, unless the caller supplied one.
+if [[ -z "${LOONFS_IMAGE:-}" ]]; then
+  echo "building $IMAGE from $REPO_ROOT"
+  docker build --file "$REPO_ROOT/crates/loonfs-server/Dockerfile" --tag "$IMAGE" "$REPO_ROOT"
+  BUILT_IMAGE="$IMAGE"
+fi
+pass "image $IMAGE is available"
+
+# 2. The config and the store directory this run serves.
+WORK_DIR="$(mktemp -d)"
+mkdir -p "$WORK_DIR/store"
+# The image runs as a normal user whose id the host does not share, so the
+# mounted store has to be writable by whoever that turns out to be.
+chmod 0777 "$WORK_DIR" "$WORK_DIR/store"
+AUTH_TOKEN="$(random_hex)"
+CONTENT_TOKEN_SECRET="$(random_hex)"
+cat >"$WORK_DIR/config.toml" <<'CONFIG'
+bind = "0.0.0.0:9400"
+writer_id = "loonfs-server-container-test"
+# The bind serves every interface, so the config has to say that something
+# else terminates TLS. Here that something else is the test itself.
+allow_remote_without_tls = true
+
+[store]
+kind = "local-fs"
+root = "/var/lib/loonfs/store"
+CONFIG
+chmod 0644 "$WORK_DIR/config.toml"
+pass "wrote a config and a store directory under $WORK_DIR"
+
+# 3. Run the first container. The two secrets arrive through the
+#    environment, the way a deployment supplies them.
+docker run --detach --name "$FIRST_CONTAINER" \
+  --env "LOONFS_AUTH_TOKEN=$AUTH_TOKEN" \
+  --env "LOONFS_CONTENT_TOKEN_SECRET=$CONTENT_TOKEN_SECRET" \
+  --volume "$WORK_DIR/config.toml:/etc/loonfs/config.toml:ro" \
+  --volume "$WORK_DIR/store:/var/lib/loonfs/store" \
+  --publish "127.0.0.1::9400" \
+  "$IMAGE" >/dev/null
+BASE_URL="$(container_base_url "$FIRST_CONTAINER")"
+pass "started $FIRST_CONTAINER on $BASE_URL"
+
+# 4. The probes.
+wait_for_health "$FIRST_CONTAINER" "$BASE_URL"
+pass "GET /health answered 200"
+READINESS="$(status_code "$BASE_URL/readiness")"
+[[ "$READINESS" == "200" ]] || fail "GET /readiness answered $READINESS, expected 200"
+pass "GET /readiness answered 200"
+
+# 5. The first log line. Logging is on with no environment variable set, and
+#    the line names the bind address and the store kind.
+FIRST_LOG_LINE="$(first_log_line "$FIRST_CONTAINER")"
+[[ "$FIRST_LOG_LINE" == *"$STARTUP_MESSAGE"* ]] \
+  || fail "the first log line does not carry the startup message: $FIRST_LOG_LINE"
+[[ "$FIRST_LOG_LINE" == *"0.0.0.0:9400"* ]] \
+  || fail "the startup line does not name the bind address: $FIRST_LOG_LINE"
+[[ "$FIRST_LOG_LINE" == *"local-fs"* ]] \
+  || fail "the startup line does not name the store kind: $FIRST_LOG_LINE"
+pass "the first log line is the startup line: $FIRST_LOG_LINE"
+
+# 6. The process is not root.
+CONTAINER_UID="$(docker exec "$FIRST_CONTAINER" id -u)"
+[[ "$CONTAINER_UID" != "0" ]] || fail "the container runs as root"
+pass "the container runs as uid $CONTAINER_UID"
+
+# 7. The bearer token guards the authenticated routes.
+METRICS_AUTHORIZED="$(status_code --header "Authorization: Bearer $AUTH_TOKEN" "$BASE_URL/metrics")"
+[[ "$METRICS_AUTHORIZED" == "200" ]] \
+  || fail "GET /metrics with the token answered $METRICS_AUTHORIZED, expected 200"
+METRICS_ANONYMOUS="$(status_code "$BASE_URL/metrics")"
+[[ "$METRICS_ANONYMOUS" == "401" ]] \
+  || fail "GET /metrics without the token answered $METRICS_ANONYMOUS, expected 401"
+pass "GET /metrics answered 200 with the token and 401 without it"
+
+# 8. Durable state: create a namespace and read its status back.
+CREATE_STATUS="$(status_code --request POST \
+  --header "Authorization: Bearer $AUTH_TOKEN" \
+  --header 'Content-Type: application/json' \
+  --data "{\"namespace_id\":\"$NAMESPACE\"}" \
+  "$BASE_URL/v0/namespaces")"
+[[ "$CREATE_STATUS" == "200" ]] \
+  || fail "POST /v0/namespaces answered $CREATE_STATUS, expected 200"
+STATUS_CODE="$(status_code --header "Authorization: Bearer $AUTH_TOKEN" \
+  "$BASE_URL/v0/namespaces/$NAMESPACE")"
+[[ "$STATUS_CODE" == "200" ]] \
+  || fail "GET /v0/namespaces/$NAMESPACE answered $STATUS_CODE, expected 200"
+pass "created namespace $NAMESPACE and read its status back"
+
+# 9. SIGTERM shuts the process down cleanly. The server settles its
+#    background work before it returns, and a settle that failed exits
+#    non-zero, so the exit code is the assertion.
+docker stop --timeout 120 "$FIRST_CONTAINER" >/dev/null
+EXIT_CODE="$(docker inspect --format '{{.State.ExitCode}}' "$FIRST_CONTAINER")"
+[[ "$EXIT_CODE" == "0" ]] || fail "the container exited $EXIT_CODE after SIGTERM, expected 0"
+pass "the container exited 0 after SIGTERM"
+
+# 10. A new process on the same store finds the namespace.
+docker run --detach --name "$SECOND_CONTAINER" \
+  --env "LOONFS_AUTH_TOKEN=$AUTH_TOKEN" \
+  --env "LOONFS_CONTENT_TOKEN_SECRET=$CONTENT_TOKEN_SECRET" \
+  --volume "$WORK_DIR/config.toml:/etc/loonfs/config.toml:ro" \
+  --volume "$WORK_DIR/store:/var/lib/loonfs/store" \
+  --publish "127.0.0.1::9400" \
+  "$IMAGE" >/dev/null
+SECOND_BASE_URL="$(container_base_url "$SECOND_CONTAINER")"
+wait_for_health "$SECOND_CONTAINER" "$SECOND_BASE_URL"
+RESTART_STATUS="$(status_code --header "Authorization: Bearer $AUTH_TOKEN" \
+  "$SECOND_BASE_URL/v0/namespaces/$NAMESPACE")"
+[[ "$RESTART_STATUS" == "200" ]] \
+  || fail "after the restart GET /v0/namespaces/$NAMESPACE answered $RESTART_STATUS, expected 200"
+pass "namespace $NAMESPACE survived the restart"
+docker stop --timeout 120 "$SECOND_CONTAINER" >/dev/null
+SECOND_EXIT_CODE="$(docker inspect --format '{{.State.ExitCode}}' "$SECOND_CONTAINER")"
+[[ "$SECOND_EXIT_CODE" == "0" ]] \
+  || fail "the second container exited $SECOND_EXIT_CODE after SIGTERM, expected 0"
+pass "the second container exited 0 after SIGTERM"
+
+# 11. The trap removes the containers, the temp directory, and any image
+#     this run built.
+echo "PASS: the image serves, authenticates, persists, and shuts down cleanly"

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -427,6 +427,15 @@ pub async fn serve_with_shutdown(
     let listener = tokio::net::TcpListener::bind(bind)
         .await
         .map_err(|source| ServeError::Bind { addr: bind, source })?;
+    // The first line a deployment sees. An idle server logs nothing until
+    // a request arrives, so without this line a container that started
+    // correctly and a container that is stuck look the same. This one says
+    // the config loaded and the process holds the port.
+    tracing::info!(
+        bind = %bind,
+        store = config.store.kind().as_str(),
+        "loonfs-server is listening"
+    );
     match tls {
         Some(tls) => serve_on(TlsListener::new(listener, tls), config, shutdown).await,
         None => serve_on(listener, config, shutdown).await,


### PR DESCRIPTION
The server gets an official container image. The Dockerfile is a plain two-stage build: `rust:bookworm` builds one package with default features, `debian:bookworm-slim` plus `ca-certificates` runs it as uid 10001 with an exec-form entrypoint, so the server is PID 1 and receives SIGTERM itself. The image is 140 MB.

**Notes:**

- The server now logs one line after it binds, naming the bind address and the store kind. Before this, an idle server printed nothing, so a healthy container and a stuck one looked the same.
- The build does not pass `--all-features`, which would ship the `loonfs-openapi` spec-generation binary. The base tag pins no version because `rust-toolchain.toml` picks the compiler; the CI msrv job enforces the floor.
- `test-image.sh` asserts eleven things, including: the first log line is the startup line, the process is not root, `/metrics` needs the token, a namespace survives stop and restart on the same store, and SIGTERM exits zero (a failed shutdown settle exits non-zero, so that assertion has teeth). It ran twice locally against the real image — once building, once in the CI reuse mode.
- The new CI job builds through the Actions cache and runs the script. It has no path filter because no job in this workflow does, and the image carries every crate anyway.
- The guide documents the local build and run only. Registry publishing arrives with the release PR.
