### PR TITLE
feat(server): minimal helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,53 @@ jobs:
         env:
           LOONFS_IMAGE: loonfs-server:ci
 
+  # Lints and renders the server's Helm chart. `helm lint` runs the chart's
+  # strict values schema, so a value name the chart does not know fails here
+  # rather than being ignored. The renders cover the combinations that take
+  # different template branches, and the last step greps one render for the
+  # three settings that make the chart correct for a single-writer server.
+  # Those three live in the template rather than in values, so this job is
+  # what stops an edit from turning them into something else.
+  #
+  # The runner ships helm, so the job installs nothing.
+  helm:
+    name: helm
+    runs-on: ubuntu-latest
+    env:
+      CHART: crates/loonfs-server/deploy/helm/loonfs-server
+      # The schema requires a config Secret name, so every command below
+      # supplies one. The chart creates no Secret and reads none while it
+      # renders, so any name works here.
+      SECRET: --set config.existingSecret=test
+    steps:
+      - uses: actions/checkout@v4
+      - run: helm version
+      - name: lint
+        run: helm lint "$CHART" $SECRET
+      - name: render every value combination
+        run: |
+          helm template rel "$CHART" $SECRET >/dev/null
+          helm template rel "$CHART" $SECRET \
+            --set localCache.enabled=true --set localCache.sizeLimit=100Gi >/dev/null
+          helm template rel "$CHART" $SECRET --set image.tag=0.2.0 >/dev/null
+          helm template rel "$CHART" $SECRET \
+            --set image.digest=sha256:1111111111111111111111111111111111111111111111111111111111111111 >/dev/null
+          helm template rel "$CHART" $SECRET \
+            --set 'extraEnvFrom[0].secretRef.name=loonfs-server-secrets' >/dev/null
+      - name: assert the single-writer settings
+        run: |
+          rendered="$(helm template rel "$CHART" $SECRET)"
+          assert_line() {
+            grep -qE "$1" <<<"$rendered" || {
+              echo "FAIL: the render has no line matching $1" >&2
+              exit 1
+            }
+            echo "ok: $1"
+          }
+          assert_line '^  replicas: 1$'
+          assert_line '^    type: Recreate$'
+          assert_line '^      automountServiceAccountToken: false$'
+
   dist:
     name: dist
     runs-on: ubuntu-latest

--- a/crates/loonfs-server/Dockerfile
+++ b/crates/loonfs-server/Dockerfile
@@ -43,7 +43,12 @@ RUN groupadd --system --gid 10001 loonfs \
 
 COPY --from=builder /src/target/release/loonfs-server /usr/local/bin/loonfs-server
 
-USER loonfs
+# Numeric, not the name. A kubelet running a pod with `runAsNonRoot: true`
+# reads this field to decide whether the user is root, and it cannot resolve
+# a name to an id without starting the container first. A named user there
+# fails the container with "cannot verify user is non-root", which also puts
+# the image outside the restricted Pod Security Standard.
+USER 10001:10001
 
 # A convention, not a server default. The config's `bind` decides the address
 # and the port; this line documents the port the examples use.

--- a/crates/loonfs-server/README.md
+++ b/crates/loonfs-server/README.md
@@ -55,3 +55,6 @@ would report, so it belongs in a deployment pipeline ahead of the rollout.
 
 Read [docs/self-hosting.md](docs/self-hosting.md) for the topology, the
 minimal config, the probes, logging, and the local cache.
+
+[`deploy/helm/loonfs-server`](deploy/helm/loonfs-server) holds a Helm chart
+that runs the image on Kubernetes as one pod.

--- a/crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: loonfs-server
+description: The LoonFS server, one active process behind the v0 HTTP API.
+type: application
+# Both track the workspace version. The chart ships with the server it runs,
+# so a chart version names the server version it defaults to.
+version: 0.2.0
+appVersion: "0.2.0"

