### PR TITLE
fix(uploads): store failures during completion verification are retryable, not content errors

### DIFF
--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -35,7 +35,7 @@ use crate::namespace::control::load_namespace_head_control;
 use crate::storage::content::{
     abort_unpublished_multipart_upload, delete_unpublished_content_object,
     identify_streamed_payload, stage_bytes_under_content_id, stage_streamed_under_content_id,
-    verify_durable_content_checksum,
+    verify_durable_content_checksum, DurableContentValidationError,
 };
 use crate::storage::content_admission::{
     CompletedUploadReceipt, ContentAdmission, PreparedContent,
@@ -1379,6 +1379,7 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
             match verify_durable_content_checksum(store, content_store_id, promised).await {
                 Ok(()) => Ok(CompletionOutcome::Verified(promised.clone())),
                 Err(err) => {
+                    let reason = content_failure_reason(err)?;
                     // The id is random and still open, so the object nothing
                     // can name is safe to remove and would otherwise leak.
                     delete_unpublished_content_object(
@@ -1387,7 +1388,7 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
                         &requested.content_id,
                     )
                     .await;
-                    Err(CoreError::InvalidUploadContent(err.to_string()))
+                    Err(CoreError::InvalidUploadContent(reason))
                 }
             }
         }
@@ -1446,20 +1447,38 @@ async fn assemble_multipart_upload<S: ObjectStore + ?Sized>(
         // same read of the object, so neither needs its own path.
         Ok(MultipartCompletion::Assembled | MultipartCompletion::UnknownUpload) => {}
         Err(err) => {
-            // The provider refused to assemble. On AWS S3 that includes a
-            // whole-object checksum that does not match the parts, which is
-            // a wrong upload and not a transient one, so this is where the
-            // session stops.
-            return Ok(CompletionOutcome::Unusable(format!(
-                "multipart completion failed: {}",
-                err.message()
-            )));
+            // The object was not assembled on this call. The provider may
+            // have refused the parts, or the call may not have completed at
+            // all: a refusal arrives as the same transport failure as a lost
+            // response, so this cannot tell them apart and does not guess.
+            // Reporting the store failure leaves the session open and the
+            // object, if the provider did assemble one, in place — which is
+            // what a repeated completion reconciles from.
+            return Err(CoreError::store(&object_key, &err));
         }
     }
 
     match verify_durable_content_checksum(store, content_store_id, expected).await {
         Ok(()) => Ok(CompletionOutcome::Verified(expected.clone())),
-        Err(err) => Ok(CompletionOutcome::Unusable(err.to_string())),
+        Err(err) => Ok(CompletionOutcome::Unusable(content_failure_reason(err)?)),
+    }
+}
+
+/// Reports what a failed verification proves about the content.
+///
+/// A verification that ran and disagreed is evidence about the bytes: the
+/// object is absent, the wrong length, or hashes to something else. Nothing
+/// the session can do changes that, so the reason is returned for the caller
+/// to end the session with.
+///
+/// A verification that could not run is evidence about nothing. The store
+/// refused the read or did not answer it, and the object it was asked about
+/// is untouched, so the store failure is propagated as itself: the session
+/// stays open, the object stays, and the completion can be retried.
+fn content_failure_reason(error: DurableContentValidationError) -> Result<String> {
+    match error {
+        DurableContentValidationError::Store { .. } => Err(CoreError::DurableContent(error)),
+        error => Ok(error.to_string()),
     }
 }
 

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -501,6 +501,7 @@ mod direct_multipart {
     use loonfs_core::{gc_namespace, GcConfig};
     use loonfs_objectstore::keys::content_blob;
     use loonfs_test_support::stores::{MultipartChecksumEnforcement, MultipartStore};
+    use std::sync::Arc;
 
     const PART: &[u8] = b"a part's worth of bytes, repeated enough to be a part\n";
 
@@ -517,8 +518,8 @@ mod direct_multipart {
         payload: Vec<u8>,
     }
 
-    async fn open_session(
-        store: &MultipartStore<LocalFsStore>,
+    async fn open_session<S: ObjectStore>(
+        store: &MultipartStore<S>,
         context: &MutationContext,
     ) -> Session {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -581,8 +582,8 @@ mod direct_multipart {
 
     /// Uploads every part, the way a client would after asking for the
     /// signed URLs, and returns the bookkeeping it carries to completion.
-    fn upload_every_part(
-        store: &MultipartStore<LocalFsStore>,
+    fn upload_every_part<S: ObjectStore>(
+        store: &MultipartStore<S>,
         session: &Session,
     ) -> Vec<CompletedUploadPart> {
         let mut parts = Vec::new();
@@ -812,10 +813,14 @@ mod direct_multipart {
     }
 
     /// A provider that treats the whole-object checksum as a precondition
-    /// refuses the assembly outright. The session still ends terminally:
-    /// the upload is spent either way.
+    /// refuses the assembly outright. A refusal and a completion whose
+    /// response was lost arrive as the same transport failure, so the first
+    /// attempt reports the store failure and leaves the session open. The
+    /// object ends the session instead: the retry finds the upload consumed
+    /// and nothing at the key, and the completion contract already calls
+    /// that terminal.
     #[tokio::test]
-    async fn a_refused_assembly_is_terminal_too() {
+    async fn a_refused_assembly_is_a_store_failure_and_the_retry_is_terminal() {
         let temp_dir = tempdir().expect("tempdir");
         let store = MultipartStore::with_enforcement(
             LocalFsStore::new(temp_dir.path()).expect("store"),
@@ -832,16 +837,37 @@ mod direct_multipart {
             etag,
             crc64nvme: StorageChecksum::crc64nvme(short).value,
         };
+        let request = complete_request(&session, parts);
 
         let error = complete_upload(
             &store,
             &session.namespace_id,
             &session.upload_id,
-            &complete_request(&session, parts),
+            &request,
             &context,
         )
         .await
         .expect_err("a refused assembly cannot complete");
+        assert_eq!(error.code(), ErrorCode::ServerError);
+        assert!(
+            matches!(
+                session_state(&store, &session.namespace_id, &session.upload_id)
+                    .await
+                    .state,
+                UploadSessionLifecycle::Open { .. }
+            ),
+            "a provider failure the server cannot read is not proof about content"
+        );
+
+        let error = complete_upload(
+            &store,
+            &session.namespace_id,
+            &session.upload_id,
+            &request,
+            &context,
+        )
+        .await
+        .expect_err("neither an upload nor an object is left to complete");
         assert_eq!(error.code(), ErrorCode::InvalidRequest);
         assert!(matches!(
             session_state(&store, &session.namespace_id, &session.upload_id)
@@ -854,6 +880,71 @@ mod direct_multipart {
             .await
             .expect("head")
             .is_none());
+    }
+
+    /// A read-back the store refuses to answer says nothing about the object
+    /// the provider assembled. The completion reports the store failure, and
+    /// the object and the session survive it. The retry then completes from
+    /// the object: the provider reports an upload it no longer knows, and
+    /// the read-back settles the rest.
+    #[tokio::test]
+    async fn a_verification_the_store_refuses_leaves_the_completion_retryable() {
+        let temp_dir = tempdir().expect("tempdir");
+        let failing = Arc::new(FailStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("store"),
+            KeyPredicate::content_blob(),
+            OperationClass::Read,
+            InjectedError::Transport("injected content read failure".to_owned()),
+        ));
+        let store = MultipartStore::new(Arc::clone(&failing));
+        let context = mutation_context();
+        let session = open_session(&store, &context).await;
+        let parts = upload_every_part(&store, &session);
+        let request = complete_request(&session, parts);
+
+        failing.fail_next(1);
+        let error = complete_upload(
+            &store,
+            &session.namespace_id,
+            &session.upload_id,
+            &request,
+            &context,
+        )
+        .await
+        .expect_err("a verification that cannot run does not complete the upload");
+        assert_eq!(error.code(), ErrorCode::ServerError);
+        assert_eq!(failing.attempts(), 1, "the read-back is what failed");
+        assert!(
+            matches!(
+                session_state(&store, &session.namespace_id, &session.upload_id)
+                    .await
+                    .state,
+                UploadSessionLifecycle::Open { .. }
+            ),
+            "a store failure must not end the session"
+        );
+        assert_eq!(
+            store
+                .get(&session.object_key, None)
+                .await
+                .expect("read object")
+                .expect("the assembled object survives a failed read-back"),
+            Bytes::from(session.payload.clone())
+        );
+
+        let completed = complete_upload(
+            &store,
+            &session.namespace_id,
+            &session.upload_id,
+            &request,
+            &context,
+        )
+        .await
+        .expect("the retried completion verifies the assembled object");
+        assert_eq!(
+            completed.content_ref.storage_checksum,
+            StorageChecksum::crc64nvme(&session.payload)
+        );
     }
 
     /// A session abandoned mid-upload leaves parts sitting at the provider.

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -11,7 +11,7 @@ use loonfs::{
     CreateNamespaceOptions, DestinationBehavior, ErrorCode, NamespaceId, PutFileOptions,
     RuntimeCacheConfig, SharedObjectStore,
 };
-use loonfs_api::v0::DirectPutContentClaim;
+use loonfs_api::v0::{DirectPutContentClaim, UploadSessionStatus};
 use loonfs_api::StorageChecksum;
 use loonfs_objectstore::keys::wal_head;
 
@@ -52,6 +52,15 @@ fn fail_content_blob_puts_store(root: &Path) -> FailStore<LocalFsStore> {
         KeyPredicate::content_blob(),
         OperationClass::Put,
         InjectedError::Transport("injected content write failure".to_owned()),
+    )
+}
+
+fn fail_content_blob_heads_store(root: &Path) -> FailStore<LocalFsStore> {
+    FailStore::new(
+        LocalFsStore::new(root).expect("create local-fs store"),
+        KeyPredicate::content_blob(),
+        OperationClass::Head,
+        InjectedError::Transport("injected checksum head failure".to_owned()),
     )
 }
 #[test]
@@ -236,6 +245,11 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
             &CompleteUploadRequest::for_content_ref(content_ref),
         )
         .expect_err("mismatched bytes must fail completion");
+    assert_eq!(
+        error.code(),
+        ErrorCode::InvalidRequest,
+        "a read-back that ran and disagreed is reported against the content: {error}"
+    );
     assert!(
         error.to_string().contains("content checksum mismatch"),
         "completion names the checksum mismatch: {error}"
@@ -246,6 +260,57 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
             .is_none(),
         "a rejected completion leaves no orphan behind"
     );
+}
+
+/// A read-back that could not run is not evidence about the bytes. The
+/// completion reports the store failure it hit, keeps the object the client
+/// uploaded and the session that owns it, and the retry completes.
+#[test]
+fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("demo");
+    let raw_store = Arc::new(fail_content_blob_heads_store(temp_dir.path()));
+    let object_store: SharedObjectStore = raw_store.clone();
+    let fs = open_runtime(object_store, "direct-put-read-back-failure-test");
+    let bytes = b"direct put bytes the store would not vouch for";
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    let begin = block_on(fs.begin_direct_put_upload_target(&namespace_id, direct_put_claim(bytes)))
+        .expect("begin direct put");
+    let content_ref = begin.target.content_ref.clone();
+    let request = CompleteUploadRequest::for_content_ref(content_ref.clone());
+
+    let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
+    block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
+        .expect("write direct object");
+
+    raw_store.fail_next(1);
+    let error = fs
+        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
+        .expect_err("a verification that cannot run does not complete the upload");
+    assert_eq!(error.code(), ErrorCode::ServerError);
+    assert_eq!(raw_store.attempts(), 1, "the checksum head is what failed");
+    assert!(
+        block_on(direct_store.head(&begin.target.object_key))
+            .expect("head the uploaded object")
+            .is_some(),
+        "a store failure must not delete the client's object"
+    );
+    let (status, _) = block_on(
+        fs.writer
+            .read_upload_status(&namespace_id, &begin.upload_id),
+    )
+    .expect("read upload status");
+    assert!(
+        matches!(status.status, UploadSessionStatus::Open { .. }),
+        "a store failure must not end the session"
+    );
+
+    let completed = fs
+        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
+        .expect("the retried completion verifies and completes");
+    assert_eq!(completed.content_ref, content_ref);
 }
 
 #[test]

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1002,7 +1002,10 @@ provider enforcement is real but not uniform across S3-compatible providers,
 and a random object id says nothing about its bytes, so the comparison is the
 load-bearing check rather than a formality. A mismatch fails the completion and
 deletes the object — safe because the id was never published, so nothing
-references it. Nothing is read back through the server either way.
+references it. A metadata request the provider does not answer is a different
+outcome: nothing was compared, so the completion reports `server_error`, leaves
+the object and the session as they were, and the client repeats it. Nothing is
+read back through the server either way.
 
 #### Direct multipart upload
 
@@ -1111,6 +1114,13 @@ retry against and the session can never produce the content it promised. The
 session goes to `aborted`, the object it assembled is deleted, and the
 failure is reported. The client starts a new session; there is no
 completion retry that could succeed.
+
+**A completion that could not be verified is not terminal.** Terminal means
+the read-back ran and disagreed. When the assembly call or the read-back
+fails at the transport instead, nothing was established about the object, so
+the completion reports `server_error` and changes nothing: the session stays
+`open` and any object the provider did assemble is left alone. The client
+repeats the completion, which resolves from durable state as below.
 
 **A lost completion response is not a failure.** Replaying the provider's
 completion is useless — one provider replays a success carrying no checksum,


### PR DESCRIPTION
Upload completion treated object-store failures during verification as invalid content and could end an upload that was safe to retry.

Store failures now leave the session and object intact for retry. Confirmed missing or mismatched content remains terminal.