### PR TITLE
fix(server): check-config runs the TLS and cache checks a start runs

### DIFF
--- a/crates/loonfs-server/README.md
+++ b/crates/loonfs-server/README.md
@@ -52,8 +52,12 @@ Validate a config without starting the server:
 loonfs-server --config /etc/loonfs/server.toml --check-config
 ```
 
-The command prints one line and exits. It reports the same errors a start
-would report, so it belongs in a deployment pipeline ahead of the rollout.
+The command prints one line and exits. It runs the checks a start runs
+before it serves: the config fields, the TLS certificate and key, and the
+local block cache directory. It does not bind the configured address and it
+performs no object-store operation, so it belongs in a deployment pipeline
+ahead of the rollout. Opening the cache takes the directory lock a start
+takes, so run the check where the server is not already running.
 
 ## Deploying it
 

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -40,8 +40,20 @@ loonfs-server --config /etc/loonfs/server.toml --check-config
 ```
 
 It prints one line naming the bind address and the store kind, then exits.
-A `local-fs` store creates its root directory during the check; the cloud
-providers touch no storage.
+
+The check runs the startup work a config file cannot describe by itself. It
+decodes and validates the file, it loads the TLS certificate and key, and it
+opens the local block cache. It does not bind the configured address, and it
+performs no object-store operation, so it says nothing about whether the
+store is reachable. `loonfs admin store-probe` answers that.
+
+Two of those steps touch the filesystem, exactly as a start does. A
+`local-fs` store creates its root directory. A configured `[local_cache]`
+creates its directory, takes the directory lock, allocates the disk tier,
+and then releases the lock again. Run the check where the server it is
+checking is not already running: the lock belongs to one process, so a check
+against a running server's cache directory fails, and so would a second
+start.
 
 ### The minimal config
 

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -22,7 +22,7 @@ mod tls;
 
 #[cfg(feature = "openapi")]
 pub use self::openapi::{openapi_document, openapi_json_pretty};
