### PR TITLE
feat(core): read spans name their anchor and the missing lookup

### DIFF
--- a/crates/loonfs-core/src/metadata/tests.rs
+++ b/crates/loonfs-core/src/metadata/tests.rs
@@ -957,3 +957,29 @@ fn has_visible_children_sees_through_unbinds() {
             .expect("probe emptied directory")
     );
 }
+
+/// The leg names land in log records that operators grep for. They are fixed
+/// strings, and no two legs share one.
+#[test]
+fn every_absent_visibility_leg_has_its_own_stable_name() {
+    use visibility::AbsentVisibilityLeg;
+
+    let legs = [
+        (AbsentVisibilityLeg::ParentInode, "parent_inode"),
+        (
+            AbsentVisibilityLeg::ParentNotDirectory,
+            "parent_not_directory",
+        ),
+        (AbsentVisibilityLeg::ForwardBinding, "forward_binding"),
+        (AbsentVisibilityLeg::BindingUnbound, "binding_unbound"),
+        (AbsentVisibilityLeg::ReverseIndex, "reverse_index"),
+        (AbsentVisibilityLeg::BindingSuperseded, "binding_superseded"),
+        (AbsentVisibilityLeg::ChildInode, "child_inode"),
+    ];
+
+    for (leg, name) in legs {
+        assert_eq!(leg.name(), name, "{leg:?} was renamed");
+    }
+    let names: std::collections::BTreeSet<&str> = legs.iter().map(|(leg, _)| leg.name()).collect();
+    assert_eq!(names.len(), legs.len(), "two legs share one name");
+}

--- a/crates/loonfs-core/src/metadata/visibility.rs
+++ b/crates/loonfs-core/src/metadata/visibility.rs
@@ -19,6 +19,9 @@
 //!   [`would_create_directory_cycle`], [`resolve_visible_path`]) are the
 //!   canonical rule bodies that both the provided trait methods and every
 //!   caching/gating override delegate to.
+//! - [`AbsentVisibilityLeg`] names the lookup a walk stopped on when it
+//!   answers "no child". The rules decide nothing differently for it; it
+//!   only makes an absence say which of the agreeing lookups was empty.
 //!
 //! The at-head indexes ([`super::MetadataState`]'s `indexes`) are a
 //! materialization of these same rules, maintained incrementally. The
@@ -187,6 +190,76 @@ pub(crate) trait MetadataVisibilityReads {
     }
 }
 
+/// Which leg of the child-visibility walk answered no.
+///
+/// A visible child needs three durable families to agree: the forward bind
+/// row under `(parent, name_key)`, the child's own latest parent binding,
+/// and the inode rows for the parent and the child. When any one of them
+/// comes back empty, the walk answers "no child", and from the outside every
+/// leg looks the same. This names the leg that stopped the walk, so a read
+/// that answers not-found says which lookup produced the absence instead of
+/// only that there was one.
+///
+/// Only absences are named. A visible child is the ordinary answer and says
+/// nothing at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AbsentVisibilityLeg {
+    /// The parent inode is not visible at the read seq.
+    ParentInode,
+    /// The parent inode is visible but is not a directory, so it binds no
+    /// children under any name.
+    ParentNotDirectory,
+    /// No bind row exists under `(parent, name_key)`.
+    ForwardBinding,
+    /// A bind row exists and an unbind revokes it.
+    BindingUnbound,
+    /// The bound child has no current parent binding of its own.
+    ReverseIndex,
+    /// The child's current parent binding is a different bind event: the
+    /// child was bound elsewhere and this name is the stale one.
+    BindingSuperseded,
+    /// The bound child's inode is not visible at the read seq.
+    ChildInode,
+}
+
+impl AbsentVisibilityLeg {
+    /// The leg's stable name for the `leg` field.
+    ///
+    /// Every name is a `&'static str`, so naming a leg allocates nothing.
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::ParentInode => "parent_inode",
+            Self::ParentNotDirectory => "parent_not_directory",
+            Self::ForwardBinding => "forward_binding",
+            Self::BindingUnbound => "binding_unbound",
+            Self::ReverseIndex => "reverse_index",
+            Self::BindingSuperseded => "binding_superseded",
+            Self::ChildInode => "child_inode",
+        }
+    }
+}
+
+/// Says which leg made `(parent, name_key)` absent, once per absence.
+///
+/// Ids only, no names. The events around this one log namespace ids, object
+/// keys, and content ids, and none of them logs a path or a display name; a
+/// name key is derived from user text, so it stays out of the record too.
+/// The child fields are absent when no bind row was found, because there was
+/// no child to name.
+fn trace_absent_leg(
+    leg: AbsentVisibilityLeg,
+    parent_inode_id: InodeId,
+    direntry: Option<&DirentryBindRecord>,
+) {
+    tracing::debug!(
+        leg = leg.name(),
+        parent_inode_id = parent_inode_id.0,
+        child_inode_id = direntry.map(|direntry| direntry.child_inode_id.0),
+        bind_seq = direntry.map(|direntry| direntry.bind_seq.0),
+        "visibility walk found no child"
+    );
+}
+
 /// The child's current parent binding: the latest binding for the child that
 /// has not been unbound. Returns `None` when the latest binding was revoked,
 /// even if an older un-revoked binding row still exists — bindings are
