### PR TITLE
fix(checkpoint): a merge output is base-tier only when its window is bottom-anchored

### DIFF
--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -12,7 +12,10 @@ use super::cache::{
 use super::error::ManifestLoadError;
 use super::partial_fold::parse_row_digest;
 use super::partition::{GroupPartitioning, PartitionCursor};
-use super::runs::{runs_in_materialization_order, runs_in_scan_order, REORGANIZE_FAMILY_GROUPS};
+use super::runs::{
+    runs_in_materialization_order, runs_in_scan_order, MetadataRunManifest,
+    CHECKPOINT_L0_RUN_LEVEL, REORGANIZE_FAMILY_GROUPS,
+};
 use super::scan::{ordered_manifest_tables, VerifiedMetadataTables};
 use super::validate::{validate_manifest_materialization_ranges, validate_namespace_manifest};
 use crate::error::{CoreError, MetadataProjectionLoadError};
@@ -333,7 +336,9 @@ fn validate_manifest_table_descriptors(
     manifest_object_key: &str,
     manifest: &NamespaceManifestEnvelope,
 ) -> Result<(), ManifestLoadError> {
-    for run in runs_in_materialization_order(&manifest.payload) {
+    let runs = runs_in_materialization_order(&manifest.payload);
+    validate_one_base_run_per_family_group(manifest_object_key, &runs)?;
+    for run in &runs {
         let ordered_tables = ordered_manifest_tables(manifest_object_key, &run.tables)?;
         let mut direntry_bind_rows = 0u64;
         let mut direntry_child_bind_rows = 0u64;
@@ -341,6 +346,7 @@ fn validate_manifest_table_descriptors(
         let mut revision_by_inode_desc_rows = 0u64;
         for table in ordered_tables {
             validate_segment_descriptors(&table.segments)?;
+            validate_segment_numbering(&table.segments)?;
             for descriptor in &table.segments {
                 match table.family {
                     MetadataTableFamily::DirentryBinds => {
@@ -438,30 +444,88 @@ fn validate_segment_descriptors(descriptors: &[MetadataFileRef]) -> Result<(), M
     Ok(())
 }
 
-/// Checks that one family's output segments of a partial fold are numbered
-/// the way the fold numbers them: from zero, once each, in the order it wrote
-/// them.
+/// Checks that one family's segments inside one run are numbered the way the
+/// producer that wrote them numbered them: from zero, once each, in the order
+/// they were written.
 ///
-/// The check is the fold's own, not the file set's. A whole-group fold can
-/// stamp a second base run at an existing base run's identity when its window
-/// has to start above that run, so `metadata_files` does hold repeated
-/// segment indexes within one run and family today. A fold's outputs are one
-/// run built by one producer, so there the numbering is an invariant, and
-/// each slice reads the count back to number the segments it adds.
-fn validate_output_segment_numbering(
-    descriptors: &[MetadataFileRef],
-) -> Result<(), ManifestLoadError> {
+/// One family in one run has exactly one producer — a flush's delta run, a
+/// merge's output, or the run a partial fold builds across its slices — and
+/// every one of them numbers from zero. Two producers writing one family at
+/// one run identity is what this rejects. That used to be reachable: a merge
+/// that had to start above the group's base wrote its output at the base tier
+/// stamped at the manifest head, so a group whose base already sat at that
+/// identity ended up with two sets of segments both numbered from zero. A
+/// merge above the base now writes a delta run at its newest input's identity
+/// instead, and that identity's segments for the group leave the file set in
+/// the same publication the output's enter it.
+///
+/// Segments reach this sorted by index (`runs_from_metadata_files`), so
+/// comparing each index against its position catches a repeat, a gap, and a
+/// number no producer would have written.
+fn validate_segment_numbering(descriptors: &[MetadataFileRef]) -> Result<(), ManifestLoadError> {
     for (position, descriptor) in descriptors.iter().enumerate() {
         if descriptor.segment_index as usize != position {
             return Err(ManifestLoadError::SegmentDescriptorMismatch {
                 object_key: descriptor.object_key.clone(),
                 message: format!(
-                    "reorganize output segment carries index {} at position {position} of its \
-                     family; a fold numbers its outputs from zero in the order it writes them",
-                    descriptor.segment_index
+                    "segment carries index {} at position {position} of family `{:?}` in run seq \
+                     `{}` level {}; a family's segments within one run are numbered from zero, \
+                     once each, in the order they were written",
+                    descriptor.segment_index,
+                    descriptor.family,
+                    descriptor.run_seq,
+                    descriptor.level
                 ),
             });
         }
+    }
+    Ok(())
+}
+
+/// Checks that no family group holds more than one base-tier run.
+///
+/// A merge writes a base-tier run only when its window starts at the group's
+/// oldest run, and such a window always contains the group's existing base
+/// run, so the merge replaces it rather than adding one. A completed partial
+/// fold does the same over the whole group. Nothing else in the system mints
+/// a base run: a flush appends a delta run, and a merge above the base writes
+/// a delta run too.
+///
+/// A group with two base runs is the state a merge above the base used to
+/// leave behind, and it is worse than untidy. Each fragment on its own stays
+/// under the per-step budget, so nothing reports the group as too large to
+/// fold from its oldest run, the group goes on merging delta runs above the
+/// fragments instead, and the rows its retention floor covers can never be
+/// dropped — dropping needs a merge that starts at the group's oldest run.
+///
+/// Different groups may share one base-tier run identity, and usually do:
+/// each group folds at the manifest head, so the base runs they write land at
+/// the same sequence and become one run holding several groups' families.
+/// That is one run per group, which is what this counts.
+fn validate_one_base_run_per_family_group(
+    manifest_object_key: &str,
+    runs: &[MetadataRunManifest],
+) -> Result<(), ManifestLoadError> {
+    for group in REORGANIZE_FAMILY_GROUPS {
+        let mut base_runs = runs.iter().filter(|run| {
+            run.level != CHECKPOINT_L0_RUN_LEVEL
+                && run
+                    .tables
+                    .iter()
+                    .any(|table| group.contains(&table.family) && !table.segments.is_empty())
+        });
+        let (Some(first), Some(second)) = (base_runs.next(), base_runs.next()) else {
+            continue;
+        };
+        return Err(ManifestLoadError::RunManifestMismatch {
+            object_key: manifest_object_key.to_owned(),
+            message: format!(
+                "family group {group:?} holds base-tier runs at seq `{}` level {} and seq `{}` \
+                 level {}; a group holds at most one base run, because a merge writes one only \
+                 when it starts at the group's oldest run and then replaces it",
+                first.run_seq, first.level, second.run_seq, second.level
+            ),
+        });
     }
     Ok(())
 }
@@ -667,7 +731,7 @@ fn validate_manifest_reorganize_progress(
     }
     for (family, segments) in &segments_by_family {
         validate_segment_descriptors(segments)?;
-        validate_output_segment_numbering(segments)?;
+        validate_segment_numbering(segments)?;
         let bound = written_through(*family);
         let mut previous: Option<&MetadataFileRef> = None;
         for segment in segments {

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -347,6 +347,7 @@ fn validate_manifest_table_descriptors(
         for table in ordered_tables {
             validate_segment_descriptors(&table.segments)?;
             validate_segment_numbering(&table.segments)?;
+            validate_segment_key_order(&table.segments)?;
             for descriptor in &table.segments {
                 match table.family {
                     MetadataTableFamily::DirentryBinds => {
@@ -478,6 +479,47 @@ fn validate_segment_numbering(descriptors: &[MetadataFileRef]) -> Result<(), Man
                 ),
             });
         }
+    }
+    Ok(())
+}
+
+/// Checks that one family's segments inside one run ascend by key range in
+/// index order, without overlap.
+///
+/// One producer writes a family's rows in ascending key order and never
+/// writes a key twice, so each of its segments starts strictly above where
+/// the previous one ended. The progress checks already hold a fold's outputs
+/// to this while the fold is in flight; this holds every run a manifest
+/// references to it. The numbering check cannot notice a descriptor stamped
+/// with the wrong run identity when the list it joins stays densely
+/// numbered. This check notices it as soon as the stray range overlaps a
+/// neighbour's, and the wide ranges of folded segments make that the common
+/// case.
+fn validate_segment_key_order(descriptors: &[MetadataFileRef]) -> Result<(), ManifestLoadError> {
+    let mut previous: Option<&MetadataFileRef> = None;
+    for descriptor in descriptors {
+        if descriptor.row_count == 0 {
+            continue;
+        }
+        if let Some(previous) = previous {
+            if descriptor.min_key <= previous.max_key {
+                return Err(ManifestLoadError::SegmentDescriptorMismatch {
+                    object_key: descriptor.object_key.clone(),
+                    message: format!(
+                        "segment starts at `{}`, at or below the preceding segment's last key \
+                         `{}`, in family `{:?}` of run seq `{}` level {}; one producer writes a \
+                         family's segments in ascending key order, so consecutive ranges never \
+                         touch",
+                        descriptor.min_key,
+                        previous.max_key,
+                        descriptor.family,
+                        descriptor.run_seq,
+                        descriptor.level
+                    ),
+                });
+            }
+        }
+        previous = Some(descriptor);
     }
     Ok(())
 }
@@ -732,13 +774,10 @@ fn validate_manifest_reorganize_progress(
     for (family, segments) in &segments_by_family {
         validate_segment_descriptors(segments)?;
         validate_segment_numbering(segments)?;
+        validate_segment_key_order(segments)?;
         let bound = written_through(*family);
-        let mut previous: Option<&MetadataFileRef> = None;
         for segment in segments {
-            // A fold writes one family's outputs in ascending key order and
-            // never revisits a key, so two output segments of one family can
-            // neither overlap nor descend. Only segments holding rows carry a
-            // range to compare.
+            // Only segments holding rows carry a range to compare.
             if segment.row_count == 0 {
                 continue;
             }
@@ -757,19 +796,6 @@ fn validate_manifest_reorganize_progress(
                     ),
                 });
             }
-            if let Some(previous) = previous {
-                if segment.min_key <= previous.max_key {
-                    return Err(ManifestLoadError::SegmentDescriptorMismatch {
-                        object_key: segment.object_key.clone(),
-                        message: format!(
-                            "reorganize output segment starts at `{}`, at or below the preceding \
-                             segment's last key `{}` in family `{family:?}`",
-                            segment.min_key, previous.max_key
-                        ),
-                    });
-                }
-            }
-            previous = Some(segment);
         }
     }
 

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -5,12 +5,22 @@
 //! follows the WAL delta, never the namespace. Folding those L0 runs into
 //! the base happens here instead, one **family group** at a time: the
 //! group's rows are merged from an oldest-first, budgeted subset of complete
-//! runs, rows no retained sequence can observe are dropped, new base
-//! segments are written, and a manifest publishes that swaps just those
-//! references. Families whose rows must stay mutually consistent compact
-//! together — bind, child bind, and unbind rows form one group because their
-//! drop rules read each other; revisions travel with their descending index
-//! so index parity holds within every unit.
+//! runs, rows no retained sequence can observe are dropped, new segments are
+//! written, and a manifest publishes that swaps just those references.
+//! Families whose rows must stay mutually consistent compact together —
+//! bind, child bind, and unbind rows form one group because their drop rules
+//! read each other; revisions travel with their descending index so index
+//! parity holds within every unit.
+//!
+//! A merge writes a base-tier run when, and only when, its window starts at
+//! the group's oldest run. That is the same condition retention dropping
+//! needs, so the level a run carries and the rules that produced it say the
+//! same thing: a base run is a run some fold was allowed to drop rows from, a
+//! delta run is a run nothing has dropped from yet. A merge that had to start
+//! above the group's base therefore writes a bigger delta run rather than a
+//! second base run, and a family group holds at most one base run at any
+//! time (`super::load::validate_manifest_table_descriptors` refuses a
+//! manifest that says otherwise).
 //!
 //! There is no progress record: each unit ends in a durable manifest, so a
 //! crashed or interrupted reorganization resumes by reading the live
@@ -20,17 +30,19 @@
 //! the unit's segments are left unreferenced for garbage collection and the
 //! next step retries against the fresh manifest.
 //!
-//! A group whose oldest run no longer fits one step folds a slice at a time
-//! instead ([`super::partial_fold`]). That fold does keep a progress record,
-//! in the manifest, because its output arrives in pieces. While it is in
-//! flight its group folds no other way: a step that selects the group
-//! advances the fold and does nothing else for it. Group selection still
-//! runs per step, so the other groups keep folding on the steps they win.
+//! A group that can no longer be folded from its oldest run in one step folds
+//! a slice at a time instead ([`super::partial_fold`]). That fold does keep a
+//! progress record, in the manifest, because its output arrives in pieces.
+//! While it is in flight its group folds no other way: a step that selects
+//! the group advances the fold and does nothing else for it. Group selection
+//! still runs per step, so the other groups keep folding on the steps they
+//! win.
 //!
-//! A manifest carries one such fold at a time. A second group whose oldest
-//! run does not fit either waits its turn: it merges its delta runs the way
-//! it did before partial folds existed, and its fold starts once the slot is
-//! free.
+//! A manifest carries one such fold at a time. A second group in the same
+//! position waits its turn: it merges its delta runs into fewer, bigger delta
+//! runs, and its fold starts once the slot is free. A group that has merged
+//! them down to one has nothing left to do that way, and the step it wins
+//! goes to the fold in flight instead.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::build::{
@@ -74,8 +86,10 @@ pub enum MetadataReorganizeOutcome {
     /// The manifest's L0 run count is below the policy trigger; nothing to
     /// fold yet.
     NotNeeded { l0_runs: usize },
-    /// One bounded complete-run subset for a family group folded into new
-    /// base segments and the manifest advanced.
+    /// One bounded complete-run subset for a family group merged into one new
+    /// run and the manifest advanced. The new run is the group's base when
+    /// the subset started at the group's oldest run, and a bigger delta run
+    /// otherwise.
     UnitPublished {
         families: Vec<MetadataTableFamily>,
         folded_l0_rows: u64,
@@ -84,9 +98,9 @@ pub enum MetadataReorganizeOutcome {
         decoded_input_bytes: u64,
         manifest_id: ManifestId,
     },
-    /// One slice of a partial fold merged and published. The group's oldest
-    /// run does not fit one step, so the group is being folded a partition
-    /// at a time and this step moved that fold along.
+    /// One slice of a partial fold merged and published. The group cannot be
+    /// folded from its oldest run in one step, so it is being folded a
+    /// partition at a time and this step moved that fold along.
     PartialFoldAdvanced {
         families: Vec<MetadataTableFamily>,
         /// Partitions of the group's keyspace this slice covered.
@@ -114,8 +128,11 @@ pub enum MetadataReorganizeOutcome {
         output_rows: u64,
         manifest_id: ManifestId,
     },
-    /// The trigger fired, but no oldest-first subset that would make
-    /// progress fit the hard per-step input budgets.
+    /// The trigger fired, but no oldest-first subset of this group's runs
+    /// would make progress, and nothing said the group needs folding a slice
+    /// at a time either. A budget that stopped the window says that, so what
+    /// is left here is a per-step run limit too small to reach a delta run:
+    /// the step has nothing to do for the group and nothing to blame.
     BudgetExhausted {
         families: Vec<MetadataTableFamily>,
         l0_runs: usize,
@@ -190,7 +207,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     // unfoldable for as long as the trigger stayed quiet.
     if l0_runs < policy.max_l0_runs.get()
         && previous.payload.reorganize.is_none()
-        && !manifest_has_partial_reorganization(tables.scan_runs.as_ref())
+        && !folding_started_above_unfolded_delta_runs(tables.scan_runs.as_ref())
     {
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
@@ -239,6 +256,16 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         }
     }
     let Some(input) = selection.input else {
+        // Nothing this group can merge this step. A group waiting for the
+        // fold slot reaches this once it has merged its delta runs down to
+        // one: its base needs a fold and the slot is taken, and merging one
+        // delta run into itself would rewrite every row for nothing. The
+        // step spends itself on the fold in flight instead, which is the one
+        // piece of work that moves this group's turn closer.
+        if folding_group.is_some() {
+            return advance_partial_fold(store, namespace_id, &tables, policy, context, timer)
+                .await;
+        }
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::BudgetExhausted {
@@ -311,8 +338,8 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let run_tables = build_manifest_tables_from_rows(
         store,
         namespace_id,
-        previous.payload.head_seq,
-        CHECKPOINT_BASE_RUN_LEVEL,
+        input.output.run_seq,
+        input.output.level,
         |family| rows_by_family.remove(&family).unwrap_or_default(),
         MetadataTableSegmentation::Base {
             max_rows_per_segment: policy.max_rows_per_segment,
@@ -519,21 +546,82 @@ pub(super) struct ReorganizationInput {
     /// run — the cancelling row is always the newer of the two, so every row
     /// it can cancel is already in the window (format spec, "Compaction").
     pub(super) starts_at_group_bottom: bool,
+    /// The run identity this merge writes its output at, decided by
+    /// [`merge_output_run`].
+    pub(super) output: MetadataRunId,
+}
+
+/// The run identity a merge writes its output at.
+///
+/// **A merge's output is base-tier if and only if its window is
+/// bottom-anchored.** Base-tier means "rows a fold was allowed to drop from",
+/// which is exactly what [`ReorganizationInput::starts_at_group_bottom`]
+/// decides, so the level a run carries and the rules that produced it say the
+/// same thing.
+///
+/// A bottom-anchored merge writes the group's base run, stamped at the
+/// manifest head. Base-tier runs sort below every delta run whatever sequence
+/// they carry, so the output lands at the bottom where its inputs were and
+/// the sequence is free to be the head's — which is also what keeps a file at
+/// `head_seq` in the manifest when the merge consumed the group's whole top.
+/// It replaces the group's previous base run, because a bottom-anchored
+/// window always contains it, so the group is left with exactly one.
+///
+/// A merge that had to start above the group's base rewrites delta runs into
+/// one bigger delta run. Two things follow from writing it at the delta level
+/// instead of the base level. It cannot mint a second base run, so a group's
+/// base never fragments and the trigger that folds a group in slices weighs
+/// the whole base rather than one fragment of it. And its rows stay counted
+/// as delta pressure, so the L0 run count reports what is really waiting
+/// rather than hiding merged runs at the base tier.
+///
+/// Its sequence is its newest input's, not the manifest head's, so the output
+/// stands exactly where that run stood: above every run the window left below
+/// it and below every run it left above. The head would put it above runs the
+/// window did not reach, and moving merged rows above newer runs is what a
+/// later bottom-anchored fold must never see — it could then drop an unbind
+/// whose bind had moved out of the window and put a deleted file back.
+///
+/// Nothing else in the manifest already holds that identity for these
+/// families: the newest input run's segments for this group leave
+/// `metadata_files` in the same publication the output's enter it. Segments
+/// of other families at that identity stay where they are, which is ordinary
+/// — a run is a set of families, and each family in it has one producer.
+fn merge_output_run(
+    runs: &[MetadataRunManifest],
+    starts_at_group_bottom: bool,
+    head_seq: ChangeSeq,
+) -> MetadataRunId {
+    if starts_at_group_bottom {
+        return MetadataRunId {
+            run_seq: head_seq,
+            level: CHECKPOINT_BASE_RUN_LEVEL,
+        };
+    }
+    MetadataRunId {
+        run_seq: runs.iter().map(|run| run.run_seq).max().unwrap_or(head_seq),
+        level: CHECKPOINT_L0_RUN_LEVEL,
+    }
 }
 
 /// What one selection attempt found.
 ///
 /// The saturation record travels beside the input rather than replacing it.
-/// A group whose oldest run has outgrown one step's budget is folded a slice
-/// at a time instead of whole, which is the caller's decision to make; the
-/// delta-only window this search still finds is what the group would have
-/// merged before partial folds existed.
+/// A group that cannot be folded from its oldest run in one step is folded a
+/// slice at a time instead, which is the caller's decision to make; the
+/// delta-only window this search still finds is what such a group merges
+/// while it waits for the fold slot.
 pub(super) struct ReorganizationSelection {
     pub(super) input: Option<ReorganizationInput>,
+    /// What stopped the window that starts at the group's oldest run, when
+    /// the group needs folding a slice at a time. Set when that run does not
+    /// fit one step on its own, and also when no window makes progress at
+    /// all — see [`select_reorganization_input`].
     pub(super) group_bottom_over_budget: Option<OverBudgetRun>,
 }
 
-/// A run that does not fit one step's budgets on its own.
+/// A run that stopped a window: it does not fit one step's budgets beside
+/// what the window already held, and at index zero that means on its own.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct OverBudgetRun {
     pub(super) run_seq: ChangeSeq,
@@ -548,33 +636,39 @@ pub(super) struct OverBudgetRun {
 ///
 /// **The order.** The comparator below is the group's recency order, oldest
 /// first. Base-tier runs hold rows an earlier fold already absorbed, so they
-/// sit under every L0 run whatever their `run_seq` says: a bounded fold
-/// stamps its output at the manifest head, which can leave a base run
-/// carrying a higher `run_seq` than an L0 run it did not fold (see
-/// [`manifest_has_partial_reorganization`]). Within one tier the lower
-/// `run_seq` is the older run.
+/// sit under every delta run whatever their `run_seq` says: a bottom-anchored
+/// fold stamps its output at the manifest head, which can leave a base run
+/// carrying a higher `run_seq` than a delta run some other group has not
+/// folded yet (see [`folding_started_above_unfolded_delta_runs`]). Within one
+/// tier the lower `run_seq` is the older run.
 ///
-/// **The invariant.** A merge writes its inputs back as one base-tier run
-/// stamped at the manifest head. That output is older than every L0 run in
-/// the order above, so it may not carry a row newer than an L0 run it left
-/// behind — otherwise a later fold could drop a row while the row it cancels
-/// sits outside the window. Two rules keep that true. The window is a
-/// *contiguous* slice of the order, and its start only ever moves forward
-/// past **base-tier** runs; an L0 run is never stepped over. Every run the
-/// window leaves out therefore sits wholly below it or wholly above it, never
-/// interleaved, and the output can stand in for the whole window without
+/// **The invariant.** A merge writes its inputs back as one run standing
+/// where the window stood: at the bottom of the group when the window is
+/// bottom-anchored, and at its newest input's identity otherwise
+/// ([`merge_output_run`]). Either way the output may not carry a row newer
+/// than a run it left above the window — otherwise a later fold could drop a
+/// row while the row it cancels sits outside that fold's window. What keeps
+/// that true is that the window is a *contiguous* slice of the order: every
+/// run it leaves out sits wholly below it or wholly above it, never
+/// interleaved, so the output can stand in for the whole window without
 /// moving any row past any other. When the window starts at the very bottom
 /// nothing is left out below it at all, and that is the stronger property
 /// retention dropping needs — see
 /// [`ReorganizationInput::starts_at_group_bottom`].
 ///
+/// **There are two windows to try.** A manifest holds at most one base-tier
+/// run per family group, so the search is short: the window starting at the
+/// group's oldest run, and — when a base run blocks that one — the window
+/// starting at the oldest delta run above it. A delta run is never stepped
+/// over.
+///
 /// **The budgets pace the work; they never end it.** When no window starting
 /// at the group's oldest run can fit the budgets, the start moves past the
-/// base-tier runs that block it and the window merges the L0 runs above them
-/// on their own, so the group keeps shedding runs. The caller has a better
-/// answer for that case now and takes it — it folds the group a slice at a
-/// time instead ([`super::partial_fold`]) — but the window is still what
-/// this search reports, and it is still the one the group would merge if the
+/// base run that blocks it and the window merges the delta runs above it on
+/// their own, so the group keeps shedding runs. The caller has a better
+/// answer for that case and takes it — it folds the group a slice at a time
+/// instead ([`super::partial_fold`]) — but the window is still what this
+/// search reports, and it is still the one the group would merge if the
 /// oldest run fit.
 ///
 /// Index sections are read before row payloads so the decoded-byte budget is
@@ -599,26 +693,36 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
             .then(right.level.cmp(&left.level))
     });
     let candidate_count = candidates.len();
+    let head_seq = tables.manifest().payload.head_seq;
     let row_budget =
         u64::try_from(policy.max_decoded_input_rows_per_step.get()).unwrap_or(u64::MAX);
     let byte_budget =
         u64::try_from(policy.max_decoded_input_bytes_per_step.get()).unwrap_or(u64::MAX);
     let max_runs = policy.max_input_runs_per_step.get();
-    // Base-tier runs sort first, so this is also the index of the oldest L0
-    // candidate. The window start may move up to it and no further.
-    let base_tier_candidates = candidates
+    // Base-tier runs sort first, so this is the index of the oldest delta
+    // candidate, and starting there is what skips a base run the budgets
+    // cannot admit. A group has at most one base run, so this is one place
+    // and the only alternative to the bottom.
+    let first_delta_candidate = candidates
         .iter()
         .take_while(|run| run.level != CHECKPOINT_L0_RUN_LEVEL)
         .count();
-    let window_starts = (base_tier_candidates + 1)
-        .min(candidate_count)
-        .min(max_runs);
+    let delta_only_start = (first_delta_candidate > 0 && first_delta_candidate < candidate_count)
+        .then_some(first_delta_candidate);
     // Reading a run's decoded byte total costs its index sections, so each
     // candidate's total is read at most once however many windows weigh it.
     let mut decoded_bytes_by_candidate = vec![None::<u64>; candidate_count];
-    let mut group_bottom_over_budget = None;
+    // What stopped the window that starts at the group's oldest run, and how
+    // far into that window it stood. Position zero means the oldest run does
+    // not fit one step on its own, which is reported whatever else the search
+    // finds; a later position means the oldest run fits but cannot be read
+    // together with what sits above it, which is only reported when no window
+    // makes progress at all. A group in that second position still has its
+    // delta runs to merge, and doing that first is cheaper than folding the
+    // group in slices.
+    let mut bottom_window_blocked_by: Option<(usize, OverBudgetRun)> = None;
 
-    for window_start in 0..window_starts {
+    for window_start in std::iter::once(0).chain(delta_only_start) {
         let mut runs = Vec::new();
         let mut decoded_rows = 0u64;
         let mut decoded_bytes = 0u64;
@@ -629,16 +733,16 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 .map(|descriptor| descriptor.row_count)
                 .sum::<u64>();
             if decoded_rows.saturating_add(run_rows) > row_budget {
-                // Index zero is only reached by the first window, whose
-                // accumulator is still empty there, so this is the group's
-                // oldest run failing the budget on its own.
-                if index == 0 {
-                    group_bottom_over_budget = Some(OverBudgetRun {
-                        run_seq: run.run_seq,
-                        level: run.level,
-                        rows: run_rows,
-                        decoded_bytes: None,
-                    });
+                if window_start == 0 {
+                    bottom_window_blocked_by = Some((
+                        index,
+                        OverBudgetRun {
+                            run_seq: run.run_seq,
+                            level: run.level,
+                            rows: run_rows,
+                            decoded_bytes: None,
+                        },
+                    ));
                 }
                 break;
             }
@@ -651,13 +755,16 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 }
             };
             if decoded_bytes.saturating_add(run_bytes) > byte_budget {
-                if index == 0 {
-                    group_bottom_over_budget = Some(OverBudgetRun {
-                        run_seq: run.run_seq,
-                        level: run.level,
-                        rows: run_rows,
-                        decoded_bytes: Some(run_bytes),
-                    });
+                if window_start == 0 {
+                    bottom_window_blocked_by = Some((
+                        index,
+                        OverBudgetRun {
+                            run_seq: run.run_seq,
+                            level: run.level,
+                            rows: run_rows,
+                            decoded_bytes: Some(run_bytes),
+                        },
+                    ));
                 }
                 break;
             }
@@ -669,16 +776,30 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
             runs.push(run.clone());
         }
 
-        // Every merge writes one base-tier run, so each L0 run it takes
-        // leaves L0 for good and the group's L0 count strictly falls. That
-        // is the whole progress condition, and it is what makes the fold
-        // terminate: a window holding no L0 run would only rewrite base-tier
-        // rows where they stand, forever.
-        let makes_progress = runs.iter().any(|run| run.level == CHECKPOINT_L0_RUN_LEVEL);
+        // A merge must leave the group with less to fold than it found, or
+        // the same window would be chosen again forever. What counts as less
+        // follows from the level the output gets.
+        //
+        // A bottom-anchored merge writes a base run, so every delta run it
+        // takes leaves the delta tier for good: one delta run in the window
+        // is enough, and a window holding none would only rewrite base rows
+        // where they stand.
+        //
+        // A merge above the base writes another delta run, so it only gains
+        // by merging two or more into one. A single-run window there would
+        // rewrite that run as itself, at its own identity, having read and
+        // written every row for nothing.
+        let starts_at_group_bottom = window_start == 0;
+        let makes_progress = if starts_at_group_bottom {
+            runs.iter().any(|run| run.level == CHECKPOINT_L0_RUN_LEVEL)
+        } else {
+            runs.len() > 1
+        };
         if !makes_progress {
             continue;
         }
         let run_ids = runs.iter().map(|run| (run.run_seq, run.level)).collect();
+        let output = merge_output_run(&runs, starts_at_group_bottom, head_seq);
         return Ok(ReorganizationSelection {
             input: Some(ReorganizationInput {
                 runs,
@@ -686,20 +807,46 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 folded_l0_rows,
                 decoded_rows,
                 decoded_bytes,
-                starts_at_group_bottom: window_start == 0,
+                starts_at_group_bottom,
+                output,
             }),
-            group_bottom_over_budget,
+            // Position zero is only ever reached by the bottom-anchored
+            // window, whose accumulator is still empty there, so it is the
+            // group's oldest run failing the budget on its own.
+            group_bottom_over_budget: blocker_at_the_group_bottom(bottom_window_blocked_by),
         });
     }
 
+    // No window makes progress. The group's oldest run cannot be merged with
+    // anything above it, and there is no pair of delta runs to merge either,
+    // so folding the group a slice at a time is the only move left. That is
+    // reported here even when the run that stopped the bottom window was not
+    // the group's oldest: the group is just as unfoldable either way, and a
+    // group left to report a blocked step every step would never drop a row
+    // again.
     Ok(ReorganizationSelection {
         input: None,
-        group_bottom_over_budget,
+        group_bottom_over_budget: bottom_window_blocked_by.map(|(_, blocker)| blocker),
     })
 }
 
-/// Says out loud that a family group's oldest run no longer fits one
-/// reorganization step.
+/// The blocker that stopped the bottom-anchored window at its very first run,
+/// which is the reading that means "the group's oldest run does not fit one
+/// step on its own".
+fn blocker_at_the_group_bottom(
+    bottom_window_blocked_by: Option<(usize, OverBudgetRun)>,
+) -> Option<OverBudgetRun> {
+    bottom_window_blocked_by
+        .filter(|(index, _)| *index == 0)
+        .map(|(_, blocker)| blocker)
+}
+
+/// Says out loud that a family group can no longer be folded from its oldest
+/// run in one reorganization step.
+///
+/// The run named here is what stopped the window: the group's oldest run
+/// failing the budget on its own, or — when no window makes progress at all —
+/// the run above it that would not fit beside it.
 ///
 /// Nothing is broken when this fires and nothing stalls. The step that logs
 /// this line starts a partial fold of the group, which rebuilds it a
@@ -729,16 +876,33 @@ fn report_group_bottom_over_budget(
         run_decoded_bytes = bottom.decoded_bytes,
         max_decoded_input_rows_per_step = policy.max_decoded_input_rows_per_step.get(),
         max_decoded_input_bytes_per_step = policy.max_decoded_input_bytes_per_step.get(),
-        "the oldest metadata run in this family group no longer fits one reorganization step; \
-         the group folds a slice at a time from here, over as many steps as that takes",
+        "this family group can no longer be folded from its oldest run in one reorganization \
+         step; the run named here is what stopped the window, and the group folds a slice at a \
+         time from here, over as many steps as that takes",
     );
 }
 
-/// A bounded fold stamps its output at the manifest head. If older or
-/// same-seq L0 runs remain, that ordering is the durable resume marker. A
-/// fresh L0 appended after a completed fold is strictly newer than every
-/// base-tier run and therefore does not bypass the normal trigger.
-fn manifest_has_partial_reorganization(runs: &[MetadataRunManifest]) -> bool {
+/// Whether a fold has already run against this manifest head while delta
+/// runs are still waiting to be folded.
+///
+/// A bottom-anchored fold stamps its base run at the manifest head, which is
+/// at or above every delta run's sequence. So a base run sitting at or above
+/// the oldest delta run says one group folded here and delta runs remain —
+/// usually other groups' rows in the very runs it just took its own rows out
+/// of. The step keeps going on that evidence rather than stopping at the
+/// trigger, which is what makes a run of bounded steps end in the same
+/// manifest shape one unbounded step would have produced.
+///
+/// This used to carry a second job. A merge above the base wrote its output
+/// at the base tier too, so its inputs stopped being counted as delta runs
+/// and the trigger under-reported what was waiting; this predicate was what
+/// kept such a group folding anyway. That job is gone: a merge above the base
+/// now writes a delta run ([`merge_output_run`]), so the L0 run count says
+/// what is really there.
+///
+/// A fresh delta run appended after a completed fold is strictly newer than
+/// every base run and therefore does not bypass the normal trigger.
+fn folding_started_above_unfolded_delta_runs(runs: &[MetadataRunManifest]) -> bool {
     let Some(oldest_l0_seq) = runs
         .iter()
         .filter(|run| run.level == CHECKPOINT_L0_RUN_LEVEL)

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -1742,7 +1742,7 @@ fn partition_offset_key(partition: u64, revision_no: u64) -> String {
 /// One output segment of a partial fold, modelled on a segment the manifest
 /// already holds: a fresh table id and object key, stamped with the run the
 /// fold is building.
-fn reorganize_output_segment(
+pub(super) fn reorganize_output_segment(
     modelled_on: &MetadataFileRef,
     namespace_id: &NamespaceId,
     output_run_seq: ChangeSeq,
@@ -1761,7 +1761,7 @@ fn reorganize_output_segment(
 
 /// Republishes a payload under a fresh manifest id and loads it back, so a
 /// caller can assert on what validation makes of an edited manifest.
-async fn load_perturbed_manifest(
+pub(super) async fn load_perturbed_manifest(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
     mut payload: NamespaceManifestPayload,

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -324,6 +324,43 @@ fn l0_runs(manifest: &NamespaceManifestEnvelope) -> Vec<MetadataRunManifest> {
         .collect()
 }
 
+/// A run's identity: the sequence and level a manifest names it by.
+type RunId = (ChangeSeq, u32);
+
+/// The base-tier runs one family group holds right now.
+///
+/// A group holds at most one: only a merge that starts at the group's oldest
+/// run writes a base run, and such a merge always replaces the one that was
+/// there. More than one is the fragmented base a merge above the base used to
+/// create, which manifest load now refuses.
+fn group_base_runs(
+    manifest: &NamespaceManifestEnvelope,
+    group: &[ApiMetadataTableFamily],
+) -> Vec<RunId> {
+    runs_from_metadata_files(&manifest.payload)
+        .into_iter()
+        .filter(|run| {
+            run.level != CHECKPOINT_L0_RUN_LEVEL
+                && run
+                    .tables
+                    .iter()
+                    .any(|table| group.contains(&table.family) && !table.segments.is_empty())
+        })
+        .map(|run| (run.run_seq, run.level))
+        .collect()
+}
+
+/// Every family group's base-tier runs, for a caller asserting that none of
+/// them has fragmented.
+fn base_runs_per_family_group(
+    manifest: &NamespaceManifestEnvelope,
+) -> Vec<(&'static [ApiMetadataTableFamily], Vec<RunId>)> {
+    REORGANIZE_FAMILY_GROUPS
+        .into_iter()
+        .map(|group| (group, group_base_runs(manifest, group)))
+        .collect()
+}
+
 fn base_segment_object_keys_for_family(
     manifest: &NamespaceManifestEnvelope,
     family: ApiMetadataTableFamily,

--- a/crates/loonfs-core/src/checkpoint/tests/partial_fold.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/partial_fold.rs
@@ -9,6 +9,7 @@ use super::super::partial_fold::{
 use super::super::partition::{GroupPartitioning, PartitionCursor, PartitionKey};
 use super::super::row::manifest_row_commit_seq;
 use super::super::scan::VerifiedMetadataTables;
+use super::index_parity::{load_perturbed_manifest, reorganize_output_segment};
 use super::*;
 use crate::path::read::{
     load_metadata_view, resolve_current_files, CurrentFileState, ReadLoadContext,
@@ -1591,6 +1592,20 @@ async fn visible_namespace(
         .expect("resolve every inode the namespace knows")
 }
 
+/// The check every reorganization step in these tests must pass: nothing a
+/// reader can see moved.
+async fn continue_after_step(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    visible: &[CurrentFileState],
+) {
+    assert_eq!(
+        visible_namespace(store, namespace_id).await,
+        visible,
+        "a step changed what a read answers"
+    );
+}
+
 /// The binding one row names: what an unbind retires, and what a bind is.
 fn binding_generation(row: &MetadataRow) -> Option<(InodeId, NameKey, ChangeSeq, u32)> {
     match row {
@@ -1669,7 +1684,6 @@ async fn an_over_budget_group_folds_through_repeated_maintenance_steps() {
                 drops,
                 ..
             } => {
-                assert_eq!(families, group, "only this group folds in slices here");
                 // A slice that covers no partition is one that stepped over
                 // a stretch of the keyspace holding no row at all, and it
                 // must have read nothing for it.
@@ -1678,14 +1692,22 @@ async fn an_over_budget_group_folds_through_repeated_maintenance_steps() {
                     decoded_input_rows == 0,
                     "a slice must read the rows of the partitions it covers"
                 );
-                // A slice may keep nothing: every row in its partitions can
-                // be churn the frozen floor lets go.
-                written_rows += output_rows;
                 assert_eq!(
                     drops,
                     MetadataFoldSliceDrops::Applied,
                     "every partition of this workload fits one step"
                 );
+                // This budget is one row under this group's base run, and
+                // another group's base can be larger still, so more than one
+                // group may fold in slices here. The arc below is this
+                // group's, so only its slices are counted.
+                if families != group {
+                    continue_after_step(&store, &namespace_id, &visible).await;
+                    continue;
+                }
+                // A slice may keep nothing: every row in its partitions can
+                // be churn the frozen floor lets go.
+                written_rows += output_rows;
                 cursors.push(cursor.clone());
                 slices += 1;
                 if slices == 1 {
@@ -1722,7 +1744,10 @@ async fn an_over_budget_group_folds_through_repeated_maintenance_steps() {
                 output_rows,
                 ..
             } => {
-                assert_eq!(families, group);
+                if families != group {
+                    continue_after_step(&store, &namespace_id, &visible).await;
+                    continue;
+                }
                 assert!(!completed, "the fold must finish exactly once");
                 assert!(output_segments > 0);
                 assert_eq!(
@@ -1755,11 +1780,7 @@ async fn an_over_budget_group_folds_through_repeated_maintenance_steps() {
                 panic!("no concurrent publisher exists in this test")
             }
         }
-        assert_eq!(
-            visible_namespace(&store, &namespace_id).await,
-            visible,
-            "a step changed what a read answers"
-        );
+        continue_after_step(&store, &namespace_id, &visible).await;
     }
 
     assert!(
@@ -2328,5 +2349,255 @@ async fn a_walk_refuses_to_swap_in_a_run_whose_reverse_index_disagrees() {
             .reorganize
             .is_some(),
         "a refused swap leaves the fold in flight rather than half applied"
+    );
+}
+
+// -------------------------------------------------------------------------
+// The fragmented base
+// -------------------------------------------------------------------------
+
+/// A namespace with one folded base run and one delta run above it, which is
+/// the smallest shape a second base-tier run can be added to.
+async fn seed_folded_base_with_a_delta_run(store: &LocalFsStore, namespace_id: &NamespaceId) {
+    let context = test_context();
+    bootstrap_namespace(store, namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_seed_file(store, namespace_id, 0, 0).await;
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the seed");
+    drain_reorganization(store, namespace_id, &context, MetadataLsmPolicy::default()).await;
+    write_seed_file(store, namespace_id, 0, 1).await;
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint a delta run above the base");
+}
+
+/// One base-tier segment of `family`, for a test that builds a second run out
+/// of it.
+fn base_segment_of_family(
+    manifest: &NamespaceManifestEnvelope,
+    family: ApiMetadataTableFamily,
+) -> MetadataFileRef {
+    manifest
+        .payload
+        .metadata_files
+        .iter()
+        .find(|descriptor| {
+            descriptor.family == family && descriptor.level == CHECKPOINT_BASE_RUN_LEVEL
+        })
+        .expect("a folded base segment of this family")
+        .clone()
+}
+
+/// A group with two base-tier runs does not load.
+///
+/// This is the shape a merge above the base used to write: its output went to
+/// the base tier stamped at the manifest head, so it became a second base run
+/// for the group rather than a bigger delta run. Every fragment stayed under
+/// the per-step budget on its own, so nothing ever reported the group's oldest
+/// run as over budget, the fold in slices never started, and the group's rows
+/// below the retention floor could never be dropped — dropping needs a fold
+/// whose window starts at the group's oldest run.
+///
+/// Refusing the shape at load is what says it cannot come back: no builder
+/// writes it now, and a manifest carrying it is corruption rather than a
+/// state to carry on from.
+#[tokio::test]
+async fn a_manifest_whose_group_base_fragmented_does_not_load() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_folded_base_with_a_delta_run(&store, &namespace_id).await;
+
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let manifest = tables.manifest().clone();
+    drop(tables);
+    let group = group_containing(ApiMetadataTableFamily::Inodes);
+    assert_eq!(
+        group_base_runs(&manifest, group).len(),
+        1,
+        "the seed must leave the group in one base run"
+    );
+
+    let mut fragmented = manifest.payload.clone();
+    fragmented.metadata_files.push(reorganize_output_segment(
+        &base_segment_of_family(&manifest, ApiMetadataTableFamily::Inodes),
+        &namespace_id,
+        manifest.payload.head_seq,
+        CHECKPOINT_BASE_RUN_LEVEL,
+    ));
+
+    let error = load_perturbed_manifest(&store, &namespace_id, fragmented, 1)
+        .await
+        .expect_err("a group with two base runs must not load");
+    let ManifestLoadError::RunManifestMismatch { message, .. } = &error else {
+        panic!("expected a run mismatch, got {error:?}")
+    };
+    assert!(
+        message.contains("Inodes") && message.contains("base"),
+        "the rejection must name the group and what it holds too many of, got `{message}`"
+    );
+}
+
+/// Two segments of one family carrying the same index inside one run do not
+/// load.
+///
+/// A family in a run has one producer, and every producer numbers from zero,
+/// so the numbers are a dense sequence. Two sets of them at one identity is
+/// what a merge above the base used to leave behind when the group's base
+/// already sat at the identity the merge stamped: both sets started at zero.
+/// The hardening pass could only check this for a fold's own outputs, because
+/// the file set genuinely held repeats; with the level rule it holds for every
+/// run, and the check moved there.
+#[tokio::test]
+async fn a_manifest_that_numbers_one_family_twice_in_one_run_does_not_load() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_folded_base_with_a_delta_run(&store, &namespace_id).await;
+
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let manifest = tables.manifest().clone();
+    drop(tables);
+    let existing = base_segment_of_family(&manifest, ApiMetadataTableFamily::Inodes);
+    assert_eq!(existing.segment_index, 0);
+
+    let mut repeated = manifest.payload.clone();
+    repeated.metadata_files.push(reorganize_output_segment(
+        &existing,
+        &namespace_id,
+        existing.run_seq,
+        existing.level,
+    ));
+
+    let error = load_perturbed_manifest(&store, &namespace_id, repeated, 2)
+        .await
+        .expect_err("two segments of one family at one index must not load");
+    let ManifestLoadError::SegmentDescriptorMismatch { message, .. } = &error else {
+        panic!("expected a segment descriptor mismatch, got {error:?}")
+    };
+    assert!(
+        message.contains("Inodes") && message.contains("numbered from zero"),
+        "the rejection must name the family and the numbering rule, got `{message}`"
+    );
+}
+
+/// The end state the soak never reached.
+///
+/// Four cycles of writes, deletions, and a retention floor that moves past
+/// them, folded under budgets too small to take a group whole. The old level
+/// rule turned every merge above the base into another base-tier run, so the
+/// bases fragmented and the fold in slices never started: a live soak of that
+/// code ended with six base-tier runs — direntry binds split across three of
+/// them, revisions across four — with no fold in flight and every unbind
+/// below the floor still there.
+///
+/// What is pinned here is what that run should have reached: one base run per
+/// group throughout, a fold in slices that starts once a group stops fitting
+/// one step, and the churn below the floor gone.
+#[tokio::test]
+async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    // Small segments so a fold in slices has places to stop, and a row budget
+    // the groups outgrow within a couple of cycles.
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(24).expect("nonzero"),
+        max_rows_per_segment: NonZeroUsize::new(4).expect("nonzero"),
+        ..MetadataLsmPolicy::default()
+    };
+
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let mut folds_in_slices = 0usize;
+    for cycle in 0..4u64 {
+        for file in 0..4u64 {
+            write_seed_file(&store, &namespace_id, cycle, file).await;
+        }
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("checkpoint the writes");
+        for file in 0..3u64 {
+            delete_path(
+                &store,
+                &namespace_id,
+                &format!("/d{cycle}/f{file}.txt"),
+                &context,
+                None,
+            )
+            .await
+            .expect("delete a file");
+        }
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("checkpoint the deletions");
+        advance_retention_floor(&store, &namespace_id, &context)
+            .await
+            .expect("advance the floor past the deletions");
+        let visible = visible_namespace(&store, &namespace_id).await;
+
+        let mut quiet = false;
+        for _step in 0..512 {
+            let report = reorganize_metadata_step(&store, &namespace_id, &context, policy)
+                .await
+                .expect("reorganization step");
+            let tables = load_current_manifest_tables(&store, &namespace_id).await;
+            for (folded, base_runs) in base_runs_per_family_group(tables.manifest()) {
+                assert!(
+                    base_runs.len() <= 1,
+                    "cycle {cycle}: {folded:?} holds base runs {base_runs:?}"
+                );
+            }
+            drop(tables);
+            continue_after_step(&store, &namespace_id, &visible).await;
+            match report.outcome {
+                MetadataReorganizeOutcome::PartialFoldCompleted { .. } => folds_in_slices += 1,
+                MetadataReorganizeOutcome::NotNeeded { .. } => {
+                    quiet = true;
+                    break;
+                }
+                MetadataReorganizeOutcome::BudgetExhausted { ref families, .. } => {
+                    panic!("cycle {cycle}: {families:?} parked instead of folding")
+                }
+                MetadataReorganizeOutcome::Superseded => {
+                    panic!("no concurrent publisher exists in this test")
+                }
+                MetadataReorganizeOutcome::PartialFoldAdvanced { .. }
+                | MetadataReorganizeOutcome::UnitPublished { .. } => {}
+            }
+        }
+        assert!(quiet, "cycle {cycle}: reorganization did not go quiet");
+    }
+
+    assert!(
+        folds_in_slices > 0,
+        "a group must have outgrown one step and been folded in slices"
+    );
+    // The bindings group ends in one run, and the churn the floor covers is
+    // gone from it: every deletion below the floor left an unbind, and an
+    // unbind is only ever dropped by a fold that starts at the group's oldest
+    // run.
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    assert_eq!(group_base_runs(tables.manifest(), group).len(), 1);
+    drop(tables);
+    let floor_seq = read_floor_seq(&store, &namespace_id).await;
+    let rows = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    assert!(
+        rows[&ApiMetadataTableFamily::DirentryUnbinds]
+            .iter()
+            .all(|row| !matches!(row, MetadataRow::DirentryUnbind { unbind_seq, .. } if *unbind_seq <= floor_seq)),
+        "the unbind markers the floor covers must have been dropped"
+    );
+    assert_eq!(
+        rows[&ApiMetadataTableFamily::DirentryBinds].len(),
+        rows[&ApiMetadataTableFamily::DirentryChildBinds].len(),
+        "the two bind families must drop in lockstep"
     );
 }

--- a/crates/loonfs-core/src/checkpoint/tests/partial_fold.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/partial_fold.rs
@@ -2484,6 +2484,51 @@ async fn a_manifest_that_numbers_one_family_twice_in_one_run_does_not_load() {
     );
 }
 
+/// Two segments of one family whose key ranges touch inside one run do not
+/// load.
+///
+/// One producer writes a family's segments in ascending key order, so
+/// segment one starts strictly above where segment zero ended. A descriptor
+/// can keep the numbering dense and still not belong — stamped with another
+/// run's identity, say — and then its key range is what disagrees with its
+/// neighbours'. Here the second segment repeats the first one's whole range,
+/// which is the shape a duplicated descriptor takes.
+#[tokio::test]
+async fn a_manifest_whose_run_segments_overlap_in_key_range_does_not_load() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_folded_base_with_a_delta_run(&store, &namespace_id).await;
+
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let manifest = tables.manifest().clone();
+    drop(tables);
+    let existing = base_segment_of_family(&manifest, ApiMetadataTableFamily::Inodes);
+    assert_eq!(existing.segment_index, 0);
+
+    let mut overlapping = manifest.payload.clone();
+    let mut second = reorganize_output_segment(
+        &existing,
+        &namespace_id,
+        existing.run_seq,
+        existing.level,
+    );
+    // Index one keeps the numbering dense, so only the key order can object.
+    second.segment_index = 1;
+    overlapping.metadata_files.push(second);
+
+    let error = load_perturbed_manifest(&store, &namespace_id, overlapping, 3)
+        .await
+        .expect_err("overlapping segment ranges within one run must not load");
+    let ManifestLoadError::SegmentDescriptorMismatch { message, .. } = &error else {
+        panic!("expected a segment descriptor mismatch, got {error:?}")
+    };
+    assert!(
+        message.contains("Inodes") && message.contains("ascending key order"),
+        "the rejection must name the family and the ordering rule, got `{message}`"
+    );
+}
+
 /// The end state the soak never reached.
 ///
 /// Four cycles of writes, deletions, and a retention floor that moves past

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1669,6 +1669,10 @@ async fn a_base_run_over_the_step_budget_folds_the_group_a_slice_at_a_time() {
 
     // Repeated steps keep the group moving. Nothing parks, and the fold of
     // the group runs a slice at a time until it swaps its finished run in.
+    //
+    // This budget is one row under this group's base run, and another group's
+    // base can be larger still, so more than one group may end up folding in
+    // slices here. Only this group's slices are counted.
     let mut slices = 0usize;
     let mut completions = 0usize;
     let mut units = 0usize;
@@ -1683,16 +1687,15 @@ async fn a_base_run_over_the_step_budget_folds_the_group_a_slice_at_a_time() {
             super::MetadataReorganizeOutcome::PartialFoldAdvanced {
                 families, cursor, ..
             } => {
-                assert_eq!(
-                    families, group,
-                    "only the over-budget group folds in slices"
-                );
-                slices += 1;
-                cursors.push(cursor);
+                if families == group {
+                    slices += 1;
+                    cursors.push(cursor);
+                }
             }
             super::MetadataReorganizeOutcome::PartialFoldCompleted { families, .. } => {
-                assert_eq!(families, group);
-                completions += 1;
+                if families == group {
+                    completions += 1;
+                }
             }
             super::MetadataReorganizeOutcome::Superseded => {
                 panic!("no concurrent publisher exists in this test")
@@ -1867,6 +1870,13 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
         selection.group_bottom_over_budget.is_none(),
         "the base fits one step here, so nothing should fold this group in slices"
     );
+    let base_before = group_base_runs(&before.manifest, &group);
+    let newest_input = input
+        .runs
+        .iter()
+        .map(|run| run.run_seq)
+        .max()
+        .expect("the window holds runs");
 
     let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
         .await
@@ -1887,6 +1897,29 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     )
     .await
     .expect("load the manifest after the fold");
+    // The merge wrote a delta run, not a second base run: the group's base is
+    // exactly the one it was, and the merged rows sit at the identity of the
+    // newest run the window held, which is where that run stood.
+    assert_eq!(
+        group_base_runs(&after.manifest, &group),
+        base_before,
+        "a merge above the base must not mint a base run"
+    );
+    let merged_run: BTreeSet<(ChangeSeq, u32)> = after
+        .manifest
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| {
+            group.contains(&descriptor.family) && descriptor.level == CHECKPOINT_L0_RUN_LEVEL
+        })
+        .map(|descriptor| (descriptor.run_seq, descriptor.level))
+        .collect();
+    assert_eq!(
+        merged_run,
+        BTreeSet::from([(newest_input, CHECKPOINT_L0_RUN_LEVEL)]),
+        "the merged delta runs must leave one delta run at the newest input's identity"
+    );
     // A merge that skipped older runs drops nothing, so the row set is
     // exactly what it was: the cancelling row still shadows the base's
     // binding and the deleted file stays deleted.
@@ -1913,10 +1946,17 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
 
 /// Skipping is only ever legal at the recency bottom.
 ///
-/// A run in the middle that busts the budget stops the window. The step
-/// refuses to reach past it for a newer run that would have fit, because a
-/// merge stamped at the manifest head lands above everything it left behind
-/// and would reorder the group.
+/// A run in the middle that busts the budget stops the window. The selector
+/// refuses to reach past it for a newer run that would have fit, because the
+/// merged output stands where the window stood and reaching past a run would
+/// move rows past it.
+///
+/// So no window makes progress at all, and that is what says this group can
+/// only be folded a slice at a time. The selector names the run that stopped
+/// the window — here the wide run in the middle, not the group's oldest run,
+/// which fits one step on its own — and the step starts the fold rather than
+/// reporting a blocked group and leaving it to report the same thing every
+/// step after that.
 #[tokio::test]
 async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1992,26 +2032,21 @@ async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
         selection.input.is_none(),
         "no legal window exists; the selector must not assemble one across the wide run"
     );
-    assert!(
-        selection.group_bottom_over_budget.is_none(),
-        "the base run fits here, so nothing should claim it does not"
+    let blocked_by = selection
+        .group_bottom_over_budget
+        .expect("a group no window can fold must be reported as needing slices");
+    assert_eq!(
+        blocked_by.rows, wide,
+        "the wide run in the middle is what stopped the window, not the group's oldest run"
     );
+    assert_eq!(blocked_by.level, CHECKPOINT_L0_RUN_LEVEL);
 
-    let root_before = current_manifest_id(&store, &namespace_id).await;
     let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
         .await
         .expect("reorganization step");
-    assert!(
-        matches!(
-            report.outcome,
-            super::MetadataReorganizeOutcome::BudgetExhausted { .. }
-        ),
-        "expected a blocked step, got {:?}",
-        report.outcome
-    );
-    assert_eq!(
-        current_manifest_id(&store, &namespace_id).await,
-        root_before,
-        "a blocked step must not publish"
-    );
+    let super::MetadataReorganizeOutcome::PartialFoldAdvanced { families, .. } = &report.outcome
+    else {
+        panic!("expected a fold in slices, got {:?}", report.outcome)
+    };
+    assert_eq!(families, &group);
 }

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -387,11 +387,14 @@ it goes. It does that one group of metadata at a time, and one step reads a
 whole group. A group that has grown past what one step may read is handled
 differently, and it logs three kinds of line.
 
-The first is a warning saying that the oldest metadata run in a family group
-no longer fits one reorganization step. It names the group, the run, how many
-rows and bytes that run holds, and the two per-step budgets it did not fit.
-It is logged once, on the step that decides to rebuild that group a slice at
-a time.
+The first is a warning saying that a family group can no longer be rebuilt
+from its oldest metadata run in one step. It names the group, the run that
+stopped the step, how many rows and bytes that run holds, and the two
+per-step budgets it did not fit. The run it names is usually the group's
+oldest, which did not fit on its own; when the oldest one does fit, the named
+run is the one above it that would not fit beside it, which leaves the group
+just as unrebuildable in one step. The line is logged once, on the step that
+decides to rebuild that group a slice at a time.
 
 After that, the same group logs `metadata partial fold advanced` on every
 step it gets, saying how many partitions the step covered, how many rows it

--- a/docs/design/metadata-partial-fold.md
+++ b/docs/design/metadata-partial-fold.md
@@ -226,6 +226,29 @@ it. Two mechanisms cover the two pairs:
   from seeing the snapshot to seeing the output in one step; no manifest
   ever shows both to a scan.
 
+A walk is bottom-anchored by construction — its snapshot is every run of the
+group — which is why its output is a base run. That is the general rule the
+whole-group fold follows too: **a merge's output is base-tier if and only if
+its window is bottom-anchored**, and a merge that had to start above the
+group's base writes a bigger delta run instead, stamped at its newest input's
+sequence. This was added after a soak showed the ceiling coming back in a new
+shape. A merge above the base used to write a base-tier run stamped at the
+manifest head, so it minted a *second* base run for the group. Each fragment
+stayed under one step's budget, so the trigger above — the group's oldest run
+alone over the budget — never fired, no walk ever started, and the group's
+below-floor rows could never be dropped. With the rule as stated a group has
+one base run, the trigger sees the whole of it, and the delta runs a merge
+above the base produces stay counted as delta pressure instead of hiding at
+the base tier.
+
+The trigger has one more case for the same reason. A group whose oldest run
+fits one step but cannot be read together with the run above it can never
+fold from its bottom either. When no window makes progress at all — not the
+bottom-anchored one, and not a merge of two or more delta runs above it —
+the group is folded in slices, and the step names the run that stopped the
+bottom-anchored window rather than reporting a blocked group every step
+forever.
+
 ## Garbage collection
 
 Progress output segments are referenced only by the progress state, so the

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1856,12 +1856,15 @@ format is versioned by the manifest that references it (`namespace_manifest`
 
 A run is identified by its `run_seq` and `level` together, and holds one
 family's segments from one producer: a WAL flush's delta run, a rebuild's
-output, or the run a rebuild in slices builds up. So one family's
-`segment_index` values inside one run are numbered from zero, once each, in
-the order they were written, and a manifest whose descriptors say otherwise
-does not load. Two runs of different levels may share a sequence, and two
-family groups routinely share one base run — they rebuild at the same
-manifest head — but within one run each family has exactly one producer.
+output, or the run a rebuild in slices builds up. A producer writes a
+family's rows in ascending key order and writes no key twice. So one
+family's `segment_index` values inside one run are numbered from zero, once
+each, in the order they were written, the segments' key ranges ascend in
+that same order without touching, and a manifest whose descriptors say
+otherwise does not load. Two runs of different levels may share a sequence,
+and two family groups routinely share one base run — they rebuild at the
+same manifest head — but within one run each family has exactly one
+producer.
 
 #### 4.2.2 Grep roots, manifests, and gram-index segments
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1854,6 +1854,15 @@ out-of-order index entries, and checksum failures as malformed. The segment
 format is versioned by the manifest that references it (`namespace_manifest`
 `format_version`), since a segment is unreachable except through a manifest.
 
+A run is identified by its `run_seq` and `level` together, and holds one
+family's segments from one producer: a WAL flush's delta run, a rebuild's
+output, or the run a rebuild in slices builds up. So one family's
+`segment_index` values inside one run are numbered from zero, once each, in
+the order they were written, and a manifest whose descriptors say otherwise
+does not load. Two runs of different levels may share a sequence, and two
+family groups routinely share one base run — they rebuild at the same
+manifest head — but within one run each family has exactly one producer.
+
 #### 4.2.2 Grep roots, manifests, and gram-index segments
 
 `loonfs-grep` owns all grep durability under the namespace extension prefix:
@@ -2057,11 +2066,31 @@ Compaction rewrites metadata runs (and, in the future, content layouts) into
 more efficient physical shapes.
 
 A rebuild merges an oldest-first run of runs for one family group. It may
-skip runs at the oldest end that are too large to read inside one step's
-budget, and then it merges the runs above them; it never steps over a delta
-run, so its output is always older than every delta run it leaves behind. A
-rebuild that skipped runs drops nothing, because the rules below read across
-the merged rows and a skipped run may hold the other half of a pair.
+skip the run at the oldest end when that run is too large to read inside one
+step's budget, and then it merges the delta runs above it; it never steps
+over a delta run.
+
+**A rebuild's output is a base run if and only if its window starts at the
+group's oldest run.** The level a run carries and the rules that produced it
+say the same thing: a base run is one some rebuild was allowed to drop rows
+from, a delta run is one nothing has dropped from yet. So a family group
+holds at most one base run — a bottom-anchored rebuild always contains the
+group's existing base run and replaces it, and nothing else writes one — and
+a manifest that carries two base runs for one group does not load.
+
+The output stands where its window stood, so no row moves past any other. A
+bottom-anchored rebuild's output is stamped at the manifest's `head_seq`;
+base runs sort below every delta run whatever sequence they carry, so it
+lands at the bottom of the group where its inputs were. A rebuild that
+skipped the oldest run writes a delta run stamped at its newest input's
+sequence, which is where that run stood: above every run the window left
+below it, below every run it left above.
+
+A rebuild that skipped the oldest run drops nothing, because the rules below
+read across the merged rows and a skipped run may hold the other half of a
+pair. Such a rebuild is what a group does while it waits for a rebuild in
+slices (section 6.2.1): it reduces the group's run count without touching its
+base.
 
 A base rebuild that starts at the group's oldest run drops rows that no
 retained sequence can observe: bindings superseded or unbound at or below the


### PR DESCRIPTION
A live S3 soak exposed a case where metadata reorganization stopped making progress. The final manifest contained six base-tier runs and no partial fold in progress. Bindings were spread across three base runs and revisions across four. Because each run fit within a single-step budget, the system never recognized that the complete family group needed a partial fold. As a result, the runs were not fully consolidated and rows below the retention floor could not be removed.

The problem occurred when a merge did not include the oldest run in a family group. That merge still wrote a new base-tier run at the manifest head, even though the existing base run remained in place. Repeating this process created multiple base runs for one group.

This change makes the output level reflect the merge inputs. A merge writes a base-tier run only when its input window starts with the group's oldest run. In that case, the output replaces the existing base run and may apply retention rules. A merge that starts above the oldest run now writes a delta run at the sequence of its newest input. It combines delta runs without creating another base run or dropping retained metadata.

The reorganization planner now considers two possible input windows: one beginning with the group's oldest run and one containing only delta runs above it. A delta-only merge must combine at least two runs so that it reduces the run count. If no valid window fits in a single step, the group is processed through a partial fold. When another group is waiting for the partial-fold slot and has no useful delta merge available, the maintenance step advances the fold already in progress.

Manifest loading now rejects a family group with more than one base-tier run. It also verifies that each family's segment indexes within a run begin at zero, contain no gaps or duplicates, and remain in order. Each family's segments within one run must also ascend by key range without overlap, which is the same rule a partial fold's own outputs already pass. These checks prevent the invalid state found during the soak from being loaded.

A live S3 soak passed after the fix. The workspace test suite passed with 1,732 tests and no failures. Clippy, formatting, and OpenAPI checks also passed, and golden files were unchanged.

