### PR TITLE
feat(checkpoint): the partial-fold walk executor

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -359,6 +359,32 @@ impl ActiveDeletionRowAction {
     }
 }
 
+impl MetadataTableFamily {
+    /// The fixed text every row key in this family starts with, up to but
+    /// not including the family's first variable component.
+    ///
+    /// Defined here because it is the front of [`MetadataRow::row_key_for_family`]
+    /// and must change with it; `row_key_prefixes_match_the_row_keys_they_front`
+    /// holds the two together. A partial fold carves its partitions out of
+    /// the component that follows this prefix, so the boundary between two
+    /// partitions is this prefix followed by one component value (format
+    /// spec, "Partial folds").
+    pub const fn row_key_prefix(self) -> &'static str {
+        match self {
+            Self::Inodes => "inode-",
+            Self::DirentryBinds => "direntry-",
+            Self::DirentryChildBinds => "direntry-child-",
+            Self::DirentryUnbinds => "direntry-unbind-",
+            Self::Revisions => "revision-",
+            Self::RevisionsByInodeDesc => "revision-by-inode-desc-",
+            Self::Tombstones => "tombstone-",
+            Self::ActiveDeletions => "active-deletion-",
+            Self::CommitReceipts => "commit-receipt-",
+            Self::Attributes => "attributes-",
+        }
+    }
+}
+
 impl MetadataRow {
     /// Builds this row's canonical durable key in its primary table family.
     ///
@@ -1243,6 +1269,138 @@ mod tests {
         assert!(!row_of(3, 12, 1)
             .row_key()
             .starts_with(&super::lookup_keys::attributes_prefix(InodeId(43))));
+    }
+
+    /// [`MetadataTableFamily::row_key_prefix`] states the front of every row
+    /// key in a family, and a partial fold reads partition boundaries out of
+    /// the component that follows it. A prefix that drifted from the row-key
+    /// format would put boundaries in the wrong place, so the two are pinned
+    /// against each other for every family.
+    #[test]
+    fn row_key_prefixes_match_the_row_keys_they_front() {
+        let name_key = NameKey::parse("report.txt").expect("valid name key");
+        let display_name = crate::DisplayName::parse("report.txt").expect("valid display name");
+        let bind = super::MetadataRow::DirentryBind {
+            parent_inode_id: InodeId(9),
+            name_key: name_key.clone(),
+            display_name: display_name.clone(),
+            child_inode_id: InodeId(42),
+            bind_seq: ChangeSeq(17),
+            bind_delta_index: 3,
+        };
+        let rows: [(MetadataTableFamily, super::MetadataRow); 10] = [
+            (
+                MetadataTableFamily::Inodes,
+                super::MetadataRow::Inode {
+                    inode_id: InodeId(42),
+                    inode_kind: crate::InodeKind::File,
+                    created_seq: ChangeSeq(3),
+                },
+            ),
+            (MetadataTableFamily::DirentryBinds, bind.clone()),
+            (MetadataTableFamily::DirentryChildBinds, bind.clone()),
+            (
+                MetadataTableFamily::DirentryUnbinds,
+                super::MetadataRow::DirentryUnbind {
+                    parent_inode_id: InodeId(9),
+                    name_key,
+                    display_name,
+                    child_inode_id: InodeId(42),
+                    bind_seq: ChangeSeq(17),
+                    bind_delta_index: 3,
+                    unbind_seq: ChangeSeq(19),
+                    unbind_delta_index: 0,
+                },
+            ),
+            (
+                MetadataTableFamily::Revisions,
+                super::MetadataRow::Revision {
+                    inode_id: InodeId(42),
+                    revision_no: crate::RevisionNo(7),
+                    committed_seq: ChangeSeq(12),
+                    committed_at_ms: 12_000,
+                    revision_delta_index: 3,
+                    content_ref: crate::ContentRef::blob_v1(
+                        crate::ContentId::parse("con_0123456789abcdef0123456789abcdef")
+                            .expect("valid content id"),
+                        b"row key prefix sample",
+                    ),
+                },
+            ),
+            (
+                MetadataTableFamily::RevisionsByInodeDesc,
+                super::MetadataRow::Revision {
+                    inode_id: InodeId(42),
+                    revision_no: crate::RevisionNo(7),
+                    committed_seq: ChangeSeq(12),
+                    committed_at_ms: 12_000,
+                    revision_delta_index: 3,
+                    content_ref: crate::ContentRef::blob_v1(
+                        crate::ContentId::parse("con_0123456789abcdef0123456789abcdef")
+                            .expect("valid content id"),
+                        b"row key prefix sample",
+                    ),
+                },
+            ),
+            (
+                MetadataTableFamily::Tombstones,
+                super::MetadataRow::Tombstone {
+                    root_inode_id: InodeId(42),
+                    generation: super::TombstoneGeneration {
+                        seq: ChangeSeq(12),
+                        delta_index: 0,
+                    },
+                    action: super::TombstoneRowAction::Set {
+                        deleted_direntry: None,
+                    },
+                    deleted_at_ms: 12_000,
+                },
+            ),
+            (
+                MetadataTableFamily::ActiveDeletions,
+                super::MetadataRow::ActiveDeletion {
+                    root_inode_id: InodeId(42),
+                    deleted_at_seq: ChangeSeq(12),
+                    action: super::ActiveDeletionRowAction::Removed {
+                        revoked_at_seq: ChangeSeq(15),
+                    },
+                },
+            ),
+            (
+                MetadataTableFamily::CommitReceipts,
+                super::MetadataRow::CommitReceipt {
+                    commit_id: CommitId::parse("c_00000000000000000000000000000001")
+                        .expect("commit id"),
+                    semantic_commit_fingerprint: "sha256:unused".to_owned(),
+                    committed_seq: ChangeSeq(12),
+                    committed_at_ms: 12_000,
+                    message: None,
+                },
+            ),
+            (
+                MetadataTableFamily::Attributes,
+                super::MetadataRow::AttributesRevision {
+                    inode_id: InodeId(42),
+                    attributes_revision_no: crate::AttributeRevisionNo(3),
+                    committed_seq: ChangeSeq(12),
+                    delta_index: 0,
+                    attributes: crate::Attributes::default(),
+                },
+            ),
+        ];
+
+        for (family, row) in rows {
+            let row_key = row.row_key_for_family(family);
+            let prefix = family.row_key_prefix();
+            assert!(
+                row_key.starts_with(prefix),
+                "row key `{row_key}` for `{family:?}` does not start with `{prefix}`"
+            );
+            assert!(
+                !prefix.is_empty(),
+                "family `{family:?}` must declare a row-key prefix"
+            );
+        }
     }
 
     fn metadata_file_ref(

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -10,6 +10,7 @@ use super::cache::{
     DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache, MetadataTableCacheKey,
 };
 use super::error::ManifestLoadError;
+use super::partition::GroupPartitioning;
 use super::runs::{runs_in_materialization_order, runs_in_scan_order, REORGANIZE_FAMILY_GROUPS};
 use super::scan::{ordered_manifest_tables, VerifiedMetadataTables};
 use super::validate::{validate_manifest_materialization_ranges, validate_namespace_manifest};
@@ -505,15 +506,20 @@ fn validate_manifest_reorganize_progress(
         )));
     }
 
