### PR TITLE
fix(objectstore): streamed create-if-absent keeps its meaning past one part

### DIFF
--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -683,7 +683,11 @@ pub(crate) async fn upload_streamed_content<S: ObjectStore + ?Sized>(
                     }
                     Some(_) => Err(CoreError::UploadContentConflict { upload_id }),
                     // Nothing is recorded yet, so an occupied key holds
-                    // bytes this session never acknowledged writing.
+                    // bytes this session never acknowledged writing. Past the
+                    // store's multipart threshold `already_present` cannot
+                    // see a concurrent request that occupies the key after
+                    // this write observed it absent; `complete_upload` reads
+                    // the object again and is the backstop for that case.
                     None if already_present => Err(CoreError::UploadContentConflict { upload_id }),
                     None => {
                         *open_staging_slot(&mut state.state, &upload_id)? = Some(content_ref);
@@ -1365,7 +1369,7 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
                     "completed content ref does not match staged content".to_owned(),
                 ));
             }
-            Ok(CompletionOutcome::Verified(staged.clone()))
+            verify_staged_content_object(store, content_store_id, staged).await
         }
         CompletionPlan::DirectPut {
             requested,
@@ -1406,6 +1410,56 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
             .await
         }
     }
+}
+
+/// Checks that the object a proxied session staged is still the object that
+/// session staged.
+///
+/// The staging write hashed its own bytes, so the reference is trusted. The
+/// object is not, because a second request against the same session can
+/// write over it. A streamed write past the store's multipart threshold
+/// cannot make its create-only condition part of the write (see
+/// [`stage_streamed_under_content_id`]), so the second request assembles its
+/// own bytes over the first request's object. The `already_present` guard in
+/// [`upload_streamed_content`] usually refuses that second request, but it
+/// cannot see a writer that lands inside its own window. The second request
+/// is then refused a record while its bytes sit at the key, and the session
+/// keeps holding the first request's digest. This check catches that, so the
+/// reference is never frozen and published.
+///
+/// One `head` decides it, and it decides it by size. A proxied reference
+/// carries the SHA-256 this server folded over the payload. The provider's
+/// stored checksum is a different number: Cloudflare R2 stores a CRC-64/NVME
+/// it computed itself, and an AWS S3 multipart object's SHA-256 covers the
+/// part digests rather than the payload. So
+/// [`verify_durable_content_checksum`] has nothing to compare here, and the
+/// direct transports use it only because their references name the algorithm
+/// the provider stores. Size does not tell two payloads of the same length
+/// apart. A completion whose object is missing or a different length can
+/// never publish.
+async fn verify_staged_content_object<S: ObjectStore + ?Sized>(
+    store: &S,
+    content_store_id: &ContentStoreId,
+    staged: &ContentRef,
+) -> Result<CompletionOutcome> {
+    let object_key = content_blob(content_store_id.as_str(), &staged.content_id);
+    let observed = store
+        .head(&object_key)
+        .await
+        .map_err(|err| CoreError::store(&object_key, &err))?;
+    let Some(observed) = observed else {
+        return Ok(CompletionOutcome::Unusable(format!(
+            "staged content object `{object_key}` is gone"
+        )));
+    };
+    if observed.size_bytes != staged.size_bytes {
+        return Ok(CompletionOutcome::Unusable(format!(
+            "staged content object `{object_key}` holds {} bytes, not the {} bytes this session \
+             staged",
+            observed.size_bytes, staged.size_bytes
+        )));
+    }
+    Ok(CompletionOutcome::Verified(staged.clone()))
 }
 
 /// Asks the provider to assemble the parts a client uploaded, then proves
@@ -1577,6 +1631,55 @@ mod tests {
             }
         ));
         assert!(store.head(&content_key).await.expect("head").is_none());
