### PR TITLE
chore(core): delete duplicate state and dead defenses

### DIFF
--- a/crates/loonfs-core/src/checkpoint/block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/block_load.rs
@@ -6,7 +6,7 @@ use super::data_block_load::load_segment_data_block_span;
 use super::error::ManifestLoadError;
 use super::scan::Readahead;
 use super::validate::validate_manifest_row_seq_range;
-use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow};
 use loonfs_api::wire::sst_blocks::{index_blocks_for_key_range, DecodedDataBlock};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
@@ -103,12 +103,10 @@ const RANGE_SCAN_READAHEAD_BLOCKS: usize = 32;
 /// `[lower_bound, upper_bound)`: index first, then only the data blocks the
 /// index says can match. Callers trim edge blocks with
 /// [`SegmentKeyRangeBlocks::rows_in_key_range`].
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
-    family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     lower_bound: &str,
     upper_bound: Option<&str>,
@@ -132,7 +130,6 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
         store,
         table_cache,
         memo,
-        family,
         descriptor,
         &index[needed.start..extended_end],
     )

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -372,29 +372,11 @@ pub struct WalTailProjectionCacheKey {
     pub head_etag: String,
 }
 
-#[derive(Debug, Clone)]
-struct CachedWalTailProjection {
-    rows: Arc<MetadataState>,
-    row_count: usize,
-    decoded_bytes: usize,
-}
-
-impl CachedWalTailProjection {
-    fn new(rows: Arc<MetadataState>) -> Self {
-        Self {
-            row_count: rows.row_count(),
-            decoded_bytes: rows.decoded_bytes(),
-            rows,
-        }
-    }
-
-    fn rows(&self) -> Arc<MetadataState> {
-        Arc::clone(&self.rows)
-    }
-
-    fn weight(&self) -> (usize, usize) {
-        (self.row_count, self.decoded_bytes)
-    }
+/// What one entry counts against the row and byte budgets. The projection
+/// carries both totals, and a projection in the cache is immutable, so the
+/// cache reads them rather than keeping its own copies.
+fn projection_weight(rows: &MetadataState) -> (usize, usize) {
+    (rows.row_count(), rows.decoded_bytes())
 }
 
 #[derive(Debug)]
@@ -406,7 +388,7 @@ pub struct WalTailProjectionCache {
 
 #[derive(Debug, Default)]
 struct WalTailProjectionCacheInner {
-    entries: HashMap<WalTailProjectionCacheKey, CachedWalTailProjection>,
+    entries: HashMap<WalTailProjectionCacheKey, Arc<MetadataState>>,
     order: VecDeque<WalTailProjectionCacheKey>,
     cached_rows: usize,
     cached_decoded_bytes: usize,
@@ -462,7 +444,7 @@ impl WalTailProjectionCache {
             .inner
             .lock()
             .expect("wal tail projection cache lock should not be poisoned");
-        let Some(rows) = inner.entries.get(key).map(CachedWalTailProjection::rows) else {
+        let Some(rows) = inner.entries.get(key).map(Arc::clone) else {
             self.stats.misses.fetch_add(1, Ordering::SeqCst);
             return None;
         };
@@ -475,8 +457,7 @@ impl WalTailProjectionCache {
         if self.config.max_entries == 0 {
             return;
         }
-        let cached = CachedWalTailProjection::new(rows);
-        let (row_count, decoded_bytes) = cached.weight();
+        let (row_count, decoded_bytes) = projection_weight(&rows);
         if row_count > self.config.max_rows || decoded_bytes > self.config.max_decoded_bytes {
             self.stats.uncacheable_count.fetch_add(1, Ordering::SeqCst);
             self.stats
@@ -492,10 +473,10 @@ impl WalTailProjectionCache {
             .inner
             .lock()
             .expect("wal tail projection cache lock should not be poisoned");
-        if let Some(previous) = inner.entries.insert(key.clone(), cached) {
-            let (rows, bytes) = previous.weight();
-            inner.cached_rows = inner.cached_rows.saturating_sub(rows);
-            inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(bytes);
+        if let Some(previous) = inner.entries.insert(key.clone(), rows) {
+            let (previous_rows, previous_bytes) = projection_weight(&previous);
+            inner.cached_rows = inner.cached_rows.saturating_sub(previous_rows);
+            inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(previous_bytes);
         }
         inner.cached_rows = inner.cached_rows.saturating_add(row_count);
         inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_add(decoded_bytes);
@@ -510,7 +491,7 @@ impl WalTailProjectionCache {
                 break;
             };
             if let Some(previous) = inner.entries.remove(&evicted) {
-                let (rows, bytes) = previous.weight();
+                let (rows, bytes) = projection_weight(&previous);
                 inner.cached_rows = inner.cached_rows.saturating_sub(rows);
                 inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(bytes);
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);
@@ -535,7 +516,7 @@ impl WalTailProjectionCache {
             .collect::<Vec<_>>();
         for key in keys {
             if let Some(previous) = inner.entries.remove(&key) {
-                let (rows, bytes) = previous.weight();
+                let (rows, bytes) = projection_weight(&previous);
                 inner.cached_rows = inner.cached_rows.saturating_sub(rows);
                 inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(bytes);
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -29,7 +29,6 @@ pub(super) async fn load_segment_data_block<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
-    family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     entry: &SegmentIndexEntry,
 ) -> Result<Arc<DecodedDataBlock>, ManifestLoadError> {
@@ -51,7 +50,7 @@ pub(super) async fn load_segment_data_block<S: ObjectStore + ?Sized>(
         )
         .await
         {
-            return Ok(decoded_data_cache_block(family, decoded));
+            return Ok(decoded_data_cache_block(descriptor.family, decoded));
         }
         let bytes = load_section_bytes(
             store,
@@ -68,7 +67,7 @@ pub(super) async fn load_segment_data_block<S: ObjectStore + ?Sized>(
             &bytes,
         );
         Ok(decoded_data_cache_block(
-            family,
+            descriptor.family,
             decode_data_block(&bytes, &handle)
                 .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,
         ))
@@ -109,7 +108,6 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
-    family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     entries: &[SegmentIndexEntry],
 ) -> Result<Vec<Arc<DecodedDataBlock>>, ManifestLoadError> {
@@ -149,7 +147,7 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
                 memo,
                 probe_key.clone(),
                 &DecodedMetadataTableBlock::Data {
-                    decoded_byte_len: decoded_manifest_block_weight(family, &block.rows),
+                    decoded_byte_len: decoded_manifest_block_weight(descriptor.family, &block.rows),
                     block: Arc::clone(&block),
                 },
             );
@@ -193,7 +191,7 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
                 span[0].block.offset,
             );
             let fetch = || async {
-                load_and_publish_span(store, table_cache, memo, family, descriptor, span).await
+                load_and_publish_span(store, table_cache, memo, descriptor, span).await
             };
             match table_cache {
                 Some(cache) => {
@@ -214,9 +212,8 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
         if blocks[position].is_some() {
             continue;
         }
-        blocks[position] = Some(
-            load_segment_data_block(store, table_cache, memo, family, descriptor, entry).await?,
-        );
+        blocks[position] =
+            Some(load_segment_data_block(store, table_cache, memo, descriptor, entry).await?);
     }
 
     Ok(blocks
@@ -234,7 +231,6 @@ async fn load_and_publish_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
-    family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
     span: &[SegmentIndexEntry],
 ) -> Result<DecodedMetadataTableBlock, ManifestLoadError> {
@@ -263,7 +259,7 @@ async fn load_and_publish_span<S: ObjectStore + ?Sized>(
         let cache_key =
             segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, handle.offset);
         let cache_block = DecodedMetadataTableBlock::Data {
-            decoded_byte_len: decoded_manifest_block_weight(family, &decoded.rows),
+            decoded_byte_len: decoded_manifest_block_weight(descriptor.family, &decoded.rows),
             block: decoded,
         };
         memo.record(&cache_key, &cache_block);

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -14,10 +14,8 @@ use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_object, ControlObjectKind, WalFloorEnvelope, WalFloorState,
 };
-use loonfs_api::{AdvanceRetentionResponse, ChangeSeq, NamespaceId};
+use loonfs_api::{AdvanceRetentionResponse, NamespaceId};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
-
-const MAX_RETENTION_PROBE_IO: usize = 8;
 
 pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     store: &S,
@@ -29,6 +27,14 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
     // `wal/floor.json`. The WAL head is never touched — it changes only when
     // commits land. Root monotonicity keeps a mid-flight root swap benign:
     // any replacement covers at least this basis's coverage above the floor.
+    //
+    // Nothing here probes the basis manifest's segments before the floor
+    // moves. Advancing surrenders the WAL replay promise below the target,
+    // and what keeps that safe is the deleter: GC must never remove an
+    // object reachable from the current manifest or a retained checkpoint or
+    // pin (format spec, "Garbage collection"). Corruption that slips past it
+    // is caught by read-path checksums, which an existence probe here could
+    // not have caught anyway.
     let head = read_head_object(store, namespace_id)
         .await
         .map_err(CoreError::load_head)?
@@ -61,43 +67,10 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         .await
         .map_err(CoreError::load_head)?;
     if current_floor >= target_floor {
-        // Already advanced; skip the existence probes on the idempotent
-        // re-invocation path.
+        // Already advanced, so the idempotent re-invocation writes nothing.
         return Ok(AdvanceRetentionResponse {
             retention_floor_seq: current_floor,
         });
-    }
-
-    // Advancing the floor surrenders the WAL replay promise below the
-    // target, so every metadata segment the basis manifest references must
-    // still exist before that promise is given up. This probe is advisory
-    // defense-in-depth: the atomic guarantee belongs to the deleter — GC
-    // must never remove an object reachable from the current manifest or a
-    // retained checkpoint or pin (format spec, "Garbage collection").
-    // Corruption discovered later is caught by read-path checksums.
-    let segment_keys = manifest_tables
-        .manifest()
-        .payload
-        .metadata_files
-        .iter()
-        .map(|metadata_file| metadata_file.object_key.as_str())
-        .collect::<Vec<_>>();
-    for segment_keys in segment_keys.chunks(MAX_RETENTION_PROBE_IO) {
-        let probes = segment_keys.iter().copied().map(|object_key| async move {
-            let present = store
-                .head(object_key)
-                .await
-                .map_err(|error| CoreError::store(object_key, &error))?
-                .is_some();
-            if present {
-                Ok(())
-            } else {
-                Err(CoreError::CheckpointUnavailable(format!(
-                    "retention floor cannot advance: missing metadata segment `{object_key}`"
-                )))
-            }
-        });
-        futures::future::try_join_all(probes).await?;
     }
 
     // Monotonic floor publication: never decrease. The first advance
@@ -108,13 +81,12 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
             Err(ControlObjectLoadError::MissingObject { .. }) => None,
             Err(error) => return Err(CoreError::load_head(error)),
         };
-        if loaded
+        let published_floor = loaded
             .as_ref()
-            .is_some_and(|loaded| loaded.envelope.state.floor_seq >= target_floor)
-        {
+            .map(|loaded| loaded.envelope.state.floor_seq);
+        if let Some(floor_seq) = published_floor.filter(|floor_seq| *floor_seq >= target_floor) {
             return Ok(AdvanceRetentionResponse {
-                retention_floor_seq: loaded
-                    .map_or(ChangeSeq(0), |loaded| loaded.envelope.state.floor_seq),
+                retention_floor_seq: floor_seq,
             });
         }
         let next = WalFloorState {

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -325,7 +325,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
                 matching_descriptors[next_descriptor_index..chunk_end]
                     .iter()
                     .map(|descriptor| {
-                        self.segment_rows(family, descriptor, lower_bound, upper_bound, readahead)
+                        self.segment_rows(descriptor, lower_bound, upper_bound, readahead)
                     }),
             )
             .await?;
@@ -385,7 +385,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
 
     async fn segment_rows(
         &self,
-        family: MetadataTableFamily,
         descriptor: &MetadataFileRef,
         lower_bound: &str,
         upper_bound: Option<&str>,
@@ -395,7 +394,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             self.store,
             self.table_cache,
             &self.block_memo,
-            family,
             descriptor,
             lower_bound,
             upper_bound,

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -1157,19 +1157,12 @@ async fn segment_rows(
     let index = block_fetch::load_segment_index(store, None, &memo, descriptor)
         .await
         .expect("segment index");
-    data_block_load::load_segment_data_block_span(
-        store,
-        None,
-        &memo,
-        descriptor.family,
-        descriptor,
-        &index,
-    )
-    .await
-    .expect("segment data blocks")
-    .iter()
-    .flat_map(|block| block.rows.iter().cloned())
-    .collect()
+    data_block_load::load_segment_data_block_span(store, None, &memo, descriptor, &index)
+        .await
+        .expect("segment data blocks")
+        .iter()
+        .flat_map(|block| block.rows.iter().cloned())
+        .collect()
 }
 
 /// One segment object's whole body, which the seeding helpers slice.
@@ -1265,16 +1258,10 @@ async fn wide_read(
 ) -> (Vec<Arc<DecodedDataBlock>>, usize) {
     let memo = load::SessionBlockMemo::default();
     store.reset();
-    let blocks = data_block_load::load_segment_data_block_span(
-        store,
-        cache,
-        &memo,
-        descriptor.family,
-        descriptor,
-        index,
-    )
-    .await
-    .expect("wide read");
+    let blocks =
+        data_block_load::load_segment_data_block_span(store, cache, &memo, descriptor, index)
+            .await
+            .expect("wide read");
     (blocks, store.count(OperationClass::Read))
 }
 
@@ -1298,7 +1285,6 @@ async fn a_narrow_data_block_load_fills_the_local_cache_and_then_reads_from_it()
         &store,
         Some(&cold_cache),
         &load::SessionBlockMemo::default(),
-        descriptor.family,
         &descriptor,
         entry,
     )
@@ -1331,7 +1317,6 @@ async fn a_narrow_data_block_load_fills_the_local_cache_and_then_reads_from_it()
         &store,
         Some(&warm_cache),
         &load::SessionBlockMemo::default(),
-        descriptor.family,
         &descriptor,
         entry,
     )

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -177,9 +177,9 @@ where
         for chunk in descriptors.chunks(MAX_MAINTENANCE_TABLE_IO) {
             loaded_segments.extend(
                 try_join_all(
-                    chunk.iter().map(|descriptor| {
-                        load_manifest_segment_rows(store, table.family, descriptor)
-                    }),
+                    chunk
+                        .iter()
+                        .map(|descriptor| load_manifest_segment_rows(store, descriptor)),
                 )
                 .await?,
             );
@@ -221,10 +221,9 @@ where
 #[cfg(test)]
 pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
     store: &S,
-    family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
 ) -> Result<SegmentKeyRangeBlocks, ManifestLoadError> {
-    load_manifest_segment_rows_with_cache(store, None, family, descriptor).await
+    load_manifest_segment_rows_with_cache(store, None, descriptor).await
 }
 
 /// Loads a segment's full row set: every data block, in key order, checked
@@ -234,14 +233,12 @@ pub(super) async fn load_manifest_segment_rows<S: ObjectStore + ?Sized>(
 pub(super) async fn load_manifest_segment_rows_with_cache<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
-    family: MetadataTableFamily,
     descriptor: &MetadataFileRef,
 ) -> Result<SegmentKeyRangeBlocks, ManifestLoadError> {
     let row_set = load_manifest_segment_rows_in_key_range_with_cache(
         store,
         table_cache,
         &SessionBlockMemo::default(),
-        family,
         descriptor,
         "",
         None,

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -286,52 +286,6 @@ async fn retention_floor_advancement_preserves_writer_identity() {
     assert_eq!(after, before);
 }
 
-#[tokio::test]
-async fn retention_floor_does_not_advance_past_missing_metadata_segment() {
-    let temp_dir = tempdir().expect("tempdir");
-    let store = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let context = test_context();
-    bootstrap_namespace(&store, &namespace_id, &context, false)
-        .await
-        .expect("bootstrap");
-    write_file_bytes(
-        &store,
-        &namespace_id,
-        "/docs/hello.txt",
-        b"hello\n",
-        &context,
-        None,
-    )
-    .await
-    .expect("write hello");
-    let checkpoint = create_checkpoint(&store, &namespace_id, &context)
-        .await
-        .expect("create checkpoint");
-    let materialized =
-        load_manifest_materialization_for_inspection(&store, &namespace_id, checkpoint.manifest_id)
-            .await
-            .expect("load manifest");
-    let missing_key = materialized
-        .manifest
-        .payload
-        .metadata_files
-        .first()
-        .expect("metadata file")
-        .object_key
-        .clone();
-    store.delete(&missing_key).await.expect("delete segment");
-
-    let error = advance_retention_floor(&store, &namespace_id, &context)
-        .await
-        .expect_err("floor must not advance past missing segment");
-    assert!(
-        matches!(error, CoreError::CheckpointUnavailable(_)),
-        "unexpected error: {error:?}"
-    );
-    assert_eq!(read_floor_seq(&store, &namespace_id).await, ChangeSeq(0));
-}
-
 /// Reads the files one checkpoint pins, or the error that says it no longer
 /// pins anything.
 async fn read_checkpoint_files<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -30,14 +30,12 @@ impl CandidateFamily {
         Self::UploadSessions,
     ];
 
+    /// This family's position in [`Self::ALL`], which is the sweep order.
     pub(super) fn index(self) -> usize {
-        match self {
-            Self::WalSegments => 0,
-            Self::MetadataTables => 1,
-            Self::Manifests => 2,
-            Self::Checkpoints => 3,
-            Self::UploadSessions => 4,
-        }
+        Self::ALL
+            .iter()
+            .position(|family| *family == self)
+            .expect("every family is listed in ALL")
     }
 
     pub(super) fn prefix(self, namespace_id: &NamespaceId) -> String {

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -105,8 +105,9 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     // overrunning — the sessions waiting on it are retained and the sweep
     // continues.
     let mut references = ContentReferences::over(&mark);
-    let mut position = resume.clone();
-    let mut decided = 0_u64;
+    // The position this pass walked to, or `None` while it has decided
+    // nothing and has no progress of its own to report.
+    let mut position: Option<GcCursor> = None;
 
     // Data precedes mutable records. A crash or bounded return can therefore
     // leave data protected for an extra pass, never a readable record whose
@@ -128,7 +129,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
             // candidate reads or mutations, and the key is reconsidered
             // from the exclusive last-examined position on resume.
             if budget.exhausted() {
-                return stopped_on_budget(report, config, &position, decided, &sweep);
+                return stopped_on_budget(report, config, position.as_ref(), &sweep);
             }
 
             let step = process_candidate(
@@ -150,7 +151,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
                 // The re-verification this candidate's decision needs could
                 // not be paid for, so the candidate stays undecided and is
                 // reconsidered from the same exclusive position on resume.
-                return stopped_on_budget(report, config, &position, decided, &sweep);
+                return stopped_on_budget(report, config, position.as_ref(), &sweep);
             }
             // Every candidate that gets past the check above comes back
             // decided one way or the other, so the cursor always advances
@@ -160,8 +161,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
             // rather than by leaving the key undecided. A budget below that
             // scan's cost would otherwise pin the walk to one key forever.
             budget.charge();
-            decided += 1;
-            position = GcCursor::after(namespace_id, family, key);
+            position = Some(GcCursor::after(namespace_id, family, key));
         }
     }
 
@@ -181,15 +181,13 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
 fn stopped_on_budget(
     mut report: GcResponse,
     config: &GcConfig,
-    position: &GcCursor,
-    decided: u64,
+    position: Option<&GcCursor>,
     sweep: &SweepVerifier,
 ) -> Result<GcResponse> {
     report.budget_exhausted = true;
-    if decided == 0 {
-        report.next_cursor.clone_from(&config.cursor);
-    } else {
-        report.next_cursor = Some(position.encode()?);
+    match position {
+        Some(position) => report.next_cursor = Some(position.encode()?),
+        None => report.next_cursor.clone_from(&config.cursor),
     }
     report.degraded_retention = sweep.degraded;
     Ok(report)
@@ -251,7 +249,10 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         CandidateFamily::MetadataTables => !mark.tables.contains(key),
         CandidateFamily::Manifests => match manifest_object_id_of(key) {
             Some(Ok(id)) => !mark.manifests.contains(&id),
-            None | Some(Err(_)) => false,
+            // A key that names no readable manifest is reachable from no
+            // root, so it is selected like any other unreferenced
+            // candidate; the decision below is where it is kept and said.
+            None | Some(Err(_)) => true,
         },
         CandidateFamily::Checkpoints => !mark.checkpoint_keys.contains(key),
         CandidateFamily::UploadSessions => false,
@@ -301,9 +302,9 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
                             report.deleted_manifests += 1;
                         }
                     }
-                    // Candidate selection above never picks an unreadable
-                    // manifest key, so this arm is the same belt-and-braces
-                    // the selection already wears.
+                    // A key under the manifest prefix that does not name a
+                    // manifest is never deleted: this pass cannot tell what
+                    // wrote it, so it is retained and reported.
                     None | Some(Err(_)) => report.retain(RetainedReason::UnrecognizedKey),
                 }
             }

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -245,33 +245,28 @@ enum ContentReference {
     Unknown,
     /// The set did not fit in the budget the pass had left, so content
     /// reclamation is skipped for the rest of this invocation. It is not an
-    /// answer of any kind — see [`ScanOutcome::BudgetExhausted`].
+    /// answer of any kind — see [`CollectedReferences::Deferred`].
     Deferred,
 }
 
+/// What the reference scan has produced for this invocation.
 enum CollectedReferences {
+    /// The scan has not run yet. Only the memo starts here.
     NotYet,
+    /// A root could not be read, so this pass has no reference set at all
+    /// (format spec, "Garbage collection", rule 5).
     Unavailable,
     /// The scan ran out of budget once, which settles it for the whole
     /// invocation: a later candidate must not pay to start the same scan
     /// over, and being skipped is a property of the invocation rather than
-    /// of the session that happened to ask first.
+    /// of the session that happened to ask first. The ids gathered before
+    /// the budget ran out are dropped, because a partial set is not a
+    /// smaller answer, it is no answer: every id it is missing looks
+    /// unreferenced, so deciding a deletion from one would delete live
+    /// content.
     Deferred,
-    Referenced(BTreeSet<ContentId>),
-}
-
-/// What one attempt at the reference scan produced.
-enum ScanOutcome {
     /// Every root was read. The set is complete and may decide deletions.
-    Complete(BTreeSet<ContentId>),
-    /// A root could not be read, so this pass has no reference set at all
-    /// (format spec, "Garbage collection", rule 5).
-    Unavailable,
-    /// The pass budget ran out before the last root was read. The ids
-    /// gathered so far are dropped: a partial set is not a smaller answer,
-    /// it is no answer. Every id it is missing looks unreferenced, so
-    /// deciding a deletion from one would delete live content.
-    BudgetExhausted,
+    Referenced(BTreeSet<ContentId>),
 }
 
 /// Every content id the namespace's live metadata references, collected at
@@ -309,24 +304,11 @@ impl<'a> ContentReferences<'a> {
         budget: &mut PassBudget,
     ) -> Result<ContentReference> {
         if matches!(self.collected, CollectedReferences::NotYet) {
-            if self.live.degraded {
-                self.collected = CollectedReferences::Unavailable;
+            self.collected = if self.live.degraded {
+                CollectedReferences::Unavailable
             } else {
-                match collect_referenced_content(store, namespace_id, self.live, budget).await? {
-                    ScanOutcome::Complete(referenced) => {
-                        self.collected = CollectedReferences::Referenced(referenced);
-                    }
-                    ScanOutcome::Unavailable => {
-                        self.collected = CollectedReferences::Unavailable;
-                    }
-                    // The partial set is dropped, not remembered — but the
-                    // fact that it did not fit is, so the rest of the
-                    // invocation stops asking.
-                    ScanOutcome::BudgetExhausted => {
-                        self.collected = CollectedReferences::Deferred;
-                    }
-                }
-            }
+                collect_referenced_content(store, namespace_id, self.live, budget).await?
+            };
         }
         Ok(match &self.collected {
             CollectedReferences::NotYet | CollectedReferences::Unavailable => {
@@ -361,34 +343,37 @@ impl<'a> ContentReferences<'a> {
 /// Every manifest root read costs a budget unit — one per manifest opened,
 /// one per page of revision rows — so this scan is part of the pass's bound
 /// rather than an exception to it. Running out stops the scan where it
-/// stands and reports [`ScanOutcome::BudgetExhausted`]; the caller retains
+/// stands and reports [`CollectedReferences::Deferred`]; the caller retains
 /// the session that triggered it, marks the pass as having deferred content
 /// reclamation, and carries on. A namespace whose scan never fits therefore
 /// keeps its completed content — `max_objects` has to be at least the
 /// scan's size for content reclamation to happen at all — but the sweep
 /// around it still advances, which is the difference between leaking
 /// content for a while and not collecting anything ever.
+///
+/// Every return is a verdict the memo can hold: an attempt that has run
+/// never comes back as [`CollectedReferences::NotYet`].
 async fn collect_referenced_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     live: &LiveSet,
     budget: &mut PassBudget,
-) -> Result<ScanOutcome> {
+) -> Result<CollectedReferences> {
     let mut referenced = BTreeSet::new();
     for manifest_object_id in &live.manifests {
         if !budget.try_charge() {
-            return Ok(ScanOutcome::BudgetExhausted);
+            return Ok(CollectedReferences::Deferred);
         }
         let Ok(tables) =
             load_verified_manifest_tables(store, namespace_id, manifest_object_id).await
         else {
-            return Ok(ScanOutcome::Unavailable);
+            return Ok(CollectedReferences::Unavailable);
         };
         let mut lower_bound = lookup_keys::REVISION_ROW_PREFIX.to_owned();
         let upper_bound = string_prefix_upper_bound(lookup_keys::REVISION_ROW_PREFIX);
         loop {
             if !budget.try_charge() {
-                return Ok(ScanOutcome::BudgetExhausted);
+                return Ok(CollectedReferences::Deferred);
             }
             let Ok(rows) = tables
                 .scan_range_page_with_keys(
@@ -399,7 +384,7 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
                 )
                 .await
             else {
-                return Ok(ScanOutcome::Unavailable);
+                return Ok(CollectedReferences::Unavailable);
             };
             let exhausted = rows.len() < REVISION_SCAN_WAVE_ROWS;
             match rows.last() {
@@ -422,5 +407,5 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
     // in one pass.
     referenced.extend(live.wal_content_ids.iter().cloned());
 
-    Ok(ScanOutcome::Complete(referenced))
+    Ok(CollectedReferences::Referenced(referenced))
 }

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -19,13 +19,22 @@ const MAX_DELETE_CAS_ATTEMPTS: usize = 8;
 /// `acquired_writer` is the deleting session's writer epoch, so no stale
 /// writer session can publish past the delete. The caller owns acquisition —
 /// [`NamespaceCommitEngine`](crate::publish::NamespaceCommitEngine), which
-/// refuses outright when the session is already fenced. Every retry re-checks
-/// that epoch against the reloaded head, so a writer takeover between
-/// acquisition and the swap aborts the delete instead of deleting a namespace
-/// another writer now owns.
+/// refuses outright when the session is already fenced. Every retry that
+/// still has a swap to make re-checks that epoch against the reloaded head,
+/// so a writer takeover between acquisition and the swap aborts the delete
+/// instead of deleting a namespace another writer now owns.
 /// The delete linearizes at that swap: commits whose
 /// head advance serialized before it stay committed and durable; everything
 /// that observes the deleted head afterward fails with `namespace_deleted`.
+///
+/// A reload that finds the head already deleted answers before the fence,
+/// because there is no swap left to fence. The namespace is in the terminal
+/// state this call was asking for, so the answer is the same whoever owns
+/// the writer epoch now: `namespace_deleted` when this call never swapped
+/// (API spec, "DELETE /v0/namespaces/{ns}"), and success when it did. Every
+/// acquisition bumps the epoch, so checking the fence first would report a
+/// concurrent deleter's tombstone as `writer_fenced` and, worse, would fence
+/// this session for good over a delete that landed.
 ///
 /// Because `deleted` is terminal, a lost acknowledgment is self-resolving:
 /// if a reload after an ambiguous swap shows the head deleted, the delete
@@ -44,10 +53,13 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
             .map_err(|error| CoreError::MetadataProjection(error.into()))?;
         let head = loaded.envelope.state.clone();
 
+        // Terminal state first, ahead of the fence and the precondition
+        // below: both of those decide whether this call may swap, and there
+        // is nothing left to swap. See the fence paragraph above.
         if head.state == NamespaceState::Deleted {
-            // Terminal state reached. If we already sent a swap, the delete
-            // is done regardless of whose swap landed; if we never sent one,
-            // the namespace was already deleted when we arrived.
+            // If we already sent a swap, the delete is done regardless of
+            // whose swap landed; if we never sent one, the namespace was
+            // already deleted when we arrived.
             if attempted_swap {
                 return Ok(DeleteNamespaceResponse {
                     namespace_id: namespace_id.clone(),

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -317,8 +317,15 @@ impl Default for SystemMaintenanceClock {
 impl MaintenanceClock for SystemMaintenanceClock {
     fn now_ms(&self) -> u64 {
         // A clock before the unix epoch reads as the epoch here rather than
-        // failing: it can only make a scheduling decision early, and every
-        // durable path already refuses such a clock outright.
+        // failing. Every eligibility test is `at_ms <= now_ms`, so the
+        // epoch is the reading under which nothing timed comes due: work
+        // that answers to a durable deadline parks until something nudges
+        // it. That is the safe end to fall off. The opposite fallback would
+        // make every deadline due at once, and since the timer's sleep is
+        // floored at one millisecond it would drive reconciliation sweeps
+        // at that floor for as long as the clock stayed wrong. A pre-epoch
+        // clock is also a condition every durable path refuses outright, so
+        // there is no useful maintenance to run through it either way.
         loonfs_core::time::current_time_ms().unwrap_or(0)
     }
 

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -174,7 +174,7 @@ impl RegistryShared {
         &self,
         namespace_id: &NamespaceId,
         weight: Option<PublishTailWeight>,
-        budget: ProjectionBudget,
+        budget: &RuntimeCacheConfig,
     ) -> RetainedProjectionTotals {
         let victims = {
             let mut state = self.lock_state();
@@ -215,25 +215,6 @@ impl RegistryShared {
         let mut state = self.lock_state();
         state.projections.forget(namespace_id);
         state.projections.totals()
-    }
-}
-
-/// The aggregate ceiling on retained publish-tail projections: the same
-/// three knobs, read the same way, as the read-side projection cache.
-#[derive(Debug, Clone, Copy)]
-struct ProjectionBudget {
-    max_namespaces: usize,
-    max_rows: usize,
-    max_decoded_bytes: usize,
-}
-
-impl ProjectionBudget {
-    fn of(config: &RuntimeCacheConfig) -> Self {
-        Self {
-            max_namespaces: config.max_cached_namespaces,
-            max_rows: config.max_cached_wal_tail_projection_rows,
-            max_decoded_bytes: config.max_cached_wal_tail_projection_decoded_bytes,
-        }
     }
 }
 
@@ -321,17 +302,18 @@ impl RetainedProjections {
     }
 
     /// The namespaces to drop, least-recently-published first, until what
-    /// remains fits the budget. Selection changes nothing: only an eviction
-    /// that actually took the engine does.
-    fn over_budget_victims(&self, budget: ProjectionBudget) -> Vec<RetainedProjection> {
+    /// remains fits the budget — the same three knobs, read the same way, as
+    /// the read-side projection cache. Selection changes nothing: only an
+    /// eviction that actually took the engine does.
+    fn over_budget_victims(&self, budget: &RuntimeCacheConfig) -> Vec<RetainedProjection> {
         let mut projections = self.entries.len();
         let mut rows = self.rows;
         let mut decoded_bytes = self.decoded_bytes;
         let mut victims = Vec::new();
         for entry in &self.entries {
-            if projections <= budget.max_namespaces
-                && rows <= budget.max_rows
-                && decoded_bytes <= budget.max_decoded_bytes
+            if projections <= budget.max_cached_namespaces
+                && rows <= budget.max_cached_wal_tail_projection_rows
+                && decoded_bytes <= budget.max_cached_wal_tail_projection_decoded_bytes
             {
                 break;
             }
@@ -722,7 +704,7 @@ impl NamespacePublisher {
         let Some(shared) = self.shared.upgrade() else {
             return;
         };
-        let budget = ProjectionBudget::of(self.read_core.runtime_cache_config());
+        let budget = self.read_core.runtime_cache_config();
         let totals = shared.settle_projection(&self.namespace_id, weight, budget);
         self.report_retained_projections(totals);
     }


### PR DESCRIPTION
Core contained wrappers, copied counters, duplicate parameters, and checks that repeated information already available elsewhere.

This removes that duplication across GC, checkpoints, retention, and publishing. Retention also stops issuing an advisory HEAD request for every WAL segment before advancing the floor; deletion and read-time integrity checks remain.