@@ -224,18 +297,34 @@ pub(crate) async fn active_child_binding<R: MetadataVisibilityReads>(
         .find_latest_bound_child(parent_inode_id, name_key)
         .await?
     else {
+        trace_absent_leg(AbsentVisibilityLeg::ForwardBinding, parent_inode_id, None);
         return Ok(None);
     };
     if reads.is_binding_unbound(&direntry).await? {
+        trace_absent_leg(
+            AbsentVisibilityLeg::BindingUnbound,
+            parent_inode_id,
+            Some(&direntry),
+        );
         return Ok(None);
     }
     let Some(latest_binding) = reads
         .current_parent_binding_for_child(direntry.child_inode_id)
         .await?
     else {
+        trace_absent_leg(
+            AbsentVisibilityLeg::ReverseIndex,
+            parent_inode_id,
+            Some(&direntry),
+        );
         return Ok(None);
     };
     if !latest_binding.same_binding(&direntry) {
+        trace_absent_leg(
+            AbsentVisibilityLeg::BindingSuperseded,
+            parent_inode_id,
+            Some(&direntry),
+        );
         return Ok(None);
     }
     Ok(Some(direntry))
@@ -323,9 +412,15 @@ pub(crate) async fn visible_child<R: MetadataVisibilityReads>(
     name_key: &NameKey,
 ) -> Result<Option<DirentryBindRecord>, R::Error> {
     let Some(parent) = reads.visible_inode(parent_inode_id).await? else {
+        trace_absent_leg(AbsentVisibilityLeg::ParentInode, parent_inode_id, None);
         return Ok(None);
     };
     if parent.inode_kind != InodeKind::Directory {
+        trace_absent_leg(
+            AbsentVisibilityLeg::ParentNotDirectory,
+            parent_inode_id,
+            None,
+        );
         return Ok(None);
     }
 
@@ -333,6 +428,8 @@ pub(crate) async fn visible_child<R: MetadataVisibilityReads>(
         .active_child_binding(parent_inode_id, name_key)
         .await?
     else {
+        // No record here. The binding rule names its own leg, and one
+        // absence is one record.
         return Ok(None);
     };
     if reads
@@ -340,6 +437,11 @@ pub(crate) async fn visible_child<R: MetadataVisibilityReads>(
         .await?
         .is_none()
     {
+        trace_absent_leg(
+            AbsentVisibilityLeg::ChildInode,
+            parent_inode_id,
+            Some(&direntry),
+        );
         return Ok(None);
     }
     Ok(Some(direntry))

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -23,7 +23,8 @@ use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::{
     AbsolutePath, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ContentRef,
     ContentStoreId, DirectoryPageCursor, DisplayName, FileRevision, FileRevisionsPageCursor,
-    InodeId, InodeKind, NamespaceId, Page, PageRequest, RevisionNo, TrashEntry, TrashPageCursor,
+    InodeId, InodeKind, ManifestId, NamespaceId, Page, PageRequest, RevisionNo, TrashEntry,
+    TrashPageCursor,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -106,6 +107,25 @@ impl<'a> ReadLoadContext<'a> {
     }
 }
 
+/// The metadata anchor one read is pinned to.
+///
+/// Three numbers say where a read's answer came from: the head sequence it
+/// answers at, the manifest its verified tables were loaded from, and the
+/// head sequence that manifest was published at. A read that answers
+/// not-found for a path a writer had already committed is either anchored
+/// behind that write or reading tables that do not hold it, and the two
+/// cases are told apart by these three numbers alone.
+///
+/// They are the same three the WAL-tail projection cache keys a projection
+/// by, so a read span names its anchor with the words that cache already
+/// uses. All three are plain numbers, so recording them costs no allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReadAnchor {
+    head_seq: ChangeSeq,
+    manifest_id: ManifestId,
+    manifest_head_seq: ChangeSeq,
+}
+
 pub(crate) async fn load_metadata_view<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     namespace_id: &NamespaceId,
@@ -162,6 +182,7 @@ pub(crate) struct LoadedMetadataView<'a, S: ObjectStore + ?Sized> {
     pub(super) head: HeadState,
     pub(super) tables: VerifiedMetadataTables<'a, S>,
     wal_tail_rows: Arc<MetadataState>,
+    anchor: ReadAnchor,
 }
 
 impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
@@ -190,6 +211,11 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 .await?;
         let tables = loaded_basis.tables;
         let manifest_head = head_from_manifest(&head, tables.manifest());
+        let anchor = ReadAnchor {
+            head_seq: head.seq,
+            manifest_id,
+            manifest_head_seq: manifest_head.seq,
+        };
         let cache_key = match load_context.view {
             #[cfg(test)]
             ReadViewContext::Latest => None,
@@ -211,6 +237,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                     head,
                     tables,
                     wal_tail_rows,
+                    anchor,
                 });
             }
         }
