### PR TITLE
fix(gc): corrupt control objects fail the pass instead of degrading it forever

### DIFF
--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -4,7 +4,7 @@
 use super::budget::PassBudget;
 use super::fork_checkpoints::fork_target_proven_gone;
 use super::reap::{lease_expired, manifest_object_id_of};
-use crate::checkpoint::load_namespace_manifest_envelope_if_present;
+use crate::checkpoint::{load_namespace_manifest_envelope_if_present, ManifestLoadFailureClass};
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::basis::{
@@ -41,8 +41,9 @@ pub(super) struct LiveSet {
     /// the crash window between record write and verification. The pass
     /// releases them; they never degrade sweeping.
     pub(super) missing_basis_records: BTreeSet<String>,
-    /// Record resolution failed somewhere: manifest/table deletion must not
-    /// proceed on this pass.
+    /// A root manifest did not resolve: it read as absent, or the read
+    /// failed. Manifest and table deletion must not proceed on this pass.
+    /// A corrupt root never lands here, because it fails the pass instead.
     pub(super) degraded: bool,
     /// The inspected namespace head is the terminal, absorbing tombstone.
     pub(super) namespace_deleted: bool,
@@ -397,11 +398,21 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
                     .push(key.clone());
                 live.checkpoint_keys.insert(key);
             }
-            // Unreadable records are ambiguous roots: retain them and keep
-            // sweeping conservative for manifests/tables.
-            Err(_) => {
-                live.checkpoint_keys.insert(key);
-                live.degraded = true;
+            // Nothing but checkpoint records lives under this prefix, so
+            // bytes that do not decode as one are corruption rather than an
+            // ambiguous root. `checkpoint/list.rs` reads the same prefix and
+            // reaches the same conclusion. The store read above already
+            // fails the pass, so every error left here is a decode error.
+            //
+            // Retaining instead would hide the damage permanently: the key
+            // would join `checkpoint_keys`, which is what keeps the sweep
+            // from deleting it, and the degraded flag would suppress
+            // manifest and table reclamation on this pass and on every pass
+            // after it, with nothing logged.
+            Err(error) => {
+                return Err(CoreError::NamespaceCorrupt(format!(
+                    "`{key}` is not a checkpoint record: {error}"
+                )));
             }
         }
     }
@@ -440,9 +451,29 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
                         .extend(record_keys.iter().cloned());
                 }
             }
-            Err(_) => {
-                live.degraded = true;
-            }
+            // A manifest the store could not hand over is a transient
+            // obstacle: keep the pass conservative and let the next one try
+            // again. A manifest that was read but does not validate is
+            // corruption, and the pass reports it instead of degrading every
+            // future pass over this namespace. `failure_class` is the same
+            // split every other surface uses (`error.rs`), so this arm
+            // cannot drift from them.
+            Err(error) => match error.failure_class() {
+                ManifestLoadFailureClass::Store => {
+                    live.degraded = true;
+                    tracing::warn!(
+                        namespace_id = %namespace_id,
+                        object_key = manifest_key,
+                        error = %error,
+                        "a root manifest did not read; this pass reclaims no manifests or tables"
+                    );
+                }
+                ManifestLoadFailureClass::Corrupt => {
+                    return Err(CoreError::NamespaceCorrupt(format!(
+                        "a manifest this namespace still references does not load: {error}"
+                    )));
+                }
+            },
         }
     }
 

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -39,8 +39,8 @@ use futures::stream::BoxStream;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ByteRange, ObjectBody, ObjectMetadata, ObjectStoreError, PutMode};
 use loonfs_test_support::stores::{
-    BlockingStore, CountingStore, KeyPredicate, MetadataMapStore, OperationClass, OperationContext,
-    OperationKind, RecordingStore,
+    BlockingStore, CountingStore, FailStore, InjectedError, KeyPredicate, MetadataMapStore,
+    OperationClass, OperationContext, OperationKind, RecordingStore,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::tempdir;
@@ -3153,11 +3153,12 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
         .expect("forked file readable");
 }
 
-/// Unreadable checkpoint records are ambiguous roots on their own,
-/// without any pin involved: the record is retained and the pass
-/// degrades.
+/// Only checkpoint records live under the checkpoints prefix, so bytes
+/// there that do not decode as one are corruption. The pass reports it and
+/// stops. It does not retain the object and suppress reclamation on every
+/// pass after this one.
 #[tokio::test]
