### PR TITLE
fix(uploads): one session admits one staging writer at a time

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -687,6 +687,24 @@ pub enum UploadSessionLifecycle {
         /// completed one names its content once, below.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         staged_content: Option<ContentRef>,
+        /// Unix-millisecond stamp of the staging request currently writing
+        /// the content object, or `None` when no request holds the slot.
+        ///
+        /// The claim is what makes staging exclusive. A service-proxied
+        /// session writes one object key, and a provider cannot make the
+        /// create-only condition on a multipart write part of the write, so
+        /// two requests that both found the key absent would both assemble
+        /// over it and only one of them would record its digest. Taking this
+        /// claim is a compare-and-swap, so exactly one request writes at a
+        /// time and the recorded reference always describes the object.
+        ///
+        /// It carries no expiry of its own. The claim is honoured only while
+        /// the session is open, so `expires_at_ms` above bounds it: a request
+        /// that is cancelled while holding the claim leaves the session
+        /// unable to stage until its lease passes, and garbage collection
+        /// aborts the session at exactly that point.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        staging_claimed_at_ms: Option<u64>,
     },
     /// Terminal: the content is durable and verified. This is the only state
     /// a receipt may be minted from, and the content reference it carries is
@@ -806,6 +824,32 @@ impl UploadSessionState {
                 "upload session `{}` writes past the service but holds staged content",
                 self.upload_id
             )),
+            // Only a proxied session stages, so only a proxied session can
+            // hold the claim that makes staging exclusive.
+            (
+                UploadSessionTransport::DirectPut { .. }
+                | UploadSessionTransport::DirectMultipart { .. },
+                UploadSessionLifecycle::Open {
+                    staging_claimed_at_ms: Some(_),
+                    ..
+                },
+            ) => Err(format!(
+                "upload session `{}` writes past the service but holds a staging claim",
+                self.upload_id
+            )),
+            // The compare-and-swap that records staged content is the one
+            // that releases the claim, so the two never stand together.
+            (
+                UploadSessionTransport::ServiceProxied {},
+                UploadSessionLifecycle::Open {
+                    staged_content: Some(_),
+                    staging_claimed_at_ms: Some(_),
+                    ..
+                },
+            ) => Err(format!(
+                "upload session `{}` holds a staging claim over content it already staged",
+                self.upload_id
+            )),
             (
                 UploadSessionTransport::DirectPut { promised_content },
                 UploadSessionLifecycle::Completed { content_ref, .. },
@@ -872,6 +916,8 @@ enum StrictUploadSessionLifecycle {
         expires_at_ms: u64,
         #[serde(default)]
         staged_content: Option<StrictContentRef>,
+        #[serde(default)]
+        staging_claimed_at_ms: Option<u64>,
     },
     Completed {
         completed_at_ms: u64,
@@ -888,9 +934,11 @@ impl From<StrictUploadSessionLifecycle> for UploadSessionLifecycle {
             StrictUploadSessionLifecycle::Open {
                 expires_at_ms,
                 staged_content,
+                staging_claimed_at_ms,
             } => Self::Open {
                 expires_at_ms,
                 staged_content: staged_content.map(Into::into),
+                staging_claimed_at_ms,
             },
             StrictUploadSessionLifecycle::Completed {
                 completed_at_ms,

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -659,6 +659,7 @@ fn control_objects_match_golden_bytes() {
             state: UploadSessionLifecycle::Open {
                 expires_at_ms: 87_400_000,
                 staged_content: None,
+                staging_claimed_at_ms: None,
             },
         },
     );
@@ -682,6 +683,7 @@ fn control_objects_match_golden_bytes() {
             state: UploadSessionLifecycle::Open {
                 expires_at_ms: 87_400_000,
                 staged_content: None,
+                staging_claimed_at_ms: None,
             },
         },
     );
@@ -700,6 +702,7 @@ fn control_objects_match_golden_bytes() {
             state: UploadSessionLifecycle::Open {
                 expires_at_ms: 87_400_000,
                 staged_content: Some(sample_content_ref()),
+                staging_claimed_at_ms: None,
             },
         },
     );

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -574,7 +574,14 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         upload_id: &UploadId,
         bytes: &[u8],
     ) -> Result<UploadContentResponse> {
-        crate::protocol::upload_content(&self.store, &self.namespace_id, upload_id, bytes).await
+        crate::protocol::upload_content(
+            &self.store,
+            &self.namespace_id,
+            upload_id,
+            bytes,
+            &self.mutation_context()?,
+        )
+        .await
     }
 
     /// Uploads content that arrives as a stream into an upload session,
