### PR TITLE
feat(checkpoint): over-budget groups fold a slice at a time

### DIFF
--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -63,6 +63,7 @@ pub use self::cache::{
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
+pub use self::partial_fold::MetadataFoldSliceDrops;
 pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
 pub(crate) use self::runs::MetadataLsmPolicy;
 pub use self::stored_block_cache::{

--- a/crates/loonfs-core/src/checkpoint/partial_fold.rs
+++ b/crates/loonfs-core/src/checkpoint/partial_fold.rs
@@ -17,10 +17,9 @@
 //! runs without deduplicating — so a manifest showing both would show every
 //! rebuilt row twice.
 //!
-//! Nothing calls this from the maintenance path yet: the selector picks it
-//! up in the next change, and until then every path below is driven by
-//! tests.
-#![allow(dead_code)]
+//! The reorganization step reaches this ([`super::reorganize`]): it starts a
+//! walk when a group's oldest run no longer fits one step, and advances the
+//! walk a manifest carries before it selects anything else for that group.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::build::{
@@ -88,8 +87,12 @@ pub(super) struct MetadataFoldSliceReport {
 
 /// Whether a slice dropped what the frozen floor allows, and why not when
 /// it did not.
+///
+/// Public because a reorganization step reports it: an operator watching a
+/// walk needs to know whether it is reclaiming rows or only rebuilding the
+/// run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum MetadataFoldSliceDrops {
+pub enum MetadataFoldSliceDrops {
     /// The slice dropped every row the frozen floor allows.
     Applied,
     /// The unbind set the bind drop reads did not fit its bound, so the

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -19,6 +19,13 @@
 //! concurrent checkpoint racing a unit wins at the root compare-and-swap;
 //! the unit's segments are left unreferenced for garbage collection and the
 //! next step retries against the fresh manifest.
+//!
+//! A group whose oldest run no longer fits one step folds a slice at a time
+//! instead ([`super::partial_fold`]). That fold does keep a progress record,
+//! in the manifest, because its output arrives in pieces. While it is in
+//! flight its group folds no other way: a step that selects the group
+//! advances the fold and does nothing else for it. Group selection still
+//! runs per step, so the other groups keep folding on the steps they win.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::build::{
@@ -31,6 +38,7 @@ use super::load::{
     load_verified_manifest_tables, validate_direntry_child_bind_index,
     validate_revision_by_inode_desc_index,
 };
+use super::partial_fold::{MetadataFoldSliceDrops, MetadataFoldWalk, MetadataFoldWalkOutcome};
 use super::publish::{
     manifest_write_failure, publish_metadata_root, write_namespace_manifest,
     ManifestPublicationOutcome,
@@ -46,7 +54,7 @@ use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::{read_head_object, read_metadata_root_object_if_present};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::manifest::{
-    ActiveDeletionRowAction, MetadataFileRef, MetadataRow, MetadataTableFamily,
+    ActiveDeletionRowAction, MetadataFileRef, MetadataRow, MetadataRunId, MetadataTableFamily,
     NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
 use loonfs_api::{
@@ -69,6 +77,33 @@ pub enum MetadataReorganizeOutcome {
         input_runs: usize,
         decoded_input_rows: u64,
         decoded_input_bytes: u64,
+        manifest_id: ManifestId,
+    },
+    /// One slice of a partial fold merged and published. The group's oldest
+    /// run does not fit one step, so the group is being folded a partition
+    /// at a time and this step moved that fold along.
+    PartialFoldAdvanced {
+        families: Vec<MetadataTableFamily>,
+        /// Partitions of the group's keyspace this slice covered.
+        partitions: u64,
+        decoded_input_rows: u64,
+        decoded_input_bytes: u64,
+        /// Rows this slice wrote into the run the fold is building.
+        output_rows: u64,
+        /// Where the fold now stands: the next partition it has not
+        /// processed.
+        cursor: String,
+        /// Whether this slice dropped what the frozen floor allows.
+        drops: MetadataFoldSliceDrops,
+        manifest_id: ManifestId,
+    },
+    /// A partial fold's last publication: the runs it merged left the
+    /// manifest, the run it built took their place, and its progress state
+    /// cleared.
+    PartialFoldCompleted {
+        families: Vec<MetadataTableFamily>,
+        output_segments: usize,
+        output_rows: u64,
         manifest_id: ManifestId,
     },
     /// The trigger fired, but no oldest-first subset that would make
@@ -141,7 +176,12 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let previous = tables.manifest();
 
     let l0_runs = l0_run_count(&previous.payload);
+    // A partial fold in flight keeps stepping whatever the trigger says.
+    // Its state is durable and only its own steps clear it, so a step that
+    // returned here would leave the fold's outputs unfinished and its group
+    // unfoldable for as long as the trigger stayed quiet.
     if l0_runs < policy.max_l0_runs.get()
+        && previous.payload.reorganize.is_none()
         && !manifest_has_partial_reorganization(tables.scan_runs.as_ref())
     {
         return Ok(MetadataReorganizeReport {
@@ -149,20 +189,37 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
         });
     }
-    let Some(group) = select_family_group(&previous.payload) else {
+    let folding_group = manifest_partial_fold_group(&previous.payload);
+    // Group selection runs once per step, so a fold in flight takes its
+    // turn like anything else rather than holding the namespace. The runs
+    // it is already merging do not count as work waiting for its group (see
+    // `select_family_group`), so a group with a fold in flight only wins a
+    // step when runs have arrived above the fold — and when no group has
+    // work waiting at all, the fold is what the step does.
+    let Some(group) = select_family_group(&previous.payload).or(folding_group) else {
         // L0 runs exist but hold no rows (empty families); nothing to fold.
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
         });
     };
+    // A group with a fold in flight folds no other way: no delta merge for
+    // it, no second fold, until the fold finishes and swaps its output in.
+    if folding_group == Some(group) {
+        return advance_partial_fold(store, namespace_id, &tables, policy, context, timer).await;
+    }
     let selection = select_reorganization_input(&tables, group, policy)
         .await
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
         })?;
     if let Some(bottom) = selection.group_bottom_over_budget {
+        // The group's oldest run no longer fits one step. Say so once, then
+        // start folding the group a slice at a time; from the next step on
+        // the fold's progress is what this group reports.
         report_group_bottom_over_budget(namespace_id, group, &bottom, policy);
+        return start_partial_fold(store, namespace_id, &tables, group, policy, context, timer)
+            .await;
     }
     let Some(input) = selection.input else {
         return Ok(MetadataReorganizeReport {
@@ -309,6 +366,128 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     }
 }
 
+/// The family group a manifest's partial fold names, or `None` when it
+/// carries no fold.
+///
+/// Manifest load already refused a state naming anything but a
+/// reorganization family group, so this only turns the stored list back into
+/// the static entry the rest of the module is written against.
+fn manifest_partial_fold_group(
+    payload: &NamespaceManifestPayload,
+) -> Option<&'static [MetadataTableFamily]> {
+    let progress = payload.reorganize.as_ref()?;
+    REORGANIZE_FAMILY_GROUPS
+        .into_iter()
+        .find(|candidate| *candidate == progress.families.as_slice())
+}
+
+/// Advances the partial fold a manifest carries by one slice, or publishes
+/// the swap that finishes it.
+async fn advance_partial_fold<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    tables: &VerifiedMetadataTables<'_, S>,
+    policy: MetadataLsmPolicy,
+    context: &MutationContext,
+    timer: &dyn MonotonicTimer,
+) -> Result<MetadataReorganizeReport> {
+    let Some(mut walk) = MetadataFoldWalk::resume_from_manifest(tables, policy).await? else {
+        return Err(CoreError::Internal(
+            "a partial fold was selected against a manifest that carries none".to_owned(),
+        ));
+    };
+    let outcome = walk
+        .advance(store, namespace_id, tables, policy, context, timer)
+        .await?;
+    Ok(partial_fold_report(namespace_id, &walk, outcome))
+}
+
+/// Starts a partial fold of `group` and runs its first slice.
+///
+/// Starting is not a step of its own. The executor publishes nothing until a
+/// slice is written, so one step both starts the fold and folds its first
+/// slice, and the manifest that step publishes carries the state a resume
+/// reads back. The budgets still hold across the pair: the start scans the
+/// group's unbind rows to freeze the set its drops read, and
+/// `MetadataFoldWalk` charges those rows against this step's row budget
+/// before it plans the slice.
+///
+/// The input is every run of the manifest that holds rows of the group.
+/// Dropping rows is only visibility-preserving over a merge that starts at
+/// the group's oldest run, and taking the whole group is also what leaves it
+/// in one run when the fold finishes.
+async fn start_partial_fold<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    tables: &VerifiedMetadataTables<'_, S>,
+    group: &'static [MetadataTableFamily],
+    policy: MetadataLsmPolicy,
+    context: &MutationContext,
+    timer: &dyn MonotonicTimer,
+) -> Result<MetadataReorganizeReport> {
+    let head = read_head_object(store, namespace_id)
+        .await
+        .map_err(CoreError::load_head)?
+        .envelope
+        .state;
+    let frozen_floor_seq = resolve_retention_floor_seq(store, &head)
+        .await
+        .map_err(CoreError::load_head)?;
+    let snapshot = tables
+        .scan_runs
+        .iter()
+        .filter(|run| run_has_group_rows(run, group))
+        .cloned()
+        .collect();
+    let mut walk =
+        MetadataFoldWalk::start(tables, group, snapshot, frozen_floor_seq, policy).await?;
+    let outcome = walk
+        .advance(store, namespace_id, tables, policy, context, timer)
+        .await?;
+    Ok(partial_fold_report(namespace_id, &walk, outcome))
+}
+
+/// Reads one partial-fold step as a reorganization report.
+fn partial_fold_report(
+    namespace_id: &NamespaceId,
+    walk: &MetadataFoldWalk,
+    outcome: MetadataFoldWalkOutcome,
+) -> MetadataReorganizeReport {
+    let families = walk.group().to_vec();
+    let outcome = match outcome {
+        MetadataFoldWalkOutcome::SlicePublished(slice) => {
+            MetadataReorganizeOutcome::PartialFoldAdvanced {
+                families,
+                partitions: slice.partitions,
+                decoded_input_rows: slice.decoded_input_rows,
+                decoded_input_bytes: slice.decoded_input_bytes,
+                output_rows: slice.output_rows,
+                // Read back from the fold rather than from the slice: this
+                // is the position the manifest now carries, which is where
+                // the next step resumes.
+                cursor: walk.progress().cursor.clone(),
+                drops: slice.drops,
+                manifest_id: slice.manifest_id,
+            }
+        }
+        MetadataFoldWalkOutcome::Completed {
+            manifest_id,
+            output_segments,
+            output_rows,
+        } => MetadataReorganizeOutcome::PartialFoldCompleted {
+            families,
+            output_segments,
+            output_rows,
+            manifest_id,
+        },
+        MetadataFoldWalkOutcome::Superseded => MetadataReorganizeOutcome::Superseded,
+    };
+    MetadataReorganizeReport {
+        namespace_id: namespace_id.clone(),
+        outcome,
+    }
+}
+
 pub(super) struct ReorganizationInput {
     pub(super) runs: Vec<MetadataRunManifest>,
     run_ids: BTreeSet<(ChangeSeq, u32)>,
@@ -329,10 +508,11 @@ pub(super) struct ReorganizationInput {
 
 /// What one selection attempt found.
 ///
-/// The saturation record travels beside the input because the caller
-/// reports it on both paths: a group whose oldest run has outgrown one
-/// step's budget still folds its newer runs, and that is exactly when an
-/// operator needs to hear that the run underneath them is frozen.
+/// The saturation record travels beside the input rather than replacing it.
+/// A group whose oldest run has outgrown one step's budget is folded a slice
+/// at a time instead of whole, which is the caller's decision to make; the
+/// delta-only window this search still finds is what the group would have
+/// merged before partial folds existed.
 pub(super) struct ReorganizationSelection {
     pub(super) input: Option<ReorganizationInput>,
     pub(super) group_bottom_over_budget: Option<OverBudgetRun>,
@@ -375,9 +555,12 @@ pub(super) struct OverBudgetRun {
 ///
 /// **The budgets pace the work; they never end it.** When no window starting
 /// at the group's oldest run can fit the budgets, the start moves past the
-/// base-tier runs that block it and the step merges the L0 runs above them
-/// on their own. The group keeps shedding runs even while the run at its
-/// bottom stays too large to fold.
+/// base-tier runs that block it and the window merges the L0 runs above them
+/// on their own, so the group keeps shedding runs. The caller has a better
+/// answer for that case now and takes it — it folds the group a slice at a
+/// time instead ([`super::partial_fold`]) — but the window is still what
+/// this search reports, and it is still the one the group would merge if the
+/// oldest run fit.
 ///
 /// Index sections are read before row payloads so the decoded-byte budget is
 /// known exactly from each data block's durable `decoded_len`; a run that
@@ -503,15 +686,16 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
 /// Says out loud that a family group's oldest run no longer fits one
 /// reorganization step.
 ///
-/// Nothing is broken when this fires and nothing stalls: folds keep merging
-/// the newer runs above the run named here. What stops is reclamation of
-/// that run's rows, because no step can rewrite a run it cannot read whole.
-/// The group's run count therefore drifts up over time. Raising
+/// Nothing is broken when this fires and nothing stalls. The step that logs
+/// this line starts a partial fold of the group, which rebuilds it a
+/// partition at a time over the steps that follow; those steps report their
+/// progress instead of repeating this line. Raising
 /// `max_decoded_input_rows_per_step` and `max_decoded_input_bytes_per_step`
-/// past the numbers in this line is the operator's lever.
+/// past the numbers here is what makes a fold like that finish in fewer
+/// steps.
 ///
-/// One line per step: a step is already the unit maintenance schedules, so
-/// the cadence of the warning is the cadence of maintenance.
+/// One line per fold: the step after this one has a fold in flight, and a
+/// group with a fold in flight never reaches the selection that logs this.
 fn report_group_bottom_over_budget(
     namespace_id: &NamespaceId,
     group: &[MetadataTableFamily],
@@ -528,8 +712,7 @@ fn report_group_bottom_over_budget(
         max_decoded_input_rows_per_step = policy.max_decoded_input_rows_per_step.get(),
         max_decoded_input_bytes_per_step = policy.max_decoded_input_bytes_per_step.get(),
         "the oldest metadata run in this family group no longer fits one reorganization step; \
-         folds skip it and merge the newer runs, so its rows are never reclaimed and the \
-         group's run count grows",
+         the group folds a slice at a time from here, over as many steps as that takes",
     );
 }
 
@@ -585,14 +768,23 @@ async fn decoded_group_run_bytes<S: ObjectStore + ?Sized>(
     Ok(decoded_bytes)
 }
 
-/// The family group with the most L0 rows to fold; ties resolve in group
-/// order. `None` when no group has L0 rows.
+/// The family group with the most L0 rows still waiting to be folded; ties
+/// resolve in group order. `None` when no group has any.
+///
+/// The L0 rows a partial fold has already taken into its input do not count
+/// for the group that fold belongs to. They are work in progress, not work
+/// waiting, and counting them would let a fold in flight win every step for
+/// as long as it ran: its input is frozen, so its count would never fall,
+/// while every other group's falls to zero the moment it folds. Leaving them
+/// out is what makes a fold share the maintenance cadence — it takes the
+/// steps no other group has work for, plus one for every run that arrives
+/// above it while it runs.
 pub(super) fn select_family_group(
     payload: &NamespaceManifestPayload,
 ) -> Option<&'static [MetadataTableFamily]> {
     REORGANIZE_FAMILY_GROUPS
         .into_iter()
-        .map(|group| (group_l0_rows(payload, group), group))
+        .map(|group| (group_unfolded_l0_rows(payload, group), group))
         .filter(|(rows, _)| *rows > 0)
         .max_by(|(left_rows, left), (right_rows, right)| {
             left_rows.cmp(right_rows).then_with(|| {
@@ -611,12 +803,24 @@ fn position_of(group: &[MetadataTableFamily]) -> usize {
         .unwrap_or(usize::MAX)
 }
 
-fn group_l0_rows(payload: &NamespaceManifestPayload, group: &[MetadataTableFamily]) -> u64 {
+fn group_unfolded_l0_rows(
+    payload: &NamespaceManifestPayload,
+    group: &[MetadataTableFamily],
+) -> u64 {
+    let in_flight: &[MetadataRunId] = match &payload.reorganize {
+        Some(progress) if progress.families == group => &progress.input_runs,
+        _ => &[],
+    };
     payload
         .metadata_files
         .iter()
         .filter(|descriptor| {
             descriptor.level == CHECKPOINT_L0_RUN_LEVEL && group.contains(&descriptor.family)
+        })
+        .filter(|descriptor| {
+            !in_flight
+                .iter()
+                .any(|run| run.run_seq == descriptor.run_seq && run.level == descriptor.level)
         })
         .map(|descriptor| descriptor.row_count)
         .sum()
@@ -645,9 +849,11 @@ async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
         next_inode_id: previous.payload.next_inode_id,
         retention_floor_seq,
         metadata_files,
-        // Nothing produces a partial fold yet; a whole-group fold clears
-        // the field it never set.
-        reorganize: None,
+        // A whole-group fold only ever runs for a group with no partial
+        // fold in flight, so any fold the manifest carries belongs to some
+        // other group and travels forward untouched. Dropping it here would
+        // strand that group's outputs and leave its base frozen.
+        reorganize: previous.payload.reorganize.clone(),
     })
     .map_err(|err| CoreError::Internal(format!("failed to build reorganized manifest: {err}")))?;
     write_namespace_manifest(store, &manifest)

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -225,8 +225,11 @@ async fn checkpoint_then_reorganize<S: ObjectStore + ?Sized>(
     drain_reorganization(store, namespace_id, context, policy).await
 }
 
-/// Runs reorganization units until nothing is left to fold, with the
+/// Runs reorganization steps until nothing is left to fold, with the
 /// trigger forced so even one L0 run folds.
+///
+/// Whether a group folds whole or a slice at a time is the step's decision,
+/// so both count as work here and the loop just keeps going.
 async fn drain_reorganization<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -243,6 +246,8 @@ async fn drain_reorganization<S: ObjectStore + ?Sized>(
             .expect("reorganization step");
         match report.outcome {
             super::MetadataReorganizeOutcome::UnitPublished { .. }
+            | super::MetadataReorganizeOutcome::PartialFoldAdvanced { .. }
+            | super::MetadataReorganizeOutcome::PartialFoldCompleted { .. }
             | super::MetadataReorganizeOutcome::Superseded => continue,
             super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
             super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {

--- a/crates/loonfs-core/src/checkpoint/tests/partial_fold.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/partial_fold.rs
@@ -1,6 +1,6 @@
 //! Folding a family group one slice at a time: the partition grammar, the
-//! walk executor, and the oracle that says a walk and a whole-group fold
-//! reach the same place.
+//! walk executor, the oracle that says a walk and a whole-group fold reach
+//! the same place, and the whole arc through the maintenance step.
 
 use super::super::partial_fold::{
     MetadataFoldSliceDrops, MetadataFoldSliceReport, MetadataFoldWalk, MetadataFoldWalkOutcome,
@@ -9,6 +9,9 @@ use super::super::partition::{GroupPartitioning, PartitionCursor, PartitionKey};
 use super::super::row::manifest_row_commit_seq;
 use super::super::scan::VerifiedMetadataTables;
 use super::*;
+use crate::path::read::{
+    load_metadata_view, resolve_current_files, CurrentFileState, ReadLoadContext,
+};
 use crate::timing::StdMonotonicTimer;
 use loonfs_api::wire::manifest::{
     ActiveDeletionRowAction, TombstoneGeneration, TombstoneRowAction,
@@ -1088,4 +1091,593 @@ async fn the_completing_step_swaps_the_snapshot_for_the_run_it_built() {
             .expect("the manifest names files"),
         "the swap must restate the manifest's oldest run"
     );
+}
+
+// -------------------------------------------------------------------------
+// Through the maintenance step
+// -------------------------------------------------------------------------
+
+async fn write_seed_file(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    directory: u64,
+    file: u64,
+) {
+    write_file_bytes(
+        store,
+        namespace_id,
+        &format!("/d{directory}/f{file}.txt"),
+        format!("body {directory}/{file}\n").as_bytes(),
+        &test_context(),
+        None,
+    )
+    .await
+    .expect("write file");
+}
+
+/// A namespace whose bindings group cannot be folded in one step.
+///
+/// Three things have to line up for the whole arc to be visible. The base
+/// run must be larger than the budget, or nothing starts a partial fold.
+/// Delta runs must sit above it, or there is nothing left to merge normally
+/// afterwards. And most of the group's rows must be churn below the
+/// retention floor, so that folding the group shrinks it back under the
+/// budget and the condition that started the fold stops holding.
+///
+/// The base is cut into small segments on purpose: a slice stops at a
+/// partition boundary the planner can see in a segment index, so many small
+/// segments give it many places to stop.
+async fn seed_over_budget_bindings_group(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+) -> MetadataLsmPolicy {
+    let context = test_context();
+    bootstrap_namespace(store, namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    for directory in 0..7u64 {
+        for file in 0..4u64 {
+            write_seed_file(store, namespace_id, directory, file).await;
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint");
+    }
+    let seed_policy = MetadataLsmPolicy {
+        max_rows_per_segment: NonZeroUsize::new(8).expect("nonzero"),
+        ..MetadataLsmPolicy::default()
+    };
+    drain_reorganization(store, namespace_id, &context, seed_policy).await;
+
+    for directory in 7..10u64 {
+        for file in 0..4u64 {
+            write_seed_file(store, namespace_id, directory, file).await;
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint");
+    }
+    for directory in 0..10u64 {
+        for file in 0..3u64 {
+            delete_path(
+                store,
+                namespace_id,
+                &format!("/d{directory}/f{file}.txt"),
+                &context,
+                None,
+            )
+            .await
+            .expect("delete file");
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint the deletions");
+    }
+    advance_retention_floor(store, namespace_id, &context)
+        .await
+        .expect("advance the floor past the deletions");
+
+    // One last delta run, written above the floor, so the fold has rows it
+    // must carry through untouched as well as rows it may drop.
+    for file in 0..2u64 {
+        write_seed_file(store, namespace_id, 10, file).await;
+    }
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the late writes");
+    seed_policy
+}
+
+/// A budget one row short of what the group's base run needs, which is the
+/// condition that starts a partial fold.
+async fn policy_that_cannot_fold_the_group_base(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    group: &[ApiMetadataTableFamily],
+    seed_policy: MetadataLsmPolicy,
+) -> MetadataLsmPolicy {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    let base_rows: u64 = tables
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| {
+            descriptor.level == CHECKPOINT_BASE_RUN_LEVEL && group.contains(&descriptor.family)
+        })
+        .map(|descriptor| descriptor.row_count)
+        .sum();
+    assert!(base_rows > 1, "the base run must hold rows in this group");
+    MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(
+            usize::try_from(base_rows).expect("test row counts are small") - 1,
+        )
+        .expect("nonzero"),
+        ..seed_policy
+    }
+}
+
+/// Whether the step would warn about this group's oldest run.
+///
+/// The step logs one line when the selector reports an over-budget bottom,
+/// and the selector's record is what that line reads from, so asserting on
+/// the record is how these tests pin the warning.
+async fn group_bottom_is_over_budget(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    group: &[ApiMetadataTableFamily],
+    policy: MetadataLsmPolicy,
+) -> bool {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    reorganize::select_reorganization_input(&tables, group, policy)
+        .await
+        .expect("select a reorganization input")
+        .group_bottom_over_budget
+        .is_some()
+}
+
+/// The group's segment keys that a fold in flight is not merging: the runs
+/// that arrived above its snapshot after it started.
+async fn group_segment_keys_outside_the_fold(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    group: &[ApiMetadataTableFamily],
+) -> BTreeSet<String> {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    let payload = &tables.manifest().payload;
+    let progress = payload
+        .reorganize
+        .clone()
+        .expect("a fold must be in flight to have anything outside it");
+    payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| group.contains(&descriptor.family))
+        .filter(|descriptor| {
+            !progress
+                .input_runs
+                .iter()
+                .any(|run| run.run_seq == descriptor.run_seq && run.level == descriptor.level)
+        })
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect()
+}
+
+async fn manifest_segment_keys(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+) -> BTreeSet<String> {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    tables
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect()
+}
+
+/// What a reader sees right now: every inode the namespace knows, resolved
+/// the way a read resolves it — visible or not, at what path, at what
+/// revision.
+///
+/// This is the answer that must not move while a fold runs. Comparing rows
+/// would say the opposite of what is wanted: a fold drops rows precisely
+/// because no read can observe them, so the row set is meant to change and
+/// this is not.
+async fn visible_namespace(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+) -> Vec<CurrentFileState> {
+    let inode_ids: Vec<InodeId> = current_metadata_state(store, namespace_id)
+        .await
+        .inodes()
+        .iter()
+        .map(|inode| inode.inode_id)
+        .collect();
+    let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+        .await
+        .expect("load the read view");
+    resolve_current_files(&view, &inode_ids)
+        .await
+        .expect("resolve every inode the namespace knows")
+}
+
+/// The binding one row names: what an unbind retires, and what a bind is.
+fn binding_generation(row: &MetadataRow) -> Option<(InodeId, NameKey, ChangeSeq, u32)> {
+    match row {
+        MetadataRow::DirentryUnbind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        }
+        | MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } => Some((
+            *parent_inode_id,
+            name_key.clone(),
+            *bind_seq,
+            *bind_delta_index,
+        )),
+        _ => None,
+    }
+}
+
+/// The whole arc, driven through the entry point the maintenance runner
+/// calls rather than through the executor.
+///
+/// A group whose oldest run no longer fits one step is warned about once,
+/// folded a slice at a time over the steps that follow, and left in one run
+/// that the delta runs arriving meanwhile then merge with normally. Nothing
+/// a reader can see moves anywhere along the way, the other groups keep
+/// folding while it runs, and the warning stops once the group fits again.
+#[tokio::test]
+async fn an_over_budget_group_folds_through_repeated_maintenance_steps() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let seed_policy = seed_over_budget_bindings_group(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let policy =
+        policy_that_cannot_fold_the_group_base(&store, &namespace_id, group, seed_policy).await;
+
+    assert!(
+        group_bottom_is_over_budget(&store, &namespace_id, group, policy).await,
+        "the warning must fire before anything folds this group"
+    );
+    let rows_before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    let mut visible = visible_namespace(&store, &namespace_id).await;
+    assert!(
+        visible.iter().any(|state| state.visible),
+        "the seed must leave something to read"
+    );
+
+    let mut slices = 0usize;
+    let mut written_rows = 0u64;
+    let mut cursors = Vec::new();
+    let mut completed = false;
+    let mut other_groups_folded_during_the_fold = 0usize;
+    let mut group_merged_after_the_fold = 0usize;
+    let mut arrived_segment_keys = BTreeSet::new();
+
+    for _step in 0..256 {
+        let report = reorganize_metadata_step(&store, &namespace_id, &context, policy)
+            .await
+            .expect("reorganization step");
+        match report.outcome {
+            MetadataReorganizeOutcome::PartialFoldAdvanced {
+                ref families,
+                partitions,
+                decoded_input_rows,
+                output_rows,
+                ref cursor,
+                drops,
+                ..
+            } => {
+                assert_eq!(families, group, "only this group folds in slices here");
+                assert!(partitions > 0, "a slice must cover at least one partition");
+                assert!(
+                    decoded_input_rows > 0,
+                    "a slice must read the rows it covers"
+                );
+                // A slice may keep nothing: every row in its partitions can
+                // be churn the frozen floor lets go.
+                written_rows += output_rows;
+                assert_eq!(
+                    drops,
+                    MetadataFoldSliceDrops::Applied,
+                    "this budget leaves room for the unbind set"
+                );
+                cursors.push(cursor.clone());
+                slices += 1;
+                if slices == 1 {
+                    // A delta run arrives while the fold is running, under
+                    // the root inode, which is a partition the fold has
+                    // already passed. It is not in the fold's snapshot, so
+                    // the fold never reads it and the swap must land
+                    // underneath it.
+                    write_file_bytes(
+                        &store,
+                        &namespace_id,
+                        "/arrived-mid-fold.txt",
+                        b"arrived mid-fold\n",
+                        &context,
+                        None,
+                    )
+                    .await
+                    .expect("write a file while the fold runs");
+                    create_checkpoint(&store, &namespace_id, &context)
+                        .await
+                        .expect("checkpoint it");
+                    arrived_segment_keys =
+                        group_segment_keys_outside_the_fold(&store, &namespace_id, group).await;
+                    assert!(
+                        !arrived_segment_keys.is_empty(),
+                        "the arriving run must sit outside the fold's input"
+                    );
+                    visible = visible_namespace(&store, &namespace_id).await;
+                }
+            }
+            MetadataReorganizeOutcome::PartialFoldCompleted {
+                ref families,
+                output_segments,
+                output_rows,
+                ..
+            } => {
+                assert_eq!(families, group);
+                assert!(!completed, "the fold must finish exactly once");
+                assert!(output_segments > 0);
+                assert_eq!(
+                    output_rows, written_rows,
+                    "the finished run must hold what every slice wrote and nothing else"
+                );
+                completed = true;
+                let referenced = manifest_segment_keys(&store, &namespace_id).await;
+                assert!(
+                    arrived_segment_keys.is_subset(&referenced),
+                    "runs that arrived while the fold ran must survive the swap"
+                );
+            }
+            MetadataReorganizeOutcome::UnitPublished { ref families, .. } => {
+                if families == group {
+                    assert!(
+                        completed,
+                        "this group folds no other way while its fold is in flight"
+                    );
+                    group_merged_after_the_fold += 1;
+                } else if !completed {
+                    other_groups_folded_during_the_fold += 1;
+                }
+            }
+            MetadataReorganizeOutcome::NotNeeded { .. } => break,
+            MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                panic!("the group parked instead of folding a slice at a time")
+            }
+            MetadataReorganizeOutcome::Superseded => {
+                panic!("no concurrent publisher exists in this test")
+            }
+        }
+        assert_eq!(
+            visible_namespace(&store, &namespace_id).await,
+            visible,
+            "a step changed what a read answers"
+        );
+    }
+
+    assert!(
+        slices > 1,
+        "the fold must take several slices, got {slices}"
+    );
+    assert!(completed, "the fold must finish");
+    let mut ascending = cursors.clone();
+    ascending.sort();
+    ascending.dedup();
+    assert_eq!(
+        cursors, ascending,
+        "every slice must leave the fold further along than it found it"
+    );
+    assert!(
+        other_groups_folded_during_the_fold > 0,
+        "the other groups must keep folding while one group folds in slices"
+    );
+    assert!(
+        group_merged_after_the_fold > 0,
+        "the runs that arrived during the fold must merge normally once it finishes"
+    );
+
+    // The base is folded: the group is left in the one run the fold built.
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let after_payload = tables.manifest().payload.clone();
+    drop(tables);
+    assert!(after_payload.reorganize.is_none());
+    let group_runs: BTreeSet<(ChangeSeq, u32)> = after_payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| group.contains(&descriptor.family))
+        .map(|descriptor| (descriptor.run_seq, descriptor.level))
+        .collect();
+    assert_eq!(
+        group_runs.len(),
+        1,
+        "the group must end in one run, got {group_runs:?}"
+    );
+
+    // Retention reclaimed the churn: every spent unbind marker went, and so
+    // did the binding each one retired.
+    let rows_after = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    let retired: BTreeSet<_> = rows_before[&ApiMetadataTableFamily::DirentryUnbinds]
+        .iter()
+        .filter_map(binding_generation)
+        .collect();
+    assert!(
+        !retired.is_empty(),
+        "the seed must delete files for this to mean anything"
+    );
+    assert!(
+        rows_after[&ApiMetadataTableFamily::DirentryUnbinds].is_empty(),
+        "every unbind marker sat at or below the floor and must have gone"
+    );
+    for family in [
+        ApiMetadataTableFamily::DirentryBinds,
+        ApiMetadataTableFamily::DirentryChildBinds,
+    ] {
+        for row in &rows_after[&family] {
+            assert!(
+                binding_generation(row).is_none_or(|generation| !retired.contains(&generation)),
+                "a retired binding survived the fold in {family:?}"
+            );
+        }
+    }
+
+    // And the condition that started the fold no longer holds: the group
+    // fits one step again, so nothing warns about it.
+    write_seed_file(&store, &namespace_id, 11, 0).await;
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint one more delta run");
+    assert!(
+        !group_bottom_is_over_budget(&store, &namespace_id, group, policy).await,
+        "the folded group fits one step again, so the warning must stop"
+    );
+}
+
+/// One step's tally, and whether the namespace has gone quiet.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct DriveTally {
+    slices: usize,
+    completions: usize,
+    units: usize,
+}
+
+impl DriveTally {
+    fn record(&mut self, outcome: &MetadataReorganizeOutcome) -> bool {
+        match outcome {
+            MetadataReorganizeOutcome::PartialFoldAdvanced { .. } => self.slices += 1,
+            MetadataReorganizeOutcome::PartialFoldCompleted { .. } => self.completions += 1,
+            MetadataReorganizeOutcome::UnitPublished { .. } => self.units += 1,
+            MetadataReorganizeOutcome::NotNeeded { .. } => return true,
+            other => panic!("unexpected reorganization outcome {other:?}"),
+        }
+        false
+    }
+}
+
+async fn drive_reorganization_to_quiescence(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+) -> DriveTally {
+    let mut tally = DriveTally::default();
+    for _step in 0..256 {
+        let report = reorganize_metadata_step(store, namespace_id, context, policy)
+            .await
+            .expect("reorganization step");
+        if tally.record(&report.outcome) {
+            return tally;
+        }
+    }
+    panic!("reorganization did not go quiet in a bounded number of steps")
+}
+
+/// The same arc with nothing carried between steps but the store.
+///
+/// A step already rebuilds everything it needs from durable state, so the
+/// harsher version of a crash is to throw the store handle away as well and
+/// build a new one over the same directory before every step. The fold must
+/// land where an uninterrupted one lands.
+#[tokio::test]
+async fn a_fold_through_maintenance_steps_resumes_from_the_store_alone() {
+    let straight_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(straight_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let seed_policy = seed_over_budget_bindings_group(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let policy =
+        policy_that_cannot_fold_the_group_base(&store, &namespace_id, group, seed_policy).await;
+
+    let resumed_dir = tempdir().expect("tempdir");
+    copy_store_tree(straight_dir.path(), resumed_dir.path());
+
+    let straight =
+        drive_reorganization_to_quiescence(&store, &namespace_id, &context, policy).await;
+    let mut resumed = DriveTally::default();
+    let mut quiet = false;
+    for _step in 0..256 {
+        // Everything a step could have remembered dies here: the handle,
+        // its caches, and the fold it was running.
+        let rebuilt = LocalFsStore::new(resumed_dir.path()).expect("rebuild the store handle");
+        let report = reorganize_metadata_step(&rebuilt, &namespace_id, &context, policy)
+            .await
+            .expect("reorganization step");
+        if resumed.record(&report.outcome) {
+            quiet = true;
+            break;
+        }
+    }
+    assert!(quiet, "the rebuilt run must go quiet too");
+
+    assert!(straight.slices > 1);
+    assert_eq!(
+        straight, resumed,
+        "a fold rebuilt at every step must take the same steps"
+    );
+    let resumed_store = LocalFsStore::new(resumed_dir.path()).expect("store");
+    assert_eq!(
+        group_rows_of_current_manifest(&store, &namespace_id, group).await,
+        group_rows_of_current_manifest(&resumed_store, &namespace_id, group).await,
+        "a fold rebuilt at every step must keep the same rows"
+    );
+    assert_eq!(
+        visible_namespace(&store, &namespace_id).await,
+        visible_namespace(&resumed_store, &namespace_id).await,
+        "and must answer reads the same way"
+    );
+}
+
+/// The drops mode reaches the step's report, including the one that says the
+/// fold is only rebuilding the run.
+///
+/// An operator watching a fold needs to tell a fold that is reclaiming rows
+/// from one that is not, and the executor keeps a distinct answer for the
+/// case that produces the second: an unbind set too large to hold.
+#[tokio::test]
+async fn a_step_reports_a_fold_that_is_only_rewriting_the_run() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_bindings_workload(&store, &namespace_id).await;
+
+    // A byte budget too small for even one unbind entry, which is also too
+    // small for any run, so the group folds a slice at a time.
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
+        ..MetadataLsmPolicy::default()
+    };
+    let report = reorganize_metadata_step(&store, &namespace_id, &context, policy)
+        .await
+        .expect("reorganization step");
+    let MetadataReorganizeOutcome::PartialFoldAdvanced {
+        families, drops, ..
+    } = report.outcome
+    else {
+        panic!("a group no run of which fits one step must fold in slices")
+    };
+    assert_eq!(
+        families,
+        group_containing(ApiMetadataTableFamily::DirentryUnbinds)
+    );
+    assert_eq!(drops, MetadataFoldSliceDrops::UnbindSetOverBound);
 }

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -150,6 +150,10 @@ async fn drain_reorganization_with_count<S: ObjectStore + ?Sized>(
             super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
                 panic!("test budget must admit a progress-making subset")
             }
+            super::MetadataReorganizeOutcome::PartialFoldAdvanced { .. }
+            | super::MetadataReorganizeOutcome::PartialFoldCompleted { .. } => {
+                panic!("this budget admits every group whole; no partial fold should start")
+            }
             super::MetadataReorganizeOutcome::NotNeeded { .. } => {
                 return (current_manifest_id(store, namespace_id).await, published);
             }
@@ -808,6 +812,10 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
             super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
                 panic!("test reorganization budget should admit a progress-making subset")
             }
+            super::MetadataReorganizeOutcome::PartialFoldAdvanced { .. }
+            | super::MetadataReorganizeOutcome::PartialFoldCompleted { .. } => {
+                panic!("this budget admits every group whole; no partial fold should start")
+            }
         }
     }
     assert!(units >= 2, "several family groups should fold, got {units}");
@@ -855,27 +863,31 @@ async fn reorganization_step_honors_run_row_and_decoded_byte_budgets() {
             .expect("create checkpoint");
     }
 
-    let root_before = current_manifest_id(&store, &namespace_id).await;
     let tiny_byte_policy = MetadataLsmPolicy {
         max_l0_runs: NonZeroUsize::MIN,
         max_input_runs_per_step: NonZeroUsize::new(2).expect("test run budget should be nonzero"),
         max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
+    // Selection, not a step: one byte admits no run whole, and what a step
+    // does about that is the partial fold's business, tested with the fold.
+    // What is pinned here is the price of finding out.
     store.reset();
-    let blocked =
-        super::reorganize_metadata_step(&store, &namespace_id, &context, tiny_byte_policy)
-            .await
-            .expect("budgeted step");
-    let super::MetadataReorganizeOutcome::BudgetExhausted { families, .. } = blocked.outcome else {
-        panic!("one byte must not admit an SST run");
-    };
-    assert_eq!(
-        current_manifest_id(&store, &namespace_id).await,
-        root_before,
-        "a budget-blocked step must not publish"
+    let (families, selection) =
+        select_reorganization_window(&store, &namespace_id, tiny_byte_policy).await;
+    assert!(
+        selection.input.is_none(),
+        "one byte must not admit an SST run"
     );
-    assert_eq!(store.count(OperationClass::Put), 0);
+    assert!(
+        selection.group_bottom_over_budget.is_some(),
+        "the group's oldest run must be reported as over budget"
+    );
+    assert_eq!(
+        store.count(OperationClass::Put),
+        0,
+        "selection writes nothing"
+    );
     assert!(
         store.count(OperationClass::Read) <= families.len(),
         "byte preflight should read only the oldest candidate's index sections"
@@ -1279,6 +1291,10 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
             super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
                 panic!("test reorganization budget should admit a progress-making subset")
             }
+            super::MetadataReorganizeOutcome::PartialFoldAdvanced { .. }
+            | super::MetadataReorganizeOutcome::PartialFoldCompleted { .. } => {
+                panic!("this budget admits every group whole; no partial fold should start")
+            }
         }
     }
     assert!(folded_groups.len() >= 2);
@@ -1550,16 +1566,35 @@ fn policy_that_cannot_fold_the_base(base_rows: u64) -> MetadataLsmPolicy {
     }
 }
 
+/// A per-step row budget that admits the group's base run on its own but
+/// nothing above it, so the only window that makes progress starts above the
+/// base. The base still fits one step, so nothing here starts a partial
+/// fold.
+fn policy_that_folds_only_above_the_base(base_rows: u64) -> MetadataLsmPolicy {
+    let row_budget = usize::try_from(base_rows).expect("test row counts are small");
+    MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(row_budget)
+            .expect("test row budget should be nonzero"),
+        ..MetadataLsmPolicy::default()
+    }
+}
+
 /// A group whose base run alone busts the per-step row budget used to park
 /// forever: selection broke on the first candidate, chose nothing, and
 /// reported the group blocked on every step after that while delta runs
 /// piled up behind it with nothing saying why.
 ///
-/// The budget paces the work instead of ending it. The step skips the base
-/// run it cannot read whole, merges the delta runs above it, and says out
-/// loud that the base has outgrown the budget.
+/// The budget paces the work instead of ending it. The step says out loud
+/// that the base has outgrown the budget and then folds the group a slice at
+/// a time, so the base is rebuilt rather than skipped and the group ends up
+/// in one run.
+///
+/// The window that skips the base is still what the selector reports — that
+/// part of the search has not changed — but the step has a better answer for
+/// it now and takes that instead.
 #[tokio::test]
-async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
+async fn a_base_run_over_the_step_budget_folds_the_group_a_slice_at_a_time() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1589,7 +1624,7 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
         current_manifest_id(&store, &namespace_id).await,
     )
     .await
-    .expect("load the parked manifest");
+    .expect("load the manifest the group starts from");
     let (group, _) =
         select_reorganization_window(&store, &namespace_id, MetadataLsmPolicy::default()).await;
     let base = base_run(&before.manifest);
@@ -1598,6 +1633,9 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
     assert!(base_rows > 1, "the base run must hold rows in this group");
     let policy = policy_that_cannot_fold_the_base(base_rows);
 
+    // The selector is unchanged: it still reports the over-budget bottom —
+    // which is what the step warns about — and still finds the delta-only
+    // window the group used to merge instead.
     let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
     let input = selection
         .input
@@ -1629,16 +1667,33 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
     assert_eq!(bottom.level, CHECKPOINT_BASE_RUN_LEVEL);
     assert_eq!(bottom.rows, base_rows);
 
-    // Repeated steps keep draining the group. The base run stays exactly
-    // where it is.
-    let mut published = 0usize;
+    // Repeated steps keep the group moving. Nothing parks, and the fold of
+    // the group runs a slice at a time until it swaps its finished run in.
+    let mut slices = 0usize;
+    let mut completions = 0usize;
+    let mut units = 0usize;
+    let mut cursors = Vec::new();
     let mut group_l0_runs = vec![l0_runs(&before.manifest).len()];
     for _ in 0..64 {
         let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
             .await
             .expect("reorganization step");
         match report.outcome {
-            super::MetadataReorganizeOutcome::UnitPublished { .. } => published += 1,
+            super::MetadataReorganizeOutcome::UnitPublished { .. } => units += 1,
+            super::MetadataReorganizeOutcome::PartialFoldAdvanced {
+                families, cursor, ..
+            } => {
+                assert_eq!(
+                    families, group,
+                    "only the over-budget group folds in slices"
+                );
+                slices += 1;
+                cursors.push(cursor);
+            }
+            super::MetadataReorganizeOutcome::PartialFoldCompleted { families, .. } => {
+                assert_eq!(families, group);
+                completions += 1;
+            }
             super::MetadataReorganizeOutcome::Superseded => {
                 panic!("no concurrent publisher exists in this test")
             }
@@ -1656,7 +1711,16 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
         .expect("load the folded manifest");
         group_l0_runs.push(l0_runs(&current.manifest).len());
     }
-    assert!(published > 0, "at least one unit must publish");
+    assert!(slices > 0, "the over-budget group must fold in slices");
+    assert_eq!(completions, 1, "the fold must finish exactly once");
+    assert!(units > 0, "the groups that fit must still fold whole");
+    let mut ascending = cursors.clone();
+    ascending.sort();
+    ascending.dedup();
+    assert_eq!(
+        cursors, ascending,
+        "every slice must leave the fold further along than it found it"
+    );
 
     let after = load_manifest_materialization_for_inspection(
         &store,
@@ -1667,7 +1731,7 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
     .expect("load the drained manifest");
     assert!(
         l0_runs(&after.manifest).is_empty(),
-        "delta runs must drain even with the base frozen, ran {group_l0_runs:?}"
+        "delta runs must drain, ran {group_l0_runs:?}"
     );
     assert!(
         runs_from_metadata_files(&after.manifest.payload).len()
@@ -1677,10 +1741,23 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
     let remaining = run_segment_object_keys(&after.manifest);
     for segment in &base_segments {
         assert!(
-            remaining.contains(segment),
-            "the base run this step could not read must stay referenced untouched"
+            !remaining.contains(segment),
+            "the base run no step could read whole must be rebuilt, not left behind"
         );
     }
+    let group_runs: BTreeSet<(ChangeSeq, u32)> = after
+        .manifest
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| group.contains(&descriptor.family))
+        .map(|descriptor| (descriptor.run_seq, descriptor.level))
+        .collect();
+    assert_eq!(
+        group_runs.len(),
+        1,
+        "the fold must leave the group in one run, got {group_runs:?}"
+    );
     let projection = load_current_projection(&store, &namespace_id)
         .await
         .expect("materialization");
@@ -1696,6 +1773,11 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
 /// the bind it names, and both have to leave together. A window that starts
 /// above the base cannot see the bind at all, so dropping the unbind there
 /// would put a deleted file back. The step merges without dropping instead.
+///
+/// This is also the normal path a partial fold leaves alone. The budget here
+/// admits the group's base run on its own, so nothing reports an over-budget
+/// bottom and nothing starts a fold in slices: the step merges the delta
+/// runs above the base, exactly as it always did.
 #[tokio::test]
 async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1773,12 +1855,16 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
         "this test is about the binding families, got {group:?}"
     );
     let base_rows = group_run_rows(&base_run(&before.manifest), &group);
-    let policy = policy_that_cannot_fold_the_base(base_rows);
+    let policy = policy_that_folds_only_above_the_base(base_rows);
 
     let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
     let input = selection.input.expect("the delta runs must still merge");
     assert!(!input.starts_at_group_bottom);
     assert!(input.runs.len() > 1);
+    assert!(
+        selection.group_bottom_over_budget.is_none(),
+        "the base fits one step here, so nothing should fold this group in slices"
+    );
 
     let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
         .await

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -177,8 +177,8 @@ pub mod publish {
 // `MetadataReorganizeReport` has no caller that names it; it stays public
 // because it is the return type of `NamespaceEngine::reorganize_metadata`.
 pub use checkpoint::{
-    CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, MetadataReorganizeOutcome,
-    MetadataReorganizeReport,
+    CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, MetadataFoldSliceDrops,
+    MetadataReorganizeOutcome, MetadataReorganizeReport,
 };
 pub use context::MutationContext;
 pub use engine::RuntimeReadContext;

--- a/crates/loonfs-core/tests/it/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/it/visibility_equivalence.rs
@@ -896,6 +896,10 @@ async fn drain_reorganization(
             MetadataReorganizeOutcome::BudgetExhausted { .. } => {
                 panic!("default budget must admit the visibility scenario")
             }
+            MetadataReorganizeOutcome::PartialFoldAdvanced { .. }
+            | MetadataReorganizeOutcome::PartialFoldCompleted { .. } => {
+                panic!("default budget must admit every group whole in this scenario")
+            }
         }
     }
     panic!("reorganization did not drain within the family-group bound");

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -380,6 +380,36 @@ all. Any other value fails the process rather than being guessed at.
 and leaves the rest alone. `LOONFS_TRACE=off` silences the output whatever
 `RUST_LOG` says.
 
+### Metadata folds that take several steps
+
+Background maintenance rewrites a namespace's metadata into fewer files as
+it goes. It does that one group of metadata at a time, and one step reads a
+whole group. A group that has grown past what one step may read is handled
+differently, and it logs three kinds of line.
+
+The first is a warning saying that the oldest metadata run in a family group
+no longer fits one reorganization step. It names the group, the run, how many
+rows and bytes that run holds, and the two per-step budgets it did not fit.
+It is logged once, on the step that decides to rebuild that group a slice at
+a time.
+
+After that, the same group logs `metadata partial fold advanced` on every
+step it gets, saying how many partitions the step covered, how many rows it
+read and wrote, and where it has reached. A final `metadata partial fold
+completed` says the group has been rebuilt into one file set.
+
+Nothing needs doing about any of this. The rebuild records where it is in the
+namespace manifest, so it survives restarts and picks up where it stopped;
+the other groups keep being maintained on the steps in between; and reads
+answer exactly the same thing from the first step to the last. A large
+namespace can spend many steps here, which is expected — the warning is
+saying the work is now paced, not that it is stuck.
+
+The two budgets the warning names are what set that pace: a step folds as
+much as they allow and no more. This build does not expose them in the
+config, so the way to finish a long rebuild sooner is to run maintenance
+steps more often rather than to make each one bigger.
+
 ## The optional local cache
 
 The server can keep encoded metadata blocks on this machine's disk, in front

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -196,7 +196,13 @@ impl FsAdmin {
             loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. } => {
                 ReorganizeStepOutcome::NotNeeded
             }
-            loonfs_core::MetadataReorganizeOutcome::UnitPublished { .. } => {
+            loonfs_core::MetadataReorganizeOutcome::UnitPublished { .. }
+            // A partial fold's steps each publish a manifest and each move
+            // the group along, so they read as published units at the
+            // coarseness this outcome carries. What they did in detail is in
+            // the log line `run_reorganization` writes.
+            | loonfs_core::MetadataReorganizeOutcome::PartialFoldAdvanced { .. }
+            | loonfs_core::MetadataReorganizeOutcome::PartialFoldCompleted { .. } => {
                 ReorganizeStepOutcome::UnitPublished
             }
             loonfs_core::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
@@ -215,6 +221,10 @@ impl FsAdmin {
     /// `loonfs-core`'s `reorganize_metadata`). Explicit steps stay bounded at
     /// one unit per call; the returned outcome lets writer-scheduled
     /// background work keep folding until nothing is left.
+    ///
+    /// A family group whose oldest run no longer fits one step folds a slice
+    /// at a time instead, over as many steps as that takes. Those steps
+    /// publish a manifest each and report their progress here.
     async fn run_reorganization(
         &self,
         namespace_id: &NamespaceId,
@@ -242,6 +252,42 @@ impl FsAdmin {
                     decoded_input_rows,
                     decoded_input_bytes,
                     "metadata reorganization unit published"
+                );
+            }
+            loonfs_core::MetadataReorganizeOutcome::PartialFoldAdvanced {
+                families,
+                partitions,
+                decoded_input_rows,
+                decoded_input_bytes,
+                output_rows,
+                cursor,
+                drops,
+                ..
+            } => {
+                self.invalidate_namespace(namespace_id);
+                tracing::info!(
+                    families = ?families,
+                    partitions,
+                    decoded_input_rows,
+                    decoded_input_bytes,
+                    output_rows,
+                    cursor = cursor.as_str(),
+                    drops = ?drops,
+                    "metadata partial fold advanced"
+                );
+            }
+            loonfs_core::MetadataReorganizeOutcome::PartialFoldCompleted {
+                families,
+                output_segments,
+                output_rows,
+                ..
+            } => {
+                self.invalidate_namespace(namespace_id);
+                tracing::info!(
+                    families = ?families,
+                    output_segments,
+                    output_rows,
+                    "metadata partial fold completed"
                 );
             }
             loonfs_core::MetadataReorganizeOutcome::BudgetExhausted { families, .. } => {


### PR DESCRIPTION
This integrates partial folds with metadata maintenance. When the oldest run for a family group cannot fit in a normal reorganization step, maintenance starts or advances a partial fold instead of leaving the base run unchanged.

The first partition range is processed in the same step that starts the operation. While a family group has active progress, it cannot run delta merges or start another fold. Other family groups continue normal reorganization. Input runs already assigned to the operation are excluded from pending-work ranking, newer runs remain outside the operation, and unrelated whole-group folds preserve the progress state. Maintenance results report partitions, rows read and written, cursor progress, retention behavior, and completion. The operator documentation explains these fields.

End-to-end tests cover an oversized bindings base, retention cleanup, a delta run published during the operation, progress by other family groups, restart between maintenance steps, unchanged read results, and normal delta merging after completion. Budget-selection regression tests continue to verify row and decoded-byte preflight behavior.
