### PR TITLE
fix(checkpoint): merge placement derives level and retention from one type

### DIFF
--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -10,7 +10,10 @@ use super::cache::{
     DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache, MetadataTableCacheKey,
 };
 use super::error::ManifestLoadError;
-use super::runs::{runs_in_materialization_order, runs_in_scan_order};
+use super::runs::{
+    runs_in_materialization_order, runs_in_scan_order, MetadataRunManifest,
+    CHECKPOINT_L0_RUN_LEVEL, REORGANIZE_FAMILY_GROUPS,
+};
 use super::scan::{ordered_manifest_tables, VerifiedMetadataTables};
 use super::validate::{validate_manifest_materialization_ranges, validate_namespace_manifest};
 use crate::error::{CoreError, MetadataProjectionLoadError};
@@ -327,13 +330,17 @@ fn validate_manifest_table_descriptors(
     manifest_object_key: &str,
     manifest: &NamespaceManifestEnvelope,
 ) -> Result<(), ManifestLoadError> {
-    for run in runs_in_materialization_order(&manifest.payload) {
+    let runs = runs_in_materialization_order(&manifest.payload);
+    validate_one_base_run_per_family_group(manifest_object_key, &runs)?;
+    for run in &runs {
         let ordered_tables = ordered_manifest_tables(manifest_object_key, &run.tables)?;
         let mut direntry_bind_rows = 0u64;
         let mut direntry_child_bind_rows = 0u64;
         let mut revision_rows = 0u64;
         let mut revision_by_inode_desc_rows = 0u64;
         for table in ordered_tables {
+            validate_segment_numbering(&table.segments)?;
+            validate_segment_key_order(&table.segments)?;
             for descriptor in &table.segments {
                 let expected_key = metadata_file_object_key(descriptor);
                 if descriptor.object_key != expected_key {
@@ -432,6 +439,129 @@ fn validate_manifest_table_descriptors(
         }
     }
 
+    Ok(())
+}
+
+/// Checks that one family's segments inside one run are numbered the way the
+/// producer that wrote them numbered them: from zero, once each, in the order
+/// they were written.
+///
+/// One family in one run has exactly one producer — a flush's delta run or a
+/// merge's output — and both number from zero. Two producers writing one
+/// family at one run identity is what this rejects. That used to be
+/// reachable: a merge that had to start above the group's base wrote its
+/// output at the base tier stamped at the manifest head, so a group whose
+/// base already sat at that identity ended up with two sets of segments both
+/// numbered from zero. A merge above the base now writes a delta run at its
+/// newest input's identity instead, and that identity's segments for the
+/// group leave the file set in the same publication the output's enter it.
+///
+/// Segments reach this sorted by index (`runs_from_metadata_files`), so
+/// comparing each index against its position catches a repeat, a gap, and a
+/// number no producer would have written.
+fn validate_segment_numbering(descriptors: &[MetadataFileRef]) -> Result<(), ManifestLoadError> {
+    for (position, descriptor) in descriptors.iter().enumerate() {
+        if descriptor.segment_index as usize != position {
+            return Err(ManifestLoadError::SegmentDescriptorMismatch {
+                object_key: descriptor.object_key.clone(),
+                message: format!(
+                    "segment carries index {} at position {position} of family `{:?}` in run seq \
+                     `{}` level {}; a family's segments within one run are numbered from zero, \
+                     once each, in the order they were written",
+                    descriptor.segment_index,
+                    descriptor.family,
+                    descriptor.run_seq,
+                    descriptor.level
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Checks that one family's segments inside one run ascend by key range in
+/// index order, without overlap.
+///
+/// One producer writes a family's rows in ascending key order and never
+/// writes a key twice, so each of its segments starts strictly above where
+/// the previous one ended (`build::segment_rows_by_row_key_range`). The
+/// numbering check cannot notice a descriptor stamped with the wrong run
+/// identity when the list it joins stays densely numbered; this check notices
+/// it as soon as the stray range overlaps a neighbour's, and the wide ranges
+/// of folded segments make that the common case.
+fn validate_segment_key_order(descriptors: &[MetadataFileRef]) -> Result<(), ManifestLoadError> {
+    let mut previous: Option<&MetadataFileRef> = None;
+    for descriptor in descriptors {
+        if descriptor.row_count == 0 {
+            continue;
+        }
+        if let Some(previous) = previous {
+            if descriptor.min_key <= previous.max_key {
+                return Err(ManifestLoadError::SegmentDescriptorMismatch {
+                    object_key: descriptor.object_key.clone(),
+                    message: format!(
+                        "segment starts at `{}`, at or below the preceding segment's last key \
+                         `{}`, in family `{:?}` of run seq `{}` level {}; one producer writes a \
+                         family's segments in ascending key order, so consecutive ranges never \
+                         touch",
+                        descriptor.min_key,
+                        previous.max_key,
+                        descriptor.family,
+                        descriptor.run_seq,
+                        descriptor.level
+                    ),
+                });
+            }
+        }
+        previous = Some(descriptor);
+    }
+    Ok(())
+}
+
+/// Checks that no family group holds more than one base-tier run.
+///
+/// A merge writes a base-tier run only when its window starts at the group's
+/// oldest run, and such a window always contains the group's existing base
+/// run, so the merge replaces it rather than adding one. Nothing else in the
+/// system mints a base run: a flush appends a delta run, and a merge above
+/// the base writes a delta run too.
+///
+/// A group with two base runs is the state a merge above the base used to
+/// leave behind, and it is worse than untidy. Each fragment on its own stays
+/// under the per-step budget, so nothing reports the group as too large to
+/// fold from its oldest run, the group goes on merging delta runs above the
+/// fragments instead, and the rows its retention floor covers can never be
+/// dropped — dropping needs a merge that starts at the group's oldest run.
+///
+/// Different groups may share one base-tier run identity, and usually do:
+/// each group folds at the manifest head, so the base runs they write land at
+/// the same sequence and become one run holding several groups' families.
+/// That is one run per group, which is what this counts.
+fn validate_one_base_run_per_family_group(
+    manifest_object_key: &str,
+    runs: &[MetadataRunManifest],
+) -> Result<(), ManifestLoadError> {
+    for group in REORGANIZE_FAMILY_GROUPS {
+        let mut base_runs = runs.iter().filter(|run| {
+            run.level != CHECKPOINT_L0_RUN_LEVEL
+                && run
+                    .tables
+                    .iter()
+                    .any(|table| group.contains(&table.family) && !table.segments.is_empty())
+        });
+        let (Some(first), Some(second)) = (base_runs.next(), base_runs.next()) else {
+            continue;
+        };
+        return Err(ManifestLoadError::RunManifestMismatch {
+            object_key: manifest_object_key.to_owned(),
+            message: format!(
+                "family group {group:?} holds base-tier runs at seq `{}` level {} and seq `{}` \
+                 level {}; a group holds at most one base run, because a merge writes one only \
+                 when it starts at the group's oldest run and then replaces it",
+                first.run_seq, first.level, second.run_seq, second.level
+            ),
+        });
+    }
     Ok(())
 }
 

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -5,12 +5,22 @@
 //! follows the WAL delta, never the namespace. Folding those L0 runs into
 //! the base happens here instead, one **family group** at a time: the
 //! group's rows are merged from an oldest-first, budgeted subset of complete
-//! runs, rows no retained sequence can observe are dropped, new base
-//! segments are written, and a manifest publishes that swaps just those
-//! references. Families whose rows must stay mutually consistent compact
-//! together — bind, child bind, and unbind rows form one group because their
-//! drop rules read each other; revisions travel with their descending index
-//! so index parity holds within every unit.
+//! runs, rows no retained sequence can observe are dropped, new segments are
+//! written, and a manifest publishes that swaps just those references.
+//! Families whose rows must stay mutually consistent compact together —
+//! bind, child bind, and unbind rows form one group because their drop rules
+//! read each other; revisions travel with their descending index so index
+//! parity holds within every unit.
+//!
+//! A merge writes a base-tier run when, and only when, its window starts at
+//! the group's oldest run. That is the same condition retention dropping
+//! needs, so the level a run carries and the rules that produced it say the
+//! same thing: a base run is a run some fold was allowed to drop rows from,
+//! a delta run is a run nothing has dropped from yet ([`MergePlacement`]). A
+//! merge that had to start above the group's base therefore writes a bigger
+//! delta run rather than a second base run, and a family group holds at most
+//! one base run at any time (manifest load refuses a manifest that says
+//! otherwise).
 //!
 //! There is no progress record: each unit ends in a durable manifest, so a
 //! crashed or interrupted reorganization resumes by reading the live
@@ -37,7 +47,7 @@ use super::publish::{
 };
 use super::runs::{
     flatten_manifest_tables, l0_run_count, MetadataLsmPolicy, MetadataRunManifest,
-    CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
+    CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, REORGANIZE_FAMILY_GROUPS,
 };
 use super::scan::VerifiedMetadataTables;
 use crate::context::MutationContext;
@@ -55,40 +65,16 @@ use loonfs_api::{
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Families whose rows merge in one reorganization unit. Families that read
-/// each other's rows to decide what to drop (see
-/// `drop_rows_below_retention_floor`) must compact together, and a secondary
-/// index always travels with its canonical family.
-const REORGANIZE_FAMILY_GROUPS: [&[MetadataTableFamily]; 7] = [
-    &[
-        MetadataTableFamily::DirentryBinds,
-        MetadataTableFamily::DirentryChildBinds,
-        MetadataTableFamily::DirentryUnbinds,
-    ],
-    &[
-        MetadataTableFamily::Revisions,
-        MetadataTableFamily::RevisionsByInodeDesc,
-    ],
-    &[MetadataTableFamily::Inodes],
-    &[MetadataTableFamily::Tombstones],
-    // Active deletions fold alone: a removal marker is cancelled by the
-    // listed row it names, and both live in this family.
-    &[MetadataTableFamily::ActiveDeletions],
-    &[MetadataTableFamily::CommitReceipts],
-    // Attributes fold alone too: a revision supersedes the revisions of the
-    // same inode, and they all live in this family. The family has no
-    // secondary index to travel with.
-    &[MetadataTableFamily::Attributes],
-];
-
 /// What one reorganization step did.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MetadataReorganizeOutcome {
     /// The manifest's L0 run count is below the policy trigger; nothing to
     /// fold yet.
     NotNeeded { l0_runs: usize },
-    /// One bounded complete-run subset for a family group folded into new
-    /// base segments and the manifest advanced.
+    /// One bounded complete-run subset for a family group merged into one
+    /// new run and the manifest advanced. The new run is the group's base
+    /// when the subset started at the group's oldest run, and a bigger delta
+    /// run otherwise.
     UnitPublished {
         families: Vec<MetadataTableFamily>,
         folded_l0_rows: u64,
@@ -251,20 +237,19 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let floor_seq = resolve_retention_floor_seq(store, &head)
         .await
         .map_err(CoreError::load_head)?;
-    // Dropping is only visibility-preserving over a merge that starts at
-    // the group's oldest run; see
-    // [`ReorganizationInput::starts_at_group_bottom`]. A window that had to
-    // skip older runs merges them exactly as they are, so its output holds
-    // every row its inputs held.
-    if input.starts_at_group_bottom {
+    // Dropping is only visibility-preserving over a merge that starts at the
+    // group's oldest run, which is what the placement records. A window that
+    // had to skip older runs merges them exactly as they are, so its output
+    // holds every row its inputs held.
+    if input.placement.may_drop_rows_below_the_retention_floor() {
         drop_rows_below_retention_floor(&mut rows_by_family, floor_seq)?;
     }
 
     let run_tables = build_manifest_tables_from_rows(
         store,
         namespace_id,
-        previous.payload.head_seq,
-        CHECKPOINT_BASE_RUN_LEVEL,
+        input.placement.output_seq(),
+        input.placement.output_level(),
         |family| rows_by_family.remove(&family).unwrap_or_default(),
         MetadataTableSegmentation::Base {
             max_rows_per_segment: policy.max_rows_per_segment,
@@ -341,16 +326,102 @@ pub(super) struct ReorganizationInput {
     folded_l0_rows: u64,
     decoded_rows: u64,
     decoded_bytes: u64,
-    /// Whether the selected window starts at the group's oldest run.
+    /// Where this merge's output stands in the group, which decides both the
+    /// level it is written at and whether it may drop rows.
+    pub(super) placement: MergePlacement,
+}
+
+/// Where a merge's output stands in its family group.
+///
+/// **A merge's output is base-tier if and only if its window starts at the
+/// group's oldest run.** Base-tier means "rows a fold was allowed to drop
+/// from", so the level a run carries and the rules that produced it say the
+/// same thing. Both the output level and the right to drop rows are read off
+/// this one value; there is no separate flag either can disagree with.
+///
+/// A bottom-anchored merge writes the group's base run, stamped at the
+/// manifest head. Base-tier runs sort below every delta run whatever sequence
+/// they carry, so the output lands at the bottom where its inputs were, and
+/// the sequence is free to be the head's — which is also what keeps a file at
+/// `head_seq` in the manifest when the merge consumed the group's whole top.
+/// It replaces the group's previous base run, because a bottom-anchored
+/// window always contains it, so the group is left with exactly one.
+///
+/// A merge that had to start above the group's base rewrites delta runs into
+/// one bigger delta run. Two things follow from writing it at the delta level
+/// rather than the base level. It cannot mint a second base run, so a group's
+/// base never fragments and nothing ever hides an over-budget bottom behind
+/// fragments that each fit. And its rows stay counted as delta pressure, so
+/// the L0 run count reports what is really waiting.
+///
+/// Its sequence is its newest input's, not the manifest head's, so the output
+/// stands exactly where that run stood: above every run the window left below
+/// it and below every run it left above. The head would put it above runs the
+/// window never reached, and moving merged rows above newer runs is what a
+/// later bottom-anchored fold must never see — it could then drop an unbind
+/// whose bind had moved out of the window and put a deleted file back. The
+/// head is also shared by consecutive maintenance steps on a quiet namespace,
+/// so head-stamped outputs of different merges collide at one identity.
+///
+/// Nothing else in the manifest already holds that identity for these
+/// families: the newest input run's segments for this group leave
+/// `metadata_files` in the same publication the output's enter it. Segments
+/// of other families at that identity stay where they are, which is ordinary
+/// — a run is a set of families, and each family in it has one producer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MergePlacement {
+    /// The window started at the group's oldest run. The output is the
+    /// group's base run at the manifest head, and retention may drop rows.
     ///
-    /// Retention dropping reads across the merged rows: an unbind cancels
-    /// the bind it names, and a removal marker cancels the listed deletion
-    /// it repeats. Dropping one half of such a pair is only
-    /// visibility-preserving when the other half is in the same merge, and
-    /// what guarantees that is starting the merge at the group's oldest
-    /// run — the cancelling row is always the newer of the two, so every row
-    /// it can cancel is already in the window (format spec, "Compaction").
-    pub(super) starts_at_group_bottom: bool,
+    /// Retention dropping reads across the merged rows: an unbind cancels the
+    /// bind it names, and a removal marker cancels the listed deletion it
+    /// repeats. Dropping one half of such a pair is only visibility-preserving
+    /// when the other half is in the same merge, and what guarantees that is
+    /// starting the merge at the group's oldest run — the cancelling row is
+    /// always the newer of the two, so every row it can cancel is already in
+    /// the window (format spec, "Compaction").
+    Base { output_seq: ChangeSeq },
+    /// The window started above the group's oldest run. The output is a delta
+    /// run at the newest input's sequence, and nothing is dropped.
+    Delta { output_seq: ChangeSeq },
+}
+
+impl MergePlacement {
+    fn output_seq(self) -> ChangeSeq {
+        match self {
+            Self::Base { output_seq } | Self::Delta { output_seq } => output_seq,
+        }
+    }
+
+    fn output_level(self) -> u32 {
+        match self {
+            Self::Base { .. } => CHECKPOINT_BASE_RUN_LEVEL,
+            Self::Delta { .. } => CHECKPOINT_L0_RUN_LEVEL,
+        }
+    }
+
+    fn may_drop_rows_below_the_retention_floor(self) -> bool {
+        matches!(self, Self::Base { .. })
+    }
+}
+
+/// Where the output of the selected window stands.
+fn merge_placement(
+    bottom_anchored: bool,
+    runs: &[MetadataRunManifest],
+    head_seq: ChangeSeq,
+) -> MergePlacement {
+    if bottom_anchored {
+        return MergePlacement::Base {
+            output_seq: head_seq,
+        };
+    }
+    // The newest input's sequence. A merge above the base needs two runs to
+    // make progress, so the window is never empty here and the fallback only
+    // keeps this total.
+    MergePlacement::Delta {
+        output_seq: runs.iter().map(|run| run.run_seq).max().unwrap_or(head_seq),
+    }
 }
 
 /// What one selection attempt found.
@@ -379,31 +450,36 @@ pub(super) struct OverBudgetRun {
 ///
 /// **The order.** The comparator below is the group's recency order, oldest
 /// first. Base-tier runs hold rows an earlier fold already absorbed, so they
-/// sit under every L0 run whatever their `run_seq` says: a bounded fold
-/// stamps its output at the manifest head, which can leave a base run
-/// carrying a higher `run_seq` than an L0 run it did not fold (see
-/// [`manifest_has_partial_reorganization`]). Within one tier the lower
-/// `run_seq` is the older run.
+/// sit under every L0 run whatever their `run_seq` says: a bottom-anchored
+/// fold stamps its output at the manifest head, which can leave a base run
+/// carrying a higher `run_seq` than an L0 run some other group has not folded
+/// yet (see [`manifest_has_partial_reorganization`]). Within one tier the
+/// lower `run_seq` is the older run.
 ///
-/// **The invariant.** A merge writes its inputs back as one base-tier run
-/// stamped at the manifest head. That output is older than every L0 run in
-/// the order above, so it may not carry a row newer than an L0 run it left
-/// behind — otherwise a later fold could drop a row while the row it cancels
-/// sits outside the window. Two rules keep that true. The window is a
-/// *contiguous* slice of the order, and its start only ever moves forward
-/// past **base-tier** runs; an L0 run is never stepped over. Every run the
-/// window leaves out therefore sits wholly below it or wholly above it, never
-/// interleaved, and the output can stand in for the whole window without
-/// moving any row past any other. When the window starts at the very bottom
-/// nothing is left out below it at all, and that is the stronger property
-/// retention dropping needs — see
-/// [`ReorganizationInput::starts_at_group_bottom`].
+/// **The invariant.** A merge writes its inputs back as one run standing
+/// where the window stood: at the bottom of the group when the window is
+/// bottom-anchored, and at its newest input's identity otherwise
+/// ([`MergePlacement`]). Either way the output may not carry a row newer than
+/// a run it left above the window — otherwise a later fold could drop a row
+/// while the row it cancels sits outside that fold's window. What keeps that
+/// true is that the window is a *contiguous* slice of the order: every run it
+/// leaves out sits wholly below it or wholly above it, never interleaved, so
+/// the output can stand in for the whole window without moving any row past
+/// any other. When the window starts at the very bottom nothing is left out
+/// below it at all, and that is the stronger property retention dropping
+/// needs — see [`MergePlacement::Base`].
+///
+/// **There are two windows to try.** A manifest holds at most one base-tier
+/// run per family group, so the search is short: the window starting at the
+/// group's oldest run, and — when a base run blocks that one — the window
+/// starting at the oldest delta run above it. A delta run is never stepped
+/// over.
 ///
 /// **The budgets pace the work; they never end it.** When no window starting
 /// at the group's oldest run can fit the budgets, the start moves past the
-/// base-tier runs that block it and the step merges the L0 runs above them
-/// on their own. The group keeps shedding runs even while the run at its
-/// bottom stays too large to fold.
+/// base run that blocks it and the step merges the L0 runs above it on their
+/// own. The group keeps shedding runs even while the run at its bottom stays
+/// too large to fold.
 ///
 /// Index sections are read before row payloads so the decoded-byte budget is
 /// known exactly from each data block's durable `decoded_len`; a run that
@@ -427,26 +503,28 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
             .then(right.level.cmp(&left.level))
     });
     let candidate_count = candidates.len();
+    let head_seq = tables.manifest().payload.head_seq;
     let row_budget =
         u64::try_from(policy.max_decoded_input_rows_per_step.get()).unwrap_or(u64::MAX);
     let byte_budget =
         u64::try_from(policy.max_decoded_input_bytes_per_step.get()).unwrap_or(u64::MAX);
     let max_runs = policy.max_input_runs_per_step.get();
-    // Base-tier runs sort first, so this is also the index of the oldest L0
-    // candidate. The window start may move up to it and no further.
-    let base_tier_candidates = candidates
+    // Base-tier runs sort first, so this is the index of the oldest L0
+    // candidate, and starting there is what skips a base run the budgets
+    // cannot admit. A group has at most one base run, so this is one place
+    // and the only alternative to the bottom.
+    let first_delta_candidate = candidates
         .iter()
         .take_while(|run| run.level != CHECKPOINT_L0_RUN_LEVEL)
         .count();
-    let window_starts = (base_tier_candidates + 1)
-        .min(candidate_count)
-        .min(max_runs);
+    let delta_only_start = (first_delta_candidate > 0 && first_delta_candidate < candidate_count)
+        .then_some(first_delta_candidate);
     // Reading a run's decoded byte total costs its index sections, so each
     // candidate's total is read at most once however many windows weigh it.
     let mut decoded_bytes_by_candidate = vec![None::<u64>; candidate_count];
     let mut group_bottom_over_budget = None;
 
-    for window_start in 0..window_starts {
+    for window_start in std::iter::once(0).chain(delta_only_start) {
         let mut runs = Vec::new();
         let mut decoded_rows = 0u64;
         let mut decoded_bytes = 0u64;
@@ -497,16 +575,29 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
             runs.push(run.clone());
         }
 
-        // Every merge writes one base-tier run, so each L0 run it takes
-        // leaves L0 for good and the group's L0 count strictly falls. That
-        // is the whole progress condition, and it is what makes the fold
-        // terminate: a window holding no L0 run would only rewrite base-tier
-        // rows where they stand, forever.
-        let makes_progress = runs.iter().any(|run| run.level == CHECKPOINT_L0_RUN_LEVEL);
+        // A merge must leave the group with less to fold than it found, or
+        // the same window would be chosen again forever. What counts as less
+        // follows from where the output lands.
+        //
+        // A bottom-anchored merge writes a base run, so every L0 run it takes
+        // leaves L0 for good: one L0 run in the window is enough, and a
+        // window holding none would only rewrite base rows where they stand.
+        //
+        // A merge above the base writes another delta run, so it only gains
+        // by merging two or more into one. A single-run window there would
+        // rewrite that run as itself, at its own identity, having read and
+        // written every row for nothing.
+        let bottom_anchored = window_start == 0;
+        let makes_progress = if bottom_anchored {
+            runs.iter().any(|run| run.level == CHECKPOINT_L0_RUN_LEVEL)
+        } else {
+            runs.len() > 1
+        };
         if !makes_progress {
             continue;
         }
         let run_ids = runs.iter().map(|run| (run.run_seq, run.level)).collect();
+        let placement = merge_placement(bottom_anchored, &runs, head_seq);
         return Ok(ReorganizationSelection {
             input: Some(ReorganizationInput {
                 runs,
@@ -514,7 +605,7 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 folded_l0_rows,
                 decoded_rows,
                 decoded_bytes,
-                starts_at_group_bottom: window_start == 0,
+                placement,
             }),
             group_bottom_over_budget,
         });
@@ -529,12 +620,17 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
 /// Says out loud that a family group's oldest run no longer fits one
 /// reorganization step.
 ///
-/// Nothing is broken when this fires and nothing stalls: folds keep merging
-/// the newer runs above the run named here. What stops is reclamation of
-/// that run's rows, because no step can rewrite a run it cannot read whole.
-/// The group's run count therefore drifts up over time. Raising
+/// Nothing is corrupt when this fires, but work does stop. Folds keep
+/// merging the newer runs above the run named here, into one bigger delta run
+/// each time, until only one delta run is left; from then on the group has no
+/// window that makes progress and every step reports it blocked. Reclamation
+/// of the named run's rows stops first, because no step can rewrite a run it
+/// cannot read whole. Group selection then keeps choosing this group — it
+/// still holds the most L0 rows, and a merge that cannot drop rows never
+/// reduces them — so the other groups stop folding too. Raising
 /// `max_decoded_input_rows_per_step` and `max_decoded_input_bytes_per_step`
-/// past the numbers in this line is the operator's lever.
+/// past the numbers in this line is the operator's lever until the streaming
+/// compactor takes this case off the step.
 ///
 /// One line per step: a step is already the unit maintenance schedules, so
 /// the cadence of the warning is the cadence of maintenance.
@@ -554,15 +650,25 @@ fn report_group_bottom_over_budget(
         max_decoded_input_rows_per_step = policy.max_decoded_input_rows_per_step.get(),
         max_decoded_input_bytes_per_step = policy.max_decoded_input_bytes_per_step.get(),
         "the oldest metadata run in this family group no longer fits one reorganization step; \
-         folds skip it and merge the newer runs, so its rows are never reclaimed and the \
-         group's run count grows",
+         folds skip it and merge the newer runs into one delta run, so its rows are never \
+         reclaimed, and once that merge has nothing left to take this group blocks every step \
+         and the other groups stop folding behind it",
     );
 }
 
-/// A bounded fold stamps its output at the manifest head. If older or
-/// same-seq L0 runs remain, that ordering is the durable resume marker. A
-/// fresh L0 appended after a completed fold is strictly newer than every
-/// base-tier run and therefore does not bypass the normal trigger.
+/// A bottom-anchored fold stamps its base run at the manifest head, which is
+/// at or above every L0 run's sequence. So a base run sitting at or above the
+/// oldest L0 run says one group folded here and L0 runs remain — usually
+/// other groups' rows in the very runs it just took its own rows out of. The
+/// step keeps going on that evidence rather than stopping at the trigger,
+/// which is what makes a run of bounded steps end in the same manifest shape
+/// one unbounded step would have produced.
+///
+/// A merge above the base writes a delta run at its newest input's sequence
+/// ([`MergePlacement`]), so it never puts a base run here and its inputs stay
+/// counted as L0 pressure. A fresh L0 appended after a completed fold is
+/// strictly newer than every base-tier run and therefore does not bypass the
+/// normal trigger.
 fn manifest_has_partial_reorganization(runs: &[MetadataRunManifest]) -> bool {
     let Some(oldest_l0_seq) = runs
         .iter()

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -19,6 +19,7 @@ pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_BYTES: usize = 64 * 1024 * 102
 pub(super) const MAX_MAINTENANCE_TABLE_IO: usize = 8;
 pub(super) const CHECKPOINT_L0_RUN_LEVEL: u32 = 0;
 pub(super) const CHECKPOINT_BASE_RUN_LEVEL: u32 = 1;
+
 pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 10] = [
     MetadataTableFamily::Inodes,
     MetadataTableFamily::DirentryBinds,
@@ -30,6 +31,36 @@ pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 10] = [
     MetadataTableFamily::ActiveDeletions,
     MetadataTableFamily::CommitReceipts,
     MetadataTableFamily::Attributes,
+];
+
+/// Families whose rows merge in one reorganization unit. Families that read
+/// each other's rows to decide what to drop (see
+/// `super::reorganize::drop_rows_below_retention_floor`) must compact
+/// together, and a secondary index always travels with its canonical family.
+///
+/// The grouping is layout policy, not reorganization's alone: manifest load
+/// checks a per-group invariant — at most one base-tier run per group — so
+/// the loader reads this table too.
+pub(super) const REORGANIZE_FAMILY_GROUPS: [&[MetadataTableFamily]; 7] = [
+    &[
+        MetadataTableFamily::DirentryBinds,
+        MetadataTableFamily::DirentryChildBinds,
+        MetadataTableFamily::DirentryUnbinds,
+    ],
+    &[
+        MetadataTableFamily::Revisions,
+        MetadataTableFamily::RevisionsByInodeDesc,
+    ],
+    &[MetadataTableFamily::Inodes],
+    &[MetadataTableFamily::Tombstones],
+    // Active deletions fold alone: a removal marker is cancelled by the
+    // listed row it names, and both live in this family.
+    &[MetadataTableFamily::ActiveDeletions],
+    &[MetadataTableFamily::CommitReceipts],
+    // Attributes fold alone too: a revision supersedes the revisions of the
+    // same inode, and they all live in this family. The family has no
+    // secondary index to travel with.
+    &[MetadataTableFamily::Attributes],
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -146,6 +146,113 @@ async fn overwrite_manifest(
     }
 }
 
+/// Republishes a payload under a fresh manifest id and loads it back, so a
+/// caller can assert on what validation makes of an edited manifest.
+async fn load_perturbed_manifest(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    mut payload: NamespaceManifestPayload,
+    id_offset: u64,
+) -> Result<(), ManifestLoadError> {
+    payload.manifest_id = ManifestId(payload.manifest_id.0 + id_offset);
+    payload.manifest_object_id = ManifestObjectId::generate(payload.manifest_id);
+    let manifest_object_id = payload.manifest_object_id.clone();
+    let envelope =
+        NamespaceManifestEnvelope::from_payload(payload).expect("perturbed manifest envelope");
+    write_namespace_manifest(store, &envelope)
+        .await
+        .expect("write perturbed manifest");
+    load_verified_manifest_tables(store, namespace_id, &manifest_object_id)
+        .await
+        .map(|_| ())
+}
+
+/// A second descriptor modelled on one the manifest already holds: a fresh
+/// table id and object key, stamped with whatever run identity the caller
+/// wants to test. The rows it points at are the modelled segment's, which is
+/// what a stray or duplicated descriptor looks like.
+fn segment_modelled_on(
+    modelled_on: &MetadataFileRef,
+    namespace_id: &NamespaceId,
+    run_seq: ChangeSeq,
+    level: u32,
+) -> MetadataFileRef {
+    let table_id = loonfs_api::MetadataTableId::generate();
+    MetadataFileRef {
+        object_key: metadata_table(namespace_id.as_str(), table_id.as_str()),
+        table_id,
+        run_seq,
+        level,
+        segment_index: 0,
+        ..modelled_on.clone()
+    }
+}
+
+/// One base-tier segment of `family`, for a test that builds a second
+/// descriptor out of it.
+fn base_segment_of_family(
+    manifest: &NamespaceManifestEnvelope,
+    family: ApiMetadataTableFamily,
+) -> MetadataFileRef {
+    manifest
+        .payload
+        .metadata_files
+        .iter()
+        .find(|descriptor| {
+            descriptor.family == family && descriptor.level == CHECKPOINT_BASE_RUN_LEVEL
+        })
+        .expect("a folded base segment of this family")
+        .clone()
+}
+
+/// A namespace with one folded base run and one delta run above it, which is
+/// the smallest shape a second base-tier run can be added to.
+async fn seed_folded_base_with_a_delta_run(store: &LocalFsStore, namespace_id: &NamespaceId) {
+    let context = test_context();
+    bootstrap_namespace(store, namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        store,
+        namespace_id,
+        "/docs/first.txt",
+        b"first\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write the seed file");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the seed");
+    drain_reorganization(store, namespace_id, &context, MetadataLsmPolicy::default()).await;
+    write_file_bytes(
+        store,
+        namespace_id,
+        "/docs/second.txt",
+        b"second\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write a file above the base");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint a delta run above the base");
+}
+
+/// The current manifest, loaded and detached from the tables that hold it.
+async fn current_manifest(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+) -> NamespaceManifestEnvelope {
+    let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
+    let tables = load_verified_manifest_tables(store, namespace_id, &manifest_object_id)
+        .await
+        .expect("load the current manifest's tables");
+    tables.manifest().clone()
+}
+
 fn assert_revision_index_mismatch<T>(result: Result<T, ManifestLoadError>) {
     match result {
         Err(ManifestLoadError::RevisionIndexMismatch { .. }) => {}
@@ -1393,8 +1500,6 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
     ];
     for (index, (label, perturb)) in perturbations.iter().enumerate() {
         let mut perturbed = payload.clone();
-        perturbed.manifest_id = ManifestId(perturbed.manifest_id.0 + 1 + index as u64);
-        perturbed.manifest_object_id = ManifestObjectId::generate(perturbed.manifest_id);
         let descriptor = perturbed
             .metadata_files
             .iter_mut()
@@ -1405,21 +1510,139 @@ async fn manifest_load_rejects_descriptors_off_the_frozen_segment_layout() {
             })
             .expect("an inline-filtered descriptor spanning several keys");
         perturb(descriptor);
-        let perturbed_object_id = perturbed.manifest_object_id.clone();
-        let envelope = NamespaceManifestEnvelope::from_payload(perturbed)
-            .expect("perturbed manifest envelope");
-        write_namespace_manifest(&store, &envelope)
-            .await
-            .expect("write perturbed manifest");
-        let error = match load_verified_manifest_tables(&store, &namespace_id, &perturbed_object_id)
-            .await
-        {
-            Ok(_) => panic!("{label}: perturbed manifest must not load"),
-            Err(error) => error,
+        let Err(error) =
+            load_perturbed_manifest(&store, &namespace_id, perturbed, 1 + index as u64).await
+        else {
+            panic!("{label}: perturbed manifest must not load")
         };
         assert!(
             matches!(error, ManifestLoadError::SegmentDescriptorMismatch { .. }),
             "{label}: unexpected error {error:?}"
         );
     }
+}
+
+/// A group with two base-tier runs does not load.
+///
+/// This is the shape a merge above the base used to write: its output went to
+/// the base tier stamped at the manifest head, so it became a second base run
+/// for the group rather than a bigger delta run. Every fragment stayed under
+/// the per-step budget on its own, so nothing ever reported the group's oldest
+/// run as over budget, and the group's rows below the retention floor could
+/// never be dropped — dropping needs a fold whose window starts at the group's
+/// oldest run.
+///
+/// Refusing the shape at load is what says it cannot come back: no builder
+/// writes it now, and a manifest carrying it is corruption rather than a
+/// state to carry on from.
+#[tokio::test]
+async fn a_manifest_whose_group_base_fragmented_does_not_load() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_folded_base_with_a_delta_run(&store, &namespace_id).await;
+
+    let manifest = current_manifest(&store, &namespace_id).await;
+    let group = group_containing(ApiMetadataTableFamily::Inodes);
+    assert_eq!(
+        group_base_runs(&manifest, group).len(),
+        1,
+        "the seed must leave the group in one base run"
+    );
+
+    let mut fragmented = manifest.payload.clone();
+    fragmented.metadata_files.push(segment_modelled_on(
+        &base_segment_of_family(&manifest, ApiMetadataTableFamily::Inodes),
+        &namespace_id,
+        manifest.payload.head_seq,
+        CHECKPOINT_BASE_RUN_LEVEL,
+    ));
+
+    let error = load_perturbed_manifest(&store, &namespace_id, fragmented, 1)
+        .await
+        .expect_err("a group with two base runs must not load");
+    let ManifestLoadError::RunManifestMismatch { message, .. } = &error else {
+        panic!("expected a run mismatch, got {error:?}")
+    };
+    assert!(
+        message.contains("Inodes") && message.contains("base"),
+        "the rejection must name the group and what it holds too many of, got `{message}`"
+    );
+}
+
+/// Two segments of one family carrying the same index inside one run do not
+/// load.
+///
+/// A family in a run has one producer, and every producer numbers from zero,
+/// so the numbers are a dense sequence. Two sets of them at one identity is
+/// what a merge above the base used to leave behind when the group's base
+/// already sat at the identity the merge stamped: both sets started at zero.
+#[tokio::test]
+async fn a_manifest_that_numbers_one_family_twice_in_one_run_does_not_load() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_folded_base_with_a_delta_run(&store, &namespace_id).await;
+
+    let manifest = current_manifest(&store, &namespace_id).await;
+    let existing = base_segment_of_family(&manifest, ApiMetadataTableFamily::Inodes);
+    assert_eq!(existing.segment_index, 0);
+
+    let mut repeated = manifest.payload.clone();
+    repeated.metadata_files.push(segment_modelled_on(
+        &existing,
+        &namespace_id,
+        existing.run_seq,
+        existing.level,
+    ));
+
+    let error = load_perturbed_manifest(&store, &namespace_id, repeated, 2)
+        .await
+        .expect_err("two segments of one family at one index must not load");
+    let ManifestLoadError::SegmentDescriptorMismatch { message, .. } = &error else {
+        panic!("expected a segment descriptor mismatch, got {error:?}")
+    };
+    assert!(
+        message.contains("Inodes") && message.contains("numbered from zero"),
+        "the rejection must name the family and the numbering rule, got `{message}`"
+    );
+}
+
+/// Two segments of one family whose key ranges touch inside one run do not
+/// load.
+///
+/// One producer writes a family's segments in ascending key order, so segment
+/// one starts strictly above where segment zero ended. A descriptor can keep
+/// the numbering dense and still not belong — stamped with another run's
+/// identity, say — and then its key range is what disagrees with its
+/// neighbours'. Here the second segment repeats the first one's whole range,
+/// which is the shape a duplicated descriptor takes.
+#[tokio::test]
+async fn a_manifest_whose_run_segments_overlap_in_key_range_does_not_load() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_folded_base_with_a_delta_run(&store, &namespace_id).await;
+
+    let manifest = current_manifest(&store, &namespace_id).await;
+    let existing = base_segment_of_family(&manifest, ApiMetadataTableFamily::Inodes);
+    assert_eq!(existing.segment_index, 0);
+
+    let mut overlapping = manifest.payload.clone();
+    let mut second =
+        segment_modelled_on(&existing, &namespace_id, existing.run_seq, existing.level);
+    // Index one keeps the numbering dense, so only the key order can object.
+    second.segment_index = 1;
+    overlapping.metadata_files.push(second);
+
+    let error = load_perturbed_manifest(&store, &namespace_id, overlapping, 3)
+        .await
+        .expect_err("overlapping segment ranges within one run must not load");
+    let ManifestLoadError::SegmentDescriptorMismatch { message, .. } = &error else {
+        panic!("expected a segment descriptor mismatch, got {error:?}")
+    };
+    assert!(
+        message.contains("Inodes") && message.contains("ascending key order"),
+        "the rejection must name the family and the ordering rule, got `{message}`"
+    );
 }

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -31,7 +31,7 @@ use super::row::{manifest_rows_for_family, metadata_states_equivalent};
 use super::runs::{
     flatten_manifest_tables, runs_from_metadata_files, runs_in_scan_order, MetadataLsmPolicy,
     MetadataRunManifest, CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
-    CHECKPOINT_TABLE_FAMILIES, DEFAULT_MAX_CHECKPOINT_L0_RUNS,
+    CHECKPOINT_TABLE_FAMILIES, DEFAULT_MAX_CHECKPOINT_L0_RUNS, REORGANIZE_FAMILY_GROUPS,
 };
 use super::stored_block_cache::{
     StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind,
@@ -48,6 +48,9 @@ use crate::namespace::control::{
 };
 use crate::namespace::status::load_namespace_head_summary;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
+use crate::path::read::{
+    load_metadata_view, resolve_current_files, CurrentFileState, ReadLoadContext,
+};
 use crate::path::write::ops::{
     delete_path, move_path, put_file_bytes, restore_file_revision, write_file_bytes,
 };
@@ -315,6 +318,70 @@ fn l0_runs(manifest: &NamespaceManifestEnvelope) -> Vec<MetadataRunManifest> {
         .into_iter()
         .filter(|run| run.level == CHECKPOINT_L0_RUN_LEVEL)
         .collect()
+}
+
+/// A run's identity: the sequence and level a manifest names it by.
+type RunId = (ChangeSeq, u32);
+
+/// Every run that holds rows of one family group right now.
+fn group_runs(
+    manifest: &NamespaceManifestEnvelope,
+    group: &[ApiMetadataTableFamily],
+) -> Vec<RunId> {
+    runs_from_metadata_files(&manifest.payload)
+        .into_iter()
+        .filter(|run| {
+            run.tables
+                .iter()
+                .any(|table| group.contains(&table.family) && !table.segments.is_empty())
+        })
+        .map(|run| (run.run_seq, run.level))
+        .collect()
+}
+
+/// The base-tier runs one family group holds right now.
+///
+/// A group holds at most one: only a merge that starts at the group's oldest
+/// run writes a base run, and such a merge always replaces the one that was
+/// there. More than one is the fragmented base a merge above the base used to
+/// create, which manifest load now refuses.
+fn group_base_runs(
+    manifest: &NamespaceManifestEnvelope,
+    group: &[ApiMetadataTableFamily],
+) -> Vec<RunId> {
+    group_runs(manifest, group)
+        .into_iter()
+        .filter(|(_, level)| *level != CHECKPOINT_L0_RUN_LEVEL)
+        .collect()
+}
+
+/// The delta runs one family group holds right now.
+fn group_delta_runs(
+    manifest: &NamespaceManifestEnvelope,
+    group: &[ApiMetadataTableFamily],
+) -> Vec<RunId> {
+    group_runs(manifest, group)
+        .into_iter()
+        .filter(|(_, level)| *level == CHECKPOINT_L0_RUN_LEVEL)
+        .collect()
+}
+
+/// Every family group's base-tier runs, for a caller asserting that none of
+/// them has fragmented.
+fn base_runs_per_family_group(
+    manifest: &NamespaceManifestEnvelope,
+) -> Vec<(&'static [ApiMetadataTableFamily], Vec<RunId>)> {
+    REORGANIZE_FAMILY_GROUPS
+        .into_iter()
+        .map(|group| (group, group_base_runs(manifest, group)))
+        .collect()
+}
+
+fn group_containing(family: ApiMetadataTableFamily) -> &'static [ApiMetadataTableFamily] {
+    REORGANIZE_FAMILY_GROUPS
+        .into_iter()
+        .find(|group| group.contains(&family))
+        .expect("every family belongs to a reorganization group")
 }
 
 fn base_segment_object_keys_for_family(

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1551,15 +1551,22 @@ fn policy_that_cannot_fold_the_base(base_rows: u64) -> MetadataLsmPolicy {
 }
 
 /// A group whose base run alone busts the per-step row budget used to park
-/// forever: selection broke on the first candidate, chose nothing, and
+/// immediately: selection broke on the first candidate, chose nothing, and
 /// reported the group blocked on every step after that while delta runs
 /// piled up behind it with nothing saying why.
 ///
-/// The budget paces the work instead of ending it. The step skips the base
-/// run it cannot read whole, merges the delta runs above it, and says out
-/// loud that the base has outgrown the budget.
+/// The step skips the base run it cannot read whole, merges the delta runs
+/// above it into one bigger delta run, and says out loud that the base has
+/// outgrown the budget. The merged output is a delta run at its newest
+/// input's identity, so the base stays exactly one run: minting a second
+/// base run here is what hid the over-budget bottom from the report.
+///
+/// Once the delta runs are down to one the group has nothing left to merge,
+/// and the step reports it blocked. That is honest — the base still cannot
+/// be read in one step — and it is the case the streaming compactor is being
+/// built for.
 #[tokio::test]
-async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
+async fn a_base_run_over_the_step_budget_merges_the_delta_runs_above_it() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1603,8 +1610,12 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
         .input
         .expect("a group must keep finding work above a base run it cannot fold");
     assert!(
-        !input.starts_at_group_bottom,
-        "the window must start above the base run it cannot read whole"
+        matches!(
+            input.placement,
+            super::reorganize::MergePlacement::Delta { .. }
+        ),
+        "a window that starts above the base run must write a delta run, got {:?}",
+        input.placement
     );
     assert!(
         input
@@ -1629,24 +1640,15 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
     assert_eq!(bottom.level, CHECKPOINT_BASE_RUN_LEVEL);
     assert_eq!(bottom.rows, base_rows);
 
-    // Repeated steps keep draining the group. The base run stays exactly
-    // where it is.
+    // Repeated steps keep merging what fits. The base run stays exactly where
+    // it is, and stays one run.
     let mut published = 0usize;
-    let mut group_l0_runs = vec![l0_runs(&before.manifest).len()];
+    let mut blocked = 0usize;
+    let mut group_delta_run_counts = vec![group_delta_runs(&before.manifest, &group).len()];
     for _ in 0..64 {
         let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
             .await
             .expect("reorganization step");
-        match report.outcome {
-            super::MetadataReorganizeOutcome::UnitPublished { .. } => published += 1,
-            super::MetadataReorganizeOutcome::Superseded => {
-                panic!("no concurrent publisher exists in this test")
-            }
-            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
-                panic!("the group parked instead of folding what fits")
-            }
-            super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
-        }
         let current = load_manifest_materialization_for_inspection(
             &store,
             &namespace_id,
@@ -1654,9 +1656,32 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
         )
         .await
         .expect("load the folded manifest");
-        group_l0_runs.push(l0_runs(&current.manifest).len());
+        assert_eq!(
+            group_base_runs(&current.manifest, &group).len(),
+            1,
+            "a merge above the base must not mint a second base run"
+        );
+        group_delta_run_counts.push(group_delta_runs(&current.manifest, &group).len());
+        match report.outcome {
+            super::MetadataReorganizeOutcome::UnitPublished { .. } => published += 1,
+            super::MetadataReorganizeOutcome::Superseded => {
+                panic!("no concurrent publisher exists in this test")
+            }
+            // The group's delta runs are down to one, and merging one run
+            // into itself is not progress. Only a fold of the whole group
+            // moves this on, and that fold does not fit one step.
+            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                blocked += 1;
+                break;
+            }
+            super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
+        }
     }
     assert!(published > 0, "at least one unit must publish");
+    assert_eq!(
+        blocked, 1,
+        "the group must end blocked on the base it cannot read, ran {group_delta_run_counts:?}"
+    );
 
     let after = load_manifest_materialization_for_inspection(
         &store,
@@ -1665,13 +1690,16 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
     )
     .await
     .expect("load the drained manifest");
-    assert!(
-        l0_runs(&after.manifest).is_empty(),
-        "delta runs must drain even with the base frozen, ran {group_l0_runs:?}"
+    assert_eq!(
+        group_delta_runs(&after.manifest, &group).len(),
+        1,
+        "the delta runs must merge down to one, ran {group_delta_run_counts:?}"
     );
+    // The group's own run count, not the manifest's: a merge only takes this
+    // group's segments out of its input runs, and those runs stay in the
+    // manifest holding the other groups' families.
     assert!(
-        runs_from_metadata_files(&after.manifest.payload).len()
-            < runs_from_metadata_files(&before.manifest.payload).len(),
+        group_runs(&after.manifest, &group).len() < group_runs(&before.manifest, &group).len(),
         "the group's run count must fall"
     );
     let remaining = run_segment_object_keys(&after.manifest);
@@ -1690,12 +1718,19 @@ async fn a_base_run_over_the_step_budget_no_longer_parks_the_group() {
     ));
 }
 
-/// A merge that skipped older runs must carry every row its inputs held.
+/// A merge that skipped older runs must carry every row its inputs held, and
+/// must leave the group's base alone.
 ///
 /// The retention drop rules read across the merged rows: an unbind cancels
 /// the bind it names, and both have to leave together. A window that starts
 /// above the base cannot see the bind at all, so dropping the unbind there
 /// would put a deleted file back. The step merges without dropping instead.
+///
+/// The output is a delta run at the newest input's sequence, so it stands
+/// where that run stood and the group keeps exactly one base run. Writing it
+/// at the base tier instead is what fragmented the base, and stamping it at
+/// the manifest head is what made two merges of one quiet namespace collide
+/// at one identity.
 #[tokio::test]
 async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1777,8 +1812,21 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
 
     let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
     let input = selection.input.expect("the delta runs must still merge");
-    assert!(!input.starts_at_group_bottom);
+    let newest_input = input
+        .runs
+        .iter()
+        .map(|run| run.run_seq)
+        .max()
+        .expect("the window holds runs");
+    assert_eq!(
+        input.placement,
+        super::reorganize::MergePlacement::Delta {
+            output_seq: newest_input
+        },
+        "a merge above the base writes a delta run at its newest input's sequence"
+    );
     assert!(input.runs.len() > 1);
+    let base_before = group_base_runs(&before.manifest, &group);
 
     let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
         .await
@@ -1799,6 +1847,19 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     )
     .await
     .expect("load the manifest after the fold");
+    // The merge wrote a delta run, not a second base run: the group's base is
+    // exactly the one it was, and the merged rows sit at the identity of the
+    // newest run the window held, which is where that run stood.
+    assert_eq!(
+        group_base_runs(&after.manifest, &group),
+        base_before,
+        "a merge above the base must not mint a base run"
+    );
+    assert_eq!(
+        group_delta_runs(&after.manifest, &group),
+        vec![(newest_input, CHECKPOINT_L0_RUN_LEVEL)],
+        "the merged delta runs must leave one delta run at the newest input's identity"
+    );
     // A merge that skipped older runs drops nothing, so the row set is
     // exactly what it was: the cancelling row still shadows the base's
     // binding and the deleted file stays deleted.
@@ -1825,10 +1886,10 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
 
 /// Skipping is only ever legal at the recency bottom.
 ///
-/// A run in the middle that busts the budget stops the window. The step
-/// refuses to reach past it for a newer run that would have fit, because a
-/// merge stamped at the manifest head lands above everything it left behind
-/// and would reorder the group.
+/// A run in the middle that busts the budget stops the window. The selector
+/// refuses to reach past it for a newer run that would have fit, because the
+/// merged output stands where the window stood and reaching past a run would
+/// move rows past it.
 #[tokio::test]
 async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1925,5 +1986,174 @@ async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
         current_manifest_id(&store, &namespace_id).await,
         root_before,
         "a blocked step must not publish"
+    );
+}
+
+/// What a reader sees right now: every inode the namespace knows, resolved
+/// the way a read resolves it — visible or not, at what path, at what
+/// revision.
+///
+/// This is the answer that must not move while folds run. Comparing rows
+/// would say the opposite of what is wanted: a fold drops rows precisely
+/// because no read can observe them, so the row set is meant to change and
+/// this is not.
+async fn visible_namespace(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+) -> Vec<CurrentFileState> {
+    let materialized = load_manifest_materialization_for_inspection(
+        store,
+        namespace_id,
+        current_manifest_id(store, namespace_id).await,
+    )
+    .await
+    .expect("materialize the manifest");
+    let inode_ids: Vec<InodeId> = materialized
+        .metadata_state
+        .inodes()
+        .iter()
+        .map(|inode| inode.inode_id)
+        .collect();
+    let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+        .await
+        .expect("load the read view");
+    resolve_current_files(&view, &inode_ids)
+        .await
+        .expect("resolve every inode the namespace knows")
+}
+
+/// The soak's end state, as a test.
+///
+/// Four cycles of writes, deletions, and a retention floor that moves past
+/// them, folded under budgets too small to take a group whole. The old level
+/// rule turned every merge above the base into another base-tier run, so the
+/// bases fragmented: a live S3 soak ended with six base-tier runs — direntry
+/// binds split across three of them, revisions across four — and one run
+/// identity carrying the output of several publications. Nothing then
+/// reported any group as too large to fold from its oldest run, because every
+/// fragment fit one step on its own, and the rows below the retention floor
+/// could never be dropped.
+///
+/// What is pinned here is that neither happens. No group's base fragments,
+/// whatever the budgets do; every step leaves reads answering exactly what
+/// they answered before; and a group whose bottom stops fitting one step says
+/// so and stops, rather than minting another base run. Folding such a group
+/// is the streaming compactor's job, and this test gains that half when the
+/// compactor lands.
+#[tokio::test]
+async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    // Small segments so the folded base is many segments rather than one, and
+    // a row budget the groups outgrow within a couple of cycles.
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(24).expect("nonzero"),
+        max_rows_per_segment: NonZeroUsize::new(4).expect("nonzero"),
+        ..MetadataLsmPolicy::default()
+    };
+
+    let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
+    let mut blocked_groups = 0usize;
+    for cycle in 0..4u64 {
+        for file in 0..4u64 {
+            write_file_bytes(
+                &store,
+                &namespace_id,
+                &format!("/d{cycle}/f{file}.txt"),
+                format!("body {cycle}/{file}\n").as_bytes(),
+                &context,
+                None,
+            )
+            .await
+            .expect("write file");
+        }
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("checkpoint the writes");
+        for file in 0..3u64 {
+            delete_path(
+                &store,
+                &namespace_id,
+                &format!("/d{cycle}/f{file}.txt"),
+                &context,
+                None,
+            )
+            .await
+            .expect("delete a file");
+        }
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("checkpoint the deletions");
+        advance_retention_floor(&store, &namespace_id, &context)
+            .await
+            .expect("advance the floor past the deletions");
+        let visible = visible_namespace(&store, &namespace_id).await;
+
+        let mut settled = false;
+        for _step in 0..512 {
+            let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+                .await
+                .expect("reorganization step");
+            let current = load_manifest_materialization_for_inspection(
+                &store,
+                &namespace_id,
+                current_manifest_id(&store, &namespace_id).await,
+            )
+            .await
+            .expect("load the current manifest");
+            for (folded, base_runs) in base_runs_per_family_group(&current.manifest) {
+                assert!(
+                    base_runs.len() <= 1,
+                    "cycle {cycle}: {folded:?} holds base runs {base_runs:?}"
+                );
+            }
+            assert_eq!(
+                visible_namespace(&store, &namespace_id).await,
+                visible,
+                "cycle {cycle}: a step changed what a read answers"
+            );
+            match report.outcome {
+                super::MetadataReorganizeOutcome::NotNeeded { .. } => {
+                    settled = true;
+                    break;
+                }
+                // The group's bottom no longer fits one step and its delta
+                // runs are merged down to one. The step says so and mints
+                // nothing; the streaming compactor is what folds it.
+                super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+                    blocked_groups += 1;
+                    settled = true;
+                    break;
+                }
+                super::MetadataReorganizeOutcome::Superseded => {
+                    panic!("no concurrent publisher exists in this test")
+                }
+                super::MetadataReorganizeOutcome::UnitPublished { .. } => {}
+            }
+        }
+        assert!(settled, "cycle {cycle}: reorganization did not settle");
+    }
+
+    assert!(
+        blocked_groups > 0,
+        "a group must have outgrown one step and reported it"
+    );
+    let final_manifest = load_manifest_materialization_for_inspection(
+        &store,
+        &namespace_id,
+        current_manifest_id(&store, &namespace_id).await,
+    )
+    .await
+    .expect("load the final manifest");
+    assert_eq!(
+        group_base_runs(&final_manifest.manifest, group).len(),
+        1,
+        "the bindings group must end in one base run"
     );
 }

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1854,6 +1854,17 @@ out-of-order index entries, and checksum failures as malformed. The segment
 format is versioned by the manifest that references it (`namespace_manifest`
 `format_version`), since a segment is unreachable except through a manifest.
 
+A run is identified by its `run_seq` and `level` together, and holds one
+family's segments from one producer: a WAL flush's delta run or a rebuild's
+output. A producer writes a family's rows in ascending key order and writes
+no key twice. So one family's `segment_index` values inside one run are
+numbered from zero, once each, in the order they were written, the segments'
+key ranges ascend in that same order without touching, and a manifest whose
+descriptors say otherwise does not load. Two runs of different levels may
+share a sequence, and two family groups routinely share one base run — they
+rebuild at the same manifest head — but within one run each family has
+exactly one producer.
+
 #### 4.2.2 Grep roots, manifests, and gram-index segments
 
 `loonfs-grep` owns all grep durability under the namespace extension prefix:
@@ -2057,11 +2068,32 @@ Compaction rewrites metadata runs (and, in the future, content layouts) into
 more efficient physical shapes.
 
 A rebuild merges an oldest-first run of runs for one family group. It may
-skip runs at the oldest end that are too large to read inside one step's
-budget, and then it merges the runs above them; it never steps over a delta
-run, so its output is always older than every delta run it leaves behind. A
-rebuild that skipped runs drops nothing, because the rules below read across
-the merged rows and a skipped run may hold the other half of a pair.
+skip the run at the oldest end when that run is too large to read inside one
+step's budget, and then it merges the delta runs above it; it never steps
+over a delta run.
+
+**A rebuild's output is a base run if and only if its window starts at the
+group's oldest run.** The level a run carries and the rules that produced it
+say the same thing: a base run is one some rebuild was allowed to drop rows
+from, a delta run is one nothing has dropped from yet. So a family group
+holds at most one base run — a bottom-anchored rebuild always contains the
+group's existing base run and replaces it, and nothing else writes one — and
+a manifest that carries two base runs for one group does not load.
+
+The output stands where its window stood, so no row moves past any other. A
+bottom-anchored rebuild's output is stamped at the manifest's `head_seq`;
+base runs sort below every delta run whatever sequence they carry, so it
+lands at the bottom of the group where its inputs were. A rebuild that
+skipped the oldest run writes a delta run stamped at its newest input's
+sequence, which is where that run stood: above every run the window left
+below it, below every run it left above.
+
+A rebuild that skipped the oldest run drops nothing, because the rules below
+read across the merged rows and a skipped run may hold the other half of a
+pair. Such a rebuild reduces the group's run count without touching its base.
+It merges two or more runs into one — merging a single run would rewrite it
+as itself, at its own identity — so a group whose delta runs are down to one
+and whose base is over budget has no rebuild left to run.
 
 A base rebuild that starts at the group's oldest run drops rows that no
 retained sequence can observe: bindings superseded or unbound at or below the


### PR DESCRIPTION
A live S3 test exposed two related metadata reorganization defects. One family group could accumulate several base-tier runs, and separate merges could publish output under the same run identity. Both problems occurred when a merge that started above the group’s oldest run wrote a base-tier result at the manifest head sequence.

This change introduces `MergePlacement` as the single source of the output level, output sequence, and retention eligibility. A merge beginning with the group’s oldest run writes a base-tier result at the manifest head and may remove rows below the retention floor. A merge beginning above the oldest run writes a delta result at the sequence of its newest input and keeps every input row.

The planner now considers a window beginning with the oldest run and, when a base run prevents that window from fitting, a second window containing delta runs above the base. A delta-only merge must combine at least two runs so it reduces the run count.

Manifest loading now rejects more than one base-tier run for a family group. It also requires each family’s segment indexes within a run to start at zero without gaps or duplicates, and requires segment key ranges to be strictly ordered and non-overlapping. The family-group definitions move into the run-layout module so planning and validation use the same definitions.

An oversized group can still merge its delta runs while the base remains over budget. After those deltas have been reduced to one run, the planner reports that the group requires full streaming compaction.

The workspace test suite, Clippy, formatting, OpenAPI checks, and existing golden files all pass.
