### PR TITLE
chore(checkpoint): one manifest write per publication, and one status type

### DIFF
--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -8,11 +8,11 @@
 //! [`create`](super::create).
 
 use super::build::{build_manifest_l0_run_tables, build_manifest_tables};
-use super::error::ManifestLoadError;
-use super::load::{
-    head_from_manifest, load_basis_metadata_tables, load_namespace_manifest_envelope_if_present,
+use super::load::{head_from_manifest, load_basis_metadata_tables};
+use super::publish::{
+    manifest_write_failure, publish_metadata_root, write_namespace_manifest,
+    ManifestPublicationOutcome,
 };
-use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
 use super::runs::{flatten_manifest_tables, MetadataLsmPolicy, CHECKPOINT_BASE_RUN_LEVEL};
 use super::scan::VerifiedMetadataTables;
 use crate::commit::CommitHeadPublishError;
@@ -34,7 +34,6 @@ use loonfs_api::{
     ChangeSeq, CommitId, FlushWalOutcome, FlushWalResponse, ManifestId, ManifestObjectId,
     NamespaceId,
 };
-use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use tracing::Instrument;
 
@@ -154,61 +153,21 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
         })));
     }
 
+    // One generated object id, one write. The generated id ends in 16 random
+    // hex characters, so the key is this attempt's alone and a conflict under
+    // it is corruption rather than contention.
     let manifest_id = next_manifest_id_after(basis_manifest_id)?;
-    let mut written_manifest = None;
-    for _allocation_attempt in 0..CONTENTION_RETRY_LIMIT {
-        let manifest_object_id = ManifestObjectId::generate(manifest_id);
-        let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
-        match load_namespace_manifest_envelope_if_present(
-            store,
-            namespace_id,
-            &manifest_object_id,
-            &manifest_key,
-        )
+    let manifest = build_namespace_manifest_for_projection(
+        store,
+        namespace_id,
+        &projection,
+        manifest_id,
+        ManifestObjectId::generate(manifest_id),
+    )
+    .await?;
+    write_namespace_manifest(store, &manifest)
         .await
-        {
-            Ok(Some(_existing)) => {
-                // Physical-id collision or retry; keep the logical slot and
-                // generate another object id.
-                continue;
-            }
-            Ok(None) => {
-                let manifest = build_namespace_manifest_for_projection(
-                    store,
-                    namespace_id,
-                    &projection,
-                    manifest_id,
-                    manifest_object_id,
-                )
-                .await?;
-                // `write_namespace_manifest` owns the idempotent "manifest
-                // already exists" path. A same-id/different-payload conflict
-                // means another writer won this slot, so try the next
-                // manifest id.
-                match write_namespace_manifest(store, &manifest).await {
-                    Ok(()) => {}
-                    Err(MetadataProjectionLoadError::ManifestLoad(
-                        ManifestLoadError::ManifestConflict { .. },
-                    )) => {
-                        continue;
-                    }
-                    Err(error) => return Err(CoreError::MetadataProjection(error)),
-                }
-                written_manifest = Some(manifest);
-                break;
-            }
-            Err(error) => {
-                return Err(CoreError::MetadataProjection(
-                    MetadataProjectionLoadError::ManifestLoad(error),
-                ))
-            }
-        }
-    }
-    let Some(manifest) = written_manifest else {
-        return Err(CoreError::Internal(
-            "manifest id allocation retry exhausted".to_owned(),
-        ));
-    };
+        .map_err(manifest_write_failure)?;
     // The publication budget gates the root compare-and-swap: past it, the
     // written tables and manifest may have aged into the GC grace window,
     // so this attempt must abort without publishing (format spec, "Garbage

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -89,6 +89,26 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
     }
 }
 