+    }
+
+    /// A streamed write past the store's multipart threshold cannot make its
+    /// create-only condition part of the write, so a second request against
+    /// one session can assemble its own bytes over the object the session
+    /// staged and be refused only its record. The completion reads the object
+    /// and refuses to freeze a reference the object no longer matches.
+    #[tokio::test]
+    async fn a_completion_refuses_a_staged_object_that_was_written_over() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let setup = context(1_000);
+        let (namespace_id, content_store_id, upload_id, content_ref, content_key) =
+            staged_session(&store, &setup).await;
+
+        // What the refused request's multipart completion leaves at the key.
+        store
+            .put_overwrite(
+                &content_key,
+                Bytes::from_static(b"bytes from a second request"),
+            )
+            .await
+            .expect("overwrite the staged object");
+
+        let error = complete(
+            &store,
+            &namespace_id,
+            &content_store_id,
+            &upload_id,
+            &content_ref,
+            &context(2_000),
+        )
+        .await
+        .expect_err("a staged object that was written over cannot be frozen");
+        assert!(matches!(error, CoreError::InvalidUploadContent(_)));
+
+        let state = read_upload_session_state(&store, &namespace_id, &upload_id)
+            .await
+            .expect("session still readable");
+        assert!(matches!(
+            state.state,
+            UploadSessionLifecycle::Aborted {
+                aborted_at_ms: 2_000
+            }
+        ));
+        assert!(
+            store.head(&content_key).await.expect("head").is_none(),
+            "the object nothing can name again is removed",
+        );
     }
 
     /// Completion is terminal in the other direction. An abort cannot

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -652,13 +652,16 @@ pub(crate) struct StagedStream {
 /// — the LoonFS write path hashed the complete payload itself — and it is
 /// the constructor, not a convention, that guarantees it.
 ///
-/// The write is create-only, exactly like the buffered staging write, and
-/// degrades to an overwrite past the store's multipart threshold for the
-/// same reason that one does: a provider assembles a multipart object
-/// unconditionally. On a key named by 128 random bits the condition is a
-/// corruption tripwire rather than a concurrency control, so what it
-/// catches either way is a key occupied by something this session did not
-/// write.
+/// The write is create-only, exactly like the buffered staging write. Past
+/// the store's multipart threshold the store cannot make that condition part
+/// of the write — a provider assembles a multipart object unconditionally —
+/// so it reads the key instead, immediately before the assembly.
+/// `already_present` is therefore authoritative about a key that was already
+/// occupied when this write started, and blind to a writer that lands inside
+/// that window. Only another request against the same upload session can be
+/// that writer, because the key is named by 128 random bits one session
+/// owns, and [`crate::protocol::complete_upload`] reads the object again
+/// before it freezes the reference.
 pub(crate) async fn stage_streamed_under_content_id<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: ContentStoreId,

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -353,14 +353,21 @@ pub trait ObjectStore: Send + Sync + Debug {
     ///   the write is refused — which is what lets it tell "these are the
     ///   same bytes again" from "these are different bytes".
     ///
-    /// `mode` is honoured exactly while the payload fits inside one
-    /// internal part. Beyond that, the write goes through the provider's
-    /// multipart upload, whose completion is an unconditional overwrite, so
-    /// a create-only or compare-and-swap request degrades to one there.
-    /// That is the same trade [`Self::put_immutable_verified`] already makes
-    /// at its multipart threshold, and the reason both are for immutable
-    /// keys only: on a key whose bytes are fixed by its name, the condition
-    /// is a corruption tripwire rather than a concurrency control.
+    /// `mode` is enforced by the provider, as part of the write, while the
+    /// payload fits inside one internal part. Beyond that, an implementation
+    /// that uses a provider multipart upload cannot enforce it that way,
+    /// because providers assemble a multipart upload unconditionally. Such
+    /// an implementation evaluates the condition against a separate
+    /// observation of the key, taken after the payload has been consumed and
+    /// immediately before the assembly. A key that was already occupied is
+    /// still refused with [`ObjectStoreError::PreconditionFailed`]; a writer
+    /// that lands between that observation and the assembly is not, and this
+    /// write assembles over it.
+    ///
+    /// That is why this operation is for immutable keys only: on a key whose
+    /// bytes are fixed by its name, the condition is a corruption tripwire
+    /// rather than a concurrency control. A caller that must also detect the
+    /// concurrent case has to check the object again before it relies on it.
     ///
     /// A failed or abandoned write leaves no provider state behind: an
     /// implementation that opened a multipart upload aborts it.

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -545,11 +545,16 @@ impl MultipartWrite<'_> {
     /// is: there is no payload left in memory to prove a landed write
     /// against. An ambiguous completion is a failure, and the caller abandons
     /// the upload.
+    ///
+    /// `mode` is evaluated by [`Self::precondition_holds`] once the stream
+    /// has been consumed and immediately before the completion, because the
+    /// completion itself cannot carry it.
     async fn upload_stream_and_complete(
         &self,
         upload_id: &provider_store::MultipartId,
         head: Bytes,
         mut parts_reader: PartReader,
+        mode: &PutMode,
     ) -> Result<u64> {
         let mut size_bytes = head.len() as u64;
         let mut parts = vec![self.upload_part(upload_id, 0, head).await?];
@@ -568,6 +573,8 @@ impl MultipartWrite<'_> {
             parts.push(self.upload_part(upload_id, parts.len(), payload).await?);
         }
 
+        self.precondition_holds(mode).await?;
+
         match self
             .multipart
             .complete_multipart(self.path, upload_id, parts)
@@ -575,6 +582,40 @@ impl MultipartWrite<'_> {
         {
             Ok(_) => Ok(size_bytes),
             Err(err) => Err(map_provider_error(self.key, err)),
+        }
+    }
+
+    /// Evaluates the caller's write mode against the object at the key, in
+    /// the last moment before the completion assembles over it.
+    ///
+    /// A provider assembles a multipart upload unconditionally, so this
+    /// separate read is the only way a streamed create-only or
+    /// compare-and-swap write can be refused at all. Two things follow, and
+    /// both are contract:
+    ///
+    /// - It runs after the stream has been consumed, which is what
+    ///   [`ObjectStore::put_streamed`] promises a caller that folds a digest
+    ///   over the same stream: a refused write still leaves that caller a
+    ///   digest over the complete payload.
+    /// - It is not atomic with the completion. A key that was already
+    ///   occupied is refused; a writer that lands between this read and the
+    ///   completion is not, and this write assembles over it.
+    async fn precondition_holds(&self, mode: &PutMode) -> Result<()> {
+        let refused = || {
+            Err(ObjectStoreError::PreconditionFailed {
+                object_key: self.key.to_owned(),
+            })
+        };
+        match mode {
+            PutMode::Overwrite => Ok(()),
+            PutMode::CreateIfAbsent => match self.store.head(self.key).await? {
+                None => Ok(()),
+                Some(_) => refused(),
+            },
+            PutMode::CompareAndSwap { expected_etag } => match self.store.head(self.key).await? {
+                Some(current) if current.etag.as_deref() == Some(expected_etag.as_str()) => Ok(()),
+                _ => refused(),
+            },
         }
     }
 
@@ -901,10 +942,13 @@ impl ObjectStore for ProviderObjectStore {
     ///
     /// The first part is cut before anything is decided. A payload that
     /// ends inside it is an ordinary [`ObjectStore::put`] with the caller's
-    /// mode intact — which is the same size line `put` itself draws, so a
-    /// small streamed write behaves exactly like a small buffered one.
-    /// Anything longer goes through the provider's multipart upload, whose
-    /// completion is an unconditional overwrite.
+    /// mode enforced by the provider — which is the same size line `put`
+    /// itself draws, so a small streamed write behaves exactly like a small
+    /// buffered one. Anything longer goes through the provider's multipart
+    /// upload. A provider assembles one unconditionally, so a conditional
+    /// mode is evaluated by [`MultipartWrite::precondition_holds`] against a
+    /// separate read of the key, taken after the payload is consumed and
+    /// immediately before the completion.
     async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
         let path = self.to_path(key)?;
         let mut reader = PartReader::new(body, self.multipart_geometry.part_bytes as usize);
@@ -940,7 +984,7 @@ impl ObjectStore for ProviderObjectStore {
             upload_id: upload_id.clone(),
         };
         let result = upload
-            .upload_stream_and_complete(&upload_id, head, reader)
+            .upload_stream_and_complete(&upload_id, head, reader, &mode)
             .await;
         abort_on_drop.disarm();
         match result {
@@ -2426,6 +2470,66 @@ mod tests {
             store.get(MULTIPART_KEY, None).await.expect("get"),
             Some(Bytes::from(payload))
         );
+    }
+
+    /// Create-only means the same thing past one part as it does inside
+    /// one. The provider assembles a multipart upload unconditionally, so
+    /// the store evaluates the condition itself, and the object already at
+    /// the key survives.
+    #[tokio::test]
+    async fn a_streamed_multipart_put_refuses_an_occupied_key() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = multipart_test_store(Arc::clone(&flaky));
+        let occupant = multipart_payload(7);
+        seed_scoped_object(&flaky, MULTIPART_KEY, Bytes::from(occupant.clone())).await;
+        let payload = multipart_payload(1300);
+
+        let error = store
+            .put_streamed(
+                MULTIPART_KEY,
+                streamed(&payload, 100),
+                PutMode::CreateIfAbsent,
+            )
+            .await
+            .expect_err("the key is taken and create-only means it");
+
+        assert!(matches!(error, ObjectStoreError::PreconditionFailed { .. }));
+        assert_eq!(
+            part_attempts(&flaky, 2),
+            1,
+            "the whole payload is consumed before the condition is evaluated",
+        );
+        assert_eq!(
+            flaky.gets.load(Ordering::SeqCst),
+            1,
+            "one read decides the condition",
+        );
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            flaky.multipart_aborts.load(Ordering::SeqCst),
+            1,
+            "the refused upload is aborted, not left holding parts",
+        );
+        assert_eq!(
+            store.get(MULTIPART_KEY, None).await.expect("get"),
+            Some(Bytes::from(occupant)),
+        );
+    }
+
+    /// An overwrite has no condition to evaluate, so it costs no read.
+    #[tokio::test]
+    async fn a_streamed_multipart_overwrite_reads_nothing() {
+        let flaky = Arc::new(FlakyStore::default());
+        let store = multipart_test_store(Arc::clone(&flaky));
+        let payload = multipart_payload(1300);
+
+        store
+            .put_streamed(MULTIPART_KEY, streamed(&payload, 100), PutMode::Overwrite)
+            .await
+            .expect("streamed multipart overwrite");
+
+        assert_eq!(flaky.multipart_completes.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.gets.load(Ordering::SeqCst), 0);
     }
 
     /// An empty stream still writes an object, and still writes it the way

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -522,7 +522,11 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
         .expect("complete upload with proof");
     let prepared = completed.prepared;
     assert_eq!(prepared.content_ref(), &completed.response.content_ref);