-async fn gc_retains_unreadable_checkpoint_records_and_degrades() {
+async fn gc_fails_the_pass_on_a_corrupt_checkpoint_record() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
@@ -3170,32 +3171,179 @@ async fn gc_retains_unreadable_checkpoint_records_and_degrades() {
         .await
         .expect("checkpoint");
 
-    for key in store
+    let record_keys = store
         .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
         .await
-        .expect("list checkpoints")
-    {
+        .expect("list checkpoints");
+    let corrupt_key = record_keys
+        .first()
+        .expect("the checkpoint wrote a record")
+        .clone();
+    store
+        .put_overwrite(&corrupt_key, Bytes::from_static(b"not json"))
+        .await
+        .expect("corrupt record");
+
+    let before = namespace_keys(&store, &namespace_id).await;
+    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    let error = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect_err("a corrupt record fails the pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(
+        error.message().contains(&corrupt_key),
+        "the error names the object: {error}"
+    );
+    assert_eq!(
+        namespace_keys(&store, &namespace_id).await,
+        before,
+        "a failed pass deletes nothing"
+    );
+}
+
+/// A record the store will not hand over is a different failure from a
+/// record whose bytes do not decode. The read is not part of the split,
+/// because it already failed the pass before this change. This test holds
+/// that behavior in place: the message names the key, and the code tells
+/// the caller to try again.
+#[tokio::test]
+async fn gc_fails_the_pass_when_a_checkpoint_record_does_not_read() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(checkpoint_prefix(namespace_id.as_str())),
+        OperationClass::Read,
+        InjectedError::Transport("checkpoint record read timed out".to_owned()),
+    );
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    create_checkpoint(&store, &namespace_id, &setup)
+        .await
+        .expect("checkpoint");
+
+    let record_keys = store
+        .inner()
+        .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+        .await
+        .expect("list checkpoints");
+    let record_key = record_keys
+        .first()
+        .expect("the checkpoint wrote a record")
+        .clone();
+    let before = namespace_keys(store.inner(), &namespace_id).await;
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+    store.fail_all();
+
+    let error = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect_err("a record the store will not read fails the pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::ServerError);
+    assert!(
+        error.message().contains(&record_key),
+        "the error names the object: {error}"
+    );
+    assert_eq!(
+        namespace_keys(store.inner(), &namespace_id).await,
+        before,
+        "a failed pass deletes nothing"
+    );
+}
+
+/// The manifest arm of the same split: a rooted manifest that reads but
+/// does not decode is corruption, and the pass says so.
+#[tokio::test]
+async fn gc_fails_the_pass_on_a_corrupt_root_manifest() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    create_checkpoint(&store, &namespace_id, &setup)
+        .await
+        .expect("checkpoint");
+
+    let manifest_keys = store
+        .list_prefix(&metadata_manifest_prefix(namespace_id.as_str()))
+        .await
+        .expect("list manifests");
+    assert!(
+        !manifest_keys.is_empty(),
+        "the checkpoint published a manifest"
+    );
+    for key in &manifest_keys {
         store
-            .put_overwrite(&key, bytes::Bytes::from_static(b"not json"))
+            .put_overwrite(key, Bytes::from_static(b"not json"))
             .await
-            .expect("corrupt record");
+            .expect("corrupt manifest");
     }
 
+    let before = namespace_keys(&store, &namespace_id).await;
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    let error = gc_namespace(&store, &namespace_id, &config(), &aged)
+        .await
+        .expect_err("a corrupt root manifest fails the pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(
+        manifest_keys
+            .iter()
+            .any(|key| error.message().contains(key)),
+        "the error names the object: {error}"
+    );
+    assert_eq!(
+        namespace_keys(&store, &namespace_id).await,
+        before,
+        "a failed pass deletes nothing"
+    );
+}
+
+/// The other half of the manifest arm: a rooted manifest the store will
+/// not hand over says nothing about the bytes, so the pass keeps its old
+/// behavior. It degrades, reclaims no manifests or tables, and counts what
+/// it kept under `degraded_roots`.
+#[tokio::test]
+async fn gc_degrades_when_a_root_manifest_does_not_read() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let store = FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::prefix(metadata_manifest_prefix(namespace_id.as_str())),
+        OperationClass::Read,
+        InjectedError::Transport("manifest read timed out".to_owned()),
+    );
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    create_checkpoint(&store, &namespace_id, &setup)
+        .await
+        .expect("checkpoint");
+
+    let before = namespace_keys(store.inner(), &namespace_id).await;
+    let aged = context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+    store.fail_all();
+
     let report = gc_namespace(&store, &namespace_id, &config(), &aged)
         .await