-pub use self::serve::{app, serve, serve_with_shutdown, ServeError};
+pub use self::serve::{app, check_config, serve, serve_with_shutdown, ServeError};
 pub use self::tls::TlsConfigError;
 
 use self::error::ApiResponseError;

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -184,12 +184,7 @@ pub(super) async fn app_with_store_and_direct_transfers(
     // Opened before the handles, because the handles are what it is
     // installed on: a directory that cannot be owned fails startup here
     // rather than after a runtime is already running on it.
-    let local_cache = match &config.local_cache {
-        Some(local_cache) => Some(Arc::new(
-            FoyerStoredMetadataBlockCache::open(local_cache, metrics.recorder().as_ref()).await?,
-        )),
-        None => None,
-    };
+    let local_cache = open_local_cache(&config, &metrics).await?;
     // Grep reads and checkpoints through the same handles the HTTP planes
     // use, so it is composed after them. Nothing has to be wired back into
     // the writer for its publications to reach the index: the job says on
@@ -279,6 +274,25 @@ pub(super) async fn app_with_store_and_direct_transfers(
         local_cache,
     };
     Ok((router(state.clone()), state))
+}
+
+/// Opens the node-local block cache the config asks for, or answers `None`
+/// where it asks for none.
+///
+/// The one place the cache is opened, so [`check_config`] takes the
+/// configured directory exactly the way a start takes it: the root is
+/// created if it is missing, the lock is claimed, and the disk tier is
+/// allocated.
+async fn open_local_cache(
+    config: &ServerConfig,
+    metrics: &ServerMetrics,
+) -> Result<Option<Arc<FoyerStoredMetadataBlockCache>>, ServerConfigError> {
+    match &config.local_cache {
+        Some(local_cache) => Ok(Some(Arc::new(
+            FoyerStoredMetadataBlockCache::open(local_cache, metrics.recorder().as_ref()).await?,
+        ))),
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]
@@ -401,6 +415,48 @@ pub enum ServeError {
     LocalCacheClose(#[source] StoredMetadataBlockCacheCloseError),
 }
 
+/// Builds the rustls configuration this deployment terminates with, or
+/// answers `None` where TLS terminates in front of the process.
+///
+/// The one place the identity is loaded, so [`check_config`] reads the files
+/// a start reads and reports what a start reports.
+fn tls_server_config(
+    config: &ServerConfig,
+) -> Result<Option<rustls::ServerConfig>, TlsConfigError> {
+    config.tls.as_ref().map(tls::server_config).transpose()
+}
+
+/// Runs the startup work that reads more than the config file, then releases
+/// what it took.
+///
+/// `loonfs-server --check-config` calls this once the config has loaded, so
+/// the flag also fails on the two things that load correctly and start
+/// incorrectly: a TLS identity this process cannot use, and a local cache
+/// directory it cannot own. Both go through the functions [`app`] and
+/// [`serve_with_shutdown`] call, so what this accepts is what a start
+/// accepts.
+///
+/// Two startup failures stay outside it. It does not bind the configured
+/// address, because a check that held the port could not run beside the
+/// server it is checking, and it performs no object-store operation, because
+/// a reachability check belongs to `loonfs admin store-probe`. Constructing
+/// the store still creates a `local-fs` root, as a start does.
+pub async fn check_config(config: &ServerConfig) -> Result<(), ServeError> {
+    config.validate()?;
+    config.object_store()?;
+    // Building the identity is the whole check; nothing here serves with it.
+    let _identity = tls_server_config(config).map_err(ServeError::Tls)?;
+    if let Some(local_cache) = open_local_cache(config, &ServerMetrics::new()).await? {
+        // Closing is what releases the directory lock, so a check leaves the
+        // directory in the state the start that follows it needs to find.
+        local_cache
+            .close()
+            .await
+            .map_err(ServeError::LocalCacheClose)?;
+    }
+    Ok(())
+}
+
 /// Serves until ctrl-c or SIGTERM, then shuts down gracefully: the listener
 /// stops accepting, in-flight requests drain, publisher work finishes, and
 /// writer maintenance — the runtime's steps and grep's alike — settles
@@ -418,12 +474,7 @@ pub async fn serve_with_shutdown(
     let bind = config.bind_addr()?;
     // The identity is loaded before the bind, so a deployment with an
     // unreadable certificate fails without ever having held the port.
-    let tls = config
-        .tls
-        .as_ref()
-        .map(tls::server_config)
-        .transpose()
-        .map_err(ServeError::Tls)?;
+    let tls = tls_server_config(&config).map_err(ServeError::Tls)?;
     let listener = tokio::net::TcpListener::bind(bind)
         .await
         .map_err(|source| ServeError::Bind { addr: bind, source })?;

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -14,7 +14,7 @@ pub use config::{
     load_server_config, GrepConfig, GrepMode, LocalCacheConfig, MaintenanceMode,
     RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig, TlsServerConfig,
 };
-pub use http::{app, serve, serve_with_shutdown, ServeError, TlsConfigError};
+pub use http::{app, check_config, serve, serve_with_shutdown, ServeError, TlsConfigError};
 #[cfg(feature = "openapi")]
 pub use http::{openapi_document, openapi_json_pretty};
 pub use local_cache::FoyerStoredMetadataBlockCache;

--- a/crates/loonfs-server/src/main.rs
+++ b/crates/loonfs-server/src/main.rs
@@ -10,9 +10,11 @@ struct Args {
     /// Config file to load.
     #[arg(long)]
     config: String,
-    /// Load and validate the config, report the result, and exit without
-    /// serving. A `local-fs` store creates its root directory during the
-    /// check; the cloud providers touch no storage.
+    /// Run the startup checks, report the result, and exit without serving.
+    /// The check reads the config, loads the TLS identity, and opens the
+    /// local block cache. It does not bind the configured address and it
+    /// performs no object-store operation, though constructing a `local-fs`
+    /// store creates its root directory as a start does.
     #[arg(long)]
     check_config: bool,
 }
@@ -25,6 +27,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     loonfs_server::init_tracing_from_env()?;
     let config = loonfs_server::load_server_config(&args.config)?;
     if args.check_config {
+        // The summary is printed only once the checks a start runs have
+        // passed, so the printed line means the same thing the flag claims.
+        loonfs_server::check_config(&config).await?;
         let mut stdout = std::io::stdout().lock();
         writeln!(stdout, "{}", config.check_summary())?;
         stdout.flush()?;

--- a/crates/loonfs-server/tests/it/check_config.rs
+++ b/crates/loonfs-server/tests/it/check_config.rs
@@ -9,6 +9,12 @@ use std::process::Command;
 
 /// Writes a server config that binds `bind` and stores under `store_root`.
 fn write_config(dir: &Path, bind: &str, store_root: &Path) -> PathBuf {
+    write_config_with(dir, bind, store_root, "")
+}
+
+/// [`write_config`] with `extra` written verbatim between the top-level
+/// fields and the `[store]` table, for the optional tables a test needs.
+fn write_config_with(dir: &Path, bind: &str, store_root: &Path, extra: &str) -> PathBuf {
     let path = dir.join("loonfs-server.toml");
     let contents = format!(
         r#"
@@ -16,7 +22,7 @@ bind = "{bind}"
 auth_token = "check-config-token"
 content_token_secret = "check-config-secret"
 writer_id = "check-config-writer"
-
+{extra}
 [store]
 kind = "local-fs"
 root = "{}"
@@ -25,6 +31,36 @@ root = "{}"
     );
     std::fs::write(&path, contents).expect("write server config");
     path
+}
+
+/// A `[tls]` table naming the two files.
+fn tls_table(cert_path: &Path, key_path: &Path) -> String {
+    format!(
+        "\n[tls]\ncert_path = \"{}\"\nkey_path = \"{}\"\n",
+        cert_path.display(),
+        key_path.display()
+    )
+}
+
+/// A `[local_cache]` table at `path`, sized at the smallest disk tier the
+/// config accepts so the check allocates as little as it can.
+fn local_cache_table(path: &Path) -> String {
+    format!(
+        "\n[local_cache]\npath = \"{}\"\nmemory_bytes = 4194304\ndisk_bytes = 100663296\n",
+        path.display()
+    )
+}
+
+/// Generates a self-signed identity in `dir` and returns its certificate and
+/// key paths.
+fn write_tls_identity(dir: &Path) -> (PathBuf, PathBuf) {
+    let cert_path = dir.join("server.crt");
+    let key_path = dir.join("server.key");
+    let identity = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])
+        .expect("generate self-signed identity");
+    std::fs::write(&cert_path, identity.cert.pem()).expect("write certificate");
+    std::fs::write(&key_path, identity.signing_key.serialize_pem()).expect("write private key");
+    (cert_path, key_path)
 }
 
 fn check_config(config_path: &Path) -> std::process::Output {
@@ -84,6 +120,143 @@ root = "/tmp/loonfs-check-config-unused"
     assert!(
         stderr.contains("bind"),
         "expected the config error to name the field, got: {stderr}"
+    );
+}
+
+/// The check loads the TLS identity, so an identity a start could not use
+/// fails the check too. Field validation passes both configs below: each one
+/// names two non-empty paths, which is all the config file can say about
+/// them.
+#[test]
+fn check_config_reports_a_tls_identity_it_cannot_load() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store_root = dir.path().join("store");
+    let (cert_path, key_path) = write_tls_identity(dir.path());
+
+    // A certificate path that names no file.
+    let missing_cert = dir.path().join("absent.crt");
+    let config_path = write_config_with(
+        dir.path(),
+        "127.0.0.1:9400",
+        &store_root,
+        &tls_table(&missing_cert, &key_path),
+    );
+
+    let output = check_config(&config_path);
+
+    assert!(
+        !output.status.success(),
+        "a certificate file that is not there must fail the check"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        stderr.contains("absent.crt"),
+        "the error must name the file it could not read, got: {stderr}"
+    );
+
+    // A key file that is there and is not the PEM it is configured as.
+    let not_pem = dir.path().join("not-pem.key");
+    std::fs::write(&not_pem, b"this file holds no private key\n")
+        .expect("write a key that is not PEM");
+    let config_path = write_config_with(
+        dir.path(),
+        "127.0.0.1:9400",
+        &store_root,
+        &tls_table(&cert_path, &not_pem),
+    );
+
+    let output = check_config(&config_path);
+
+    assert!(
+        !output.status.success(),
+        "a key file that is not PEM must fail the check"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        stderr.contains("not-pem.key"),
+        "the error must name the file it could not parse, got: {stderr}"
+    );
+}
+
+/// The check opens the local block cache, so a directory a start could not
+/// own fails the check too. A plain file where the directory belongs is one
+/// way to be unable to own it, and it fails whichever user runs the test.
+#[test]
+fn check_config_reports_a_local_cache_it_cannot_open() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let occupied = dir.path().join("cache");
+    std::fs::write(&occupied, b"a file, not a directory").expect("occupy the cache path");
+    let config_path = write_config_with(
+        dir.path(),
+        "127.0.0.1:9400",
+        &dir.path().join("store"),
+        &local_cache_table(&occupied),
+    );
+
+    let output = check_config(&config_path);
+
+    assert!(
+        !output.status.success(),
+        "a cache directory the server cannot open must fail the check"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        stderr.contains("local_cache.path"),
+        "the error must name the field it came from, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("cache"),
+        "the error must name the directory, got: {stderr}"
+    );
+}
+
+/// A configured identity and a configured cache both pass, and the check
+/// leaves the cache directory the way the start that follows it needs to
+/// find it.
+///
+/// The second run is what proves the release: it calls the same open a start
+/// calls, so a lock the first run still held would fail it.
+#[test]
+fn check_config_opens_the_local_cache_and_leaves_it_openable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store_root = dir.path().join("store");
+    let (cert_path, key_path) = write_tls_identity(dir.path());
+    let cache_root = dir.path().join("cache");
+    let config_path = write_config_with(
+        dir.path(),
+        "127.0.0.1:9400",
+        &store_root,
+        &format!(
+            "{}{}",
+            tls_table(&cert_path, &key_path),
+            local_cache_table(&cache_root)
+        ),
+    );
+
+    let output = check_config(&config_path);
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(
+        output.status.success(),
+        "expected success, got {:?}: {stdout}{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        stdout.trim(),
+        "config ok: bind 127.0.0.1:9400, store local-fs"
+    );
+    assert!(
+        cache_root.is_dir(),
+        "the check opens the cache, and opening it builds the directory"
+    );
+
+    let second = check_config(&config_path);
+
+    assert!(
+        second.status.success(),
+        "the checked directory must be one the next open can take: {}",
+        String::from_utf8_lossy(&second.stderr)
     );
 }
 


### PR DESCRIPTION
`--check-config` only validated parsed settings, so TLS and local-cache failures appeared only when the server started.

It now loads TLS and opens and closes the local cache using the same code as startup. It still does not bind the port or contact cloud storage.