### PR TITLE
feat(checkpoint): the streaming compaction executor

### DIFF
--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -359,6 +359,32 @@ impl ActiveDeletionRowAction {
     }
 }
 
+impl MetadataTableFamily {
+    /// The fixed text every row key in this family starts with, up to but
+    /// not including the family's first variable component.
+    ///
+    /// Defined here because it is the front of [`MetadataRow::row_key_for_family`]
+    /// and must change with it; `row_key_prefixes_match_the_row_keys_they_front`
+    /// holds the two together. A streaming compaction reads its retention
+    /// groupings out of the components that follow this prefix, so the
+    /// boundary between two groupings is this prefix followed by whole
+    /// component values (format spec, "Compaction").
+    pub const fn row_key_prefix(self) -> &'static str {
+        match self {
+            Self::Inodes => "inode-",
+            Self::DirentryBinds => "direntry-",
+            Self::DirentryChildBinds => "direntry-child-",
+            Self::DirentryUnbinds => "direntry-unbind-",
+            Self::Revisions => "revision-",
+            Self::RevisionsByInodeDesc => "revision-by-inode-desc-",
+            Self::Tombstones => "tombstone-",
+            Self::ActiveDeletions => "active-deletion-",
+            Self::CommitReceipts => "commit-receipt-",
+            Self::Attributes => "attributes-",
+        }
+    }
+}
+
 impl MetadataRow {
     /// Builds this row's canonical durable key in its primary table family.
     ///
@@ -1176,6 +1202,122 @@ mod tests {
         assert!(!row_of(3, 12, 1)
             .row_key()
             .starts_with(&super::lookup_keys::attributes_prefix(InodeId(43))));
+    }
+
+    /// [`MetadataTableFamily::row_key_prefix`] states the front of every row
+    /// key in a family, and a streaming compaction reads its retention
+    /// groupings out of the components that follow it. A prefix that drifted
+    /// from the row-key format would put grouping boundaries in the wrong
+    /// place, so the two are pinned against each other for every family.
+    #[test]
+    fn row_key_prefixes_match_the_row_keys_they_front() {
+        let name_key = NameKey::parse("report.txt").expect("valid name key");
+        let display_name = crate::DisplayName::parse("report.txt").expect("valid display name");
+        let bind = super::MetadataRow::DirentryBind {
+            parent_inode_id: InodeId(9),
+            name_key: name_key.clone(),
+            display_name: display_name.clone(),
+            child_inode_id: InodeId(42),
+            bind_seq: ChangeSeq(17),
+            bind_delta_index: 3,
+        };
+        let revision = super::MetadataRow::Revision {
+            inode_id: InodeId(42),
+            revision_no: crate::RevisionNo(7),
+            committed_seq: ChangeSeq(12),
+            committed_at_ms: 12_000,
+            revision_delta_index: 3,
+            content_ref: crate::ContentRef::blob_v1(
+                crate::ContentId::parse("con_0123456789abcdef0123456789abcdef")
+                    .expect("valid content id"),
+                b"row key prefix sample",
+            ),
+        };
+        let rows: [(MetadataTableFamily, super::MetadataRow); 10] = [
+            (
+                MetadataTableFamily::Inodes,
+                super::MetadataRow::Inode {
+                    inode_id: InodeId(42),
+                    inode_kind: crate::InodeKind::File,
+                    created_seq: ChangeSeq(3),
+                },
+            ),
+            (MetadataTableFamily::DirentryBinds, bind.clone()),
+            (MetadataTableFamily::DirentryChildBinds, bind),
+            (
+                MetadataTableFamily::DirentryUnbinds,
+                super::MetadataRow::DirentryUnbind {
+                    parent_inode_id: InodeId(9),
+                    name_key,
+                    display_name,
+                    child_inode_id: InodeId(42),
+                    bind_seq: ChangeSeq(17),
+                    bind_delta_index: 3,
+                    unbind_seq: ChangeSeq(19),
+                    unbind_delta_index: 0,
+                },
+            ),
+            (MetadataTableFamily::Revisions, revision.clone()),
+            (MetadataTableFamily::RevisionsByInodeDesc, revision),
+            (
+                MetadataTableFamily::Tombstones,
+                super::MetadataRow::Tombstone {
+                    root_inode_id: InodeId(42),
+                    generation: super::TombstoneGeneration {
+                        seq: ChangeSeq(12),
+                        delta_index: 0,
+                    },
+                    action: super::TombstoneRowAction::Set {
+                        deleted_direntry: None,
+                    },
+                    deleted_at_ms: 12_000,
+                },
+            ),
+            (
+                MetadataTableFamily::ActiveDeletions,
+                super::MetadataRow::ActiveDeletion {
+                    root_inode_id: InodeId(42),
+                    deleted_at_seq: ChangeSeq(12),
+                    action: super::ActiveDeletionRowAction::Removed {
+                        revoked_at_seq: ChangeSeq(15),
+                    },
+                },
+            ),
+            (
+                MetadataTableFamily::CommitReceipts,
+                super::MetadataRow::CommitReceipt {
+                    commit_id: CommitId::parse("c_00000000000000000000000000000001")
+                        .expect("commit id"),
+                    semantic_commit_fingerprint: "sha256:unused".to_owned(),
+                    committed_seq: ChangeSeq(12),
+                    committed_at_ms: 12_000,
+                    message: None,
+                },
+            ),
+            (
+                MetadataTableFamily::Attributes,
+                super::MetadataRow::AttributesRevision {
+                    inode_id: InodeId(42),
+                    attributes_revision_no: crate::AttributeRevisionNo(3),
+                    committed_seq: ChangeSeq(12),
+                    delta_index: 0,
+                    attributes: crate::Attributes::default(),
+                },
+            ),
+        ];
+
+        for (family, row) in rows {
+            let row_key = row.row_key_for_family(family);
+            let prefix = family.row_key_prefix();
+            assert!(
+                !prefix.is_empty(),
+                "`{family:?}` declares no row-key prefix"
+            );
+            assert!(
+                row_key.starts_with(prefix),
+                "row key `{row_key}` for `{family:?}` does not start with `{prefix}`"
+            );
+        }
     }
 
     fn metadata_file_ref(

--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -123,16 +123,16 @@ where
                 .map_err(|_| CoreError::Internal("metadata SST index overflow".to_owned()))?;
             let table_id = MetadataTableId::generate();
             let object_key = metadata_table(namespace_id.as_str(), table_id.as_str());
-            requests.push(MetadataSstWriteRequest {
+            requests.push(MetadataSstWriteRequest::new(
                 namespace_id,
                 table_id,
+                object_key,
                 run_seq,
                 level,
                 family,
                 segment_index,
-                rows: segment_rows.rows,
-                object_key,
-            });
+                segment_rows.rows,
+            ));
         }
 
         let mut descriptors = Vec::with_capacity(requests.len());
@@ -171,6 +171,35 @@ pub(super) struct MetadataSstWriteRequest<'a> {
     segment_index: u32,
     rows: Vec<MetadataRow>,
     object_key: String,
+}
+
+impl<'a> MetadataSstWriteRequest<'a> {
+    /// One segment to write. The caller supplies the object key rather than
+    /// having it derived, because a streaming compaction writes the same
+    /// segment shape to the staging directory instead of to
+    /// `metadata/tables/` (format spec, "Compaction").
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        namespace_id: &'a NamespaceId,
+        table_id: MetadataTableId,
+        object_key: String,
+        run_seq: ChangeSeq,
+        level: u32,
+        family: MetadataTableFamily,
+        segment_index: u32,
+        rows: Vec<MetadataRow>,
+    ) -> Self {
+        Self {
+            namespace_id,
+            table_id,
+            run_seq,
+            level,
+            family,
+            segment_index,
+            rows,
+            object_key,
+        }
+    }
 }
 
 /// Largest filter block inlined into the segment's manifest descriptor, in

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -27,7 +27,9 @@ use loonfs_api::wire::manifest::{
     NAMESPACE_MANIFEST_FORMAT_VERSION,
 };
 use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId, WriterEpoch};
-use loonfs_objectstore::keys::{metadata_manifest_object, metadata_table};
+use loonfs_objectstore::keys::{
+    metadata_compaction_staging_table, metadata_manifest_object, metadata_table,
+};
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
 use tracing::Instrument;
@@ -342,13 +344,7 @@ fn validate_manifest_table_descriptors(
             validate_segment_numbering(&table.segments)?;
             validate_segment_key_order(&table.segments)?;
             for descriptor in &table.segments {
-                let expected_key = metadata_file_object_key(descriptor);
-                if descriptor.object_key != expected_key {
-                    return Err(ManifestLoadError::SegmentObjectKeyMismatch {
-                        object_key: descriptor.object_key.clone(),
-                        expected: expected_key,
-                    });
-                }
+                ensure_segment_object_key(descriptor)?;
                 // The one segment layout: the filter block sits immediately
                 // before the index block at the object tail. The read path
                 // assumes it (a filter fetch extends through the index; the
@@ -547,7 +543,7 @@ fn validate_one_base_run_per_family_group(
                 && run
                     .tables
                     .iter()
-                    .any(|table| group.contains(&table.family) && !table.segments.is_empty())
+                    .any(|table| group.contains(table.family) && !table.segments.is_empty())
         });
         let (Some(first), Some(second)) = (base_runs.next(), base_runs.next()) else {
             continue;
@@ -555,10 +551,14 @@ fn validate_one_base_run_per_family_group(
         return Err(ManifestLoadError::RunManifestMismatch {
             object_key: manifest_object_key.to_owned(),
             message: format!(
-                "family group {group:?} holds base-tier runs at seq `{}` level {} and seq `{}` \
+                "family group {:?} holds base-tier runs at seq `{}` level {} and seq `{}` \
                  level {}; a group holds at most one base run, because a merge writes one only \
                  when it starts at the group's oldest run and then replaces it",
-                first.run_seq, first.level, second.run_seq, second.level
+                group.families(),
+                first.run_seq,
+                first.level,
+                second.run_seq,
+                second.level
             ),
         });
     }
@@ -570,4 +570,32 @@ pub(super) fn metadata_file_object_key(descriptor: &MetadataFileRef) -> String {
         descriptor.owner_namespace_id.as_str(),
         descriptor.table_id.as_str(),
     )
+}
+
+/// Checks that a descriptor names one of the two keys a segment of its
+/// identity may live at.
+///
+/// The ordinary key is the metadata-table key its owner and table id build.
+/// The other is the staging directory a streaming compaction writes to: a
+/// compaction writes its output before any manifest names it, so its segments
+/// must sit outside the listing a collector sweeps for unreferenced tables
+/// (format spec, "Compaction"). Publication moves no bytes, so the manifest
+/// that swaps a compaction's output in names the staged keys. The segment is
+/// an ordinary one either way — same encoding, same descriptor — and the
+/// table id still makes the key its producer's alone.
+pub(super) fn ensure_segment_object_key(
+    descriptor: &MetadataFileRef,
+) -> Result<(), ManifestLoadError> {
+    let expected = metadata_file_object_key(descriptor);
+    let staged = metadata_compaction_staging_table(
+        descriptor.owner_namespace_id.as_str(),
+        descriptor.table_id.as_str(),
+    );
+    if descriptor.object_key == expected || descriptor.object_key == staged {
+        return Ok(());
+    }
+    Err(ManifestLoadError::SegmentObjectKeyMismatch {
+        object_key: descriptor.object_key.clone(),
+        expected,
+    })
 }

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -20,7 +20,9 @@
 //!   materialization is test-only).
 //! - [`scan`] answers verified row scans over loaded manifest tables, while
 //!   [`row`] handles manifest-row encoding.
-//! - [`reorganize`] compacts bounded family groups into new base runs.
+//! - [`reorganize`] compacts bounded family groups into new base runs, and
+//!   [`streaming_compaction`] rebuilds a group whose bottom-anchored window
+//!   no longer fits one of those steps.
 //! - [`retention`] advances the retention floor behind verified progress.
 //! - [`runs`] models the LSM run layout shared by all of the above,
 //!   [`cache`] holds decoded SST blocks keyed by content digest, and
@@ -47,6 +49,7 @@ mod row;
 mod runs;
 mod scan;
 mod stored_block_cache;
+mod streaming_compaction;
 #[cfg(test)]
 pub(crate) mod tests;
 mod validate;

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -29,6 +29,12 @@
 //! concurrent checkpoint racing a unit wins at the root compare-and-swap;
 //! the unit's segments are left unreferenced for garbage collection and the
 //! next step retries against the fresh manifest.
+//!
+//! The planner answers with one of two plans ([`ReorganizationPlan`]). A
+//! group with a window that fits the budgets and makes progress gets that
+//! window. A group with no such window gets a streaming compaction over
+//! every run it holds ([`super::streaming_compaction`]), which is what takes
+//! a frozen base off the step budgets entirely.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::build::{
@@ -46,10 +52,12 @@ use super::publish::{
     ManifestPublicationOutcome,
 };
 use super::runs::{
-    flatten_manifest_tables, l0_run_count, MetadataLsmPolicy, MetadataRunManifest,
-    CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, REORGANIZE_FAMILY_GROUPS,
+    flatten_manifest_tables, l0_run_count, MetadataFamilyGroup, MetadataLsmPolicy,
+    MetadataRunManifest, CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
+    REORGANIZE_FAMILY_GROUPS,
 };
 use super::scan::VerifiedMetadataTables;
+use super::streaming_compaction::MetadataCompactionSpec;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::basis::resolve_retention_floor_seq;
@@ -60,7 +68,7 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
 use loonfs_api::{
-    AttributeRevisionNo, ChangeSeq, InodeId, ManifestId, ManifestObjectId, NamespaceId,
+    AttributeRevisionNo, ChangeSeq, InodeId, ManifestId, ManifestObjectId, NameKey, NamespaceId,
 };
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
@@ -168,7 +176,19 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
         });
     };