@@ -252,6 +279,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             head,
             tables,
             wal_tail_rows,
+            anchor,
         })
     }
 
@@ -260,7 +288,12 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         name = "loonfs.phase",
         err,
         skip_all,
-        fields(phase = "walk_path")
+        fields(
+            phase = "walk_path",
+            head_seq = self.anchor.head_seq.0,
+            manifest_id = self.anchor.manifest_id.0,
+            manifest_head_seq = self.anchor.manifest_head_seq.0,
+        )
     )]
     pub(crate) async fn resolve_path(
         &self,
@@ -311,11 +344,31 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 kind: entry.inode_kind,
             });
         }
-        let content_ref = entry
-            .content_ref
-            .clone()
-            .ok_or_else(|| CoreError::PathNotFound(absolute_path.to_owned()))?;
+        let Some(content_ref) = entry.content_ref.clone() else {
+            self.trace_entry_without_content_ref(entry.inode_id, entry.revision_no);
+            return Err(CoreError::PathNotFound(absolute_path.to_owned()));
+        };
         Ok((entry, content_ref))
+    }
+
+    /// Says that a path resolved to a visible file whose revision named no
+    /// content, at the point the read turns that into not-found.
+    ///
+    /// The answer on the wire is deliberately the same as for a path that
+    /// does not exist, and it stays that way. This record is the only thing
+    /// that tells the two apart, so it carries the read's anchor as well as
+    /// the entry: an operator reads one line instead of reconstructing a
+    /// chain. It fires only on the broken case, so the ordinary read pays
+    /// nothing for it.
+    fn trace_entry_without_content_ref(&self, inode_id: InodeId, revision_no: Option<RevisionNo>) {
+        tracing::debug!(
+            head_seq = self.anchor.head_seq.0,
+            manifest_id = self.anchor.manifest_id.0,
+            manifest_head_seq = self.anchor.manifest_head_seq.0,
+            inode_id = inode_id.0,
+            revision_no = revision_no.map(|revision_no| revision_no.0),
+            "entry visible without content_ref"
+        );
     }
 
     /// The content store this view's namespace is bound to.
@@ -352,11 +405,21 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
                 (revision.revision_no, revision.content_ref)
             }
             // A visible file carries both; a path that resolves without
-            // them is the same absence a proxied read reports.
-            None => match (entry.revision_no, entry.content_ref) {
-                (Some(revision_no), Some(content_ref)) => (revision_no, content_ref),
-                _ => return Err(CoreError::PathNotFound(absolute_path.to_owned())),
-            },
+            // them is the same absence a proxied read reports, and it says
+            // so in the same words.
+            None => {
+                // The ids are read out first, because the match moves the
+                // content reference out of the entry.
+                let inode_id = entry.inode_id;
+                let revision_no = entry.revision_no;
+                match (revision_no, entry.content_ref) {
+                    (Some(revision_no), Some(content_ref)) => (revision_no, content_ref),
+                    _ => {
+                        self.trace_entry_without_content_ref(inode_id, revision_no);
+                        return Err(CoreError::PathNotFound(absolute_path.to_owned()));
+                    }
+                }
+            }
         };
         let object_key = content_object_key_for_ref(&self.content_store_id, &content_ref)?;
 
