### PR TITLE
fix(wal): the chain walk counts requests in budget 

### DIFF
--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -17,9 +17,10 @@ use super::config::GcConfig;
 /// * one manifest opened, whether to mark its tables or by the content
 ///   reference scan;
 /// * one page of revision rows read out of an opened manifest;
-/// * the retained WAL chain, charged as one block of one unit per segment
-///   body read. The pass caps that load at what it has left, so the chain
-///   cannot read past the bound either;
+/// * the retained WAL chain, charged as one block of one unit per request
+///   the load issued for a segment body — a failed request included, since
+///   the store was asked. The pass caps that load at what it has left, so
+///   the chain cannot read past the bound either;
 /// * one enumerated candidate key, decided — the original meaning of
 ///   `max_objects`.
 ///
@@ -92,8 +93,8 @@ impl PassBudget {
         true
     }
 
-    /// Charges `units` for one block of work already done — the segment
-    /// bodies one chain load read. The caller sizes that load by what
+    /// Charges `units` for one block of work already done — the requests
+    /// one chain load issued. The caller sizes that load by what
     /// [`PassBudget::remaining`] reports, so a block never charges more
     /// than the budget had left.
     pub(super) fn charge_block(&mut self, units: u64) {

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -475,9 +475,9 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     if !namespace_deleted && head.seq > floor_seq {
         // The loader keeps no budget of its own, because foreground reads
         // and the changefeed share it. The pass caps the load at what it
-        // has left to spend instead. The loader then reads no more segment
-        // bodies than the pass can pay for, and the charge below can never
-        // go past the bound.
+        // has left to spend instead. The loader then issues no more
+        // requests than the pass can pay for, and the charge below can
+        // never go past the bound.
         let remaining = budget.remaining();
         if remaining == 0 {
             return Ok(LiveSetCollection::BudgetExhausted);
@@ -498,19 +498,27 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
         })?;
+        // Either way the pass pays for the requests the loader issued, not
+        // for the segments it came back with. The two differ when a request
+        // fails or a hint names an object the chain does not use, and the
+        // store was asked either way.
         let chain = match load {
-            WalChainLoad::Complete(chain) => chain,
-            // The load stopped where the budget did. The pass pays for the
-            // bodies it read and then stops, because a partial chain roots
-            // nothing.
-            WalChainLoad::LimitReached { segments_fetched } => {
-                budget.charge_block(u64::try_from(segments_fetched).unwrap_or(u64::MAX));
+            WalChainLoad::Complete {
+                chain,
+                requests_issued,
+            } => {
+                budget.charge_block(u64::try_from(requests_issued).unwrap_or(u64::MAX));
+                chain
+            }
+            // The load stopped where the budget did. The pass pays for what
+            // it spent getting there and then stops, because a partial
+            // chain roots nothing.
+            WalChainLoad::LimitReached { requests_issued } => {
+                budget.charge_block(u64::try_from(requests_issued).unwrap_or(u64::MAX));
                 return Ok(LiveSetCollection::BudgetExhausted);
             }
         };
-        let segments = chain.segments();
-        budget.charge_block(u64::try_from(segments.len()).unwrap_or(u64::MAX));
-        for segment in segments {
+        for segment in chain.segments() {
             live.wal_segments.insert(segment.object_key().to_owned());
             // The bodies are decoded and validated right here, so the
             // content these commits name is read off them now rather than

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -1358,9 +1358,10 @@ async fn a_budget_that_dies_at_the_chain_gate_sweeps_nothing() {
 }
 
 /// The chain can be longer than the budget has room for. The pass caps the
-/// load at what it has left, so the loader reads no more segment bodies
-/// than the pass may pay for. The pass then decides nothing and reports
-/// that it ran out.
+/// load at what it has left, so the loader issues no more requests than the
+/// pass may pay for, and it issues all of them: the head names the whole
+/// tail, and a hint list longer than the cap is cut down to the cap rather
+/// than refused. The pass then decides nothing and reports that it ran out.
 #[tokio::test]
 async fn a_chain_longer_than_the_budget_is_not_read_past_the_budget() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1387,10 +1388,10 @@ async fn a_chain_longer_than_the_budget_is_not_read_past_the_budget() {
         .await
         .expect("pass over a chain it cannot afford");
 
-    let fetched = store.take_get_keys().len();
-    assert!(
-        u64::try_from(fetched).expect("fetch count fits") <= at_the_gate,
-        "the pass read {fetched} segment bodies with {at_the_gate} units left"
+    let fetched = u64::try_from(store.take_get_keys().len()).expect("fetch count fits");
+    assert_eq!(
+        fetched, at_the_gate,
+        "the pass had {at_the_gate} units left at the chain and spent them"
     );
     assert!(report.budget_exhausted);
     assert_eq!(
@@ -1408,6 +1409,65 @@ async fn a_chain_longer_than_the_budget_is_not_read_past_the_budget() {
             report.deleted_content_objects,
         ),
         (0, 0, 0, 0, 0, 0)
+    );
+}
+
+/// A collection that reaches the chain with less budget than the chain
+/// costs used to charge nothing for it. The head names every segment of the
+/// retained tail, that hint list was longer than the cap the pass handed
+/// the loader, and the loader refused up front rather than reading the part
+/// the cap covered. The pass then reported that it ran out while its budget
+/// still showed unspent units, which is the wrong account of where the
+/// budget went.
+///
+/// Now every unit the collection has left at the chain is spent on the
+/// chain, at every budget from one unit up to the whole chain, and a budget
+/// that covers the chain collects it.
+#[tokio::test]
+async fn a_chain_the_budget_cannot_cover_still_spends_what_the_budget_had_left() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&store, &namespace_id, &setup).await;
+    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    let (live, marking) = marked(&store, &namespace_id, &aged).await;
+    let chain_units = u64::try_from(live.wal_segments.len()).expect("segment count fits");
+    assert!(
+        chain_units > 1,
+        "the fixture must retain a chain a budget can fall short of"
+    );
+    // What the collection charges before it reaches the chain.
+    let roots = marking - chain_units;
+
+    for at_the_chain in 1..chain_units {
+        let mut budget = PassBudget::new(Some(roots + at_the_chain));
+        let collection =
+            recollect_live_set(&store, &namespace_id, GRACE_MS, None, &mut budget, &aged)
+                .await
+                .expect("bounded collection");
+        assert!(
+            collection.complete().is_none(),
+            "{at_the_chain} of {chain_units} segments is a partial chain and roots nothing"
+        );
+        assert_eq!(
+            budget.spent(),
+            roots + at_the_chain,
+            "the collection had {at_the_chain} units left at the chain and must spend them"
+        );
+    }
+
+    let mut budget = PassBudget::new(Some(marking));
+    let collected = recollect_live_set(&store, &namespace_id, GRACE_MS, None, &mut budget, &aged)
+        .await
+        .expect("bounded collection")
+        .complete()
+        .expect("a budget that covers the chain collects it");
+    assert_eq!(collected.wal_segments, live.wal_segments);
+    assert_eq!(
+        budget.spent(),
+        marking,
+        "the collection charges the requests the load issued, no more"
     );
 }
 

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -6,7 +6,7 @@ use super::{ValidatedWalChain, ValidatedWalSegment, WalChainLoadError, WalChainL
 use bytes::Bytes;
 use loonfs_api::wire::control::WalSegmentPointer;
 use loonfs_api::wire::wal::{decode_wal_segment_envelope_zstd, WalSegmentEnvelope};
-use loonfs_api::ChangeSeq;
+use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
 
@@ -30,23 +30,49 @@ fn hints_in_gap(
 
 /// Fetches the hinted segments covering the replay gap concurrently.
 ///
-/// Failures and misses are silently dropped: the chain walk re-fetches
-/// anything the prefetch did not deliver, so hints can only save latency.
+/// Failures and misses do not stop the load: the chain walk fetches anything
+/// the prefetch did not deliver, and a real read error surfaces there as
+/// [`WalChainLoadError::ReadWal`]. Hints therefore change where the bytes
+/// come from, never what the load returns.
+///
+/// A failed request is still a request, so the caller counts it against the
+/// fetch budget and the walk's own fetch of that segment counts again. A
+/// flaky store then drains the budget faster than the chain is long, which
+/// an operator reads as a budget problem. The failures are reported here,
+/// once per load, so the store shows up as the cause.
 async fn prefetch_recent_segments<S: ObjectStore + ?Sized>(
     store: &S,
+    namespace_id: &NamespaceId,
     in_gap: &[String],
 ) -> HashMap<String, Bytes> {
     let mut prefetched = HashMap::new();
+    let mut failed_requests: usize = 0;
+    let mut first_error: Option<String> = None;
     for chunk in in_gap.chunks(RECENT_SEGMENT_PREFETCH_CONCURRENCY) {
-        let fetches = chunk.iter().map(|object_key| async move {
-            let bytes = store.get(object_key, None).await.ok().flatten()?;
-            Some((object_key.clone(), bytes))
-        });
-        prefetched.extend(
-            futures::future::join_all(fetches)
-                .await
-                .into_iter()
-                .flatten(),
+        let fetches = chunk
+            .iter()
+            .map(|object_key| async move { (object_key, store.get(object_key, None).await) });
+        for (object_key, result) in futures::future::join_all(fetches).await {
+            match result {
+                Ok(Some(bytes)) => {
+                    prefetched.insert(object_key.clone(), bytes);
+                }
+                // A miss is not an error here. The object may legitimately
+                // be gone, and the walk reports that on its own fetch.
+                Ok(None) => {}
+                Err(error) => {
+                    failed_requests += 1;
+                    first_error.get_or_insert_with(|| error.to_string());
+                }
+            }
+        }
+    }
+    if let Some(first_error) = first_error {
+        tracing::info!(
+            namespace_id = %namespace_id,
+            failed_requests,
+            %first_error,
+            "WAL segment prefetch requests failed; the walk fetches those segments again out of the same budget"
         );
     }
     prefetched
@@ -56,9 +82,11 @@ async fn prefetch_recent_segments<S: ObjectStore + ?Sized>(
 struct WalkedChain {
     /// The segments the walk found, oldest first.
     segments: Vec<ValidatedWalSegment>,
-    /// How many segment bodies the walk read from the store. Every read
-    /// counts, including a prefetch that missed and a hint the walk never
-    /// used.
+    /// How many `get` requests the load issued, prefetch included. A
+    /// request that failed or missed counts, because the round trip
+    /// happened; a segment the prefetch delivered is not counted a second
+    /// time when the walk consumes it. This is never more than the
+    /// `max_segment_fetches` the caller gave.
     fetches: usize,
     /// `true` when the walk stopped at its fetch limit instead of reaching
     /// the base. `segments` is then a partial chain. Nothing may replay
@@ -85,16 +113,26 @@ impl WalkedChain {
 }
 
 /// What a bounded chain load produced.
+///
+/// Both outcomes report `requests_issued`: how many `get` requests the load
+/// sent for segment bodies, prefetch included. A caller that meters its own
+/// reads charges for that number and nothing else, so its budget drains by
+/// what the store was actually asked for. It is never more than the limit
+/// the caller gave.
 pub(crate) enum WalChainLoad {
     /// The whole chain was read inside the fetch limit.
-    Complete(ValidatedWalChain),
-    /// The load stopped at the fetch limit. `segments_fetched` is how many
-    /// segment bodies it read before it stopped, and it is never more than
-    /// the limit the caller gave.
-    LimitReached { segments_fetched: usize },
+    Complete {
+        chain: ValidatedWalChain,
+        requests_issued: usize,
+    },
+    /// The load stopped at the fetch limit. The chain it walked is partial,
+    /// so it is dropped rather than returned, but the requests it spent
+    /// getting there are reported so the caller can charge for them.
+    LimitReached { requests_issued: usize },
 }
 
-/// Loads the chain, reading at most `max_segment_fetches` segment bodies.
+/// Loads the chain, issuing at most `max_segment_fetches` requests for
+/// segment bodies.
 ///
 /// A caller that meters its own reads uses this so that the loader cannot
 /// read past what the caller may pay for. The loader itself keeps no
@@ -114,13 +152,13 @@ pub(crate) async fn load_wal_chain_within<S: ObjectStore + ?Sized>(
     let walked = walk_chain(store, &request, max_segment_fetches).await?;
     if walked.stopped_at_limit {
         return Ok(WalChainLoad::LimitReached {
-            segments_fetched: walked.fetches,
+            requests_issued: walked.fetches,
         });
     }
-    Ok(WalChainLoad::Complete(finish_chain(
-        &request,
-        walked.segments,
-    )?))
+    Ok(WalChainLoad::Complete {
+        chain: finish_chain(&request, walked.segments)?,
+        requests_issued: walked.fetches,
+    })
 }
 
 #[tracing::instrument(
@@ -142,8 +180,8 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
     finish_chain(&request, walked.segments)
 }
 
-/// Walks the chain links from the visible tip down to the base, reading at
-/// most `max_segment_fetches` segment bodies.
+/// Walks the chain links from the visible tip down to the base, issuing at
+/// most `max_segment_fetches` requests for segment bodies.
 async fn walk_chain<S: ObjectStore + ?Sized>(
     store: &S,
     request: &WalChainLoadRequest<'_>,
@@ -175,17 +213,25 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
 
     let stop_after_seq = request.stop_after_seq.unwrap_or(request.chain_base_seq);
     let in_gap = hints_in_gap(request.recent_segments, stop_after_seq, request.head_seq);
-    // The prefetch issues one request per hint, and it issues them before
-    // the walk can decide it has read enough. The walk stops here instead,
-    // having read nothing at all.
-    if in_gap.len() > max_segment_fetches {
-        return Ok(WalkedChain::stopped_at_limit(0));
-    }
-    let mut fetches = in_gap.len();
-    let mut prefetched = if in_gap.is_empty() {
+    // The invariant this function maintains: `fetches` counts every `get`
+    // request issued for a segment body, prefetch included, and it never
+    // exceeds `max_segment_fetches`.
+    //
+    // The prefetch issues its requests before the walk can decide it has
+    // read enough, so it takes its share of the budget up front and the
+    // walk spends what is left. Hints are newest first and the walk starts
+    // at the tip, so the prefix the budget covers is the part of the gap
+    // the walk reaches first. A hint list longer than the budget is cut
+    // down to the budget rather than refused: the walk reads what the
+    // budget covers and reports what it spent, so a caller that meters its
+    // reads is told where its budget went instead of being handed an empty
+    // answer that claims to have cost nothing.
+    let prefetched_hints = in_gap.len().min(max_segment_fetches);
+    let mut fetches = prefetched_hints;
+    let mut prefetched = if prefetched_hints == 0 {
         HashMap::new()
     } else {
-        prefetch_recent_segments(store, &in_gap).await
+        prefetch_recent_segments(store, request.namespace_id, &in_gap[..prefetched_hints]).await
     };
     let mut reversed = Vec::new();
     loop {
@@ -195,6 +241,8 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
 
         let object_key = pointer.object_key.clone();
         let encoded_bytes = match prefetched.remove(&object_key) {
+            // The prefetch already paid for this body, so consuming it
+            // costs nothing further.
             Some(bytes) => bytes,
             None => {
                 if fetches >= max_segment_fetches {

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -16,7 +16,8 @@ use loonfs_objectstore::keys::{wal_segment, wal_segment_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
 use loonfs_test_support::stores::{
-    ConcurrencyWatchStore, CountingStore, KeyPredicate, OperationClass, RecordingStore,
+    ConcurrencyWatchStore, CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+    RecordingStore,
 };
 use std::borrow::Cow;
 use tempfile::tempdir;
@@ -654,8 +655,8 @@ async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
     .await
     .expect("bounded chain load");
     match bounded {
-        WalChainLoad::Complete(_) => panic!("a five-segment chain does not fit in two fetches"),
-        WalChainLoad::LimitReached { segments_fetched } => assert_eq!(segments_fetched, 2),
+        WalChainLoad::Complete { .. } => panic!("a five-segment chain does not fit in two fetches"),
+        WalChainLoad::LimitReached { requests_issued } => assert_eq!(requests_issued, 2),
     }
     assert_eq!(
         store.count(OperationClass::Get),
@@ -663,8 +664,10 @@ async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
         "the walk reads no more bodies than the limit allows"
     );
 
-    // The hinted gap is known before the prefetch issues anything, so a
-    // hint list longer than the limit costs no read at all.
+    // A hint list longer than the limit is cut down to what the limit
+    // covers rather than refused. The prefetch takes the newest hints,
+    // which is where the walk starts, and the walk stops once the limit is
+    // spent — reporting what it spent, not zero.
     let mut newest_first = pointers.clone();
     newest_first.reverse();
     store.reset();
@@ -683,10 +686,14 @@ async fn a_bounded_chain_load_stops_at_its_fetch_limit() {
     .await
     .expect("bounded hinted load");
     match hinted {
-        WalChainLoad::Complete(_) => panic!("five hints do not fit in two fetches"),
-        WalChainLoad::LimitReached { segments_fetched } => assert_eq!(segments_fetched, 0),
+        WalChainLoad::Complete { .. } => panic!("five hints do not fit in two fetches"),
+        WalChainLoad::LimitReached { requests_issued } => assert_eq!(requests_issued, 2),
     }
-    assert_eq!(store.count(OperationClass::Get), 0);
+    assert_eq!(
+        store.count(OperationClass::Get),
+        2,
+        "the prefetch issued the requests the limit allows, not none and not five"
+    );
 }
 
 /// A limit that covers the chain exactly does not truncate it. The load
@@ -718,12 +725,130 @@ async fn a_limit_that_covers_the_chain_loads_all_of_it() {
         .await
         .expect("bounded chain load");
     match bounded {
-        WalChainLoad::Complete(chain) => assert_eq!(chain.segments(), unbounded.segments()),
-        WalChainLoad::LimitReached { segments_fetched } => {
-            panic!("a five-segment chain fits in five fetches, not {segments_fetched}")
+        WalChainLoad::Complete {
+            chain,
+            requests_issued,
+        } => {
+            assert_eq!(chain.segments(), unbounded.segments());
+            assert_eq!(requests_issued, 5);
+        }
+        WalChainLoad::LimitReached { requests_issued } => {
+            panic!("a five-segment chain fits in five fetches, not {requests_issued}")
         }
     }
     assert_eq!(store.count(OperationClass::Get), 5);
+}
+
+/// A prefetch request that fails is a request the store answered, so it
+/// counts like any other. The walk fetches that segment itself and the
+/// chain still loads. The number the load reports is the number of requests
+/// it issued: one failed prefetch and one walk fetch for each of the three
+/// segments, which is what the counting wrapper saw.
+#[tokio::test]
+async fn a_failed_prefetch_costs_its_own_request_and_the_walk_loads_the_chain() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let pointers = write_linked_chain(&inner, &namespace_id, 3).await;
+    let tip = pointers.last().expect("a chain was written").clone();
+    let mut newest_first = pointers.clone();
+    newest_first.reverse();
+
+    // The prefetch completes before the walk fetches anything, so arming
+    // one failure per hint fails every prefetch request and leaves the
+    // walk's own fetches to succeed.
+    let failing = FailStore::new(
+        inner,
+        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+        OperationClass::Get,
+        InjectedError::Transport("the store is flaky".to_owned()),
+    );
+    failing.fail_next(newest_first.len());
+    let store = CountingStore::new(failing, KeyPredicate::any());
+
+    let loaded = load_wal_chain_within(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(tip),
+            stop_after_seq: None,
+            recent_segments: &newest_first,
+        },
+        16,
+    )
+    .await
+    .expect("the walk fetches what the prefetch could not deliver");
+
+    let issued = store.count(OperationClass::Get);
+    assert_eq!(
+        issued, 6,
+        "three failed prefetch requests and three walk fetches"
+    );
+    match loaded {
+        WalChainLoad::Complete {
+            chain,
+            requests_issued,
+        } => {
+            assert_eq!(chain.segments().len(), 3);
+            assert_eq!(
+                requests_issued, issued,
+                "the load reports the requests it issued"
+            );
+        }
+        WalChainLoad::LimitReached { requests_issued } => {
+            panic!("three segments fit in sixteen requests, not {requests_issued}")
+        }
+    }
+}
+
+/// The limit bounds every request the load issues, prefetch included. A
+/// store that fails every prefetch cannot make the load exceed it: the walk
+/// stops once the failures have spent the limit.
+#[tokio::test]
+async fn failed_prefetch_requests_count_against_the_limit() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let pointers = write_linked_chain(&inner, &namespace_id, 3).await;
+    let tip = pointers.last().expect("a chain was written").clone();
+    let mut newest_first = pointers.clone();
+    newest_first.reverse();
+
+    let failing = FailStore::new(
+        inner,
+        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+        OperationClass::Get,
+        InjectedError::Transport("the store is flaky".to_owned()),
+    );
+    failing.fail_all();
+    let store = CountingStore::new(failing, KeyPredicate::any());
+
+    let loaded = load_wal_chain_within(
+        &store,
+        WalChainLoadRequest {
+            namespace_id: &namespace_id,
+            chain_base_seq: ChangeSeq(0),
+            head_seq: ChangeSeq(3),
+            visible_tip: Some(tip),
+            stop_after_seq: None,
+            recent_segments: &newest_first,
+        },
+        3,
+    )
+    .await
+    .expect("a load whose limit the failures spent");
+
+    match loaded {
+        WalChainLoad::Complete { .. } => panic!("no body was ever delivered"),
+        WalChainLoad::LimitReached { requests_issued } => assert_eq!(requests_issued, 3),
+    }
+    assert_eq!(
+        store.count(OperationClass::Get),
+        3,
+        "the limit bounds prefetch requests exactly as it bounds walk fetches"
+    );
 }
 
 async fn write_create_directory_segment(

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -679,7 +679,9 @@ not only the candidates it enumerates. Building the live root set spends it
 too: the head and metadata root together, the retention floor, each
 checkpoint record, each live manifest, each manifest the pass ages to find
 its reference manifest, and each retained WAL segment, read
-once, while marking. Deciding whether a completed session's content is still
+once, while marking. A WAL segment request the store fails is charged like
+one it serves, so a flaky store spends the budget faster than the retained
+chain is long. Deciding whether a completed session's content is still
 referenced then spends it again on each live manifest and the revision rows
 inside it. A pass that runs out partway through that scan skips
 completed-content reclamation for the rest of the invocation: the session is


### PR DESCRIPTION
Bounded WAL walks counted returned segments instead of every store request, so prefetching could use work that GC did not count.

The loader now stays within the request limit and reports how many requests it actually issued. GC uses that number.