--- a/crates/loonfs-server/deploy/helm/loonfs-server/README.md
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/README.md
@@ -1,0 +1,184 @@
+# loonfs-server chart
+
+This chart runs the LoonFS server on Kubernetes. It renders a Deployment and
+a ClusterIP Service, and it renders nothing else.
+
+The chart is not published to a registry yet. Install it from a checkout of
+this repository:
+
+```bash
+helm install loonfs-server crates/loonfs-server/deploy/helm/loonfs-server \
+  --namespace loonfs \
+  --set config.existingSecret=loonfs-server-config
+```
+
+[`docs/self-hosting.md`](../../../docs/self-hosting.md) covers the server
+itself: the config fields, the probes, the logging, and the upgrade rule.
+This file covers the chart.
+
+## Topology
+
+One pod serves the API.
+
+LoonFS has one writer. A second replica is not high availability: the newer
+process takes the writer epoch, and the superseded process's writes are
+rejected from then on. The replica count is written into the template rather
+than exposed as a value, because raising it does not make the deployment more
+available.
+
+The update strategy is `Recreate` for the same reason. The old pod stops
+before the new one starts, and the API is offline for that gap.
+
+## The config Secret
+
+The chart does not create a Secret and never sees your config. Create one
+first, then name it in `config.existingSecret`:
+
+```bash
+kubectl --namespace loonfs create secret generic loonfs-server-config \
+  --from-file=config.toml=/path/to/your/config.toml
+```
+
+The whole Secret mounts read-only at `/etc/loonfs`, so every entry in it
+lands at `/etc/loonfs/<entry>`. Files the config points at ride along in the
+same Secret:
+
+```bash
+kubectl --namespace loonfs create secret generic loonfs-server-config \
+  --from-file=config.toml=/path/to/your/config.toml \
+  --from-file=gcs-service-account.json=/path/to/sa.json \
+  --from-file=tls.crt=/path/to/tls.crt \
+  --from-file=tls.key=/path/to/tls.key
+```
+
+That config names them at `/etc/loonfs/gcs-service-account.json`,
+`/etc/loonfs/tls.crt`, and `/etc/loonfs/tls.key`.
+
+`config.key` names the entry holding the TOML, and the container reads
+`/etc/loonfs/<key>`. The default is `config.toml`.
+
+Changing the Secret does not restart the pod. Roll it yourself:
+
+```bash
+kubectl --namespace loonfs rollout restart deployment/loonfs-server
+```
+
+## The two secret values
+
+`auth_token` and `content_token_secret` can sit in the config file, and they
+can also arrive through the environment as `LOONFS_AUTH_TOKEN` and
+`LOONFS_CONTENT_TOKEN_SECRET`. A non-blank value in the file wins.
+
+The chart models no providers and no credentials. It passes `extraEnv` and
+`extraEnvFrom` through as written, which is how those values reach the
+process from a Secret you already keep:
+
+```yaml
+extraEnvFrom:
+  - secretRef:
+      name: loonfs-server-secrets
+```
+
+The same two lists carry provider credentials, `RUST_LOG`, and anything else
+the process reads from the environment.
+
+## The local cache
+
+`localCache.enabled` mounts an `emptyDir` at `/var/cache/loonfs`. The chart
+writes nothing into your config, so the config's `[local_cache]` table has to
+name that same directory:
+
+```toml
+[local_cache]
+path = "/var/cache/loonfs"
+memory_bytes = 67108864
+disk_bytes = 107374182400
+```
+
+Three numbers have to line up, and the server enforces the first of them.
+
+`disk_bytes` has a floor of 100663296 bytes, which is 96 MiB. A smaller value
+fails the process at startup rather than starting a cache that holds nothing.
+
+The disk tier claims the whole of `disk_bytes` up front, as 16 MiB files, and
+it holds every one of them open. `localCache.sizeLimit` has to be at least
+`disk_bytes` for that reason. The kubelet evicts a pod whose `emptyDir` grows
+past its limit, and a cache sized above the limit reaches it as it fills. The
+100 GiB config above needs `sizeLimit: 100Gi` or more.
+
+The container's open-file limit has to be above `disk_bytes` divided by
+16 MiB, because every claimed file stays open. The 100 GiB config above asks
+for 6400 files.
+
+Changing `disk_bytes` across a restart is safe either way. Growing it keeps
+what the directory already holds. Shrinking it starts the directory empty.
+Nothing in the cache is durable, so deleting it is always safe, and the pod
+deletes it every time it stops.
+
+## Values
+
+| Value | Default | What it does |
+| --- | --- | --- |
+| `image.repository` | `ghcr.io/loonfs/loonfs-server` | The repository to pull the server image from. |
+| `image.tag` | `""` | The tag to run. Empty means the chart's `appVersion`. |
+| `image.digest` | `""` | A digest, written as `sha256:...`. Setting it ignores the tag. |
+| `image.pullPolicy` | `IfNotPresent` | The container's `imagePullPolicy`. |
+| `imagePullSecrets` | `[]` | Pull secrets for a private registry. Each entry is `{name: ...}`. |
+| `config.existingSecret` | `""` | The name of an existing Secret holding the config. Required. |
+| `config.key` | `config.toml` | The entry in that Secret holding the TOML config. |
+| `service.port` | `9400` | The port the Service publishes and the probes call. |
+| `service.annotations` | `{}` | Annotations for the Service. |
+| `terminationGracePeriodSeconds` | `600` | How long the kubelet waits after SIGTERM before SIGKILL. |
+| `localCache.enabled` | `false` | Mount an `emptyDir` at `/var/cache/loonfs`. |
+| `localCache.sizeLimit` | `""` | That `emptyDir`'s `sizeLimit`, such as `100Gi`. Empty means no limit. |
+| `extraEnv` | `[]` | Environment variables for the container, as Kubernetes `EnvVar` entries. |
+| `extraEnvFrom` | `[]` | Environment sources for the container, as Kubernetes `EnvFromSource` entries. |
+| `podAnnotations` | `{}` | Annotations for the pod. |
+| `podLabels` | `{}` | Labels for the pod, beside the ones the chart sets. |
+| `nodeSelector` | `{}` | Passed through to the pod. |
+| `tolerations` | `[]` | Passed through to the pod. |
+| `affinity` | `{}` | Passed through to the pod. |
+| `resources` | `{}` | Requests and limits for the container. |
+
+`service.port` is the port the Service publishes, the port the container
+declares, and the port the probes call. The config's `bind` decides the port
+the process actually listens on, so both have to name the same number.
+
+There is no `replicaCount`, and the chart offers no ingress, no autoscaler,
+and no pod disruption budget. One writer needs none of them.
+
+## The strict schema
+
+`values.schema.json` sets `additionalProperties: false` at every level the
+chart owns, so a misspelled value name fails `helm lint` and `helm install`:
+
+```
+Error: values don't meet the specifications of the schema(s) in the following chart(s):
+loonfs-server:
+- (root): Additional property replicaCount is not allowed
+```
+
+A value that is quietly ignored is worse than one that is rejected, and this
+is the rule the server already applies to its TOML config. The schema stops
+at the chart's own values: it checks that `config.existingSecret` is set and
+that `service.port` is a port, and it does not model the TOML. Check the
+config itself with the server's own flag:
+
+```bash
+loonfs-server --config /etc/loonfs/config.toml --check-config
+```
+
+## Shutdown
+
+`terminationGracePeriodSeconds` defaults to 600.
+
+The server's shutdown stops accepting, drains the requests in flight, and
+settles its background work. It holds no timeout of its own, and one degraded
+object-store operation is bounded at roughly six minutes. 600 seconds clears
+that case.
+
+The kubelet sends SIGKILL when the grace period runs out. Writer-epoch
+fencing contains what that leaves behind, so a killed process corrupts
+nothing. It does discard a clean settle, and work the server had already
+accepted can be lost with it. Lower this value only if you would rather have
+the faster rollout.