@@ -584,8 +591,14 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         upload_id: &UploadId,
         body: ByteStream,
     ) -> Result<UploadContentResponse> {
-        crate::protocol::upload_streamed_content(&self.store, &self.namespace_id, upload_id, body)
-            .await
+        crate::protocol::upload_streamed_content(
+            &self.store,
+            &self.namespace_id,
+            upload_id,
+            body,
+            &self.mutation_context()?,
+        )
+        .await
     }
 
     /// Completes an upload session when the expected content ref matches.

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -327,6 +327,7 @@ async fn write_upload_session(store: &LocalFsStore, namespace_id: &NamespaceId) 
         state: loonfs_api::wire::control::UploadSessionLifecycle::Open {
             expires_at_ms: 1_000 + UPLOAD_SESSION_LEASE_MS,
             staged_content: None,
+            staging_claimed_at_ms: None,
         },
     };
     let envelope = loonfs_api::wire::control::UploadSessionEnvelope::from_state(
@@ -357,10 +358,15 @@ async fn stage_upload<S: ObjectStore + ?Sized>(
     )
     .await
     .expect("begin upload");
-    let staged =
-        crate::protocol::upload_content(store, namespace_id, begin.upload_id(), b"racing upload\n")
-            .await
-            .expect("stage upload");
+    let staged = crate::protocol::upload_content(
+        store,
+        namespace_id,
+        begin.upload_id(),
+        b"racing upload\n",
+        context,
+    )
+    .await
+    .expect("stage upload");
     let content_store_id =
         crate::namespace::catalog::load_namespace_content_store_id(store, namespace_id)
             .await
@@ -948,9 +954,10 @@ async fn complete_upload_for_gc<S: ObjectStore + ?Sized>(
     )
     .await
     .expect("begin upload");
-    let staged = crate::protocol::upload_content(store, namespace_id, begin.upload_id(), bytes)
-        .await
-        .expect("stage upload");
+    let staged =
+        crate::protocol::upload_content(store, namespace_id, begin.upload_id(), bytes, context)
+            .await
+            .expect("stage upload");
     let content_store_id =
         crate::namespace::catalog::load_namespace_content_store_id(store, namespace_id)
             .await

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -442,6 +442,7 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
         state: UploadSessionLifecycle::Open {
             expires_at_ms: context.now_ms.saturating_add(UPLOAD_SESSION_LEASE_MS),
             staged_content: None,
+            staging_claimed_at_ms: None,
         },
     };
     let envelope = UploadSessionEnvelope::from_state(ControlObjectKind::UploadSession, state)
@@ -527,6 +528,119 @@ fn staged_content(state: &UploadSessionLifecycle) -> Option<&ContentRef> {
     }
 }
 
