### PR TITLE
fix(api): request bodies reject unknown fields

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -128,6 +128,7 @@ pub struct ErrorDetails {
 /// Request to create a namespace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct CreateNamespaceRequest {
     /// Durable namespace id to create.
     pub namespace_id: NamespaceId,
@@ -136,6 +137,7 @@ pub struct CreateNamespaceRequest {
 /// Request to fork a namespace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct ForkNamespaceRequest {
     /// Durable namespace id for the fork target.
     pub new_namespace_id: NamespaceId,
@@ -206,9 +208,20 @@ pub enum DeleteDirectoryBehavior {
 }
 
 /// One path-oriented filesystem operation.
+///
+/// Unknown fields are rejected because every optimistic-concurrency guard
+/// below is an optional field. A misspelled `expected_revision_no` or
+/// `expected_inode_id` would otherwise decode to `None`, and the write would
+/// apply unguarded and answer 200 — a lost update reported as a success. A
+/// guard the server never saw must fail the request, not the precondition.
+///
+/// Every variant here carries fields. A variant that carries none must still
+/// be spelled with empty braces, because serde lets a *unit* variant of a
+/// tagged enum swallow whatever else the body held; `BeginUploadRequest` in
+/// [`super::uploads`] shows the same rule.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum FilesystemOperation {
     /// Create one directory.
     #[cfg_attr(feature = "openapi", schema(title = "FsOpCreateDirectory"))]
@@ -338,8 +351,13 @@ pub enum FilesystemOperation {
 /// A one-operation request is the one-element case of this shape, not a
 /// different request: a convenience call and a batch produce the same commit
 /// and the same fingerprint.
+///
+/// Unknown fields are rejected here for the same reason they are on
+/// [`FilesystemOperation`]: the fields a typo can hide are the ones that
+/// decide whether the commit is guarded at all.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct CommitRequest {
     /// Caller-supplied idempotency key for the whole request.
     pub commit_id: CommitId,
@@ -411,6 +429,7 @@ pub struct ListFileRevisionsResponse {
 /// Request to create a durable checkpoint pin.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct CreateCheckpointRequest {
     /// Label recorded on the checkpoint record. A label, not a key: several
     /// records may carry the same name over different bases.
@@ -549,8 +568,13 @@ pub struct FlushWalResponse {
 
 /// Optional overrides for one garbage-collection pass. Absent fields use
 /// the server's conservative defaults.
+///
+/// Every field is optional, so a typo would take the default instead of the
+/// override the caller asked for. Unknown fields are rejected so a misspelled
+/// `max_objects` fails loudly rather than running an unbounded pass.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct GcRequest {
     /// Objects younger than this are never deleted, reachable or not. The
     /// window has a derived safety floor (publication budgets plus provider
@@ -864,9 +888,13 @@ pub struct AdvanceRetentionResponse {
 ///
 /// Selection is presence. Each field names one independent action, and a
 /// step runs exactly the ones the body carries — a request that selects
-/// nothing is rejected rather than quietly doing nothing.
+/// nothing is rejected rather than quietly doing nothing. Unknown fields are
+/// rejected for the same reason: a misspelled selector would leave its action
+/// unrun, and the caller would read the empty report as "there was nothing to
+/// do".
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct MaintenanceStepRequest {
     /// Fold the visible WAL tail into metadata tables and merge one bounded
     /// reorganization unit. The two travel together: folding a tail is what
@@ -886,6 +914,7 @@ pub struct MaintenanceStepRequest {
 /// Overrides for the metadata-upkeep action.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct MetadataMaintenanceRequest {
     /// Flush the visible WAL tail once it reaches this many segments.
     /// Absent uses the server's default threshold; zero, and any value above
@@ -974,9 +1003,12 @@ pub struct MetadataMaintenanceResponse {
 }
 
 /// Options for one store contract probe. Empty today; a body is still sent
-/// so later options do not change the shape of the request.
+/// so later options do not change the shape of the request. An option this
+/// build does not know is rejected rather than ignored, so a caller never
+/// believes it selected something.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct StoreProbeRequest {}
 
 /// What one store contract probe observed, check by check.
@@ -1033,6 +1065,13 @@ mod tests {
 
     fn attribute_key(value: &str) -> AttributeKey {
         AttributeKey::parse(value).expect("valid test attribute key")
+    }
+
+    fn sample_content_ref() -> ContentRef {
+        ContentRef::blob_v1(
+            ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("valid content id"),
+            b"hello",
+        )
     }
 
     #[test]
@@ -1403,5 +1442,154 @@ mod tests {
         ] {
             assert!(serde_json::from_value::<FilesystemOperation>(encoded).is_err());
         }
+    }
+
+    /// A guard the server never saw must fail the request, not the
+    /// precondition. Every guard is optional, so a misspelled one used to
+    /// decode to `None` and let the write apply unguarded.
+    #[test]
+    fn a_misspelled_guard_does_not_decode() {
+        let put = |guard: &str| {
+            let mut operation = serde_json::json!({
+                "kind": "put_file",
+                "path": "/docs/a.txt",
+                "content_ref": sample_content_ref(),
+                "behavior": "replace"
+            });
+            operation[guard] = serde_json::json!(3);
+            serde_json::json!({
+                "commit_id": "guarded-put",
+                "operations": [operation]
+            })
+        };
+
+        let spelled: CommitRequest = serde_json::from_value(put("expected_revision_no"))
+            .expect("the guard spelled correctly decodes");
+        assert!(matches!(
+            spelled.operations.as_slice(),
+            [FilesystemOperation::PutFile {
+                expected_revision_no: Some(RevisionNo(3)),
+                ..
+            }]
+        ));
+
+        for misspelling in ["expected_revsion_no", "expectedRevisionNo"] {
+            assert!(
+                serde_json::from_value::<CommitRequest>(put(misspelling)).is_err(),
+                "`{misspelling}` decoded instead of failing the request"
+            );
+        }
+    }
+
+    /// The whole commit request tree is strict, not just its root: a typo one
+    /// level down hides the same guards.
+    #[test]
+    fn a_commit_request_rejects_unknown_fields_at_every_level() {
+        let valid = || {
+            serde_json::json!({
+                "commit_id": "strict-commit",
+                "content_tokens": [{
+                    "content_ref": sample_content_ref(),
+                    "token": "opaque-proof"
+                }],
+                "operations": [{
+                    "kind": "update_attributes",
+                    "path": "/docs/a.txt",
+                    "set": {"owner": {"kind": "string", "value": "ada"}},
+                    "expected_inode_id": 7
+                }]
+            })
+        };
+        serde_json::from_value::<CommitRequest>(valid())
+            .expect("the same body without a typo decodes");
+
+        let mut at_root = valid();
+        at_root["mesage"] = serde_json::json!("a note");
+
+        let mut in_operation = valid();
+        in_operation["operations"][0]["expectedAttributesRevisionNo"] = serde_json::json!(3);
+
+        let mut in_attribute_value = valid();
+        in_attribute_value["operations"][0]["set"]["owner"]["values"] =
+            serde_json::json!(["ada", "grace"]);
+
+        let mut in_content_token = valid();
+        in_content_token["content_tokens"][0]["expires_at_ms"] = serde_json::json!(1);
+
+        let mut in_content_ref = valid();
+        in_content_ref["content_tokens"][0]["content_ref"]["sizeBytes"] = serde_json::json!(5);
+
+        for (level, body) in [
+            ("the request root", at_root),
+            ("an operation variant", in_operation),
+            ("a nested attribute value", in_attribute_value),
+            ("a nested content token", in_content_token),
+            ("a content ref below that", in_content_ref),
+        ] {
+            assert!(
+                serde_json::from_value::<CommitRequest>(body).is_err(),
+                "an unknown field in {level} decoded instead of failing the request"
+            );
+        }
+    }
+
+    /// The maintenance bodies are optional selectors and overrides all the
+    /// way down, so a typo would run a different step than the caller asked
+    /// for and report the difference as "nothing to do".
+    #[test]
+    fn maintenance_request_bodies_reject_unknown_fields() {
+        serde_json::from_value::<MaintenanceStepRequest>(serde_json::json!({
+            "metadata": {"max_wal_tail_segments": 4},
+            "advance_retention": true,
+            "gc": {"grace_window_ms": 1_800_000, "max_objects": 32}
+        }))
+        .expect("the same body without a typo decodes");
+
+        for body in [
+            serde_json::json!({"advance_retenton": true}),
+            serde_json::json!({"metadata": {"maxWalTailSegments": 4}}),
+            serde_json::json!({"gc": {"max_object": 32}}),
+        ] {
+            assert!(
+                serde_json::from_value::<MaintenanceStepRequest>(body.clone()).is_err(),
+                "an unknown field decoded instead of failing the step: {body}"
+            );
+        }
+
+        serde_json::from_value::<CreateCheckpointRequest>(
+            serde_json::json!({"name": "nightly", "ttl_ms": 60_000}),
+        )
+        .expect("the same checkpoint body without a typo decodes");
+        assert!(serde_json::from_value::<CreateCheckpointRequest>(
+            serde_json::json!({"name": "nightly", "ttlMs": 60_000})
+        )
+        .is_err());
+
+        // The probe body carries no options yet, so an unknown one is the
+        // only thing it can be sent.
+        serde_json::from_value::<StoreProbeRequest>(serde_json::json!({}))
+            .expect("an empty probe body decodes");
+        assert!(
+            serde_json::from_value::<StoreProbeRequest>(serde_json::json!({"deep": true})).is_err()
+        );
+
+        serde_json::from_value::<CreateNamespaceRequest>(serde_json::json!({
+            "namespace_id": "demo"
+        }))
+        .expect("the same create body without a typo decodes");
+        assert!(
+            serde_json::from_value::<CreateNamespaceRequest>(serde_json::json!({
+                "namespace_id": "demo",
+                "fork_of": "other"
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<ForkNamespaceRequest>(serde_json::json!({
+                "new_namespace_id": "demo",
+                "source_namespace_id": "other"
+            }))
+            .is_err()
+        );
     }
 }

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -6,8 +6,14 @@ use serde::{Deserialize, Serialize};
 use xxhash_rust::xxh64::xxh64;
 
 /// One content-search request.
+///
+/// Every field but `pattern` is optional, and each one selects results. A
+/// misspelled `case_insensitive` or `path_prefix` would decode to the default
+/// and answer a different search than the caller asked for, with no sign that
+/// anything was dropped, so unknown fields are rejected.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct GrepRequest {
     /// The pattern, in the Rust `regex` crate's dialect (no backreferences
     /// or lookaround). Patterns that require no literal bytes are rejected
@@ -212,6 +218,7 @@ pub struct DisableGrepIndexResponse {
 /// One explicit grep-index garbage-collection pass (admin plane).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct GrepGcRequest {
     /// Reads this pass may spend before returning with a `next_cursor`.
     /// Omit to take the same per-pass default the runtime's own collection
@@ -364,5 +371,39 @@ mod tests {
         });
 
         assert!(serde_json::from_value::<GrepRequest>(encoded).is_err());
+    }
+
+    /// Every optional field on a search body selects results, so a typo would
+    /// answer a different question than the caller asked and say nothing
+    /// about it.
+    #[test]
+    fn search_request_bodies_reject_unknown_fields() {
+        serde_json::from_value::<GrepRequest>(serde_json::json!({
+            "pattern": "needle",
+            "case_insensitive": true,
+            "path_prefix": "/docs",
+            "limit": 10,
+            "allow_stale": true,
+            "allow_scan": true
+        }))
+        .expect("the same body without a typo decodes");
+
+        for body in [
+            serde_json::json!({"pattern": "needle", "case_insensitve": true}),
+            serde_json::json!({"pattern": "needle", "caseInsensitive": true}),
+            serde_json::json!({"pattern": "needle", "pathPrefix": "/docs"}),
+            serde_json::json!({"pattern": "needle", "allow_scans": true}),
+        ] {
+            assert!(
+                serde_json::from_value::<GrepRequest>(body.clone()).is_err(),
+                "an unknown field decoded instead of failing the search: {body}"
+            );
+        }
+
+        serde_json::from_value::<GrepGcRequest>(serde_json::json!({"max_objects": 8}))
+            .expect("the same collection body without a typo decodes");
+        assert!(
+            serde_json::from_value::<GrepGcRequest>(serde_json::json!({"maxObjects": 8})).is_err()
+        );
     }
 }

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -257,8 +257,12 @@ pub struct CompletedUploadPart {
 }
 
 /// Stateless proof that a LoonFS server already validated a content ref.
+///
+/// This travels in a commit request, so it decodes under the request rule:
+/// unknown fields are rejected.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
 pub struct ValidatedContentToken {
     /// Content identity the server attests it already verified.
     pub content_ref: ContentRef,

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -7,8 +7,8 @@ use crate::common::start_server;
 use loonfs::publish::CommitRequest as CoreCommitRequest;
 use loonfs::{CreateNamespaceOptions, FsWriter, ListChangesOptions, StoreConfig};
 use loonfs_api::{
-    v0::CommittedChange, AbsolutePath, ChangeSeq, CommitId, CommitRequest, ContentRef,
-    DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, FilesystemOperation,
+    v0::CommittedChange, AbsolutePath, ApiError, ChangeSeq, CommitId, CommitRequest, ContentRef,
+    DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, FilesystemOperation, RevisionNo,
 };
 use loonfs_client::{ClientError, NamespacePath};
 use loonfs_test_support::ids::namespace_id;
@@ -716,6 +716,109 @@ async fn a_commit_id_used_embedded_replays_over_http() {
         }
         other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
     }
+
+    harness.server.abort();
+}
+
+/// A misspelled guard fails the request rather than the precondition.
+///
+/// Every optimistic-concurrency guard on a commit is an optional field, so
+/// before the commit body rejected unknown fields a typo decoded to `None`
+/// and the write applied unguarded — a lost update reported as a 200. The two
+/// bodies below differ only in how `expected_revision_no` is spelled.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_misspelled_commit_guard_is_rejected_rather_than_dropped() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-strict-commit",
+        "http-strict-commit",
+    ))
+    .await;
+
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let first = stage_uploaded_content(&harness.client, &namespace, FIRST_BYTES).await;
+    let second = stage_uploaded_content(&harness.client, &namespace, SECOND_BYTES).await;
+
+    harness
+        .client
+        .commit(
+            &namespace,
+            &CommitRequest {
+                commit_id: commit_id("guarded-create"),
+                message: None,
+                content_tokens: vec![validated_content_token(&first)],
+                operations: vec![FilesystemOperation::PutFile {
+                    path: absolute(FIRST_FILE),
+                    content_ref: first.content_ref.clone(),
+                    behavior: DestinationBehavior::NoReplace,
+                    expected_revision_no: None,
+                }],
+            },
+        )
+        .await
+        .expect("the file is created at revision 1");
+
+    // One replace, spelled two ways. Both name the revision that is actually
+    // current, so the spelling of the guard is the only difference.
+    let replace = |commit: &str, guard: &str| {
+        let mut put = serde_json::json!({
+            "kind": "put_file",
+            "path": FIRST_FILE,
+            "content_ref": second.content_ref.clone(),
+            "behavior": "replace"
+        });
+        put[guard] = serde_json::json!(1);
+        serde_json::json!({
+            "commit_id": commit,
+            "content_tokens": [validated_content_token(&second)],
+            "operations": [put]
+        })
+    };
+
+    let ureq::Error::Status(status, response) = *send_commit_json(
+        &harness.server_url,
+        &namespace,
+        &replace("misspelled-guard", "expected_revsion_no"),
+    )
+    .expect_err("a misspelled guard is not a commit this API accepts") else {
+        unreachable!("a rejected commit body returns an HTTP status");
+    };
+    assert_eq!(status, 400);
+    let error: ApiError =
+        serde_json::from_reader(response.into_reader()).expect("API error envelope");
+    assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
+
+    // The rejected body wrote nothing: the file is still the one the guarded
+    // create published.
+    let unchanged = harness
+        .client
+        .stat_path(&NamespacePath::parse("demo", FIRST_FILE).expect("path"))
+        .await
+        .expect("the file is still there");
+    assert_eq!(unchanged.revision_no, Some(RevisionNo(1)));
+    assert_eq!(unchanged.content_ref.as_ref(), Some(&first.content_ref));
+
+    // Spelled correctly the same body commits, which is what says the typo
+    // was the only thing wrong with it.
+    send_commit_json(
+        &harness.server_url,
+        &namespace,
+        &replace("spelled-guard", "expected_revision_no"),
+    )
+    .expect("the guard spelled correctly commits");
+    let replaced = harness
+        .client
+        .stat_path(&NamespacePath::parse("demo", FIRST_FILE).expect("path"))
+        .await
+        .expect("the replace landed");
+    assert_eq!(replaced.revision_no, Some(RevisionNo(2)));
+    assert_eq!(replaced.content_ref.as_ref(), Some(&second.content_ref));
 
     harness.server.abort();
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -374,6 +374,10 @@ own cross-request guards on the operation itself where staleness matters:
 delete. A guard is evaluated against the state its own operation sees, which
 includes what earlier operations in the same request did.
 
+Every guard is an optional field, which is why a commit body rejects unknown
+fields (section 6). A misspelled `expected_revision_no` is `invalid_request`
+rather than a write that applies unguarded and answers 200.
+
 The server validates each request against authoritative namespace state and
 may reject it immediately. A tentatively accepted request becomes one
 committed logical commit only after its WAL segment is durably written and the
@@ -581,6 +585,16 @@ are what a load balancer probes: `GET /health` and `GET /readiness`.
 Everything else, `GET /v0/capabilities` included, requires the token. The
 generated `openapi.json` states this as a global `bearer_auth` requirement
 with those two operations overriding it.
+
+Request bodies reject unknown fields, at every level of nesting, with 400
+`invalid_request`. Most request fields are optional and several of those are
+preconditions, so a field the server does not recognize cannot be ignored: a
+misspelled guard would decode to its default and the server would carry out
+a different request than the caller asked for. Response bodies are the other
+way round, because a client must keep working against a server newer than
+itself and so must tolerate fields it does not know (section 7.2). The
+encoding conventions in `format.md` state the same two rules and extend them
+to durable shapes.
 
 The token is a bearer credential and so is everything the upload routes hand
 back: a presigned direct-upload URL is a capability to write to the

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -15,9 +15,26 @@ a deployment exposes.
 
 Encoding conventions used by every durable and wire shape in this specification:
 field names and enum values are `snake_case`; fields holding typed identifiers
-are suffixed `_id`; tagged unions carry their discriminator in a `kind` field;
-HTTP wire shapes and immutable, never-rewritten families tolerate unknown
-fields, while mutable control-object envelopes and payloads reject them.
+are suffixed `_id`; tagged unions carry their discriminator in a `kind` field.
+
+Unknown fields are tolerated where a reader must accept what a newer writer
+added, and rejected where accepting one would lose information the sender
+meant to send:
+
+- **HTTP request bodies reject them.** Most request fields are optional, and
+  many of those are preconditions, so a misspelled field would decode to its
+  default and the server would carry out a different request than the caller
+  asked for — an unguarded write answering 200. Rejection is over the whole
+  request, at every level of nesting.
+- **HTTP response bodies tolerate them**, so a client keeps working against a
+  server newer than itself.
+- **Immutable, never-rewritten durable families tolerate them**, for the same
+  reason: nothing rewrites them, so nothing can erase a field it did not
+  understand.
+- **Mutable control-object envelopes and payloads reject them**, because a
+  reader that tolerated an unknown field would erase it on the next
+  read-modify-write and still report a successful guarded update
+  (section 1.7).
 
 ## 1. Object store contract
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3391,7 +3391,7 @@
       },
       "CommitRequest": {
         "type": "object",
-        "description": "One commit: an idempotency key, an optional annotation, and an ordered\nlist of path operations that commit together (API spec, section 5.1).\n\nA one-operation request is the one-element case of this shape, not a\ndifferent request: a convenience call and a batch produce the same commit\nand the same fingerprint.",
+        "description": "One commit: an idempotency key, an optional annotation, and an ordered\nlist of path operations that commit together (API spec, section 5.1).\n\nA one-operation request is the one-element case of this shape, not a\ndifferent request: a convenience call and a batch produce the same commit\nand the same fingerprint.\n\nUnknown fields are rejected here for the same reason they are on\n[`FilesystemOperation`]: the fields a typo can hide are the ones that\ndecide whether the commit is guarded at all.",
         "required": [
           "commit_id",
           "operations"
@@ -3422,7 +3422,8 @@
             },
             "description": "Ordered operations to apply. Must be non-empty; they commit all\ntogether or not at all."
           }
-        }
+        },
+        "additionalProperties": false
       },
       "CommitResponse": {
         "type": "object",
@@ -3664,7 +3665,8 @@
             "description": "Optional lifetime; the server computes the record's expiry from its\nown clock. Absent means the pin holds until explicitly released.",
             "minimum": 0
           }
-        }
+        },
+        "additionalProperties": false
       },
       "CreateCheckpointResponse": {
         "type": "object",
@@ -3725,7 +3727,8 @@
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Durable namespace id to create."
           }
