### PR TITLE
fix(gc): grace protects readers from unreferencing, not from write time

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -603,6 +603,12 @@ pub struct RetainedCandidates {
     /// Unreachable, and the provider reported no last-modified time at all,
     /// so the object's age is unknown and it is treated as young.
     pub no_provider_timestamp: u64,
+    /// Unreachable, but this namespace published no manifest old enough to
+    /// say what it referenced when the grace window opened, so nothing
+    /// proves the object was already unreferenced then. A reader that pinned
+    /// its anchor inside the window may still be reading it, and the pass
+    /// keeps it until a manifest ages past the window.
+    pub no_reference_manifest: u64,
     /// Root resolution failed somewhere in this pass, so manifest and table
     /// deletion was suppressed wholesale (`degraded_retention` is set too).
     pub degraded_roots: u64,
@@ -767,6 +773,8 @@ pub enum RetainedReason {
     GraceWindow,
     /// Counts into [`RetainedCandidates::no_provider_timestamp`].
     NoProviderTimestamp,
+    /// Counts into [`RetainedCandidates::no_reference_manifest`].
+    NoReferenceManifest,
     /// Counts into [`RetainedCandidates::degraded_roots`].
     DegradedRoots,
     /// Counts into [`RetainedCandidates::unrecognized_key`].
@@ -787,6 +795,7 @@ impl RetainedReason {
             Self::Referenced => &mut retained.referenced,
             Self::GraceWindow => &mut retained.grace_window,
             Self::NoProviderTimestamp => &mut retained.no_provider_timestamp,
+            Self::NoReferenceManifest => &mut retained.no_reference_manifest,
             Self::DegradedRoots => &mut retained.degraded_roots,
             Self::UnrecognizedKey => &mut retained.unrecognized_key,
             Self::CheckpointNotReleasable => &mut retained.checkpoint_not_releasable,
@@ -800,11 +809,12 @@ impl RetainedReason {
 impl RetainedCandidates {
     /// Every reason and its count, in a fixed order, for callers that
     /// report the breakdown rather than read one field of it.
-    pub fn by_reason(&self) -> [(&'static str, u64); 9] {
+    pub fn by_reason(&self) -> [(&'static str, u64); 10] {
         [
             ("referenced", self.referenced),
             ("grace_window", self.grace_window),
             ("no_provider_timestamp", self.no_provider_timestamp),
+            ("no_reference_manifest", self.no_reference_manifest),
             ("degraded_roots", self.degraded_roots),
             ("unrecognized_key", self.unrecognized_key),
             ("checkpoint_not_releasable", self.checkpoint_not_releasable),
@@ -819,6 +829,7 @@ impl RetainedCandidates {
         self.referenced += other.referenced;
         self.grace_window += other.grace_window;
         self.no_provider_timestamp += other.no_provider_timestamp;
+        self.no_reference_manifest += other.no_reference_manifest;
         self.degraded_roots += other.degraded_roots;
         self.unrecognized_key += other.unrecognized_key;
         self.checkpoint_not_releasable += other.checkpoint_not_releasable;

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -4209,6 +4209,7 @@ fn admin_store_probe_reports_every_check_against_the_profile_store() {
         "compare_and_swap_missing_object_rejected",
         "overwrite_updates_head_and_body",
         "get_with_metadata_round_trip",
+        "head_reports_last_modified",
         "visibility_after_write",
         "visibility_after_delete",
         "delete_missing_idempotent",
@@ -4220,13 +4221,13 @@ fn admin_store_probe_reports_every_check_against_the_profile_store() {
     ] {
         assert!(text.contains(check), "missing `{check}` in: {text}");
     }
-    assert!(text.contains("13 checks passed"), "{text}");
+    assert!(text.contains("14 checks passed"), "{text}");
 
     let json = harness.run(&["--json", "admin", "store-probe"]);
     assert_success(&json);
     let data = json_data(&json);
     assert_eq!(data["kind"], "store_probed");
-    assert_eq!(data["checks"].as_array().expect("checks array").len(), 13);
+    assert_eq!(data["checks"].as_array().expect("checks array").len(), 14);
     assert_eq!(data["checks"][0]["name"], "create_if_absent_enforced");
     assert_eq!(data["checks"][0]["outcome"], "passed");
 
@@ -5145,7 +5146,7 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_eq!(probe_data["kind"], "store_probed");
         assert_eq!(
             probe_data["checks"].as_array().expect("checks array").len(),
-            13
+            14
         );
 
         shapes_by_mode.push((

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -3,7 +3,7 @@
 
 use super::budget::PassBudget;
 use super::fork_checkpoints::fork_target_proven_gone;
-use super::reap::lease_expired;
+use super::reap::{lease_expired, manifest_object_id_of};
 use crate::checkpoint::load_namespace_manifest_envelope_if_present;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
@@ -17,8 +17,10 @@ use loonfs_api::wire::control::{
     ControlObjectKind, NamespaceState,
 };
 use loonfs_api::wire::wal::WalDelta;
-use loonfs_api::{ContentId, ManifestObjectId, NamespaceId};
-use loonfs_objectstore::keys::{checkpoint_prefix, metadata_manifest_object};
+use loonfs_api::{wal_segment_id_start_seq, ChangeSeq, ContentId, ManifestObjectId, NamespaceId};
+use loonfs_objectstore::keys::{
+    checkpoint_prefix, metadata_manifest_object, metadata_manifest_prefix, wal_segment_id_from_key,
+};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
@@ -44,6 +46,106 @@ pub(super) struct LiveSet {
     pub(super) degraded: bool,
     /// The inspected namespace head is the terminal, absorbing tombstone.
     pub(super) namespace_deleted: bool,
+    /// What this pass knows about the references this namespace held when
+    /// the grace window opened.
+    pub(super) anchor: ReferenceAnchor,
+}
+
+impl LiveSet {
+    /// Whether anything still protects one WAL segment key.
+    ///
+    /// The current chain protects what a read at this instant replays; the
+    /// reference anchor protects what a read pinned earlier in the grace
+    /// window replays, which is every segment above the anchor's own head.
+    pub(super) fn protects_wal_segment(&self, key: &str) -> bool {
+        self.wal_segments.contains(key) || self.anchor.replays_wal_segment(key)
+    }
+}
+
+/// The reference manifest and what it named — the pass's evidence about
+/// which objects this namespace referenced a grace window ago.
+///
+/// The grace window exists to protect a reader that pinned an anchor (a head
+/// and the basis manifest under it) and is still reading through it. Aging an
+/// unreferenced object by its own write time protects the wrong thing: a
+/// table written yesterday and superseded by a fold one second ago has
+/// already outlived any window, so it is reaped while the reader that pinned
+/// the anchor just before the fold is still reading it. The window has to run
+/// from the moment an object stopped being referenced, and nothing durable
+/// records that moment.
+///
+/// Manifests record it collectively. Each one is a timestamped snapshot of
+/// what the namespace referenced when it was published, so the newest
+/// manifest published at least a grace window ago says what was referenced
+/// when the window opened. Call it R. An object is reaped only when the
+/// current live set, R, and the object's own write time all agree it is
+/// unreferenced:
+///
+/// 1. it is not reachable now,
+/// 2. R did not name it,
+/// 3. its provider write time is a grace window old.
+///
+/// **The theorem.** Take a reader that pinned a head at any instant T inside
+/// the last grace window. It can only reference what the namespace
+/// referenced at T. If the object was written after the window opened, arm 3
+/// keeps it. Otherwise it was written before, so the publication that first
+/// referenced it had already landed by T — publications self-enforce a
+/// budget below the grace floor (`limits::GC_MIN_GRACE_WINDOW_MS`) — and
+/// references only start at a publication. Its reference span is one
+/// interval: manifests are built on their immediate predecessor
+/// (`checkpoint/publish.rs`) and every id is freshly generated, so an object
+/// that leaves a file set never re-enters one. R's publication falls inside
+/// that span, because it is at or before the window's opening and the object
+/// was still referenced at T. So R named it, and arm 2 keeps it. Either way
+/// the reader's object survives the pass.
+///
+/// R protects itself, so the anchor cannot be swept out from under the
+/// namespace: it is in its own reference set, and it stops being the anchor
+/// only once a newer manifest has aged past the window in its place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ReferenceAnchor {
+    /// R, with everything it named.
+    Manifest(Box<AnchoredManifest>),
+    /// This namespace has never published a manifest, so no publication has
+    /// ever stopped referencing anything: everything a reader could hold is
+    /// the WAL chain from the namespace's birth, which the floor cannot have
+    /// advanced past without a root. Or the namespace is the terminal
+    /// tombstone, which no read can reach at all. Aged candidates are debris
+    /// either way, and the pass reaps them.
+    NotNeeded,
+    /// Manifests exist but none has aged past the window, so nothing proves
+    /// an unreferenced object was already unreferenced when the window
+    /// opened. The pass keeps every aged candidate instead of guessing.
+    Missing,
+}
+
+/// One reference manifest, reduced to what a sweep decision asks of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AnchoredManifest {
+    manifest_object_id: ManifestObjectId,
+    /// Greatest sequence the anchor materialized. A read pinned on it
+    /// replays every segment above this, and a manifest always materializes
+    /// through the end of a committed segment, so nothing above it is reaped.
+    head_seq: ChangeSeq,
+    /// Object keys of the metadata tables the anchor named.
+    tables: BTreeSet<String>,
+}
+
+impl ReferenceAnchor {
+    /// Whether the pass may reap an aged, unreferenced candidate at all.
+    pub(super) fn proves_unreferencing(&self) -> bool {
+        !matches!(self, Self::Missing)
+    }
+
+    /// Whether a read pinned on the anchor still replays this segment.
+    fn replays_wal_segment(&self, key: &str) -> bool {
+        let Self::Manifest(anchor) = self else {
+            return false;
+        };
+        wal_segment_id_from_key(key)
+            .and_then(wal_segment_id_start_seq)
+            .is_some_and(|start_seq| start_seq > anchor.head_seq)
+    }
 }
 
 /// What one collection produced. Marking is all or nothing: a partial root
@@ -96,11 +198,27 @@ impl SweepVerifier {
         &mut self,
         store: &S,
         namespace_id: &NamespaceId,
+        grace_window_ms: u64,
         budget: &mut PassBudget,
         context: &MutationContext,
     ) -> Result<SweepStep> {
         if self.decided_since_collect >= self.reverify_chunk {
-            match recollect_live_set(store, namespace_id, budget, context).await? {
+            // The anchor is a fact about the past, so a re-collection reuses
+            // the one the pass opened with rather than paying for it again.
+            // Nothing inside a pass can change it: the pass's clock is
+            // fixed, a manifest published while it runs is young, and the
+            // anchor is protected from the pass's own sweep.
+            let anchor = self.live.anchor.clone();
+            match recollect_live_set(
+                store,
+                namespace_id,
+                grace_window_ms,
+                Some(anchor),
+                budget,
+                context,
+            )
+            .await?
+            {
                 LiveSetCollection::Complete(live) => {
                     self.live = Arc::new(live);
                     self.degraded |= self.live.degraded;
@@ -124,6 +242,8 @@ impl SweepVerifier {
 pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    grace_window_ms: u64,
+    anchor: Option<ReferenceAnchor>,
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> Result<LiveSetCollection> {
@@ -133,7 +253,16 @@ pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
     let loaded = read_head_and_metadata_basis(store, namespace_id)
         .await
         .map_err(CoreError::load_head)?;
-    collect_live_set(store, namespace_id, &loaded, budget, context).await
+    collect_live_set(
+        store,
+        namespace_id,
+        &loaded,
+        grace_window_ms,
+        anchor,
+        budget,
+        context,
+    )
+    .await
 }
 
 /// Collects from the head and basis the pass already read and charged for.
@@ -141,6 +270,8 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     loaded: &LoadedNamespaceBasis,
+    grace_window_ms: u64,
+    reused_anchor: Option<ReferenceAnchor>,
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> Result<LiveSetCollection> {
@@ -177,6 +308,7 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
         missing_basis_records: BTreeSet::new(),
         degraded: false,
         namespace_deleted,
+        anchor: ReferenceAnchor::NotNeeded,
     };
     // Terminal namespaces forget (format spec, rule 4): the tombstone pair
     // and the root/floor pointers survive as non-candidates, but nothing
@@ -314,6 +446,28 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
         }
     }
 
+    // The second anchor: what this namespace referenced a grace window ago.
+    // A terminal namespace needs none — no read can reach a tombstone, and
+    // its whole tree is meant to age out.
+    let selected = match (namespace_deleted, reused_anchor) {
+        (true, _) => Some(ReferenceAnchor::NotNeeded),
+        (false, Some(anchor)) => Some(anchor),
+        (false, None) => {
+            select_reference_anchor(store, namespace_id, grace_window_ms, budget, context).await?
+        }
+    };
+    let Some(anchor) = selected else {
+        return Ok(LiveSetCollection::BudgetExhausted);
+    };
+    live.anchor = anchor;
+    // The anchor roots what it named exactly as the current root does. Its
+    // own key goes in too, so the pass cannot sweep away the evidence the
+    // next pass needs.
+    if let ReferenceAnchor::Manifest(anchor) = &live.anchor {
+        live.manifests.insert(anchor.manifest_object_id.clone());
+        live.tables.extend(anchor.tables.iter().cloned());
+    }
+
     // Keep every WAL segment needed to replay from the floor through the
     // head. The floor never passes the root's basis, so this also covers
     // root-to-head replay (rule 7). A terminal namespace has no replay
@@ -372,4 +526,97 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     }
 
     Ok(LiveSetCollection::Complete(live))
+}
+
+/// Finds the reference manifest R and reads what it named.
+///
+/// Manifest keys sort by logical manifest position, which is publication
+/// order, so the scan walks the listing from the oldest manifest and stops at
+/// the first one the window still covers. The last aged manifest before that
+/// is R. Stopping at the first young one rather than taking the newest aged
+/// timestamp is the conservative reading of a provider clock: one manifest
+/// reporting an early stamp cannot pull the anchor forward past a manifest
+/// that reads as young.
+///
+/// The age test is the sweep's own (`gc/reap.rs`), on the same provider
+/// timestamp, so a manifest with no timestamp reads as young here exactly as
+/// a candidate without one does there.
+///
+/// `None` reports that the budget ran out. A pass that cannot pay for this
+/// has no root set at all, the same as any other partial collection.
+async fn select_reference_anchor<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    grace_window_ms: u64,
+    budget: &mut PassBudget,
+    context: &MutationContext,
+) -> Result<Option<ReferenceAnchor>> {
+    let prefix = metadata_manifest_prefix(namespace_id.as_str());
+    let mut keys = store.list_prefix_stream(&prefix);
+    let mut published_any = false;
+    let mut aged = None;
+    while let Some(item) = keys.next().await {
+        let key = item.map_err(|error| CoreError::store(&prefix, &error))?;
+        // Keys this collector does not recognize are never manifests of
+        // its own, so they neither anchor the pass nor end the scan.
+        let Some(Ok(manifest_object_id)) = manifest_object_id_of(&key) else {
+            continue;
+        };
+        published_any = true;
+        if !budget.try_charge() {
+            return Ok(None);
+        }
+        let Some(metadata) = store
+            .head(&key)
+            .await
+            .map_err(|error| CoreError::store(&key, &error))?
+        else {
+            continue;
+        };
+        let aged_out = metadata.last_modified_ms.is_some_and(|written_at_ms| {
+            context.now_ms.saturating_sub(written_at_ms) >= grace_window_ms
+        });
+        if !aged_out {
+            break;
+        }
+        aged = Some((manifest_object_id, key));
+    }
+
+    let Some((manifest_object_id, key)) = aged else {
+        // Nothing published, nothing unreferenced: a namespace with no
+        // manifest of its own has never taken an object out of a file set,
+        // and its floor cannot have advanced past its birth without a root.
+        return Ok(Some(match published_any {
+            true => ReferenceAnchor::Missing,
+            false => ReferenceAnchor::NotNeeded,
+        }));
+    };
+    if !budget.try_charge() {
+        return Ok(None);
+    }
+    // A manifest that will not load is no evidence. Retaining is what the
+    // pass does with every root it cannot resolve.
+    let Ok(Some(manifest)) =
+        load_namespace_manifest_envelope_if_present(store, namespace_id, &manifest_object_id, &key)
+            .await
+    else {
+        tracing::debug!(
+            namespace_id = %namespace_id,
+            object_key = key,
+            "the reference manifest did not load; retaining every aged candidate"
+        );
+        return Ok(Some(ReferenceAnchor::Missing));
+    };
+    Ok(Some(ReferenceAnchor::Manifest(Box::new(
+        AnchoredManifest {
+            manifest_object_id,
+            head_seq: manifest.payload.head_seq,
+            tables: manifest
+                .payload
+                .metadata_files
+                .iter()
+                .map(|file| file.object_key.clone())
+                .collect(),
+        },
+    ))))
 }

--- a/crates/loonfs-core/src/gc/mod.rs
+++ b/crates/loonfs-core/src/gc/mod.rs
@@ -7,6 +7,12 @@
 //! publish or checkpoint creation. The grace window, delete-time
 //! re-verification, and retain-on-ambiguity defaults close those races. When
 //! in doubt, this module retains.
+//!
+//! Readers do not coordinate with it either. A read pins a head and the
+//! basis manifest under it and then keeps reading through that pair, so the
+//! grace window has to run from the moment an object stopped being
+//! referenced rather than from the moment it was written. The reference
+//! anchor in `live_set.rs` is what dates that moment.
 
 mod budget;
 mod config;

--- a/crates/loonfs-core/src/gc/reap.rs
+++ b/crates/loonfs-core/src/gc/reap.rs
@@ -4,6 +4,12 @@
 //! they were written. Checkpoint records do not: their lifecycle instants
 //! (`created_at_ms`, `expires_at_ms`, `released_at_ms`) live in the record,
 //! so no checkpoint state transition depends on object metadata.
+//!
+//! A write time is when an object appeared, not when it stopped being
+//! referenced, and those are the same instant only for an object nothing
+//! ever referenced. The namespace sweep therefore asks this module for the
+//! age and decides the rest itself, from the reference anchor in
+//! `gc/live_set.rs`.
 
 use crate::checkpoint::record::encode_checkpoint_record;
 use crate::context::MutationContext;
@@ -148,30 +154,74 @@ impl AgedSweep {
     }
 }
 
+/// Where one unreferenced candidate stands against the grace window, before
+/// anything acts on the answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GraceAge {
+    /// The window has passed over the object.
+    Aged,
+    /// Younger than the window by its own provider timestamp.
+    Young,
+    /// The provider reported no last-modified time, so the object's age is
+    /// unknown and it is treated as young (rule 1).
+    Unknown,
+    /// The object is not there any more.
+    Gone,
+}
+
+/// Reads how one candidate stands against the grace window.
+///
+/// Store failures surface unmapped so each collector keeps its own error
+/// vocabulary; everything about the reading itself — which timestamp, what
+/// an absent one means, what the window is measured against — is the same
+/// wherever objects age out, so it is decided once here. What being aged
+/// entitles a candidate to is the caller's question: the namespace sweep
+/// wants durable evidence of when the object stopped being referenced as
+/// well (`gc/live_set.rs`, `ReferenceAnchor`).
+pub(super) async fn grace_age<S: ObjectStore + ?Sized>(
+    store: &S,
+    key: &str,
+    grace_window_ms: u64,
+    now_ms: u64,
+) -> std::result::Result<GraceAge, ObjectStoreError> {
+    let Some(metadata) = store.head(key).await? else {
+        return Ok(GraceAge::Gone);
+    };
+    let Some(last_modified_ms) = metadata.last_modified_ms else {
+        return Ok(GraceAge::Unknown);
+    };
+    Ok(
+        match now_ms.saturating_sub(last_modified_ms) < grace_window_ms {
+            true => GraceAge::Young,
+            false => GraceAge::Aged,
+        },
+    )
+}
+
 /// Deletes one unreferenced candidate if the grace window has passed over
 /// it, and says what it decided otherwise.
 ///
-/// Store failures surface unmapped so each collector keeps its own error
-/// vocabulary; everything about the decision itself — which timestamp, what
-/// an absent one means, what the window is measured against — is the same
-/// wherever objects age out, so it is decided once here.
+/// This is the whole decision where the window's only job is to cover a
+/// write that may still be publishing: install debris a repair proved
+/// non-completable, and the keyspaces extensions collect for themselves.
+/// Where an object can also stop being referenced while something is still
+/// reading it, the window has to run from that moment instead, and the
+/// namespace sweep is what works out when it was.
 pub async fn delete_if_aged<S: ObjectStore + ?Sized>(
     store: &S,
     key: &str,
     grace_window_ms: u64,
     now_ms: u64,
 ) -> std::result::Result<AgedSweep, ObjectStoreError> {
-    let Some(metadata) = store.head(key).await? else {
-        return Ok(AgedSweep::AlreadyGone);
-    };
-    let Some(last_modified_ms) = metadata.last_modified_ms else {
-        return Ok(AgedSweep::RetainedWithoutTimestamp);
-    };
-    if now_ms.saturating_sub(last_modified_ms) < grace_window_ms {
-        return Ok(AgedSweep::RetainedInGraceWindow);
+    match grace_age(store, key, grace_window_ms, now_ms).await? {
+        GraceAge::Gone => Ok(AgedSweep::AlreadyGone),
+        GraceAge::Unknown => Ok(AgedSweep::RetainedWithoutTimestamp),
+        GraceAge::Young => Ok(AgedSweep::RetainedInGraceWindow),
+        GraceAge::Aged => {
+            store.delete(key).await?;
+            Ok(AgedSweep::Deleted)
+        }
     }
-    store.delete(key).await?;
-    Ok(AgedSweep::Deleted)
 }
 
 pub(super) fn manifest_object_id_of(

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -9,7 +9,7 @@ use super::fork_checkpoints::{
 };
 use super::live_set::{collect_live_set, LiveSet, LiveSetCollection, SweepStep, SweepVerifier};
 use super::reap::{
-    delete_if_aged, manifest_object_id_of, sweep_checkpoint_record, CheckpointSweep,
+    grace_age, manifest_object_id_of, sweep_checkpoint_record, CheckpointSweep, GraceAge,
 };
 use super::uploads::{sweep_upload_session, ContentReferences, UploadSessionSweep};
 use crate::context::MutationContext;
@@ -71,7 +71,17 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
 
     // Every invocation rebuilds all roots before interpreting the cursor.
     // The cursor can skip enumeration only; it never carries safety state.
-    let mark = match collect_live_set(store, namespace_id, &loaded, &mut budget, context).await? {
+    let mark = match collect_live_set(
+        store,
+        namespace_id,
+        &loaded,
+        config.grace_window_ms,
+        None,
+        &mut budget,
+        context,
+    )
+    .await?
+    {
         LiveSetCollection::Complete(live) => Arc::new(live),
         // The pass has no root set, so it may not decide any candidate. It
         // deletes nothing and hands back the token it was given, because it
@@ -233,11 +243,11 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         return Ok(SweepStep::Continue);
     }
 
-    // Preserve the existing mark selection exactly: objects reachable from
-    // the invocation's root snapshot are skipped, while every selected
-    // candidate is re-verified immediately before its decision.
+    // Objects reachable from the invocation's root snapshot — either
+    // anchor's — are skipped, while every selected candidate is re-verified
+    // immediately before its decision.
     let selected = match family {
-        CandidateFamily::WalSegments => !mark.wal_segments.contains(key),
+        CandidateFamily::WalSegments => !mark.protects_wal_segment(key),
         CandidateFamily::MetadataTables => !mark.tables.contains(key),
         CandidateFamily::Manifests => match manifest_object_id_of(key) {
             Some(Ok(id)) => !mark.manifests.contains(&id),
@@ -251,7 +261,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     }
 
     if sweep
-        .refresh_if_due(store, namespace_id, budget, context)
+        .refresh_if_due(store, namespace_id, config.grace_window_ms, budget, context)
         .await?
         == SweepStep::BudgetExhausted
     {
@@ -262,9 +272,9 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     // split only so a retention can say which half of the condition held.
     match family {
         CandidateFamily::WalSegments => {
-            if sweep.live.wal_segments.contains(key) {
+            if sweep.live.protects_wal_segment(key) {
                 report.retain(RetainedReason::Referenced);
-            } else if sweep_aged(store, key, config, context, report).await? {
+            } else if sweep_aged(store, key, config, context, sweep, report).await? {
                 report.deleted_wal_segments += 1;
             }
         }
@@ -274,7 +284,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
                 report.retain(RetainedReason::DegradedRoots);
             } else if sweep.live.tables.contains(key) {
                 report.retain(RetainedReason::Referenced);
-            } else if sweep_aged(store, key, config, context, report).await? {
+            } else if sweep_aged(store, key, config, context, sweep, report).await? {
                 report.deleted_metadata_tables += 1;
             }
         }
@@ -287,7 +297,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
                         report.retain(RetainedReason::Referenced);
                     }
                     Some(Ok(_)) => {
-                        if sweep_aged(store, key, config, context, report).await? {
+                        if sweep_aged(store, key, config, context, sweep, report).await? {
                             report.deleted_manifests += 1;
                         }
                     }
@@ -309,20 +319,48 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
 /// Ages one unreferenced key out, recording the reason when it stays.
 /// Answers whether the key was deleted, so each family still counts its own
 /// deletions.
+///
+/// Two things have to hold before the key goes. The object's own write time
+/// has to be a grace window old, which is what protects a publication still
+/// in flight and every object the reference anchor predates. And the
+/// reference anchor has to say the object was already unreferenced when the
+/// window opened, which is what protects a reader still holding an anchor it
+/// pinned inside the window. A pass with no anchor cannot answer the second
+/// question, so it keeps every aged candidate and says so.
 async fn sweep_aged<S: ObjectStore + ?Sized>(
     store: &S,
     key: &str,
     config: &GcConfig,
     context: &MutationContext,
+    sweep: &SweepVerifier,
     report: &mut GcResponse,
 ) -> Result<bool> {
-    let outcome = delete_if_aged(store, key, config.grace_window_ms, context.now_ms)
+    match grace_age(store, key, config.grace_window_ms, context.now_ms)
+        .await
+        .map_err(|error| CoreError::store(key, &error))?
+    {
+        // Nothing was decided about a key that is already gone, so nothing
+        // is counted for it either.
+        GraceAge::Gone => return Ok(false),
+        GraceAge::Young => {
+            report.retain(RetainedReason::GraceWindow);
+            return Ok(false);
+        }
+        GraceAge::Unknown => {
+            report.retain(RetainedReason::NoProviderTimestamp);
+            return Ok(false);
+        }
+        GraceAge::Aged if !sweep.live.anchor.proves_unreferencing() => {
+            report.retain(RetainedReason::NoReferenceManifest);
+            return Ok(false);
+        }
+        GraceAge::Aged => {}
+    }
+    store
+        .delete(key)
         .await
         .map_err(|error| CoreError::store(key, &error))?;
-    if let Some(reason) = outcome.retained_reason() {
-        report.retain(reason);
-    }
-    Ok(outcome.deleted())
+    Ok(true)
 }
 
 async fn process_checkpoint<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -86,7 +86,7 @@ async fn marked<S: ObjectStore + ?Sized>(
     context: &MutationContext,
 ) -> (LiveSet, u64) {
     let mut budget = PassBudget::new(None);
-    let live = recollect_live_set(store, namespace_id, &mut budget, context)
+    let live = recollect_live_set(store, namespace_id, GRACE_MS, None, &mut budget, context)
         .await
         .expect("collect live set")
         .complete()
@@ -1760,6 +1760,130 @@ async fn gc_retains_everything_inside_the_grace_window() {
     stat_root(&store, &namespace_id).await;
 }
 
+/// Every object under the namespace, as the keys stand right now.
+async fn namespace_key_set(store: &LocalFsStore, namespace_id: &NamespaceId) -> BTreeSet<String> {
+    store
+        .list_prefix(&loonfs_objectstore::keys::namespace_prefix(namespace_id))
+        .await
+        .expect("list namespace")
+        .into_iter()
+        .collect()
+}
+
+/// Reports every object written before this point as ancient, leaving
+/// everything written after it with its real age.
+///
+/// Real filesystem stamps put a whole fixture inside the same millisecond,
+/// so a test that needs "written long ago" and "written just now" in one
+/// namespace has to say which is which itself.
+fn aged_before_now(
+    inner: LocalFsStore,
+    already_written: BTreeSet<String>,
+) -> MetadataMapStore<LocalFsStore> {
+    MetadataMapStore::aged(
+        inner,
+        KeyPredicate::new(move |key| already_written.contains(key)),
+    )
+}
+
+/// Folds the L0 runs into fresh base segments, which is what leaves the
+/// previous run tables unreferenced.
+async fn fold_metadata<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) {
+    let fold_policy = crate::checkpoint::MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        ..Default::default()
+    };
+    let mut folded = false;
+    for _ in 0..16 {
+        let report =
+            crate::checkpoint::reorganize_metadata_step(store, namespace_id, context, fold_policy)
+                .await
+                .expect("reorganize step");
+        if matches!(
+            report.outcome,
+            crate::checkpoint::MetadataReorganizeOutcome::NotNeeded { .. }
+        ) {
+            folded = true;
+            break;
+        }
+    }
+    assert!(folded, "the fold must reach a steady state");
+}
+
+/// The whole point of the reference anchor: a read that pinned its anchor
+/// before a fold is still reading through it afterwards, and the grace
+/// window is what that read is owed.
+///
+/// The tables here are old by write time and unreferenced by the fold, which
+/// is exactly the pair that used to make them collectable on the spot. They
+/// stay until a grace window has passed since the fold, and then they go —
+/// protecting a reader must not turn into never reclaiming.
+#[tokio::test]
+async fn a_read_pinned_before_a_fold_still_reads_after_the_sweep() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    for round in 0..3 {
+        write_test_file(
+            &inner,
+            &namespace_id,
+            &format!("/docs/file-{round}.txt"),
+            &format!("gc-anchor-{round}"),
+            &setup,
+        )
+        .await;
+        crate::checkpoint::flush_wal(&inner, &namespace_id, &setup)
+            .await
+            .expect("flush wal");
+    }
+    // Everything the namespace holds at this point is a grace window old;
+    // the fold below writes the only young objects.
+    let before_fold = namespace_key_set(&inner, &namespace_id).await;
+    let store = aged_before_now(inner, before_fold);
+
+    let pinned = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+        .await
+        .expect("pin a read anchor");
+
+    fold_metadata(&store, &namespace_id, &setup).await;
+
+    let after_fold = context(now_after_newest_object(store.inner(), &namespace_id, 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &after_fold)
+        .await
+        .expect("gc pass right after the fold");
+
+    // The read is the assertion that matters: it reaches for its tables
+    // after the sweep has been over them.
+    pinned
+        .resolve_path("/docs/file-0.txt", AttributeProjection::Omit)
+        .await
+        .expect("the pinned anchor still resolves through its own tables");
+    assert_eq!(
+        report.deleted_metadata_tables, 0,
+        "the fold unreferenced these tables a moment ago, not a grace window ago"
+    );
+
+    // A grace window after the fold, the anchor moves on to the folded
+    // manifest and the superseded tables are collectable.
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect("gc pass a grace window after the fold");
+    assert!(
+        report.deleted_metadata_tables > 0,
+        "folded-away tables must still be reclaimed, one window later"
+    );
+    stat_root(&store, &namespace_id).await;
+}
+
 /// Every reason's count, summed — what `retained_candidates` must equal.
 fn reason_total(report: &GcResponse) -> u64 {
     report
@@ -1768,6 +1892,173 @@ fn reason_total(report: &GcResponse) -> u64 {
         .into_iter()
         .map(|(_, count)| count)
         .sum()
+}
+
+/// The write-time arm is what covers an object the reference manifest
+/// predates: it was written after the anchor, so the anchor cannot be asked
+/// about it, and only its own age says anything. Once that age passes and
+/// neither anchor names it, it goes.
+#[tokio::test]
+async fn an_object_the_anchor_predates_is_kept_by_its_own_age_alone() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&inner, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    crate::checkpoint::flush_wal(&inner, &namespace_id, &setup)
+        .await
+        .expect("flush wal");
+
+    // The namespace ages past the window; the orphan below is written after
+    // it, so no manifest can ever have named it.
+    let published = namespace_key_set(&inner, &namespace_id).await;
+    let store = aged_before_now(inner, published);
+    let orphan_key = metadata_table(
+        namespace_id.as_str(),
+        "tbl_0123456789abcdef0123456789abcdef",
+    );
+    store
+        .put_if_absent(&orphan_key, Bytes::from_static(b"orphan table"))
+        .await
+        .expect("write an unreferenced table");
+
+    let young = context(now_after_newest_object(store.inner(), &namespace_id, 0).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &young)
+        .await
+        .expect("gc pass while the orphan is young");
+    assert_eq!(report.deleted_metadata_tables, 0);
+    assert_eq!(
+        report.retained.grace_window, 1,
+        "the orphan is kept by its own write time, and the pass says so"
+    );
+    assert_eq!(report.retained.no_reference_manifest, 0);
+
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect("gc pass once the orphan has aged");
+    assert_eq!(report.deleted_metadata_tables, 1);
+    assert!(store
+        .head(&orphan_key)
+        .await
+        .expect("head orphan")
+        .is_none());
+}
+
+/// A namespace whose manifests are all younger than the window has nothing
+/// that says what it referenced when the window opened. The pass keeps every
+/// aged candidate and names the reason, rather than reaping against evidence
+/// it does not have.
+#[tokio::test]
+async fn a_pass_with_no_aged_manifest_reaps_nothing_and_says_why() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&inner, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    crate::checkpoint::flush_wal(&inner, &namespace_id, &setup)
+        .await
+        .expect("flush wal");
+    let orphan_key = metadata_table(
+        namespace_id.as_str(),
+        "tbl_0123456789abcdef0123456789abcdef",
+    );
+    inner
+        .put_if_absent(&orphan_key, Bytes::from_static(b"orphan table"))
+        .await
+        .expect("write an unreferenced table");
+
+    // Only the orphan is old: the manifests are all inside the window, so
+    // the pass has no anchor to reason from.
+    let store = aged_before_now(inner, BTreeSet::from([orphan_key.clone()]));
+    let young = context(now_after_newest_object(store.inner(), &namespace_id, 0).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &young)
+        .await
+        .expect("gc pass with no aged manifest");
+
+    assert_eq!(report.deleted_metadata_tables, 0);
+    assert_eq!(report.deleted_wal_segments, 0);
+    assert_eq!(report.deleted_manifests, 0);
+    assert_eq!(
+        report.retained.no_reference_manifest, 1,
+        "the aged orphan is the one candidate the missing anchor spared"
+    );
+    assert_eq!(reason_total(&report), report.retained_candidates);
+    assert!(store
+        .head(&orphan_key)
+        .await
+        .expect("head orphan")
+        .is_some());
+
+    // Once a manifest ages past the window, the same orphan is collectable.
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect("gc pass once a manifest anchors it");
+    assert_eq!(report.deleted_metadata_tables, 1);
+    assert_eq!(report.retained.no_reference_manifest, 0);
+}
+
+/// A budget that runs out while the anchor is still being established buys
+/// nothing at all. Reaping needs both anchors, and half a root set is not a
+/// smaller answer, it is no answer.
+#[tokio::test]
+async fn a_budget_that_dies_before_the_anchor_sweeps_nothing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
+    let orphan_key = wal_segment(
+        namespace_id.as_str(),
+        "00000000000000000000-0123456789abcdef",
+    );
+    inner
+        .put_if_absent(&orphan_key, Bytes::from_static(b"orphan"))
+        .await
+        .expect("write an unreferenced segment");
+
+    let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
+    let (live, marking) = marked(&inner, &namespace_id, &aged).await;
+    let chain_units = u64::try_from(live.wal_segments.len()).expect("segment count fits");
+    // One unit short of reading the reference manifest, which is the last
+    // thing marking pays for before the chain.
+    let mut starved = config();
+    starved.max_objects = Some(marking - chain_units - 1);
+    let report = gc_namespace(&inner, &namespace_id, &starved, &aged)
+        .await
+        .expect("pass that could not finish its anchor");
+
+    assert!(report.budget_exhausted);
+    assert_eq!(report.next_cursor, None);
+    assert_eq!(report.retained_candidates, 0, "no candidate was examined");
+    assert_eq!(
+        (
+            report.deleted_wal_segments,
+            report.deleted_metadata_tables,
+            report.deleted_manifests,
+        ),
+        (0, 0, 0)
+    );
+    assert!(inner
+        .head(&orphan_key)
+        .await
+        .expect("head orphan")
+        .is_some());
+
+    // The same namespace, unbounded: the anchor is established and the
+    // orphan goes.
+    let report = gc_namespace(&inner, &namespace_id, &config(), &aged)
+        .await
+        .expect("unbounded rerun");
+    assert!(!report.budget_exhausted);
+    assert_eq!(report.deleted_wal_segments, 1);
 }
 
 /// A pass that keeps a checkpoint record says so as a checkpoint decision,

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -1905,14 +1905,17 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
     assert_eq!(
         aged_store.listed_prefixes(),
         vec![
+            // Marking lists the records it roots from, then the manifests
+            // it ages to find its reference manifest.
             checkpoint_prefix(live_namespace.as_str()),
+            metadata_manifest_prefix(live_namespace.as_str()),
             wal_segment_prefix(live_namespace.as_str()),
             metadata_table_prefix(live_namespace.as_str()),
             metadata_manifest_prefix(live_namespace.as_str()),
             checkpoint_prefix(live_namespace.as_str()),
             upload_session_prefix(live_namespace.as_str()),
         ],
-        "core GC must list only its six core prefixes"
+        "core GC must list only its own core prefixes"
     );
     assert!(
         store

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -131,6 +131,10 @@ pub async fn run_store_contract_probe(store: &dyn ObjectStore, run_id: &str) -> 
             get_with_metadata_round_trip(store, &run).await,
         ),
         check(
+            "head_reports_last_modified",
+            head_reports_last_modified(store, &run).await,
+        ),
+        check(
             "visibility_after_write",
             visibility_after_write(store, &run).await,
         ),
@@ -437,6 +441,41 @@ async fn get_with_metadata_round_trip(store: &dyn ObjectStore, run: &ProbeRun) -
         ));
     }
     Ok(())
+}
+
+/// Garbage collection measures its grace window against the object's own
+/// last-modified time, so a store that does not report one — or reports the
+/// unix epoch, which is what an S3-compatible endpoint that omits the header
+/// turns into — hands every object an infinite age and reclamation loses the
+/// window that protects in-flight publications and live readers.
+///
+/// The write's own result carries no timestamp, so the check heads the
+/// object the way the sweep does.
+async fn head_reports_last_modified(store: &dyn ObjectStore, run: &ProbeRun) -> CheckResult {
+    let key = run.key("last-modified");
+
+    ok(
+        "write",
+        store
+            .put_if_absent(&key, Bytes::from_static(br#"{"seq":1}"#))
+            .await,
+    )?;
+    let head = present(
+        "the written object's metadata",
+        ok("head", store.head(&key).await)?,
+    )?;
+    match head.last_modified_ms {
+        None => Err(wrong(
+            "the store reports no last-modified time, so nothing can age out of the grace window",
+        )),
+        // Nothing LoonFS writes predates the software, so a stamp at or near
+        // the epoch is a synthesized one rather than a real age.
+        Some(0) => Err(wrong(
+            "the store reports the unix epoch as an object's last-modified time, \
+             which reads as infinitely old and defeats the grace window",
+        )),
+        Some(_) => Ok(()),
+    }
 }
 
 /// A write must be listable immediately. Recovery and garbage collection
@@ -791,6 +830,7 @@ mod tests {
                 "compare_and_swap_missing_object_rejected",
                 "overwrite_updates_head_and_body",
                 "get_with_metadata_round_trip",
+                "head_reports_last_modified",
                 "visibility_after_write",
                 "visibility_after_delete",
                 "delete_missing_idempotent",
@@ -945,6 +985,60 @@ mod tests {
         fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
             self.inner.list_prefix_stream(prefix)
         }
+    }
+
+    /// A store that stamps every object at the unix epoch — what an
+    /// S3-compatible endpoint that omits `Last-Modified` becomes once the
+    /// AWS client path synthesizes a time for it.
+    #[derive(Debug)]
+    struct EpochLastModifiedStore {
+        inner: LocalFsStore,
+    }
+
+    #[async_trait]
+    impl ObjectStore for EpochLastModifiedStore {
+        async fn head(&self, key: &str) -> StoreResult<Option<ObjectMetadata>> {
+            Ok(self.inner.head(key).await?.map(|mut metadata| {
+                metadata.last_modified_ms = Some(0);
+                metadata
+            }))
+        }
+
+        async fn get_with_metadata(&self, key: &str) -> StoreResult<Option<ObjectBody>> {
+            self.inner.get_with_metadata(key).await
+        }
+
+        async fn get(&self, key: &str, range: Option<ByteRange>) -> StoreResult<Option<Bytes>> {
+            self.inner.get(key, range).await
+        }
+
+        async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> StoreResult<ObjectMetadata> {
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn delete(&self, key: &str) -> StoreResult<()> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
+            self.inner.list_prefix_stream(prefix)
+        }
+    }
+
+    #[tokio::test]
+    async fn a_store_that_stamps_every_object_at_the_epoch_fails_loudly() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let store = EpochLastModifiedStore {
+            inner: LocalFsStore::new(temp_dir.path()).expect("create local object store"),
+        };
+
+        let report = run_store_contract_probe(&store, "probe_test_epoch_stamp").await;
+
+        assert!(!report.all_passed());
+        assert!(matches!(
+            outcome(&report, "head_reports_last_modified"),
+            StoreProbeOutcome::Failed { message } if message.contains("unix epoch")
+        ));
     }
 
     #[tokio::test]

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -255,7 +255,7 @@ impl ProviderObjectStore {
             etag: meta.e_tag,
             version: meta.version,
             size_bytes: meta.size,
-            last_modified_ms: u64::try_from(meta.last_modified.timestamp_millis()).ok(),
+            last_modified_ms: last_modified_ms(meta.last_modified.timestamp_millis()),
         }
     }
 
@@ -1026,6 +1026,30 @@ fn map_put_mode(mode: PutMode) -> provider_store::PutMode {
     }
 }
 
+/// Reads a provider last-modified stamp as the age evidence it is, or as
+/// nothing.
+///
+/// A response without a `Last-Modified` header is not an object written at
+/// the unix epoch, but the AWS-compatible client path synthesizes one for it
+/// (`object_store`'s header parsing falls back to `timestamp_nanos(0)` where
+/// the header is not required, and the AWS path is the one that does not
+/// require it). S3-compatible endpoints — MinIO, Ceph RGW, gateways — are
+/// configured through exactly that path, so the synthesized stamp is
+/// reachable in production. Passing it on would make every object read as
+/// infinitely old, and garbage collection's grace window is measured against
+/// this number: an object stamped at the epoch is past every window there
+/// is, so the window would protect nothing.
+///
+/// Absent is the honest reading, and it is the reading the rest of the system
+/// already handles — an object whose age is unknown is treated as young and
+/// retained (format spec, "Garbage collection", rule 1).
+fn last_modified_ms(timestamp_millis: i64) -> Option<u64> {
+    match timestamp_millis > 0 {
+        true => u64::try_from(timestamp_millis).ok(),
+        false => None,
+    }
+}
+
 enum RangedGet {
     Bytes(Bytes),
     NotFound,
@@ -1194,6 +1218,18 @@ mod tests {
             },
         )
         .expect("provider store")
+    }
+
+    /// The epoch stamp an AWS-compatible client synthesizes for a response
+    /// with no `Last-Modified` header is not an age, and grace protection is
+    /// exactly what reading it as one would cost.
+    #[test]
+    fn a_synthesized_epoch_stamp_reads_as_no_timestamp_at_all() {
+        assert_eq!(last_modified_ms(0), None);
+        assert_eq!(last_modified_ms(-1), None);
+        assert_eq!(last_modified_ms(i64::MIN), None);
+        assert_eq!(last_modified_ms(1), Some(1));
+        assert_eq!(last_modified_ms(1_754_000_000_000), Some(1_754_000_000_000));
     }
 
     #[test]

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -292,14 +292,14 @@ async fn http_admin_gc_is_explicit_and_retains_young_namespaces() {
     let bounded = post_gc_with(
         &server_url,
         namespace.as_str(),
-        serde_json::json!({ "max_objects": 6 }),
+        serde_json::json!({ "max_objects": 7 }),
     )
     .expect("bounded gc pass");
     let cursor = bounded.next_cursor.expect("more candidate families remain");
     let resumed = post_gc_with(
         &server_url,
         namespace.as_str(),
-        serde_json::json!({ "max_objects": 6, "cursor": cursor }),
+        serde_json::json!({ "max_objects": 7, "cursor": cursor }),
     )
     .expect("resumed gc pass");
     assert!(resumed.next_cursor.is_some());
@@ -527,6 +527,7 @@ async fn http_admin_store_probe_reports_every_check_against_the_configured_store
             "compare_and_swap_missing_object_rejected",
             "overwrite_updates_head_and_body",
             "get_with_metadata_round_trip",
+            "head_reports_last_modified",
             "visibility_after_write",
             "visibility_after_delete",
             "delete_missing_idempotent",
@@ -585,7 +586,7 @@ async fn http_admin_store_probe_requires_a_token_and_accepts_a_bodyless_request(
     // the same request as `{}`.
     let bodyless: loonfs_api::v0::StoreProbeResponse =
         post_admin_json(&url, "test-token").expect("probe with no body");
-    assert_eq!(bodyless.checks.len(), 13);
+    assert_eq!(bodyless.checks.len(), 14);
 
     harness.server.abort();
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -677,7 +677,8 @@ rather than configured (format spec, "Garbage collection", rule 11).
 `max_objects` bounds the whole pass, from its first read to its last, and
 not only the candidates it enumerates. Building the live root set spends it
 too: the head and metadata root together, the retention floor, each
-checkpoint record, each live manifest, and each retained WAL segment, read
+checkpoint record, each live manifest, each manifest the pass ages to find
+its reference manifest, and each retained WAL segment, read
 once, while marking. Deciding whether a completed session's content is still
 referenced then spends it again on each live manifest and the revision rows
 inside it. A pass that runs out partway through that scan skips
@@ -797,6 +798,7 @@ that reason, and the fields sum to the total:
 | `referenced` | Selected as unreachable, then found reachable by the re-verification that runs immediately before every deletion. A candidate the pass already knew was reachable is never examined, so this counts the namespace moving underneath the pass, not the size of its live set. |
 | `grace_window` | Unreachable, but younger than `grace_window_ms` by the object's own provider timestamp. |
 | `no_provider_timestamp` | Unreachable, and the provider reported no last-modified time, so the object's age is unknown and it is treated as young. |
+| `no_reference_manifest` | Unreachable and aged, but the namespace has published no manifest old enough to say what it referenced when the grace window opened. A reader that pinned its anchor inside the window may still be reading the object, so the pass keeps it until a manifest ages past the window. |
 | `degraded_roots` | Root resolution failed somewhere in the pass, so manifest and table deletion was suppressed wholesale. `degraded_retention` is set too. |
 | `unrecognized_key` | A key under a swept family that this collector does not recognize as one of its own. Never deleted, whatever its age. |
 | `checkpoint_not_releasable` | A checkpoint record the pass could not advance: a lost compare-and-swap, an unreadable record, a fork target not provably gone, a released record still inside its grace, or an active pin doing its job. |
@@ -806,6 +808,15 @@ that reason, and the fields sum to the total:
 
 Retention is counted per candidate examined, not per object in the
 namespace, so one object two passes both examine is counted by each.
+
+An object that something once referenced is not collectable the moment it
+stops being referenced. Reads pin a head and the manifest under it and go on
+reading through that pair, so `grace_window_ms` runs from the unreferencing
+as well as from the write: a table a reorganization folds away today is
+collected a grace window from now, not on the next pass. A namespace too
+young to have any manifest older than the window has nothing that dates its
+unreferencing yet, and a pass over one collects nothing and reports every
+candidate under `no_reference_manifest`.
 
 #### Deleting, retaining, and reclaiming
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2135,6 +2135,25 @@ publishing CAS) — under these rules:
    `released_at_ms`, and a record whose basis is verifiably absent is
    released only `T` after its own `created_at_ms`, which is what keeps a
    create still inside its verify budget from being raced.
+
+   An object's provider timestamp says when it appeared, not when it stopped
+   being referenced, and those differ for every object a publication once
+   named. `T` therefore also runs from the unreferencing, which the
+   **reference manifest** dates. Call R the newest surviving manifest under
+   the namespace's own prefix whose provider timestamp is at least `T` old:
+   it is a durable snapshot of what the namespace referenced when the window
+   opened. R roots what it names exactly as `metadata/root.json` does — its
+   own key, its `metadata_files`, its content references, and every WAL
+   segment above its `head_seq` — so an unreferenced object is deleted only
+   when the current root set, R, and the object's own age all agree. A
+   namespace that has published no manifest needs no R: nothing has ever
+   stopped referencing anything under it, and its floor cannot have advanced
+   past its birth sequence without a root. A namespace whose manifests are
+   all younger than `T` has no R available, and the pass then deletes no aged
+   object at all rather than deleting against evidence it does not have. A
+   terminally deleted namespace needs no R either: no read can reach a
+   tombstone. R protects itself, so a pass never sweeps away the evidence the
+   next pass needs.
 2. **Floor is necessary, not sufficient.** Being below `wal/floor.json` only
    nominates an object for deletion.
 3. **Delete-time re-verification.** Immediately before deleting, GC re-lists
@@ -2143,7 +2162,8 @@ publishing CAS) — under these rules:
    may be arbitrarily stale; deletion may not. On large batches the
    re-verification repeats at least every bounded number of deletion
    decisions, so no deletion consults an arbitrarily stale root set.
-4. Roots: `metadata/root.json`; active checkpoint records whose owner still
+4. Roots: `metadata/root.json`; the reference manifest R (rule 1); active
+   checkpoint records whose owner still
    stands — a user pin until its expiry passes, a fork pin until its target
    is provably gone (rule 10), whatever its lease says; and the visible chain from
    `wal/head.json.visible_wal_tip` down to the floor. A namespace with no

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -5615,6 +5615,7 @@
           "referenced",
           "grace_window",
           "no_provider_timestamp",
+          "no_reference_manifest",
           "degraded_roots",
           "unrecognized_key",
           "checkpoint_not_releasable",
@@ -5651,6 +5652,12 @@
             "type": "integer",
             "format": "int64",
             "description": "Unreachable, and the provider reported no last-modified time at all,\nso the object's age is unknown and it is treated as young.",
+            "minimum": 0
+          },
+          "no_reference_manifest": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unreachable, but this namespace published no manifest old enough to\nsay what it referenced when the grace window opened, so nothing\nproves the object was already unreferenced then. A reader that pinned\nits anchor inside the window may still be reading it, and the pass\nkeeps it until a manifest ages past the window.",
             "minimum": 0
           },
           "referenced": {


### PR DESCRIPTION
Fixes two bugs in the GC grace window.

Bug 1: GC aged unreferenced objects by their write time. An old table that a fold just superseded was deleted immediately, even though a reader that loaded the head just before the fold still needs it. That reader fails with MissingSegment, which surfaces as a 500. The grace window exists to protect that reader, so it needs to run from when the object became unreferenced — but nothing records that time directly.

The fix uses manifests as the record. Each manifest says what the namespace referenced when it was published. GC now picks the newest manifest that is at least one grace window old (the reference manifest) and treats it as an additional root: its tables, its content, and all WAL segments above its head seq are kept. An object is deleted only when the current root set, the reference manifest, and the write-time check all agree it is unreferenced.

Why this is safe: a reader that pinned a head inside the last grace window can only reference what was referenced at pin time. Objects written inside the window are kept by the write-time check. Objects referenced before the window opened were named by the reference manifest, because an object's reference span is contiguous: ids are random and never reused, and each manifest builds on its immediate predecessor. One narrow gap remains: an object written just before the window opened but first referenced just after it. That gap is at most one publication budget wide. Closing it would mean widening the write-time check by that budget, which breaks the test suite's clock model, so this PR leaves it open and documents it.

Special cases: a namespace that has never published a manifest has never unreferenced anything, and a deleted namespace can never be read, so neither needs a reference manifest. A namespace whose manifests are all younger than the window deletes nothing and reports its candidates under a new `no_reference_manifest` counter. That counter is an additive wire change; openapi.json is regenerated.

Bug 2: on stores that omit the Last-Modified header, the AWS-compatible client path synthesizes a Unix-epoch timestamp. Every object then looks infinitely old, which disabled the grace window entirely on such deployments. The provider adapter now treats a non-positive timestamp as absent, which GC already handles by retaining the object. The store probe gains a check that fails when HEAD does not return a real timestamp, so such a deployment fails qualification loudly.

Main test: pin a read view, fold the metadata so its tables become unreferenced, run a GC pass. Before the fix the pass deletes 18 tables and the pinned read fails; after it the read succeeds, and once the clock passes the window the tables are reclaimed. Three more tests cover write-time-only retention, the missing-reference-manifest case, and budget exhaustion. 1671 passed, 0 failed; clippy, fmt, and openapi checks pass.