+/// What a staging request found when it asked for the right to write.
+enum StagingSlot {
+    /// The request holds the claim and is the only one that may write.
+    Claimed,
+    /// The session already staged content, so nothing is written. The
+    /// caller decides from this reference whether its bytes are the same
+    /// upload arriving twice or a conflicting one.
+    AlreadyStaged(ContentRef),
+}
+
+/// Takes the exclusive right to write this session's content object.
+///
+/// A proxied session writes one object key, and past the store's multipart
+/// threshold the create-only condition on that write cannot be part of the
+/// write (see [`stage_streamed_under_content_id`]). Two requests that both
+/// found the key absent would therefore both assemble over it, and the one
+/// that lost the record compare-and-swap would leave its bytes behind under
+/// the winner's digest. This compare-and-swap is what stops that: exactly
+/// one request holds the claim, so only one ever writes.
+///
+/// A session that already staged content needs no claim, because nothing
+/// will be written — the caller answers from the reference instead.
+async fn claim_staging_slot<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &UploadId,
+    now_ms: u64,
+) -> Result<StagingSlot> {
+    update_upload_session(
+        store,
+        namespace_id,
+        upload_id,
+        CONTENTION_RETRY_LIMIT,
+        |mut state| {
+            let upload_id = upload_id.to_owned();
+            async move {
+                if let Some(error) = terminal_session_error(&state.state, upload_id.clone()) {
+                    return Err(error);
+                }
+                if let Some(staged) = staged_content(&state.state) {
+                    return Ok(UploadSessionUpdate::Noop(StagingSlot::AlreadyStaged(
+                        staged.clone(),
+                    )));
+                }
+                let UploadSessionLifecycle::Open {
+                    staging_claimed_at_ms,
+                    ..
+                } = &mut state.state
+                else {
+                    return Err(CoreError::UploadNotFound { upload_id });
+                };
+                // Another request is writing the object right now. Its bytes
+                // are not this request's to overwrite, and its digest is not
+                // this request's to displace.
+                if staging_claimed_at_ms.is_some() {
+                    return Err(CoreError::UploadContentConflict { upload_id });
+                }
+                *staging_claimed_at_ms = Some(now_ms);
+                Ok(UploadSessionUpdate::Replace {
+                    next: Box::new(state),
+                    outcome: StagingSlot::Claimed,
+                })
+            }
+        },
+    )
+    .await
+}
+
+/// Gives the staging claim back after a write that will never be recorded.
+///
+/// Best effort on purpose. The claim is bounded by the session's own lease,
+/// so a release lost to a crash costs the session the rest of that lease and
+/// nothing more; failing the caller's request over it would replace a
+/// recoverable error with a worse one.
+async fn release_staging_claim<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &UploadId,
+) {
+    let released = update_upload_session(
+        store,
+        namespace_id,
+        upload_id,
+        CONTENTION_RETRY_LIMIT,
+        |mut state| async move {
+            let UploadSessionLifecycle::Open {
+                staging_claimed_at_ms,
+                ..
+            } = &mut state.state
+            else {
+                return Ok(UploadSessionUpdate::Noop(()));
+            };
+            if staging_claimed_at_ms.take().is_none() {
+                return Ok(UploadSessionUpdate::Noop(()));
+            }
+            Ok(UploadSessionUpdate::Replace {
+                next: Box::new(state),
+                outcome: (),
+            })
+        },
+    )
+    .await;
+    if let Err(error) = released {
+        tracing::warn!(
+            namespace_id = %namespace_id,
+            upload_id = %upload_id,
+            error = %error,
+            "failed to release the staging claim of a failed upload; \
+             the session cannot stage again until its lease passes"
+        );
+    }
+}
+
 /// What one session's transport is called in a message to its client.
 fn transport_name(transport: &UploadSessionTransport) -> &'static str {
     match transport {
@@ -548,59 +662,110 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
     bytes: &[u8],
+    context: &MutationContext,
 ) -> Result<UploadContentResponse> {
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
+    let loaded = read_upload_session_state(store, namespace_id, upload_id).await?;
+    if let Some(error) = terminal_session_error(&loaded.state, upload_id.clone()) {
+        return Err(error);
+    }
+    if !matches!(loaded.transport, UploadSessionTransport::ServiceProxied {}) {
+        return Err(CoreError::InvalidUploadContent(format!(
+            "{} sessions must be completed after using the presigned URLs",
+            transport_name(&loaded.transport)
+        )));
+    }
 
+    let content_ref = ContentRef::blob_v1(loaded.content_id.clone(), bytes);
+    let response = UploadContentResponse {
+        namespace_id: namespace_id.clone(),
+        upload_id: upload_id.clone(),
+        content_ref: content_ref.clone(),
+    };
+    // The claim is what makes the write exclusive, so it is taken before any
+    // byte is written and released by the same swap that records the result.
+    match claim_staging_slot(store, namespace_id, upload_id, context.now_ms).await? {
+        StagingSlot::AlreadyStaged(staged) if staged == content_ref => return Ok(response),
+        StagingSlot::AlreadyStaged(_) => {
+            return Err(CoreError::UploadContentConflict {
+                upload_id: upload_id.clone(),
+            })
+        }
+        StagingSlot::Claimed => {}
+    }
+
+    let stored = match stage_bytes_under_content_id(
+        store,
+        content_store_id,
+        loaded.content_id.clone(),
+        bytes,
+    )
+    .await
+    {
+        Ok(stored) => stored,
+        Err(error) => {
+            release_staging_claim(store, namespace_id, upload_id).await;
+            return Err(error);
+        }
+    };
+
+    record_staged_content(store, namespace_id, upload_id, stored.content_ref, false).await
+}
+
+/// Records what a staging write produced and releases the claim it held, in
+/// the one compare-and-swap that makes the staged reference the session's.
+///
+/// `already_present` says the store refused to create the object because the
+/// key was occupied. Only this session can name that key, and the claim means
+/// no other request on it was writing, so an occupied key holds bytes from an
+/// earlier attempt of this session that never recorded them. Equal bytes are
+/// that attempt arriving again; different bytes are a conflict.
+async fn record_staged_content<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &UploadId,
+    content_ref: ContentRef,
+    already_present: bool,
+) -> Result<UploadContentResponse> {
     update_upload_session(
         store,
         namespace_id,
         upload_id,
         CONTENTION_RETRY_LIMIT,
         |mut state| {
-            let content_store_id = content_store_id.clone();
             let namespace_id = namespace_id.clone();
             let upload_id = upload_id.to_owned();
+            let content_ref = content_ref.clone();
             async move {
                 if let Some(error) = terminal_session_error(&state.state, upload_id.clone()) {
                     return Err(error);
                 }
-                if !matches!(state.transport, UploadSessionTransport::ServiceProxied {}) {
-                    return Err(CoreError::InvalidUploadContent(format!(
-                        "{} sessions must be completed after using the presigned URLs",
-                        transport_name(&state.transport)
-                    )));
-                }
-
-                let content_ref = ContentRef::blob_v1(state.content_id.clone(), bytes);
-                if let Some(existing) = staged_content(&state.state) {
-                    if existing == &content_ref {
-                        return Ok(UploadSessionUpdate::Noop(UploadContentResponse {
-                            namespace_id,
-                            upload_id,
-                            content_ref,
-                        }));
+                let response = UploadContentResponse {
+                    namespace_id,
+                    upload_id: upload_id.clone(),
+                    content_ref: content_ref.clone(),
+                };
+                match staged_content(&state.state) {
+                    Some(existing) if existing == &content_ref => {
+                        Ok(UploadSessionUpdate::Noop(response))
                     }
-                    return Err(CoreError::UploadContentConflict { upload_id });
+                    Some(_) => Err(CoreError::UploadContentConflict { upload_id }),
+                    None if already_present => Err(CoreError::UploadContentConflict { upload_id }),
+                    None => {
+                        if let UploadSessionLifecycle::Open {
+                            staging_claimed_at_ms,
+                            ..
+                        } = &mut state.state
+                        {
+                            *staging_claimed_at_ms = None;
+                        }
+                        *open_staging_slot(&mut state.state, &upload_id)? = Some(content_ref);
+                        Ok(UploadSessionUpdate::Replace {
+                            next: Box::new(state),
+                            outcome: response,
+                        })
+                    }
                 }
-
-                let stored = stage_bytes_under_content_id(
-                    store,
-                    content_store_id,
-                    state.content_id.clone(),
-                    bytes,
-                )
-                .await?;
-                *open_staging_slot(&mut state.state, &upload_id)? =
-                    Some(stored.content_ref.clone());
-
-                Ok(UploadSessionUpdate::Replace {
-                    next: Box::new(state),
-                    outcome: UploadContentResponse {
-                        namespace_id,
-                        upload_id,
-                        content_ref: stored.content_ref,
-                    },
-                })
             }
         },
     )
@@ -623,6 +788,7 @@ pub(crate) async fn upload_streamed_content<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
     body: ByteStream,
+    context: &MutationContext,
 ) -> Result<UploadContentResponse> {
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
     let loaded = read_upload_session_state(store, namespace_id, upload_id).await?;
@@ -640,65 +806,45 @@ pub(crate) async fn upload_streamed_content<S: ObjectStore + ?Sized>(
     // rewritten while the answer is being worked out. Reading the body
     // without writing it decides the question: the same bytes are one
     // upload arriving twice, and different bytes are a conflict either way.
-    if let Some(staged) = staged_content(&loaded.state) {
-        let content_ref = identify_streamed_payload(loaded.content_id.clone(), body).await?;
-        if staged != &content_ref {
-            return Err(CoreError::UploadContentConflict {
+    // Taking the claim is what establishes that nothing else is writing.
+    match claim_staging_slot(store, namespace_id, upload_id, context.now_ms).await? {
+        StagingSlot::AlreadyStaged(staged) => {
+            let content_ref = identify_streamed_payload(loaded.content_id.clone(), body).await?;
+            if staged != content_ref {
+                return Err(CoreError::UploadContentConflict {
+                    upload_id: upload_id.clone(),
+                });
+            }
+            return Ok(UploadContentResponse {
+                namespace_id: namespace_id.clone(),
                 upload_id: upload_id.clone(),
+                content_ref,
             });
         }
-        return Ok(UploadContentResponse {
-            namespace_id: namespace_id.clone(),
-            upload_id: upload_id.clone(),
-            content_ref,
-        });
+        StagingSlot::Claimed => {}
     }
 
-    let staged =
-        stage_streamed_under_content_id(store, content_store_id, loaded.content_id.clone(), body)
-            .await?;
+    let staged = match stage_streamed_under_content_id(
+        store,
+        content_store_id,
+        loaded.content_id.clone(),
+        body,
+    )
+    .await
+    {
+        Ok(staged) => staged,
+        Err(error) => {
+            release_staging_claim(store, namespace_id, upload_id).await;
+            return Err(error);
+        }
+    };
 
-    update_upload_session(
+    record_staged_content(
         store,
         namespace_id,
         upload_id,
-        CONTENTION_RETRY_LIMIT,
-        |mut state| {
-            let namespace_id = namespace_id.clone();
-            let upload_id = upload_id.to_owned();
-            let content_ref = staged.content_ref.clone();
-            let already_present = staged.already_present;
-            async move {
-                if let Some(error) = terminal_session_error(&state.state, upload_id.clone()) {
-                    return Err(error);
-                }
-                let response = UploadContentResponse {
-                    namespace_id,
-                    upload_id: upload_id.clone(),
-                    content_ref: content_ref.clone(),
-                };
-                match staged_content(&state.state) {
-                    Some(existing) if existing == &content_ref => {
-                        Ok(UploadSessionUpdate::Noop(response))
-                    }
-                    Some(_) => Err(CoreError::UploadContentConflict { upload_id }),
-                    // Nothing is recorded yet, so an occupied key holds
-                    // bytes this session never acknowledged writing. Past the
-                    // store's multipart threshold `already_present` cannot
-                    // see a concurrent request that occupies the key after
-                    // this write observed it absent; `complete_upload` reads
-                    // the object again and is the backstop for that case.
-                    None if already_present => Err(CoreError::UploadContentConflict { upload_id }),
-                    None => {
-                        *open_staging_slot(&mut state.state, &upload_id)? = Some(content_ref);
-                        Ok(UploadSessionUpdate::Replace {
-                            next: Box::new(state),
-                            outcome: response,
-                        })
-                    }
-                }
-            }
-        },
+        staged.content_ref,
+        staged.already_present,
     )
     .await
 }
@@ -1369,7 +1515,7 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
                     "completed content ref does not match staged content".to_owned(),
                 ));
             }
-            verify_staged_content_object(store, content_store_id, staged).await
+            Ok(CompletionOutcome::Verified(staged.clone()))
         }
         CompletionPlan::DirectPut {
             requested,
@@ -1411,56 +1557,6 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
             .await
         }
     }
-}
-
-/// Checks that the object a proxied session staged is still the object that
-/// session staged.
-///
-/// The staging write hashed its own bytes, so the reference is trusted. The
-/// object is not, because a second request against the same session can
-/// write over it. A streamed write past the store's multipart threshold
-/// cannot make its create-only condition part of the write (see
-/// [`stage_streamed_under_content_id`]), so the second request assembles its
-/// own bytes over the first request's object. The `already_present` guard in
-/// [`upload_streamed_content`] usually refuses that second request, but it
-/// cannot see a writer that lands inside its own window. The second request
-/// is then refused a record while its bytes sit at the key, and the session
-/// keeps holding the first request's digest. This check catches that, so the
-/// reference is never frozen and published.
-///
-/// One `head` decides it, and it decides it by size. A proxied reference
-/// carries the SHA-256 this server folded over the payload. The provider's
-/// stored checksum is a different number: Cloudflare R2 stores a CRC-64/NVME
-/// it computed itself, and an AWS S3 multipart object's SHA-256 covers the
-/// part digests rather than the payload. So
-/// [`verify_durable_content_checksum`] has nothing to compare here, and the
-/// direct transports use it only because their references name the algorithm
-/// the provider stores. Size does not tell two payloads of the same length
-/// apart. A completion whose object is missing or a different length can
-/// never publish.
-async fn verify_staged_content_object<S: ObjectStore + ?Sized>(
-    store: &S,
-    content_store_id: &ContentStoreId,
-    staged: &ContentRef,
-) -> Result<CompletionOutcome> {
-    let object_key = content_blob(content_store_id.as_str(), &staged.content_id);
-    let observed = store
-        .head(&object_key)
-        .await
-        .map_err(|err| CoreError::store(&object_key, &err))?;
-    let Some(observed) = observed else {
-        return Ok(CompletionOutcome::Unusable(format!(
-            "staged content object `{object_key}` is gone"
-        )));
-    };
-    if observed.size_bytes != staged.size_bytes {
-        return Ok(CompletionOutcome::Unusable(format!(
-            "staged content object `{object_key}` holds {} bytes, not the {} bytes this session \
-             staged",
-            observed.size_bytes, staged.size_bytes
-        )));
-    }
-    Ok(CompletionOutcome::Verified(staged.clone()))
 }
 
 /// Asks the provider to assemble the parts a client uploaded, then proves
@@ -1570,7 +1666,7 @@ mod tests {
         )
         .await
         .expect("begin upload");
-        let staged = upload_content(store, &namespace_id, begin.upload_id(), BYTES)
+        let staged = upload_content(store, &namespace_id, begin.upload_id(), BYTES, context)
             .await
             .expect("stage upload");
         let content_store_id = load_namespace_content_store_id(store, &namespace_id)
@@ -1650,55 +1746,6 @@ mod tests {
             }
         ));
         assert!(store.head(&content_key).await.expect("head").is_none());
