### PR TITLE
chore(format): drop the builder's unread field and pin grep's final-block case

### DIFF
--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -183,7 +183,6 @@ pub struct SegmentBlocksBuilder {
     /// segment's max key. A block's first entry stores its key in full
     /// regardless, because a restart point always begins a block.
     previous_key: String,
-    block_first_key: String,
     finished_blocks: Vec<(String, Vec<u8>)>,
     filter_hashes: Vec<(u64, u64)>,
     row_count: u64,
@@ -205,7 +204,6 @@ impl SegmentBlocksBuilder {
             restarts: Vec::new(),
             entry_count: 0,
             previous_key: String::new(),
-            block_first_key: String::new(),
             finished_blocks: Vec::new(),
             filter_hashes: Vec::new(),
             row_count: 0,
@@ -237,9 +235,6 @@ impl SegmentBlocksBuilder {
         let restart = self.entry_count % RESTART_INTERVAL == 0;
         if restart {
             self.restarts.push(self.entries.len() as u32);
-        }
-        if self.entries.is_empty() {
-            self.block_first_key = row_key.to_owned();
         }
         let shared_len = if restart {
             0

--- a/crates/loonfs-grep/src/codec.rs
+++ b/crates/loonfs-grep/src/codec.rs
@@ -436,6 +436,29 @@ mod tests {
         );
     }
 
+    /// The index segment builder is the shared `SegmentBlocksBuilder`, so a
+    /// lost `max_key` would surface here as a segment whose row range
+    /// descends — which `GrepManifestState` rejects, parking the reorganize
+    /// step on `InvalidSegmentRange`. Target 1 closes a data block on every
+    /// push, the final one included, which is the case that once lost the key.
+    #[test]
+    fn segment_max_row_key_survives_a_full_final_block() {
+        use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
+
+        let mut builder = SegmentBlocksBuilder::new(std::num::NonZeroUsize::MIN);
+        let mut last_key = String::new();
+        for gram in [Gram(*b"abc"), Gram(*b"abd"), Gram(*b"abe")] {
+            let row = IndexRow::gram_postings(gram, &[posting(42, 7)]).expect("row");
+            last_key = row.row_key();
+            builder
+                .push(&last_key, &row.filter_key(), &row)
+                .expect("push");
+        }
+        let built = builder.finish().expect("finish");
+        assert_eq!(built.max_key, last_key);
+        assert!(built.min_key <= built.max_key);
+    }
+
     #[test]
     fn rows_reject_first_inode_mismatch() {
         let row = IndexRow::GramPostings {


### PR DESCRIPTION
Two small follow-ups to #525.

`SegmentBlocksBuilder` had a field, `block_first_key`, that was written but never read. This PR deletes it.

It also adds a grep-side regression test for the #525 bug. The grep index uses the same segment builder, but fails differently: an empty `max_key` fails validation in `GrepManifestState` and blocks the reorganize step until the input rows change. The metadata-side test would not catch a grep regression. The new test builds grep index rows with a 1-byte block target, so the last row always closes a block, and asserts the segment's key range is correct.

Tests: 1666 passed, 0 failed. Clippy, fmt, and openapi checks pass.