-    // PR 2 brings the per-group partition grammar, and with it the check
-    // that the cursor parses as a partition key for this group and that
-    // every output range lies below the cursor's bound for its family. Until
-    // then the loader can only say that the fold has a position at all.
-    if progress.cursor.is_empty() {
-        return Err(invalid(
-            "reorganize progress carries an empty cursor, so the fold has no position".to_owned(),
-        ));
-    }
+    // The cursor is the fold's whole position. A fold resumed from one that
+    // does not parse would rewrite the wrong slice of the keyspace, so a
+    // state that cannot say where it stands is refused here.
+    let partitioning = GroupPartitioning::for_group(&progress.families).ok_or_else(|| {
+        invalid(format!(
+            "reorganize progress names families {:?}, whose row keys share no partition grammar",
+            progress.families
+        ))
+    })?;
+    let cursor = partitioning.parse_cursor(&progress.cursor).map_err(|why| {
+        invalid(format!(
+            "reorganize progress carries an unusable cursor: {why}"
+        ))
+    })?;
 
     let mut previous_by_family: BTreeMap<MetadataTableFamily, &MetadataFileRef> = BTreeMap::new();
     for segment in &progress.output_segments {
@@ -546,6 +552,21 @@ fn validate_manifest_reorganize_progress(
         // a range to compare.
         if segment.row_count == 0 {
             continue;
+        }
+        // Everything written so far belongs to a partition the fold has
+        // passed, so it sorts below where the fold now stands. A row at or
+        // above the cursor would be rewritten again by the next step and
+        // land in the finished run twice.
+        let cursor_bound = partitioning.family_lower_bound(segment.family, &cursor);
+        if segment.max_key >= cursor_bound {
+            return Err(ManifestLoadError::SegmentDescriptorMismatch {
+                object_key: segment.object_key.clone(),
+                message: format!(
+                    "reorganize output segment ends at `{}`, at or above the cursor's bound `{}` \
+                     for family `{:?}`",
+                    segment.max_key, cursor_bound, segment.family
+                ),
+            });
         }
         if let Some(previous) = previous_by_family.insert(segment.family, segment) {
             if segment.min_key <= previous.max_key {

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -20,7 +20,9 @@
 //!   materialization is test-only).
 //! - [`scan`] answers verified row scans over loaded manifest tables, while
 //!   [`row`] handles manifest-row encoding.
-//! - [`reorganize`] compacts bounded family groups into new base runs.
+//! - [`reorganize`] compacts bounded family groups into new base runs, and
+//!   [`partial_fold`] folds a group too large for one step a slice at a
+//!   time, along the partition grammar [`partition`] defines.
 //! - [`retention`] advances the retention floor behind verified progress.
 //! - [`runs`] models the LSM run layout shared by all of the above,
 //!   [`cache`] holds decoded SST blocks keyed by content digest, and
@@ -38,6 +40,8 @@ mod files;
 mod flush;
 mod list;
 mod load;
+mod partial_fold;
+mod partition;
 mod publish;
 pub(crate) mod record;
 mod release;

--- a/crates/loonfs-core/src/checkpoint/partial_fold.rs
+++ b/crates/loonfs-core/src/checkpoint/partial_fold.rs
@@ -1,0 +1,924 @@
+//! Folding one family group a slice at a time.
+//!
+//! A whole-group fold reads every row of every input run in one step. A
+//! group whose oldest run alone busts the per-step budget can never do that
+//! again, so its base is frozen and its retention stops (#528 made that
+//! survivable and loud; this makes it foldable). Such a group is folded by a
+//! **walk**: the step that starts it records the input runs, the identity of
+//! the run it is building, the retention floor it froze, and a cursor into
+//! the group's partition keyspace ([`super::partition`]). Each step merges
+//! one bounded slice into fresh segments and publishes a manifest carrying
+//! the outputs so far and the cursor advanced. The completing step swaps the
+//! input runs for the finished run and clears the state, in one publication.
+//!
+//! Readers never see any of it. The input runs stay in `metadata_files` and
+//! serve reads unchanged; the outputs live in the progress state, which no
+//! scan consults. Metadata rows must appear exactly once — scans concatenate
+//! runs without deduplicating — so a manifest showing both would show every
+//! rebuilt row twice.
+//!
+//! Nothing calls this from the maintenance path yet: the selector picks it
+//! up in the next change, and until then every path below is driven by
+//! tests.
+#![allow(dead_code)]
+
+use super::block_fetch::load_segment_index_for_reorganization;
+use super::build::{
+    build_manifest_tables_from_rows, debug_assert_manifest_table_segments_do_not_overlap,
+    MetadataTableSegmentation,
+};
+use super::error::ManifestLoadError;
+use super::flush::{ensure_metadata_publication_budget, next_manifest_id_after};
+use super::partition::{GroupPartitioning, PartitionCursor, PartitionKey};
+use super::publish::{
+    manifest_write_failure, publish_metadata_root, write_namespace_manifest,
+    ManifestPublicationOutcome,
+};
+use super::reorganize::{
+    drop_rows_below_frozen_floor, unbindings_at_or_below_floor, BindingGeneration,
+};
+use super::runs::{
+    MetadataLsmPolicy, MetadataRunManifest, CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
+    PARTIAL_FOLD_UNBIND_SCAN_PAGE_ROWS, REORGANIZE_FAMILY_GROUPS,
+};
+use super::scan::VerifiedMetadataTables;
+use crate::context::MutationContext;
+use crate::error::{CoreError, MetadataProjectionLoadError, Result};
+use crate::timing::MonotonicTimer;
+use loonfs_api::wire::manifest::{
+    MetadataFileRef, MetadataReorganizeProgress, MetadataRow, MetadataRunId, MetadataTableFamily,
+    NamespaceManifestEnvelope, NamespaceManifestPayload,
+};
+use loonfs_api::wire::sst_blocks::{index_blocks_for_key_range, SegmentIndexEntry};
+use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
+use loonfs_objectstore::ObjectStore;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+/// What one call to [`MetadataFoldWalk::advance`] did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum MetadataFoldWalkOutcome {
+    /// One slice merged, its segments written, and the manifest published
+    /// with the cursor advanced.
+    SlicePublished(MetadataFoldSliceReport),
+    /// The cursor passed the last partition, so this publication removed the
+    /// input runs, inserted the finished run, and cleared the state.
+    Completed {
+        manifest_id: ManifestId,
+        output_segments: usize,
+        output_rows: u64,
+    },
+    /// A concurrent publication moved the root while this step ran. Its
+    /// segments are unreferenced, garbage collection reclaims them, and the
+    /// next step resumes from the manifest that won.
+    Superseded,
+}
+
+/// What one slice of a walk cost and dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MetadataFoldSliceReport {
+    pub(super) manifest_id: ManifestId,
+    /// Partitions the slice covered, counted over the rows it decoded.
+    pub(super) partitions: u64,
+    pub(super) decoded_input_rows: u64,
+    pub(super) decoded_input_bytes: u64,
+    pub(super) output_rows: u64,
+    pub(super) drops: MetadataFoldSliceDrops,
+}
+
+/// Whether a slice dropped what the frozen floor allows, and why not when
+/// it did not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MetadataFoldSliceDrops {
+    /// The slice dropped every row the frozen floor allows.
+    Applied,
+    /// The unbind set the bind drop reads did not fit its bound, so the
+    /// whole walk is a pure rewrite. That still unfreezes the base, and the
+    /// next walk drops with a smaller set.
+    UnbindSetOverBound,
+}
+
+/// The frozen unbind set a walk decides bind drops against, or the record
+/// that it did not fit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FrozenUnbindSet {
+    /// Every unbinding at or below the frozen floor, read from the snapshot
+    /// at walk start and re-read identically on every resumption.
+    Complete(BTreeSet<BindingGeneration>),
+    /// The set was larger than its bound. The walk still runs, as a pure
+    /// rewrite that unfreezes the base; the next walk drops with a smaller
+    /// set (design doc, "Retention during the walk").
+    OverBound,
+}
+
+/// One partial fold in flight, rebuilt from the manifest that carries it.
+///
+/// Everything here is either durable in [`MetadataReorganizeProgress`] or
+/// derived from it and the snapshot the state names. Nothing survives in
+/// memory that a resumption cannot rebuild, which is what makes a crash at
+/// any step boundary a resume rather than a restart.
+pub(super) struct MetadataFoldWalk {
+    group: &'static [MetadataTableFamily],
+    partitioning: GroupPartitioning,
+    progress: MetadataReorganizeProgress,
+    /// The snapshot's runs, resolved against the manifest the walk is
+    /// standing on. Re-resolved on every resumption from `input_runs`.
+    snapshot: Vec<MetadataRunManifest>,
+    unbind_set: FrozenUnbindSet,
+    /// Rows the start-up unbind scan decoded, charged against the starting
+    /// step's budgets and zero on every step after it.
+    start_scan_rows: u64,
+}
+
+impl MetadataFoldWalk {
+    /// Starts a walk over `group`, snapshotting the runs it will merge.
+    ///
+    /// The input must be the group's runs from the oldest one: dropping rows
+    /// is only visibility-preserving over a merge that starts at the bottom,
+    /// because the row that cancels another is always the newer of the two
+    /// (see `ReorganizationInput::starts_at_group_bottom`). A walk builds
+    /// its whole output from that input, so the requirement is the same one
+    /// and it is checked here rather than assumed.
+    pub(super) async fn start<S: ObjectStore + ?Sized>(
+        tables: &VerifiedMetadataTables<'_, S>,
+        group: &'static [MetadataTableFamily],
+        snapshot: Vec<MetadataRunManifest>,
+        frozen_floor_seq: ChangeSeq,
+        policy: MetadataLsmPolicy,
+    ) -> Result<Self> {
+        let partitioning = group_partitioning(group)?;
+        let payload = &tables.manifest().payload;
+        if !snapshot_is_group_bottom_anchored(tables.scan_runs.as_ref(), group, &snapshot) {
+            return Err(CoreError::Internal(format!(
+                "a partial fold of {group:?} was started on a run subset that is not the group's \
+                 oldest runs; its drops would not be visibility-preserving"
+            )));
+        }
+        let progress = MetadataReorganizeProgress {
+            families: group.to_vec(),
+            input_runs: snapshot
+                .iter()
+                .map(|run| MetadataRunId {
+                    run_seq: run.run_seq,
+                    level: run.level,
+                })
+                .collect(),
+            // The output run's identity is fixed here: stamped at the
+            // manifest head and at the base level, it lands where the input
+            // runs sat, below every run that arrives while the walk runs.
+            output_run_seq: payload.head_seq,
+            output_level: CHECKPOINT_BASE_RUN_LEVEL,
+            frozen_floor_seq,
+            cursor: partitioning.spell_cursor(&partitioning.first_cursor()),
+            output_segments: Vec::new(),
+        };
+        let (unbind_set, start_scan_rows) =
+            derive_unbind_set(tables, group, &snapshot, frozen_floor_seq, policy).await?;
+        Ok(Self {
+            group,
+            partitioning,
+            progress,
+            snapshot,
+            unbind_set,
+            start_scan_rows,
+        })
+    }
+
+    /// Rebuilds the walk a manifest carries, or `None` when it carries none.
+    ///
+    /// The unbind set is re-derived here rather than carried: the floor is
+    /// frozen and the snapshot is immutable, so the scan that built it
+    /// answers identically however many times it runs.
+    pub(super) async fn resume_from_manifest<S: ObjectStore + ?Sized>(
+        tables: &VerifiedMetadataTables<'_, S>,
+        policy: MetadataLsmPolicy,
+    ) -> Result<Option<Self>> {
+        let payload = &tables.manifest().payload;
+        let Some(progress) = payload.reorganize.clone() else {
+            return Ok(None);
+        };
+        // Load validation already refused a state whose group is not a
+        // reorganization family group, so this only turns the stored list
+        // back into the static entry the fold is written against.
+        let group = REORGANIZE_FAMILY_GROUPS
+            .into_iter()
+            .find(|candidate| *candidate == progress.families.as_slice())
+            .ok_or_else(|| {
+                CoreError::NamespaceCorrupt(format!(
+                    "a partial fold names families {:?}, which is not a reorganization family group",
+                    progress.families
+                ))
+            })?;
+        let partitioning = group_partitioning(group)?;
+        // The cursor is the walk's whole position; a state that cannot say
+        // where it stands is refused rather than restarted from the front,
+        // which would rewrite partitions the state's outputs already hold.
+        partitioning.parse_cursor(&progress.cursor).map_err(|why| {
+            CoreError::NamespaceCorrupt(format!(
+                "a partial fold carries an unreadable cursor: {why}"
+            ))
+        })?;
+        let snapshot = resolve_snapshot_runs(tables, &progress)?;
+        if !snapshot_is_group_bottom_anchored(tables.scan_runs.as_ref(), group, &snapshot) {
+            return Err(CoreError::NamespaceCorrupt(format!(
+                "a partial fold of {group:?} is merging a run subset that is no longer the \
+                 group's oldest runs"
+            )));
+        }
+        let (unbind_set, start_scan_rows) =
+            derive_unbind_set(tables, group, &snapshot, progress.frozen_floor_seq, policy).await?;
+        Ok(Some(Self {
+            group,
+            partitioning,
+            progress,
+            snapshot,
+            unbind_set,
+            start_scan_rows,
+        }))
+    }
+
+    pub(super) fn group(&self) -> &'static [MetadataTableFamily] {
+        self.group
+    }
+
+    pub(super) fn progress(&self) -> &MetadataReorganizeProgress {
+        &self.progress
+    }
+
+    /// Runs one step: either the next slice, or the publication that
+    /// finishes the walk.
+    ///
+    /// `tables` must be the manifest this walk is standing on: the step
+    /// publishes its successor, and a root that moved off it in the
+    /// meantime supersedes this step rather than overwriting the winner.
+    pub(super) async fn advance<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        tables: &VerifiedMetadataTables<'_, S>,
+        policy: MetadataLsmPolicy,
+        context: &MutationContext,
+        timer: &dyn MonotonicTimer,
+    ) -> Result<MetadataFoldWalkOutcome> {
+        let publication_started_ms = timer.monotonic_now_ms();
+        let cursor = self.cursor()?;
+        let plan = self.plan_slice(tables, &cursor, policy).await?;
+        let Some(plan) = plan else {
+            return self
+                .complete(
+                    store,
+                    namespace_id,
+                    tables,
+                    context,
+                    timer,
+                    publication_started_ms,
+                )
+                .await;
+        };
+        self.publish_slice(
+            store,
+            namespace_id,
+            tables,
+            policy,
+            context,
+            timer,
+            publication_started_ms,
+            &cursor,
+            plan,
+        )
+        .await
+    }
+
+    /// Where the walk stands, read back from the state it published.
+    ///
+    /// Both constructors parse the cursor before handing the walk out, so
+    /// this only ever fails on a spelling that changed underneath. It fails
+    /// rather than starting over: a walk that restarted from the front would
+    /// rewrite partitions its own outputs already hold, and every rewritten
+    /// row would land in the finished run twice.
+    fn cursor(&self) -> Result<PartitionCursor> {
+        self.partitioning
+            .parse_cursor(&self.progress.cursor)
+            .map_err(|why| {
+                CoreError::NamespaceCorrupt(format!(
+                    "a partial fold carries an unreadable cursor: {why}"
+                ))
+            })
+    }
+
+    /// Chooses the next slice by reading the snapshot's index sections.
+    ///
+    /// A segment's index publishes the last key of every data block and that
+    /// block's decoded length, so a plan can be priced without decoding a
+    /// row. Per-block row counts are not durable — only the segment's
+    /// total — so the row side of the plan is the segment's average spread
+    /// over its blocks, and the step charges the rows it actually decodes.
+    ///
+    /// `None` means no rows of the group remain at or above the cursor, so
+    /// the walk is finished and the next publication completes it.
+    async fn plan_slice<S: ObjectStore + ?Sized>(
+        &self,
+        tables: &VerifiedMetadataTables<'_, S>,
+        cursor: &PartitionCursor,
+        policy: MetadataLsmPolicy,
+    ) -> Result<Option<SlicePlan>> {
+        let mut segments = Vec::new();
+        let mut boundaries = BTreeSet::<PartitionKey>::new();
+        for family in self.group {
+            let lower_bound = self.partitioning.family_lower_bound(*family, cursor);
+            for descriptor in self.snapshot_descriptors(*family) {
+                let index = load_segment_index_for_reorganization(
+                    tables.store,
+                    tables.table_cache,
+                    &tables.block_memo,
+                    descriptor,
+                )
+                .await
+                .map_err(manifest_load_failure)?;
+                if index.is_empty() {
+                    continue;
+                }
+                let first = index.partition_point(|entry| entry.last_key < lower_bound);
+                if first == index.len() {
+                    continue;
+                }
+                let rows_per_block = descriptor.row_count.div_ceil(index.len() as u64);
+                for entry in index[first..].iter() {
+                    if let Some(partition) = self
+                        .partitioning
+                        .partition_of_row_key(*family, &entry.last_key)
+                    {
+                        boundaries.insert(partition);
+                    }
+                }
+                segments.push(PlannedSegment {
+                    family: *family,
+                    index,
+                    lower_bound: lower_bound.clone(),
+                    consumed: first,
+                    rows_per_block,
+                });
+            }
+        }
+        if boundaries.is_empty() {
+            return Ok(None);
+        }
+
+        let row_budget = u64::try_from(policy.max_decoded_input_rows_per_step.get())
+            .unwrap_or(u64::MAX)
+            .saturating_sub(self.start_scan_rows);
+        let byte_budget =
+            u64::try_from(policy.max_decoded_input_bytes_per_step.get()).unwrap_or(u64::MAX);
+        let mut planned_rows = 0u64;
+        let mut planned_bytes = 0u64;
+        let mut through = None;
+        for boundary in boundaries {
+            let next = self.partitioning.cursor_after(&boundary);
+            let (added_rows, added_bytes) = segments
+                .iter_mut()
+                .map(|segment| segment.extend_through(self.partitioning, &next))
+                .fold((0u64, 0u64), |(rows, bytes), (added_rows, added_bytes)| {
+                    (
+                        rows.saturating_add(added_rows),
+                        bytes.saturating_add(added_bytes),
+                    )
+                });
+            let candidate_rows = planned_rows.saturating_add(added_rows);
+            let candidate_bytes = planned_bytes.saturating_add(added_bytes);
+            // The first partition goes in whatever it costs. A walk that
+            // parked on an oversized partition would be the very stall this
+            // design exists to remove, and one partition is bounded by what
+            // one inode or one directory can accumulate, not by group size.
+            if through.is_some() && (candidate_rows > row_budget || candidate_bytes > byte_budget) {
+                break;
+            }
+            planned_rows = candidate_rows;
+            planned_bytes = candidate_bytes;
+            through = Some(boundary);
+        }
+        let through = through.expect("a non-empty boundary set always admits its first partition");
+        Ok(Some(SlicePlan {
+            next_cursor: self.partitioning.cursor_after(&through),
+            planned_bytes,
+        }))
+    }
+
+    fn snapshot_descriptors(
+        &self,
+        family: MetadataTableFamily,
+    ) -> impl Iterator<Item = &MetadataFileRef> {
+        self.snapshot
+            .iter()
+            .flat_map(|run| run.tables.iter())
+            .filter(move |table| table.family == family)
+            .flat_map(|table| table.segments.iter())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn publish_slice<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        tables: &VerifiedMetadataTables<'_, S>,
+        policy: MetadataLsmPolicy,
+        context: &MutationContext,
+        timer: &dyn MonotonicTimer,
+        publication_started_ms: u64,
+        cursor: &PartitionCursor,
+        plan: SlicePlan,
+    ) -> Result<MetadataFoldWalkOutcome> {
+        let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
+        for family in self.group {
+            let lower_bound = self.partitioning.family_lower_bound(*family, cursor);
+            let upper_bound = self
+                .partitioning
+                .family_lower_bound(*family, &plan.next_cursor);
+            let rows = tables
+                .scan_key_range_page_in_runs(
+                    &self.snapshot,
+                    *family,
+                    &lower_bound,
+                    Some(&upper_bound),
+                    usize::MAX,
+                )
+                .await
+                .map_err(manifest_load_failure)?
+                .into_iter()
+                .map(|(_, row)| row)
+                .collect::<Vec<_>>();
+            rows_by_family.insert(*family, rows);
+        }
+        let decoded_input_rows = rows_by_family
+            .values()
+            .map(|rows| rows.len() as u64)
+            .sum::<u64>();
+        let partitions = self.partitions_covered(&rows_by_family);
+
+        let mut drops = MetadataFoldSliceDrops::Applied;
+        match &self.unbind_set {
+            FrozenUnbindSet::OverBound => drops = MetadataFoldSliceDrops::UnbindSetOverBound,
+            FrozenUnbindSet::Complete(unbound_at_floor) => {
+                // The reverse index leaves the shared pass: its rows are
+                // keyed by child, so the slice holding one does not hold the
+                // forward binds that pass reads. It is decided against the
+                // frozen set instead, just below.
+                let reverse_rows = rows_by_family.remove(&MetadataTableFamily::DirentryChildBinds);
+                drop_rows_below_frozen_floor(
+                    &mut rows_by_family,
+                    self.progress.frozen_floor_seq,
+                    unbound_at_floor,
+                )?;
+                if let Some(mut reverse_rows) = reverse_rows {
+                    reverse_rows.retain(|row| {
+                        retain_reverse_bind_row(
+                            row,
+                            self.progress.frozen_floor_seq,
+                            unbound_at_floor,
+                        )
+                    });
+                    rows_by_family.insert(MetadataTableFamily::DirentryChildBinds, reverse_rows);
+                }
+            }
+        }
+        let output_rows = rows_by_family
+            .values()
+            .map(|rows| rows.len() as u64)
+            .sum::<u64>();
+
+        let run_tables = build_manifest_tables_from_rows(
+            store,
+            namespace_id,
+            self.progress.output_run_seq,
+            self.progress.output_level,
+            |family| rows_by_family.remove(&family).unwrap_or_default(),
+            MetadataTableSegmentation::Base {
+                max_rows_per_segment: policy.max_rows_per_segment,
+            },
+        )
+        .await?;
+        debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
+
+        let mut progress = self.progress.clone();
+        for table in run_tables {
+            // Segment indexes number a family's segments within one run, and
+            // this walk keeps adding to the same run, so each slice's
+            // segments continue where the previous slice's left off.
+            let already_written = progress
+                .output_segments
+                .iter()
+                .filter(|segment| segment.family == table.family)
+                .count() as u32;
+            for (offset, mut segment) in table.segments.into_iter().enumerate() {
+                segment.segment_index = already_written + offset as u32;
+                progress.output_segments.push(segment);
+            }
+        }
+        progress.cursor = self.partitioning.spell_cursor(&plan.next_cursor);
+
+        let mut payload = successor_payload(namespace_id, &tables.manifest().payload)?;
+        // The floor the walk decides drops against must never sit above the
+        // floor the manifest promises, so a walk that froze a newer floor
+        // carries the manifest up to it.
+        if payload.retention_floor_seq < progress.frozen_floor_seq {
+            payload.retention_floor_seq = progress.frozen_floor_seq;
+        }
+        payload.reorganize = Some(progress.clone());
+        let manifest_id = payload.manifest_id;
+
+        match self
+            .publish_manifest(
+                store,
+                namespace_id,
+                payload,
+                &tables.manifest().payload.manifest_object_id,
+                context,
+                timer,
+                publication_started_ms,
+            )
+            .await?
+        {
+            Some(()) => {
+                self.progress = progress;
+                self.start_scan_rows = 0;
+                Ok(MetadataFoldWalkOutcome::SlicePublished(
+                    MetadataFoldSliceReport {
+                        manifest_id,
+                        partitions,
+                        decoded_input_rows,
+                        decoded_input_bytes: plan.planned_bytes,
+                        output_rows,
+                        drops,
+                    },
+                ))
+            }
+            None => Ok(MetadataFoldWalkOutcome::Superseded),
+        }
+    }
+
+    fn partitions_covered(
+        &self,
+        rows_by_family: &BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
+    ) -> u64 {
+        let mut partitions = BTreeSet::new();
+        for (family, rows) in rows_by_family {
+            for row in rows {
+                if let Some(partition) = self.partitioning.partition_of_row(*family, row) {
+                    partitions.insert(partition);
+                }
+            }
+        }
+        partitions.len() as u64
+    }
+
+    /// The publication that finishes the walk: the input runs leave
+    /// `metadata_files`, the run the walk built takes their place, and the
+    /// state clears. Readers go from seeing the inputs to seeing the output
+    /// in one step, so no manifest ever shows both to a scan.
+    async fn complete<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        tables: &VerifiedMetadataTables<'_, S>,
+        context: &MutationContext,
+        timer: &dyn MonotonicTimer,
+        publication_started_ms: u64,
+    ) -> Result<MetadataFoldWalkOutcome> {
+        let previous = &tables.manifest().payload;
+        let snapshot_runs: BTreeSet<(ChangeSeq, u32)> = self
+            .progress
+            .input_runs
+            .iter()
+            .map(|run| (run.run_seq, run.level))
+            .collect();
+        let mut metadata_files: Vec<MetadataFileRef> = previous
+            .metadata_files
+            .iter()
+            .filter(|descriptor| {
+                !self.group.contains(&descriptor.family)
+                    || !snapshot_runs.contains(&(descriptor.run_seq, descriptor.level))
+            })
+            .cloned()
+            .collect();
+        metadata_files.extend(self.progress.output_segments.iter().cloned());
+        let output_rows = self
+            .progress
+            .output_segments
+            .iter()
+            .map(|segment| segment.row_count)
+            .sum();
+        let base_seq = metadata_files
+            .iter()
+            .map(|descriptor| descriptor.run_seq)
+            .min()
+            .unwrap_or(previous.base_seq);
+
+        let mut payload = successor_payload(namespace_id, previous)?;
+        payload.metadata_files = metadata_files;
+        payload.base_seq = base_seq;
+        payload.reorganize = None;
+        let manifest_id = payload.manifest_id;
+        let output_segments = self.progress.output_segments.len();
+
+        match self
+            .publish_manifest(
+                store,
+                namespace_id,
+                payload,
+                &tables.manifest().payload.manifest_object_id,
+                context,
+                timer,
+                publication_started_ms,
+            )
+            .await?
+        {
+            Some(()) => Ok(MetadataFoldWalkOutcome::Completed {
+                manifest_id,
+                output_segments,
+                output_rows,
+            }),
+            None => Ok(MetadataFoldWalkOutcome::Superseded),
+        }
+    }
+
+    /// Writes the manifest and advances the root, through the one write per
+    /// publication every other manifest producer uses. `None` means a
+    /// concurrent publication won.
+    #[allow(clippy::too_many_arguments)]
+    async fn publish_manifest<S: ObjectStore + ?Sized>(
+        &self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        payload: NamespaceManifestPayload,
+        expected_predecessor: &ManifestObjectId,
+        context: &MutationContext,
+        timer: &dyn MonotonicTimer,
+        publication_started_ms: u64,
+    ) -> Result<Option<()>> {
+        let manifest = NamespaceManifestEnvelope::from_payload(payload).map_err(|err| {
+            CoreError::Internal(format!("failed to build a partial fold's manifest: {err}"))
+        })?;
+        write_namespace_manifest(store, &manifest)
+            .await
+            .map_err(manifest_write_failure)?;
+        ensure_metadata_publication_budget(timer, publication_started_ms, namespace_id)?;
+        match publish_metadata_root(
+            store,
+            namespace_id,
+            &manifest,
+            Some(expected_predecessor.clone()),
+            context.now_ms,
+        )
+        .await?
+        {
+            ManifestPublicationOutcome::Published(_) => Ok(Some(())),
+            ManifestPublicationOutcome::Superseded(_)
+            | ManifestPublicationOutcome::RootCasRaceLost => Ok(None),
+        }
+    }
+}
+
+/// Whether one reverse bind row survives the frozen floor.
+///
+/// The forward rule keeps a bind at or below the floor when it is both the
+/// latest in its (parent, name) slot and not unbound. A slice of the reverse
+/// index is keyed by child, so it holds neither the parent's other binds nor
+/// the parent's unbinds and can check neither directly. The frozen set
+/// settles it on its own: a bind is only ever superseded by an operation
+/// that also unbinds it — the invariant `drop_rows_below_frozen_floor`
+/// refuses to compact without — so a bind that is not unbound at the floor
+/// is the latest in its slot, and the two-part forward rule collapses to
+/// this membership test. That the two agree row for row on real histories is
+/// what the equivalence oracle checks.
+///
+/// The row carries everything the set is keyed by: a reverse row is a bind
+/// row, holding its parent, name, sequence, and delta index whichever family
+/// stores it.
+fn retain_reverse_bind_row(
+    row: &MetadataRow,
+    frozen_floor_seq: ChangeSeq,
+    unbound_at_floor: &BTreeSet<BindingGeneration>,
+) -> bool {
+    let MetadataRow::DirentryBind {
+        parent_inode_id,
+        name_key,
+        bind_seq,
+        bind_delta_index,
+        ..
+    } = row
+    else {
+        return true;
+    };
+    *bind_seq > frozen_floor_seq
+        || !unbound_at_floor.contains(&(
+            *parent_inode_id,
+            name_key.clone(),
+            *bind_seq,
+            *bind_delta_index,
+        ))
+}
+
+/// The slice one step will merge.
+struct SlicePlan {
+    /// The cursor the manifest carries once this slice is published.
+    next_cursor: PartitionCursor,
+    /// Decoded data-block bytes the slice reads, exact from the index
+    /// sections the plan already fetched.
+    planned_bytes: u64,
+}
+
+/// One snapshot segment as slice planning walks it: how far into its index
+/// the plan has reached, and what one more block costs.
+struct PlannedSegment {
+    family: MetadataTableFamily,
+    index: Arc<Vec<SegmentIndexEntry>>,
+    lower_bound: String,
+    consumed: usize,
+    /// The segment's rows spread evenly over its blocks. Per-block row
+    /// counts are not durable, so this is the plan's estimate; the step
+    /// charges what it actually decodes.
+    rows_per_block: u64,
+}
+
+impl PlannedSegment {
+    /// Adds the blocks this segment contributes to a slice that now runs up
+    /// to `next`, and returns what they cost.
+    fn extend_through(
+        &mut self,
+        partitioning: GroupPartitioning,
+        next: &PartitionCursor,
+    ) -> (u64, u64) {
+        let upper_bound = partitioning.family_lower_bound(self.family, next);
+        let end =
+            index_blocks_for_key_range(&self.index, &self.lower_bound, Some(&upper_bound)).end;
+        let mut rows = 0u64;
+        let mut bytes = 0u64;
+        while self.consumed < end {
+            bytes = bytes.saturating_add(u64::from(self.index[self.consumed].block.decoded_len));
+            rows = rows.saturating_add(self.rows_per_block);
+            self.consumed += 1;
+        }
+        (rows, bytes)
+    }
+}
+
+fn group_partitioning(group: &[MetadataTableFamily]) -> Result<GroupPartitioning> {
+    GroupPartitioning::for_group(group).ok_or_else(|| {
+        CoreError::Internal(format!(
+            "family group {group:?} has no partition grammar, so it cannot be folded in slices"
+        ))
+    })
+}
+
+fn manifest_load_failure(error: ManifestLoadError) -> CoreError {
+    CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+}
+
+/// The manifest a step publishes: the previous one with a fresh identity.
+/// Everything a fold does not touch travels unchanged, so a slice moves only
+/// the fold's own state.
+fn successor_payload(
+    namespace_id: &NamespaceId,
+    previous: &NamespaceManifestPayload,
+) -> Result<NamespaceManifestPayload> {
+    let manifest_id = next_manifest_id_after(previous.manifest_id)?;
+    Ok(NamespaceManifestPayload {
+        namespace_id: namespace_id.clone(),
+        manifest_id,
+        // One generated object id, one write. The generated id ends in 16
+        // random hex characters, so the key is this step's alone.
+        manifest_object_id: ManifestObjectId::generate(manifest_id),
+        head_seq: previous.head_seq,
+        head_commit_id: previous.head_commit_id.clone(),
+        base_seq: previous.base_seq,
+        writer_epoch: previous.writer_epoch,
+        next_inode_id: previous.next_inode_id,
+        retention_floor_seq: previous.retention_floor_seq,
+        metadata_files: previous.metadata_files.clone(),
+        reorganize: previous.reorganize.clone(),
+    })
+}
+
+/// Turns the run ids a progress state names back into the manifest's runs.
+fn resolve_snapshot_runs<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    progress: &MetadataReorganizeProgress,
+) -> Result<Vec<MetadataRunManifest>> {
+    progress
+        .input_runs
+        .iter()
+        .map(|input| {
+            tables
+                .scan_runs
+                .iter()
+                .find(|run| run.run_seq == input.run_seq && run.level == input.level)
+                .cloned()
+                .ok_or_else(|| {
+                    CoreError::NamespaceCorrupt(format!(
+                        "a partial fold names input run seq `{}` level {}, which the manifest \
+                         does not reference",
+                        input.run_seq, input.level
+                    ))
+                })
+        })
+        .collect()
+}
+
+/// Whether `snapshot` holds every run of the group that sorts at or below
+/// its own oldest run — the property that makes dropping rows
+/// visibility-preserving.
+///
+/// The order is the selector's: base-tier runs sit under every delta run
+/// whatever their sequence says, because a bounded fold stamps its output at
+/// the manifest head.
+fn snapshot_is_group_bottom_anchored(
+    runs: &[MetadataRunManifest],
+    group: &[MetadataTableFamily],
+    snapshot: &[MetadataRunManifest],
+) -> bool {
+    // Base-tier runs hold rows an earlier fold already absorbed, so they sit
+    // under every delta run whatever their sequence says.
+    let rank = |run: &MetadataRunManifest| (run.level == CHECKPOINT_L0_RUN_LEVEL, run.run_seq);
+    let Some(highest_in_snapshot) = snapshot.iter().map(rank).max() else {
+        return false;
+    };
+    let holds_group_rows = |run: &MetadataRunManifest| {
+        run.tables
+            .iter()
+            .any(|table| group.contains(&table.family) && !table.segments.is_empty())
+    };
+    // Nothing this group owns may sit below the snapshot's top without being
+    // in it: a row the snapshot cannot see is a row its drops cannot account
+    // for.
+    runs.iter()
+        .filter(|run| holds_group_rows(run) && rank(run) <= highest_in_snapshot)
+        .all(|run| {
+            snapshot
+                .iter()
+                .any(|input| input.run_seq == run.run_seq && input.level == run.level)
+        })
+}
+
+/// Reads the unbindings at or below the frozen floor out of the snapshot.
+///
+/// This is the one derived thing a step needs that a slice cannot see:
+/// the bind drop asks whether a binding was retired, and the unbind that
+/// retired it may sit in any partition the walk has not reached. The scan
+/// runs at the start and again on every resumption, and answers identically
+/// both times because the floor is frozen and the snapshot is immutable.
+///
+/// Groups other than the bindings group have no such rule, so they get an
+/// empty set and no scan.
+async fn derive_unbind_set<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    group: &[MetadataTableFamily],
+    snapshot: &[MetadataRunManifest],
+    frozen_floor_seq: ChangeSeq,
+    policy: MetadataLsmPolicy,
+) -> Result<(FrozenUnbindSet, u64)> {
+    if !group.contains(&MetadataTableFamily::DirentryUnbinds) {
+        return Ok((FrozenUnbindSet::Complete(BTreeSet::new()), 0));
+    }
+    // The set is held for the whole walk, so it is bounded by what one step
+    // may hold in decoded rows anyway. Over the bound the walk keeps going
+    // as a pure rewrite: that still unfreezes the base, and the next walk
+    // drops with a smaller set.
+    let byte_bound = policy.max_decoded_input_bytes_per_step.get() as u64;
+    let mut estimated_bytes = 0u64;
+    let mut scanned_rows = 0u64;
+    let mut unbound = BTreeSet::new();
+    let mut lower_bound = MetadataTableFamily::DirentryUnbinds
+        .row_key_prefix()
+        .to_owned();
+    loop {
+        let page = tables
+            .scan_key_range_page_in_runs(
+                snapshot,
+                MetadataTableFamily::DirentryUnbinds,
+                &lower_bound,
+                None,
+                PARTIAL_FOLD_UNBIND_SCAN_PAGE_ROWS,
+            )
+            .await
+            .map_err(manifest_load_failure)?;
+        let Some((last_key, _)) = page.last() else {
+            break;
+        };
+        // Row keys are globally unique, so resuming strictly past the last
+        // one returned skips exactly that row.
+        lower_bound = format!("{last_key}\0");
+        scanned_rows = scanned_rows.saturating_add(page.len() as u64);
+        let rows: Vec<MetadataRow> = page.into_iter().map(|(_, row)| row).collect();
+        for generation in unbindings_at_or_below_floor(&rows, frozen_floor_seq) {
+            estimated_bytes = estimated_bytes.saturating_add(unbind_entry_bytes(&generation));
+            if estimated_bytes > byte_bound {
+                return Ok((FrozenUnbindSet::OverBound, scanned_rows));
+            }
+            unbound.insert(generation);
+        }
+    }
+    Ok((FrozenUnbindSet::Complete(unbound), scanned_rows))
+}
+
+fn unbind_entry_bytes(generation: &BindingGeneration) -> u64 {
+    (std::mem::size_of::<BindingGeneration>() + generation.1.as_str().len()) as u64
+}