-    }
-
-    /// A streamed write past the store's multipart threshold cannot make its
-    /// create-only condition part of the write, so a second request against
-    /// one session can assemble its own bytes over the object the session
-    /// staged and be refused only its record. The completion reads the object
-    /// and refuses to freeze a reference the object no longer matches.
-    #[tokio::test]
-    async fn a_completion_refuses_a_staged_object_that_was_written_over() {
-        let temp_dir = tempdir().expect("tempdir");
-        let store = LocalFsStore::new(temp_dir.path()).expect("store");
-        let setup = context(1_000);
-        let (namespace_id, content_store_id, upload_id, content_ref, content_key) =
-            staged_session(&store, &setup).await;
-
-        // What the refused request's multipart completion leaves at the key.
-        store
-            .put_overwrite(
-                &content_key,
-                Bytes::from_static(b"bytes from a second request"),
-            )
-            .await
-            .expect("overwrite the staged object");
-
-        let error = complete(
-            &store,
-            &namespace_id,
-            &content_store_id,
-            &upload_id,
-            &content_ref,
-            &context(2_000),
-        )
-        .await
-        .expect_err("a staged object that was written over cannot be frozen");
-        assert!(matches!(error, CoreError::InvalidUploadContent(_)));
-
-        let state = read_upload_session_state(&store, &namespace_id, &upload_id)
-            .await
-            .expect("session still readable");
-        assert!(matches!(
-            state.state,
-            UploadSessionLifecycle::Aborted {
-                aborted_at_ms: 2_000
-            }
-        ));
-        assert!(
-            store.head(&content_key).await.expect("head").is_none(),
-            "the object nothing can name again is removed",
-        );
     }
 
     /// Completion is terminal in the other direction. An abort cannot