-        }
+        },
+        "additionalProperties": false
       },
       "DeleteDirectoryBehavior": {
         "type": "string",
@@ -4664,7 +4667,7 @@
             }
           }
         ],
-        "description": "One path-oriented filesystem operation."
+        "description": "One path-oriented filesystem operation.\n\nUnknown fields are rejected because every optimistic-concurrency guard\nbelow is an optional field. A misspelled `expected_revision_no` or\n`expected_inode_id` would otherwise decode to `None`, and the write would\napply unguarded and answer 200 — a lost update reported as a success. A\nguard the server never saw must fail the request, not the precondition.\n\nEvery variant here carries fields. A variant that carries none must still\nbe spelled with empty braces, because serde lets a *unit* variant of a\ntagged enum swallow whatever else the body held; `BeginUploadRequest` in\n[`super::uploads`] shows the same rule."
       },
       "ForkNamespaceRequest": {
         "type": "object",
@@ -4677,11 +4680,12 @@
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Durable namespace id for the fork target."
           }
-        }
+        },
+        "additionalProperties": false
       },
       "GcRequest": {
         "type": "object",
-        "description": "Optional overrides for one garbage-collection pass. Absent fields use\nthe server's conservative defaults.",
+        "description": "Optional overrides for one garbage-collection pass. Absent fields use\nthe server's conservative defaults.\n\nEvery field is optional, so a typo would take the default instead of the\noverride the caller asked for. Unknown fields are rejected so a misspelled\n`max_objects` fails loudly rather than running an unbounded pass.",
         "properties": {
           "cursor": {
             "type": [
@@ -4708,7 +4712,8 @@
             "description": "Maximum objects this invocation may read or decide. Omit to retain\nthe run-to-completion behavior.\n\nA completed upload session past its reclamation grace makes the pass\nread every live manifest and retained WAL segment to find out\nwhether anything still references its content, and that read is\ncharged here like any other. A budget too small to finish it does\nnot stall the pass: the session is retained, the response sets\n`content_reclamation_deferred`, and the sweep carries on through\neverything else. What a chronically small budget costs is content\nleft unreclaimed, not progress. Give a pass at least as many objects\nas the namespace has live manifests and retained segments for that\ncontent to come back.",
             "minimum": 0
           }
-        }
+        },
+        "additionalProperties": false
       },
       "GcResponse": {
         "type": "object",
@@ -4842,7 +4847,8 @@
             "description": "Reads this pass may spend before returning with a `next_cursor`.\nOmit to take the same per-pass default the runtime's own collection\ntakes.",
             "minimum": 0
           }