--- a/crates/loonfs-core/src/checkpoint/partition.rs
+++ b/crates/loonfs-core/src/checkpoint/partition.rs
@@ -1,0 +1,262 @@
+//! The partition grammar a partial fold walks a family group by.
+//!
+//! A whole-group fold reads every row of the group at once. A group too
+//! large for that is folded a slice at a time, and the slice boundary must
+//! be a place where the drop rules stay local: two rows where one cancels
+//! the other have to land on the same side of it. Each family group
+//! therefore names one **partition key** that every family in the group
+//! prefixes its row keys by, and the fold advances in whole partitions.
+//!
+//! The partition key per group is read off the row-key grammar in
+//! `MetadataRow::row_key_for_family`, family by family:
+//!
+//! | group | partition | per-family key prefix |
+//! | --- | --- | --- |
+//! | binds, child binds, unbinds | inode id | `direntry-{parent}`, `direntry-child-{child}`, `direntry-unbind-{parent}` |
+//! | revisions, revisions by inode | inode id | `revision-{inode}`, `revision-by-inode-desc-{inode}` |
+//! | inodes | inode id | `inode-{inode}` |
+//! | tombstones | root inode id | `tombstone-{root}` |
+//! | active deletions | deletion sequence | `active-deletion-{deleted_at_seq}` |
+//! | commit receipts | receipt id | `commit-receipt-{commit_id_hex}` |
+//! | attributes | inode id | `attributes-{inode}` |
+//!
+//! Two entries need their own sentence. The bindings group partitions by
+//! **parent** inode for the two forward families, because an unbind cancels
+//! the bind under the same parent and name; the reverse index is keyed by
+//! **child**, so it shares the group's partition space without sharing a
+//! partition with the rows it indexes, and the fold decides its drops against
+//! the unbind set it froze at the start rather than against the slice (see
+//! [`super::partial_fold`]). Active deletions partition
+//! by **deletion sequence**, the family's leading key component — not by
+//! root inode, which sits second — and a removal marker repeats its target's
+//! sequence, so the cancelling pair still shares a partition.
+
+use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
+
+/// How wide a numeric partition component is written in a row key. Every
+/// numeric component in the grammar is a `u64` zero-padded to this width, so
+/// row-key order is value order and a boundary is one padded number.
+const NUMERIC_PARTITION_WIDTH: usize = 20;
+
+/// The cursor component that sorts above every partition of a group.
+/// Decimal digits and lowercase hex digits all sort below it, so a bound
+/// built from it is above every row of every family in the group.
+const PAST_LAST_PARTITION: &str = "~";
+
+/// One partition of a family group's keyspace.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum PartitionKey {
+    /// A `u64` component: an inode id, a parent inode id, a child inode id,
+    /// a root inode id, or a deletion sequence, depending on the group and
+    /// the family.
+    Number(u64),
+    /// A receipt id in the hex spelling its row key carries. Commit ids are
+    /// variable length, so this component is too.
+    ReceiptId(String),
+}
+
+/// How far a partial fold has got: the next partition it has not processed,
+/// or the end of the group's keyspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PartitionCursor {
+    /// Every partition from this one upward is unprocessed.
+    At(PartitionKey),
+    /// Every partition is processed.
+    End,
+}
+
+/// What a group's partition keys are made of.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PartitionSpace {
+    /// Partitions are `u64` values written zero-padded to twenty digits.
+    Number,
+    /// Partitions are hex-encoded receipt ids of any length.
+    ReceiptId,
+}
+
+/// The partition grammar of one family group.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct GroupPartitioning {
+    /// The family whose row-key prefix spells a cursor. Any family in the
+    /// group would do; the first one is chosen so the spelling is stable.
+    cursor_family: MetadataTableFamily,
+    space: PartitionSpace,
+}
+
+impl GroupPartitioning {
+    /// The partition grammar of `group`, or `None` when the group's families
+    /// do not share one partition space and no single cursor could bound
+    /// them all.
+    pub(super) fn for_group(group: &[MetadataTableFamily]) -> Option<Self> {
+        let cursor_family = *group.first()?;
+        let space = partition_space_of(cursor_family);
+        if group
+            .iter()
+            .any(|family| partition_space_of(*family) != space)
+        {
+            return None;
+        }
+        Some(Self {
+            cursor_family,
+            space,
+        })
+    }
+
+    /// The cursor a fold starts at: the group's first possible partition.
+    pub(super) fn first_cursor(self) -> PartitionCursor {
+        match self.space {
+            PartitionSpace::Number => PartitionCursor::At(PartitionKey::Number(0)),
+            // The empty hex string sorts below every receipt id.
+            PartitionSpace::ReceiptId => {
+                PartitionCursor::At(PartitionKey::ReceiptId(String::new()))
+            }
+        }
+    }
+
+    /// The cursor a fold stands at once it has processed `partition`.
+    ///
+    /// The result is the smallest boundary above `partition`: no partition
+    /// of the group sorts between the two, so nothing is skipped.
+    pub(super) fn cursor_after(self, partition: &PartitionKey) -> PartitionCursor {
+        match partition {
+            PartitionKey::Number(value) => match value.checked_add(1) {
+                Some(next) => PartitionCursor::At(PartitionKey::Number(next)),
+                // Nothing sorts above the last representable partition.
+                None => PartitionCursor::End,
+            },
+            // Every hex digit sorts at or above `0`, so appending one lands
+            // at or below every receipt id that extends this one, and below
+            // every receipt id that diverges from it upward.
+            PartitionKey::ReceiptId(hex) => {
+                PartitionCursor::At(PartitionKey::ReceiptId(format!("{hex}0")))
+            }
+        }
+    }
+
+    /// The durable spelling of `cursor`: the cursor family's row-key prefix
+    /// followed by the partition component.
+    pub(super) fn spell_cursor(self, cursor: &PartitionCursor) -> String {
+        self.bound_for(self.cursor_family, cursor)
+    }
+
+    /// Reads back a cursor spelled by [`Self::spell_cursor`].
+    ///
+    /// The loader runs this over every manifest that carries a partial fold:
+    /// a cursor that does not parse is a fold with no position, and a fold
+    /// resumed from one would rewrite the wrong slice.
+    pub(super) fn parse_cursor(self, spelled: &str) -> Result<PartitionCursor, String> {
+        let prefix = self.cursor_family.row_key_prefix();
+        let component = spelled.strip_prefix(prefix).ok_or_else(|| {
+            format!("`{spelled}` does not start with this group's cursor prefix `{prefix}`")
+        })?;
+        if component == PAST_LAST_PARTITION {
+            return Ok(PartitionCursor::End);
+        }
+        exact_partition_component(self.space, component)
+            .map(PartitionCursor::At)
+            .ok_or_else(|| format!("`{component}` is not a partition key of this group"))
+    }
+
+    /// The least row key of `family` that `cursor` admits: every row of the
+    /// family in the cursor's partition or above sorts at or above this, and
+    /// every row below it sorts below.
+    pub(super) fn family_lower_bound(
+        self,
+        family: MetadataTableFamily,
+        cursor: &PartitionCursor,
+    ) -> String {
+        self.bound_for(family, cursor)
+    }
+
+    fn bound_for(self, family: MetadataTableFamily, cursor: &PartitionCursor) -> String {
+        let prefix = family.row_key_prefix();
+        match cursor {
+            PartitionCursor::At(PartitionKey::Number(value)) => {
+                format!("{prefix}{value:0width$}", width = NUMERIC_PARTITION_WIDTH)
+            }
+            PartitionCursor::At(PartitionKey::ReceiptId(hex)) => format!("{prefix}{hex}"),
+            PartitionCursor::End => format!("{prefix}{PAST_LAST_PARTITION}"),
+        }
+    }
+
+    /// The partition a row of `family` belongs to, or `None` when the row
+    /// does not belong to `family` at all.
+    pub(super) fn partition_of_row(
+        self,
+        family: MetadataTableFamily,
+        row: &MetadataRow,
+    ) -> Option<PartitionKey> {
+        self.partition_of_row_key(family, &row.row_key_for_family(family))
+    }
+
+    /// The partition a stored row key of `family` belongs to. Slice planning
+    /// reads this off the last key of each index entry, which is the only
+    /// key-order information a segment publishes without being decoded.
+    pub(super) fn partition_of_row_key(
+        self,
+        family: MetadataTableFamily,
+        row_key: &str,
+    ) -> Option<PartitionKey> {
+        let component = row_key.strip_prefix(family.row_key_prefix())?;
+        leading_partition_component(self.space, component)
+    }
+}
+
+fn partition_space_of(family: MetadataTableFamily) -> PartitionSpace {
+    match family {
+        MetadataTableFamily::CommitReceipts => PartitionSpace::ReceiptId,
+        MetadataTableFamily::Inodes
+        | MetadataTableFamily::DirentryBinds
+        | MetadataTableFamily::DirentryChildBinds
+        | MetadataTableFamily::DirentryUnbinds
+        | MetadataTableFamily::Revisions
+        | MetadataTableFamily::RevisionsByInodeDesc
+        | MetadataTableFamily::Tombstones
+        | MetadataTableFamily::ActiveDeletions
+        | MetadataTableFamily::Attributes => PartitionSpace::Number,
+    }
+}
+
+/// Reads the partition component that opens a row key's variable part,
+/// ignoring the rest of the row key behind it.
+fn leading_partition_component(space: PartitionSpace, component: &str) -> Option<PartitionKey> {
+    match space {
+        PartitionSpace::Number => number_partition(component.get(..NUMERIC_PARTITION_WIDTH)?),
+        // A receipt row key is `{hex}-{committed_seq}`, and hex carries no
+        // `-`, so the first one ends the partition component.
+        PartitionSpace::ReceiptId => {
+            receipt_partition(component.split('-').next().unwrap_or(component))
+        }
+    }
+}
+
+/// Reads a partition component that is the whole of `component`, which is
+/// what a cursor carries: a cursor with anything trailing is not a boundary.
+fn exact_partition_component(space: PartitionSpace, component: &str) -> Option<PartitionKey> {
+    match space {
+        PartitionSpace::Number => {
+            if component.len() != NUMERIC_PARTITION_WIDTH {
+                return None;
+            }
+            number_partition(component)
+        }
+        PartitionSpace::ReceiptId => receipt_partition(component),
+    }
+}
+
+fn number_partition(digits: &str) -> Option<PartitionKey> {
+    if !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    digits.parse::<u64>().ok().map(PartitionKey::Number)
+}
+
+fn receipt_partition(hex: &str) -> Option<PartitionKey> {
+    if !hex
+        .bytes()
+        .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return None;
+    }
+    Some(PartitionKey::ReceiptId(hex.to_owned()))
+}

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -50,7 +50,7 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
 use loonfs_api::{
-    AttributeRevisionNo, ChangeSeq, InodeId, ManifestId, ManifestObjectId, NamespaceId,
+    AttributeRevisionNo, ChangeSeq, InodeId, ManifestId, ManifestObjectId, NameKey, NamespaceId,
 };
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
@@ -667,18 +667,36 @@ pub(super) fn drop_rows_below_retention_floor(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,
 ) -> Result<()> {
-    // At the floor only the latest non-unbound bind per (parent, name) slot
-    // is visible; an unbind marker at or below the floor has finished its
-    // work once every bind it covered is gone.
-    // Unbind identity here omits child_inode_id (the read path also matches
-    // it); the 4-tuple is already unique for writer-produced rows, so the
-    // predicates agree on every legal history.
+    let unbound_at_floor = unbindings_at_or_below_floor(
+        rows_by_family
+            .get(&MetadataTableFamily::DirentryUnbinds)
+            .map_or(&[], Vec::as_slice),
+        retention_floor_seq,
+    );
+    drop_rows_below_frozen_floor(rows_by_family, retention_floor_seq, &unbound_at_floor)
+}
+
+/// Identifies one binding generation, which is what an unbind names and what
+/// the bind drop matches on.
+///
+/// Identity here omits `child_inode_id` (the read path also matches it); the
+/// 4-tuple is already unique for writer-produced rows, so the predicates
+/// agree on every legal history.
+pub(super) type BindingGeneration = (InodeId, NameKey, ChangeSeq, u32);
+
+/// The binding generations an unbind at or below `retention_floor_seq`
+/// retires.
+///
+/// A whole-group fold builds this from its merged rows. A partial fold
+/// builds it once at the start from the whole snapshot, because the slice it
+/// is working on holds only part of the unbind family (design doc,
+/// "Retention during the walk").
+pub(super) fn unbindings_at_or_below_floor(
+    unbind_rows: &[MetadataRow],
+    retention_floor_seq: ChangeSeq,
+) -> BTreeSet<BindingGeneration> {
     let mut unbound_at_floor = BTreeSet::new();
-    for row in rows_by_family
-        .get(&MetadataTableFamily::DirentryUnbinds)
-        .into_iter()
-        .flatten()
-    {
+    for row in unbind_rows {
         if let MetadataRow::DirentryUnbind {
             parent_inode_id,
             name_key,
@@ -698,6 +716,26 @@ pub(super) fn drop_rows_below_retention_floor(
             }
         }
     }
+    unbound_at_floor
+}
+
+/// [`drop_rows_below_retention_floor`] against a floor and an unbind set the
+/// caller froze, rather than against rows it can see right now.
+///
+/// A partial fold calls this per slice: the floor and the unbind set are
+/// fixed for the whole walk, so every step and every resumption decides
+/// identically. The families the caller leaves out of `rows_by_family` are
+/// untouched, which is how a walk keeps the reverse bind index out of this
+/// pass — its rows are keyed by child, so the slice holding one does not
+/// hold the forward binds the rule below reads.
+pub(super) fn drop_rows_below_frozen_floor(
+    rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
+    retention_floor_seq: ChangeSeq,
+    unbound_at_floor: &BTreeSet<BindingGeneration>,
+) -> Result<()> {
+    // At the floor only the latest non-unbound bind per (parent, name) slot
+    // is visible; an unbind marker at or below the floor has finished its
+    // work once every bind it covered is gone.
     let mut latest_bind_at_floor = BTreeMap::new();
     for row in rows_by_family
         .get(&MetadataTableFamily::DirentryBinds)

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -16,6 +16,10 @@ pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_RUNS: usize = 8;
 pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_ROWS: usize = 131_072;
 pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_BYTES: usize = 64 * 1024 * 1024;
 
+/// Rows one page of a partial fold's start-up unbind scan reads. The scan
+/// covers a whole family, so it pages rather than materializing it.
+pub(super) const PARTIAL_FOLD_UNBIND_SCAN_PAGE_ROWS: usize = 4_096;
+
 pub(super) const MAX_MAINTENANCE_TABLE_IO: usize = 8;
 pub(super) const CHECKPOINT_L0_RUN_LEVEL: u32 = 0;
 pub(super) const CHECKPOINT_BASE_RUN_LEVEL: u32 = 1;

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -125,6 +125,33 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         ))
     }
 