+/// Maps a manifest write failure onto a core error.
+///
+/// Callers write each manifest under a freshly generated object id, and
+/// every generated id ends in 16 random hex characters, so no other writer
+/// proposes the same key. [`write_namespace_manifest`] already accepts a
+/// byte-identical rewrite of a key it wrote, which covers a retried request.
+/// A different payload under the key is therefore corruption rather than
+/// contention, and it is reported as such.
+pub(super) fn manifest_write_failure(error: MetadataProjectionLoadError) -> CoreError {
+    match error {
+        MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestConflict {
+            object_key,
+            ..
+        }) => CoreError::NamespaceCorrupt(format!(
+            "namespace manifest `{object_key}` already exists with a different payload"
+        )),
+        error => CoreError::MetadataProjection(error),
+    }
+}
+
 #[tracing::instrument(
     level = "info",
     name = "loonfs.phase",

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -28,10 +28,13 @@ use super::build::{
 use super::error::ManifestLoadError;
 use super::flush::{ensure_metadata_publication_budget, next_manifest_id_after};
 use super::load::{
-    load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
-    validate_direntry_child_bind_index, validate_revision_by_inode_desc_index,
+    load_verified_manifest_tables, validate_direntry_child_bind_index,
+    validate_revision_by_inode_desc_index,
 };
-use super::publish::{publish_metadata_root, write_namespace_manifest, ManifestPublicationOutcome};
+use super::publish::{
+    manifest_write_failure, publish_metadata_root, write_namespace_manifest,
+    ManifestPublicationOutcome,
+};
 use super::runs::{
     flatten_manifest_tables, l0_run_count, MetadataLsmPolicy, MetadataRunManifest,
     CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
@@ -39,7 +42,6 @@ use super::runs::{
 use super::scan::VerifiedMetadataTables;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
-use crate::limits::CONTENTION_RETRY_LIMIT;
 use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::{read_head_object, read_metadata_root_object_if_present};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
@@ -50,7 +52,6 @@ use loonfs_api::wire::manifest::{
 use loonfs_api::{
     AttributeRevisionNo, ChangeSeq, InodeId, ManifestId, ManifestObjectId, NamespaceId,
 };
-use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -655,52 +656,27 @@ async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
     base_seq: ChangeSeq,
     retention_floor_seq: ChangeSeq,
 ) -> Result<NamespaceManifestEnvelope> {
+    // One generated object id, one write. The generated id ends in 16 random
+    // hex characters, so the key is this unit's alone and a conflict under it
+    // is corruption rather than contention.
     let manifest_id = next_manifest_id_after(previous.payload.manifest_id)?;
-    for _allocation_attempt in 0..CONTENTION_RETRY_LIMIT {
-        let manifest_object_id = ManifestObjectId::generate(manifest_id);
-        let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
-        match load_namespace_manifest_envelope_if_present(
-            store,
-            namespace_id,
-            &manifest_object_id,
-            &manifest_key,
-        )
+    let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
+        namespace_id: namespace_id.clone(),
+        manifest_id,
+        manifest_object_id: ManifestObjectId::generate(manifest_id),
+        head_seq: previous.payload.head_seq,
+        head_commit_id: previous.payload.head_commit_id.clone(),
+        base_seq,
+        writer_epoch: previous.payload.writer_epoch,
+        next_inode_id: previous.payload.next_inode_id,
+        retention_floor_seq,
+        metadata_files,
+    })
+    .map_err(|err| CoreError::Internal(format!("failed to build reorganized manifest: {err}")))?;
+    write_namespace_manifest(store, &manifest)
         .await
-        {
-            Ok(Some(_existing)) => continue,
-            Ok(None) => {}
-            Err(error) => {
-                return Err(CoreError::MetadataProjection(
-                    MetadataProjectionLoadError::ManifestLoad(error),
-                ))
-            }
-        }
-        let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
-            namespace_id: namespace_id.clone(),
-            manifest_id,
-            manifest_object_id,
-            head_seq: previous.payload.head_seq,
-            head_commit_id: previous.payload.head_commit_id.clone(),
-            base_seq,
-            writer_epoch: previous.payload.writer_epoch,
-            next_inode_id: previous.payload.next_inode_id,
-            retention_floor_seq,
-            metadata_files: metadata_files.clone(),
-        })
-        .map_err(|err| {
-            CoreError::Internal(format!("failed to build reorganized manifest: {err}"))
-        })?;
-        match write_namespace_manifest(store, &manifest).await {
-            Ok(()) => return Ok(manifest),
-            Err(MetadataProjectionLoadError::ManifestLoad(
-                ManifestLoadError::ManifestConflict { .. },
-            )) => continue,
-            Err(error) => return Err(CoreError::MetadataProjection(error)),
-        }
-    }
-    Err(CoreError::Internal(
-        "reorganized manifest allocation retry exhausted".to_owned(),
-    ))
+        .map_err(manifest_write_failure)?;
+    Ok(manifest)
 }
 
 /// Drops rows that no retained sequence can observe (format spec,

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -488,7 +488,7 @@ async fn retention_advance_aborts_when_current_manifest_changes() {
 }
 
 #[tokio::test]