-        }
+        },
+        "additionalProperties": false
       },
       "GrepGcResponse": {
         "type": "object",
@@ -5055,7 +5061,7 @@
       },
       "GrepRequest": {
         "type": "object",
-        "description": "One content-search request.",
+        "description": "One content-search request.\n\nEvery field but `pattern` is optional, and each one selects results. A\nmisspelled `case_insensitive` or `path_prefix` would decode to the default\nand answer a different search than the caller asked for, with no sign that\nanything was dropped, so unknown fields are rejected.",
         "required": [
           "pattern"
         ],
@@ -5103,7 +5109,8 @@
             "type": "string",
             "description": "The pattern, in the Rust `regex` crate's dialect (no backreferences\nor lookaround). Patterns that require no literal bytes are rejected\nwith `query_unindexable` unless `allow_scan` is set."
           }
-        }
+        },
+        "additionalProperties": false
       },
       "GrepResponse": {
         "type": "object",
@@ -5294,7 +5301,7 @@
       },
       "MaintenanceStepRequest": {
         "type": "object",
-        "description": "One explicit maintenance step: the actions it selects, and nothing more.\n\nSelection is presence. Each field names one independent action, and a\nstep runs exactly the ones the body carries — a request that selects\nnothing is rejected rather than quietly doing nothing.",
+        "description": "One explicit maintenance step: the actions it selects, and nothing more.\n\nSelection is presence. Each field names one independent action, and a\nstep runs exactly the ones the body carries — a request that selects\nnothing is rejected rather than quietly doing nothing. Unknown fields are\nrejected for the same reason: a misspelled selector would leave its action\nunrun, and the caller would read the empty report as \"there was nothing to\ndo\".",
         "properties": {
           "advance_retention": {
             "type": "boolean",
@@ -5322,7 +5329,8 @@
               }
             ]
           }
