### PR TITLE
chore(commit): delete the unread op results and the derived attributes revision

### DIFF
--- a/crates/loonfs-core/src/commit/materialize.rs
+++ b/crates/loonfs-core/src/commit/materialize.rs
@@ -1,10 +1,9 @@
-//! Materializes a prepared commit into ordered WAL deltas plus per-op
-//! results.
+//! Materializes a prepared commit into ordered WAL deltas.
 
 use super::{PreparedCommit, ResolvedBinding, ValidatedOp};
 use loonfs_api::wire::manifest::DeletedDirentry;
 use loonfs_api::wire::wal::WalDelta;
-use loonfs_api::{AttributeRevisionNo, ContentRef, InodeId, InodeKind, RevisionNo};
+use loonfs_api::{InodeKind, RevisionNo};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -23,56 +22,6 @@ pub(crate) struct MaterializedCommit {
     /// different clocks share a fingerprint.
     pub committed_at_ms: u64,
     pub deltas: Vec<MaterializedCommitDelta>,
-    pub results: Vec<CommitOpResult>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum CommitOpResult {
-    CreateDirectory {
-        op_index: u32,
-        inode_id: InodeId,
-    },
-    CreateFile {
-        op_index: u32,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-        content_ref: ContentRef,
-    },
-    ReplaceFile {
-        op_index: u32,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-        content_ref: ContentRef,
-    },
-    RestoreRevision {
-        op_index: u32,
-        inode_id: InodeId,
-        source_revision_no: RevisionNo,
-        revision_no: RevisionNo,
-        content_ref: ContentRef,
-    },
-    DeleteFile {
-        op_index: u32,
-        inode_id: InodeId,
-    },
-    Rename {
-        op_index: u32,
-        inode_id: InodeId,
-    },
-    DeleteSubtree {
-        op_index: u32,
-        root_inode_id: InodeId,
-    },
-    Undelete {
-        op_index: u32,
-        inode_id: InodeId,
-    },
-    UpdateAttributes {
-        op_index: u32,
-        inode_id: InodeId,
-        attributes_revision_no: AttributeRevisionNo,
-    },
 }
 
 pub(crate) fn materialize_commit(
@@ -80,26 +29,20 @@ pub(crate) fn materialize_commit(
     committed_at_ms: u64,
 ) -> MaterializedCommit {
     let mut deltas = Vec::new();
-    let mut results = Vec::with_capacity(prepared.plan.validated_ops.len());
     for op in &prepared.plan.validated_ops {
-        let (mut op_deltas, result) = materialize_validated_op(op);
-        deltas.append(&mut op_deltas);
-        results.push(result);
+        deltas.append(&mut materialize_validated_op(op));
     }
 
     MaterializedCommit {
         prepared,
         committed_at_ms,
         deltas,
-        results,
     }
 }
 
-pub(super) fn materialize_validated_op(
-    op: &ValidatedOp,
-) -> (Vec<MaterializedCommitDelta>, CommitOpResult) {
+pub(super) fn materialize_validated_op(op: &ValidatedOp) -> Vec<MaterializedCommitDelta> {
     let mut deltas = Vec::new();
-    let result = match op {
+    match op {
         ValidatedOp::CreateDir {
             op_index,
             parent_inode_id,
@@ -129,10 +72,6 @@ pub(super) fn materialize_validated_op(
                     child_inode_id: *child_inode_id,
                 },
             );
-            CommitOpResult::CreateDirectory {
-                op_index: *op_index,
-                inode_id: *child_inode_id,
-            }
         }
         ValidatedOp::CreateFile {
             op_index,
@@ -175,12 +114,6 @@ pub(super) fn materialize_validated_op(
                     content_ref: content_ref.clone(),
                 },
             );
-            CommitOpResult::CreateFile {
-                op_index: *op_index,
-                inode_id: *child_inode_id,
-                revision_no: RevisionNo(1),
-                content_ref: content_ref.clone(),
-            }
         }
         ValidatedOp::ReplaceFile {
             op_index,
@@ -199,17 +132,13 @@ pub(super) fn materialize_validated_op(
                     content_ref: content_ref.clone(),
                 },
             );
-            CommitOpResult::ReplaceFile {
-                op_index: *op_index,
-                inode_id: *inode_id,
-                revision_no: *revision_no,
-                content_ref: content_ref.clone(),
-            }
         }
         ValidatedOp::RestoreRevision {
             op_index,
             inode_id,
-            source_revision_no,
+            // The source is what validation resolved the content from; the
+            // delta records only the revision this op appends.
+            source_revision_no: _,
             revision_no,
             content_ref,
             revision_delta_index,
@@ -224,13 +153,6 @@ pub(super) fn materialize_validated_op(
                     content_ref: content_ref.clone(),
                 },
             );
-            CommitOpResult::RestoreRevision {
-                op_index: *op_index,
-                inode_id: *inode_id,
-                source_revision_no: *source_revision_no,
-                revision_no: *revision_no,
-                content_ref: content_ref.clone(),
-            }
         }
         ValidatedOp::DeleteFile {
             op_index,
@@ -249,10 +171,6 @@ pub(super) fn materialize_validated_op(
                     deleted_direntry: Some(deleted_direntry(source_binding)),
                 },
             );
-            CommitOpResult::DeleteFile {
-                op_index: *op_index,
-                inode_id: *inode_id,
-            }
         }
         ValidatedOp::Rename {
             op_index,
@@ -276,10 +194,6 @@ pub(super) fn materialize_validated_op(
                     child_inode_id: *inode_id,
                 },
             );
-            CommitOpResult::Rename {
-                op_index: *op_index,
-                inode_id: *inode_id,
-            }
         }
         ValidatedOp::DeleteSubtree {
             op_index,
@@ -298,10 +212,6 @@ pub(super) fn materialize_validated_op(
                     deleted_direntry: Some(deleted_direntry(source_binding)),
                 },
             );