-async fn create_checkpoint_retries_same_id_different_payload_allocation_race() {
+async fn create_checkpoint_fails_when_its_manifest_key_holds_a_different_payload() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
@@ -507,6 +507,10 @@ async fn create_checkpoint_retries_same_id_different_payload_allocation_race() {
     .await
     .expect("write hello");
 
+    // Every manifest object id ends in 16 random hex characters, so only this
+    // publication proposes the key it writes. The store puts a different
+    // payload there anyway, which is corruption, and the checkpoint must say
+    // so rather than generate another id.
     let store = ConflictOnManifestCreateStore::mutate_next_inode(
         LocalFsStore::new(temp_dir.path()).expect("store"),
         format!(
@@ -516,30 +520,24 @@ async fn create_checkpoint_retries_same_id_different_payload_allocation_race() {
         ),
     );
 
-    let checkpoint = create_checkpoint(&store, &namespace_id, &context)
+    let error = create_checkpoint(&store, &namespace_id, &context)
         .await
-        .expect("create checkpoint should retry allocation");
+        .expect_err("a conflicting manifest payload must fail the checkpoint");
 
-    assert_eq!(checkpoint.manifest_id, ManifestId(2));
-    let record = read_checkpoint_record(&store, &namespace_id, &checkpoint.checkpoint_id)
-        .await
-        .expect("read checkpoint record")
-        .expect("record exists")
-        .state;
-    assert_eq!(record.manifest_id, ManifestId(2));
-    let manifest_objects = store
-        .list_prefix(&metadata_manifest_prefix(namespace_id.as_str()))
-        .await
-        .expect("list manifest objects");
-    assert_eq!(
-        manifest_objects.len(),
-        3,
-        "first-flush, injected conflict, and retried checkpoint manifests should all be immutable"
-    );
+    match error {
+        CoreError::NamespaceCorrupt(message) => {
+            assert!(
+                message.contains(&metadata_manifest_prefix(namespace_id.as_str())),
+                "the error must name the manifest key, got {message}"
+            );
+        }
+        other => panic!("expected a namespace corruption error, got {other:?}"),
+    }
+
     let materialization_after = load_current_projection(&store, &namespace_id)
         .await
         .expect("materialization");
-    assert_eq!(materialization_after.root.manifest_id, ManifestId(2));
+    assert_eq!(materialization_after.root.manifest_id, ManifestId(1));
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -135,7 +135,7 @@ pub mod cache {
     };
     pub use crate::namespace::status::{
         load_deleted_namespace_head_summary, load_namespace_fold_basis,
-        load_namespace_head_summary, NamespaceFoldBasis, NamespaceHeadSummary,
+        load_namespace_head_summary, NamespaceFoldBasis,
     };
 }
 

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -6,31 +6,10 @@ use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::namespace::basis::{read_head_and_metadata_basis, resolve_retention_floor_seq};
 use crate::wal::{count_visible_wal_tail_segments, WalChainLoadRequest};
+use loonfs_api::v0::NamespaceStatusResponse;
 use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
-use serde::{Deserialize, Serialize};
-
-/// Lightweight namespace head status.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NamespaceHeadSummary {
-    pub namespace_id: NamespaceId,
-    pub head_seq: ChangeSeq,
-    /// Manifest this namespace has materialized for itself, or `None` when
-    /// it has published none yet: a fresh namespace reads from the genesis
-    /// state, and a fresh fork target reads from its source's manifest.
-    pub current_manifest_id: Option<ManifestId>,
-    /// Number of visible WAL segments after the current manifest.
-    ///
-    /// Counted from the head's chain pointers (`recent_segments`, published
-    /// under the same CAS as the tip and long enough to name every segment a
-    /// legal unflushed tail can hold); no segment body is read. A head that
-    /// under-describes its own tail fails the summary rather than being
-    /// walked. An inspection count for maintenance gating and operators —
-    /// replay consumers load the validated chain instead.
-    pub wal_tail_segments: u64,
-    pub retention_floor_seq: ChangeSeq,
-}
 
 /// Whether a namespace carries visible commits its basis manifest does not
 /// cover, and the head sequence they run to.
@@ -104,10 +83,18 @@ async fn load_namespace_head_basis<S: ObjectStore + ?Sized>(
     })
 }
 