@@ -1789,7 +1836,7 @@ mod tests {
         )
         .await
         .expect("complete");
-        let error = upload_content(&store, &namespace_id, &upload_id, BYTES)
+        let error = upload_content(&store, &namespace_id, &upload_id, BYTES, &context(2_000))
             .await
             .expect_err("a completed session takes no more bytes");
         assert!(matches!(error, CoreError::UploadAlreadyCompleted { .. }));
@@ -1811,9 +1858,15 @@ mod tests {
         )
         .await
         .expect("abort");
-        let error = upload_content(&store, &namespace_id, aborted.upload_id(), BYTES)
-            .await
-            .expect_err("an aborted session takes no more bytes");
+        let error = upload_content(
+            &store,
+            &namespace_id,
+            aborted.upload_id(),
+            BYTES,
+            &context(3_000),
+        )
+        .await
+        .expect_err("an aborted session takes no more bytes");
         assert!(matches!(error, CoreError::UploadNotFound { .. }));
     }
 

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -655,13 +655,19 @@ pub(crate) struct StagedStream {
 /// The write is create-only, exactly like the buffered staging write. Past
 /// the store's multipart threshold the store cannot make that condition part
 /// of the write — a provider assembles a multipart object unconditionally —
-/// so it reads the key instead, immediately before the assembly.
-/// `already_present` is therefore authoritative about a key that was already
-/// occupied when this write started, and blind to a writer that lands inside
-/// that window. Only another request against the same upload session can be
-/// that writer, because the key is named by 128 random bits one session
-/// owns, and [`crate::protocol::complete_upload`] reads the object again
-/// before it freezes the reference.
+/// so it reads the key instead, immediately before the assembly. That read
+/// is not atomic with the assembly, so `already_present` answers for a key
+/// that was occupied before this write started and not for one occupied
+/// during it.
+///
+/// The only writer that could occupy the key during the write is another
+/// request against the same upload session, because the key is named by 128
+/// random bits one session owns. The staging claim in
+/// [`crate::protocol::upload_streamed_content`] is what keeps that writer
+/// away: exactly one request holds the claim, so `already_present` is exact
+/// for every caller that takes it. A caller that stages under a freshly
+/// minted identity nobody else holds — [`crate::protocol::stage_owned_stream`]
+/// — needs no claim for the same reason.
 pub(crate) async fn stage_streamed_under_content_id<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: ContentStoreId,

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -19,8 +19,11 @@ use loonfs_core::{
 use loonfs_objectstore::keys::{upload_session, upload_session_prefix};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::ObjectStore;
-use loonfs_test_support::stores::{FailStore, InjectedError, KeyPredicate, OperationClass};
+use loonfs_test_support::stores::{
+    BlockingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+};
 use std::path::Path;
+use std::sync::Arc;
 use tempfile::tempdir;
 
 async fn begin_upload<S: ObjectStore + ?Sized>(
@@ -487,6 +490,119 @@ mod streamed_content {
             Bytes::from(bytes),
             "a refused upload must not have rewritten what the session staged"
         );
+    }
+
+    /// Two staging requests against one session, overlapped so the second
+    /// starts while the first is still writing the object.
+    ///
+    /// This is the shape that used to corrupt the session. Both requests
+    /// would find the key absent, both would assemble over it, and the one
+    /// that lost the record compare-and-swap would leave its bytes behind
+    /// under the winner's digest. The payloads here are the same length and
+    /// different bytes, which is exactly the pair a size comparison cannot
+    /// tell apart, so nothing downstream could have caught it.
+    ///
+    /// The staging claim is what settles it: exactly one request writes, the
+    /// other is refused before it touches the object, and the reference the
+    /// session recorded describes the object byte for byte.
+    #[tokio::test]
+    async fn one_session_admits_one_writer_and_records_what_that_writer_wrote() {
+        let temp_dir = tempdir().expect("tempdir");
+        let blocking = Arc::new(BlockingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("store"),
+            KeyPredicate::content_blob(),
+            OperationClass::Put,
+        ));
+        let context = mutation_context();
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        bootstrap_namespace(blocking.as_ref(), &namespace_id, &context, false)
+            .await
+            .expect("bootstrap");
+        let begin = begin_upload(blocking.as_ref(), &namespace_id, &context)
+            .await
+            .expect("begin upload");
+
+        let first_bytes = payload();
+        let mut second_bytes = first_bytes.clone();
+        // Same length, different bytes.
+        second_bytes[0] ^= 0xff;
+        assert_eq!(first_bytes.len(), second_bytes.len());
+
+        // Park only the first content write, so the second request runs to
+        // whatever conclusion the protocol gives it rather than parking too.
+        blocking.block_next();
+        let first = tokio::spawn({
+            let blocking = Arc::clone(&blocking);
+            let namespace_id = namespace_id.clone();
+            let upload_id = begin.upload_id().clone();
+            let context = context.clone();
+            let bytes = first_bytes.clone();
+            async move {
+                upload_streamed(
+                    blocking.as_ref(),
+                    &namespace_id,
+                    &upload_id,
+                    &bytes,
+                    &context,
+                )
+                .await
+            }
+        });
+        blocking.wait_until_blocked().await;
+
+        // The second request arrives while the first still holds the claim.
+        let second = upload_streamed(
+            blocking.as_ref(),
+            &namespace_id,
+            begin.upload_id(),
+            &second_bytes,
+            &context,
+        )
+        .await;
+
+        blocking.release();
+        let first = first.await.expect("first staging task");
+
+        // Whichever request the protocol lets through, the session must end
+        // up holding a digest that describes the object. This is the
+        // assertion the shared-key race breaks: without the claim both
+        // requests write, and the session records one request's digest over
+        // the other request's bytes.
+        let staged = match (first, second) {
+            (Ok(staged), Err(refused)) => {
+                assert_eq!(refused.code(), ErrorCode::UploadContentConflict);
+                staged
+            }
+            (Err(refused), Ok(staged)) => {
+                assert_eq!(refused.code(), ErrorCode::UploadContentConflict);
+                staged
+            }
+            (Ok(_), Ok(_)) => panic!("two requests staged into one session"),
+            (Err(first), Err(second)) => {
+                panic!("no request staged: {first:?} then {second:?}")
+            }
+        };
+
+        let catalog =
+            loonfs_core::control::load_namespace_catalog_entry(blocking.as_ref(), &namespace_id)
+                .await
+                .expect("catalog");
+        let object_key = content_blob(
+            catalog.content_store_id().as_str(),
+            &staged.content_ref.content_id,
+        );
+        let stored = blocking
+            .get(&object_key, None)
+            .await
+            .expect("read staged object")
+            .expect("staged object exists");
+        assert_eq!(
+            staged.content_ref,
+            ContentRef::blob_v1(staged.content_ref.content_id.clone(), &stored),
+            "the recorded reference must describe the object byte for byte"
+        );
+        // The claim admits the first writer, so those are the bytes that last.
+        assert_eq!(stored, Bytes::from(first_bytes));
     }
 }
 

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -598,8 +598,11 @@ impl MultipartWrite<'_> {
     ///   over the same stream: a refused write still leaves that caller a
     ///   digest over the complete payload.
     /// - It is not atomic with the completion. A key that was already