@@ -577,7 +640,12 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         name = "loonfs.phase",
         err,
         skip_all,
-        fields(phase = "walk_path")
+        fields(
+            phase = "walk_path",
+            head_seq = self.anchor.head_seq.0,
+            manifest_id = self.anchor.manifest_id.0,
+            manifest_head_seq = self.anchor.manifest_head_seq.0,
+        )
     )]
     pub(crate) async fn list_path_page(
         &self,

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -368,6 +368,35 @@ all. Any other value fails the process rather than being guessed at.
 and leaves the rest alone. `LOONFS_TRACE=off` silences the output whatever
 `RUST_LOG` says.
 
+### Diagnosing a read that answers not-found for a path that should exist
+
+Set `LOONFS_TRACE=json` and `RUST_LOG=loonfs_server=info,loonfs_core=debug`,
+then repeat the read.
+
+Find the read's span. It is the `loonfs.phase` span whose `phase` is
+`walk_path`, and it names the anchor the read answered from. `head_seq` is
+the namespace head the read was pinned to. `manifest_id` and
+`manifest_head_seq` name the manifest its tables came from; a `manifest_id`
+of 0 means the namespace has published no manifest yet, so every row is
+still in the WAL. Compare `head_seq` against the sequence the write
+returned. A lower `head_seq` means the read was anchored behind the write,
+and nothing is missing.
+
+Then read the events inside that span. `visibility walk found no child`
+names the lookup that came back empty in its `leg` field.
+`binding_unbound` and `binding_superseded` mean the name was deleted or
+moved, which is an ordinary answer. `forward_binding`, `reverse_index`,
+`parent_inode`, and `child_inode` mean the durable families disagree about
+one name, which is a storage problem. `entry visible without content_ref`
+means the path resolved to a visible file whose revision named no content.
+That event carries the anchor and the inode id, and it is the only thing
+that tells the case apart from a path that never existed.
+
+The write path emits `visibility walk found no child` as well, under a
+`prepare_commit` or a `build_commit_plan` span, because a commit checks
+that a name is free before it binds one. Read only the events under
+`walk_path`.
+
 ## The optional local cache
 
 The server can keep encoded metadata blocks on this machine's disk, in front

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -368,35 +368,6 @@ all. Any other value fails the process rather than being guessed at.
 and leaves the rest alone. `LOONFS_TRACE=off` silences the output whatever
 `RUST_LOG` says.
 
-### Diagnosing a read that answers not-found for a path that should exist
-
-Set `LOONFS_TRACE=json` and `RUST_LOG=loonfs_server=info,loonfs_core=debug`,
-then repeat the read.
-
-Find the read's span. It is the `loonfs.phase` span whose `phase` is
-`walk_path`, and it names the anchor the read answered from. `head_seq` is
-the namespace head the read was pinned to. `manifest_id` and
-`manifest_head_seq` name the manifest its tables came from; a `manifest_id`
-of 0 means the namespace has published no manifest yet, so every row is
-still in the WAL. Compare `head_seq` against the sequence the write
-returned. A lower `head_seq` means the read was anchored behind the write,
-and nothing is missing.
-
-Then read the events inside that span. `visibility walk found no child`
-names the lookup that came back empty in its `leg` field.
-`binding_unbound` and `binding_superseded` mean the name was deleted or
-moved, which is an ordinary answer. `forward_binding`, `reverse_index`,
-`parent_inode`, and `child_inode` mean the durable families disagree about
-one name, which is a storage problem. `entry visible without content_ref`
-means the path resolved to a visible file whose revision named no content.
-That event carries the anchor and the inode id, and it is the only thing
-that tells the case apart from a path that never existed.
-
-The write path emits `visibility walk found no child` as well, under a
-`prepare_commit` or a `build_commit_plan` span, because a commit checks
-that a name is free before it binds one. Read only the events under
-`walk_path`.
-
 ## The optional local cache
 
 The server can keep encoded metadata blocks on this machine's disk, in front

--- a/crates/loonfs/tests/read_tracing_capture.rs
+++ b/crates/loonfs/tests/read_tracing_capture.rs
@@ -1,0 +1,117 @@
+#![allow(clippy::panic)]
+// Tracing-capture tests panic in helper assertions for precise diagnostics.
+
+//! Asserts a read names the anchor it answered from, and that a walk which
+//! finds nothing names the lookup that came back empty.
+//!
+//! This keeps its own test binary — its own process — for the reason
+//! `tracing_capture.rs` gives: tracing caches per-callsite interest
+//! process-globally, and a callsite first exercised on a thread with no
+//! subscriber can race the interest rebuild that `set_default` performs.
+//! Alone in its process, the read callsites are first hit with the capture
+//! subscriber installed, and the assertions are deterministic.
+
+use loonfs::{CreateNamespaceOptions, FsBackgroundWork, FsWriter, PutFileOptions, StoreConfig};
+use loonfs_test_support::block_on::block_on;
+use loonfs_test_support::ids::namespace_id;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+use tracing_subscriber::fmt::format::FmtSpan;
+
+fn store_config(root: &Path) -> StoreConfig {
+    StoreConfig::LocalFs {
+        root: root.to_string_lossy().into_owned(),
+        key_prefix: None,
+    }
+}
+
+async fn writer(root: &Path) -> FsWriter {
+    FsWriter::builder(store_config(root))
+        .writer_id("read-tracing-capture-writer")
+        // No background maintenance: the only spans in the capture are the
+        // ones the write and the two reads produce.
+        .background_work(FsBackgroundWork::ManualOnly)
+        .build()
+        .await
+        .expect("build writer")
+}
+
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn reads_name_their_anchor_and_the_lookup_that_came_back_empty() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&captured);
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_ansi(false)
+        // Closing spans are recorded so the walk span names its anchor in
+        // the capture whether or not the walk emitted an event.
+        .with_span_events(FmtSpan::CLOSE)
+        .with_writer(move || CaptureWriter(Arc::clone(&sink)))
+        .finish();
+    // Thread-local so the capture cannot leak into other tests.
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    block_on(async {
+        let writer = writer(temp_dir.path()).await;
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/report.txt",
+                b"body",
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("put file");
+        let reader = writer.reader();
+        reader
+            .stat_path(&namespace_id, "/docs/report.txt")
+            .await
+            .expect("stat the file that was just written");
+        let missing = reader.stat_path(&namespace_id, "/docs/missing.txt").await;
+        assert!(missing.is_err(), "a path that was never written is absent");
+    });
+
+    let log = String::from_utf8(captured.lock().expect("capture lock").clone())
+        .expect("captured log is utf8");
+    // The walk span says which anchor the read was pinned to: the head it
+    // answered at, and the manifest its tables came from. Fields are matched
+    // with their `=` so a line that merely carries the word cannot satisfy
+    // the assertion.
+    let walk = find_line(&log, "phase=\"walk_path\"");
+    for field in ["head_seq=", "manifest_id=", "manifest_head_seq="] {
+        assert!(walk.contains(field), "missing `{field}` in: {walk}");
+    }
+    // The walk that found nothing says which of the agreeing lookups was
+    // empty. Nothing was ever bound under that name, so the forward binding
+    // is the leg that stopped it.
+    let absent = find_line(&log, "visibility walk found no child");
+    for field in ["leg=", "forward_binding", "parent_inode_id="] {
+        assert!(absent.contains(field), "missing `{field}` in: {absent}");
+    }
+}
+
+fn find_line<'log>(log: &'log str, needle: &str) -> &'log str {
+    log.lines()
+        .find(|line| line.contains(needle))
+        .unwrap_or_else(|| panic!("`{needle}` missing from captured tracing:\n{log}"))
+}


### PR DESCRIPTION
Adds tracing to the read path so a wrong not-found answer can be diagnosed from logs. This follows the #525 investigation, which took hours because the read path records almost nothing about what it looked at.

Three changes:

- Path-walk spans now record `head_seq`, `manifest_id`, and `manifest_head_seq` — which head and manifest the read used. These are the same field names the WAL-tail projection cache already uses.
- When the visibility walk finds no child, a debug event records which lookup came back empty (forward binding, reverse index, inode row, and so on). Previously all failures looked identical from outside.
- When a visible file has no content reference — the exact condition behind the #525 failure — a debug event fires. The returned error is unchanged.

Also adds a section to the self-hosting runbook explaining how to use these fields.

No behavior, wire, or metric changes. One new tracing-capture test and one unit test on the event names. 1667 passed, 0 failed; clippy, fmt, and openapi checks pass.