+/// Summarizes a live namespace head.
+///
+/// The WAL tail is counted from the head's chain pointers
+/// (`recent_segments`, published under the same CAS as the tip and long
+/// enough to name every segment a legal unflushed tail can hold); no segment
+/// body is read. A head that under-describes its own tail fails the summary
+/// rather than being walked. The count is for inspection and maintenance
+/// gating — replay consumers load the validated chain instead.
 pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<NamespaceHeadSummary> {
+) -> Result<NamespaceStatusResponse> {
     let loaded = load_namespace_head_basis(store, expected_namespace_id).await?;
     let wal_tail_segments = count_visible_wal_tail_segments(WalChainLoadRequest {
         namespace_id: expected_namespace_id,
@@ -120,7 +107,7 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     .map_err(|error| {
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
-    Ok(NamespaceHeadSummary {
+    Ok(NamespaceStatusResponse {
         namespace_id: loaded.head.namespace_id,
         head_seq: loaded.head.seq,
         current_manifest_id: loaded.current_manifest_id,
@@ -157,7 +144,7 @@ pub async fn load_namespace_fold_basis<S: ObjectStore + ?Sized>(
 pub async fn load_deleted_namespace_head_summary<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
-) -> Result<NamespaceHeadSummary> {
+) -> Result<NamespaceStatusResponse> {
     let head = crate::namespace::control::read_head_object(store, expected_namespace_id)
         .await
         .map_err(|error| {
@@ -175,7 +162,7 @@ pub async fn load_deleted_namespace_head_summary<S: ObjectStore + ?Sized>(
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
         })?;
-    Ok(NamespaceHeadSummary {
+    Ok(NamespaceStatusResponse {
         namespace_id: head.namespace_id,
         head_seq: head.seq,
         current_manifest_id: None,

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -52,14 +52,7 @@ impl FsAdmin {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<NamespaceStatusResponse> {
-        let summary = load_namespace_head_summary(self.core.store(), namespace_id).await?;
-        Ok(NamespaceStatusResponse {
-            namespace_id: summary.namespace_id,
-            head_seq: summary.head_seq,
-            current_manifest_id: summary.current_manifest_id,
-            wal_tail_segments: summary.wal_tail_segments,
-            retention_floor_seq: summary.retention_floor_seq,
-        })
+        Ok(load_namespace_head_summary(self.core.store(), namespace_id).await?)
     }
 
     /// Runs one bounded maintenance step against a namespace.
@@ -117,18 +110,11 @@ impl FsAdmin {
             Err(RuntimeError::Core(error))
                 if error.code() == ErrorCode::NamespaceDeleted && collects_only =>
             {
-                let summary = loonfs_core::cache::load_deleted_namespace_head_summary(
+                loonfs_core::cache::load_deleted_namespace_head_summary(
                     self.core.store(),
                     namespace_id,
                 )
-                .await?;
-                NamespaceStatusResponse {
-                    namespace_id: summary.namespace_id,
-                    head_seq: summary.head_seq,
-                    current_manifest_id: summary.current_manifest_id,
-                    wal_tail_segments: summary.wal_tail_segments,
-                    retention_floor_seq: summary.retention_floor_seq,
-                }
+                .await?
             }
             Err(error) => return Err(error),
         };


### PR DESCRIPTION
Manifest publication used retry loops that reused the same manifest id and performed a redundant read before every write. Core also duplicated the API namespace-status type.

Each publication now performs one manifest write and treats a conflicting payload at its generated key as corruption. Core returns the API status type directly.