--- a/crates/loonfs-server/deploy/helm/loonfs-server/templates/NOTES.txt
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/templates/NOTES.txt
@@ -1,0 +1,14 @@
+{{ .Chart.Name }} {{ .Chart.AppVersion }} is installed as {{ include "loonfs-server.fullname" . }} in namespace {{ .Release.Namespace }}.
+
+One pod serves the API. Watch it come up:
+
+  kubectl --namespace {{ .Release.Namespace }} rollout status deployment/{{ include "loonfs-server.fullname" . }}
+
+Reach the API from your workstation:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "loonfs-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  curl http://127.0.0.1:{{ .Values.service.port }}/health
+
+The config, the probes, and the local cache are covered in the self-hosting
+guide at crates/loonfs-server/docs/self-hosting.md, and the chart's own
+values are covered in its README.

--- a/crates/loonfs-server/deploy/helm/loonfs-server/templates/_helpers.tpl
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/*
+The name the Deployment and the Service carry. A release already named after
+the chart is used as it stands, so `helm install loonfs-server ...` does not
+produce `loonfs-server-loonfs-server`.
+*/}}
+{{- define "loonfs-server.fullname" -}}
+{{- if contains .Chart.Name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The labels the Deployment's selector matches. A Deployment's selector is
+immutable, so nothing that changes between upgrades belongs here.
+*/}}
+{{- define "loonfs-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "loonfs-server.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "loonfs-server.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+The image reference. A digest names one build and wins over the tag. Without
+either, the chart runs the server version it shipped with.
+*/}}
+{{- define "loonfs-server.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else if .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The Secret holding the config has to exist before the install, and the chart
+cannot create it. Say so here rather than rendering a pod that never starts.
+*/}}
+{{- define "loonfs-server.configSecret" -}}
+{{- required "config.existingSecret is required: create the Secret holding your config.toml first, then name it here" .Values.config.existingSecret -}}
+{{- end -}}

