### PR TITLE
chore(server): update store-probe command everywhere

### DIFF
--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -348,7 +348,7 @@ To prove the object store is reachable, run the probe from a CLI profile
 pointed at the same store:
 
 ```bash
-loonfs admin probe-store
+loonfs admin store-probe
 ```
 
 That command performs real store operations and reports what came back check

--- a/crates/loonfs-server/scripts/smoke-test.sh
+++ b/crates/loonfs-server/scripts/smoke-test.sh
@@ -26,7 +26,6 @@ WORK_DIR=""
 PORT_FORWARD_PID=""
 NAMESPACE=""
 NAMESPACE_LIVES="no"
-PROBE_SUBCOMMAND=""
 CHECKS=()
 
 usage() {
@@ -132,21 +131,6 @@ report_pod_events() {
     --sort-by=.lastTimestamp >&2 || true
 }
 
-# The admin subcommand that probes the object store is being renamed from
-# `probe-store` to `store-probe`. Ask the binary which spelling it has rather
-# than pinning one that changes underneath this script. Once the rename has
-# landed everywhere, the second branch goes.
-detect_probe_subcommand() {
-  local help
-  help="$(loonfs admin --help 2>&1)" || fail "loonfs admin --help failed"
-  if echo "$help" | grep -q 'store-probe'; then
-    PROBE_SUBCOMMAND="store-probe"
-  elif echo "$help" | grep -q 'probe-store'; then
-    PROBE_SUBCOMMAND="probe-store"
-  else
-    fail "loonfs admin --help names neither store-probe nor probe-store"
-  fi
-}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -255,10 +239,9 @@ pass "built a throwaway CLI profile for $BASE_URL"
 
 # 6. The object store. Readiness never touches it, so this is the check that
 #    catches a wrong bucket, a wrong region, or an expired credential.
-detect_probe_subcommand
-loonfs admin "$PROBE_SUBCOMMAND" \
-  || fail "loonfs admin $PROBE_SUBCOMMAND found the object store wanting"
-pass "loonfs admin $PROBE_SUBCOMMAND passed every check"
+loonfs admin store-probe \
+  || fail "loonfs admin store-probe found the object store wanting"
+pass "loonfs admin store-probe passed every check"
 
 # 7. A file through a namespace of this run's own, and the same bytes back.
 NAMESPACE="smoke-$(random_hex 4)"


### PR DESCRIPTION
The CLI renamed the probe from `probe-store` to `store-probe`, and the rename and the self-hosting guide merged side by side, so the guide still named the old spelling. The guide's one reference is updated, and the smoke test's runtime spelling detection — which existed for exactly this window — is deleted in favor of calling `store-probe` directly.

Docs and one script only; `bash -n` and shellcheck clean.