### PR TITLE
feat(server): release pipeline and runbook

### DIFF
--- a/.github/workflows/release-loonfs.yml
+++ b/.github/workflows/release-loonfs.yml
@@ -1,4 +1,4 @@
-name: Release LoonFS CLI
+name: Release LoonFS
 
 on:
   release:
@@ -14,6 +14,9 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  IMAGE_NAME: ghcr.io/loonfs/loonfs-server
+  CHART_PATH: crates/loonfs-server/deploy/helm/loonfs-server
+  CHART_REGISTRY: oci://ghcr.io/loonfs/charts
 
 jobs:
   prepare:
@@ -41,6 +44,26 @@ jobs:
           expected_tag="v$VERSION"
           if [ "$TAG_NAME" != "$expected_tag" ]; then
             echo "release tag $TAG_NAME does not match workspace version $expected_tag" >&2
+            exit 1
+          fi
+
+      # The chart ships in this release and names the server version it runs,
+      # so a chart that disagrees with the tag would publish a wrong default
+      # image. `sed` reads the two lines rather than a YAML tool, because the
+      # runner promises no such tool.
+      - name: Validate chart version matches workspace version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          chart="$CHART_PATH/Chart.yaml"
+          chart_version="$(sed -n 's/^version: *//p' "$chart" | tr -d '"')"
+          app_version="$(sed -n 's/^appVersion: *//p' "$chart" | tr -d '"')"
+          if [ "$chart_version" != "$VERSION" ]; then
+            echo "chart version $chart_version does not match workspace version $VERSION" >&2
+            exit 1
+          fi
+          if [ "$app_version" != "$VERSION" ]; then
+            echo "chart appVersion $app_version does not match workspace version $VERSION" >&2
             exit 1
           fi
 
@@ -110,11 +133,232 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # One image per architecture, each built on a runner of that architecture,
+  # so no emulation is involved. Each leg pushes its image by digest and
+  # carries no tag: the merge job below is what publishes the tag.
+  server-image:
+    name: Build server image ${{ matrix.arch }}
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            platform: linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The build carries no cache. A release image is built from the tag's
+      # own source every time.
+      #
+      # `provenance: false` keeps each push a plain single-platform image. An
+      # attestation manifest would make it an index instead, and the merged
+      # manifest would then carry `unknown/unknown` entries beside the two
+      # architectures the release claims.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/loonfs-server/Dockerfile
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}
+          provenance: false
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      # The released image is the tested image: this pulls the digest the step
+      # above pushed and runs the image test against those exact bytes. Both
+      # legs run it, because both images ship.
+      - name: Test the image this job pushed
+        env:
+          LOONFS_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: |
+          docker pull "$LOONFS_IMAGE"
+          crates/loonfs-server/scripts/test-image.sh
+
+      - name: Record the digest for the manifest
+        env:
+          ARCH: ${{ matrix.arch }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          case "$DIGEST" in
+            sha256:*) ;;
+            *)
+              echo "the build reported no image digest: $DIGEST" >&2
+              exit 1
+              ;;
+          esac
+          mkdir -p digests
+          echo "$DIGEST" > "digests/$ARCH"
+
+      - name: Upload the digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-image-digest-${{ matrix.arch }}
+          path: digests/${{ matrix.arch }}
+          if-no-files-found: error
+          retention-days: 1
+
+  server-image-manifest:
+    name: Publish server image
+    needs: [prepare, server-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      tag: ${{ steps.manifest.outputs.tag }}
+      digest: ${{ steps.manifest.outputs.digest }}
+      platforms: ${{ steps.manifest.outputs.platforms }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: digests
+          pattern: server-image-digest-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Both per-architecture images are already in the registry, addressed by
+      # digest and carrying no tag. This step publishes the release: it creates
+      # the one manifest the tag names, then reads that manifest back and
+      # proves it carries both architectures.
+      - name: Create the multi-platform manifest
+        id: manifest
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          tag="$IMAGE_NAME:v$VERSION"
+          docker buildx imagetools create --tag "$tag" \
+            "$IMAGE_NAME@$(cat digests/amd64)" \
+            "$IMAGE_NAME@$(cat digests/arm64)"
+
+          digest="$(docker buildx imagetools inspect "$tag" --format '{{ .Manifest.Digest }}')"
+          case "$digest" in
+            sha256:*) ;;
+            *)
+              echo "the published manifest reported no digest: $digest" >&2
+              exit 1
+              ;;
+          esac
+
+          raw="$(docker buildx imagetools inspect "$tag" --raw)"
+          platforms="$(jq -r '[.manifests[] | "\(.platform.os)/\(.platform.architecture)"] | join(", ")' <<<"$raw")"
+          for required in linux/amd64 linux/arm64; do
+            case ", $platforms, " in
+              *", $required, "*) ;;
+              *)
+                echo "the published manifest does not carry $required: $platforms" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          {
+            echo "tag=$tag"
+            echo "digest=$digest"
+            echo "platforms=$platforms"
+          } >> "$GITHUB_OUTPUT"
+
+  helm-publish:
+    name: Publish Helm chart
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      version: ${{ steps.push.outputs.version }}
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      # The runner ships helm, so this job installs nothing. `helm lint` runs
+      # the chart's strict values schema, and that schema requires a config
+      # Secret name. The chart creates no Secret and reads none while it
+      # renders, so any name works here.
+      - name: Lint the chart
+        run: helm lint "$CHART_PATH" --set config.existingSecret=release
+
+      # The chart's own Chart.yaml already carries this version, and prepare
+      # refused the release otherwise. Passing it again names the version this
+      # package claims in the one command that builds it.
+      - name: Package the chart
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          helm package "$CHART_PATH" \
+            --version "$VERSION" \
+            --app-version "$VERSION" \
+            --destination dist
+
+      - name: Log in to ghcr.io
+        shell: bash
+        env:
+          REGISTRY_USER: ${{ github.actor }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s' "$REGISTRY_TOKEN" \
+            | helm registry login ghcr.io --username "$REGISTRY_USER" --password-stdin
+
+      - name: Push the chart
+        id: push
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          package="dist/loonfs-server-$VERSION.tgz"
+          test -f "$package"
+          helm push "$package" "$CHART_REGISTRY" 2>&1 | tee push.log
+          digest="$(sed -n 's/^Digest: *//p' push.log | tr -d '[:space:]')"
+          case "$digest" in
+            sha256:*) ;;
+            *)
+              echo "helm push reported no chart digest" >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "version=$VERSION"
+            echo "digest=$digest"
+          } >> "$GITHUB_OUTPUT"
+
   publish:
     name: Publish release assets
     # Default needs-gating: publish only when every build leg succeeded, so a