-    ///   occupied is refused; a writer that lands between this read and the
-    ///   completion is not, and this write assembles over it.
+    ///   occupied when this read ran is refused; a writer that lands between
+    ///   this read and the completion is not, and this write assembles over
+    ///   it. Callers that cannot tolerate that must keep concurrent writers
+    ///   off the key themselves, which is what the upload protocol's staging
+    ///   claim does.
     async fn precondition_holds(&self, mode: &PutMode) -> Result<()> {
         let refused = || {
             Err(ObjectStoreError::PreconditionFailed {

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -522,11 +522,7 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
         .expect("complete upload with proof");
     let prepared = completed.prepared;
     assert_eq!(prepared.content_ref(), &completed.response.content_ref);
-    // One object HEAD and nothing else: the completion checks that the object
-    // the session staged is still the object it staged, because a streamed
-    // staging write past the store's multipart threshold cannot make its
-    // create-only condition part of the write. It never reads the blob.
-    assert_content_counts(harness.recording.snapshot(), 1, 0, 0, 0);
+    assert_content_counts(harness.recording.snapshot(), 0, 0, 0, 0);
     harness.recording.reset();
 
     harness

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -381,8 +381,8 @@ to such a write:
    that is already occupied. A writer that lands inside that window is not
    refused. Incremental writes are therefore for immutable, uniquely-named
    keys, where the condition is a corruption tripwire rather than a
-   concurrency control, and a caller that must also catch the concurrent case
-   observes the object again before it relies on it.
+   concurrency control; a caller that needs two writers kept off one key
+   must exclude them itself, as staging does in §2.4.2.
 
 ### 1.8 Provider conformance
 
@@ -1052,6 +1052,18 @@ one per id. Retrying *within* one upload session reuses that session's id and
 therefore its object, which is where staging idempotency now lives. An
 orphaned content object — one whose upload never completed — is harmless
 because nothing can reference an id that was never published.
+
+Because every request against one session writes one object key, staging is
+**exclusive**: a request takes a durable claim on the session record before it
+writes, and gives it back in the same compare-and-swap that records what it
+wrote. A second request that arrives while the claim is held is refused and
+writes nothing. This is required rather than an optimization — step 3's
+create-if-absent condition cannot be part of a multipart write (§1.7 rule 2),
+so two requests that both found the key absent would both assemble over it,
+and the one that lost the record swap would leave its bytes behind under the
+winner's digest. The claim carries no expiry of its own: it is honoured only
+while the session is open, so the session's lease bounds it and a request
+cancelled while holding it costs that session the rest of its lease.
 
 **Direct upload** hands the transfer to the client instead of proxying it. The
 client declares the size and SHA-256 of bytes it already holds; the server


### PR DESCRIPTION
#537 still allowed two service-proxied requests for the same upload session to write the session’s random object at the same time. With different content of the same size, the session could record one request’s digest while the object contained the other request’s bytes. Large buffered uploads had the same problem.

Staging now claims the session record before writing. A second request is rejected before it touches the object, and the claim is cleared when the first request records its result or fails. This protects both buffered and streamed staging and removes #537’s size-only completion check.