+    /// One page of `[lower_bound, upper_bound)` over `runs` only, for a
+    /// partial fold reading one slice of the run subset it is merging. Rows
+    /// come back with their stored keys so the caller can resume past the
+    /// last one without recomputing it.
+    pub(super) async fn scan_key_range_page_in_runs(
+        &self,
+        runs: &[MetadataRunManifest],
+        family: MetadataTableFamily,
+        lower_bound: &str,
+        upper_bound: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        self.scan_range_page_rows(
+            runs,
+            family,
+            lower_bound,
+            upper_bound,
+            limit,
+            None,
+            Readahead::Disabled,
+        )
+        .await
+    }
+
     /// [`Self::scan_prefix`] for a point lookup: `filter_probe` is the
     /// family's exact filter key for the value being looked up, so each
     /// candidate segment's bloom filter is consulted before its index or

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -1487,7 +1487,9 @@ async fn manifest_load_rejects_a_reorganize_state_that_disagrees_with_its_manife
         output_run_seq,
         output_level: CHECKPOINT_BASE_RUN_LEVEL,
         frozen_floor_seq: payload.retention_floor_seq,
-        cursor: lookup_keys::inode_key(InodeId(9)),
+        // A revisions-group cursor: the family's row-key prefix and one
+        // padded inode id, above every inode the segment below holds.
+        cursor: format!("{}{:020}", lookup_keys::REVISION_ROW_PREFIX, u32::MAX),
         output_segments: vec![reorganize_output_segment(
             input,
             &namespace_id,
@@ -1520,7 +1522,16 @@ async fn manifest_load_rejects_a_reorganize_state_that_disagrees_with_its_manife
     fn cursor_is_empty(progress: &mut MetadataReorganizeProgress) {
         progress.cursor.clear();
     }
-    let state_perturbations: [(&str, Perturbation); 4] = [
+    // A partition key of another group: it parses as nothing here, and a
+    // fold resumed from it would rewrite the wrong slice of the keyspace.
+    fn cursor_belongs_to_another_group(progress: &mut MetadataReorganizeProgress) {
+        progress.cursor = lookup_keys::inode_key(InodeId(9));
+    }
+    // A row key rather than a boundary between partitions.
+    fn cursor_is_not_a_partition_boundary(progress: &mut MetadataReorganizeProgress) {
+        progress.cursor.push_str("-00000000000000000001-0000000000");
+    }
+    let state_perturbations: [(&str, Perturbation); 6] = [
         ("families are not a family group", families_are_not_a_group),
         (
             "input run is not in the manifest",
@@ -1531,6 +1542,14 @@ async fn manifest_load_rejects_a_reorganize_state_that_disagrees_with_its_manife
             frozen_floor_is_above_the_manifest_floor,
         ),
         ("cursor is empty", cursor_is_empty),
+        (
+            "cursor belongs to another group",
+            cursor_belongs_to_another_group,
+        ),
+        (
+            "cursor is not a partition boundary",
+            cursor_is_not_a_partition_boundary,
+        ),
     ];
     for (index, (label, perturb)) in state_perturbations.iter().enumerate() {
         let mut perturbed = progress.clone();
@@ -1566,8 +1585,18 @@ async fn manifest_load_rejects_a_reorganize_state_that_disagrees_with_its_manife
         second.min_key = progress.output_segments[0].min_key.clone();
         progress.output_segments.push(second);
     }
-    let segment_perturbations: [(&str, Perturbation); 5] = [
+    // Everything written so far belongs to a partition the fold has passed.
+    // A range reaching the cursor would be rewritten by the next step and
+    // land in the finished run twice.
+    fn output_range_reaches_the_cursor(progress: &mut MetadataReorganizeProgress) {
+        progress.output_segments[0].max_key = progress.cursor.clone();
+    }
+    let segment_perturbations: [(&str, Perturbation); 6] = [
         ("output segment range is empty", output_range_is_empty),
+        (
+            "output segment range reaches the cursor",
+            output_range_reaches_the_cursor,
+        ),
         (
             "output segment carries another run seq",
             output_run_seq_is_not_the_folds,

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -11,6 +11,7 @@ mod index_parity;
 pub(crate) mod inspection_materialization;
 mod inventory;
 mod manifest_round_trips;
+mod partial_fold;
 mod retention;
 
 use super::build::{

--- a/crates/loonfs-core/src/checkpoint/tests/partial_fold.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/partial_fold.rs
@@ -1,0 +1,1091 @@
+//! Folding a family group one slice at a time: the partition grammar, the
+//! walk executor, and the oracle that says a walk and a whole-group fold
+//! reach the same place.
+
+use super::super::partial_fold::{
+    MetadataFoldSliceDrops, MetadataFoldSliceReport, MetadataFoldWalk, MetadataFoldWalkOutcome,
+};
+use super::super::partition::{GroupPartitioning, PartitionCursor, PartitionKey};
+use super::super::row::manifest_row_commit_seq;
+use super::super::scan::VerifiedMetadataTables;
+use super::*;
+use crate::timing::StdMonotonicTimer;
+use loonfs_api::wire::manifest::{
+    ActiveDeletionRowAction, TombstoneGeneration, TombstoneRowAction,
+};
+use loonfs_api::{AttributeRevisionNo, Attributes, DisplayName, InodeKind};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+// -------------------------------------------------------------------------
+// The partition grammar
+// -------------------------------------------------------------------------
+
+/// Every reorganization family group must have a partition grammar, and
+/// every family in a group must read the same partition space, or one cursor
+/// could not bound them all.
+#[test]
+fn every_family_group_has_a_partition_grammar() {
+    for group in REORGANIZE_FAMILY_GROUPS {
+        let partitioning = GroupPartitioning::for_group(group)
+            .unwrap_or_else(|| panic!("family group {group:?} has no partition grammar"));
+        let first = partitioning.first_cursor();
+        let spelled = partitioning.spell_cursor(&first);
+        assert_eq!(
+            partitioning.parse_cursor(&spelled).expect("parse"),
+            first,
+            "{group:?}: the first cursor must survive a round trip"
+        );
+        let end = partitioning.spell_cursor(&PartitionCursor::End);
+        assert_eq!(
+            partitioning.parse_cursor(&end).expect("parse"),
+            PartitionCursor::End,
+            "{group:?}: the end cursor must survive a round trip"
+        );
+        // Every family's bound must sit at or below its own rows and, at the
+        // end, above all of them.
+        for family in group {
+            assert!(
+                partitioning
+                    .family_lower_bound(*family, &first)
+                    .starts_with(family.row_key_prefix()),
+                "{group:?}: the bound for {family:?} must be a key of that family"
+            );
+            assert!(
+                partitioning.family_lower_bound(*family, &PartitionCursor::End)
+                    > partitioning.family_lower_bound(*family, &first),
+                "{group:?}: the end bound for {family:?} must sort above the first"
+            );
+        }
+    }
+}
+
+/// The invariant every drop rule rests on: two rows where one cancels the
+/// other land in the same partition, so a slice that holds one holds both.
+#[test]
+fn an_unbind_shares_a_partition_with_the_bind_it_cancels() {
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let partitioning = GroupPartitioning::for_group(group).expect("grammar");
+    let parent = InodeId(7);
+    let name_key = NameKey::parse("report.txt").expect("name key");
+    let display_name = DisplayName::parse("report.txt").expect("display name");
+    let bind = MetadataRow::DirentryBind {
+        parent_inode_id: parent,
+        name_key: name_key.clone(),
+        display_name: display_name.clone(),
+        child_inode_id: InodeId(42),
+        bind_seq: ChangeSeq(11),
+        bind_delta_index: 0,
+    };
+    let unbind = MetadataRow::DirentryUnbind {
+        parent_inode_id: parent,
+        name_key,
+        display_name,
+        child_inode_id: InodeId(42),
+        bind_seq: ChangeSeq(11),
+        bind_delta_index: 0,
+        unbind_seq: ChangeSeq(19),
+        unbind_delta_index: 0,
+    };
+
+    assert_eq!(
+        partitioning.partition_of_row(ApiMetadataTableFamily::DirentryBinds, &bind),
+        partitioning.partition_of_row(ApiMetadataTableFamily::DirentryUnbinds, &unbind),
+        "an unbind and the bind it cancels must fold in one slice"
+    );
+    // The reverse index is the documented exception: it keys by child, so it
+    // shares the group's partition space without sharing a partition with
+    // the forward row. Its drops are resolved against the frozen unbind set
+    // instead of against the slice.
+    assert_ne!(
+        partitioning.partition_of_row(ApiMetadataTableFamily::DirentryChildBinds, &bind),
+        partitioning.partition_of_row(ApiMetadataTableFamily::DirentryBinds, &bind),
+        "this test only means something while the reverse index is keyed by child"
+    );
+}
+
+#[test]
+fn a_removal_marker_shares_a_partition_with_the_deletion_it_cancels() {
+    let group = group_containing(ApiMetadataTableFamily::ActiveDeletions);
+    let partitioning = GroupPartitioning::for_group(group).expect("grammar");
+    let listed = MetadataRow::ActiveDeletion {
+        root_inode_id: InodeId(42),
+        deleted_at_seq: ChangeSeq(11),
+        action: ActiveDeletionRowAction::Listed {
+            deleted_at_ms: 1_000,
+            deleted_direntry: None,
+        },
+    };
+    let removed = MetadataRow::ActiveDeletion {
+        root_inode_id: InodeId(42),
+        deleted_at_seq: ChangeSeq(11),
+        action: ActiveDeletionRowAction::Removed {
+            revoked_at_seq: ChangeSeq(19),
+        },
+    };
+
+    assert_eq!(
+        partitioning.partition_of_row(ApiMetadataTableFamily::ActiveDeletions, &listed),
+        partitioning.partition_of_row(ApiMetadataTableFamily::ActiveDeletions, &removed),
+        "a removal marker and the listed row it cancels must fold in one slice"
+    );
+    // The pair sorts together because the marker repeats its target's
+    // sequence, which is the family's leading key component. The root inode
+    // sits second and does not partition the family.
+    assert_eq!(
+        partitioning.partition_of_row(ApiMetadataTableFamily::ActiveDeletions, &listed),
+        Some(PartitionKey::Number(11)),
+    );
+}
+
+#[test]
+fn an_attribute_revision_shares_a_partition_with_the_revisions_it_supersedes() {
+    let group = group_containing(ApiMetadataTableFamily::Attributes);
+    let partitioning = GroupPartitioning::for_group(group).expect("grammar");
+    let revision_of = |revision: u64, seq: u64| MetadataRow::AttributesRevision {
+        inode_id: InodeId(42),
+        attributes_revision_no: AttributeRevisionNo(revision),
+        committed_seq: ChangeSeq(seq),
+        delta_index: 0,
+        attributes: Attributes::default(),
+    };
+
+    assert_eq!(
+        partitioning.partition_of_row(ApiMetadataTableFamily::Attributes, &revision_of(1, 5)),
+        partitioning.partition_of_row(ApiMetadataTableFamily::Attributes, &revision_of(2, 9)),
+        "an attribute revision and the revisions it supersedes must fold in one slice"
+    );
+}
+
+/// The two-family groups partition on the identity their index shares with
+/// its canonical family, so a slice always holds both sides of a row.
+#[test]
+fn a_secondary_index_row_shares_a_partition_with_the_row_it_indexes() {
+    let group = group_containing(ApiMetadataTableFamily::Revisions);
+    let partitioning = GroupPartitioning::for_group(group).expect("grammar");
+    let revision = MetadataRow::Revision {
+        inode_id: InodeId(42),
+        revision_no: RevisionNo(3),
+        committed_seq: ChangeSeq(11),
+        committed_at_ms: 11_000,
+        revision_delta_index: 0,
+        content_ref: loonfs_api::ContentRef::blob_v1(
+            loonfs_api::ContentId::parse("con_0123456789abcdef0123456789abcdef")
+                .expect("content id"),
+            b"partition sample",
+        ),
+    };
+
+    assert_eq!(
+        partitioning.partition_of_row(ApiMetadataTableFamily::Revisions, &revision),
+        partitioning.partition_of_row(ApiMetadataTableFamily::RevisionsByInodeDesc, &revision),
+    );
+    assert_eq!(
+        partitioning.partition_of_row(ApiMetadataTableFamily::Revisions, &revision),
+        Some(PartitionKey::Number(42)),
+    );
+}
+
+/// The single-family groups partition on their own leading key component,
+/// which is the inode for inodes and attributes, the root inode for
+/// tombstones, and the receipt id for receipts.
+#[test]
+fn single_family_groups_partition_on_their_leading_key_component() {
+    let inode_group = group_containing(ApiMetadataTableFamily::Inodes);
+    let inodes = GroupPartitioning::for_group(inode_group).expect("grammar");
+    assert_eq!(
+        inodes.partition_of_row(
+            ApiMetadataTableFamily::Inodes,
+            &MetadataRow::Inode {
+                inode_id: InodeId(42),
+                inode_kind: InodeKind::File,
+                created_seq: ChangeSeq(3),
+            }
+        ),
+        Some(PartitionKey::Number(42)),
+    );
+
+    let tombstone_group = group_containing(ApiMetadataTableFamily::Tombstones);
+    let tombstones = GroupPartitioning::for_group(tombstone_group).expect("grammar");
+    assert_eq!(
+        tombstones.partition_of_row(
+            ApiMetadataTableFamily::Tombstones,
+            &MetadataRow::Tombstone {
+                root_inode_id: InodeId(42),
+                generation: TombstoneGeneration {
+                    seq: ChangeSeq(11),
+                    delta_index: 0,
+                },
+                action: TombstoneRowAction::Set {
+                    deleted_direntry: None,
+                },
+                deleted_at_ms: 11_000,
+            }
+        ),
+        Some(PartitionKey::Number(42)),
+    );
+
+    let receipt_group = group_containing(ApiMetadataTableFamily::CommitReceipts);
+    let receipts = GroupPartitioning::for_group(receipt_group).expect("grammar");
+    let commit_id = CommitId::parse("c_00000000000000000000000000000001").expect("commit id");
+    let receipt_partition = receipts
+        .partition_of_row(
+            ApiMetadataTableFamily::CommitReceipts,
+            &MetadataRow::CommitReceipt {
+                commit_id: commit_id.clone(),
+                semantic_commit_fingerprint: "sha256:unused".to_owned(),
+                committed_seq: ChangeSeq(11),
+                committed_at_ms: 11_000,
+                message: None,
+            },
+        )
+        .expect("a receipt row has a partition");
+    assert_eq!(
+        receipt_partition,
+        PartitionKey::ReceiptId(loonfs_api::wire::manifest::hex_encode_row_key_component(
+            commit_id.as_str()
+        )),
+    );
+    // Receipt ids are variable length, so the boundary after one is the
+    // shortest hex string above it: nothing sorts between the two.
+    let after = receipts.cursor_after(&receipt_partition);
+    assert!(
+        receipts.spell_cursor(&after)
+            > MetadataRow::CommitReceipt {
+                commit_id,
+                semantic_commit_fingerprint: "sha256:unused".to_owned(),
+                committed_seq: ChangeSeq(u64::MAX),
+                committed_at_ms: 0,
+                message: None,
+            }
+            .row_key_for_family(ApiMetadataTableFamily::CommitReceipts),
+        "the boundary after a receipt must sort above every row of that receipt"
+    );
+}
+
+/// The cursor is a boundary between partitions, so a spelling with anything
+/// else in it is not a position a fold may resume from.
+#[test]
+fn a_cursor_that_is_not_a_partition_boundary_does_not_parse() {
+    let group = group_containing(ApiMetadataTableFamily::Revisions);
+    let partitioning = GroupPartitioning::for_group(group).expect("grammar");
+    for spelled in [
+        "",
+        "inode-00000000000000000009",
+        "revision-",
+        "revision-9",
+        "revision-000000000000000000009",
+        "revision-0000000000000000000x",
+        "revision-00000000000000000009-00000000000000000001-0000000000",
+    ] {
+        assert!(
+            partitioning.parse_cursor(spelled).is_err(),
+            "`{spelled}` must not parse as a revisions-group cursor"
+        );
+    }
+    assert_eq!(
+        partitioning
+            .parse_cursor("revision-00000000000000000009")
+            .expect("a padded inode id is a boundary"),
+        PartitionCursor::At(PartitionKey::Number(9)),
+    );
+}
+
+fn group_containing(family: ApiMetadataTableFamily) -> &'static [ApiMetadataTableFamily] {
+    REORGANIZE_FAMILY_GROUPS
+        .into_iter()
+        .find(|group| group.contains(&family))
+        .expect("every family belongs to a reorganization group")
+}
+
+// -------------------------------------------------------------------------
+// The walk
+// -------------------------------------------------------------------------
+
+/// A namespace whose bindings group holds many parent directories, deletions
+/// and moves below the retention floor, and more of both above it — enough
+/// for a walk to cross many partitions and for the drop rules to have
+/// something to do.
+async fn seed_bindings_workload(store: &LocalFsStore, namespace_id: &NamespaceId) {
+    let context = test_context();
+    bootstrap_namespace(store, namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // Below the floor: files created, some deleted, some moved. The
+    // deletions and moves leave unbinds the fold may drop.
+    for directory in 0..6u64 {
+        for file in 0..3u64 {
+            write_file_bytes(
+                store,
+                namespace_id,
+                &format!("/d{directory}/f{file}.txt"),
+                format!("body {directory}/{file}\n").as_bytes(),
+                &context,
+                None,
+            )
+            .await
+            .expect("write file");
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint");
+    }
+    for directory in 0..3u64 {
+        delete_path(
+            store,
+            namespace_id,
+            &format!("/d{directory}/f0.txt"),
+            &context,
+            None,
+        )
+        .await
+        .expect("delete file");
+        move_path(
+            store,
+            namespace_id,
+            &format!("/d{directory}/f1.txt"),
+            &format!("/d{directory}/moved-f1.txt"),
+            &context,
+            None,
+        )
+        .await
+        .expect("move file");
+    }
+    // One deleted directory, so a tombstone and an active deletion travel
+    // with the bindings the fold drops.
+    delete_path(store, namespace_id, "/d5", &context, None)
+        .await
+        .expect("delete directory");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the deletions");
+
+    // Fold everything into one base run, so the walk's snapshot has a base
+    // under its delta runs the way a real over-budget group does.
+    drain_reorganization(store, namespace_id, &context, MetadataLsmPolicy::default()).await;
+    advance_retention_floor(store, namespace_id, &context)
+        .await
+        .expect("advance the floor past the deletions");
+
+    // Above the floor: fresh directories and one more deletion, published as
+    // delta runs the walk merges with the base.
+    for directory in 6..9u64 {
+        for file in 0..2u64 {
+            write_file_bytes(
+                store,
+                namespace_id,
+                &format!("/d{directory}/f{file}.txt"),
+                format!("late body {directory}/{file}\n").as_bytes(),
+                &context,
+                None,
+            )
+            .await
+            .expect("write late file");
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint late writes");
+    }
+    delete_path(store, namespace_id, "/d6/f0.txt", &context, None)
+        .await
+        .expect("delete a late file");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the late deletion");
+}
+
+/// The runs a walk snapshots: every run of the manifest that holds rows of
+/// the group, which is what makes the input bottom-anchored and its drops
+/// legal.
+fn snapshot_runs_for_group(
+    manifest: &NamespaceManifestEnvelope,
+    group: &[ApiMetadataTableFamily],
+) -> Vec<MetadataRunManifest> {
+    runs_in_scan_order(&manifest.payload)
+        .into_iter()
+        .filter(|run| {
+            run.tables
+                .iter()
+                .any(|table| group.contains(&table.family) && !table.segments.is_empty())
+        })
+        .collect()
+}
+
+/// How a test drives the walk between steps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WalkDriver {
+    /// One executor for the whole walk.
+    KeepExecutor,
+    /// The executor is dropped at every step boundary and rebuilt from the
+    /// manifest that survived, which is what a crashed process does.
+    ResumeEveryStep,
+}
+
+struct WalkRun {
+    slices: Vec<MetadataFoldSliceReport>,
+    /// The group's rows, per family, read from `metadata_files` after every
+    /// step — the rows a reader would see at that moment.
+    visible_rows_per_step: Vec<BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>>>,
+}
+
+/// Runs a partial fold of `group` to completion against the namespace's
+/// current manifest.
+async fn run_partial_fold(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    group: &'static [ApiMetadataTableFamily],
+    policy: MetadataLsmPolicy,
+    driver: WalkDriver,
+) -> WalkRun {
+    let context = test_context();
+    let timer = StdMonotonicTimer::default();
+    let frozen_floor_seq = read_floor_seq(store, namespace_id).await;
+    let mut run = WalkRun {
+        slices: Vec::new(),
+        visible_rows_per_step: Vec::new(),
+    };
+
+    let mut tables = load_current_manifest_tables(store, namespace_id).await;
+    let snapshot = snapshot_runs_for_group(tables.manifest(), group);
+    assert!(
+        snapshot.len() > 1,
+        "this test needs a base run under at least one delta run"
+    );
+    let mut walk = MetadataFoldWalk::start(&tables, group, snapshot, frozen_floor_seq, policy)
+        .await
+        .expect("start a partial fold");
+
+    for _step in 0..256 {
+        let outcome = walk
+            .advance(store, namespace_id, &tables, policy, &context, &timer)
+            .await
+            .expect("advance the partial fold");
+        tables = load_current_manifest_tables(store, namespace_id).await;
+        match outcome {
+            MetadataFoldWalkOutcome::SlicePublished(report) => {
+                run.slices.push(report);
+                run.visible_rows_per_step
+                    .push(group_rows_from_manifest(&tables, group).await);
+                if driver == WalkDriver::ResumeEveryStep {
+                    drop(walk);
+                    walk = MetadataFoldWalk::resume_from_manifest(&tables, policy)
+                        .await
+                        .expect("resume a partial fold")
+                        .expect("the manifest must still carry the fold");
+                }
+            }
+            MetadataFoldWalkOutcome::Completed {
+                output_segments,
+                output_rows,
+                ..
+            } => {
+                assert!(
+                    tables.manifest().payload.reorganize.is_none(),
+                    "the completing publication must clear the fold's state"
+                );
+                assert_eq!(
+                    output_rows,
+                    run.slices
+                        .iter()
+                        .map(|slice| slice.output_rows)
+                        .sum::<u64>(),
+                    "the finished run must hold what every slice wrote and nothing else"
+                );
+                let finished: Vec<_> = tables
+                    .manifest()
+                    .payload
+                    .metadata_files
+                    .iter()
+                    .filter(|descriptor| group.contains(&descriptor.family))
+                    .collect();
+                assert_eq!(finished.len(), output_segments);
+                assert_eq!(
+                    finished
+                        .iter()
+                        .map(|descriptor| descriptor.row_count)
+                        .sum::<u64>(),
+                    output_rows
+                );
+                return run;
+            }
+            MetadataFoldWalkOutcome::Superseded => {
+                panic!("no concurrent publisher exists in this test")
+            }
+        }
+    }
+    panic!("a partial fold must finish in a bounded number of steps");
+}
+
+/// The group's rows a reader sees right now: read from `metadata_files`,
+/// which is exactly what a scan concatenates.
+async fn group_rows_from_manifest<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    group: &[ApiMetadataTableFamily],
+) -> BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>> {
+    let mut rows_by_family = BTreeMap::new();
+    for family in group {
+        let mut rows = tables
+            .scan_prefix(*family, "")
+            .await
+            .expect("scan the group");
+        rows.sort_by_key(|row| row.row_key_for_family(*family));
+        rows_by_family.insert(*family, rows);
+    }
+    rows_by_family
+}
+
+async fn group_rows_of_current_manifest(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    group: &[ApiMetadataTableFamily],
+) -> BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>> {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    group_rows_from_manifest(&tables, group).await
+}
+
+/// The tables of whatever manifest the namespace's root names right now.
+async fn load_current_manifest_tables<'a>(
+    store: &'a LocalFsStore,
+    namespace_id: &NamespaceId,
+) -> VerifiedMetadataTables<'a, LocalFsStore> {
+    let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
+    load_verified_manifest_tables(store, namespace_id, &manifest_object_id)
+        .await
+        .expect("load the current manifest's tables")
+}
+
+async fn current_metadata_state(store: &LocalFsStore, namespace_id: &NamespaceId) -> MetadataState {
+    load_manifest_materialization_for_inspection(
+        store,
+        namespace_id,
+        read_metadata_root_object(store, namespace_id)
+            .await
+            .expect("read root")
+            .envelope
+            .state
+            .manifest_id,
+    )
+    .await
+    .expect("materialize the manifest")
+    .metadata_state
+}
+
+/// Copies a local store's whole object tree, so two folds can start from
+/// byte-identical durable state. Content ids and table ids are generated, so
+/// building the same namespace twice would not produce the same rows.
+fn copy_store_tree(from: &Path, to: &Path) {
+    for entry in std::fs::read_dir(from).expect("read the store directory") {
+        let entry = entry.expect("directory entry");
+        let target = to.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            std::fs::create_dir_all(&target).expect("create the copied directory");
+            copy_store_tree(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), &target).expect("copy the object");
+        }
+    }
+}
+
+/// A budget that admits the whole group in one step, so the ordinary fold
+/// can rebuild in one unit whatever the walk needed many steps for.
+fn fold_everything_policy() -> MetadataLsmPolicy {
+    MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(4_000_000).expect("nonzero"),
+        max_decoded_input_bytes_per_step: NonZeroUsize::new(1 << 30).expect("nonzero"),
+        max_input_runs_per_step: NonZeroUsize::new(64).expect("nonzero"),
+        ..MetadataLsmPolicy::default()
+    }
+}
+
+/// A budget that forces the walk to take many small slices while leaving
+/// room for the unbind set.
+fn small_slice_policy() -> MetadataLsmPolicy {
+    MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(64).expect("nonzero"),
+        max_decoded_input_bytes_per_step: NonZeroUsize::new(4_096).expect("nonzero"),
+        ..MetadataLsmPolicy::default()
+    }
+}
+
+/// The oracle. A walk in many bounded steps and a whole-group fold with the
+/// budgets raised are two ways of doing the same thing, so they must land in
+/// the same place: the same surviving rows in every family of the group, the
+/// same materialized namespace, and the same rows dropped.
+#[tokio::test]
+async fn a_walk_and_a_whole_group_fold_reach_the_same_rows() {
+    let walk_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(walk_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    let frozen_floor_seq = read_floor_seq(&store, &namespace_id).await;
+
+    // The same durable bytes, folded the ordinary way.
+    let fold_dir = tempdir().expect("tempdir");
+    copy_store_tree(walk_dir.path(), fold_dir.path());
+    let fold_store = LocalFsStore::new(fold_dir.path()).expect("store");
+    let report = super::super::reorganize_metadata_step(
+        &fold_store,
+        &namespace_id,
+        &test_context(),
+        fold_everything_policy(),
+    )
+    .await
+    .expect("fold the group whole");
+    let folded_families = match report.outcome {
+        MetadataReorganizeOutcome::UnitPublished { families, .. } => families,
+        other => panic!("the whole-group fold must publish a unit, got {other:?}"),
+    };
+    assert_eq!(
+        folded_families, group,
+        "both folds must work on the same family group"
+    );
+    let folded = group_rows_of_current_manifest(&fold_store, &namespace_id, group).await;
+    let folded_state = current_metadata_state(&fold_store, &namespace_id).await;
+
+    let run = run_partial_fold(
+        &store,
+        &namespace_id,
+        group,
+        small_slice_policy(),
+        WalkDriver::KeepExecutor,
+    )
+    .await;
+    assert!(
+        run.slices.len() > 3,
+        "the budget must force many slices, got {}",
+        run.slices.len()
+    );
+    assert!(
+        run.slices
+            .iter()
+            .all(|slice| slice.drops == MetadataFoldSliceDrops::Applied),
+        "this budget must leave room for the unbind set"
+    );
+    let walked = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+
+    assert_eq!(
+        walked, folded,
+        "a walk and a whole-group fold must keep the same rows"
+    );
+    assert!(
+        metadata_states_equivalent(
+            &current_metadata_state(&store, &namespace_id).await,
+            &folded_state
+        ),
+        "a walk and a whole-group fold must materialize the same namespace"
+    );
+    // The format gives every bind row exactly one reverse row, and manifest
+    // load rejects a run whose two counts disagree. A walk drops the two
+    // families in lockstep, and this is what says so: dropping one side
+    // alone would read correctly and still fail to publish.
+    assert_eq!(
+        walked[&ApiMetadataTableFamily::DirentryBinds].len(),
+        walked[&ApiMetadataTableFamily::DirentryChildBinds].len(),
+        "a walk must never leave a reverse row without its forward row"
+    );
+
+    // Teeth: the folds must actually have dropped something, or the
+    // comparison above is comparing two copies of the input.
+    let rows_of = |rows: &BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>>| {
+        rows.values().map(Vec::len).sum::<usize>()
+    };
+    assert!(
+        rows_of(&walked) < rows_of(&before),
+        "the fold must drop rows for this comparison to mean anything: {} before, {} after",
+        rows_of(&before),
+        rows_of(&walked)
+    );
+    // What a fold may drop is bounded from both sides: it never invents a
+    // row, and it never touches one the retention floor still covers.
+    for (family, rows) in &walked {
+        let input: BTreeSet<String> = before[family]
+            .iter()
+            .map(|row| row.row_key_for_family(*family))
+            .collect();
+        for row in rows {
+            assert!(
+                input.contains(&row.row_key_for_family(*family)),
+                "the fold wrote a {family:?} row its input did not hold"
+            );
+        }
+    }
+    for (family, rows) in &before {
+        let survivors: BTreeSet<String> = walked[family]
+            .iter()
+            .map(|row| row.row_key_for_family(*family))
+            .collect();
+        for row in rows {
+            if manifest_row_commit_seq(row) > frozen_floor_seq {
+                assert!(
+                    survivors.contains(&row.row_key_for_family(*family)),
+                    "the fold dropped a {family:?} row above the retention floor"
+                );
+            }
+        }
+    }
+}
+
+/// A walk interrupted at a step boundary resumes from the manifest and
+/// nothing else. Rebuilding the executor at every boundary must reach the
+/// same place an uninterrupted walk reaches.
+#[tokio::test]
+async fn a_walk_resumed_at_every_step_boundary_lands_where_it_would_have() {
+    let uninterrupted_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(uninterrupted_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+
+    let resumed_dir = tempdir().expect("tempdir");
+    copy_store_tree(uninterrupted_dir.path(), resumed_dir.path());
+    let resumed_store = LocalFsStore::new(resumed_dir.path()).expect("store");
+
+    let straight = run_partial_fold(
+        &store,
+        &namespace_id,
+        group,
+        small_slice_policy(),
+        WalkDriver::KeepExecutor,
+    )
+    .await;
+    let resumed = run_partial_fold(
+        &resumed_store,
+        &namespace_id,
+        group,
+        small_slice_policy(),
+        WalkDriver::ResumeEveryStep,
+    )
+    .await;
+
+    assert_eq!(
+        straight.slices.len(),
+        resumed.slices.len(),
+        "a resumed walk must take the same slices"
+    );
+    for (straight_slice, resumed_slice) in straight.slices.iter().zip(&resumed.slices) {
+        assert_eq!(
+            (
+                straight_slice.partitions,
+                straight_slice.decoded_input_rows,
+                straight_slice.output_rows,
+                straight_slice.drops,
+            ),
+            (
+                resumed_slice.partitions,
+                resumed_slice.decoded_input_rows,
+                resumed_slice.output_rows,
+                resumed_slice.drops,
+            ),
+            "every step must decide the same way after a resume"
+        );
+    }
+    assert_eq!(
+        group_rows_of_current_manifest(&store, &namespace_id, group).await,
+        group_rows_of_current_manifest(&resumed_store, &namespace_id, group).await,
+        "a resumed walk must keep the same rows"
+    );
+}
+
+/// Rows appear exactly once. The outputs a walk accumulates are invisible
+/// until the swap, so every manifest it publishes on the way answers a scan
+/// of the group with exactly the rows the manifest before the walk answered.
+#[tokio::test]
+async fn a_walk_in_flight_never_changes_what_a_scan_returns() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+
+    let run = run_partial_fold(
+        &store,
+        &namespace_id,
+        group,
+        small_slice_policy(),
+        WalkDriver::KeepExecutor,
+    )
+    .await;
+
+    assert!(!run.visible_rows_per_step.is_empty());
+    for (index, visible) in run.visible_rows_per_step.iter().enumerate() {
+        assert_eq!(
+            *visible, before,
+            "step {index} changed what a scan of the group returns"
+        );
+    }
+}
+
+/// The unbind set has a bound, and a walk over it keeps going as a pure
+/// rewrite rather than stopping. That is also the check that the equivalence
+/// oracle has teeth: with the drops off, the walk must NOT reach the
+/// whole-group fold's rows.
+#[tokio::test]
+async fn a_walk_that_cannot_hold_the_unbind_set_rewrites_without_dropping() {
+    let walk_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(walk_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+
+    let fold_dir = tempdir().expect("tempdir");
+    copy_store_tree(walk_dir.path(), fold_dir.path());
+    let fold_store = LocalFsStore::new(fold_dir.path()).expect("store");
+    super::super::reorganize_metadata_step(
+        &fold_store,
+        &namespace_id,
+        &test_context(),
+        fold_everything_policy(),
+    )
+    .await
+    .expect("fold the group whole");
+    let folded = group_rows_of_current_manifest(&fold_store, &namespace_id, group).await;
+
+    // A byte budget too small for even one unbind entry.
+    let no_drop_policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(64).expect("nonzero"),
+        max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
+        ..MetadataLsmPolicy::default()
+    };
+    let run = run_partial_fold(
+        &store,
+        &namespace_id,
+        group,
+        no_drop_policy,
+        WalkDriver::KeepExecutor,
+    )
+    .await;
+    assert!(
+        run.slices
+            .iter()
+            .all(|slice| slice.drops == MetadataFoldSliceDrops::UnbindSetOverBound),
+        "an unbind set over its bound must stop the whole walk dropping"
+    );
+
+    let walked = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    assert_eq!(
+        walked, before,
+        "a no-drop walk is a pure rewrite: every input row must survive"
+    );
+    assert_ne!(
+        walked, folded,
+        "the oracle has no teeth unless a walk without the drop rules misses the fold's rows"
+    );
+    // A pure rewrite still does the thing a frozen base could not: it
+    // rebuilds the group into one run.
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    assert_eq!(
+        snapshot_runs_for_group(tables.manifest(), group).len(),
+        1,
+        "the walk must leave the group in one run"
+    );
+}
+
+/// A walk over a group with no unbind rule needs no unbind set at all; it
+/// is a straight rewrite in partitions. Revisions are never dropped, so the
+/// walk's output must hold every input row.
+#[tokio::test]
+async fn a_walk_over_the_revisions_group_rewrites_every_row_it_reads() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::Revisions);
+    let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+
+    let run = run_partial_fold(
+        &store,
+        &namespace_id,
+        group,
+        small_slice_policy(),
+        WalkDriver::ResumeEveryStep,
+    )
+    .await;
+    assert!(run.slices.len() > 1);
+    assert!(
+        run.slices
+            .iter()
+            .all(|slice| slice.drops == MetadataFoldSliceDrops::Applied),
+        "the revisions group has no reverse bind index and no unbind set"
+    );
+
+    assert_eq!(
+        group_rows_of_current_manifest(&store, &namespace_id, group).await,
+        before,
+        "revision rows are durable history and are never dropped"
+    );
+}
+
+/// The state a walk publishes is the state the loader validates and the
+/// state a resume reads back: same group, same snapshot, same output
+/// identity, same frozen floor, and a cursor that advances every step.
+#[tokio::test]
+async fn a_walk_publishes_the_state_a_resume_reads_back() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let policy = small_slice_policy();
+    let context = test_context();
+    let timer = StdMonotonicTimer::default();
+    let frozen_floor_seq = read_floor_seq(&store, &namespace_id).await;
+
+    let mut tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let head_seq = tables.manifest().payload.head_seq;
+    let snapshot = snapshot_runs_for_group(tables.manifest(), group);
+    let snapshot_ids: BTreeSet<_> = snapshot
+        .iter()
+        .map(|run| MetadataRunId {
+            run_seq: run.run_seq,
+            level: run.level,
+        })
+        .collect();
+    let mut walk = MetadataFoldWalk::start(&tables, group, snapshot, frozen_floor_seq, policy)
+        .await
+        .expect("start a partial fold");
+    assert_eq!(walk.progress().cursor, "direntry-00000000000000000000");
+
+    let mut cursors = Vec::new();
+    for _step in 0..64 {
+        let outcome = walk
+            .advance(&store, &namespace_id, &tables, policy, &context, &timer)
+            .await
+            .expect("advance");
+        tables = load_current_manifest_tables(&store, &namespace_id).await;
+        if matches!(outcome, MetadataFoldWalkOutcome::Completed { .. }) {
+            break;
+        }
+        let progress = tables
+            .manifest()
+            .payload
+            .reorganize
+            .clone()
+            .expect("a step in flight must publish its state");
+        assert_eq!(progress.families, group);
+        assert_eq!(
+            progress.input_runs.iter().copied().collect::<BTreeSet<_>>(),
+            snapshot_ids
+        );
+        assert_eq!(progress.output_run_seq, head_seq);
+        assert_eq!(progress.output_level, CHECKPOINT_BASE_RUN_LEVEL);
+        assert_eq!(progress.frozen_floor_seq, frozen_floor_seq);
+        assert!(
+            progress
+                .output_segments
+                .iter()
+                .all(|segment| segment.run_seq == head_seq
+                    && segment.level == CHECKPOINT_BASE_RUN_LEVEL),
+            "every output segment carries the identity fixed at the start"
+        );
+        cursors.push(progress.cursor.clone());
+
+        // The resumed walk must agree with the published state exactly.
+        let resumed = MetadataFoldWalk::resume_from_manifest(&tables, policy)
+            .await
+            .expect("resume")
+            .expect("the manifest carries a fold");
+        assert_eq!(*resumed.progress(), progress);
+        assert_eq!(resumed.group(), group);
+    }
+
+    assert!(cursors.len() > 2, "the walk must publish several cursors");
+    let mut ascending = cursors.clone();
+    ascending.sort();
+    ascending.dedup();
+    assert_eq!(
+        cursors, ascending,
+        "the cursor must advance strictly, so no partition is folded twice"
+    );
+    assert!(
+        MetadataFoldWalk::resume_from_manifest(&tables, policy)
+            .await
+            .expect("resume the finished manifest")
+            .is_none(),
+        "a finished walk leaves no state to resume"
+    );
+}
+
+/// The completing publication is the swap: the snapshot's group segments
+/// leave `metadata_files` in the same step the finished run enters it, and
+/// runs that arrived during the walk survive untouched.
+#[tokio::test]
+async fn the_completing_step_swaps_the_snapshot_for_the_run_it_built() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let before = tables.manifest().payload.clone();
+    let snapshot_keys: BTreeSet<String> = before
+        .metadata_files
+        .iter()
+        .filter(|descriptor| group.contains(&descriptor.family))
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect();
+    let untouched_keys: BTreeSet<String> = before
+        .metadata_files
+        .iter()
+        .filter(|descriptor| !group.contains(&descriptor.family))
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect();
+    assert!(!snapshot_keys.is_empty() && !untouched_keys.is_empty());
+    drop(tables);
+
+    run_partial_fold(
+        &store,
+        &namespace_id,
+        group,
+        small_slice_policy(),
+        WalkDriver::KeepExecutor,
+    )
+    .await;
+
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let after = &tables.manifest().payload;
+    let after_keys: BTreeSet<String> = after
+        .metadata_files
+        .iter()
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect();
+    assert!(
+        snapshot_keys.is_disjoint(&after_keys),
+        "the snapshot's segments must leave the file set"
+    );
+    assert!(
+        untouched_keys.is_subset(&after_keys),
+        "segments outside the group must survive the swap untouched"
+    );
+    assert!(after.reorganize.is_none());
+    let group_runs: BTreeSet<(ChangeSeq, u32)> = after
+        .metadata_files
+        .iter()
+        .filter(|descriptor| group.contains(&descriptor.family))
+        .map(|descriptor| (descriptor.run_seq, descriptor.level))
+        .collect();
+    assert_eq!(
+        group_runs,
+        BTreeSet::from([(before.head_seq, CHECKPOINT_BASE_RUN_LEVEL)]),
+        "the group must be left in the one run the walk built, at the identity it fixed"
+    );
+    assert_eq!(
+        after.base_seq,
+        after
+            .metadata_files
+            .iter()
+            .map(|descriptor| descriptor.run_seq)
+            .min()
+            .expect("the manifest names files"),
+        "the swap must restate the manifest's oldest run"
+    );
+}