-    # failed target can never ship a release with missing artifacts.
-    needs: [prepare, build]
+    # failed target can never ship a release with missing artifacts. The image
+    # and the chart are in that set, so the release names them only once they
+    # are in the registry.
+    needs: [prepare, build, server-image-manifest, helm-publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -125,9 +369,16 @@ jobs:
           pattern: loonfs-*
           merge-multiple: true
 
-      - name: Verify release artifacts and generate checksums
+      - name: Verify release artifacts and record what the release ships
         shell: bash
         working-directory: dist
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          IMAGE_TAG: ${{ needs.server-image-manifest.outputs.tag }}
+          IMAGE_DIGEST: ${{ needs.server-image-manifest.outputs.digest }}
+          IMAGE_PLATFORMS: ${{ needs.server-image-manifest.outputs.platforms }}
+          CHART_VERSION: ${{ needs.helm-publish.outputs.version }}
+          CHART_DIGEST: ${{ needs.helm-publish.outputs.digest }}
         run: |
           expected=(
             loonfs-aarch64-apple-darwin.tar.gz
@@ -151,6 +402,34 @@ jobs:
           fi
           sha256sum "${expected[@]}" > SHA256SUMS
 
+          # The image and the chart go to a registry rather than to the
+          # release page, so the same check covers them as coordinates. A
+          # release never names an artifact its own jobs did not report.
+          for name in IMAGE_TAG IMAGE_DIGEST IMAGE_PLATFORMS CHART_VERSION CHART_DIGEST; do
+            if [ -z "${!name}" ]; then
+              echo "the release records no $name" >&2
+              exit 1
+            fi
+          done
+
+          {
+            echo "LoonFS v$VERSION"
+            echo
+            echo "CLI archives, with their checksums in SHA256SUMS:"
+            printf '  %s\n' "${expected[@]}"
+            echo
+            echo "Server image:"
+            echo "  tag:           $IMAGE_TAG"
+            echo "  digest:        $IMAGE_DIGEST"
+            echo "  architectures: $IMAGE_PLATFORMS"
+            echo
+            echo "Helm chart:"
+            echo "  chart:   $CHART_REGISTRY/loonfs-server"
+            echo "  version: $CHART_VERSION"
+            echo "  digest:  $CHART_DIGEST"
+          } > ARTIFACTS.txt
+          cat ARTIFACTS.txt
+
       - name: Upload assets to GitHub release
         uses: softprops/action-gh-release@v2
         with:
@@ -158,4 +437,5 @@ jobs:
           files: |
             dist/loonfs-*.tar.gz
             dist/SHA256SUMS
+            dist/ARTIFACTS.txt
           fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ loonfs use {namespace_id}
 
 Use a server when multiple clients need to write to the same LoonFS deployment. (Embedded clients talk directly to object storage and compete for the single-writer role; the server instead can provide one shared writer for remote clients.)
 
-### Local development
-
 Build the server and start it with the local filesystem example:
 
 ```bash
@@ -73,37 +71,9 @@ LOONFS_AUTH_TOKEN=dev-token loonfs init default --no-input \
   --server-url http://127.0.0.1:9400
 ```
 
-### Production
+A bind beyond localhost serves the network, and the server refuses one without an authentication token and either its own TLS or an explicit declaration that a trusted proxy terminates TLS. The rule exists because the wire carries the bearer token and the short-lived object-store URLs the upload routes hand back.
 
-Start with the example in [crates/loonfs-server/config/](crates/loonfs-server/config) for your object store: `aws-s3`, `gcp-gcs`, `cloudflare-r2`, or `azure-abs`. Each file documents the provider credentials and optional server settings. Remove the example `auth_token` and `content_token_secret` values and supply real ones through the environment:
-
-```bash
-export LOONFS_AUTH_TOKEN={auth_token}
-export LOONFS_CONTENT_TOKEN_SECRET={content_token_secret}
-```
-
-Protect non-loopback connections with authentication and TLS because requests carry the bearer token and may return short-lived object-store URLs. By default, the server refuses to bind beyond localhost without an authentication token and either native TLS or an explicit declaration that a trusted proxy terminates TLS.
-
-To terminate TLS in LoonFS, set the public bind address and add a `[tls]` table:
-
-```toml
-bind = "0.0.0.0:9400"
-
-[tls]
-cert_path = "/etc/loonfs/tls/server.crt"
-key_path = "/etc/loonfs/tls/server.key"
-```
-
-If a load balancer, ingress controller, or sidecar terminates TLS instead, leave `[tls]` out and acknowledge the trusted plaintext hop:
-
-```toml
-bind = "0.0.0.0:9400"
-allow_remote_without_tls = true
-```
-
-Connect remote clients with an `https://` server URL and the same `LOONFS_AUTH_TOKEN`. If a private CA issued the server certificate, pass its bundle with `--ca-cert-path`.
-
-If you are upgrading a deployment, flush any long WAL tail before you switch builds. This build reads how long a namespace's WAL tail is from the segment pointers its head carries, and heads written by earlier builds carried only the newest 32 of them. A namespace holding more unflushed segments than that answers the namespace status read with a head-coverage error, by design, until the tail is folded — so run `loonfs admin flush` against it (or recreate the namespace) with your current build first.
+[crates/loonfs-server/docs/self-hosting.md](crates/loonfs-server/docs/self-hosting.md) is the rest: the config, the published image and Helm chart, the probes, upgrades, and what this deployment does not do.
 
 ## Documentation
 

--- a/crates/loonfs-server/README.md
+++ b/crates/loonfs-server/README.md
@@ -25,15 +25,19 @@ LOONFS_AUTH_TOKEN=dev-token loonfs init default --no-input \
 
 ## Run it in a container
 
+Every release publishes the image as `ghcr.io/loonfs/loonfs-server:vX.Y.Z`,
+one manifest covering `linux/amd64` and `linux/arm64`.
+
 ```bash
-docker build -f crates/loonfs-server/Dockerfile -t loonfs-server:dev .
 docker run --rm -p 9400:9400 \
-  -v /etc/loonfs/server.toml:/etc/loonfs/config.toml:ro loonfs-server:dev
+  -v /etc/loonfs/server.toml:/etc/loonfs/config.toml:ro \
+  ghcr.io/loonfs/loonfs-server:vX.Y.Z
 ```
 
 The image reads `/etc/loonfs/config.toml` and runs as uid 10001.
 [docs/self-hosting.md](docs/self-hosting.md#running-it-in-a-container)
-covers the secrets, the mounts, and the shutdown timeout.
+covers the secrets, the mounts, the shutdown timeout, and building the same
+image from this crate's `Dockerfile`.
 
 ## Configuration
 
@@ -54,7 +58,14 @@ would report, so it belongs in a deployment pipeline ahead of the rollout.
 ## Deploying it
 
 Read [docs/self-hosting.md](docs/self-hosting.md) for the topology, the
-minimal config, the probes, logging, and the local cache.
+minimal config, the probes, logging, the local cache, upgrades, and what a
+one-writer deployment does not do.
 
-[`deploy/helm/loonfs-server`](deploy/helm/loonfs-server) holds a Helm chart
-that runs the image on Kubernetes as one pod.
+Every release publishes the Helm chart as
+`oci://ghcr.io/loonfs/charts/loonfs-server`, at the same version as the
+server it runs. [`deploy/helm/loonfs-server`](deploy/helm/loonfs-server) is
+that chart's source: one pod, one Service, nothing else.
+
+[`scripts/smoke-test.sh`](scripts/smoke-test.sh) checks an install from the
+outside, and [`scripts/test-image.sh`](scripts/test-image.sh) checks the
+image.

--- a/crates/loonfs-server/deploy/helm/loonfs-server/README.md
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/README.md
@@ -3,8 +3,17 @@
 This chart runs the LoonFS server on Kubernetes. It renders a Deployment and
 a ClusterIP Service, and it renders nothing else.
 
-The chart is not published to a registry yet. Install it from a checkout of
-this repository:
+Every release publishes it, at the same version as the server it runs:
+
+```bash
+helm install loonfs-server oci://ghcr.io/loonfs/charts/loonfs-server \
+  --version X.Y.Z \
+  --namespace loonfs \
+  --set config.existingSecret=loonfs-server-config
+```
+
+The path in this repository is a chart reference as well. Use it to install a
+change no release has published yet:
 
 ```bash
 helm install loonfs-server crates/loonfs-server/deploy/helm/loonfs-server \
@@ -120,7 +129,7 @@ deletes it every time it stops.
 | Value | Default | What it does |
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/loonfs/loonfs-server` | The repository to pull the server image from. |
-| `image.tag` | `""` | The tag to run. Empty means the chart's `appVersion`. |
+| `image.tag` | `""` | The tag to run. Empty means `v` and the chart's `appVersion`, which is the tag a release publishes. |
 | `image.digest` | `""` | A digest, written as `sha256:...`. Setting it ignores the tag. |
 | `image.pullPolicy` | `IfNotPresent` | The container's `imagePullPolicy`. |
 | `imagePullSecrets` | `[]` | Pull secrets for a private registry. Each entry is `{name: ...}`. |

--- a/crates/loonfs-server/deploy/helm/loonfs-server/templates/_helpers.tpl
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/templates/_helpers.tpl
@@ -30,6 +30,10 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 The image reference. A digest names one build and wins over the tag. Without
 either, the chart runs the server version it shipped with.
+
+A release tags that image `v<version>` and carries the same version in
+appVersion without the `v`, so the fallback adds it back. Without the prefix
+the default would name a tag no release publishes.
 */}}
 {{- define "loonfs-server.image" -}}
 {{- if .Values.image.digest -}}
@@ -37,7 +41,7 @@ either, the chart runs the server version it shipped with.
 {{- else if .Values.image.tag -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- else -}}
-{{- printf "%s:%s" .Values.image.repository .Chart.AppVersion -}}
+{{- printf "%s:v%s" .Values.image.repository .Chart.AppVersion -}}
 {{- end -}}
 {{- end -}}
 

--- a/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
@@ -10,7 +10,8 @@
 image:
   # The repository to pull the server image from.
   repository: ghcr.io/loonfs/loonfs-server
-  # The tag to run. Empty means the chart's appVersion.
+  # The tag to run. Empty means the tag a release publishes for the chart's
+  # appVersion, which is that version with a leading "v".
   tag: ""
   # A digest, written as "sha256:...". Setting it ignores the tag.
   digest: ""

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -79,6 +79,26 @@ kind = "local-fs"
 root = "/var/lib/loonfs/store"
 ```
 
+To terminate TLS in the server itself, drop `allow_remote_without_tls` and
+name the certificate and the key:
+
+```toml
+bind = "0.0.0.0:9400"
+writer_id = "loonfs-server-1"
+
+[tls]
+cert_path = "/etc/loonfs/tls/server.crt"
+key_path = "/etc/loonfs/tls/server.key"
+
+[store]
+kind = "local-fs"
+root = "/var/lib/loonfs/store"
+```
+
+Remote clients then use an `https://` server URL and the same auth token. If
+a private CA issued the certificate, a client needs that CA's bundle as well.
+The CLI takes it as `--ca-cert-path`.
+
 Supply the two secrets through the environment:
 
 ```bash
@@ -95,12 +115,15 @@ settings this guide leaves out.
 
 ## Running it in a container
 
-The crate carries a [`Dockerfile`](../Dockerfile). Build it with the
-repository root as the context, because the build needs the whole workspace:
+Every release publishes the server image:
 
-```bash
-docker build -f crates/loonfs-server/Dockerfile -t loonfs-server:dev .
+```text
+ghcr.io/loonfs/loonfs-server:vX.Y.Z
 ```
+
+A release publishes one tag, and that tag names one manifest covering
+`linux/amd64` and `linux/arm64`. There is no floating tag, so every
+deployment names a version.
 
 The image holds the server binary and the public root certificates. It runs
 as uid 10001, and it reads `/etc/loonfs/config.toml` unless you pass another
@@ -113,7 +136,7 @@ docker run --rm \
   --volume /etc/loonfs/server.toml:/etc/loonfs/config.toml:ro \
   --volume /var/lib/loonfs/store:/var/lib/loonfs/store \
   --publish 9400:9400 \
-  loonfs-server:dev
+  ghcr.io/loonfs/loonfs-server:vX.Y.Z
 ```
 
 The second mount is the `local-fs` store from the config above, and it has to
@@ -138,7 +161,7 @@ validates a config without serving:
 ```bash
 docker run --rm \
   --volume /etc/loonfs/server.toml:/etc/loonfs/config.toml:ro \
-  loonfs-server:dev --config /etc/loonfs/config.toml --check-config
+  ghcr.io/loonfs/loonfs-server:vX.Y.Z --config /etc/loonfs/config.toml --check-config
 ```
 
 The server is PID 1 and shuts down on SIGTERM, which is what `docker stop`
@@ -151,13 +174,31 @@ from.
 
 [`scripts/test-image.sh`](../scripts/test-image.sh) builds the image and runs
 this whole path against it, down to the restart. CI runs the same script on
-every change.
+every change, and the release runs it against the image it has just pushed,
+so the published image is the tested one.
+
+### Building the image yourself
+
+The crate carries the [`Dockerfile`](../Dockerfile) that the release builds
+from. Build it with the repository root as the context, because the build
+needs the whole workspace:
+
+```bash
+docker build -f crates/loonfs-server/Dockerfile -t loonfs-server:dev .
+```
+
+Everything above then works the same against `loonfs-server:dev`.
 
 ## Running it on Kubernetes
 
-The crate carries a Helm chart at
-[`deploy/helm/loonfs-server`](../deploy/helm/loonfs-server). It renders a
-Deployment and a ClusterIP Service, and it renders nothing else.
+Every release publishes a Helm chart beside the image:
+
+```text
+oci://ghcr.io/loonfs/charts/loonfs-server
+```
+
+The chart renders a Deployment and a ClusterIP Service, and it renders
+nothing else.
 
 One pod serves the API. The chart fixes the replica count at 1 and sets the
 update strategy to `Recreate`, because LoonFS has one writer. An upgrade
@@ -165,8 +206,9 @@ stops the old pod before it starts the new one, so the API is offline for
 that gap. This is not a high-availability deployment, and a second replica
 would not make it one.
 
-The chart is not published to a registry yet. Install it from a checkout of
-this repository.
+The chart version and the server version are the same number, and the chart's
+default image is `ghcr.io/loonfs/loonfs-server` at that version. Installing
+chart 0.2.0 therefore runs server 0.2.0 without naming an image at all.
 
 Create the namespace:
 
@@ -194,17 +236,13 @@ kubectl --namespace loonfs create secret generic loonfs-server-secrets \
   --from-literal=LOONFS_CONTENT_TOKEN_SECRET={content_token_secret}
 ```
 
-Install the chart from the repository path. Point `image.repository` and
-`image.tag` at an image the cluster can pull: the build above produces one on
-your workstation, and a cluster needs it in a registry it reaches or loaded
-onto its nodes.
+Install the chart, naming the version you want:
 
 ```bash
-helm install loonfs-server crates/loonfs-server/deploy/helm/loonfs-server \
+helm install loonfs-server oci://ghcr.io/loonfs/charts/loonfs-server \
+  --version X.Y.Z \
   --namespace loonfs \
   --set config.existingSecret=loonfs-server-config \
-  --set image.repository=your-registry.example.com/loonfs-server \
-  --set image.tag=dev \
   --set 'extraEnvFrom[0].secretRef.name=loonfs-server-secrets'
 ```
 
@@ -228,6 +266,47 @@ have to name the same number.
 The chart's [README](../deploy/helm/loonfs-server/README.md) documents every
 value, the local cache's sizing rules, and the shutdown grace period.
 
+### Installing the chart from a checkout
+
+The chart lives at
+[`deploy/helm/loonfs-server`](../deploy/helm/loonfs-server), and that path is
+a chart reference like any other:
+
+```bash
+helm install loonfs-server crates/loonfs-server/deploy/helm/loonfs-server \
+  --namespace loonfs \
+  --set config.existingSecret=loonfs-server-config \
+  --set image.repository=your-registry.example.com/loonfs-server \
+  --set image.tag=dev \
+  --set 'extraEnvFrom[0].secretRef.name=loonfs-server-secrets'
+```
+
+A chart out of a checkout still defaults to the published image, so name the
+image you built yourself. The cluster needs that image in a registry it
+reaches, or loaded onto its nodes.
+
+## Verification
+
+[`scripts/smoke-test.sh`](../scripts/smoke-test.sh) checks an install from
+the outside. It waits for the rollout, calls both probes, probes the object
+store, and puts a file into a namespace of its own and reads the same bytes
+back:
+
+```bash
+export LOONFS_AUTH_TOKEN={auth_token}
+crates/loonfs-server/scripts/smoke-test.sh --namespace loonfs
+```
+
+It needs `kubectl`, `curl`, and `loonfs`, and it says which one is missing.
+`--release` names a Helm release other than `loonfs-server`, and
+`--server-url` skips the port-forward when you already have a route to the
+API.
+
+The run touches nothing you own: the CLI profile it builds lives in a
+temporary directory it removes, so the config file you use yourself is never
+read or written, and the namespace it created is deleted before it exits.
+Run it whenever you want, including after an upgrade.
+
 ## Probes and metrics
 
 Three routes report on the process. Each one answers a narrow question, and
@@ -247,6 +326,23 @@ a store-reachability check.
 bearer token, because a deployment's traffic shape is not public. When no
 `auth_token` is configured it answers anyone who asks, and on a non-loopback
 bind that is itself a sign the deployment is misconfigured.
+
+A scrape therefore carries the token, and a scrape configured without one
+collects nothing but 401s. Give Prometheus the token in a file and name that
+file in the job:
+
+```yaml
+scrape_configs:
+  - job_name: loonfs-server
+    authorization:
+      credentials_file: /etc/prometheus/loonfs-token
+    static_configs:
+      - targets: ["loonfs-server.loonfs.svc:9400"]
+```
+
+`bearer_token_file` is the older spelling of the same field. A collector that
+models neither sends the header itself, as
+`Authorization: Bearer {auth_token}`.
 
 To prove the object store is reachable, run the probe from a CLI profile
 pointed at the same store:
@@ -317,3 +413,75 @@ of them. A namespace holding more unflushed segments than that answers the
 namespace status read with a head-coverage error, by design, until the tail
 is folded. Run `loonfs admin flush` against such a namespace with your
 current build before you upgrade, or recreate the namespace.
+
+On Kubernetes, name the version you are moving to:
+
+```bash
+helm upgrade loonfs-server oci://ghcr.io/loonfs/charts/loonfs-server \
+  --version X.Y.Z \
+  --namespace loonfs \
+  --reuse-values
+```
+
+The chart's update strategy is `Recreate`, so the old pod stops before the
+new one starts and the API is offline for that gap. It lasts as long as a
+process start, and clients see refused connections rather than slow requests.
+Nothing durable rides on the gap: the object store holds the state, and the
+new pod rebuilds what it needs.
+
+Go back the same way:
+
+```bash
+helm rollback loonfs-server --namespace loonfs
+```
+
+What is running now:
+
+```bash
+helm list --namespace loonfs
+kubectl --namespace loonfs get deployment/loonfs-server \
+  --output jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+`helm list` reports the chart version and the app version of every release in
+the namespace. The jsonpath reports the image the Deployment asks for, which
+is a digest when `image.digest` is set and a tag otherwise. To read the digest
+the node actually pulled, whatever the Deployment asked for, ask the pod:
+
+```bash
+kubectl --namespace loonfs get pod \
+  --selector app.kubernetes.io/name=loonfs-server \
+  --output jsonpath='{.items[0].status.containerStatuses[0].imageID}'
+```
+
+Check the upgrade the way you checked the install, with
+[`scripts/smoke-test.sh`](../scripts/smoke-test.sh).
+
+## Security checklist
+
+- The image runs as uid 10001, and the chart asks the kubelet to refuse a
+  root user, drop every capability, and forbid privilege escalation.
+- A non-loopback bind carries an auth token. `allow_unauthenticated_remote`
+  serves every endpoint to the network, and no deployment wants that.
+- TLS terminates in the server or in a proxy you declare with
+  `allow_remote_without_tls`. The wire carries the bearer token and the
+  presigned object-store URLs.
+- The config lives in a Secret, and the two secret values reach the process
+  from a Secret through the environment rather than sitting in the config
+  file.
+- The pod mounts no service-account token. The server never calls the
+  Kubernetes API.
+- The local cache is disposable. It holds copies of bytes the object store
+  already has, so deleting it costs nothing but the next few reads.
+
+## Limitations
+
+- One pod serves the API. The chart fixes the replica count at 1.
+- An upgrade takes the API offline briefly, because the old pod stops before
+  the new one starts.
+- There is no horizontal scaling. A second replica would take the writer
+  epoch from the first, not share the load with it.
+- There is no automatic failover. The Deployment restarts a pod that dies,
+  and the API is down until the new pod is up.
+- Multi-writer and high availability are not what this chart deploys. Nothing
+  here elects a leader or coordinates replicas.

--- a/crates/loonfs-server/scripts/smoke-test.sh
+++ b/crates/loonfs-server/scripts/smoke-test.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Checks a LoonFS server install from the outside: the deployment rolls out,
+# the probes answer, the object store honours the contract LoonFS depends on,
+# and a namespace takes a file and gives the same bytes back.
+#
+#   export LOONFS_AUTH_TOKEN={auth_token}
+#   crates/loonfs-server/scripts/smoke-test.sh --namespace loonfs
+#
+# The run touches nothing you own. It builds its own CLI profile in a
+# temporary directory, creates a namespace named after 8 random hex digits,
+# and deletes both before it exits. Run it as often as you like.
+set -euo pipefail
+
+K8S_NAMESPACE="loonfs"
+RELEASE="loonfs-server"
+SERVER_URL=""
+
+# How long the deployment has to report a complete rollout.
+ROLLOUT_TIMEOUT="120s"
+# How long the API has to answer through a port-forward that was just
+# started, in one-second attempts.
+PROBE_ATTEMPTS=30
+
+BASE_URL=""
+WORK_DIR=""
+PORT_FORWARD_PID=""
+NAMESPACE=""
+NAMESPACE_LIVES="no"
+PROBE_SUBCOMMAND=""
+CHECKS=()
+
+usage() {
+  cat <<'USAGE'
+Usage: smoke-test.sh [--namespace <k8s-namespace>] [--release <helm-release>]
+                     [--server-url <url>]
+
+  --namespace <name>    The Kubernetes namespace holding the release.
+                        Default: loonfs.
+  --release <name>      The Helm release name. Default: loonfs-server.
+  --server-url <url>    Reach the API at this URL instead of port-forwarding
+                        to the Service. Use it when you already have a route.
+
+LOONFS_AUTH_TOKEN has to be exported. The throwaway CLI profile this script
+builds authenticates with it, and the script never reads or writes the config
+file you use yourself.
+USAGE
+}
+
+# Every check lands here as it is decided, so the summary at the end reports
+# the run whether it passed or stopped part way.
+pass() {
+  CHECKS+=("PASS  $1")
+  echo "ok: $1"
+}
+
+fail() {
+  CHECKS+=("FAIL  $1")
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+summary() {
+  echo
+  echo "Summary"
+  if [[ "${#CHECKS[@]}" -gt 0 ]]; then
+    local check
+    for check in "${CHECKS[@]}"; do
+      echo "  $check"
+    done
+  fi
+  case " ${CHECKS[*]-} " in
+    *"FAIL  "*) echo "FAIL: the deployment did not pass every check" ;;
+    *) echo "PASS: the deployment serves, probes, and round-trips a file" ;;
+  esac
+}
+
+cleanup() {
+  local status=$?
+  # The namespace goes first, because deleting it talks to the API, and on a
+  # port-forwarded run that path is the process killed below.
+  if [[ "$NAMESPACE_LIVES" == "yes" ]]; then
+    loonfs namespace delete "$NAMESPACE" --yes >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$PORT_FORWARD_PID" ]]; then
+    kill "$PORT_FORWARD_PID" >/dev/null 2>&1 || true
+    wait "$PORT_FORWARD_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  summary
+  return "$status"
+}
+
+status_code() {
+  curl --silent --output /dev/null --write-out '%{http_code}' "$@" || true
+}
+
+# A hex string from the kernel's random source. It names this run's namespace
+# and fills this run's payload, so two runs on one deployment never collide.
+random_hex() {
+  od -An -tx1 -N"$1" /dev/urandom | tr -d ' \n'
+}
+
+# The name the chart gives the Deployment and the Service. A release already
+# named after the chart is used as it stands, which is the rule
+# deploy/helm/loonfs-server/templates/_helpers.tpl applies.
+chart_fullname() {
+  case "$RELEASE" in
+    *loonfs-server*) echo "$RELEASE" ;;
+    *) echo "$RELEASE-loonfs-server" ;;
+  esac
+}
+
+# What the pod has to say about a rollout that did not complete. This is the
+# first thing to read when the install is wrong: an image that will not pull,
+# a Secret that is not there, a config the server rejects.
+report_pod_events() {
+  local pod
+  pod="$(kubectl --namespace "$K8S_NAMESPACE" get pods \
+    --selector "app.kubernetes.io/name=loonfs-server,app.kubernetes.io/instance=$RELEASE" \
+    --output 'jsonpath={.items[0].metadata.name}' 2>/dev/null || true)"
+  if [[ -z "$pod" ]]; then
+    echo "no pod matches release $RELEASE in namespace $K8S_NAMESPACE" >&2
+    return 0
+  fi
+  echo "pod $pod:" >&2
+  kubectl --namespace "$K8S_NAMESPACE" get "pod/$pod" >&2 || true
+  echo "recent events for $pod:" >&2
+  kubectl --namespace "$K8S_NAMESPACE" get events \
+    --field-selector "involvedObject.name=$pod" \
+    --sort-by=.lastTimestamp >&2 || true
+}
+
+# The admin subcommand that probes the object store is being renamed from
+# `probe-store` to `store-probe`. Ask the binary which spelling it has rather
+# than pinning one that changes underneath this script. Once the rename has
+# landed everywhere, the second branch goes.
+detect_probe_subcommand() {
+  local help
+  help="$(loonfs admin --help 2>&1)" || fail "loonfs admin --help failed"
+  if echo "$help" | grep -q 'store-probe'; then
+    PROBE_SUBCOMMAND="store-probe"
+  elif echo "$help" | grep -q 'probe-store'; then
+    PROBE_SUBCOMMAND="probe-store"
+  else
+    fail "loonfs admin --help names neither store-probe nor probe-store"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      [[ $# -ge 2 ]] || fail "--namespace needs a value"
+      K8S_NAMESPACE="$2"
+      shift 2
+      ;;
+    --release)
+      [[ $# -ge 2 ]] || fail "--release needs a value"
+      RELEASE="$2"
+      shift 2
+      ;;
+    --server-url)
+      [[ $# -ge 2 ]] || fail "--server-url needs a value"
+      SERVER_URL="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+trap cleanup EXIT
+
+# 1. What this script needs before it starts.
+for tool in kubectl curl loonfs; do
+  command -v "$tool" >/dev/null 2>&1 \
+    || fail "$tool is not on PATH, and this script needs it"
+done
+[[ -n "${LOONFS_AUTH_TOKEN:-}" ]] \
+  || fail "export LOONFS_AUTH_TOKEN with the deployment's auth token first"
+pass "kubectl, curl, and loonfs are on PATH and LOONFS_AUTH_TOKEN is set"
+
+FULLNAME="$(chart_fullname)"
+WORK_DIR="$(mktemp -d)"
+
+# 2. The deployment rolls out.
+if ! kubectl --namespace "$K8S_NAMESPACE" rollout status \
+  "deployment/$FULLNAME" --timeout="$ROLLOUT_TIMEOUT"; then
+  report_pod_events
+  fail "deployment/$FULLNAME did not roll out within $ROLLOUT_TIMEOUT"
+fi
+pass "deployment/$FULLNAME rolled out"
+
+# 3. A route to the API. The operator's own route is used as given; without
+#    one this forwards the Service to a loopback port the kernel picks, so
+#    two runs on one workstation never collide.
+if [[ -n "$SERVER_URL" ]]; then
+  BASE_URL="${SERVER_URL%/}"
+  pass "reaching the API at $BASE_URL"
+else
+  SERVICE_PORT="$(kubectl --namespace "$K8S_NAMESPACE" get "service/$FULLNAME" \
+    --output 'jsonpath={.spec.ports[0].port}')"
+  [[ -n "$SERVICE_PORT" ]] || fail "service/$FULLNAME publishes no port"
+  kubectl --namespace "$K8S_NAMESPACE" port-forward \
+    "service/$FULLNAME" ":$SERVICE_PORT" >"$WORK_DIR/port-forward.log" 2>&1 &
+  PORT_FORWARD_PID=$!
+  for _ in $(seq 1 "$PROBE_ATTEMPTS"); do
+    forwarding="$(grep -m1 '^Forwarding from 127\.0\.0\.1:' \
+      "$WORK_DIR/port-forward.log" || true)"
+    if [[ -n "$forwarding" ]]; then
+      local_port="${forwarding##*:}"
+      BASE_URL="http://127.0.0.1:${local_port%% *}"
+      break
+    fi
+    if ! kill -0 "$PORT_FORWARD_PID" 2>/dev/null; then
+      cat "$WORK_DIR/port-forward.log" >&2
+      fail "the port-forward to service/$FULLNAME exited"
+    fi
+    sleep 1
+  done
+  [[ -n "$BASE_URL" ]] || fail "the port-forward to service/$FULLNAME never opened"
+  pass "port-forwarded service/$FULLNAME to $BASE_URL"
+fi
+
+# 4. The probes. /health says the process is up, and /readiness says it is
+#    still admitting work.
+HEALTH=""
+for _ in $(seq 1 "$PROBE_ATTEMPTS"); do
+  HEALTH="$(status_code "$BASE_URL/health")"
+  [[ "$HEALTH" == "200" ]] && break
+  sleep 1
+done
+[[ "$HEALTH" == "200" ]] || fail "GET /health answered $HEALTH, expected 200"
+pass "GET /health answered 200"
+
+READINESS="$(status_code "$BASE_URL/readiness")"
+[[ "$READINESS" == "200" ]] || fail "GET /readiness answered $READINESS, expected 200"
+pass "GET /readiness answered 200"
+
+# 5. A CLI profile for this run alone. LOONFS_CONFIG names a file under the
+#    temporary directory, so the config file the operator uses is never read
+#    and never written. The token reaches the profile through the
+#    environment, and this run's copy of it goes with the directory.
+export LOONFS_CONFIG="$WORK_DIR/loonfs-config.toml"
+loonfs init smoke --no-input --mode remote --server-url "$BASE_URL" >/dev/null \
+  || fail "loonfs init could not build a profile for $BASE_URL"
+pass "built a throwaway CLI profile for $BASE_URL"
+
+# 6. The object store. Readiness never touches it, so this is the check that
+#    catches a wrong bucket, a wrong region, or an expired credential.
+detect_probe_subcommand
+loonfs admin "$PROBE_SUBCOMMAND" \
+  || fail "loonfs admin $PROBE_SUBCOMMAND found the object store wanting"
+pass "loonfs admin $PROBE_SUBCOMMAND passed every check"
+
+# 7. A file through a namespace of this run's own, and the same bytes back.
+NAMESPACE="smoke-$(random_hex 4)"
+loonfs namespace create "$NAMESPACE" >/dev/null \
+  || fail "could not create namespace $NAMESPACE"
+NAMESPACE_LIVES="yes"
+pass "created namespace $NAMESPACE"
+
+printf 'loonfs smoke test %s\n' "$(random_hex 16)" >"$WORK_DIR/payload"
+loonfs put "$WORK_DIR/payload" /smoke.txt --namespace "$NAMESPACE" >/dev/null \
+  || fail "could not put a file into namespace $NAMESPACE"
+loonfs cat /smoke.txt --namespace "$NAMESPACE" >"$WORK_DIR/roundtrip" \
+  || fail "could not read /smoke.txt back from namespace $NAMESPACE"
+cmp --silent "$WORK_DIR/payload" "$WORK_DIR/roundtrip" \
+  || fail "/smoke.txt came back with different bytes than it went in with"
+pass "put /smoke.txt and read the same bytes back"
+
+loonfs namespace delete "$NAMESPACE" --yes >/dev/null \
+  || fail "could not delete namespace $NAMESPACE"
+NAMESPACE_LIVES="no"
+pass "deleted namespace $NAMESPACE"
+
+# 8. The trap prints the summary, kills the port-forward, and removes the
+#    temporary directory.

--- a/crates/loonfs-server/scripts/test-image.sh
+++ b/crates/loonfs-server/scripts/test-image.sh
@@ -94,8 +94,8 @@ first_log_line() {
 # already exited is never going to answer, so that is reported at once
 # instead of after the whole budget.
 wait_for_health() {
-  local container="$1" base="$2" attempt
-  for attempt in $(seq 1 60); do
+  local container="$1" base="$2"
+  for _ in $(seq 1 60); do
     if [[ "$(status_code "$base/health")" == "200" ]]; then
       return 0
     fi


### PR DESCRIPTION
The release pipeline and the finished runbook. The release workflow is named `Release LoonFS`: it builds the server image for amd64 and arm64 on native runners, runs the full container test against the exact bytes each leg pushed, merges the two digests into one published manifest at `ghcr.io/loonfs/loonfs-server:vX.Y.Z`, and pushes the chart to `oci://ghcr.io/loonfs/charts`. A failed test on either architecture means no tag is ever created. The prepare job now also asserts the chart version equals the workspace version, so a release cannot ship a chart that disagrees with its tag.

**Details:**

- The chart's default image tag was broken against the registry: it fell back to `0.2.0` while releases publish `v0.2.0`. The helper now adds the `v`; explicit tags and digests are unchanged.
- `provenance: false` on the per-arch builds, because attestation indexes would add `unknown/unknown` platforms to the merged manifest and make the architecture claim in the release output wrong.
- `smoke-test.sh` is the operator's post-install check: rollout, probes through a port-forward, the object-store probe, and a random-namespace write/read/delete round trip. It builds a throwaway CLI profile via `LOONFS_CONFIG`, never touching the operator's real config, and it asks `loonfs admin --help` which probe spelling the installed CLI has, so the in-flight rename cannot break it. It was rehearsed end to end against fakes and a real HTTP server, including the failure paths.
- The README's deployment section shrinks to the local quickstart plus one paragraph and a link; the TLS snippets and the WAL-flush upgrade rule now live only in the guide. 
- The guide's published-artifact instructions become primary and the from-source paths stay as alternatives. This PR ships in the same release that first publishes those artifacts, so the doc and the registry become true together.
- The workflow itself cannot run until a release is cut; actionlint is clean, every registry-facing step asserts its own result, and the first tagged release is the acceptance run.