-            CommitOpResult::DeleteSubtree {
-                op_index: *op_index,
-                root_inode_id: *root_inode_id,
-            }
         }
         ValidatedOp::Undelete {
             op_index,
@@ -336,10 +246,6 @@ pub(super) fn materialize_validated_op(
                     child_inode_id: *inode_id,
                 },
             );
-            CommitOpResult::Undelete {
-                op_index: *op_index,
-                inode_id: *inode_id,
-            }
         }
         ValidatedOp::UpdateAttributes {
             op_index,
@@ -358,15 +264,10 @@ pub(super) fn materialize_validated_op(
                     attributes: attributes.clone(),
                 },
             );
-            CommitOpResult::UpdateAttributes {
-                op_index: *op_index,
-                inode_id: *inode_id,
-                attributes_revision_no: *attributes_revision_no,
-            }
         }
-    };
+    }
 
-    (deltas, result)
+    deltas
 }
 
 /// The binding a delete retires, as the tombstone records it: the same

--- a/crates/loonfs-core/src/commit/metadata_overlay.rs
+++ b/crates/loonfs-core/src/commit/metadata_overlay.rs
@@ -44,8 +44,7 @@ impl CommitOverlayRows {
         committed_at_ms: u64,
         op: &ValidatedOp,
     ) {
-        let (deltas, _result) = materialize_validated_op(op);
-        for delta in &deltas {
+        for delta in &materialize_validated_op(op) {
             self.rows.apply_committed_wal_delta_mut(
                 committed_seq,
                 committed_at_ms,
@@ -98,7 +97,7 @@ mod tests {
 
     fn materialized_wal_deltas(ops: &[ValidatedOp]) -> Vec<WalDelta> {
         ops.iter()
-            .flat_map(|op| materialize_validated_op(op).0)
+            .flat_map(materialize_validated_op)
             .map(|delta| delta.wal_delta)
             .collect()
     }

--- a/crates/loonfs-core/src/commit/mod.rs
+++ b/crates/loonfs-core/src/commit/mod.rs
@@ -23,8 +23,8 @@ mod validate_error;
 pub(crate) use self::durable_adapter::wal_payload_from_materialized_commit;
 pub use self::identity::CommitFingerprint;
 pub(crate) use self::ir::CommitIr;
+pub use self::materialize::MaterializedCommitDelta;
 pub(crate) use self::materialize::{materialize_commit, MaterializedCommit};
-pub use self::materialize::{CommitOpResult, MaterializedCommitDelta};
 pub(crate) use self::ops::{CommitOp, CommitPrecondition, PlannedOp};
 #[cfg(test)]
 pub(crate) use self::plan::CommitValidationContext;

--- a/crates/loonfs-core/src/commit/ops.rs
+++ b/crates/loonfs-core/src/commit/ops.rs
@@ -123,14 +123,14 @@ pub(crate) enum CommitOp {
     ///
     /// The planner has already applied the caller's writes and removals to
     /// what it read, so the op carries the result rather than the request.
+    /// It does not carry the revision it publishes: validation derives that
+    /// from the base.
     UpdateAttributes {
         /// Visible file or directory whose attributes are replaced.
         inode_id: InodeId,
         /// Attribute revision the planner resolved against; the operation
         /// conflicts if it is no longer current.
         base_attributes_revision_no: AttributeRevisionNo,
-        /// The revision this update publishes, one past the base.
-        attributes_revision_no: AttributeRevisionNo,
         /// The inode's complete attribute map after the update.
         attributes: Attributes,
     },
@@ -176,13 +176,6 @@ pub(crate) enum CommitPrecondition {
     DirectoryEmpty {
         /// Visible directory that must have no active child bindings.
         inode_id: InodeId,
-    },
-    /// Inode is still at this attribute revision.
-    InodeAttributesRevisionIs {
-        /// Inode whose attribute revision is tested.
-        inode_id: InodeId,
-        /// Exact attribute revision required at commit evaluation time.
-        attributes_revision_no: AttributeRevisionNo,
     },
 }
 

--- a/crates/loonfs-core/src/commit/prepared.rs
+++ b/crates/loonfs-core/src/commit/prepared.rs
@@ -51,7 +51,7 @@ impl PreparedCommit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commit::{materialize_commit, CommitOpResult, PlannedOp, ValidatedOp};
+    use crate::commit::{materialize_commit, PlannedOp, ValidatedOp};
     use crate::commit::{CommitFingerprint, CommitOp};
     use loonfs_api::wire::wal::WalDelta;
     use loonfs_api::NameKey;
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn materialize_commit_outputs_wal_ops_and_results_once() {
+    fn materialize_commit_outputs_wal_deltas_once() {
         let materialized = materialize_commit(
             PreparedCommit::new(request(), plan(), fingerprint()).expect("prepare commit"),
             4_200,
@@ -146,10 +146,6 @@ mod tests {
         assert!(matches!(
             materialized.deltas[1].wal_delta,
             WalDelta::BindDirentry { .. }
-        ));
-        assert!(matches!(
-            materialized.results[0],
-            CommitOpResult::CreateDirectory { .. }
         ));
     }
 }

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -344,7 +344,6 @@ pub(crate) async fn validate_ops<V: CommitValidationView>(
             CommitOp::UpdateAttributes {
                 inode_id,
                 base_attributes_revision_no,
-                attributes_revision_no,
                 attributes,
             } => {
                 // The target is any visible inode, file or directory: an
@@ -361,21 +360,10 @@ pub(crate) async fn validate_ops<V: CommitValidationView>(
                     *base_attributes_revision_no,
                 )
                 .await?;
-                let successor =
+                // The base is what the guard above just confirmed is current,
+                // so the revision this update publishes is one past it.
+                let attributes_revision_no =
                     next_attributes_revision_no(*inode_id, *base_attributes_revision_no)?;
-                // The planner numbers the revision, so a plan that publishes
-                // anything but the successor is a planner bug rather than a
-                // race, and it must not reach durable state.
-                if *attributes_revision_no != successor {
-                    return Err(
-                        CommitValidationError::UpdateAttributesRevisionNotSuccessive {
-                            inode_id: *inode_id,
-                            base_attributes_revision_no: *base_attributes_revision_no,
-                            attributes_revision_no: *attributes_revision_no,
-                        }
-                        .into(),
-                    );
-                }
                 validate_not_covered_by_tombstone(metadata_state, *inode_id, |tombstone| {
                     CommitValidationError::UpdateAttributesUnderSubtreeTombstone {
                         inode_id: *inode_id,
@@ -387,7 +375,7 @@ pub(crate) async fn validate_ops<V: CommitValidationView>(
                 ValidatedOp::UpdateAttributes {
                     op_index,
                     inode_id: *inode_id,
-                    attributes_revision_no: *attributes_revision_no,
+                    attributes_revision_no,
                     attributes: attributes.clone(),
                     attributes_delta_index: reserve_delta_index(next_delta_index)?,
                 }
@@ -442,17 +430,6 @@ async fn validate_explicit_preconditions<V: CommitValidationView>(
             CommitPrecondition::DirectoryEmpty { inode_id } => {
                 validate_directory_empty_precondition(metadata_state, *inode_id).await?;
             }
-            CommitPrecondition::InodeAttributesRevisionIs {
-                inode_id,
-                attributes_revision_no,
-            } => {
-                validate_inode_attributes_revision_is(
-                    metadata_state,
-                    *inode_id,
-                    *attributes_revision_no,
-                )
-                .await?;
-            }
         }
     }
 
@@ -500,8 +477,8 @@ fn next_attributes_revision_no(
         })
 }
 
-/// Shared by the `UpdateAttributes` op and the `InodeAttributesRevisionIs`
-/// explicit precondition, both of which report the stale-attributes error.
+/// The base-revision guard every `UpdateAttributes` op carries, whether or
+/// not the caller stated an expectation of its own.
 ///
 /// The inode's own attribute revision is the whole check: an inode that has
 /// never had attributes written is at revision 0, so a first write states

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -9,9 +9,7 @@
 
 use super::super::{CommitIr, CommitOp, CommitValidationContext, PlannedOp};
 use super::build_commit_plan;
-use crate::commit::{
-    materialize_commit, CommitFingerprint, CommitOpResult, CommitValidationError, PreparedCommit,
-};
+use crate::commit::{materialize_commit, CommitFingerprint, CommitValidationError, PreparedCommit};
 use crate::error::{CoreError, ErrorCode};
 use crate::metadata::MetadataState;
 use loonfs_api::wire::control::{HeadState, WriterBlock};
@@ -215,7 +213,6 @@ async fn a_stale_attribute_base_revision_is_rejected_by_the_updates_own_guard() 
         ops: planned(vec![CommitOp::UpdateAttributes {
             inode_id: InodeId(2),
             base_attributes_revision_no: AttributeRevisionNo(1),
-            attributes_revision_no: AttributeRevisionNo(2),
             attributes: test_attributes(&[("owner", "hopper")]),
         }]),
         message: None,
@@ -253,23 +250,22 @@ async fn a_first_attribute_write_states_revision_zero() {
         "docs".to_owned(),
     )]);
     let context = validation_context(&metadata_state, ChangeSeq(1), InodeId(3));
-    let request = |base: u64, revision: u64| CommitIr {
+    let request = |base: u64| CommitIr {
         namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
         commit_id: CommitId::parse("first-attributes").expect("valid commit id"),
         writer_epoch: WriterEpoch(1),
         ops: planned(vec![CommitOp::UpdateAttributes {
             inode_id: InodeId(2),
             base_attributes_revision_no: AttributeRevisionNo(base),
-            attributes_revision_no: AttributeRevisionNo(revision),
             attributes: test_attributes(&[("owner", "ada")]),
         }]),
         message: None,
     };
 
-    build_commit_plan(&request(0, 1), 4_200, &context)
+    build_commit_plan(&request(0), 4_200, &context)
         .await
         .expect("a first write states revision zero");
-    let error = build_commit_plan(&request(1, 2), 4_200, &context)
+    let error = build_commit_plan(&request(1), 4_200, &context)
         .await
         .expect_err("nothing has written revision 1 yet");
     assert!(
@@ -280,42 +276,6 @@ async fn a_first_attribute_write_states_revision_zero() {
                 actual: AttributeRevisionNo(0),
                 ..
             }
-        ),
-        "{error:?}"
-    );
-}
-
-/// The planner numbers the revision, so a plan that publishes anything but
-/// the successor is a bug in this server and must not reach durable state.
-#[tokio::test]
-async fn an_attribute_revision_that_skips_a_number_is_rejected() {
-    let metadata_state = metadata_state_after(&[wal_create_directory(
-        0,
-        InodeId(2),
-        InodeId(1),
-        "docs".to_owned(),
-    )]);
-    let context = validation_context(&metadata_state, ChangeSeq(1), InodeId(3));
-    let request = CommitIr {
-        namespace_id: NamespaceId::parse("demo").expect("valid namespace id"),
-        commit_id: CommitId::parse("skipped-attributes").expect("valid commit id"),
-        writer_epoch: WriterEpoch(1),
-        ops: planned(vec![CommitOp::UpdateAttributes {
-            inode_id: InodeId(2),
-            base_attributes_revision_no: AttributeRevisionNo(0),
-            attributes_revision_no: AttributeRevisionNo(7),
-            attributes: test_attributes(&[("owner", "ada")]),
-        }]),
-        message: None,
-    };
-
-    let error = build_commit_plan(&request, 4_200, &context)
-        .await
-        .expect_err("the revision is not one past the base");
-    assert!(
-        matches!(
-            error,
-            CommitValidationError::UpdateAttributesRevisionNotSuccessive { .. }
         ),
         "{error:?}"
     );
@@ -334,7 +294,6 @@ async fn an_attribute_update_of_a_missing_inode_is_rejected() {
         ops: planned(vec![CommitOp::UpdateAttributes {
             inode_id: InodeId(9),
             base_attributes_revision_no: AttributeRevisionNo(0),
-            attributes_revision_no: AttributeRevisionNo(1),
             attributes: test_attributes(&[("owner", "ada")]),
         }]),
         message: None,
@@ -693,8 +652,8 @@ async fn restore_revision_can_reference_revision_created_earlier_in_same_request
         4_200,
     );
     assert!(matches!(
-        &materialized.results[1],
-        CommitOpResult::RestoreRevision {
+        &materialized.deltas[1].wal_delta,
+        WalDelta::AppendFileRevision {
             content_ref,
             ..
         } if *content_ref == expected
@@ -745,15 +704,15 @@ async fn restore_revision_can_reference_restore_created_earlier_in_same_request(
         4_200,
     );
     assert!(matches!(
-        &materialized.results[0],
-        CommitOpResult::RestoreRevision {
+        &materialized.deltas[0].wal_delta,
+        WalDelta::AppendFileRevision {
             content_ref,
             ..
         } if *content_ref == expected
     ));
     assert!(matches!(
-        &materialized.results[1],
-        CommitOpResult::RestoreRevision {
+        &materialized.deltas[1].wal_delta,
+        WalDelta::AppendFileRevision {
             content_ref,
             ..
         } if *content_ref == expected

--- a/crates/loonfs-core/src/commit/validate_error.rs
+++ b/crates/loonfs-core/src/commit/validate_error.rs
@@ -266,14 +266,6 @@ pub enum CommitValidationError {
         inode_id: InodeId,
         base_attributes_revision_no: AttributeRevisionNo,
     },
-    #[error(
-        "attribute update of inode `{inode_id}` publishes revision `{attributes_revision_no}`, which is not one past base revision `{base_attributes_revision_no}`"
-    )]
-    UpdateAttributesRevisionNotSuccessive {
-        inode_id: InodeId,
-        base_attributes_revision_no: AttributeRevisionNo,
-        attributes_revision_no: AttributeRevisionNo,
-    },
     #[error("stale writer epoch: requested `{requested}` but active is `{active}`")]
     StaleWriterEpoch {
         active: WriterEpoch,

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -762,10 +762,9 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> ErrorCode 
             ErrorCode::StaleAttributes
         }
         CommitValidationError::UpdateAttributesInodeMissing { .. } => ErrorCode::PathNotFound,
-        // The planner numbers the attribute revision, so a plan that
-        // publishes anything else is a bug in this server.
-        CommitValidationError::UpdateAttributesRevisionNotSuccessive { .. }
-        | CommitValidationError::UpdateAttributesRevisionOverflow { .. } => ErrorCode::ServerError,
+        // Validation numbers the attribute revision, so running out of
+        // numbers is a bug in this server rather than a caller mistake.
+        CommitValidationError::UpdateAttributesRevisionOverflow { .. } => ErrorCode::ServerError,
         CommitValidationError::CreateChildNameCollision { .. }
         | CommitValidationError::NamePreconditionParentNotDirectory { .. }
         | CommitValidationError::BindingPreconditionMissing { .. }

--- a/crates/loonfs-core/src/path/write/plan_attributes.rs
+++ b/crates/loonfs-core/src/path/write/plan_attributes.rs
@@ -59,9 +59,9 @@ pub(super) async fn plan_publish_update_attributes<S: ObjectStore + ?Sized>(
         .metadata_state
         .attributes_at_visible_seq(target.inode_id)
         .await?;
-    // A caller-supplied guard replaces the freshly-read revision in both the
-    // op and the precondition, so commit validation rejects a raced update
-    // with the stale-attributes error and its expected/actual details.
+    // A caller-supplied guard replaces the freshly-read revision in the op,
+    // so commit validation rejects a raced update with the stale-attributes
+    // error and its expected/actual details.
     let base_attributes_revision_no =
         expected_attributes_revision_no.unwrap_or(current_revision_no);
 
@@ -86,30 +86,14 @@ pub(super) async fn plan_publish_update_attributes<S: ObjectStore + ?Sized>(
     let attributes = Attributes::new(updated).map_err(|error| {
         CoreError::InvalidCommitRequest(format!("the resulting attribute map is invalid: {error}"))
     })?;
-    let attributes_revision_no = base_attributes_revision_no
-        .0
-        .checked_add(1)
-        .map(AttributeRevisionNo)
-        .ok_or_else(|| {
-            CoreError::Internal(format!(
-                "attribute revision counter overflow for inode {}",
-                target.inode_id
-            ))
-        })?;
-
     Ok(PlannedOperation::new(
         vec![ApiCommitOp::UpdateAttributes {
             inode_id: target.inode_id,
             base_attributes_revision_no,
-            attributes_revision_no,
             attributes,
         }],
         vec![
             publish_binding_is_precondition(view, &target).await?,
-            ApiCommitPrecondition::InodeAttributesRevisionIs {
-                inode_id: target.inode_id,
-                attributes_revision_no: base_attributes_revision_no,
-            },
             ApiCommitPrecondition::AncestorsNotSubtreeDeleted {
                 inode_id: target.inode_id,
             },

--- a/crates/loonfs-core/src/path/write/plan_transfer.rs
+++ b/crates/loonfs-core/src/path/write/plan_transfer.rs
@@ -182,7 +182,6 @@ pub(super) async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
                 ops.push(ApiCommitOp::UpdateAttributes {
                     inode_id: view.next_inode_id,
                     base_attributes_revision_no: AttributeRevisionNo(0),
-                    attributes_revision_no: AttributeRevisionNo(1),
                     attributes: source_attributes,
                 });
             }

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -562,9 +562,9 @@ mod tests {
             )));
     }
 
-    /// The update's plan carries the binding the path resolved through and
-    /// the attribute revision it read, so a raced rebind and a raced update
-    /// are both rejected under the publish lock.
+    /// The update's plan carries the binding the path resolved through, and
+    /// the op states the attribute revision the planner read, so a raced
+    /// rebind and a raced update are both rejected under the publish lock.
     #[tokio::test]
     async fn update_attributes_plan_carries_the_binding_and_revision_guards() {
         let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
@@ -603,7 +603,6 @@ mod tests {
             [PlannedOp {
                 op: CommitOp::UpdateAttributes {
                     base_attributes_revision_no: loonfs_api::AttributeRevisionNo(0),
-                    attributes_revision_no: loonfs_api::AttributeRevisionNo(1),
                     ..
                 },
                 ..
@@ -613,16 +612,6 @@ mod tests {
             .preconditions
             .iter()
             .any(|precondition| matches!(precondition, CommitPrecondition::BindingIs { .. })));
-        assert!(planned.ops[0]
-            .preconditions
-            .iter()
-            .any(|precondition| matches!(
-                precondition,
-                CommitPrecondition::InodeAttributesRevisionIs {
-                    attributes_revision_no: loonfs_api::AttributeRevisionNo(0),
-                    ..
-                }
-            )));
         assert!(planned.ops[0]
             .preconditions
             .iter()


### PR DESCRIPTION
The commit pipeline built operation results that nothing read and carried attribute revision values and checks that could be derived from the current state.

This removes the unused results, the supplied next attribute revision, and the duplicate attribute precondition. Durable WAL records and commit fingerprints are unchanged.