-        }
+        },
+        "additionalProperties": false
       },
       "MaintenanceStepResponse": {
         "type": "object",
@@ -5394,7 +5402,8 @@
             "description": "Flush the visible WAL tail once it reaches this many segments.\nAbsent uses the server's default threshold; zero, and any value above\nthe write-rejection threshold, are rejected as `invalid_request`.",
             "minimum": 0
           }
-        }
+        },
+        "additionalProperties": false
       },
       "MetadataMaintenanceResponse": {
         "type": "object",
@@ -5810,7 +5819,8 @@
       },
       "StoreProbeRequest": {
         "type": "object",
-        "description": "Options for one store contract probe. Empty today; a body is still sent\nso later options do not change the shape of the request."
+        "description": "Options for one store contract probe. Empty today; a body is still sent\nso later options do not change the shape of the request. An option this\nbuild does not know is rejected rather than ignored, so a caller never\nbelieves it selected something.",
+        "additionalProperties": false
       },
       "StoreProbeResponse": {
         "type": "object",
@@ -6050,7 +6060,7 @@
       },
       "ValidatedContentToken": {
         "type": "object",
-        "description": "Stateless proof that a LoonFS server already validated a content ref.",
+        "description": "Stateless proof that a LoonFS server already validated a content ref.\n\nThis travels in a commit request, so it decodes under the request rule:\nunknown fields are rejected.",
         "required": [
           "content_ref",
           "token"
@@ -6064,7 +6074,8 @@
             "type": "string",
             "description": "Opaque, server-signed token. Clients must not parse it."
           }
-        }
+        },
+        "additionalProperties": false
       },
       "WalFlushStepOutcome": {
         "oneOf": [


### PR DESCRIPTION
JSON request bodies silently ignored unknown fields, including misspelled optional concurrency guards.

Request types now reject unknown fields, including nested upload and content-proof structures. OpenAPI documents the same behavior.