### PR TITLE
fix(format): a segment's max key survives a full final block

### DIFF
--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -178,6 +178,10 @@ pub struct SegmentBlocksBuilder {
     entries: Vec<u8>,
     restarts: Vec<u32>,
     entry_count: usize,
+    /// Last row key the builder accepted. It anchors prefix compression
+    /// inside a block, floors the ascending-order guard, and becomes the
+    /// segment's max key. A block's first entry stores its key in full
+    /// regardless, because a restart point always begins a block.
     previous_key: String,
     block_first_key: String,
     finished_blocks: Vec<(String, Vec<u8>)>,
@@ -273,8 +277,12 @@ impl SegmentBlocksBuilder {
         payload.extend_from_slice(&(self.restarts.len() as u32).to_le_bytes());
         self.restarts.clear();
         self.entry_count = 0;
+        // The block copies the last key it holds. Taking it would leave the
+        // builder without one, and the builder still needs it: as the prefix
+        // anchor inside the next block, as the order guard's floor across the
+        // boundary, and as the segment's max key once every row is in.
         self.finished_blocks
-            .push((std::mem::take(&mut self.previous_key), payload));
+            .push((self.previous_key.clone(), payload));
     }
 
     /// Encodes the remaining rows and assembles the object bytes.
@@ -282,7 +290,6 @@ impl SegmentBlocksBuilder {
         if self.row_count == 0 {
             return Err(SstBlockCodecError::EmptySegment);
         }
-        let max_key = self.previous_key.clone();
         self.finish_data_block();
 
         let mut bytes = Vec::new();
@@ -306,7 +313,7 @@ impl SegmentBlocksBuilder {
             filter,
             row_count: self.row_count,
             min_key: self.min_key,
-            max_key,
+            max_key: self.previous_key,
         })
     }
 }