--- a/docs/design/metadata-partial-fold.md
+++ b/docs/design/metadata-partial-fold.md
@@ -90,12 +90,16 @@ a partition. This is what keeps the retention drop rules local:
   its handling is defined below.
 - `Inodes`, `Tombstones`, `ActiveDeletions`, `CommitReceipts`,
   `Attributes`: single-family groups. Partition = the family's own leading
-  prefix (inode id, root inode id, deletion root, receipt id, inode id).
-  `ActiveDeletions` pairs (a removal marker and the listed row it cancels)
-  live in one family by construction — the group comment says so — and the
-  partition must keep each pair together. `Attributes` supersession is
-  per-inode. `CommitReceipts` drop by horizon, a per-row rule that needs no
-  neighbors.
+  key component (inode id, root inode id, deletion sequence, receipt id,
+  inode id). `ActiveDeletions` pairs (a removal marker and the listed row it
+  cancels) live in one family by construction — the group comment says so —
+  and the partition must keep each pair together; the marker repeats its
+  target's deletion sequence, which is the family's leading component, so
+  partitioning on that sequence does keep them together. (An earlier draft
+  said the partition was the deletion root; the root is the family's
+  *second* component, so it is not a prefix of the row keys.) `Attributes`
+  supersession is per-inode. `CommitReceipts` drop by horizon, a per-row
+  rule that needs no neighbors.
 
 Each family maps a partition boundary to a key bound with a small pure
 function per group. The implementation must state, as a tested invariant per