--- a/crates/loonfs-server/deploy/helm/loonfs-server/templates/deployment.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loonfs-server.fullname" . }}
+  labels:
+    {{- include "loonfs-server.labels" . | nindent 4 }}
+spec:
+  # LoonFS has one writer. A second replica is not high availability: the
+  # newer process takes the writer epoch and the older process's writes are
+  # rejected from then on. The count is written here instead of being a
+  # value, because raising it does not make the deployment more available.
+  replicas: 1
+  # The old pod stops before the new one starts, for the same reason. An
+  # upgrade takes the API offline for that gap.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "loonfs-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "loonfs-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      # The server never calls the Kubernetes API.
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # The shutdown drains and settles with no timeout of its own, and one
+      # degraded object-store operation runs for about six minutes.
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: loonfs-server
+          image: {{ include "loonfs-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # The whole Secret mounts, so this names the entry to read. The
+          # default key asks for the path the image reads on its own.
+          args:
+            - --config
+            - /etc/loonfs/{{ .Values.config.key }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          # /readiness answers 503 as soon as shutdown closes admission,
+          # which drains this pod from the Service before it stops.
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: http
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loonfs
+              readOnly: true
+            {{- if .Values.localCache.enabled }}
+            - name: local-cache
+              mountPath: /var/cache/loonfs
+            {{- end }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "loonfs-server.configSecret" . }}
+        {{- if .Values.localCache.enabled }}
+        # The cache holds copies of bytes the object store already has, so
+        # it goes with the pod. The config's [local_cache] path has to name
+        # this mount point.
+        - name: local-cache
+          {{- if .Values.localCache.sizeLimit }}
+          emptyDir:
+            sizeLimit: {{ .Values.localCache.sizeLimit | quote }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/crates/loonfs-server/deploy/helm/loonfs-server/templates/service.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loonfs-server.fullname" . }}
+  labels:
+    {{- include "loonfs-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  # The chart publishes the API inside the cluster and stops there. Put your
+  # own ingress or load balancer in front of it.
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "loonfs-server.selectorLabels" . | nindent 4 }}

--- a/crates/loonfs-server/deploy/helm/loonfs-server/values.schema.json
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/values.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "loonfs-server values",
+  "description": "The schema rejects value names it does not know, at every level the chart owns. A misspelled name fails the lint and the install instead of being ignored, which is the rule the server applies to its own TOML config.",
+  "type": "object",
+  "additionalProperties": false,
+  "$comment": "The required lists name what the templates read directly. Everything else is optional, because the templates skip it when it is absent.",
+  "required": [
+    "image",
+    "config",
+    "service",
+    "terminationGracePeriodSeconds",
+    "localCache"
+  ],
+  "properties": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "pullPolicy"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The repository to pull the server image from."
+        },
+        "tag": {
+          "type": "string",
+          "description": "The tag to run. Empty means the chart's appVersion."
+        },
+        "digest": {
+          "type": "string",
+          "description": "A digest, written as sha256:... . Setting it ignores the tag."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "The container's imagePullPolicy. Kubernetes accepts these three."
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Pull secrets for a private registry.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["existingSecret", "key"],
+      "properties": {
+        "existingSecret": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The name of an existing Secret holding the server config. The chart does not create it, so the install needs a name."
+        },
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The entry in that Secret holding the TOML config. The container reads /etc/loonfs/<key>."
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port"],
+      "properties": {
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "The port the Service publishes and the probes call. The config's bind has to name the same number."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "How long the kubelet waits after SIGTERM before it sends SIGKILL."
+    },
+    "localCache": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Mount an emptyDir at /var/cache/loonfs for the server's disk cache."
+        },
+        "sizeLimit": {
+          "type": "string",
+          "description": "The emptyDir's sizeLimit, as a quantity such as 100Gi. Empty means no limit."
+        }
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "description": "Environment variables for the container. Each entry is a Kubernetes EnvVar, and the chart passes it through as written.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "description": "Environment sources for the container. Each entry is a Kubernetes EnvFromSource, and the chart passes it through as written.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Passed through as written. Each entry is a Kubernetes Toleration.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Passed through as written, as a Kubernetes Affinity."
+    },
+    "resources": {
+      "type": "object",
+      "description": "Passed through as written, as a Kubernetes ResourceRequirements."
+    }
+  }
+}