-    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
+    // One object HEAD and nothing else: the completion checks that the object
+    // the session staged is still the object it staged, because a streamed
+    // staging write past the store's multipart threshold cannot make its
+    // create-only condition part of the write. It never reads the blob.
+    assert_content_counts(harness.recording.snapshot(), 1, 0, 0, 0);
     harness.recording.reset();
 
     harness

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -357,11 +357,15 @@ to such a write:
    writer folding a digest over the same bytes as it forwards them therefore
    always ends up with a digest over the complete payload, even when the
    write is refused — which is what lets it tell "these are the same bytes
-   again" from "these are different bytes". Beyond one part the write is an
-   unconditional overwrite regardless, because a provider assembles a
-   multipart object unconditionally; incremental writes are for immutable,
-   uniquely-named keys, where the condition is a corruption tripwire rather
-   than a concurrency control.
+   again" from "these are different bytes". Beyond one part the precondition
+   is not part of the write, because a provider assembles a multipart object
+   unconditionally. The writer observes the key separately instead, after the
+   payload is consumed and immediately before the assembly, and refuses a key
+   that is already occupied. A writer that lands inside that window is not
+   refused. Incremental writes are therefore for immutable, uniquely-named
+   keys, where the condition is a corruption tripwire rather than a
+   concurrency control, and a caller that must also catch the concurrent case
+   observes the object again before it relies on it.
 
 ### 1.8 Provider conformance
 


### PR DESCRIPTION
Service-proxied uploads reuse the random content ID assigned to their upload session. For large request bodies, LoonFS writes that object through provider multipart upload. Multipart completion is unconditional, so a second request against the same session could overwrite the object even though the write requested create-if-absent. Direct uploads do not use this path.

This change checks for an existing object immediately before multipart completion and checks the object’s size before completing the session. It blocks an already-present object and catches replacements with a different size. It does not prevent two simultaneous requests with different content of the same size from racing; that requires claiming the session’s staging slot before writing.