@@ -749,6 +756,119 @@ mod tests {
             .finish()
             .expect_err("empty segment should be rejected");
         assert!(matches!(error, SstBlockCodecError::EmptySegment));
+    }
+
+    /// The builder closes a data block from inside `push` as soon as the
+    /// block reaches its target size, so the last row of a segment can be
+    /// the row that closes one. The segment's max key must survive that:
+    /// an empty max key sorts below every bound, so a keyed scan would
+    /// prune the whole segment away and report the rows missing.
+    #[test]
+    fn max_key_survives_a_last_row_that_closes_its_block() {
+        // Calibrate the target so the crossing lands on the final row.
+        // Building the same rows as one block reports how many entry bytes
+        // they occupy: a block payload is the entries, then one `u32` per
+        // restart point, then the restart count.
+        let rows = 100usize;
+        let single_block = build_segment(rows);
+        let calibration = decode_index_block(
+            section(&single_block.bytes, &single_block.index),
+            &single_block.index,
+        )
+        .expect("index");
+        assert_eq!(calibration.len(), 1, "the calibration segment is one block");
+        let restarts = rows.div_ceil(RESTART_INTERVAL);
+        let entry_bytes = calibration[0].block.decoded_len as usize - 4 * restarts - 4;
+
+        let mut builder =
+            SegmentBlocksBuilder::new(NonZeroUsize::new(entry_bytes).expect("positive target"));
+        for index in 0..rows {
+            let (key, filter_key, row) = inode_row(index as u64);
+            builder.push(&key, &filter_key, &row).expect("push row");
+        }
+        let built = builder.finish().expect("finish segment");
+
+        let expected_max = inode_row((rows - 1) as u64).0;
+        assert_eq!(built.min_key, inode_row(0).0);
+        assert_eq!(built.max_key, expected_max);
+        assert_eq!(built.row_count, rows as u64);
+        // The last push closed the block, so `finish` appended nothing. The
+        // object must still be the same bytes a larger target produces.
+        assert_eq!(built.bytes, single_block.bytes);
+        let index =
+            decode_index_block(section(&built.bytes, &built.index), &built.index).expect("index");
+        assert_eq!(index.len(), 1);
+        assert_eq!(index[0].last_key, expected_max);
+    }
+
+    /// A segment's key range describes its rows, not its block geometry, so
+    /// the same rows must report the same range at every target size.
+    #[test]
+    fn block_geometry_does_not_change_the_segment_key_range() {
+        let rows = 400usize;
+        let expected: Vec<String> = (0..rows).map(|index| inode_row(index as u64).0).collect();
+        for target in [1usize, 64, 257, 1_024, 4_096, 65_536] {
+            let mut builder =
+                SegmentBlocksBuilder::new(NonZeroUsize::new(target).expect("positive target"));
+            for index in 0..rows {
+                let (key, filter_key, row) = inode_row(index as u64);
+                builder.push(&key, &filter_key, &row).expect("push row");
+            }
+            let built = builder.finish().expect("finish segment");
+            assert_eq!(built.min_key, expected[0], "target {target}");
+            assert_eq!(
+                &built.max_key,
+                expected.last().expect("rows"),
+                "target {target}"
+            );
+            assert_eq!(built.row_count, rows as u64, "target {target}");
+
+            let index = decode_index_block(section(&built.bytes, &built.index), &built.index)
+                .expect("index");
+            let mut recovered = Vec::new();
+            for entry in &index {
+                let block = decode_data_block(section(&built.bytes, &entry.block), &entry.block)
+                    .expect("data block");
+                // Each block still names its own last key, so the index the
+                // reader binary-searches keeps its shape.
+                assert_eq!(
+                    block.row_keys.last().expect("blocks are never empty"),
+                    &entry.last_key,
+                    "target {target}"
+                );
+                recovered.extend(block.row_keys);
+            }
+            assert_eq!(recovered, expected, "target {target}");
+            assert_eq!(
+                index.last().expect("blocks").last_key,
+                built.max_key,
+                "target {target}"
+            );
+        }
+    }
+
+    /// Closing a block clears the prefix anchor, so the order guard has to
+    /// read the last accepted row key instead. Every push closes a block
+    /// here, which puts the offered row first in a fresh block.
+    #[test]
+    fn a_descending_row_after_a_block_boundary_is_rejected() {
+        let mut builder = SegmentBlocksBuilder::new(NonZeroUsize::MIN);
+        let (key_high, filter_high, row_high) = inode_row(9);
+        builder
+            .push(&key_high, &filter_high, &row_high)
+            .expect("first row");
+        let (key_low, filter_low, row_low) = inode_row(3);
+        let error = builder
+            .push(&key_low, &filter_low, &row_low)
+            .expect_err("a descending key across a block boundary should be rejected");
+        assert!(
+            matches!(
+                &error,
+                SstBlockCodecError::RowKeysOutOfOrder { previous, offered }
+                    if previous == &key_high && offered == &key_low
+            ),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -372,6 +372,25 @@ fn validate_manifest_table_descriptors(
                         });
                     }
                 }