@@ -129,14 +133,30 @@ Two rules need care:
    no-drop mode for this group and says so in its outcome — a pure rewrite
    still unfreezes the base, and the next walk drops with a smaller set.
 2. The reverse-index row (`DirentryChildBinds`) for a dropped binding lives
-   in a different partition than the forward row. Its drop decision uses
-   the same frozen predicate, answered by point lookups into the snapshot
-   (bloom filters make the common live-binding case cheap), charged against
-   the step's budgets. If the implementation finds the lookups too
-   expensive, the stated fallback is to retain dangling reverse rows: a
-   reverse row whose forward binding is gone is invisible — visibility
-   requires the forward row, the reverse row, and the inode to agree — so
-   the cost is space until the next walk, not correctness.
+   in a different partition than the forward row, so the slice holding it
+   holds neither the parent's other binds nor the parent's unbinds. It is
+   decided against the same frozen unbind set rule 1 builds, which is
+   already in memory whenever the walk drops at all: a reverse row is a
+   bind row, carrying its parent, name, sequence, and delta index, which is
+   exactly what the set is keyed by. No extra read is needed, and the two
+   families drop in lockstep by construction.
+
+   The forward rule keeps a bind at or below the floor when it is both the
+   latest in its slot and not unbound; the set alone settles the reverse
+   row because a bind is only ever superseded by an operation that also
+   unbinds it, an invariant the drop pass refuses to compact without.
+
+   An earlier draft answered this with point lookups into the snapshot and
+   gave them a share of the step's budget, with a fallback that retained
+   the *dangling* reverse rows on their own — on the grounds that a reverse
+   row whose forward binding is gone is invisible, since visibility
+   requires the forward row, the reverse row, and the inode to agree. Two
+   things were wrong with it. The read argument holds but the run would not
+   publish: the format gives every bind row exactly one reverse row, and
+   manifest load rejects a run whose two counts disagree
+   (`validate_manifest_table_descriptors`). And the lookups bought nothing
+   the frozen set did not already answer, so they are gone along with their
+   budget share.
 
 ## Interaction rules
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2163,6 +2163,32 @@ alike ("Garbage collection", rule 1). An abandoned rebuild therefore leaks
 nothing: the manifest that survives the crash names every segment written so
 far, and the next step resumes from it.
 