--- a/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
@@ -1,0 +1,80 @@
+# Values for the loonfs-server chart.
+#
+# The chart renders a Deployment and a ClusterIP Service. It renders nothing
+# else: no Secret, no ServiceAccount, no ingress, no autoscaler.
+#
+# Every name here is checked against values.schema.json, and the schema
+# rejects names it does not know. A misspelled value fails the install rather
+# than being ignored.
+
+image:
+  # The repository to pull the server image from.
+  repository: ghcr.io/loonfs/loonfs-server
+  # The tag to run. Empty means the chart's appVersion.
+  tag: ""
+  # A digest, written as "sha256:...". Setting it ignores the tag.
+  digest: ""
+  # The container's imagePullPolicy.
+  pullPolicy: IfNotPresent
+
+# Pull secrets for a private registry. Each entry is {name: my-secret}.
+imagePullSecrets: []
+
+config:
+  # The name of an existing Secret holding the server config. The chart does
+  # not create this Secret, and the install fails when the name is empty.
+  # The whole Secret mounts read-only at /etc/loonfs, so a service-account
+  # JSON or a TLS certificate and key ride along beside the config file and
+  # the config names them at /etc/loonfs/<entry>.
+  existingSecret: ""
+  # The entry in that Secret holding the TOML config. The container reads
+  # /etc/loonfs/<key>.
+  key: config.toml
+
+service:
+  # The port the Service publishes, the port the container declares, and the
+  # port the probes call. The config's `bind` decides the port the process
+  # listens on, so the two have to name the same number.
+  port: 9400
+  # Annotations for the Service.
+  annotations: {}
+
+# How long the kubelet waits after SIGTERM before it sends SIGKILL. The
+# server's shutdown has no timeout of its own and one degraded object-store
+# operation runs for about six minutes, so the default clears that case.
+terminationGracePeriodSeconds: 600
+
+localCache:
+  # Mount an emptyDir at /var/cache/loonfs for the server's disk cache. The
+  # chart writes nothing into the config: the config's [local_cache] table
+  # has to name /var/cache/loonfs as its `path`.
+  enabled: false
+  # The emptyDir's sizeLimit, as a quantity such as "100Gi". Set it to at
+  # least the config's `disk_bytes`, because the kubelet evicts a pod whose
+  # emptyDir grows past the limit. Empty means the chart sets no limit.
+  sizeLimit: ""
+
+# Environment variables for the container, passed through as written. Each
+# entry is a Kubernetes EnvVar. This is how LOONFS_AUTH_TOKEN and
+# LOONFS_CONTENT_TOKEN_SECRET reach the process from a Secret you already
+# have.
+extraEnv: []
+
+# Environment sources for the container, passed through as written. Each
+# entry is a Kubernetes EnvFromSource, so one entry turns a whole Secret into
+# environment variables.
+extraEnvFrom: []
+
+# Annotations for the pod.
+podAnnotations: {}
+
+# Labels for the pod, added beside the labels the chart sets.
+podLabels: {}
+
+# Scheduling for the pod, passed through as written.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Requests and limits for the container.
+resources: {}

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -144,13 +144,89 @@ docker run --rm \
 The server is PID 1 and shuts down on SIGTERM, which is what `docker stop`
 and a Kubernetes pod deletion send. It stops accepting, drains the requests
 in flight, settles its background work, and exits zero. Allow enough time for
-that: pass `--timeout 120` to `docker stop`, or set
-`terminationGracePeriodSeconds: 120` on the pod. A process killed before it
-settles may lose work it had already accepted.
+that: pass `--timeout 120` to `docker stop`. A process killed before it
+settles may lose work it had already accepted. The chart below gives the pod
+600 seconds for the same reason, and its README says where that number comes
+from.
 
 [`scripts/test-image.sh`](../scripts/test-image.sh) builds the image and runs
 this whole path against it, down to the restart. CI runs the same script on
 every change.
