### PR TITLE
fix(checkpoint): reorganization keeps working when the base run exceeds the step budget

### DIFF
--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -181,12 +181,15 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
         });
     };
-    let Some(input) = select_reorganization_input(&tables, group, policy)
+    let selection = select_reorganization_input(&tables, group, policy)
         .await
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-        })?
-    else {
+        })?;
+    if let Some(bottom) = selection.group_bottom_over_budget {
+        report_group_bottom_over_budget(namespace_id, group, &bottom, policy);
+    }
+    let Some(input) = selection.input else {
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::BudgetExhausted {
@@ -247,7 +250,14 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let floor_seq = resolve_retention_floor_seq(store, &head)
         .await
         .map_err(CoreError::load_head)?;
-    drop_rows_below_retention_floor(&mut rows_by_family, floor_seq)?;
+    // Dropping is only visibility-preserving over a merge that starts at
+    // the group's oldest run; see
+    // [`ReorganizationInput::starts_at_group_bottom`]. A window that had to
+    // skip older runs merges them exactly as they are, so its output holds
+    // every row its inputs held.
+    if input.starts_at_group_bottom {
+        drop_rows_below_retention_floor(&mut rows_by_family, floor_seq)?;
+    }
 
     let run_tables = build_manifest_tables_from_rows(
         store,
@@ -324,24 +334,84 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     }
 }
 
-struct ReorganizationInput {
-    runs: Vec<MetadataRunManifest>,
+pub(super) struct ReorganizationInput {
+    pub(super) runs: Vec<MetadataRunManifest>,
     run_ids: BTreeSet<(ChangeSeq, u32)>,
     folded_l0_rows: u64,
     decoded_rows: u64,
     decoded_bytes: u64,
+    /// Whether the selected window starts at the group's oldest run.
+    ///
+    /// Retention dropping reads across the merged rows: an unbind cancels
+    /// the bind it names, and a removal marker cancels the listed deletion
+    /// it repeats. Dropping one half of such a pair is only
+    /// visibility-preserving when the other half is in the same merge, and
+    /// what guarantees that is starting the merge at the group's oldest
+    /// run — the cancelling row is always the newer of the two, so every row
+    /// it can cancel is already in the window (format spec, "Compaction").
+    pub(super) starts_at_group_bottom: bool,
 }
 
-/// Selects the existing compacted accumulator followed by L0 runs
-/// oldest-first. Index sections are read before row payloads so the
-/// decoded-byte budget is known exactly from each data block's durable
-/// `decoded_len`; a run that would cross a budget is not decoded or
-/// partially included.
-async fn select_reorganization_input<S: ObjectStore + ?Sized>(
+/// What one selection attempt found.
+///
+/// The saturation record travels beside the input because the caller
+/// reports it on both paths: a group whose oldest run has outgrown one
+/// step's budget still folds its newer runs, and that is exactly when an
+/// operator needs to hear that the run underneath them is frozen.
+pub(super) struct ReorganizationSelection {
+    pub(super) input: Option<ReorganizationInput>,
+    pub(super) group_bottom_over_budget: Option<OverBudgetRun>,
+}
+
+/// A run that does not fit one step's budgets on its own.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct OverBudgetRun {
+    pub(super) run_seq: ChangeSeq,
+    pub(super) level: u32,
+    pub(super) rows: u64,
+    /// The run's decoded byte total, or `None` when the row budget ruled
+    /// the run out before its byte total was read.
+    pub(super) decoded_bytes: Option<u64>,
+}
+
+/// Selects a contiguous window of complete runs to merge, oldest-first.
+///
+/// **The order.** The comparator below is the group's recency order, oldest
+/// first. Base-tier runs hold rows an earlier fold already absorbed, so they
+/// sit under every L0 run whatever their `run_seq` says: a bounded fold
+/// stamps its output at the manifest head, which can leave a base run
+/// carrying a higher `run_seq` than an L0 run it did not fold (see
+/// [`manifest_has_partial_reorganization`]). Within one tier the lower
+/// `run_seq` is the older run.
+///
+/// **The invariant.** A merge writes its inputs back as one base-tier run
+/// stamped at the manifest head. That output is older than every L0 run in
+/// the order above, so it may not carry a row newer than an L0 run it left
+/// behind — otherwise a later fold could drop a row while the row it cancels
+/// sits outside the window. Two rules keep that true. The window is a
+/// *contiguous* slice of the order, and its start only ever moves forward
+/// past **base-tier** runs; an L0 run is never stepped over. Every run the
+/// window leaves out therefore sits wholly below it or wholly above it, never
+/// interleaved, and the output can stand in for the whole window without
+/// moving any row past any other. When the window starts at the very bottom
+/// nothing is left out below it at all, and that is the stronger property
+/// retention dropping needs — see
+/// [`ReorganizationInput::starts_at_group_bottom`].
+///
+/// **The budgets pace the work; they never end it.** When no window starting
+/// at the group's oldest run can fit the budgets, the start moves past the
+/// base-tier runs that block it and the step merges the L0 runs above them
+/// on their own. The group keeps shedding runs even while the run at its
+/// bottom stays too large to fold.
+///
+/// Index sections are read before row payloads so the decoded-byte budget is
+/// known exactly from each data block's durable `decoded_len`; a run that
+/// would cross a budget is not decoded or partially included.
+pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     group: &[MetadataTableFamily],
     policy: MetadataLsmPolicy,
-) -> std::result::Result<Option<ReorganizationInput>, ManifestLoadError> {
+) -> std::result::Result<ReorganizationSelection, ManifestLoadError> {
     let mut candidates = tables
         .scan_runs
         .iter()
@@ -360,46 +430,132 @@ async fn select_reorganization_input<S: ObjectStore + ?Sized>(
         u64::try_from(policy.max_decoded_input_rows_per_step.get()).unwrap_or(u64::MAX);
     let byte_budget =
         u64::try_from(policy.max_decoded_input_bytes_per_step.get()).unwrap_or(u64::MAX);
+    let max_runs = policy.max_input_runs_per_step.get();
+    // Base-tier runs sort first, so this is also the index of the oldest L0
+    // candidate. The window start may move up to it and no further.
+    let base_tier_candidates = candidates
+        .iter()
+        .take_while(|run| run.level != CHECKPOINT_L0_RUN_LEVEL)
+        .count();
+    let window_starts = (base_tier_candidates + 1)
+        .min(candidate_count)
+        .min(max_runs);
+    // Reading a run's decoded byte total costs its index sections, so each
+    // candidate's total is read at most once however many windows weigh it.
+    let mut decoded_bytes_by_candidate = vec![None::<u64>; candidate_count];
+    let mut group_bottom_over_budget = None;
 
-    let mut runs = Vec::new();
-    let mut decoded_rows = 0u64;
-    let mut decoded_bytes = 0u64;
-    let mut folded_l0_rows = 0u64;
-    for run in candidates
-        .into_iter()
-        .take(policy.max_input_runs_per_step.get())
-    {
-        let run_rows = group_run_descriptors(run, group)
-            .map(|descriptor| descriptor.row_count)
-            .sum::<u64>();
-        if decoded_rows.saturating_add(run_rows) > row_budget {
-            break;
+    for window_start in 0..window_starts {
+        let mut runs = Vec::new();
+        let mut decoded_rows = 0u64;
+        let mut decoded_bytes = 0u64;
+        let mut folded_l0_rows = 0u64;
+        for index in window_start..candidate_count.min(window_start + max_runs) {
+            let run = candidates[index];
+            let run_rows = group_run_descriptors(run, group)
+                .map(|descriptor| descriptor.row_count)
+                .sum::<u64>();
+            if decoded_rows.saturating_add(run_rows) > row_budget {
+                // Index zero is only reached by the first window, whose
+                // accumulator is still empty there, so this is the group's
+                // oldest run failing the budget on its own.
+                if index == 0 {
+                    group_bottom_over_budget = Some(OverBudgetRun {
+                        run_seq: run.run_seq,
+                        level: run.level,
+                        rows: run_rows,
+                        decoded_bytes: None,
+                    });
+                }
+                break;
+            }
+            let run_bytes = match decoded_bytes_by_candidate[index] {
+                Some(bytes) => bytes,
+                None => {
+                    let bytes = decoded_group_run_bytes(tables, run, group).await?;
+                    decoded_bytes_by_candidate[index] = Some(bytes);
+                    bytes
+                }
+            };
+            if decoded_bytes.saturating_add(run_bytes) > byte_budget {
+                if index == 0 {
+                    group_bottom_over_budget = Some(OverBudgetRun {
+                        run_seq: run.run_seq,
+                        level: run.level,
+                        rows: run_rows,
+                        decoded_bytes: Some(run_bytes),
+                    });
+                }
+                break;
+            }
+            if run.level == CHECKPOINT_L0_RUN_LEVEL {
+                folded_l0_rows = folded_l0_rows.saturating_add(run_rows);
+            }
+            decoded_rows = decoded_rows.saturating_add(run_rows);
+            decoded_bytes = decoded_bytes.saturating_add(run_bytes);
+            runs.push(run.clone());
         }
-        let run_bytes = decoded_group_run_bytes(tables, run, group).await?;
-        if decoded_bytes.saturating_add(run_bytes) > byte_budget {
-            break;
+
+        // Every merge writes one base-tier run, so each L0 run it takes
+        // leaves L0 for good and the group's L0 count strictly falls. That
+        // is the whole progress condition, and it is what makes the fold
+        // terminate: a window holding no L0 run would only rewrite base-tier
+        // rows where they stand, forever.
+        let makes_progress = runs.iter().any(|run| run.level == CHECKPOINT_L0_RUN_LEVEL);
+        if !makes_progress {
+            continue;
         }
-        if run.level == CHECKPOINT_L0_RUN_LEVEL {
-            folded_l0_rows = folded_l0_rows.saturating_add(run_rows);
-        }
-        decoded_rows = decoded_rows.saturating_add(run_rows);
-        decoded_bytes = decoded_bytes.saturating_add(run_bytes);
-        runs.push(run.clone());
+        let run_ids = runs.iter().map(|run| (run.run_seq, run.level)).collect();
+        return Ok(ReorganizationSelection {
+            input: Some(ReorganizationInput {
+                runs,
+                run_ids,
+                folded_l0_rows,
+                decoded_rows,
+                decoded_bytes,
+                starts_at_group_bottom: window_start == 0,
+            }),
+            group_bottom_over_budget,
+        });
     }
 
-    let selected_l0 = runs.iter().any(|run| run.level == CHECKPOINT_L0_RUN_LEVEL);
-    let makes_progress = selected_l0 && (runs.len() > 1 || candidate_count == 1);
-    if !makes_progress {
-        return Ok(None);
-    }
-    let run_ids = runs.iter().map(|run| (run.run_seq, run.level)).collect();
-    Ok(Some(ReorganizationInput {
-        runs,
-        run_ids,
-        folded_l0_rows,
-        decoded_rows,
-        decoded_bytes,
-    }))
+    Ok(ReorganizationSelection {
+        input: None,
+        group_bottom_over_budget,
+    })
+}
+
+/// Says out loud that a family group's oldest run no longer fits one
+/// reorganization step.
+///
+/// Nothing is broken when this fires and nothing stalls: folds keep merging
+/// the newer runs above the run named here. What stops is reclamation of
+/// that run's rows, because no step can rewrite a run it cannot read whole.
+/// The group's run count therefore drifts up over time. Raising
+/// `max_decoded_input_rows_per_step` and `max_decoded_input_bytes_per_step`
+/// past the numbers in this line is the operator's lever.
+///
+/// One line per step: a step is already the unit maintenance schedules, so
+/// the cadence of the warning is the cadence of maintenance.
+fn report_group_bottom_over_budget(
+    namespace_id: &NamespaceId,
+    group: &[MetadataTableFamily],
+    bottom: &OverBudgetRun,
+    policy: MetadataLsmPolicy,
+) {
+    tracing::warn!(
+        namespace_id = namespace_id.as_str(),
+        families = ?group,
+        run_seq = bottom.run_seq.0,
+        run_level = bottom.level,
+        run_rows = bottom.rows,
+        run_decoded_bytes = bottom.decoded_bytes,
+        max_decoded_input_rows_per_step = policy.max_decoded_input_rows_per_step.get(),
+        max_decoded_input_bytes_per_step = policy.max_decoded_input_bytes_per_step.get(),
+        "the oldest metadata run in this family group no longer fits one reorganization step; \
+         folds skip it and merge the newer runs, so its rows are never reclaimed and the \
+         group's run count grows",
+    );
 }
 
 /// A bounded fold stamps its output at the manifest head. If older or
@@ -456,7 +612,7 @@ async fn decoded_group_run_bytes<S: ObjectStore + ?Sized>(
 
 /// The family group with the most L0 rows to fold; ties resolve in group
 /// order. `None` when no group has L0 rows.
-fn select_family_group(
+pub(super) fn select_family_group(
     payload: &NamespaceManifestPayload,
 ) -> Option<&'static [MetadataTableFamily]> {
     REORGANIZE_FAMILY_GROUPS

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1538,3 +1538,438 @@ async fn over_budget_reorganization_aborts_without_publishing() {
         super::MetadataReorganizeOutcome::UnitPublished { .. }
     ));
 }
+
+/// Runs the selector exactly as a step runs it — same family group, same
+/// policy — and returns the group beside what the selector chose.
+async fn select_reorganization_window<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    policy: MetadataLsmPolicy,
+) -> (
+    Vec<ApiMetadataTableFamily>,
+    super::reorganize::ReorganizationSelection,
+) {
+    let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
+    let tables = load_verified_manifest_tables(store, namespace_id, &manifest_object_id)
+        .await
+        .expect("load manifest tables");
+    let group = super::reorganize::select_family_group(&tables.manifest().payload)
+        .expect("a family group with L0 rows to fold");
+    let selection = super::reorganize::select_reorganization_input(&tables, group, policy)
+        .await
+        .expect("select a reorganization input");
+    (group.to_vec(), selection)
+}
+
+/// Rows one run holds in one family group: the quantity the per-step row
+/// budget is measured against.
+fn group_run_rows(run: &MetadataRunManifest, group: &[ApiMetadataTableFamily]) -> u64 {
+    run.tables
+        .iter()
+        .filter(|table| group.contains(&table.family))
+        .flat_map(|table| &table.segments)
+        .map(|descriptor| descriptor.row_count)
+        .sum()
+}
+
+fn group_segment_object_keys(
+    run: &MetadataRunManifest,
+    group: &[ApiMetadataTableFamily],
+) -> Vec<String> {
+    run.tables
+        .iter()
+        .filter(|table| group.contains(&table.family))
+        .flat_map(|table| &table.segments)
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect()
+}
+
+/// A per-step row budget one row short of what the group's base run needs,
+/// with the trigger forced so a single delta run still folds.
+fn policy_that_cannot_fold_the_base(base_rows: u64) -> MetadataLsmPolicy {
+    let row_budget = usize::try_from(base_rows).expect("test row counts are small") - 1;
+    MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(row_budget)
+            .expect("test row budget should be nonzero"),
+        ..MetadataLsmPolicy::default()
+    }
+}
+
+/// A group whose base run alone busts the per-step row budget used to park
+/// forever: selection broke on the first candidate, chose nothing, and
+/// reported the group blocked on every step after that while delta runs
+/// piled up behind it with nothing saying why.
+///
+/// The budget paces the work instead of ending it. The step skips the base
+/// run it cannot read whole, merges the delta runs above it, and says out
+/// loud that the base has outgrown the budget.
+#[tokio::test]
+async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // A compacted base first, then delta runs stacked above it.
+    for index in 1..=4 {
+        write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
+    }
+    drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
+    for index in 5..=8 {
+        write_file_and_checkpoint(&store, &namespace_id, &context, index).await;
+    }
+
+    let before = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load the parked manifest");
+    let (group, _) =
+        select_reorganization_window(&store, &namespace_id, MetadataLsmPolicy::default()).await;
+    let base = base_run(&before.manifest);
+    let base_rows = group_run_rows(&base, &group);
+    let base_segments = group_segment_object_keys(&base, &group);
+    assert!(base_rows > 1, "the base run must hold rows in this group");
+    let policy = policy_that_cannot_fold_the_base(base_rows);
+
+    let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
+    let input = selection
+        .input
+        .expect("a group must keep finding work above a base run it cannot fold");
+    assert!(
+        !input.starts_at_group_bottom,
+        "the window must start above the base run it cannot read whole"
+    );
+    assert!(
+        input
+            .runs
+            .iter()
+            .all(|run| run.level == CHECKPOINT_L0_RUN_LEVEL),
+        "skipping the base leaves a delta-only merge, got {:?}",
+        input
+            .runs
+            .iter()
+            .map(|run| (run.run_seq, run.level))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        input.runs.len() > 1,
+        "a merge must consume more than one run to reduce the count"
+    );
+    let bottom = selection
+        .group_bottom_over_budget
+        .expect("a base run over the budget must raise the alarm");
+    assert_eq!(bottom.run_seq, base.run_seq);
+    assert_eq!(bottom.level, CHECKPOINT_BASE_RUN_LEVEL);
+    assert_eq!(bottom.rows, base_rows);
+
+    // Repeated steps keep draining the group. The base run stays exactly
+    // where it is.
+    let mut published = 0usize;
+    let mut group_l0_runs = vec![l0_runs(&before.manifest).len()];
+    for _ in 0..64 {
+        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+            .await
+            .expect("reorganization step");
+        match report.outcome {
+            super::MetadataReorganizeOutcome::UnitPublished { .. } => published += 1,
+            super::MetadataReorganizeOutcome::Superseded => {
+                panic!("no concurrent publisher exists in this test")
+            }
+            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                panic!("the group parked instead of folding what fits")
+            }
+            super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+        }
+        let current = load_manifest_materialization_for_inspection(
+            &store,
+            &namespace_id,
+            current_manifest_id(&store, &namespace_id).await,
+        )
+        .await
+        .expect("load the folded manifest");
+        group_l0_runs.push(l0_runs(&current.manifest).len());
+    }
+    assert!(published > 0, "at least one unit must publish");
+
+    let after = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load the drained manifest");
+    assert!(
+        l0_runs(&after.manifest).is_empty(),
+        "delta runs must drain even with the base frozen, ran {group_l0_runs:?}"
+    );
+    assert!(
+        runs_from_metadata_files(&after.manifest.payload).len()
+            < runs_from_metadata_files(&before.manifest.payload).len(),
+        "the group's run count must fall"
+    );
+    let remaining = run_segment_object_keys(&after.manifest);
+    for segment in &base_segments {
+        assert!(
+            remaining.contains(segment),
+            "the base run this step could not read must stay referenced untouched"
+        );
+    }
+    let projection = load_current_projection(&store, &namespace_id)
+        .await
+        .expect("materialization");
+    assert!(metadata_states_equivalent(
+        &projection.metadata_state,
+        &after.metadata_state
+    ));
+}
+
+/// A merge that skipped older runs must carry every row its inputs held.
+///
+/// The retention drop rules read across the merged rows: an unbind cancels
+/// the bind it names, and both have to leave together. A window that starts
+/// above the base cannot see the bind at all, so dropping the unbind there
+/// would put a deleted file back. The step merges without dropping instead.
+#[tokio::test]
+async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // The base run holds both bindings.
+    for name in ["keep", "gone"] {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/{name}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("seed file");
+    }
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint the seed");
+    drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
+
+    // One delta run cancels a binding the base holds, a second delta run
+    // lands above it, and the floor moves past the cancellation.
+    let deleted = delete_path(&store, &namespace_id, "/docs/gone.txt", &context, None)
+        .await
+        .expect("delete");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint the delete");
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/docs/extra.txt",
+        b"body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write extra");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint the extra file");
+    advance_retention_floor(&store, &namespace_id, &context)
+        .await
+        .expect("advance the floor");
+    assert!(
+        read_floor_seq(&store, &namespace_id).await >= deleted.committed_seq,
+        "the floor must sit past the cancelling row for this test to mean anything"
+    );
+
+    let before = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load the manifest before the fold");
+    let (group, _) =
+        select_reorganization_window(&store, &namespace_id, MetadataLsmPolicy::default()).await;
+    assert!(
+        group.contains(&ApiMetadataTableFamily::DirentryUnbinds),
+        "this test is about the binding families, got {group:?}"
+    );
+    let base_rows = group_run_rows(&base_run(&before.manifest), &group);
+    let policy = policy_that_cannot_fold_the_base(base_rows);
+
+    let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
+    let input = selection.input.expect("the delta runs must still merge");
+    assert!(!input.starts_at_group_bottom);
+    assert!(input.runs.len() > 1);
+
+    let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+        .await
+        .expect("reorganization step");
+    assert!(
+        matches!(
+            report.outcome,
+            super::MetadataReorganizeOutcome::UnitPublished { .. }
+        ),
+        "expected a published unit, got {:?}",
+        report.outcome
+    );
+
+    let after = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load the manifest after the fold");
+    // A merge that skipped older runs drops nothing, so the row set is
+    // exactly what it was: the cancelling row still shadows the base's
+    // binding and the deleted file stays deleted.
+    assert!(
+        metadata_states_equivalent(&before.metadata_state, &after.metadata_state),
+        "a merge above the base must be a pure rewrite"
+    );
+    assert!(
+        !manifest_rows_for_family(
+            &after.metadata_state,
+            ApiMetadataTableFamily::DirentryUnbinds
+        )
+        .is_empty(),
+        "the cancelling row must survive the merge"
+    );
+    let projection = load_current_projection(&store, &namespace_id)
+        .await
+        .expect("materialization");
+    assert!(metadata_states_equivalent(
+        &projection.metadata_state,
+        &after.metadata_state
+    ));
+}
+
+/// Skipping is only ever legal at the recency bottom.
+///
+/// A run in the middle that busts the budget stops the window. The step
+/// refuses to reach past it for a newer run that would have fit, because a
+/// merge stamped at the manifest head lands above everything it left behind
+/// and would reorder the group.
+#[tokio::test]
+async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    write_file_and_checkpoint(&store, &namespace_id, &context, 1).await;
+    drain_reorganization(
+        &store,
+        &namespace_id,
+        &context,
+        MetadataLsmPolicy::default(),
+    )
+    .await;
+    // One wide delta run, then a narrow one above it.
+    for index in 2..=7 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/docs/file-{index}.txt"),
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write file");
+    }
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint the wide run");
+    write_file_and_checkpoint(&store, &namespace_id, &context, 8).await;
+
+    let before = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load the manifest");
+    let (group, _) =
+        select_reorganization_window(&store, &namespace_id, MetadataLsmPolicy::default()).await;
+    let base_rows = group_run_rows(&base_run(&before.manifest), &group);
+    let mut delta_rows = l0_runs(&before.manifest)
+        .iter()
+        .map(|run| group_run_rows(run, &group))
+        .collect::<Vec<_>>();
+    delta_rows.sort_unstable();
+    let (narrow, wide) = (delta_rows[0], delta_rows[1]);
+
+    // The budget admits the base run together with the narrow delta run,
+    // and rules out the wide one that sits between them. Reaching past the
+    // wide run is the illegal move this pins.
+    let row_budget = base_rows + narrow;
+    assert!(
+        row_budget < base_rows + wide && row_budget < wide,
+        "budget {row_budget} must exclude the wide run ({wide}) alone and beside the base ({base_rows})"
+    );
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(
+            usize::try_from(row_budget).expect("test row counts are small"),
+        )
+        .expect("test row budget should be nonzero"),
+        ..MetadataLsmPolicy::default()
+    };
+
+    let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
+    assert!(
+        selection.input.is_none(),
+        "no legal window exists; the selector must not assemble one across the wide run"
+    );
+    assert!(
+        selection.group_bottom_over_budget.is_none(),
+        "the base run fits here, so nothing should claim it does not"
+    );
+
+    let root_before = current_manifest_id(&store, &namespace_id).await;
+    let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+        .await
+        .expect("reorganization step");
+    assert!(
+        matches!(
+            report.outcome,
+            super::MetadataReorganizeOutcome::BudgetExhausted { .. }
+        ),
+        "expected a blocked step, got {:?}",
+        report.outcome
+    );
+    assert_eq!(
+        current_manifest_id(&store, &namespace_id).await,
+        root_before,
+        "a blocked step must not publish"
+    );
+}