+**Partition keys.** Each family group names one partition key that every
+family in the group prefixes its row keys by, and a rebuild advances in whole
+partitions so that two rows where one cancels the other always land in one
+slice. The key is the leading variable component of the group's row keys:
+
+| group | partition key | per-family bound |
+| --- | --- | --- |
+| `direntry_binds`, `direntry_child_binds`, `direntry_unbinds` | inode id | `direntry-{parent}`, `direntry-child-{child}`, `direntry-unbind-{parent}` |
+| `revisions`, `revisions_by_inode_desc` | inode id | `revision-{inode}`, `revision-by-inode-desc-{inode}` |
+| `inodes` | inode id | `inode-{inode}` |
+| `tombstones` | root inode id | `tombstone-{root}` |
+| `active_deletions` | deletion sequence | `active-deletion-{deleted_at_seq}` |
+| `commit_receipts` | receipt id | `commit-receipt-{commit_id_hex}` |
+| `attributes` | inode id | `attributes-{inode}` |
+
+A cursor is spelled as the first-named family's bound: that family's row-key
+prefix followed by one partition component, which is a twenty-digit
+zero-padded number everywhere except commit receipts, where it is the hex
+receipt id. The single spelling `~` in place of the component means every
+partition is done. The reverse bind index is keyed by child rather than by
+parent, so it shares the group's partition space without sharing a partition
+with the rows it indexes; a rebuild decides its drops against the retired
+bindings it recorded when it froze the floor, so the two families always drop
+together. They have to: every bind row has exactly one reverse row, and a run
+whose two counts disagree does not load.
+
 **Validation at load.** A manifest carrying the state is rejected unless
 `families` is one of the family groups, every `input_runs` entry names a run
 the manifest references, `frozen_floor_seq` is at or below the manifest's own


### PR DESCRIPTION
This adds the partial-fold executor and the partition grammar used to process one family group across multiple steps. The executor is called directly by tests in this change; maintenance selection is integrated separately.

The executor defines partition keys and durable cursor parsing for each metadata family group. It starts only from an oldest-first input run set, processes complete partitions from the recorded cursor, writes output segments, and publishes updated progress. Every step uses the same retention floor. Input descriptors remain visible and output descriptors remain hidden until one manifest publication replaces the selected inputs. Runs created after the operation starts are preserved, and all progress needed after a restart comes from the manifest. In this version, a single partition is processed as a unit even when it exceeds a configured step limit.

The main equivalence test compares a multi-step partial fold with a whole-group fold from identical durable state. Additional tests cover restart at every step boundary, unchanged reads from intermediate manifests, retention safety, cursor validation, and canonical-to-index row parity.