-    let selection = select_reorganization_input(&tables, group, policy)
+    // The floor is read before the plan rather than after it, because a plan
+    // that hands the group to a streaming compaction carries the floor that
+    // job will judge every row against, and the spec it carries is immutable
+    // for the job's life.
+    let head = read_head_object(store, namespace_id)
+        .await
+        .map_err(CoreError::load_head)?
+        .envelope
+        .state;
+    let floor_seq = resolve_retention_floor_seq(store, &head)
+        .await
+        .map_err(CoreError::load_head)?;
+    let selection = select_reorganization_input(&tables, group, policy, floor_seq)
         .await
         .map_err(|error| {
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
@@ -176,11 +196,14 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     if let Some(bottom) = selection.group_bottom_over_budget {
         report_group_bottom_over_budget(namespace_id, group, &bottom, policy);
     }
-    let Some(input) = selection.input else {
+    // A group that needs a streaming compaction reports the same blocked
+    // outcome it reported before the compactor existed. Scheduling the job is
+    // the runner's, and lands with it.
+    let Some(ReorganizationPlan::BoundedMerge(input)) = selection.plan else {
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::BudgetExhausted {
-                families: group.to_vec(),
+                families: group.families().to_vec(),
                 l0_runs,
             },
         });
@@ -190,7 +213,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     // manifest's tables — never the WAL tail — and the unselected
     // descriptors remain in the replacement manifest unchanged.
     let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
-    for family in group {
+    for family in group.families() {
         let rows = tables
             .scan_prefix_in_runs(&input.runs, *family, "")
             .await
@@ -201,7 +224,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     }
     // The paired groups exist to preserve index parity; verify it on the
     // selected complete runs before writing anything.
-    if group.contains(&MetadataTableFamily::DirentryBinds) {
+    if group.contains(MetadataTableFamily::DirentryBinds) {
         validate_direntry_child_bind_index(
             root.manifest_object_id.as_ref(),
             rows_by_family
@@ -215,7 +238,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
         })?;
     }
-    if group.contains(&MetadataTableFamily::Revisions) {
+    if group.contains(MetadataTableFamily::Revisions) {
         validate_revision_by_inode_desc_index(
             root.manifest_object_id.as_ref(),
             rows_by_family
@@ -229,14 +252,6 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
         })?;
     }
-    let head = read_head_object(store, namespace_id)
-        .await
-        .map_err(CoreError::load_head)?
-        .envelope
-        .state;
-    let floor_seq = resolve_retention_floor_seq(store, &head)
-        .await
-        .map_err(CoreError::load_head)?;
     // Dropping is only visibility-preserving over a merge that starts at the
     // group's oldest run, which is what the placement records. A window that
     // had to skip older runs merges them exactly as they are, so its output
@@ -263,7 +278,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         .metadata_files
         .iter()
         .filter(|descriptor| {
-            !group.contains(&descriptor.family)
+            !group.contains(descriptor.family)
                 || !input
                     .run_ids
                     .contains(&(descriptor.run_seq, descriptor.level))
@@ -303,7 +318,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         ManifestPublicationOutcome::Published(_) => Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::UnitPublished {
-                families: group.to_vec(),
+                families: group.families().to_vec(),
                 folded_l0_rows: input.folded_l0_rows,
                 input_runs: input.runs.len(),
                 decoded_input_rows: input.decoded_rows,
@@ -318,6 +333,23 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             })
         }
     }
+}
+
+/// What one reorganization step should do for the group it selected.
+///
+/// The two arms are the two shapes of work, not two levels of urgency: a
+/// bounded merge is one step's worth of merging that ends in a publication,
+/// and a full compaction is a background job over the whole group that no
+/// budget paces. The planner decides between them once, from the same run
+/// list, so no caller has to rediscover which case it is in.
+pub(super) enum ReorganizationPlan {
+    /// A window of complete runs fits one step's budgets and makes progress.
+    BoundedMerge(ReorganizationInput),
+    /// No window that makes progress fits the budgets, so the group is
+    /// rebuilt by a streaming compaction over every run it holds. The step
+    /// reports the group blocked and reads no further; the runner that starts
+    /// the job from this spec lands next.
+    FullCompaction(#[allow(dead_code)] MetadataCompactionSpec),
 }
 
 pub(super) struct ReorganizationInput {
@@ -387,20 +419,20 @@ pub(super) enum MergePlacement {
 }
 
 impl MergePlacement {
-    fn output_seq(self) -> ChangeSeq {
+    pub(super) fn output_seq(self) -> ChangeSeq {
         match self {
             Self::Base { output_seq } | Self::Delta { output_seq } => output_seq,
         }
     }
 
-    fn output_level(self) -> u32 {
+    pub(super) fn output_level(self) -> u32 {
         match self {
             Self::Base { .. } => CHECKPOINT_BASE_RUN_LEVEL,
             Self::Delta { .. } => CHECKPOINT_L0_RUN_LEVEL,
         }
     }
 
-    fn may_drop_rows_below_the_retention_floor(self) -> bool {
+    pub(super) fn may_drop_rows_below_the_retention_floor(self) -> bool {
         matches!(self, Self::Base { .. })
     }
 }
@@ -431,7 +463,9 @@ fn merge_placement(
 /// step's budget still folds its newer runs, and that is exactly when an
 /// operator needs to hear that the run underneath them is frozen.
 pub(super) struct ReorganizationSelection {
-    pub(super) input: Option<ReorganizationInput>,
+    /// What the step should do, or `None` when the group holds no runs at
+    /// all and there is nothing to do either way.
+    pub(super) plan: Option<ReorganizationPlan>,
     pub(super) group_bottom_over_budget: Option<OverBudgetRun>,
 }
 
@@ -479,15 +513,22 @@ pub(super) struct OverBudgetRun {
 /// at the group's oldest run can fit the budgets, the start moves past the
 /// base run that blocks it and the step merges the L0 runs above it on their
 /// own. The group keeps shedding runs even while the run at its bottom stays
-/// too large to fold.
+/// too large to fold. When not even that is left — no window at all makes
+/// progress inside the budgets — the group is handed to a streaming
+/// compaction, which merges every run it holds and is paced by nothing.
 ///
 /// Index sections are read before row payloads so the decoded-byte budget is
 /// known exactly from each data block's durable `decoded_len`; a run that
 /// would cross a budget is not decoded or partially included.
+///
+/// `frozen_floor_seq` is the live retention floor. A bounded merge reads it
+/// again at drop time; a compaction spec carries it, because the floor a job
+/// judges every row against is fixed when the job is planned.
 pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
-    group: &[MetadataTableFamily],
+    group: MetadataFamilyGroup,
     policy: MetadataLsmPolicy,
+    frozen_floor_seq: ChangeSeq,
 ) -> std::result::Result<ReorganizationSelection, ManifestLoadError> {
     let mut candidates = tables
         .scan_runs
@@ -599,20 +640,41 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
         let run_ids = runs.iter().map(|run| (run.run_seq, run.level)).collect();
         let placement = merge_placement(bottom_anchored, &runs, head_seq);
         return Ok(ReorganizationSelection {
-            input: Some(ReorganizationInput {
+            plan: Some(ReorganizationPlan::BoundedMerge(ReorganizationInput {
                 runs,
                 run_ids,
                 folded_l0_rows,
                 decoded_rows,
                 decoded_bytes,
                 placement,
-            }),
+            })),
             group_bottom_over_budget,
         });
     }
 
+    // No window makes progress inside the budgets. That is the whole of the
+    // stuck case: the bottom-anchored window cannot reach an L0 run, so
+    // retention for the group has stopped, and the delta runs above the
+    // bottom are down to one or blocked as well, so nothing shrinks the run
+    // count either. A streaming compaction takes the whole group. Its input
+    // is every run the group holds, which is bottom-anchored by
+    // construction, so its output is the group's base run and it may drop
+    // what the floor allows.
+    let spec = (!candidates.is_empty()).then(|| {
+        MetadataCompactionSpec::new(
+            group,
+            candidates
+                .iter()
+                .map(|run| (run.run_seq, run.level))
+                .collect(),
+            MergePlacement::Base {
+                output_seq: head_seq,
+            },
+            frozen_floor_seq,
+        )
+    });
     Ok(ReorganizationSelection {
-        input: None,
+        plan: spec.map(ReorganizationPlan::FullCompaction),
         group_bottom_over_budget,
     })
 }
@@ -636,13 +698,13 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
 /// the cadence of the warning is the cadence of maintenance.
 fn report_group_bottom_over_budget(
     namespace_id: &NamespaceId,
-    group: &[MetadataTableFamily],
+    group: MetadataFamilyGroup,
     bottom: &OverBudgetRun,
     policy: MetadataLsmPolicy,
 ) {
     tracing::warn!(
         namespace_id = namespace_id.as_str(),
-        families = ?group,
+        families = ?group.families(),
         run_seq = bottom.run_seq.0,
         run_level = bottom.level,
         run_rows = bottom.rows,
@@ -682,24 +744,24 @@ fn manifest_has_partial_reorganization(runs: &[MetadataRunManifest]) -> bool {
         .any(|run| run.level != CHECKPOINT_L0_RUN_LEVEL && run.run_seq >= oldest_l0_seq)
 }
 
-fn run_has_group_rows(run: &MetadataRunManifest, group: &[MetadataTableFamily]) -> bool {
+fn run_has_group_rows(run: &MetadataRunManifest, group: MetadataFamilyGroup) -> bool {
     group_run_descriptors(run, group).next().is_some()
 }
 
-fn group_run_descriptors<'a>(
-    run: &'a MetadataRunManifest,
-    group: &'a [MetadataTableFamily],
-) -> impl Iterator<Item = &'a MetadataFileRef> {
+pub(super) fn group_run_descriptors(
+    run: &MetadataRunManifest,
+    group: MetadataFamilyGroup,
+) -> impl Iterator<Item = &MetadataFileRef> {
     run.tables
         .iter()
-        .filter(|table| group.contains(&table.family))
+        .filter(move |table| group.contains(table.family))
         .flat_map(|table| &table.segments)
 }
 
 async fn decoded_group_run_bytes<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     run: &MetadataRunManifest,
-    group: &[MetadataTableFamily],
+    group: MetadataFamilyGroup,
 ) -> std::result::Result<u64, ManifestLoadError> {
     let mut decoded_bytes = 0u64;
     for descriptor in group_run_descriptors(run, group) {
@@ -721,40 +783,32 @@ async fn decoded_group_run_bytes<S: ObjectStore + ?Sized>(
 /// order. `None` when no group has L0 rows.
 pub(super) fn select_family_group(
     payload: &NamespaceManifestPayload,
-) -> Option<&'static [MetadataTableFamily]> {
+) -> Option<MetadataFamilyGroup> {
     REORGANIZE_FAMILY_GROUPS
         .into_iter()
         .map(|group| (group_l0_rows(payload, group), group))
         .filter(|(rows, _)| *rows > 0)
         .max_by(|(left_rows, left), (right_rows, right)| {
-            left_rows.cmp(right_rows).then_with(|| {
-                // On ties the EARLIER group must win; comparing positions
-                // reversed makes max_by pick it.
-                position_of(right).cmp(&position_of(left))
-            })
+            // On ties the EARLIER group must win, and group order is the
+            // enum's declaration order; comparing the groups reversed makes
+            // max_by pick it.
+            left_rows.cmp(right_rows).then_with(|| right.cmp(left))
         })
         .map(|(_, group)| group)
 }
 
-fn position_of(group: &[MetadataTableFamily]) -> usize {
-    REORGANIZE_FAMILY_GROUPS
-        .iter()
-        .position(|candidate| candidate.as_ptr() == group.as_ptr())
-        .unwrap_or(usize::MAX)
-}
-
-fn group_l0_rows(payload: &NamespaceManifestPayload, group: &[MetadataTableFamily]) -> u64 {
+fn group_l0_rows(payload: &NamespaceManifestPayload, group: MetadataFamilyGroup) -> u64 {
     payload
         .metadata_files
         .iter()
         .filter(|descriptor| {
-            descriptor.level == CHECKPOINT_L0_RUN_LEVEL && group.contains(&descriptor.family)
+            descriptor.level == CHECKPOINT_L0_RUN_LEVEL && group.contains(descriptor.family)
         })
         .map(|descriptor| descriptor.row_count)
         .sum()
 }
 
-async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
+pub(super) async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     previous: &NamespaceManifestEnvelope,
@@ -796,18 +850,36 @@ pub(super) fn drop_rows_below_retention_floor(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,
 ) -> Result<()> {
-    // At the floor only the latest non-unbound bind per (parent, name) slot
-    // is visible; an unbind marker at or below the floor has finished its
-    // work once every bind it covered is gone.
-    // Unbind identity here omits child_inode_id (the read path also matches
-    // it); the 4-tuple is already unique for writer-produced rows, so the
-    // predicates agree on every legal history.
+    let unbound_at_floor = unbindings_at_or_below_floor(
+        rows_by_family
+            .get(&MetadataTableFamily::DirentryUnbinds)
+            .map_or(&[], Vec::as_slice),
+        retention_floor_seq,
+    );
+    drop_rows_below_frozen_floor(rows_by_family, retention_floor_seq, &unbound_at_floor)
+}
+
+/// Identifies one binding generation, which is what an unbind names and what
+/// the bind drop matches on.
+///
+/// Identity here omits `child_inode_id` (the read path also matches it); the
+/// 4-tuple is already unique for writer-produced rows, so the predicates
+/// agree on every legal history.
+pub(super) type BindingGeneration = (InodeId, NameKey, ChangeSeq, u32);
+
+/// The binding generations an unbind at or below `retention_floor_seq`
+/// retires.
+///
+/// A whole-group fold builds this from every unbind row it merged. A
+/// streaming compaction builds it per slot, from the unbind rows of that one
+/// (parent, name) slot: an unbind and the bind it cancels share a slot, so
+/// the rows of one slot hold both halves of every pair they belong to.
+pub(super) fn unbindings_at_or_below_floor(
+    unbind_rows: &[MetadataRow],
+    retention_floor_seq: ChangeSeq,
+) -> BTreeSet<BindingGeneration> {
     let mut unbound_at_floor = BTreeSet::new();
-    for row in rows_by_family
-        .get(&MetadataTableFamily::DirentryUnbinds)
-        .into_iter()
-        .flatten()
-    {
+    for row in unbind_rows {
         if let MetadataRow::DirentryUnbind {
             parent_inode_id,
             name_key,
@@ -827,92 +899,75 @@ pub(super) fn drop_rows_below_retention_floor(
             }
         }
     }
-    let mut latest_bind_at_floor = BTreeMap::new();
-    for row in rows_by_family
-        .get(&MetadataTableFamily::DirentryBinds)
-        .into_iter()
-        .flatten()
-    {
-        if let MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            ..
-        } = row
-        {
-            if *bind_seq <= retention_floor_seq {
-                let candidate = (*bind_seq, *bind_delta_index);
-                let latest = latest_bind_at_floor
-                    .entry((*parent_inode_id, name_key.clone()))
-                    .or_insert(candidate);
-                if candidate > *latest {
-                    *latest = candidate;
-                }
-            }
-        }
-    }
-    // Load-bearing writer invariant: a bind is only ever superseded by an
-    // operation that also unbinds it, so every non-latest bind at or below
-    // the floor must have a matching unbind at or below the floor. The drop
-    // is only visibility-preserving under that rule; refuse to compact state
-    // that violates it.
-    for row in rows_by_family
-        .get(&MetadataTableFamily::DirentryBinds)
-        .into_iter()
-        .flatten()
-    {
-        if let MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            ..
-        } = row
-        {
-            if *bind_seq <= retention_floor_seq
-                && latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
-                    != Some(&(*bind_seq, *bind_delta_index))
-                && !unbound_at_floor.contains(&(
-                    *parent_inode_id,
-                    name_key.clone(),
-                    *bind_seq,
-                    *bind_delta_index,
-                ))
-            {
-                return Err(CoreError::NamespaceCorrupt(format!(
-                    "bind at seq `{bind_seq}` delta {bind_delta_index} for parent `{parent_inode_id}` is superseded at or below the retention floor without an unbind; refusing to drop rows"
-                )));
-            }
-        }
-    }
+    unbound_at_floor
+}
 
-    let retain_bind = |row: &MetadataRow| match row {
-        MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            ..
-        } => {
-            *bind_seq > retention_floor_seq
-                || (latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
-                    == Some(&(*bind_seq, *bind_delta_index))
-                    && !unbound_at_floor.contains(&(
-                        *parent_inode_id,
-                        name_key.clone(),
-                        *bind_seq,
-                        *bind_delta_index,
-                    )))
-        }
-        _ => true,
+/// Whether one bind row survives the frozen floor.
+///
+/// A bind above the floor always survives. At or below it the bind survives
+/// exactly when nothing retired it, because a bind is only ever superseded by
+/// an operation that also unbinds it — the writer invariant
+/// [`refuse_superseded_bind_without_unbind`] refuses to compact without.
+///
+/// Both bind families read this same rule, which is what keeps them dropping
+/// in lockstep: the format gives every bind row exactly one reverse row, and a
+/// run whose two counts disagree does not load. They reach the rule by
+/// different routes — the forward row's unbinds share its slot, the reverse
+/// row's do not — but the rule is one function and the answer is one answer.
+pub(super) fn bind_survives_frozen_floor(
+    row: &MetadataRow,
+    retention_floor_seq: ChangeSeq,
+    unbound_at_floor: &BTreeSet<BindingGeneration>,
+) -> bool {
+    let MetadataRow::DirentryBind {
+        parent_inode_id,
+        name_key,
+        bind_seq,
+        bind_delta_index,
+        ..
+    } = row
+    else {
+        return true;
     };
+    *bind_seq > retention_floor_seq
+        || !unbound_at_floor.contains(&(
+            *parent_inode_id,
+            name_key.clone(),
+            *bind_seq,
+            *bind_delta_index,
+        ))
+}
+
+/// [`drop_rows_below_retention_floor`] against a floor and an unbind set the
+/// caller froze, rather than against rows it can see right now.
+///
+/// A streaming compaction calls this per locality group: the floor is fixed
+/// for the whole job, so every group and every attempt decides identically.
+/// Families the caller leaves out of `rows_by_family` are untouched, which is
+/// how a compaction keeps the reverse bind index out of this pass — its rows
+/// are keyed by child, so the group holding one does not hold the forward
+/// binds the invariant check below reads, and the compaction decides those
+/// rows with a point read instead.
+pub(super) fn drop_rows_below_frozen_floor(
+    rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
+    retention_floor_seq: ChangeSeq,
+    unbound_at_floor: &BTreeSet<BindingGeneration>,
+) -> Result<()> {
+    refuse_superseded_bind_without_unbind(
+        rows_by_family
+            .get(&MetadataTableFamily::DirentryBinds)
+            .map_or(&[], Vec::as_slice),
+        retention_floor_seq,
+        unbound_at_floor,
+    )?;
     for family in [
         MetadataTableFamily::DirentryBinds,
         MetadataTableFamily::DirentryChildBinds,
     ] {
         if let Some(rows) = rows_by_family.get_mut(&family) {
-            rows.retain(retain_bind);
+            rows.retain(|row| {
+                bind_survives_frozen_floor(row, retention_floor_seq, unbound_at_floor)
+            });
         }
     }
     if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::DirentryUnbinds) {
@@ -930,7 +985,9 @@ pub(super) fn drop_rows_below_retention_floor(
     // other. A removal marker's listed row is always in the same merged set:
     // the deletion commits before the undelete, runs merge oldest-first, and
     // the selected subset is a prefix of that order, so a marker can never
-    // outlive the row it names.
+    // outlive the row it names. A streaming compaction groups the family by
+    // deletion generation, which is the pair's shared key prefix, so the pair
+    // lands in one group there too.
     if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::ActiveDeletions) {
         let revoked: BTreeSet<(ChangeSeq, InodeId)> = rows
             .iter()
@@ -976,6 +1033,69 @@ pub(super) fn drop_rows_below_retention_floor(
     Ok(())
 }
 
+/// Refuses to compact bind rows that break the writer invariant the drop
+/// rests on.
+///
+/// At the floor only the latest bind per (parent, name) slot is visible, and a
+/// bind is only ever superseded by an operation that also unbinds it. So every
+/// non-latest bind at or below the floor must have a matching unbind at or
+/// below the floor. Where that does not hold, dropping by
+/// [`bind_survives_frozen_floor`] would keep a bind no read can reach and call
+/// it live, so the compaction stops instead.
+fn refuse_superseded_bind_without_unbind(
+    bind_rows: &[MetadataRow],
+    retention_floor_seq: ChangeSeq,
+    unbound_at_floor: &BTreeSet<BindingGeneration>,
+) -> Result<()> {
+    let mut latest_bind_at_floor = BTreeMap::new();
+    for row in bind_rows {
+        if let MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } = row
+        {
+            if *bind_seq <= retention_floor_seq {
+                let candidate = (*bind_seq, *bind_delta_index);
+                let latest = latest_bind_at_floor
+                    .entry((*parent_inode_id, name_key.clone()))
+                    .or_insert(candidate);
+                if candidate > *latest {
+                    *latest = candidate;
+                }
+            }
+        }
+    }
+    for row in bind_rows {
+        if let MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } = row
+        {
+            if *bind_seq <= retention_floor_seq
+                && latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
+                    != Some(&(*bind_seq, *bind_delta_index))
+                && !unbound_at_floor.contains(&(
+                    *parent_inode_id,
+                    name_key.clone(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ))
+            {
+                return Err(CoreError::NamespaceCorrupt(format!(
+                    "bind at seq `{bind_seq}` delta {bind_delta_index} for parent `{parent_inode_id}` is superseded at or below the retention floor without an unbind; refusing to drop rows"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Keeps every attribute revision above the retention floor, plus the newest
 /// revision at or below it per inode, and drops the rest.
 ///
@@ -989,6 +1109,9 @@ pub(super) fn drop_rows_below_retention_floor(
 /// Attributes are never dropped for being unreachable. A deleted inode keeps
 /// its rows, the same posture inode and tombstone rows take, and that is what
 /// makes an undelete give back the map the inode had.
+///
+/// The rule reads one inode's rows and no others, so a streaming compaction
+/// runs it over one inode's rows at a time and reaches the same answer.
 fn drop_superseded_attribute_revisions(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -33,34 +33,74 @@ pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 10] = [
     MetadataTableFamily::Attributes,
 ];
 
-/// Families whose rows merge in one reorganization unit. Families that read
-/// each other's rows to decide what to drop (see
+/// One set of families whose rows merge in one reorganization unit.
+///
+/// Families that read each other's rows to decide what to drop (see
 /// `super::reorganize::drop_rows_below_retention_floor`) must compact
 /// together, and a secondary index always travels with its canonical family.
 ///
-/// The grouping is layout policy, not reorganization's alone: manifest load
-/// checks a per-group invariant — at most one base-tier run per group — so
-/// the loader reads this table too.
-pub(super) const REORGANIZE_FAMILY_GROUPS: [&[MetadataTableFamily]; 7] = [
-    &[
-        MetadataTableFamily::DirentryBinds,
-        MetadataTableFamily::DirentryChildBinds,
-        MetadataTableFamily::DirentryUnbinds,
-    ],
-    &[
-        MetadataTableFamily::Revisions,
-        MetadataTableFamily::RevisionsByInodeDesc,
-    ],
-    &[MetadataTableFamily::Inodes],
-    &[MetadataTableFamily::Tombstones],
-    // Active deletions fold alone: a removal marker is cancelled by the
-    // listed row it names, and both live in this family.
-    &[MetadataTableFamily::ActiveDeletions],
-    &[MetadataTableFamily::CommitReceipts],
-    // Attributes fold alone too: a revision supersedes the revisions of the
-    // same inode, and they all live in this family. The family has no
-    // secondary index to travel with.
-    &[MetadataTableFamily::Attributes],
+/// This is a closed enum rather than a list of family slices because every
+/// caller wants the group itself, not a slice it has to recognize by
+/// comparing it against a table. The grouping is layout policy, not
+/// reorganization's alone: manifest load checks a per-group invariant — at
+/// most one base-tier run per group — so the loader reads it too.
+///
+/// Declaration order is group order, which is what resolves ties when two
+/// groups have equally much to fold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum MetadataFamilyGroup {
+    /// A directory binding, the reverse index that finds it by child, and the
+    /// unbind that retires it.
+    Bindings,
+    /// File revision history and its newest-first index.
+    Revisions,
+    Inodes,
+    Tombstones,
+    /// Active deletions fold alone: a removal marker is cancelled by the
+    /// listed row it names, and both live in this family.
+    ActiveDeletions,
+    CommitReceipts,
+    /// Attributes fold alone too: a revision supersedes the revisions of the
+    /// same inode, and they all live in this family. The family has no
+    /// secondary index to travel with.
+    Attributes,
+}
+
+impl MetadataFamilyGroup {
+    /// The families this group merges together, in the order a run writes
+    /// them.
+    pub(super) const fn families(self) -> &'static [MetadataTableFamily] {
+        match self {
+            Self::Bindings => &[
+                MetadataTableFamily::DirentryBinds,
+                MetadataTableFamily::DirentryChildBinds,
+                MetadataTableFamily::DirentryUnbinds,
+            ],
+            Self::Revisions => &[
+                MetadataTableFamily::Revisions,
+                MetadataTableFamily::RevisionsByInodeDesc,
+            ],
+            Self::Inodes => &[MetadataTableFamily::Inodes],
+            Self::Tombstones => &[MetadataTableFamily::Tombstones],
+            Self::ActiveDeletions => &[MetadataTableFamily::ActiveDeletions],
+            Self::CommitReceipts => &[MetadataTableFamily::CommitReceipts],
+            Self::Attributes => &[MetadataTableFamily::Attributes],
+        }
+    }
+
+    pub(super) fn contains(self, family: MetadataTableFamily) -> bool {
+        self.families().contains(&family)
+    }
+}
+
+pub(super) const REORGANIZE_FAMILY_GROUPS: [MetadataFamilyGroup; 7] = [
+    MetadataFamilyGroup::Bindings,
+    MetadataFamilyGroup::Revisions,
+    MetadataFamilyGroup::Inodes,
+    MetadataFamilyGroup::Tombstones,
+    MetadataFamilyGroup::ActiveDeletions,
+    MetadataFamilyGroup::CommitReceipts,
+    MetadataFamilyGroup::Attributes,
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -1,0 +1,1132 @@
+//! Rebuilding one family group in a single streaming job.
+//!
+//! A bounded merge reads every row of its window into memory, so a group
+//! whose bottom-anchored window no longer fits one step's budgets can never
+//! fold from its bottom again: its base is frozen and its retention stops
+//! ([`super::reorganize`] reports that, loudly). Such a group is rebuilt
+//! here instead, by one job that reads every run it holds and is paced by no
+//! budget at all.
+//!
+//! Nothing about the job follows the size of the group. It opens one iterator
+//! per run per family, merges them in row-key order, feeds the merged rows
+//! through the retention rules a locality group at a time, and writes each
+//! output segment as it fills. What it holds at any instant is a fixed number
+//! of decoded input blocks per iterator, the rows of one locality group, and
+//! one segment builder per family of the group. No family, no partition, and
+//! no directory is ever collected whole.
+//!
+//! Output segments go to the staging directory rather than to
+//! `metadata/tables/` (format spec, "Compaction"): a job outlives the
+//! collector's grace window, so its output would otherwise look exactly like
+//! the unreferenced aged objects the collector reaps. The job publishes
+//! nothing. It returns the descriptors it wrote, and the caller swaps them in
+//! with one manifest publication; a cancelled or crashed job leaves staged
+//! objects nothing references and the old manifest still valid.
+//!
+//! Nothing here is reachable from the maintenance step yet. The runner that
+//! schedules the job, excludes its snapshot runs from ordinary merges,
+//! cancels it on shutdown, and finalizes it lands next. Until it does, the
+//! only caller outside tests is the planner that builds the spec, which is
+//! why this module allows dead code: every item below has a caller in the
+//! change that schedules it, and the allow goes away with that change.
+#![allow(dead_code)]
+
+use super::block_fetch::{load_segment_filter, load_segment_index_for_reorganization};
+use super::block_load::SessionBlockMemo;
+use super::build::{write_manifest_segment, MetadataSstWriteRequest};
+use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
+use super::data_block_load::load_segment_data_block_span;
+use super::error::ManifestLoadError;
+use super::load::load_manifest_segment_rows_in_key_range_with_cache;
+use super::reorganize::{
+    bind_survives_frozen_floor, drop_rows_below_frozen_floor, group_run_descriptors,
+    unbindings_at_or_below_floor, MergePlacement,
+};
+use super::runs::{MetadataFamilyGroup, MetadataLsmPolicy, MetadataRunManifest};
+use super::scan::{descriptor_may_intersect_range, Readahead, VerifiedMetadataTables};
+use super::validate::validate_manifest_row_seq_range;
+use crate::error::{CoreError, MetadataProjectionLoadError, Result};
+use loonfs_api::wire::manifest::{lookup_keys, MetadataFileRef, MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::sst_blocks::{
+    string_prefix_upper_bound, DecodedDataBlock, SegmentIndexEntry,
+};
+use loonfs_api::{ChangeSeq, MetadataTableId, NamespaceId};
+use loonfs_objectstore::keys::metadata_compaction_staging_table;
+use loonfs_objectstore::ObjectStore;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Decoded data blocks one iterator holds at a time. An iterator refills only
+/// when it has none left, so this is also the most it ever holds, and the
+/// job's input residency is this times the number of open iterators.
+const BLOCKS_PER_ITERATOR_FETCH: usize = 2;
+
+/// Iterators refilled in one wave. Refills are the job's only bulk reads, so
+/// this is the width of its fan-out at the store.
+const ITERATOR_FETCH_CONCURRENCY: usize = 8;
+
+/// Decoded-byte budget for the cache the reverse-index point reads share.
+///
+/// Those reads are keyed by child while the unbind family is keyed by parent,
+/// so they land all over the family and each one would otherwise re-fetch the
+/// filter and index sections the read before it just used. The cache is an
+/// LRU with a byte budget, so what it holds is this number and not a function
+/// of how many reads the job makes.
+const PROBE_CACHE_DECODED_BYTES: usize = 16 * 1024 * 1024;
+
+/// The immutable plan of one streaming compaction.
+///
+/// Everything the job decides is fixed here before it starts: which group it
+/// rebuilds, which runs it reads, where its output stands, and the retention
+/// floor every row is judged against. A job re-run from the same spec against
+/// the same durable state produces the same rows, which is what makes a
+/// cancelled attempt free to throw away.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MetadataCompactionSpec {
+    group: MetadataFamilyGroup,
+    /// Every run the group held when the plan was made, by sequence and
+    /// level. That is bottom-anchored by construction — a run the group holds
+    /// cannot sort below the whole of itself — which is what makes the job's
+    /// drops visibility-preserving.
+    inputs: Vec<(ChangeSeq, u32)>,
+    placement: MergePlacement,
+    frozen_floor_seq: ChangeSeq,
+}
+
+impl MetadataCompactionSpec {
+    pub(super) fn new(
+        group: MetadataFamilyGroup,
+        inputs: Vec<(ChangeSeq, u32)>,
+        placement: MergePlacement,
+        frozen_floor_seq: ChangeSeq,
+    ) -> Self {
+        Self {
+            group,
+            inputs,
+            placement,
+            frozen_floor_seq,
+        }
+    }
+
+    pub(super) fn group(&self) -> MetadataFamilyGroup {
+        self.group
+    }
+
+    pub(super) fn inputs(&self) -> &[(ChangeSeq, u32)] {
+        &self.inputs
+    }
+
+    pub(super) fn frozen_floor_seq(&self) -> ChangeSeq {
+        self.frozen_floor_seq
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_frozen_floor_seq(&self, frozen_floor_seq: ChangeSeq) -> Self {
+        Self {
+            frozen_floor_seq,
+            ..self.clone()
+        }
+    }
+}
+
+/// Stops a running job between block fetches.
+///
+/// Cancelling costs the work done so far and nothing else: the staged
+/// segments are unreferenced, the manifest never moved, and a later job runs
+/// the same spec again.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MetadataCompactionCancellation(Arc<AtomicBool>);
+
+impl MetadataCompactionCancellation {
+    pub(crate) fn cancel(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+/// How a job ended.
+#[derive(Debug)]
+pub(super) enum MetadataCompactionOutcome {
+    Completed(MetadataCompactionResult),
+    /// The cancellation token was set. Whatever the job had written stays
+    /// staged and unreferenced.
+    Cancelled,
+}
+
+/// What one finished job built, held in memory until the caller publishes it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MetadataCompactionResult {
+    /// The output run's segment descriptors, naming their staged object keys.
+    pub(super) output_segments: Vec<MetadataFileRef>,
+    pub(super) rows_read: u64,
+    pub(super) rows_written: u64,
+    pub(super) rows_written_by_family: BTreeMap<MetadataTableFamily, u64>,
+    /// Point reads into the snapshot's unbind family, one per reverse bind
+    /// row at or below the frozen floor.
+    pub(super) unbind_probes: u64,
+    /// The most decoded input blocks the job's iterators held at once, and
+    /// the most rows one locality group held. These are what bound the job's
+    /// memory, so tests assert they do not follow the size of the group.
+    pub(super) peak_resident_blocks: usize,
+    pub(super) peak_locality_rows: usize,
+}
+
+/// Rebuilds `spec`'s group from `spec`'s runs.
+///
+/// `tables` must name the manifest the spec was planned against: the job
+/// resolves its snapshot out of that manifest, so the runs it reads are the
+/// runs the plan chose and nothing else.
+pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+    policy: MetadataLsmPolicy,
+    cancellation: &MetadataCompactionCancellation,
+) -> Result<MetadataCompactionOutcome> {
+    let snapshot = resolve_snapshot_runs(tables, spec)?;
+    let mut job = CompactionJob {
+        store: tables.store,
+        namespace_id,
+        spec,
+        policy,
+        cancellation,
+        snapshot,
+        probe_cache: MetadataTableCache::new(MetadataTableCacheConfig {
+            max_decoded_bytes: PROBE_CACHE_DECODED_BYTES,
+        }),
+        result: MetadataCompactionResult {
+            output_segments: Vec::new(),
+            rows_read: 0,
+            rows_written: 0,
+            rows_written_by_family: BTreeMap::new(),
+            unbind_probes: 0,
+            peak_resident_blocks: 0,
+            peak_locality_rows: 0,
+        },
+        canonical_digest: RowDigest::default(),
+        index_digest: RowDigest::default(),
+    };
+
+    for cluster in retention_clusters(spec.group) {
+        if !job.run_cluster(cluster).await? {
+            return Ok(MetadataCompactionOutcome::Cancelled);
+        }
+    }
+    job.refuse_a_run_whose_index_disagrees()?;
+    Ok(MetadataCompactionOutcome::Completed(job.result))
+}
+
+/// One set of families the job merges and judges together, and how it groups
+/// their rows while doing it.
+struct RetentionCluster {
+    families: &'static [MetadataTableFamily],
+    locality: LocalityGrouping,
+    operator: RetentionOperator,
+}
+
+/// How many rows the retention rules need to see at once.
+///
+/// The rules that drop a row read its neighbours, and every one of them reads
+/// neighbours that share a row-key prefix: an unbind cancels the bind under
+/// the same parent and name, a removal marker repeats its deletion's sequence
+/// and root, and an attribute revision supersedes revisions of its own inode.
+/// So the grouping is read straight off the row-key grammar in
+/// `MetadataRow::row_key_for_family`, and it is the shortest prefix each rule
+/// needs rather than the whole partition the rows happen to share:
+///
+/// | families | grouped by | key components after the family prefix |
+/// | --- | --- | --- |
+/// | binds, unbinds | one name slot | `{parent}-{name}` |
+/// | active deletions | one deletion | `{deleted_at_seq}-{root}` |
+/// | attributes | one inode | `{inode}` |
+/// | everything else | one row | — |
+///
+/// A slot rather than a directory is what keeps the bindings group bounded:
+/// a directory has no size limit, and a slot holds one binding's generations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalityGrouping {
+    /// Every row is judged on its own.
+    Row,
+    /// Rows sharing the first `n` hyphen-separated components after their
+    /// family's row-key prefix are judged together. Every component of the
+    /// grammar is digits or lowercase hex, and a hyphen sorts below both, so
+    /// rows of one grouping are contiguous in row-key order and grouping
+    /// order is row-key order.
+    LeadingKeyComponents(usize),
+}
+
+/// Which rule decides the rows of a cluster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetentionOperator {
+    /// The frozen floor's rules over one locality group's rows, which is the
+    /// same function a whole-group fold runs over a whole family.
+    FrozenFloor,
+    /// Reverse bind rows, each decided by a point read into the snapshot for
+    /// the unbinds of its own binding.
+    ReverseBindProbe,
+}
+
+/// The bindings group merges its two forward families together, because an
+/// unbind retires the bind in its slot. The reverse index is keyed by child,
+/// so it shares no slot with the rows it indexes and streams on its own.
+const BINDINGS_CLUSTERS: [RetentionCluster; 2] = [
+    RetentionCluster {
+        families: &[
+            MetadataTableFamily::DirentryBinds,
+            MetadataTableFamily::DirentryUnbinds,
+        ],
+        locality: LocalityGrouping::LeadingKeyComponents(2),
+        operator: RetentionOperator::FrozenFloor,
+    },
+    RetentionCluster {
+        families: &[MetadataTableFamily::DirentryChildBinds],
+        locality: LocalityGrouping::Row,
+        operator: RetentionOperator::ReverseBindProbe,
+    },
+];
+
+/// A family whose rows are each decided on their own — either because no rule
+/// drops them at all, or because the rule reads nothing but the row.
+const fn row_cluster(families: &'static [MetadataTableFamily]) -> RetentionCluster {
+    RetentionCluster {
+        families,
+        locality: LocalityGrouping::Row,
+        operator: RetentionOperator::FrozenFloor,
+    }
+}
+
+/// Revision rows are never dropped and their index travels with them, so both
+/// families are a straight rewrite in key order.
+const REVISION_CLUSTERS: [RetentionCluster; 2] = [
+    row_cluster(&[MetadataTableFamily::Revisions]),
+    row_cluster(&[MetadataTableFamily::RevisionsByInodeDesc]),
+];
+const INODE_CLUSTERS: [RetentionCluster; 1] = [row_cluster(&[MetadataTableFamily::Inodes])];
+const TOMBSTONE_CLUSTERS: [RetentionCluster; 1] = [row_cluster(&[MetadataTableFamily::Tombstones])];
+/// A receipt is kept or dropped by its own sequence against the floor.
+const RECEIPT_CLUSTERS: [RetentionCluster; 1] =
+    [row_cluster(&[MetadataTableFamily::CommitReceipts])];
+const ACTIVE_DELETION_CLUSTERS: [RetentionCluster; 1] = [RetentionCluster {
+    families: &[MetadataTableFamily::ActiveDeletions],
+    locality: LocalityGrouping::LeadingKeyComponents(2),
+    operator: RetentionOperator::FrozenFloor,
+}];
+const ATTRIBUTE_CLUSTERS: [RetentionCluster; 1] = [RetentionCluster {
+    families: &[MetadataTableFamily::Attributes],
+    locality: LocalityGrouping::LeadingKeyComponents(1),
+    operator: RetentionOperator::FrozenFloor,
+}];
+
+fn retention_clusters(group: MetadataFamilyGroup) -> &'static [RetentionCluster] {
+    match group {
+        MetadataFamilyGroup::Bindings => &BINDINGS_CLUSTERS,
+        MetadataFamilyGroup::Revisions => &REVISION_CLUSTERS,
+        MetadataFamilyGroup::Inodes => &INODE_CLUSTERS,
+        MetadataFamilyGroup::Tombstones => &TOMBSTONE_CLUSTERS,
+        MetadataFamilyGroup::ActiveDeletions => &ACTIVE_DELETION_CLUSTERS,
+        MetadataFamilyGroup::CommitReceipts => &RECEIPT_CLUSTERS,
+        MetadataFamilyGroup::Attributes => &ATTRIBUTE_CLUSTERS,
+    }
+}
+
+/// The locality group a row key belongs to, as a slice of the key itself.
+///
+/// The family's own prefix is stripped, so two families of one cluster name
+/// the same group with the same string: a bind's `direntry-{parent}-{name}`
+/// and its unbind's `direntry-unbind-{parent}-{name}` both read as
+/// `{parent}-{name}`.
+fn locality_of(family: MetadataTableFamily, row_key: &str, locality: LocalityGrouping) -> &str {
+    let prefix_len = family.row_key_prefix().len();
+    let tail = row_key.get(prefix_len..).unwrap_or(row_key);
+    let LocalityGrouping::LeadingKeyComponents(components) = locality else {
+        return tail;
+    };
+    let mut end = 0;
+    for component in 0..components {
+        if component > 0 {
+            end += 1;
+        }
+        match tail[end..].find('-') {
+            Some(offset) => end += offset,
+            None => return tail,
+        }
+    }
+    &tail[..end]
+}
+
+struct CompactionJob<'a, S: ObjectStore + ?Sized> {
+    store: &'a S,
+    namespace_id: &'a NamespaceId,
+    spec: &'a MetadataCompactionSpec,
+    policy: MetadataLsmPolicy,
+    cancellation: &'a MetadataCompactionCancellation,
+    snapshot: Vec<MetadataRunManifest>,
+    probe_cache: MetadataTableCache,
+    result: MetadataCompactionResult,
+    canonical_digest: RowDigest,
+    index_digest: RowDigest,
+}
+
+impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
+    /// Merges one cluster end to end. `false` means the job was cancelled.
+    async fn run_cluster(&mut self, cluster: &RetentionCluster) -> Result<bool> {
+        // The descriptors are cloned out of the snapshot rather than borrowed
+        // from it: an iterator outlives every other borrow the job takes, and
+        // a cluster opens one per run per family, which is a handful.
+        let mut iterators = Vec::new();
+        for run in &self.snapshot {
+            for family in cluster.families {
+                let segments: Vec<MetadataFileRef> = group_run_descriptors(run, self.spec.group)
+                    .filter(|descriptor| descriptor.family == *family)
+                    .cloned()
+                    .collect();
+                if !segments.is_empty() {
+                    iterators.push(SegmentRowIterator::new(*family, segments));
+                }
+            }
+        }
+        let mut writers: BTreeMap<MetadataTableFamily, StagedSegmentWriter> = cluster
+            .families
+            .iter()
+            .map(|family| (*family, StagedSegmentWriter::new(*family)))
+            .collect();
+
+        let mut locality: Option<String> = None;
+        let mut group_rows: BTreeMap<MetadataTableFamily, Vec<MetadataRow>> = BTreeMap::new();
+        loop {
+            if self.cancellation.is_cancelled() {
+                return Ok(false);
+            }
+            self.refill(&mut iterators).await?;
+            let Some(next) = select_next_iterator(&iterators, cluster.locality) else {
+                break;
+            };
+            // The locality is a slice of the iterator's own key, so it is
+            // only copied when it changes — once per group rather than once
+            // per row.
+            let opened = {
+                let iterator = &iterators[next];
+                let (row_key, _) = iterator.head().expect("the selected iterator has a row");
+                let row_locality = locality_of(iterator.family, row_key, cluster.locality);
+                (locality.as_deref() != Some(row_locality)).then(|| row_locality.to_owned())
+            };
+            if let Some(opened) = opened {
+                self.flush_locality(cluster, &mut group_rows, &mut writers)
+                    .await?;
+                locality = Some(opened);
+            }
+            let family = iterators[next].family;
+            group_rows
+                .entry(family)
+                .or_default()
+                .push(iterators[next].take_head());
+            self.result.rows_read += 1;
+        }
+        self.flush_locality(cluster, &mut group_rows, &mut writers)
+            .await?;
+
+        for writer in writers.into_values() {
+            let segments = writer
+                .finish(self.store, self.namespace_id, self.spec)
+                .await?;
+            self.result.output_segments.extend(segments);
+        }
+        Ok(true)
+    }
+
+    /// Fills every iterator that has run out of rows, a bounded wave at a
+    /// time, and records what the job then holds.
+    async fn refill(&mut self, iterators: &mut [SegmentRowIterator]) -> Result<()> {
+        let mut hungry: Vec<&mut SegmentRowIterator> = iterators
+            .iter_mut()
+            .filter(|iterator| iterator.needs_fill())
+            .collect();
+        for wave in hungry.chunks_mut(ITERATOR_FETCH_CONCURRENCY) {
+            futures::future::try_join_all(
+                wave.iter_mut()
+                    .map(|iterator| Box::pin(iterator.fill(self.store))),
+            )
+            .await?;
+        }
+        let resident = iterators
+            .iter()
+            .map(SegmentRowIterator::resident_blocks)
+            .sum();
+        self.result.peak_resident_blocks = self.result.peak_resident_blocks.max(resident);
+        Ok(())
+    }
+
+    /// Judges one locality group and writes what survives.
+    async fn flush_locality(
+        &mut self,
+        cluster: &RetentionCluster,
+        group_rows: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
+        writers: &mut BTreeMap<MetadataTableFamily, StagedSegmentWriter>,
+    ) -> Result<()> {
+        let held: usize = group_rows.values().map(Vec::len).sum();
+        if held == 0 {
+            return Ok(());
+        }
+        self.result.peak_locality_rows = self.result.peak_locality_rows.max(held);
+
+        match cluster.operator {
+            RetentionOperator::FrozenFloor => {
+                // A locality group holds every unbind that can retire the
+                // binds it holds, because a bind and its unbind share a slot.
+                let unbound_at_floor = unbindings_at_or_below_floor(
+                    group_rows
+                        .get(&MetadataTableFamily::DirentryUnbinds)
+                        .map_or(&[], Vec::as_slice),
+                    self.spec.frozen_floor_seq,
+                );
+                drop_rows_below_frozen_floor(
+                    group_rows,
+                    self.spec.frozen_floor_seq,
+                    &unbound_at_floor,
+                )?;
+            }
+            RetentionOperator::ReverseBindProbe => {
+                self.retain_reverse_binds(group_rows).await?;
+            }
+        }
+
+        for (family, rows) in std::mem::take(group_rows) {
+            let writer = writers
+                .get_mut(&family)
+                .expect("a cluster writes only the families it merges");
+            for row in rows {
+                self.fold_into_index_digests(family, &row)?;
+                *self
+                    .result
+                    .rows_written_by_family
+                    .entry(family)
+                    .or_default() += 1;
+                self.result.rows_written += 1;
+                writer.push(row);
+            }
+            writer
+                .roll_full_segments(self.store, self.namespace_id, self.spec, self.policy)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Keeps the reverse bind rows the frozen floor still covers, deciding
+    /// each one by reading the snapshot for the unbinds of its own binding.
+    ///
+    /// The reverse index is keyed by child and the unbind family by parent, so
+    /// no grouping of the merged stream can hold a reverse row together with
+    /// the unbind that retires it. The point read closes that: it runs
+    /// [`unbindings_at_or_below_floor`] and [`bind_survives_frozen_floor`]
+    /// over unbind rows from the same immutable snapshot against the same
+    /// frozen floor as the forward pass, so the two bind families drop in
+    /// lockstep — which they must, because the format gives every bind row
+    /// exactly one reverse row and a run whose two counts disagree does not
+    /// load.
+    ///
+    /// Only rows at or below the floor cost a read: a bind above the floor
+    /// survives whatever retired it later. Each read returns the unbinds of
+    /// one binding generation, which is zero rows or one.
+    async fn retain_reverse_binds(
+        &mut self,
+        group_rows: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
+    ) -> Result<()> {
+        let Some(rows) = group_rows.get_mut(&MetadataTableFamily::DirentryChildBinds) else {
+            return Ok(());
+        };
+        let mut kept = Vec::with_capacity(rows.len());
+        for row in std::mem::take(rows) {
+            let MetadataRow::DirentryBind {
+                parent_inode_id,
+                name_key,
+                bind_seq,
+                bind_delta_index,
+                ..
+            } = &row
+            else {
+                kept.push(row);
+                continue;
+            };
+            if *bind_seq > self.spec.frozen_floor_seq {
+                kept.push(row);
+                continue;
+            }
+            let unbind_rows = self
+                .read_unbinds_of_binding(
+                    &lookup_keys::direntry_unbind_binding_prefix(
+                        *parent_inode_id,
+                        name_key.as_str(),
+                        *bind_seq,
+                        *bind_delta_index,
+                    ),
+                    &lookup_keys::direntry_unbind_probe(*parent_inode_id, name_key.as_str()),
+                )
+                .await?;
+            self.result.unbind_probes += 1;
+            let unbound_at_floor =
+                unbindings_at_or_below_floor(&unbind_rows, self.spec.frozen_floor_seq);
+            if bind_survives_frozen_floor(&row, self.spec.frozen_floor_seq, &unbound_at_floor) {
+                kept.push(row);
+            }
+        }
+        *rows = kept;
+        Ok(())
+    }
+
+    /// One point read into the snapshot's unbind family.
+    ///
+    /// The unbind key grammar leads with the binding a row names, so the
+    /// prefix selects the unbinds of that one binding and nothing else. The
+    /// bloom filter is keyed by parent and name, so a binding no operation
+    /// ever retired misses it outright and costs no index or data fetch.
+    /// Decoded sections land in the job's own bounded cache, and the per-read
+    /// memo is dropped with the read, so what these reads hold is the cache's
+    /// byte budget however many of them the job makes.
+    async fn read_unbinds_of_binding(
+        &self,
+        prefix: &str,
+        filter_probe: &str,
+    ) -> Result<Vec<MetadataRow>> {
+        let upper_bound = string_prefix_upper_bound(prefix);
+        let mut rows = Vec::new();
+        for run in &self.snapshot {
+            for descriptor in group_run_descriptors(run, self.spec.group)
+                .filter(|descriptor| descriptor.family == MetadataTableFamily::DirentryUnbinds)
+            {
+                if !descriptor_may_intersect_range(descriptor, prefix, upper_bound.as_deref()) {
+                    continue;
+                }
+                let memo = SessionBlockMemo::default();
+                let filter =
+                    load_segment_filter(self.store, Some(&self.probe_cache), &memo, descriptor)
+                        .await
+                        .map_err(manifest_load_failure)?;
+                if !filter.may_contain(filter_probe) {
+                    continue;
+                }
+                let blocks = load_manifest_segment_rows_in_key_range_with_cache(
+                    self.store,
+                    Some(&self.probe_cache),
+                    &memo,
+                    descriptor,
+                    prefix,
+                    upper_bound.as_deref(),
+                    Readahead::Disabled,
+                )
+                .await
+                .map_err(manifest_load_failure)?;
+                rows.extend(
+                    blocks
+                        .rows_in_key_range(prefix, upper_bound.as_deref())
+                        .map(|(_, row)| row.clone()),
+                );
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Folds a written row into the digest of its side of the group's index
+    /// pair, when the group has one.
+    fn fold_into_index_digests(
+        &mut self,
+        family: MetadataTableFamily,
+        row: &MetadataRow,
+    ) -> Result<()> {
+        let Some((canonical, index)) = index_pair(self.spec.group) else {
+            return Ok(());
+        };
+        if family == canonical {
+            self.canonical_digest.fold(row)?;
+        } else if family == index {
+            self.index_digest.fold(row)?;
+        }
+        Ok(())
+    }
+
+    /// Refuses to hand back a run whose secondary index does not hold the same
+    /// rows as its canonical family.
+    ///
+    /// A whole-group fold compares the two families outright, over rows it
+    /// holds all of. A streaming job cannot: the reverse bind index is keyed
+    /// by child, so no grouping ever holds a bind row and the reverse row that
+    /// indexes it, and the two are decided in different passes. The digests
+    /// stand in — each pass folds the rows it wrote into one, order does not
+    /// matter, and the two agree at the end exactly when the job wrote the two
+    /// families the same rows.
+    fn refuse_a_run_whose_index_disagrees(&self) -> Result<()> {
+        let Some((canonical, index)) = index_pair(self.spec.group) else {
+            return Ok(());
+        };
+        if self.canonical_digest == self.index_digest {
+            return Ok(());
+        }
+        Err(CoreError::NamespaceCorrupt(format!(
+            "a streaming compaction of {:?} wrote {} `{canonical:?}` rows digesting to `{}` and \
+             {} `{index:?}` rows digesting to `{}`; the two families must hold the same rows, so \
+             the run it built is not publishable",
+            self.spec.group.families(),
+            self.canonical_digest.rows,
+            self.canonical_digest.spell(),
+            self.index_digest.rows,
+            self.index_digest.spell(),
+        )))
+    }
+}
+
+/// Reads one family's rows out of one run, one bounded span of data blocks at
+/// a time.
+///
+/// A run's segments for one family are ascending and non-overlapping (manifest
+/// load enforces it), so walking them in index order walks the run's rows in
+/// row-key order. Only the current segment's index is held, and only the
+/// blocks not yet consumed.
+struct SegmentRowIterator {
+    family: MetadataTableFamily,
+    segments: Vec<MetadataFileRef>,
+    next_segment: usize,
+    index: Option<Arc<Vec<SegmentIndexEntry>>>,
+    next_block: usize,
+    blocks: VecDeque<Arc<DecodedDataBlock>>,
+    row: usize,
+}
+
+impl SegmentRowIterator {
+    fn new(family: MetadataTableFamily, mut segments: Vec<MetadataFileRef>) -> Self {
+        segments.sort_by_key(|descriptor| descriptor.segment_index);
+        Self {
+            family,
+            segments,
+            next_segment: 0,
+            index: None,
+            next_block: 0,
+            blocks: VecDeque::new(),
+            row: 0,
+        }
+    }
+
+    fn head(&self) -> Option<(&str, &MetadataRow)> {
+        let block = self.blocks.front()?;
+        Some((block.row_keys[self.row].as_str(), &block.rows[self.row]))
+    }
+
+    fn take_head(&mut self) -> MetadataRow {
+        let row = self.blocks.front().expect("a head to take").rows[self.row].clone();
+        self.row += 1;
+        while self
+            .blocks
+            .front()
+            .is_some_and(|block| self.row >= block.rows.len())
+        {
+            self.blocks.pop_front();
+            self.row = 0;
+        }
+        row
+    }
+
+    fn needs_fill(&self) -> bool {
+        self.blocks.is_empty() && !self.is_exhausted()
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.blocks.is_empty()
+            && self.next_segment >= self.segments.len()
+            && self
+                .index
+                .as_ref()
+                .is_none_or(|index| self.next_block >= index.len())
+    }
+
+    fn resident_blocks(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Fetches the next span of data blocks, opening the next segment first
+    /// when the current one is spent. A segment with no rows left is closed
+    /// and its index dropped before the next one is read, so one iterator
+    /// holds one index at a time.
+    async fn fill<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
+        while self.blocks.is_empty() {
+            let index = match &self.index {
+                Some(index) if self.next_block < index.len() => Arc::clone(index),
+                _ => {
+                    self.index = None;
+                    let Some(descriptor) = self.segments.get(self.next_segment) else {
+                        return Ok(());
+                    };
+                    self.next_segment += 1;
+                    self.next_block = 0;
+                    let index = load_segment_index_for_reorganization(
+                        store,
+                        None,
+                        &SessionBlockMemo::default(),
+                        descriptor,
+                    )
+                    .await
+                    .map_err(manifest_load_failure)?;
+                    self.index = Some(Arc::clone(&index));
+                    index
+                }
+            };
+            let descriptor = &self.segments[self.next_segment - 1];
+            let end = (self.next_block + BLOCKS_PER_ITERATOR_FETCH).min(index.len());
+            // Blocks are decoded into this iterator alone: no table cache and
+            // a memo that dies with the call, so nothing the job reads is
+            // retained anywhere but here.
+            let blocks = load_segment_data_block_span(
+                store,
+                None,
+                &SessionBlockMemo::default(),
+                descriptor,
+                &index[self.next_block..end],
+            )
+            .await
+            .map_err(manifest_load_failure)?;
+            self.next_block = end;
+            validate_manifest_row_seq_range(
+                &descriptor.object_key,
+                blocks.iter().flat_map(|block| block.rows.iter()),
+                descriptor.run_seq,
+            )
+            .map_err(manifest_load_failure)?;
+            self.row = 0;
+            self.blocks
+                .extend(blocks.into_iter().filter(|block| !block.rows.is_empty()));
+        }
+        Ok(())
+    }
+}
+
+/// The iterator whose next row sorts first, or `None` when every iterator is
+/// spent.
+///
+/// A linear scan rather than a heap: an iterator is opened per run per family
+/// of one cluster, which is a handful, and the scan compares borrowed key
+/// slices while a heap would have to own them.
+fn select_next_iterator(
+    iterators: &[SegmentRowIterator],
+    locality: LocalityGrouping,
+) -> Option<usize> {
+    let mut best: Option<(usize, &str, &str)> = None;
+    for (position, iterator) in iterators.iter().enumerate() {
+        let Some((row_key, _)) = iterator.head() else {
+            continue;
+        };
+        let candidate = locality_of(iterator.family, row_key, locality);
+        let take = match best {
+            // Locality first so a group's rows arrive together whatever
+            // family they come from, then family, then key: within one
+            // family that is row-key order, which is the order a segment
+            // builder demands.
+            Some((best_position, best_locality, best_key)) => {
+                (candidate, iterators[position].family, row_key)
+                    < (best_locality, iterators[best_position].family, best_key)
+            }
+            None => true,
+        };
+        if take {
+            best = Some((position, candidate, row_key));
+        }
+    }
+    best.map(|(position, _, _)| position)
+}
+
+/// Accumulates one family's surviving rows and uploads a segment every time
+/// the segment row budget fills.
+struct StagedSegmentWriter {
+    family: MetadataTableFamily,
+    rows: Vec<MetadataRow>,
+    next_segment_index: u32,
+    segments: Vec<MetadataFileRef>,
+}
+
+impl StagedSegmentWriter {
+    fn new(family: MetadataTableFamily) -> Self {
+        Self {
+            family,
+            rows: Vec::new(),
+            next_segment_index: 0,
+            segments: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, row: MetadataRow) {
+        self.rows.push(row);
+    }
+
+    async fn roll_full_segments<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        spec: &MetadataCompactionSpec,
+        policy: MetadataLsmPolicy,
+    ) -> Result<()> {
+        let max_rows = policy.max_rows_per_segment.get();
+        while self.rows.len() >= max_rows {
+            let rest = self.rows.split_off(max_rows);
+            let full = std::mem::replace(&mut self.rows, rest);
+            self.write_segment(store, namespace_id, spec, full).await?;
+        }
+        Ok(())
+    }
+
+    async fn finish<S: ObjectStore + ?Sized>(
+        mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        spec: &MetadataCompactionSpec,
+    ) -> Result<Vec<MetadataFileRef>> {
+        let rest = std::mem::take(&mut self.rows);
+        if !rest.is_empty() {
+            self.write_segment(store, namespace_id, spec, rest).await?;
+        }
+        Ok(self.segments)
+    }
+
+    async fn write_segment<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        spec: &MetadataCompactionSpec,
+        rows: Vec<MetadataRow>,
+    ) -> Result<()> {
+        let table_id = MetadataTableId::generate();
+        let object_key =
+            metadata_compaction_staging_table(namespace_id.as_str(), table_id.as_str());
+        let descriptor = write_manifest_segment(
+            store,
+            MetadataSstWriteRequest::new(
+                namespace_id,
+                table_id,
+                object_key,
+                spec.placement.output_seq(),
+                spec.placement.output_level(),
+                self.family,
+                self.next_segment_index,
+                rows,
+            ),
+        )
+        .await?;
+        self.next_segment_index += 1;
+        self.segments.push(descriptor);
+        Ok(())
+    }
+}
+
+/// An order-independent digest of the rows one family was written.
+///
+/// The combiner is wrapping addition, so the digest depends on the multiset of
+/// rows and not on the order they were written in — which is the point,
+/// because the two families of an index pair are written in different orders
+/// and, for the bind pair, in different passes. This is corruption detection,
+/// not a signature: what it has to catch is a job that wrote a secondary index
+/// rows its canonical family does not hold, including a row differing in one
+/// field. Nothing durable carries it, so the input is the row's serde
+/// encoding.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct RowDigest {
+    value: u128,
+    rows: u64,
+}
+
+impl RowDigest {
+    fn fold(&mut self, row: &MetadataRow) -> Result<()> {
+        let encoded = serde_json::to_vec(row).map_err(|err| {
+            CoreError::Internal(format!(
+                "failed to encode a metadata row for digesting: {err}"
+            ))
+        })?;
+        let digest = Sha256::digest(&encoded);
+        let mut head = [0u8; 16];
+        head.copy_from_slice(&digest[..16]);
+        self.value = self.value.wrapping_add(u128::from_be_bytes(head));
+        self.rows += 1;
+        Ok(())
+    }
+
+    fn spell(&self) -> String {
+        format!("{:032x}", self.value)
+    }
+}
+
+/// The canonical family and secondary index of a group that carries one.
+fn index_pair(group: MetadataFamilyGroup) -> Option<(MetadataTableFamily, MetadataTableFamily)> {
+    match group {
+        MetadataFamilyGroup::Bindings => Some((
+            MetadataTableFamily::DirentryBinds,
+            MetadataTableFamily::DirentryChildBinds,
+        )),
+        MetadataFamilyGroup::Revisions => Some((
+            MetadataTableFamily::Revisions,
+            MetadataTableFamily::RevisionsByInodeDesc,
+        )),
+        _ => None,
+    }
+}
+
+/// Turns the run ids a spec names back into the manifest's runs.
+fn resolve_snapshot_runs<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    spec: &MetadataCompactionSpec,
+) -> Result<Vec<MetadataRunManifest>> {
+    spec.inputs
+        .iter()
+        .map(|(run_seq, level)| {
+            tables
+                .scan_runs
+                .iter()
+                .find(|run| run.run_seq == *run_seq && run.level == *level)
+                .cloned()
+                .ok_or_else(|| {
+                    CoreError::NamespaceCorrupt(format!(
+                        "a streaming compaction names input run seq `{run_seq}` level {level}, \
+                         which the manifest does not reference"
+                    ))
+                })
+        })
+        .collect()
+}
+
+fn manifest_load_failure(error: ManifestLoadError) -> CoreError {
+    CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{locality_of, LocalityGrouping, RowDigest};
+    use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
+    use loonfs_api::{ChangeSeq, DisplayName, InodeId, NameKey};
+
+    fn bind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
+        MetadataRow::DirentryBind {
+            parent_inode_id: InodeId(parent),
+            name_key: NameKey::parse(name).expect("name key"),
+            display_name: DisplayName::parse(name).expect("display name"),
+            child_inode_id: InodeId(42),
+            bind_seq: ChangeSeq(bind_seq),
+            bind_delta_index: 0,
+        }
+    }
+
+    fn unbind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
+        MetadataRow::DirentryUnbind {
+            parent_inode_id: InodeId(parent),
+            name_key: NameKey::parse(name).expect("name key"),
+            display_name: DisplayName::parse(name).expect("display name"),
+            child_inode_id: InodeId(42),
+            bind_seq: ChangeSeq(bind_seq),
+            bind_delta_index: 0,
+            unbind_seq: ChangeSeq(bind_seq + 1),
+            unbind_delta_index: 0,
+        }
+    }
+
+    /// A bind and the unbind that retires it must name the same locality
+    /// group, because the drop rule reads one from the other. They live in
+    /// different families with different row-key prefixes, so this holds only
+    /// because the grouping is read behind the prefix.
+    #[test]
+    fn a_bind_and_its_unbind_name_one_locality_group() {
+        let slot = LocalityGrouping::LeadingKeyComponents(2);
+        let bound = bind(7, "report.txt", 11);
+        let retired = unbind(7, "report.txt", 11);
+        let bind_key = bound.row_key_for_family(MetadataTableFamily::DirentryBinds);
+        let unbind_key = retired.row_key_for_family(MetadataTableFamily::DirentryUnbinds);
+
+        assert_eq!(
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, slot),
+            locality_of(MetadataTableFamily::DirentryUnbinds, &unbind_key, slot),
+        );
+        // Another name under the same parent is a different group: the rules
+        // read one slot, not one directory.
+        let other = bind(7, "other.txt", 11).row_key_for_family(MetadataTableFamily::DirentryBinds);
+        assert_ne!(
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, slot),
+            locality_of(MetadataTableFamily::DirentryBinds, &other, slot),
+        );
+        // And so is the same name under another parent.
+        let elsewhere =
+            bind(8, "report.txt", 11).row_key_for_family(MetadataTableFamily::DirentryBinds);
+        assert_ne!(
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, slot),
+            locality_of(MetadataTableFamily::DirentryBinds, &elsewhere, slot),
+        );
+    }
+
+    /// Rows of one locality group are contiguous in row-key order, and
+    /// grouping order is row-key order. Without both, a merge would reopen a
+    /// group it had already judged and written.
+    #[test]
+    fn locality_order_follows_row_key_order() {
+        let slot = LocalityGrouping::LeadingKeyComponents(2);
+        let mut keys: Vec<String> = ["a", "ab", "b", "a-b"]
+            .into_iter()
+            .flat_map(|name| {
+                [11u64, 12].map(|seq| {
+                    bind(7, name, seq).row_key_for_family(MetadataTableFamily::DirentryBinds)
+                })
+            })
+            .collect();
+        keys.sort();
+
+        let localities: Vec<&str> = keys
+            .iter()
+            .map(|key| locality_of(MetadataTableFamily::DirentryBinds, key, slot))
+            .collect();
+        let mut runs = localities.clone();
+        runs.dedup();
+        let mut distinct = runs.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(
+            runs.len(),
+            distinct.len(),
+            "a group must not reappear after another group began: {localities:?}"
+        );
+        assert!(
+            runs.windows(2).all(|pair| pair[0] < pair[1]),
+            "grouping order must be row-key order: {runs:?}"
+        );
+    }
+
+    /// The digest compares two families written in different orders and, for
+    /// the bind pair, in different passes. So it must ignore order and still
+    /// notice one row differing in one field.
+    #[test]
+    fn the_row_digest_ignores_order_and_notices_one_changed_field() {
+        let rows = [
+            bind(7, "a.txt", 11),
+            bind(7, "b.txt", 12),
+            unbind(7, "a.txt", 11),
+        ];
+        let mut forward = RowDigest::default();
+        let mut backward = RowDigest::default();
+        for row in &rows {
+            forward.fold(row).expect("digest");
+        }
+        for row in rows.iter().rev() {
+            backward.fold(row).expect("digest");
+        }
+        assert_eq!(forward, backward);
+
+        let mut changed = RowDigest::default();
+        for row in [
+            bind(7, "a.txt", 11),
+            bind(7, "b.txt", 13),
+            unbind(7, "a.txt", 11),
+        ]
+        .iter()
+        {
+            changed.fold(row).expect("digest");
+        }
+        assert_ne!(forward, changed);
+
+        let mut short = RowDigest::default();
+        short.fold(&rows[0]).expect("digest");
+        assert_ne!(forward, short);
+    }
+}

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -5,7 +5,7 @@ use super::super::block_load::{
 };
 use super::super::cache::MetadataTableCache;
 use super::super::error::ManifestLoadError;
-use super::super::load::{load_namespace_manifest_envelope_if_present, metadata_file_object_key};
+use super::super::load::{ensure_segment_object_key, load_namespace_manifest_envelope_if_present};
 use super::super::row::manifest_row_kind;
 use super::super::runs::{
     runs_in_materialization_order, MetadataTableManifest, MAX_MAINTENANCE_TABLE_IO,
@@ -163,13 +163,7 @@ where
     for table in ordered_tables {
         let mut descriptors = Vec::with_capacity(table.segments.len());
         for descriptor in &table.segments {
-            let expected_key = metadata_file_object_key(descriptor);
-            if descriptor.object_key != expected_key {
-                return Err(ManifestLoadError::SegmentObjectKeyMismatch {
-                    object_key: descriptor.object_key.clone(),
-                    expected: expected_key,
-                });
-            }
+            ensure_segment_object_key(descriptor)?;
             descriptors.push(descriptor);
         }
 

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod inspection_materialization;
 mod inventory;
 mod manifest_round_trips;
 mod retention;
+mod streaming_compaction;
 
 use super::build::{
     build_manifest_tables, build_manifest_tables_from_rows, MetadataTableSegmentation,
@@ -373,15 +374,21 @@ fn base_runs_per_family_group(
 ) -> Vec<(&'static [ApiMetadataTableFamily], Vec<RunId>)> {
     REORGANIZE_FAMILY_GROUPS
         .into_iter()
-        .map(|group| (group, group_base_runs(manifest, group)))
+        .map(|group| {
+            (
+                group.families(),
+                group_base_runs(manifest, group.families()),
+            )
+        })
         .collect()
 }
 
 fn group_containing(family: ApiMetadataTableFamily) -> &'static [ApiMetadataTableFamily] {
     REORGANIZE_FAMILY_GROUPS
         .into_iter()
-        .find(|group| group.contains(&family))
+        .find(|group| group.contains(family))
         .expect("every family belongs to a reorganization group")
+        .families()
 }
 
 fn base_segment_object_keys_for_family(

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1509,10 +1509,23 @@ async fn select_reorganization_window<S: ObjectStore + ?Sized>(
         .expect("load manifest tables");
     let group = super::reorganize::select_family_group(&tables.manifest().payload)
         .expect("a family group with L0 rows to fold");
-    let selection = super::reorganize::select_reorganization_input(&tables, group, policy)
-        .await
-        .expect("select a reorganization input");
-    (group.to_vec(), selection)
+    let frozen_floor_seq = read_floor_seq(store, namespace_id).await;
+    let selection =
+        super::reorganize::select_reorganization_input(&tables, group, policy, frozen_floor_seq)
+            .await
+            .expect("select a reorganization input");
+    (group.families().to_vec(), selection)
+}
+
+/// The bounded merge a selection chose, or `None` when it chose a streaming
+/// compaction instead.
+fn bounded_merge(
+    selection: super::reorganize::ReorganizationSelection,
+) -> Option<super::reorganize::ReorganizationInput> {
+    match selection.plan {
+        Some(super::reorganize::ReorganizationPlan::BoundedMerge(input)) => Some(input),
+        _ => None,
+    }
 }
 
 /// Rows one run holds in one family group: the quantity the per-step row
@@ -1606,8 +1619,10 @@ async fn a_base_run_over_the_step_budget_merges_the_delta_runs_above_it() {
     let policy = policy_that_cannot_fold_the_base(base_rows);
 
     let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
-    let input = selection
-        .input
+    let bottom = selection
+        .group_bottom_over_budget
+        .expect("a base run over the budget must raise the alarm");
+    let input = bounded_merge(selection)
         .expect("a group must keep finding work above a base run it cannot fold");
     assert!(
         matches!(
@@ -1633,9 +1648,6 @@ async fn a_base_run_over_the_step_budget_merges_the_delta_runs_above_it() {
         input.runs.len() > 1,
         "a merge must consume more than one run to reduce the count"
     );
-    let bottom = selection
-        .group_bottom_over_budget
-        .expect("a base run over the budget must raise the alarm");
     assert_eq!(bottom.run_seq, base.run_seq);
     assert_eq!(bottom.level, CHECKPOINT_BASE_RUN_LEVEL);
     assert_eq!(bottom.rows, base_rows);
@@ -1811,7 +1823,7 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     let policy = policy_that_cannot_fold_the_base(base_rows);
 
     let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
-    let input = selection.input.expect("the delta runs must still merge");
+    let input = bounded_merge(selection).expect("the delta runs must still merge");
     let newest_input = input
         .runs
         .iter()
@@ -1962,12 +1974,16 @@ async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
 
     let (_, selection) = select_reorganization_window(&store, &namespace_id, policy).await;
     assert!(
-        selection.input.is_none(),
-        "no legal window exists; the selector must not assemble one across the wide run"
-    );
-    assert!(
         selection.group_bottom_over_budget.is_none(),
         "the base run fits here, so nothing should claim it does not"
+    );
+    assert!(
+        matches!(
+            selection.plan,
+            Some(super::reorganize::ReorganizationPlan::FullCompaction(_))
+        ),
+        "no legal window exists; the selector must hand the group to a streaming compaction \
+         rather than assemble one across the wide run"
     );
 
     let root_before = current_manifest_id(&store, &namespace_id).await;

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -1,0 +1,1234 @@
+//! Rebuilding a family group in one streaming job: the plan split, the
+//! oracle that says a streaming job and a whole-group fold reach the same
+//! place, restart equivalence, and the resource bounds that make the job
+//! independent of the size of what it rebuilds.
+
+use super::super::reorganize::{
+    select_reorganization_input, write_reorganized_manifest, ReorganizationPlan,
+};
+use super::super::row::manifest_row_commit_seq;
+use super::super::runs::MetadataFamilyGroup;
+use super::super::scan::VerifiedMetadataTables;
+use super::super::streaming_compaction::{
+    run_metadata_compaction, MetadataCompactionCancellation, MetadataCompactionOutcome,
+    MetadataCompactionResult, MetadataCompactionSpec,
+};
+use super::*;
+use loonfs_objectstore::keys::metadata_compaction_staging_prefix;
+use loonfs_test_support::stores::ConcurrencyWatchStore;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+// -------------------------------------------------------------------------
+// The family-group table
+// -------------------------------------------------------------------------
+
+/// Every family compacts in exactly one group. A family in none would never
+/// be folded; a family in two would be rewritten twice at one identity.
+#[test]
+fn every_family_belongs_to_exactly_one_reorganization_group() {
+    for family in CHECKPOINT_TABLE_FAMILIES {
+        let groups: Vec<_> = REORGANIZE_FAMILY_GROUPS
+            .into_iter()
+            .filter(|group| group.families().contains(&family))
+            .collect();
+        assert_eq!(
+            groups.len(),
+            1,
+            "`{family:?}` belongs to {} reorganization groups",
+            groups.len()
+        );
+    }
+    let listed: usize = REORGANIZE_FAMILY_GROUPS
+        .iter()
+        .map(|group| group.families().len())
+        .sum();
+    assert_eq!(
+        listed,
+        CHECKPOINT_TABLE_FAMILIES.len(),
+        "the groups must list every family once and nothing else"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Workloads
+// -------------------------------------------------------------------------
+
+/// A namespace whose bindings group holds many parent directories, deletions
+/// and moves below the retention floor, and more of both above it — enough
+/// for a job to cross many slots and for the drop rules to have something to
+/// do.
+async fn seed_bindings_workload(store: &LocalFsStore, namespace_id: &NamespaceId) {
+    let context = test_context();
+    bootstrap_namespace(store, namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    // Below the floor: files created, some deleted, some moved. The deletions
+    // and moves leave unbinds the job may drop.
+    for directory in 0..6u64 {
+        for file in 0..3u64 {
+            write_file_bytes(
+                store,
+                namespace_id,
+                &format!("/d{directory}/f{file}.txt"),
+                format!("body {directory}/{file}\n").as_bytes(),
+                &context,
+                None,
+            )
+            .await
+            .expect("write file");
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint");
+    }
+    for directory in 0..3u64 {
+        delete_path(
+            store,
+            namespace_id,
+            &format!("/d{directory}/f0.txt"),
+            &context,
+            None,
+        )
+        .await
+        .expect("delete file");
+        move_path(
+            store,
+            namespace_id,
+            &format!("/d{directory}/f1.txt"),
+            &format!("/d{directory}/moved-f1.txt"),
+            &context,
+            None,
+        )
+        .await
+        .expect("move file");
+    }
+    // One deleted directory, so a tombstone and an active deletion travel
+    // with the bindings the job drops.
+    delete_path(store, namespace_id, "/d5", &context, None)
+        .await
+        .expect("delete directory");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the deletions");
+
+    // Fold everything into one base run, so the snapshot has a base under its
+    // delta runs the way a real over-budget group does. The base is cut into
+    // small segments on purpose: an iterator walks whole segments, so small
+    // segments make it open and close several of them.
+    drain_reorganization(
+        store,
+        namespace_id,
+        &context,
+        MetadataLsmPolicy {
+            max_rows_per_segment: NonZeroUsize::new(4).expect("nonzero"),
+            ..MetadataLsmPolicy::default()
+        },
+    )
+    .await;
+    advance_retention_floor(store, namespace_id, &context)
+        .await
+        .expect("advance the floor past the deletions");
+
+    // Above the floor: fresh directories and one more deletion, published as
+    // delta runs the job merges with the base.
+    for directory in 6..9u64 {
+        for file in 0..2u64 {
+            write_file_bytes(
+                store,
+                namespace_id,
+                &format!("/d{directory}/f{file}.txt"),
+                format!("late body {directory}/{file}\n").as_bytes(),
+                &context,
+                None,
+            )
+            .await
+            .expect("write late file");
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint late writes");
+    }
+    delete_path(store, namespace_id, "/d6/f0.txt", &context, None)
+        .await
+        .expect("delete a late file");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the late deletion");
+}
+
+/// A namespace whose bindings group is dominated by one directory, so one
+/// parent holds most of the group's rows.
+///
+/// Renames are what make it lopsided. Every rename writes a bind and an
+/// unbind under the same parent, and no inode row and no revision row, so the
+/// parent grows while the rest of the namespace stays where it was. That is
+/// the shape the old per-step row budget had no answer for.
+async fn seed_one_wide_directory(store: &LocalFsStore, namespace_id: &NamespaceId) {
+    let context = test_context();
+    bootstrap_namespace(store, namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for file in 0..6u64 {
+        write_file_bytes(
+            store,
+            namespace_id,
+            &format!("/wide/f{file}.txt"),
+            format!("body {file}\n").as_bytes(),
+            &context,
+            None,
+        )
+        .await
+        .expect("write file");
+    }
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the writes");
+    for round in 0..10u64 {
+        for file in 0..6u64 {
+            let from = match round {
+                0 => format!("/wide/f{file}.txt"),
+                previous => format!("/wide/f{file}-r{}.txt", previous - 1),
+            };
+            move_path(
+                store,
+                namespace_id,
+                &from,
+                &format!("/wide/f{file}-r{round}.txt"),
+                &context,
+                None,
+            )
+            .await
+            .expect("rename file");
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint the renames");
+    }
+    drain_reorganization(
+        store,
+        namespace_id,
+        &context,
+        MetadataLsmPolicy {
+            max_rows_per_segment: NonZeroUsize::new(4).expect("nonzero"),
+            ..MetadataLsmPolicy::default()
+        },
+    )
+    .await;
+    advance_retention_floor(store, namespace_id, &context)
+        .await
+        .expect("advance the floor past the renames");
+
+    write_file_bytes(
+        store,
+        namespace_id,
+        "/wide/late.txt",
+        b"late body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write a late file");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the late write");
+}
+
+// -------------------------------------------------------------------------
+// Driving a job
+// -------------------------------------------------------------------------
+
+/// A budget that admits the whole group in one step, so the ordinary fold can
+/// rebuild in one unit whatever the streaming job did incrementally.
+fn fold_everything_policy() -> MetadataLsmPolicy {
+    MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(4_000_000).expect("nonzero"),
+        max_decoded_input_bytes_per_step: NonZeroUsize::new(1 << 30).expect("nonzero"),
+        max_input_runs_per_step: NonZeroUsize::new(64).expect("nonzero"),
+        ..MetadataLsmPolicy::default()
+    }
+}
+
+/// A budget that rolls many small output segments, so the job's writers are
+/// exercised rather than producing one segment per family.
+fn small_segment_policy() -> MetadataLsmPolicy {
+    MetadataLsmPolicy {
+        max_rows_per_segment: NonZeroUsize::new(4).expect("nonzero"),
+        ..fold_everything_policy()
+    }
+}
+
+/// The tables of whatever manifest the namespace's root names right now.
+async fn load_current_manifest_tables<'a, S: ObjectStore + ?Sized>(
+    store: &'a S,
+    namespace_id: &NamespaceId,
+) -> VerifiedMetadataTables<'a, S> {
+    let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
+    load_verified_manifest_tables(store, namespace_id, &manifest_object_id)
+        .await
+        .expect("load the current manifest's tables")
+}
+
+/// The runs a job snapshots: every run of the manifest that holds rows of the
+/// group, which is what makes the input bottom-anchored and its drops legal.
+fn snapshot_runs_for_group(
+    manifest: &NamespaceManifestEnvelope,
+    group: MetadataFamilyGroup,
+) -> Vec<MetadataRunManifest> {
+    runs_in_scan_order(&manifest.payload)
+        .into_iter()
+        .filter(|run| {
+            run.tables
+                .iter()
+                .any(|table| group.contains(table.family) && !table.segments.is_empty())
+        })
+        .collect()
+}
+
+/// The spec a planner would produce for `group` against the current manifest:
+/// every run the group holds, the output at the manifest head, and the live
+/// retention floor.
+async fn compaction_spec_for_group<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
+) -> MetadataCompactionSpec {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    let frozen_floor_seq = read_floor_seq(store, namespace_id).await;
+    // One byte admits no run whole, so the planner has no window that makes
+    // progress and answers with the compaction plan for this group.
+    let selection = select_reorganization_input(
+        &tables,
+        group,
+        MetadataLsmPolicy {
+            max_l0_runs: NonZeroUsize::MIN,
+            max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
+            ..MetadataLsmPolicy::default()
+        },
+        frozen_floor_seq,
+    )
+    .await
+    .expect("plan the group");
+    match selection.plan {
+        Some(ReorganizationPlan::FullCompaction(spec)) => spec,
+        _ => panic!("a group no budget admits must plan as a streaming compaction"),
+    }
+}
+
+async fn run_compaction<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+    policy: MetadataLsmPolicy,
+    cancellation: &MetadataCompactionCancellation,
+) -> MetadataCompactionOutcome {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    run_metadata_compaction(&tables, namespace_id, spec, policy, cancellation)
+        .await
+        .expect("run the streaming compaction")
+}
+
+/// The swap a finished job's caller performs, as much of it as this change
+/// owns: reload the current manifest, verify every snapshot run is still
+/// present and unchanged, replace exactly those descriptors with the output
+/// run, and publish through the ordinary manifest path.
+///
+/// The runner productionizes this — the race handling, the reporting, and the
+/// retry are its business. This is the minimum the oracle needs to look at
+/// what the job built through a manifest a reader can load.
+async fn finalize_streaming_compaction<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+    snapshot_at_start: &[MetadataRunManifest],
+    result: &MetadataCompactionResult,
+) -> ManifestId {
+    let root = read_metadata_root_object(store, namespace_id)
+        .await
+        .expect("read root")
+        .envelope
+        .state;
+    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+        .await
+        .expect("load the current manifest");
+    assert_eq!(
+        snapshot_runs_for_group(tables.manifest(), spec.group()),
+        snapshot_at_start,
+        "the snapshot must still be present and unchanged at finalization"
+    );
+
+    let previous = tables.manifest();
+    let inputs: BTreeSet<(ChangeSeq, u32)> = spec.inputs().iter().copied().collect();
+    let mut metadata_files: Vec<MetadataFileRef> = previous
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| {
+            !spec.group().contains(descriptor.family)
+                || !inputs.contains(&(descriptor.run_seq, descriptor.level))
+        })
+        .cloned()
+        .collect();
+    metadata_files.extend(result.output_segments.iter().cloned());
+    let base_seq = metadata_files
+        .iter()
+        .map(|descriptor| descriptor.run_seq)
+        .min()
+        .unwrap_or(previous.payload.base_seq);
+    let retention_floor_seq = previous
+        .payload
+        .retention_floor_seq
+        .max(spec.frozen_floor_seq());
+
+    let manifest = write_reorganized_manifest(
+        store,
+        namespace_id,
+        previous,
+        metadata_files,
+        base_seq,
+        retention_floor_seq,
+    )
+    .await
+    .expect("write the replacement manifest");
+    match publish_metadata_root(
+        store,
+        namespace_id,
+        &manifest,
+        Some(root.manifest_object_id.clone()),
+        test_context().now_ms,
+    )
+    .await
+    .expect("publish the replacement manifest")
+    {
+        ManifestPublicationOutcome::Published(_) => manifest.payload.manifest_id,
+        other => panic!("no concurrent publisher exists in this test, got {other:?}"),
+    }
+}
+
+/// The group's rows a reader sees right now: read from `metadata_files`,
+/// which is exactly what a scan concatenates.
+async fn group_rows_from_manifest<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    group: MetadataFamilyGroup,
+) -> BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>> {
+    let mut rows_by_family = BTreeMap::new();
+    for family in group.families() {
+        let mut rows = tables
+            .scan_prefix(*family, "")
+            .await
+            .expect("scan the group");
+        rows.sort_by_key(|row| row.row_key_for_family(*family));
+        rows_by_family.insert(*family, rows);
+    }
+    rows_by_family
+}
+
+async fn group_rows_of_current_manifest<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
+) -> BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>> {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    group_rows_from_manifest(&tables, group).await
+}
+
+async fn current_metadata_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> MetadataState {
+    load_manifest_materialization_for_inspection(
+        store,
+        namespace_id,
+        read_metadata_root_object(store, namespace_id)
+            .await
+            .expect("read root")
+            .envelope
+            .state
+            .manifest_id,
+    )
+    .await
+    .expect("materialize the manifest")
+    .metadata_state
+}
+
+/// Copies a local store's whole object tree, so two jobs can start from
+/// byte-identical durable state. Content ids and table ids are generated, so
+/// building the same namespace twice would not produce the same rows.
+fn copy_store_tree(from: &Path, to: &Path) {
+    for entry in std::fs::read_dir(from).expect("read the store directory") {
+        let entry = entry.expect("directory entry");
+        let target = to.join(entry.file_name());
+        if entry.file_type().expect("entry file type").is_dir() {
+            std::fs::create_dir_all(&target).expect("create the copied directory");
+            copy_store_tree(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), &target).expect("copy the object");
+        }
+    }
+}
+
+async fn staged_object_keys<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> BTreeSet<String> {
+    use futures::StreamExt;
+    store
+        .list_prefix_stream(&metadata_compaction_staging_prefix(namespace_id.as_str()))
+        .map(|key| key.expect("list staged objects"))
+        .collect()
+        .await
+}
+
+/// Runs the whole-group fold with the budgets raised, which is the other way
+/// of doing what the streaming job does.
+async fn fold_group_whole<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
+) {
+    let report = super::super::reorganize_metadata_step(
+        store,
+        namespace_id,
+        &test_context(),
+        fold_everything_policy(),
+    )
+    .await
+    .expect("fold the group whole");
+    let MetadataReorganizeOutcome::UnitPublished { families, .. } = report.outcome else {
+        panic!("the whole-group fold must publish a unit");
+    };
+    assert_eq!(
+        families,
+        group.families(),
+        "both rebuilds must work on the same family group"
+    );
+}
+
+// -------------------------------------------------------------------------
+// The plan split
+// -------------------------------------------------------------------------
+
+/// A group whose bottom-anchored window fits the budgets is a bounded merge;
+/// the same group under budgets no window can satisfy is a streaming
+/// compaction over every run it holds.
+#[tokio::test]
+async fn the_planner_answers_with_a_merge_or_with_a_compaction() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let floor_seq = read_floor_seq(&store, &namespace_id).await;
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+
+    let generous = select_reorganization_input(&tables, group, fold_everything_policy(), floor_seq)
+        .await
+        .expect("plan under generous budgets");
+    assert!(
+        matches!(generous.plan, Some(ReorganizationPlan::BoundedMerge(_))),
+        "a window that fits is a bounded merge"
+    );
+    assert!(generous.group_bottom_over_budget.is_none());
+
+    let starved = select_reorganization_input(
+        &tables,
+        group,
+        MetadataLsmPolicy {
+            max_l0_runs: NonZeroUsize::MIN,
+            max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
+            ..MetadataLsmPolicy::default()
+        },
+        floor_seq,
+    )
+    .await
+    .expect("plan under budgets nothing fits");
+    let Some(ReorganizationPlan::FullCompaction(spec)) = starved.plan else {
+        panic!("a group no window fits must plan as a streaming compaction");
+    };
+    assert!(
+        starved.group_bottom_over_budget.is_some(),
+        "the operator still hears that the group's oldest run is over budget"
+    );
+    assert_eq!(spec.group(), group);
+    assert_eq!(spec.frozen_floor_seq(), floor_seq);
+    let snapshot = snapshot_runs_for_group(tables.manifest(), group);
+    assert_eq!(
+        spec.inputs().iter().copied().collect::<BTreeSet<_>>(),
+        snapshot
+            .iter()
+            .map(|run| (run.run_seq, run.level))
+            .collect::<BTreeSet<_>>(),
+        "a compaction takes every run the group holds, which is what anchors it at the bottom"
+    );
+    assert!(
+        snapshot.len() > 1,
+        "this workload must leave a base under at least one delta run"
+    );
+}
+
+/// The step reports the same blocked outcome it reported before the compactor
+/// existed. Scheduling the job is the runner's, and lands with it.
+#[tokio::test]
+async fn a_step_that_plans_a_compaction_still_reports_the_group_blocked() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let before = current_manifest_object_id(&store, &namespace_id).await;
+
+    let report = super::super::reorganize_metadata_step(
+        &store,
+        &namespace_id,
+        &test_context(),
+        MetadataLsmPolicy {
+            max_l0_runs: NonZeroUsize::MIN,
+            max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
+            ..MetadataLsmPolicy::default()
+        },
+    )
+    .await
+    .expect("budgeted step");
+    assert!(matches!(
+        report.outcome,
+        MetadataReorganizeOutcome::BudgetExhausted { .. }
+    ));
+    assert_eq!(
+        current_manifest_object_id(&store, &namespace_id).await,
+        before,
+        "a blocked step publishes nothing"
+    );
+    assert!(
+        staged_object_keys(&store, &namespace_id).await.is_empty(),
+        "and stages nothing, because no job runs yet"
+    );
+}
+
+// -------------------------------------------------------------------------
+// The oracle
+// -------------------------------------------------------------------------
+
+/// A streaming compaction and a whole-group fold with the budgets raised are
+/// two ways of doing the same thing, so they must land in the same place: the
+/// same surviving rows in every family of the group, the same materialized
+/// namespace, and the same rows dropped.
+#[tokio::test]
+async fn a_streaming_compaction_and_a_whole_group_fold_reach_the_same_rows() {
+    let job_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(job_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    let frozen_floor_seq = read_floor_seq(&store, &namespace_id).await;
+
+    // The same durable bytes, folded the ordinary way.
+    let fold_dir = tempdir().expect("tempdir");
+    copy_store_tree(job_dir.path(), fold_dir.path());
+    let fold_store = LocalFsStore::new(fold_dir.path()).expect("store");
+    fold_group_whole(&fold_store, &namespace_id, group).await;
+    let folded = group_rows_of_current_manifest(&fold_store, &namespace_id, group).await;
+    let folded_state = current_metadata_state(&fold_store, &namespace_id).await;
+
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let snapshot = snapshot_runs_for_group(
+        load_current_manifest_tables(&store, &namespace_id)
+            .await
+            .manifest(),
+        group,
+    );
+    let outcome = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await;
+    let MetadataCompactionOutcome::Completed(result) = outcome else {
+        panic!("nothing cancelled this job");
+    };
+    assert!(
+        result.output_segments.len() > 1,
+        "the segment budget must roll several output segments, got {}",
+        result.output_segments.len()
+    );
+    assert!(
+        result.output_segments.iter().all(|descriptor| descriptor
+            .object_key
+            .starts_with(&metadata_compaction_staging_prefix(namespace_id.as_str()))),
+        "every output segment is written to the staging directory"
+    );
+    // Every reverse row the floor covers costs one point read, and no other
+    // row costs one. That is what bounds the reads a job makes.
+    let reverse_rows_at_or_below_floor = before[&ApiMetadataTableFamily::DirentryChildBinds]
+        .iter()
+        .filter(|row| {
+            matches!(row, MetadataRow::DirentryBind { bind_seq, .. } if *bind_seq <= frozen_floor_seq)
+        })
+        .count() as u64;
+    assert!(
+        reverse_rows_at_or_below_floor > 0,
+        "the seed must leave reverse rows the floor covers"
+    );
+    assert_eq!(result.unbind_probes, reverse_rows_at_or_below_floor);
+
+    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+    let compacted = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+
+    assert_eq!(
+        compacted, folded,
+        "a streaming compaction and a whole-group fold must keep the same rows"
+    );
+    assert!(
+        metadata_states_equivalent(
+            &current_metadata_state(&store, &namespace_id).await,
+            &folded_state
+        ),
+        "and must materialize the same namespace"
+    );
+    // The format gives every bind row exactly one reverse row, and manifest
+    // load rejects a run whose two counts disagree. The two families are
+    // decided in different passes here, so this is what says they stayed in
+    // lockstep.
+    assert_eq!(
+        compacted[&ApiMetadataTableFamily::DirentryBinds].len(),
+        compacted[&ApiMetadataTableFamily::DirentryChildBinds].len(),
+    );
+    assert_eq!(
+        result.rows_written,
+        compacted.values().map(Vec::len).sum::<usize>() as u64,
+        "the job's row count must be what the manifest now holds"
+    );
+    // The loader's invariants must accept the result, and the group must be
+    // left in one base run.
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let runs = snapshot_runs_for_group(tables.manifest(), group);
+    assert_eq!(runs.len(), 1, "the job must leave the group in one run");
+    assert_eq!(runs[0].level, CHECKPOINT_BASE_RUN_LEVEL);
+
+    // Teeth: the rebuilds must actually have dropped something, or the
+    // comparison above is comparing two copies of the input.
+    let rows_of = |rows: &BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>>| {
+        rows.values().map(Vec::len).sum::<usize>()
+    };
+    assert!(
+        rows_of(&compacted) < rows_of(&before),
+        "the rebuild must drop rows for this comparison to mean anything: {} before, {} after",
+        rows_of(&before),
+        rows_of(&compacted)
+    );
+    // What a rebuild may drop is bounded from both sides: it never invents a
+    // row, and it never touches one the retention floor still covers.
+    for (family, rows) in &compacted {
+        let input: BTreeSet<String> = before[family]
+            .iter()
+            .map(|row| row.row_key_for_family(*family))
+            .collect();
+        for row in rows {
+            assert!(
+                input.contains(&row.row_key_for_family(*family)),
+                "the job wrote a {family:?} row its input did not hold"
+            );
+        }
+    }
+    for (family, rows) in &before {
+        let survivors: BTreeSet<String> = compacted[family]
+            .iter()
+            .map(|row| row.row_key_for_family(*family))
+            .collect();
+        for row in rows {
+            if manifest_row_commit_seq(row) > frozen_floor_seq {
+                assert!(
+                    survivors.contains(&row.row_key_for_family(*family)),
+                    "the job dropped a {family:?} row above the retention floor"
+                );
+            }
+        }
+    }
+}
+
+/// The oracle has teeth only if the retention operators are what make the two
+/// rebuilds agree. A floor of zero is above nothing, so every rule that reads
+/// the floor keeps every row, and the job must then disagree with the fold.
+#[tokio::test]
+async fn a_compaction_that_drops_nothing_fails_the_oracle() {
+    let job_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(job_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+
+    let fold_dir = tempdir().expect("tempdir");
+    copy_store_tree(job_dir.path(), fold_dir.path());
+    let fold_store = LocalFsStore::new(fold_dir.path()).expect("store");
+    fold_group_whole(&fold_store, &namespace_id, group).await;
+    let folded = group_rows_of_current_manifest(&fold_store, &namespace_id, group).await;
+
+    let spec = compaction_spec_for_group(&store, &namespace_id, group)
+        .await
+        .with_frozen_floor_seq(ChangeSeq(0));
+    let snapshot = snapshot_runs_for_group(
+        load_current_manifest_tables(&store, &namespace_id)
+            .await
+            .manifest(),
+        group,
+    );
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job");
+    };
+    assert_eq!(result.unbind_probes, 0, "a floor of zero covers no row");
+    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+
+    let compacted = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    assert_ne!(
+        compacted, folded,
+        "with the floor rules keeping everything, the job must not reach the fold's rows"
+    );
+    assert!(
+        compacted.values().map(Vec::len).sum::<usize>()
+            > folded.values().map(Vec::len).sum::<usize>(),
+        "and must keep strictly more rows than the fold kept"
+    );
+}
+
+/// A group with no drop rule at all is a straight rewrite: revisions are
+/// durable history, so the job's output must hold every row it read.
+#[tokio::test]
+async fn a_compaction_of_the_revisions_group_rewrites_every_row_it_reads() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Revisions;
+    let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let snapshot = snapshot_runs_for_group(
+        load_current_manifest_tables(&store, &namespace_id)
+            .await
+            .manifest(),
+        group,
+    );
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job");
+    };
+    assert_eq!(
+        result.rows_read, result.rows_written,
+        "a revisions rebuild drops nothing"
+    );
+    assert_eq!(
+        result.unbind_probes, 0,
+        "the revisions group has no bind rule, so it reads no unbind"
+    );
+    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+
+    assert_eq!(
+        group_rows_of_current_manifest(&store, &namespace_id, group).await,
+        before,
+        "revision rows are durable history and are never dropped"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Restart equivalence
+// -------------------------------------------------------------------------
+
+/// Cancels the job by setting a token once the store has served a given
+/// number of reads, so a cancellation lands in the middle of a merge rather
+/// than at a boundary the test picked.
+#[derive(Debug)]
+struct CancelAfterReadsStore {
+    inner: LocalFsStore,
+    cancellation: MetadataCompactionCancellation,
+    reads_before_cancel: usize,
+    reads: AtomicUsize,
+}
+
+#[async_trait]
+impl ObjectStore for CancelAfterReadsStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        if self.reads.fetch_add(1, Ordering::SeqCst) + 1 >= self.reads_before_cancel {
+            self.cancellation.cancel();
+        }
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// A cancelled job costs its work and nothing else. The manifest never moved,
+/// so a reader answers exactly as before; the segments the attempt wrote are
+/// staged and unreferenced; and running the same spec again lands where an
+/// uninterrupted job would have landed.
+#[tokio::test]
+async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_would_have() {
+    let straight_dir = tempdir().expect("tempdir");
+    let straight_store = LocalFsStore::new(straight_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&straight_store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+
+    let interrupted_dir = tempdir().expect("tempdir");
+    copy_store_tree(straight_dir.path(), interrupted_dir.path());
+
+    // The uninterrupted run, for the comparison.
+    let spec = compaction_spec_for_group(&straight_store, &namespace_id, group).await;
+    let snapshot = snapshot_runs_for_group(
+        load_current_manifest_tables(&straight_store, &namespace_id)
+            .await
+            .manifest(),
+        group,
+    );
+    let MetadataCompactionOutcome::Completed(straight_result) = run_compaction(
+        &straight_store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job");
+    };
+    finalize_streaming_compaction(
+        &straight_store,
+        &namespace_id,
+        &spec,
+        &snapshot,
+        &straight_result,
+    )
+    .await;
+    let straight_rows = group_rows_of_current_manifest(&straight_store, &namespace_id, group).await;
+
+    let reader_answers_before = group_rows_of_current_manifest(
+        &LocalFsStore::new(interrupted_dir.path()).expect("store"),
+        &namespace_id,
+        group,
+    )
+    .await;
+    let manifest_before = current_manifest_object_id(
+        &LocalFsStore::new(interrupted_dir.path()).expect("store"),
+        &namespace_id,
+    )
+    .await;
+
+    let mut orphans = BTreeSet::new();
+    let mut cancelled_attempts = 0;
+    for reads_before_cancel in [4usize, 12, 40] {
+        let cancellation = MetadataCompactionCancellation::default();
+        let store = CancelAfterReadsStore {
+            inner: LocalFsStore::new(interrupted_dir.path()).expect("store"),
+            cancellation: cancellation.clone(),
+            reads_before_cancel,
+            reads: AtomicUsize::new(0),
+        };
+        let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+        let outcome = run_compaction(
+            &store,
+            &namespace_id,
+            &spec,
+            small_segment_policy(),
+            &cancellation,
+        )
+        .await;
+        if matches!(outcome, MetadataCompactionOutcome::Cancelled) {
+            cancelled_attempts += 1;
+        }
+        assert_eq!(
+            current_manifest_object_id(&store, &namespace_id).await,
+            manifest_before,
+            "a cancelled attempt publishes nothing"
+        );
+        assert_eq!(
+            group_rows_of_current_manifest(&store, &namespace_id, group).await,
+            reader_answers_before,
+            "and what a reader sees never moves"
+        );
+        orphans.extend(staged_object_keys(&store, &namespace_id).await);
+    }
+    assert!(
+        cancelled_attempts > 0,
+        "at least one attempt must have been cancelled mid-job"
+    );
+    assert!(
+        !orphans.is_empty(),
+        "a cancelled attempt leaves the segments it had written staged"
+    );
+
+    // The re-run from the same spec, against the same durable state.
+    let store = LocalFsStore::new(interrupted_dir.path()).expect("store");
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let snapshot = snapshot_runs_for_group(
+        load_current_manifest_tables(&store, &namespace_id)
+            .await
+            .manifest(),
+        group,
+    );
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled the re-run");
+    };
+    assert_eq!(
+        (result.rows_read, result.rows_written, result.unbind_probes),
+        (
+            straight_result.rows_read,
+            straight_result.rows_written,
+            straight_result.unbind_probes
+        ),
+        "a re-run must do the same work an uninterrupted job did"
+    );
+    let referenced: BTreeSet<String> = result
+        .output_segments
+        .iter()
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect();
+    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+
+    assert_eq!(
+        group_rows_of_current_manifest(&store, &namespace_id, group).await,
+        straight_rows,
+        "a re-run must keep the rows an uninterrupted job kept"
+    );
+    // The cancelled attempts' segments are still there and nothing names
+    // them: they are orphans for the collector, not state anything reads.
+    let staged_now = staged_object_keys(&store, &namespace_id).await;
+    for orphan in &orphans {
+        assert!(staged_now.contains(orphan));
+        assert!(
+            !referenced.contains(orphan),
+            "a cancelled attempt's segment must not be referenced by the published run"
+        );
+    }
+    let manifest_keys: BTreeSet<String> = load_current_manifest_tables(&store, &namespace_id)
+        .await
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect();
+    assert!(
+        orphans.iter().all(|orphan| !manifest_keys.contains(orphan)),
+        "no manifest names a cancelled attempt's segment"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Resource discipline
+// -------------------------------------------------------------------------
+
+/// The job's reads never overlap wider than its fetch bound, and the decoded
+/// blocks it holds never follow the size of what it is rebuilding.
+#[tokio::test]
+async fn a_compaction_keeps_its_reads_and_its_decoded_blocks_bounded() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = ConcurrencyWatchStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::metadata_table(),
+    );
+    seed_bindings_workload(store.inner(), &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let rows_in_group = group_rows_of_current_manifest(&store, &namespace_id, group)
+        .await
+        .values()
+        .map(Vec::len)
+        .sum::<usize>();
+
+    let store = ConcurrencyWatchStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::metadata_table(),
+    );
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job");
+    };
+
+    // Eight iterators refill at once at most, and each refill is one span
+    // fetch, so eight reads is the widest the job ever goes.
+    let reads = store.reads();
+    assert!(
+        reads.peak_in_flight <= 8,
+        "the job overlapped {} reads at once",
+        reads.peak_in_flight
+    );
+    assert!(reads.total > 0, "the job must have read the snapshot");
+    // Two blocks per iterator, and a bindings cluster opens one iterator per
+    // run per forward family. The bound is a property of the job, not of the
+    // group: the group here holds far more rows than the blocks ever hold.
+    let iterators = spec.inputs().len() * 2;
+    assert!(
+        result.peak_resident_blocks <= iterators * 2,
+        "the job held {} decoded blocks at once against a bound of {}",
+        result.peak_resident_blocks,
+        iterators * 2
+    );
+    assert!(
+        result.rows_read > (rows_in_group / 2) as u64,
+        "this assertion means nothing unless the job read most of the group"
+    );
+    // No locality group is a family: the rules read one name slot, and a slot
+    // holds the generations of one binding.
+    assert!(
+        result.peak_locality_rows <= 8,
+        "one locality group held {} rows",
+        result.peak_locality_rows
+    );
+}
+
+/// One directory far past the old per-step row budget streams through with
+/// the same bounded state. The case that needed a durable offset inside a
+/// partition needs nothing now: the rules read one name slot, so the peak
+/// tracks a slot's rows and not the directory's.
+#[tokio::test]
+async fn one_directory_far_past_the_row_budget_streams_a_slot_at_a_time() {
+    let job_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(job_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_one_wide_directory(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+
+    let fold_dir = tempdir().expect("tempdir");
+    copy_store_tree(job_dir.path(), fold_dir.path());
+    let fold_store = LocalFsStore::new(fold_dir.path()).expect("store");
+    fold_group_whole(&fold_store, &namespace_id, group).await;
+    let folded = group_rows_of_current_manifest(&fold_store, &namespace_id, group).await;
+    let folded_state = current_metadata_state(&fold_store, &namespace_id).await;
+
+    // How many rows the widest directory holds, which is what the peak must
+    // not follow.
+    let mut rows_per_parent = BTreeMap::<InodeId, usize>::new();
+    for family in [
+        ApiMetadataTableFamily::DirentryBinds,
+        ApiMetadataTableFamily::DirentryUnbinds,
+    ] {
+        for row in &before[&family] {
+            match row {
+                MetadataRow::DirentryBind {
+                    parent_inode_id, ..
+                }
+                | MetadataRow::DirentryUnbind {
+                    parent_inode_id, ..
+                } => *rows_per_parent.entry(*parent_inode_id).or_default() += 1,
+                _ => {}
+            }
+        }
+    }
+    let widest = rows_per_parent
+        .into_values()
+        .max()
+        .expect("the namespace holds bindings");
+    assert!(
+        widest > 32,
+        "the seed must put many rows under one parent, got {widest}"
+    );
+
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let snapshot = snapshot_runs_for_group(
+        load_current_manifest_tables(&store, &namespace_id)
+            .await
+            .manifest(),
+        group,
+    );
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job");
+    };
+    assert!(
+        result.peak_locality_rows * 4 < widest,
+        "the peak locality held {} rows against a directory of {widest}",
+        result.peak_locality_rows
+    );
+
+    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+    assert_eq!(
+        group_rows_of_current_manifest(&store, &namespace_id, group).await,
+        folded,
+        "a job that never held the directory must still reach the fold's rows"
+    );
+    assert!(
+        metadata_states_equivalent(
+            &current_metadata_state(&store, &namespace_id).await,
+            &folded_state
+        ),
+        "and must answer reads the way a whole-group fold answers them"
+    );
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    assert_eq!(
+        snapshot_runs_for_group(tables.manifest(), group).len(),
+        1,
+        "the job must leave the group in one run"
+    );
+}

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -81,6 +81,21 @@ pub fn metadata_table(namespace: &str, table_id: &str) -> String {
     ObjectLayout::new().metadata_table(namespace, table_id)
 }
 
+/// Builds the immutable staging key a streaming compaction writes one
+/// metadata segment to before any manifest references it.
+///
+/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+pub fn metadata_compaction_staging_table(namespace: &str, table_id: &str) -> String {
+    ObjectLayout::new().metadata_compaction_staging_table(namespace, table_id)
+}
+
+/// Builds the listing prefix containing staged compaction segments for one namespace.
+///
+/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+pub fn metadata_compaction_staging_prefix(namespace: &str) -> String {
+    ObjectLayout::new().metadata_compaction_staging_prefix(namespace)
+}
+
 /// Builds the mutable lifecycle key for one checkpoint record.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
@@ -119,7 +134,8 @@ pub fn content_blob(content_store: &str, content_id: &ContentId) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        checkpoint_record, content_blob, metadata_manifest_object, metadata_root, metadata_table,
+        checkpoint_record, content_blob, metadata_compaction_staging_prefix,
+        metadata_compaction_staging_table, metadata_manifest_object, metadata_root, metadata_table,
         namespace_prefix, upload_session, wal_floor, wal_head, wal_segment,
         wal_segment_id_from_key, wal_segment_prefix,
     };
@@ -217,6 +233,10 @@ mod tests {
             ),
             ("Checkpoint records", checkpoint_record("ns-1", "chk-1")),
             ("Metadata tables", metadata_table("ns-1", "tbl-1")),
+            (
+                "Compaction staging",
+                metadata_compaction_staging_table("ns-1", "tbl-1"),
+            ),
             ("Upload sessions", upload_session("ns-1", "up-1")),
             ("Metadata root", metadata_root("ns-1")),
             ("WAL floor", wal_floor("ns-1")),
@@ -272,6 +292,14 @@ mod tests {
         assert_eq!(
             metadata_table("ns-1", "tbl_00000000000000000000000000000001"),
             "namespaces/ns-1/metadata/tables/tbl_00000000000000000000000000000001.sst.zst"
+        );
+        assert_eq!(
+            metadata_compaction_staging_prefix("ns-1"),
+            "namespaces/ns-1/metadata/compaction-staging/"
+        );
+        assert_eq!(
+            metadata_compaction_staging_table("ns-1", "tbl_00000000000000000000000000000001"),
+            "namespaces/ns-1/metadata/compaction-staging/tbl_00000000000000000000000000000001.sst.zst"
         );
         assert_eq!(
             checkpoint_record("ns-1", "chk_00000000000000000000000000000001"),

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -35,6 +35,11 @@ pub enum DurableObjectFamily {
     ///
     /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     MetadataTable,
+    /// Classifies an immutable metadata SST segment a streaming compaction
+    /// wrote before any manifest referenced it.
+    ///
+    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+    MetadataCompactionStaging,
     /// Classifies a mutable checkpoint lifecycle record.
     ///
     /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
@@ -141,6 +146,22 @@ impl ObjectLayout {
         format!("namespaces/{namespace}/metadata/tables/")
     }
 
+    /// A metadata segment a streaming compaction has written but no manifest
+    /// references yet. The object is an ordinary metadata segment; only the
+    /// directory differs, which is what keeps a running job's output out of
+    /// the sweep that reaps unreferenced table keys.
+    pub(crate) fn metadata_compaction_staging_table(
+        &self,
+        namespace: &str,
+        table_id: &str,
+    ) -> String {
+        format!("namespaces/{namespace}/metadata/compaction-staging/{table_id}.sst.zst")
+    }
+
+    pub(crate) fn metadata_compaction_staging_prefix(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/metadata/compaction-staging/")
+    }
+
     /// Durable stable-view pin to a metadata manifest.
     pub(crate) fn checkpoint_record(&self, namespace: &str, checkpoint_id: &str) -> String {
         format!("namespaces/{namespace}/checkpoints/{checkpoint_id}.json")
@@ -198,6 +219,14 @@ pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
         }
         ["namespaces", namespace, "metadata", "tables", table] if table.ends_with(".sst.zst") => {
             parsed(DurableObjectFamily::MetadataTable, Some(namespace))
+        }
+        ["namespaces", namespace, "metadata", "compaction-staging", table]
+            if table.ends_with(".sst.zst") =>
+        {
+            parsed(
+                DurableObjectFamily::MetadataCompactionStaging,
+                Some(namespace),
+            )
         }
         ["namespaces", namespace, "checkpoints", checkpoint] if checkpoint.ends_with(".json") => {
             parsed(DurableObjectFamily::CheckpointRecord, Some(namespace))
@@ -267,6 +296,12 @@ mod tests {
         );
         assert_eq!(
             layout
+                .metadata_compaction_staging_table("ns-1", "tbl_00000000000000000000000000000001")
+                .as_str(),
+            "namespaces/ns-1/metadata/compaction-staging/tbl_00000000000000000000000000000001.sst.zst"
+        );
+        assert_eq!(
+            layout
                 .checkpoint_record("ns-1", "chk_00000000000000000000000000000001")
                 .as_str(),
             "namespaces/ns-1/checkpoints/chk_00000000000000000000000000000001.json"
@@ -298,6 +333,28 @@ mod tests {
             .starts_with(&prefix));
     }
 
+    /// A streaming compaction's staged segments must not appear in the
+    /// listing that enumerates referenced metadata tables. That listing is
+    /// what a collector sweeps, and a running job's output is unreferenced
+    /// for as long as the job runs.
+    #[test]
+    fn staged_compaction_segments_live_outside_the_table_listing_prefix() {
+        let layout = ObjectLayout::new();
+        let tables = layout.metadata_table_prefix("ns-1");
+        let staging = layout.metadata_compaction_staging_prefix("ns-1");
+
+        assert!(!staging.starts_with(&tables));
+        assert!(!layout
+            .metadata_compaction_staging_table("ns-1", "tbl_abc")
+            .starts_with(&tables));
+        assert!(layout
+            .metadata_compaction_staging_table("ns-1", "tbl_abc")
+            .starts_with(&staging));
+        assert!(!layout
+            .metadata_table("ns-1", "tbl_abc")
+            .starts_with(&staging));
+    }
+
     #[test]
     fn parse_build_round_trips_for_namespace_key_families() {
         let layout = ObjectLayout::new();
@@ -323,6 +380,10 @@ mod tests {
             (
                 layout.metadata_table("ns-1", "tbl_abc"),
                 DurableObjectFamily::MetadataTable,
+            ),
+            (
+                layout.metadata_compaction_staging_table("ns-1", "tbl_abc"),
+                DurableObjectFamily::MetadataCompactionStaging,
             ),
             (
                 layout.checkpoint_record("ns-1", "chk_00000000000000000000000000000001"),

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -722,7 +722,9 @@ fn classify_key(key: &str) -> KeyClass {
         DurableObjectFamily::WalHead => KeyClass::NamespaceHead,
         DurableObjectFamily::WalSegment => KeyClass::WalSegment,
         DurableObjectFamily::MetadataManifest => KeyClass::NamespaceManifest,
-        DurableObjectFamily::MetadataTable => KeyClass::MetadataSst,
+        DurableObjectFamily::MetadataTable | DurableObjectFamily::MetadataCompactionStaging => {
+            KeyClass::MetadataSst
+        }
         DurableObjectFamily::CheckpointRecord | DurableObjectFamily::WalFloor => {
             KeyClass::GcControl
         }

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -54,7 +54,8 @@ pub async fn summarize_namespace_objects<S: ObjectStore + ?Sized>(
                 DurableObjectFamily::MetadataManifest => {
                     summary.manifest_objects += 1;
                 }
-                DurableObjectFamily::MetadataTable => {
+                DurableObjectFamily::MetadataTable
+                | DurableObjectFamily::MetadataCompactionStaging => {
                     summary.compacted_metadata_objects += 1;
                 }
                 DurableObjectFamily::WalFloor

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -79,6 +79,7 @@ The required durable object families and standard key patterns are:
 | **Namespace manifests** | Immutable | Record one namespace file-set version: its metadata table references and a head summary. Table references carry their own owner, so a fork target's manifest names source-owned tables without recording anything about the fork. | `namespaces/{namespace_id}/metadata/manifests/{manifest_object_id}.manifest.json` |
 | **Checkpoint records** | Mutable lifecycle | Durable stable-view pins to a metadata manifest, each carrying a required owner (user or fork target). The lifecycle is monotonic: a record is created active under a generated id, released once by compare-and-swap, and deleted a grace window after that release. | `namespaces/{namespace_id}/checkpoints/{checkpoint_id}.json` |
 | **Metadata tables** | Immutable | Store metadata rows referenced by manifests. Files may be owned by the namespace itself or by a fork source namespace. | `namespaces/{owner_namespace_id}/metadata/tables/{table_id}.sst.zst` |
+| **Compaction staging** | Immutable | Hold metadata segments a streaming compaction has written before any manifest references them ("Compaction"). The object is an ordinary metadata segment; only the directory differs. | `namespaces/{owner_namespace_id}/metadata/compaction-staging/{table_id}.sst.zst` |
 | **Upload sessions** | Mutable lifecycle | Track one staged-content upload. The lifecycle is monotonic: a session is created `open` under a lease, and moves once to `completed` or `aborted`, both terminal. | `namespaces/{namespace_id}/uploads/{upload_id}.json` |
 | **Metadata root** | Mutable | Cold pointer to the best known materialized metadata root; monotonic CAS. | `namespaces/{namespace_id}/metadata/root.json` |
 | **WAL floor** | Mutable | Cold lower bound of retained WAL/change history; monotonic CAS. | `namespaces/{namespace_id}/wal/floor.json` |
@@ -2127,6 +2128,21 @@ rows, the same posture inode and tombstone rows take, and that is what makes
 an undelete give back the map the inode had. A rewrite refuses to compact
 when two rows for one inode share a revision number at or below the floor,
 because that makes "the newest at the floor" arbitrary and the drop unsafe.
+
+A rebuild whose bottom-anchored window cannot fit one step's budget is run as
+a streaming compaction instead: it merges every run of the group in one job
+and writes each finished output segment as it fills, so nothing about the job
+follows the size of the group. Those segments are written under
+`namespaces/{owner_namespace_id}/metadata/compaction-staging/{table_id}.sst.zst`
+rather than under `metadata/tables/`. The object is an ordinary metadata
+segment — same encoding, same descriptor, same reads — and only its directory
+differs. The directory is what keeps a running job's output out of the
+listing that enumerates metadata tables: a job outlives the collector's grace
+window, so its segments would otherwise read as unreferenced objects aged
+past grace, which is the class the collector reaps. Nothing loads or
+validates the staging directory, and a manifest may reference a staged key
+directly: a completed publication moves no bytes, because a referenced object
+is live wherever it sits.
 
 Invariants:
 


### PR DESCRIPTION
This change adds the streaming compaction executor for a metadata family group that cannot make progress through the bounded merge path. It does not schedule the executor yet, so production maintenance behavior is unchanged.

The reorganization planner can now return either a normal bounded merge or an immutable compaction specification. The specification records the family group, every input run, the output identity, and the retention floor. The executor reads only that fixed snapshot and uses the same floor for the complete job.

Each family is read through sorted iterators over its input runs. Iterator refills hold at most two decoded blocks each and fetch at most eight iterators concurrently. Output is written as segments fill, and reverse-index point reads share a 16 MiB decoded-block cache. Retention temporarily holds the rows required for one key-locality decision, such as one binding slot or one inode, before writing the surviving rows.

The existing retention rules are reused. Bindings and unbindings are evaluated together by parent and name, active-deletion rows are evaluated by deletion identity, attributes are evaluated by inode, and row-local families pass through the same frozen-floor function. Reverse binding-index rows use bloom-filtered point reads against the snapshot’s unbind rows because their key order differs from the forward binding table.

For bindings and revisions, the executor computes order-independent digests of the canonical rows and index rows it writes. A mismatch fails the job before publication. Output segments are written under the metadata compaction staging prefix and remain invisible until a caller publishes them.

Tests compare streaming output with an equivalent whole-group fold, cover cancellation at several points, verify that interrupted output remains unreferenced, exercise reverse-index retention, and measure iterator, fetch-concurrency, cache, and locality behavior. The workspace test suite, Clippy, formatting, and OpenAPI checks pass, and no golden files changed.