--- a/docs/design/metadata-block-storage.md
+++ b/docs/design/metadata-block-storage.md
@@ -88,6 +88,13 @@ decoded row count, and decoded SST data-block bytes. Rows that no retained
 history can observe are dropped during the merge; runs no longer referenced
 by any retained manifest become garbage.
 
+A budget bounds one step, and it never stops a group. When the base run has
+grown past what one step may decode, the fold starts above it and merges the
+delta runs on their own, so the delta count keeps falling. That fold drops
+nothing — the drop rules read across the merged rows, and the base holds
+rows they would need — and the step says so in a warning naming the group,
+the base run's size, and the budget it crossed.
+
 ```
 checkpoints append:          reorganization folds, one group per step:
 
@@ -130,7 +137,9 @@ Two kinds of numbers appear above, with different contracts:
   compression and base segments target 65,536 rows; readers take
   whatever the descriptor and index describe, so both can be retuned
   without a format change.
-- **Reorganization budgets are writer-side defaults.** One step inspects at
+- **Reorganization budgets are writer-side defaults.** One step merges at
   most 8 complete runs and decodes at most 131,072 row payloads or 64 MiB of
-  SST data blocks. A manifest publish is the only progress record, so later
-  steps continue with the runs the prior publish left referenced.
+  SST data blocks. It weighs a few more runs than it merges when it has to
+  start above a base run that no longer fits. A manifest publish is the only
+  progress record, so later steps continue with the runs the prior publish
+  left referenced.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2017,9 +2017,17 @@ the rewrite selected.
 Compaction rewrites metadata runs (and, in the future, content layouts) into
 more efficient physical shapes.
 
-A base rebuild drops rows that no retained sequence can observe: bindings
-superseded or unbound at or below the retention floor, spent unbind markers,
-and commit receipts below the floor. The floor governs replay state only.
+A rebuild merges an oldest-first run of runs for one family group. It may
+skip runs at the oldest end that are too large to read inside one step's
+budget, and then it merges the runs above them; it never steps over a delta
+run, so its output is always older than every delta run it leaves behind. A
+rebuild that skipped runs drops nothing, because the rules below read across
+the merged rows and a skipped run may hold the other half of a pair.
+
+A base rebuild that starts at the group's oldest run drops rows that no
+retained sequence can observe: bindings superseded or unbound at or below the
+retention floor, spent unbind markers, and commit receipts below the floor.
+The floor governs replay state only.
 Revision rows are never dropped: file revision history is durable data,
 retained in full regardless of the floor, and a revisions listing is always
 complete. Tombstone rows — set and revoke events alike — and inode rows are
@@ -2034,8 +2042,8 @@ rebuild removes there are the cancelled pairs — a `removed` row and the
 `listed` row whose key it repeats, dropped together, since a deletion that was
 undeleted is not state any reader can still observe. A `removed` row can never
 outlive the row it names: the deletion commits before the undelete, runs merge
-oldest-first, and a rebuild's input is a prefix of that order, so both rows are
-always in the same merge.
+oldest-first, and a rebuild only drops rows when its input starts at the
+group's oldest run, so both rows are always in the same merge.
 
 The `attributes` family is folded by the same rule the retention floor gives
 every other superseded row, applied per inode: every revision above the floor


### PR DESCRIPTION
Fixes a liveness bug in metadata reorganization, found while investigating #525.

The bug: reorganization selects runs to merge oldest-first and stops at the first run that would exceed the per-step row or byte budget. If the group's oldest run (the base) is itself over the budget, selection stops immediately and selects nothing — and does the same on every later step. Delta runs then accumulate forever, read fan-out grows, and nothing reports why.

The fix: selection can now start its window after base-tier runs that do not fit, so the delta runs still get merged with each other. Two restrictions keep this correct:

1. The window can only skip base-tier runs, never a delta run. The merged output is written at base tier, which sorts below all delta runs, so skipping a delta run would reorder rows relative to it.
2. Retention only drops rows when the window starts at the group's oldest run. The drop rules work on pairs: an unbind cancels a bind, and a removal marker cancels a listed deletion. A window that starts above the base can contain one half of a pair without the other, and dropping the canceling half would un-delete a file. A merge that skipped runs is now a pure rewrite of its inputs.

When a base run exceeds the budget, the step logs a warning naming the group, the run's rows and bytes, and both budget values.

format.md section 6.2 is updated. The old text said a rebuild's input is always a prefix of the run order, which is no longer true. The new text states the actual rule: drops only happen when the input starts at the oldest run.

Known limitation, not addressed here: nothing splits a family group, so the row budget (131,072) is an upper bound on how large a group's base run can get before it stops being foldable. The revisions group reaches that at roughly 65,500 revisions and stays there, since revision rows are never dropped. Fixing that requires a multi-step fold with a cursor; filed as follow-up work.

Tests: three new tests cover the stuck-selection case, the pair-splitting case, and a middle run over the budget. Reverting the selection change fails the first; reverting the retention restriction fails the second by un-deleting a file. 1668 passed, 0 failed; clippy, fmt, and openapi checks pass; goldens unchanged.