+
+## Running it on Kubernetes
+
+The crate carries a Helm chart at
+[`deploy/helm/loonfs-server`](../deploy/helm/loonfs-server). It renders a
+Deployment and a ClusterIP Service, and it renders nothing else.
+
+One pod serves the API. The chart fixes the replica count at 1 and sets the
+update strategy to `Recreate`, because LoonFS has one writer. An upgrade
+stops the old pod before it starts the new one, so the API is offline for
+that gap. This is not a high-availability deployment, and a second replica
+would not make it one.
+
+The chart is not published to a registry yet. Install it from a checkout of
+this repository.
+
+Create the namespace:
+
+```bash
+kubectl create namespace loonfs
+```
+
+Create the Secret holding the config. The chart does not create this Secret:
+
+```bash
+kubectl --namespace loonfs create secret generic loonfs-server-config \
+  --from-file=config.toml=/etc/loonfs/server.toml
+```
+
+The whole Secret mounts read-only at `/etc/loonfs`, so every entry in it
+lands at `/etc/loonfs/<entry>`. A service-account JSON, or a TLS certificate
+and key, go into that same Secret, and the config names them at those paths.
+
+Keep the two secret values in a Secret of their own, so the config file
+carries no credentials:
+
+```bash
+kubectl --namespace loonfs create secret generic loonfs-server-secrets \
+  --from-literal=LOONFS_AUTH_TOKEN={auth_token} \
+  --from-literal=LOONFS_CONTENT_TOKEN_SECRET={content_token_secret}
+```
+
+Install the chart from the repository path. Point `image.repository` and
+`image.tag` at an image the cluster can pull: the build above produces one on
+your workstation, and a cluster needs it in a registry it reaches or loaded
+onto its nodes.
+
+```bash
+helm install loonfs-server crates/loonfs-server/deploy/helm/loonfs-server \
+  --namespace loonfs \
+  --set config.existingSecret=loonfs-server-config \
+  --set image.repository=your-registry.example.com/loonfs-server \
+  --set image.tag=dev \
+  --set 'extraEnvFrom[0].secretRef.name=loonfs-server-secrets'
+```
+
+Watch the pod come up:
+
+```bash
+kubectl --namespace loonfs rollout status deployment/loonfs-server
+```
+
+Reach the API from your workstation and check the probe:
+
+```bash
+kubectl --namespace loonfs port-forward service/loonfs-server 9400:9400 &
+curl http://127.0.0.1:9400/health
+```
+
+`service.port` is the port the Service publishes and the port the probes
+call, and the config's `bind` decides the port the process listens on. Both
+have to name the same number.
+
+The chart's [README](../deploy/helm/loonfs-server/README.md) documents every
+value, the local cache's sizing rules, and the shutdown grace period.
 
 ## Probes and metrics
 


### PR DESCRIPTION
The minimal Helm chart: one Deployment, one ClusterIP Service, and notes. Replicas are hard-coded to 1 with `Recreate`, because a second LoonFS replica is not high availability. The chart mounts an operator-provided Secret at `/etc/loonfs` and creates no Secret of its own. TOML stays the only configuration language.

**Details:**

- The values schema is strict: `additionalProperties: false` everywhere, so a typo'd value fails install instead of doing nothing — the same rule the server's TOML decoder applies. Verified empirically: `replicaCount=3`, a misspelled field, and an invalid port are all rejected.
- `terminationGracePeriodSeconds` defaults to 600. The server's shutdown settles with no internal timeout and one degraded object-store operation is bounded at about six minutes.
- This PR fixes a defect the chart exposed in the image: `USER loonfs` by name fails `runAsNonRoot: true`, because the kubelet cannot verify a named user. The image now declares `USER 10001:10001`, and the full container test re-ran green against a fresh build.
- `config.key` renders explicit container args, so a non-default key actually works instead of being silently ignored.
- The cache guidance carries the real numbers: 96 MiB `disk_bytes` floor, the full size claimed up front as 16 MiB files each held open, `sizeLimit` must be at least `disk_bytes`.
- CI lints the chart, renders five value combinations, and greps the render for `replicas: 1`, `Recreate`, and `automountServiceAccountToken: false`. 