+                // Keyed scans prune a segment by this key range: a segment
+                // whose max key sorts below the scan bound is skipped
+                // without a read. An empty or descending range hides every
+                // row the segment holds, so a manifest that carries one is
+                // rejected here rather than answering "not found".
+                if descriptor.row_count > 0
+                    && (descriptor.min_key.is_empty()
+                        || descriptor.max_key.is_empty()
+                        || descriptor.min_key > descriptor.max_key)
+                {
+                    return Err(ManifestLoadError::SegmentDescriptorMismatch {
+                        object_key: descriptor.object_key.clone(),
+                        message: format!(
+                            "segment holds {} rows with key range `{}`..=`{}`; a segment with \
+                             rows must carry a non-empty ascending key range",
+                            descriptor.row_count, descriptor.min_key, descriptor.max_key
+                        ),
+                    });
+                }
                 match table.family {
                     MetadataTableFamily::DirentryBinds => {
                         direntry_bind_rows =

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -1119,6 +1119,17 @@ async fn multi_block_direntry_segment() -> (
     descriptor.index_block = built.index;
     descriptor.filter_block = built.filter;
     descriptor.payload_checksum = loonfs_api::sha256_digest(&built.bytes);
+    // A one-byte target closes a block on every push, the last row
+    // included, so this fixture carries the shape that used to drop a
+    // segment's max key. Keyed scans prune on that key, so it has to name
+    // the last row here as it would at any block size.
+    assert_eq!(
+        descriptor.max_key,
+        rows.last()
+            .expect("the segment holds rows")
+            .row_key_for_family(descriptor.family),
+        "the rebuilt descriptor must carry the segment's last row key"
+    );
 
     let index = block_fetch::load_segment_index(
         &store,

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -10,8 +10,9 @@ async fn rewrite_manifest_segment(
     family: ApiMetadataTableFamily,
     descriptor: &mut MetadataFileRef,
     rows: Vec<MetadataRow>,
+    target_block_bytes: NonZeroUsize,
 ) {
-    let mut builder = SegmentBlocksBuilder::default();
+    let mut builder = SegmentBlocksBuilder::new(target_block_bytes);
     for row in &rows {
         let row_key = row.row_key_for_family(family);
         let filter_key = row.filter_key_for_family(family);
@@ -92,8 +93,13 @@ async fn rewrite_revision_index_segment(
         ApiMetadataTableFamily::RevisionsByInodeDesc,
         descriptor,
         rows,
+        default_target_block_bytes(),
     )
     .await;
+}
+
+fn default_target_block_bytes() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_TARGET_BLOCK_BYTES).expect("the default target is positive")
 }
 
 async fn overwrite_manifest(
@@ -924,6 +930,7 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
         ApiMetadataTableFamily::DirentryChildBinds,
         child_descriptor,
         child_index_rows,
+        default_target_block_bytes(),
     )
     .await;
 
@@ -1217,6 +1224,117 @@ async fn unreferenced_manifest_run_is_ignored_by_current_projection_load() {
     ));
 }
 
+/// A data block closes from inside the builder's `push` as soon as it
+/// reaches its target size, so a segment's last row can be the row that
+/// closes its block. The descriptor's max key must still describe the rows
+/// the segment holds: a keyed scan prunes a segment whose max key sorts
+/// below the scan's lower bound, so an empty max key hides every row from
+/// every point and prefix lookup while reorganization, which scans from the
+/// empty bound, still reads them.
+#[tokio::test]
+async fn lookups_find_rows_in_a_segment_whose_last_row_closed_a_block() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for index in 1..=6 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{index}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write file");
+    }
+    // Fold the L0 runs so every inode row lands in one base segment.
+    let manifest_id = checkpoint_then_reorganize(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
+    let materialized =
+        load_manifest_materialization_for_inspection(&store, &namespace_id, manifest_id)
+            .await
+            .expect("load manifest before the rewrite");
+    let mut manifest = materialized.manifest;
+    let mut inode_rows =
+        manifest_rows_for_family(&materialized.metadata_state, ApiMetadataTableFamily::Inodes);
+    inode_rows.sort_by_key(|row| row.row_key_for_family(ApiMetadataTableFamily::Inodes));
+    assert!(
+        inode_rows.len() > 1,
+        "the namespace should hold several inodes"
+    );
+    let last_inode_key = inode_rows
+        .last()
+        .expect("inode rows")
+        .row_key_for_family(ApiMetadataTableFamily::Inodes);
+
+    let base_inode_segments = manifest
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|metadata_file| {
+            metadata_file.level == CHECKPOINT_BASE_RUN_LEVEL
+                && metadata_file.family == ApiMetadataTableFamily::Inodes
+        })
+        .count();
+    assert_eq!(
+        base_inode_segments, 1,
+        "the folded base should hold one inode segment"
+    );
+    let descriptor = manifest
+        .payload
+        .metadata_files
+        .iter_mut()
+        .find(|metadata_file| {
+            metadata_file.level == CHECKPOINT_BASE_RUN_LEVEL
+                && metadata_file.family == ApiMetadataTableFamily::Inodes
+        })
+        .expect("base inode segment");
+    // A one-byte target closes a block on every push, the last row
+    // included. That is the shape a final row produces whenever it lands on
+    // the target crossing, which happens at any block size.
+    rewrite_manifest_segment(
+        &store,
+        &namespace_id,
+        manifest.payload.head_seq,
+        ApiMetadataTableFamily::Inodes,
+        descriptor,
+        inode_rows.clone(),
+        NonZeroUsize::MIN,
+    )
+    .await;
+    assert_eq!(
+        descriptor.max_key, last_inode_key,
+        "the descriptor must carry the segment's last row key"
+    );
+    overwrite_manifest(&store, &namespace_id, manifest).await;
+
+    let manifest_object_id = current_manifest_object_id(&store, &namespace_id).await;
+    let tables = load_verified_manifest_tables(&store, &namespace_id, &manifest_object_id)
+        .await
+        .expect("the rewritten manifest should load");
+    for row in &inode_rows {
+        let key = row.row_key_for_family(ApiMetadataTableFamily::Inodes);
+        let found = tables
+            .get_for_lookup(ApiMetadataTableFamily::Inodes, &key, &key)
+            .await
+            .expect("inode lookup");
+        assert!(
+            found.is_some(),
+            "the keyed lookup lost inode row `{key}` in the rewritten segment"
+        );
+    }
+}
+
 #[tokio::test]
 async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1246,8 +1364,9 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
     let payload = tables.manifest().payload.clone();
 
     // The read path assumes the filter block directly precedes the index