-        .expect("gc pass");
+        .expect("a read failure degrades the pass instead of failing it");
     assert!(report.degraded_retention);
-    assert_eq!(report.deleted_checkpoint_records, 0);
+    assert!(
+        report.retained.degraded_roots > 0,
+        "the pass counts what the degraded roots made it keep: {report:?}"
+    );
     assert_eq!(report.deleted_manifests, 0);
     assert_eq!(report.deleted_metadata_tables, 0);
-    assert!(
-        !store
-            .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
-            .await
-            .expect("list checkpoints")
-            .is_empty(),
-        "unreadable record retained"
+    assert_eq!(
+        namespace_keys(store.inner(), &namespace_id).await,
+        before,
+        "a degraded pass reclaims nothing in the affected families"
     );
 }
 
@@ -3298,8 +3446,11 @@ async fn gc_of_an_absent_namespace_lists_and_deletes_nothing() {
     assert_eq!(store.deletes.load(Ordering::SeqCst), 0);
 }
 
+/// The same rule with a fork pin in the way: a corrupt record is corrupt
+/// whoever owns it. The source's pass fails and the basis the target reads
+/// through is left exactly as it was.
 #[tokio::test]
-async fn gc_degrades_to_retention_when_a_pin_checkpoint_is_unreadable() {
+async fn gc_fails_the_pass_when_a_fork_pin_record_is_corrupt() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let source = NamespaceId::parse("source").expect("namespace id");
@@ -3313,27 +3464,31 @@ async fn gc_degrades_to_retention_when_a_pin_checkpoint_is_unreadable() {
         .await
         .expect("fork");
 
-    // Corrupt the pinned checkpoint: ambiguous roots must retain.
-    for key in store
-        .list_prefix(&loonfs_objectstore::keys::checkpoint_prefix(
-            source.as_str(),
-        ))
+    let record_keys = store
+        .list_prefix(&checkpoint_prefix(source.as_str()))
         .await
-        .expect("list checkpoints")
-    {
-        store
-            .put_overwrite(&key, bytes::Bytes::from_static(b"not json"))
-            .await
-            .expect("corrupt record");
-    }
+        .expect("list checkpoints");
+    let corrupt_key = record_keys.first().expect("the fork pinned").clone();
+    store
+        .put_overwrite(&corrupt_key, Bytes::from_static(b"not json"))
+        .await
+        .expect("corrupt record");
 
+    let before = namespace_keys(&store, &source).await;
     let aged = context(now_after_newest_object(&store, &source, GRACE_MS + 1).await);
-    let report = gc_namespace(&store, &source, &config(), &aged)
+    let error = gc_namespace(&store, &source, &config(), &aged)
         .await
-        .expect("gc pass");
-    assert!(report.degraded_retention);
-    assert_eq!(report.deleted_manifests, 0);
-    assert_eq!(report.deleted_metadata_tables, 0);
+        .expect_err("a corrupt pin record fails the pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(
+        error.message().contains(&corrupt_key),
+        "the error names the object: {error}"
+    );
+    assert_eq!(
+        namespace_keys(&store, &source).await,
+        before,
+        "a failed pass deletes nothing"
+    );
 }
 
 async fn add_bounded_gc_fixture(

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2184,9 +2184,14 @@ publishing CAS) — under these rules:
    manifest protect nothing and age out. The head survives as the
    id-retiring tombstone, together with the root and floor objects if the
    namespace ever wrote them.
-5. Missing, corrupt, or ambiguous roots cause retention, not deletion — an
-   unreadable checkpoint record suppresses manifest and table deletion for
-   the whole pass.
+5. A root the pass cannot resolve causes retention, not deletion: a root
+   manifest that is absent, or that the store will not hand over,
+   suppresses manifest and table deletion for the whole pass. A root that
+   is corrupt is a different case, because retaining it would suppress
+   deletion on every later pass as well and nothing would ever say why. An
+   object under `checkpoints/` that does not decode as a checkpoint record,
+   and a referenced manifest that reads but fails validation, both fail the
+   pass and are reported with the object key.
 6. Only validated manifests are trusted to protect data.
 7. WAL needed to replay from the chosen metadata root to the head is never
    deleted.


### PR DESCRIPTION
GC treated corrupt checkpoint records and rooted manifests like temporary read failures, leaving the namespace permanently degraded.

GC now reports `namespace_corrupt` when stored bytes do not decode. Actual object-store read failures still use conservative retention.