-    // block and that an inline copy matches its handle's length; loading a
-    // manifest that breaks either must fail instead of degrading.
+    // block, that an inline copy matches its handle's length, and that a
+    // segment holding rows reports the key range those rows span; loading a
+    // manifest that breaks any of them must fail instead of degrading.
     type Perturbation = fn(&mut MetadataFileRef);
     fn misalign_filter(descriptor: &mut MetadataFileRef) {
         descriptor.filter_block.offset -= 1;
@@ -1256,9 +1375,21 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
         let inline = descriptor.filter_inline.as_mut().expect("inline filter");
         inline.truncate(inline.len() - 2);
     }
-    let perturbations: [(&str, Perturbation); 2] = [
+    // An empty max key sorts below every scan bound, so the segment would
+    // answer no keyed lookup while still holding its rows.
+    fn clear_max_key(descriptor: &mut MetadataFileRef) {
+        assert!(descriptor.row_count > 0, "the segment should hold rows");
+        descriptor.max_key.clear();
+    }
+    fn invert_key_range(descriptor: &mut MetadataFileRef) {
+        assert!(descriptor.row_count > 0, "the segment should hold rows");
+        std::mem::swap(&mut descriptor.min_key, &mut descriptor.max_key);
+    }
+    let perturbations: [(&str, Perturbation); 4] = [
         ("filter not adjacent to index", misalign_filter),
         ("inline length disagrees with handle", truncate_inline),
+        ("segment with rows has no max key", clear_max_key),
+        ("segment key range descends", invert_key_range),
     ];
     for (index, (label, perturb)) in perturbations.iter().enumerate() {
         let mut perturbed = payload.clone();
@@ -1267,8 +1398,12 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
         let descriptor = perturbed
             .metadata_files
             .iter_mut()
-            .find(|descriptor| descriptor.filter_inline.is_some())
-            .expect("an inline-filtered descriptor");
+            // A segment spanning several keys, so swapping its bounds
+            // actually descends.
+            .find(|descriptor| {
+                descriptor.filter_inline.is_some() && descriptor.min_key != descriptor.max_key
+            })
+            .expect("an inline-filtered descriptor spanning several keys");
         perturb(descriptor);
         let perturbed_object_id = perturbed.manifest_object_id.clone();
         let envelope = NamespaceManifestEnvelope::from_payload(perturbed)

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -69,7 +69,7 @@ use loonfs_api::wire::manifest::{
 };
 use loonfs_api::wire::sst_blocks::{
     decode_data_block, string_prefix_upper_bound, BlockHandle, DecodedDataBlock,
-    SegmentBlocksBuilder, SegmentIndexEntry,
+    SegmentBlocksBuilder, SegmentIndexEntry, DEFAULT_TARGET_BLOCK_BYTES,
 };
 use loonfs_api::{
     AbsolutePath, ChangeSeq, CheckpointId, CommitId, DestinationBehavior, EffectiveLimit, InodeId,


### PR DESCRIPTION
Previously, a segment recorded an empty max key whenever its last row was the row that closed a data block. Keyed scans prune with `max_key < lower_bound`, and an empty key sorts below every bound, so the whole segment became invisible to every point and prefix lookup while its rows stayed durable and readable to reorganization. The next fold rewrote the segment and the symptom disappeared, which is why nothing caught it.
