### PR TITLE
feat(maintenance): over-budget groups compact through a background streaming job

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -962,9 +962,15 @@ pub enum ReorganizeStepOutcome {
     NotNeeded,
     /// One family group was merged and a manifest published.
     UnitPublished,
-    /// A group needs merging but no progress-making subset fits the
-    /// per-step budget.
-    BudgetExhausted,
+    /// A group has outgrown one step, and this step started the background
+    /// streaming compaction that rebuilds it. The step published nothing;
+    /// the job publishes once, when it finishes.
+    CompactionStarted,
+    /// A group needs a streaming compaction and this step did not start one,
+    /// because one is already running for this namespace or because the
+    /// handle this step ran through schedules no background work. The server
+    /// log says which.
+    CompactionPending,
     /// Another publisher advanced the root first; a later step retries.
     Superseded,
 }

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -467,8 +467,11 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                     match metadata.reorganize {
                         ReorganizeStepOutcome::NotNeeded => "reorganize not needed",
                         ReorganizeStepOutcome::UnitPublished => "reorganized one family group",
-                        ReorganizeStepOutcome::BudgetExhausted => {
-                            "reorganize over the per-step budget"
+                        ReorganizeStepOutcome::CompactionStarted => {
+                            "started a background compaction of one family group"
+                        }
+                        ReorganizeStepOutcome::CompactionPending => {
+                            "one family group is waiting on a background compaction"
                         }
                         ReorganizeStepOutcome::Superseded => "reorganize superseded",
                     }

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -68,6 +68,9 @@ pub use self::stored_block_cache::{
     StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
     StoredMetadataBlockKind,
 };
+pub use self::streaming_compaction::{
+    MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,
+};
 
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::files::list_checkpoint_files_page;
@@ -82,3 +85,4 @@ pub(crate) use self::release::release_checkpoint;
 pub(crate) use self::reorganize::reorganize_metadata_step;
 pub(crate) use self::retention::advance_retention_floor;
 pub(crate) use self::scan::{Readahead, VerifiedMetadataTables};
+pub(crate) use self::streaming_compaction::run_metadata_compaction_job;

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -34,7 +34,10 @@
 //! group with a window that fits the budgets and makes progress gets that
 //! window. A group with no such window gets a streaming compaction over
 //! every run it holds ([`super::streaming_compaction`]), which is what takes
-//! a frozen base off the step budgets entirely.
+//! a frozen base off the step budgets entirely. The step does not run that
+//! job: it reports the plan, and the runtime starts the job in the
+//! background and hands its spec back to every step that follows, which is
+//! how a step knows to leave that group alone while it runs.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::build::{
@@ -91,11 +94,13 @@ pub enum MetadataReorganizeOutcome {
         decoded_input_bytes: u64,
         manifest_id: ManifestId,
     },
-    /// The trigger fired, but no oldest-first subset that would make
-    /// progress fit the hard per-step input budgets.
-    BudgetExhausted {
+    /// No oldest-first subset that would make progress fits the hard
+    /// per-step input budgets, so the group is rebuilt by a streaming
+    /// compaction over every run it holds. The step publishes nothing and
+    /// hands the plan back; starting the job is the runtime's.
+    CompactionPlanned {
         families: Vec<MetadataTableFamily>,
-        l0_runs: usize,
+        spec: MetadataCompactionSpec,
     },
     /// A concurrent publication moved the root while this unit ran; its
     /// output is unreferenced (garbage collection reclaims it) and the next
@@ -113,6 +118,11 @@ pub struct MetadataReorganizeReport {
 /// manifest. Callers (the maintenance step) invoke this repeatedly; each
 /// call re-reads durable state, so any two calls compose — including across
 /// process restarts.
+///
+/// `active_compaction` is the plan of the streaming compaction this process
+/// is running for the namespace, or `None` when it is running none. The step
+/// leaves that job's group alone and works on another; see
+/// [`select_family_group`].
 #[tracing::instrument(
     level = "info",
     name = "loonfs.phase",
@@ -125,9 +135,18 @@ pub(crate) async fn reorganize_metadata_step<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
     policy: MetadataLsmPolicy,
+    active_compaction: Option<&MetadataCompactionSpec>,
 ) -> Result<MetadataReorganizeReport> {
     let timer = StdMonotonicTimer::default();
-    reorganize_metadata_step_with_timer(store, namespace_id, context, policy, &timer).await
+    reorganize_metadata_step_with_timer(
+        store,
+        namespace_id,
+        context,
+        policy,
+        active_compaction,
+        &timer,
+    )
+    .await
 }
 
 pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>(
@@ -135,6 +154,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     namespace_id: &NamespaceId,
     context: &MutationContext,
     policy: MetadataLsmPolicy,
+    active_compaction: Option<&MetadataCompactionSpec>,
     timer: &dyn MonotonicTimer,
 ) -> Result<MetadataReorganizeReport> {
     // The publication budget covers the whole unit: measurement starts
@@ -169,8 +189,12 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
         });
     }
-    let Some(group) = select_family_group(&previous.payload) else {
-        // L0 runs exist but hold no rows (empty families); nothing to fold.
+    let Some(group) = select_family_group(
+        &previous.payload,
+        active_compaction.map(MetadataCompactionSpec::group),
+    ) else {
+        // L0 runs exist but hold no rows (empty families), or the only group
+        // with rows is the one a job is rebuilding; nothing to fold here.
         return Ok(MetadataReorganizeReport {
             namespace_id: namespace_id.clone(),
             outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
@@ -196,17 +220,25 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     if let Some(bottom) = selection.group_bottom_over_budget {
         report_group_bottom_over_budget(namespace_id, group, &bottom, policy);
     }
-    // A group that needs a streaming compaction reports the same blocked
-    // outcome it reported before the compactor existed. Scheduling the job is
-    // the runner's, and lands with it.
-    let Some(ReorganizationPlan::BoundedMerge(input)) = selection.plan else {
-        return Ok(MetadataReorganizeReport {
-            namespace_id: namespace_id.clone(),
-            outcome: MetadataReorganizeOutcome::BudgetExhausted {
-                families: group.families().to_vec(),
-                l0_runs,
-            },
-        });
+    let input = match selection.plan {
+        Some(ReorganizationPlan::BoundedMerge(input)) => input,
+        Some(ReorganizationPlan::FullCompaction(spec)) => {
+            return Ok(MetadataReorganizeReport {
+                namespace_id: namespace_id.clone(),
+                outcome: MetadataReorganizeOutcome::CompactionPlanned {
+                    families: group.families().to_vec(),
+                    spec,
+                },
+            })
+        }
+        // A selected group holds L0 rows, so it holds runs, so the planner
+        // always answers with one of the two plans above.
+        None => {
+            return Ok(MetadataReorganizeReport {
+                namespace_id: namespace_id.clone(),
+                outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
+            })
+        }
     };
 
     // Merge only the selected complete runs. The scan reads exactly the
@@ -347,9 +379,8 @@ pub(super) enum ReorganizationPlan {
     BoundedMerge(ReorganizationInput),
     /// No window that makes progress fits the budgets, so the group is
     /// rebuilt by a streaming compaction over every run it holds. The step
-    /// reports the group blocked and reads no further; the runner that starts
-    /// the job from this spec lands next.
-    FullCompaction(#[allow(dead_code)] MetadataCompactionSpec),
+    /// reports the plan and reads no further; the runtime starts the job.
+    FullCompaction(MetadataCompactionSpec),
 }
 
 pub(super) struct ReorganizationInput {
@@ -667,6 +698,11 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 .iter()
                 .map(|run| (run.run_seq, run.level))
                 .collect(),
+            candidates
+                .iter()
+                .flat_map(|run| group_run_descriptors(run, group))
+                .map(|descriptor| descriptor.row_count)
+                .sum(),
             MergePlacement::Base {
                 output_seq: head_seq,
             },
@@ -682,20 +718,18 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
 /// Says out loud that a family group's oldest run no longer fits one
 /// reorganization step.
 ///
-/// Nothing is corrupt when this fires, but work does stop. Folds keep
-/// merging the newer runs above the run named here, into one bigger delta run
-/// each time, until only one delta run is left; from then on the group has no
-/// window that makes progress and every step reports it blocked. Reclamation
-/// of the named run's rows stops first, because no step can rewrite a run it
-/// cannot read whole. Group selection then keeps choosing this group — it
-/// still holds the most L0 rows, and a merge that cannot drop rows never
-/// reduces them — so the other groups stop folding too. Raising
-/// `max_decoded_input_rows_per_step` and `max_decoded_input_bytes_per_step`
-/// past the numbers in this line is the operator's lever until the streaming
-/// compactor takes this case off the step.
+/// Nothing is corrupt when this fires and no work stops. Steps keep merging
+/// the newer runs above the run named here, into one bigger delta run each
+/// time. Once that merge has nothing left to take, the group has no window
+/// that makes progress, and the step hands the whole group to a background
+/// streaming compaction that rebuilds it in one pass under no budget at all.
+/// The group's rows are reclaimed when that job publishes. So this line says
+/// what a namespace has grown into, and that the rebuild of the group has
+/// moved off the step; there is nothing for an operator to do about it.
 ///
-/// One line per step: a step is already the unit maintenance schedules, so
-/// the cadence of the warning is the cadence of maintenance.
+/// One line per step until the job starts: a step is already the unit
+/// maintenance schedules, so the cadence of the warning is the cadence of
+/// maintenance.
 fn report_group_bottom_over_budget(
     namespace_id: &NamespaceId,
     group: MetadataFamilyGroup,
@@ -712,9 +746,9 @@ fn report_group_bottom_over_budget(
         max_decoded_input_rows_per_step = policy.max_decoded_input_rows_per_step.get(),
         max_decoded_input_bytes_per_step = policy.max_decoded_input_bytes_per_step.get(),
         "the oldest metadata run in this family group no longer fits one reorganization step; \
-         folds skip it and merge the newer runs into one delta run, so its rows are never \
-         reclaimed, and once that merge has nothing left to take this group blocks every step \
-         and the other groups stop folding behind it",
+         steps merge the newer runs above it into one delta run, and once that merge has \
+         nothing left to take, a background streaming compaction rebuilds the whole group and \
+         reclaims its rows",
     );
 }
 
@@ -781,11 +815,26 @@ async fn decoded_group_run_bytes<S: ObjectStore + ?Sized>(
 
 /// The family group with the most L0 rows to fold; ties resolve in group
 /// order. `None` when no group has L0 rows.
+///
+/// `rebuilding` is the group a streaming compaction is rebuilding right now,
+/// and it is skipped. That one exclusion is the whole of the input-exclusion
+/// rule the design asks for, and it holds for two reasons. The job's snapshot
+/// is every run the group held, so any window over that group would touch it.
+/// And a run is a set of families: a merge of another group rewrites only its
+/// own families' descriptors, so the segments the job is reading stay
+/// referenced and unchanged whatever else folds meanwhile.
+///
+/// Without it the excluded group would win every step for as long as the job
+/// ran — its L0 rows are frozen in the job's snapshot, so its count never
+/// falls, while every other group's falls the moment it folds — and the step
+/// would spend itself re-planning a job that is already running.
 pub(super) fn select_family_group(
     payload: &NamespaceManifestPayload,
+    rebuilding: Option<MetadataFamilyGroup>,
 ) -> Option<MetadataFamilyGroup> {
     REORGANIZE_FAMILY_GROUPS
         .into_iter()
+        .filter(|group| Some(*group) != rebuilding)
         .map(|group| (group_l0_rows(payload, group), group))
         .filter(|(rows, _)| *rows > 0)
         .max_by(|(left_rows, left), (right_rows, right)| {

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -18,18 +18,15 @@
 //! Output segments go to the staging directory rather than to
 //! `metadata/tables/` (format spec, "Compaction"): a job outlives the
 //! collector's grace window, so its output would otherwise look exactly like
-//! the unreferenced aged objects the collector reaps. The job publishes
-//! nothing. It returns the descriptors it wrote, and the caller swaps them in
-//! with one manifest publication; a cancelled or crashed job leaves staged
-//! objects nothing references and the old manifest still valid.
+//! the unreferenced aged objects the collector reaps. The executor publishes
+//! nothing itself. It returns the descriptors it wrote, and
+//! [`run_metadata_compaction_job`] swaps them in with one manifest
+//! publication; a cancelled or crashed job leaves staged objects nothing
+//! references and the old manifest still valid.
 //!
-//! Nothing here is reachable from the maintenance step yet. The runner that
-//! schedules the job, excludes its snapshot runs from ordinary merges,
-//! cancels it on shutdown, and finalizes it lands next. Until it does, the
-//! only caller outside tests is the planner that builds the spec, which is
-//! why this module allows dead code: every item below has a caller in the
-//! change that schedules it, and the allow goes away with that change.
-#![allow(dead_code)]
+//! The job runs as a background task the maintenance runner owns. The step
+//! that plans it starts it and returns; the runner cancels it on shutdown and
+//! joins it with the rest of its background work.
 
 use super::block_fetch::{load_segment_filter, load_segment_index_for_reorganization};
 use super::block_load::SessionBlockMemo;
@@ -37,24 +34,31 @@ use super::build::{write_manifest_segment, MetadataSstWriteRequest};
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
 use super::data_block_load::load_segment_data_block_span;
 use super::error::ManifestLoadError;
-use super::load::load_manifest_segment_rows_in_key_range_with_cache;
+use super::flush::ensure_metadata_publication_budget;
+use super::load::{
+    load_manifest_segment_rows_in_key_range_with_cache, load_verified_manifest_tables,
+};
+use super::publish::{publish_metadata_root, ManifestPublicationOutcome};
 use super::reorganize::{
     bind_survives_frozen_floor, drop_rows_below_frozen_floor, group_run_descriptors,
-    unbindings_at_or_below_floor, MergePlacement,
+    unbindings_at_or_below_floor, write_reorganized_manifest, MergePlacement,
 };
 use super::runs::{MetadataFamilyGroup, MetadataLsmPolicy, MetadataRunManifest};
 use super::scan::{descriptor_may_intersect_range, Readahead, VerifiedMetadataTables};
 use super::validate::validate_manifest_row_seq_range;
+use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
+use crate::namespace::control::read_metadata_root_object_if_present;
+use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::manifest::{lookup_keys, MetadataFileRef, MetadataRow, MetadataTableFamily};
 use loonfs_api::wire::sst_blocks::{
     string_prefix_upper_bound, DecodedDataBlock, SegmentIndexEntry,
 };
-use loonfs_api::{ChangeSeq, MetadataTableId, NamespaceId};
+use loonfs_api::{ChangeSeq, ManifestId, MetadataTableId, NamespaceId};
 use loonfs_objectstore::keys::metadata_compaction_staging_table;
 use loonfs_objectstore::ObjectStore;
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -76,6 +80,20 @@ const ITERATOR_FETCH_CONCURRENCY: usize = 8;
 /// of how many reads the job makes.
 const PROBE_CACHE_DECODED_BYTES: usize = 16 * 1024 * 1024;
 
+/// Rows between two progress lines. A job that needs one at all is bigger
+/// than a step's whole row budget, so this is coarse on purpose: a handful of
+/// lines over a long job rather than one per segment.
+const PROGRESS_ROW_INTERVAL: u64 = 1_000_000;
+
+/// Publication attempts one finalization makes before giving up.
+///
+/// Only an unrelated publication landing between the reload and the root
+/// compare-and-swap costs an attempt, and the reload is what the next attempt
+/// takes the race against. A namespace publishing fast enough to win four in
+/// a row is one where re-running the job later is the better answer than
+/// spinning here, and re-running is always safe.
+const MAX_FINALIZATION_ATTEMPTS: usize = 4;
+
 /// The immutable plan of one streaming compaction.
 ///
 /// Everything the job decides is fixed here before it starts: which group it
@@ -83,14 +101,22 @@ const PROBE_CACHE_DECODED_BYTES: usize = 16 * 1024 * 1024;
 /// floor every row is judged against. A job re-run from the same spec against
 /// the same durable state produces the same rows, which is what makes a
 /// cancelled attempt free to throw away.
+///
+/// The runtime holds one of these per running job and hands it back to
+/// [`super::reorganize_metadata_step`], which is how a step knows not to
+/// merge the group a job is rebuilding.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct MetadataCompactionSpec {
+pub struct MetadataCompactionSpec {
     group: MetadataFamilyGroup,
     /// Every run the group held when the plan was made, by sequence and
     /// level. That is bottom-anchored by construction — a run the group holds
     /// cannot sort below the whole of itself — which is what makes the job's
     /// drops visibility-preserving.
     inputs: Vec<(ChangeSeq, u32)>,
+    /// Rows those runs hold for the group, from their descriptors. What the
+    /// job reports it is about to read; the rows it writes are fewer by
+    /// whatever the floor lets go.
+    input_rows: u64,
     placement: MergePlacement,
     frozen_floor_seq: ChangeSeq,
 }
@@ -99,12 +125,14 @@ impl MetadataCompactionSpec {
     pub(super) fn new(
         group: MetadataFamilyGroup,
         inputs: Vec<(ChangeSeq, u32)>,
+        input_rows: u64,
         placement: MergePlacement,
         frozen_floor_seq: ChangeSeq,
     ) -> Self {
         Self {
             group,
             inputs,
+            input_rows,
             placement,
             frozen_floor_seq,
         }
@@ -112,6 +140,21 @@ impl MetadataCompactionSpec {
 
     pub(super) fn group(&self) -> MetadataFamilyGroup {
         self.group
+    }
+
+    /// The families this job rebuilds, for a caller reporting what it started.
+    pub fn families(&self) -> &'static [MetadataTableFamily] {
+        self.group.families()
+    }
+
+    /// How many runs the job reads.
+    pub fn input_runs(&self) -> usize {
+        self.inputs.len()
+    }
+
+    /// How many rows those runs hold.
+    pub fn input_rows(&self) -> u64 {
+        self.input_rows
     }
 
     pub(super) fn inputs(&self) -> &[(ChangeSeq, u32)] {
@@ -137,10 +180,10 @@ impl MetadataCompactionSpec {
 /// segments are unreferenced, the manifest never moved, and a later job runs
 /// the same spec again.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct MetadataCompactionCancellation(Arc<AtomicBool>);
+pub struct MetadataCompactionCancellation(Arc<AtomicBool>);
 
 impl MetadataCompactionCancellation {
-    pub(crate) fn cancel(&self) {
+    pub fn cancel(&self) {
         self.0.store(true, Ordering::SeqCst);
     }
 
@@ -210,6 +253,7 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
         },
         canonical_digest: RowDigest::default(),
         index_digest: RowDigest::default(),
+        next_progress_rows: PROGRESS_ROW_INTERVAL,
     };
 
     for cluster in retention_clusters(spec.group) {
@@ -219,6 +263,278 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
     }
     job.refuse_a_run_whose_index_disagrees()?;
     Ok(MetadataCompactionOutcome::Completed(job.result))
+}
+
+/// How one background compaction job ended.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetadataCompactionJobOutcome {
+    /// The rebuilt group replaced its snapshot in a published manifest.
+    Published {
+        manifest_id: ManifestId,
+        rows_read: u64,
+        rows_written: u64,
+        output_segments: usize,
+    },
+    /// The cancellation token was set. The manifest never moved and the
+    /// segments the job had written stay staged and unreferenced.
+    Cancelled,
+    /// A run the job read is no longer in the manifest, or no longer holds
+    /// what it held, so this output cannot stand in for it. Nothing is
+    /// published and the staged segments are orphans; a later step plans the
+    /// group again from what the manifest now holds.
+    Abandoned,
+    /// Every publication attempt lost the root race. The job is thrown away
+    /// and a later step plans it again.
+    Superseded,
+}
+
+/// What one finalization attempt sequence decided.
+#[derive(Debug)]
+pub(super) enum Finalization {
+    Published(ManifestId),
+    Abandoned,
+    Superseded,
+}
+
+/// Runs one streaming compaction end to end: rebuild the group, then swap the
+/// rebuilt run in with one manifest publication.
+///
+/// This is what the maintenance runner spawns from the spec a step planned.
+/// Nothing durable records that the job is running, so every way it can end
+/// short of publishing — cancellation, a snapshot that moved, a lost race, an
+/// error — costs the work it did and nothing else: the old manifest stays
+/// valid, the staged segments stay invisible, and a later step plans the group
+/// again.
+pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+    spec: &MetadataCompactionSpec,
+    cancellation: &MetadataCompactionCancellation,
+) -> Result<MetadataCompactionJobOutcome> {
+    let timer = StdMonotonicTimer::default();
+    let Some(tables) = load_current_manifest_tables(store, namespace_id).await? else {
+        return Ok(MetadataCompactionJobOutcome::Abandoned);
+    };
+    // What the job is about to read, recorded before it reads anything.
+    // Finalization compares the manifest against this, so the run it publishes
+    // stands in for exactly the segments it merged.
+    let Some(snapshot_keys) = snapshot_segment_keys(&tables, spec) else {
+        return Ok(MetadataCompactionJobOutcome::Abandoned);
+    };
+    tracing::info!(
+        namespace_id = namespace_id.as_str(),
+        families = ?spec.families(),
+        input_runs = spec.input_runs(),
+        input_rows = spec.input_rows(),
+        frozen_floor_seq = spec.frozen_floor_seq().0,
+        "streaming metadata compaction started"
+    );
+
+    let result =
+        match run_metadata_compaction(&tables, namespace_id, spec, policy, cancellation).await? {
+            MetadataCompactionOutcome::Completed(result) => result,
+            MetadataCompactionOutcome::Cancelled => {
+                // The executor stops between block fetches, so what it wrote is
+                // whatever segments had already filled. They are staged and named
+                // by nothing.
+                tracing::info!(
+                    namespace_id = namespace_id.as_str(),
+                    families = ?spec.families(),
+                    "streaming metadata compaction cancelled"
+                );
+                return Ok(MetadataCompactionJobOutcome::Cancelled);
+            }
+        };
+    drop(tables);
+
+    let rows_read = result.rows_read;
+    let rows_written = result.rows_written;
+    let output_segments = result.output_segments.len();
+    match finalize_metadata_compaction(
+        store,
+        namespace_id,
+        context,
+        spec,
+        &snapshot_keys,
+        result,
+        &timer,
+    )
+    .await?
+    {
+        Finalization::Published(manifest_id) => {
+            tracing::info!(
+                namespace_id = namespace_id.as_str(),
+                families = ?spec.families(),
+                rows_read,
+                rows_written,
+                output_segments,
+                manifest_id = manifest_id.0,
+                "streaming metadata compaction published"
+            );
+            Ok(MetadataCompactionJobOutcome::Published {
+                manifest_id,
+                rows_read,
+                rows_written,
+                output_segments,
+            })
+        }
+        Finalization::Abandoned => Ok(MetadataCompactionJobOutcome::Abandoned),
+        Finalization::Superseded => Ok(MetadataCompactionJobOutcome::Superseded),
+    }
+}
+
+/// Swaps the rebuilt run in for the snapshot it replaces.
+///
+/// Reload the root and manifest, check that every segment the job read is
+/// still exactly what the manifest holds for the group in those runs, replace
+/// those descriptors with the output run's, keep everything else — including
+/// the runs that arrived while the job ran — and publish through the ordinary
+/// compare-and-swap. An unrelated publication winning that race is a reload
+/// and another attempt; a snapshot that moved is an abandon, because this
+/// output no longer stands in for what the manifest holds.
+///
+/// The publication budget covers this publication and not the job: what it
+/// protects against is a root compare-and-swap landing after the objects it
+/// names could have aged into the collector's window, which is a property of
+/// the last few seconds and not of however long the rebuild took.
+pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    spec: &MetadataCompactionSpec,
+    snapshot_keys: &BTreeSet<String>,
+    result: MetadataCompactionResult,
+    timer: &dyn MonotonicTimer,
+) -> Result<Finalization> {
+    for attempt in 1..=MAX_FINALIZATION_ATTEMPTS {
+        let publication_started_ms = timer.monotonic_now_ms();
+        let Some(root) = read_metadata_root_object_if_present(store, namespace_id)
+            .await
+            .map_err(CoreError::load_head)?
+            .map(|loaded| loaded.envelope.state)
+        else {
+            return Ok(Finalization::Abandoned);
+        };
+        let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+            .await
+            .map_err(manifest_load_failure)?;
+        if snapshot_segment_keys(&tables, spec).as_ref() != Some(snapshot_keys) {
+            tracing::info!(
+                namespace_id = namespace_id.as_str(),
+                families = ?spec.families(),
+                "streaming metadata compaction abandoned: its input runs moved while it ran"
+            );
+            return Ok(Finalization::Abandoned);
+        }
+
+        let previous = tables.manifest();
+        let mut metadata_files: Vec<MetadataFileRef> = previous
+            .payload
+            .metadata_files
+            .iter()
+            .filter(|descriptor| !snapshot_keys.contains(&descriptor.object_key))
+            .cloned()
+            .collect();
+        metadata_files.extend(result.output_segments.iter().cloned());
+        let base_seq = metadata_files
+            .iter()
+            .map(|descriptor| descriptor.run_seq)
+            .min()
+            .unwrap_or(previous.payload.base_seq);
+        let manifest = write_reorganized_manifest(
+            store,
+            namespace_id,
+            previous,
+            metadata_files,
+            base_seq,
+            previous
+                .payload
+                .retention_floor_seq
+                .max(spec.frozen_floor_seq()),
+        )
+        .await?;
+
+        ensure_metadata_publication_budget(timer, publication_started_ms, namespace_id)?;
+        let published = publish_metadata_root(
+            store,
+            namespace_id,
+            &manifest,
+            Some(root.manifest_object_id.clone()),
+            context.now_ms,
+        )
+        .await?;
+        drop(tables);
+        match published {
+            ManifestPublicationOutcome::Published(_) => {
+                return Ok(Finalization::Published(manifest.payload.manifest_id))
+            }
+            ManifestPublicationOutcome::Superseded(_)
+            | ManifestPublicationOutcome::RootCasRaceLost => {
+                tracing::debug!(
+                    namespace_id = namespace_id.as_str(),
+                    families = ?spec.families(),
+                    attempt,
+                    attempts = MAX_FINALIZATION_ATTEMPTS,
+                    "a publication landed while a streaming metadata compaction was finalizing; \
+                     reloading"
+                );
+            }
+        }
+    }
+    tracing::info!(
+        namespace_id = namespace_id.as_str(),
+        families = ?spec.families(),
+        attempts = MAX_FINALIZATION_ATTEMPTS,
+        "streaming metadata compaction superseded at every publication attempt; a later step \
+         plans it again"
+    );
+    Ok(Finalization::Superseded)
+}
+
+/// The tables of whatever manifest the namespace's root names, or `None` when
+/// it names none.
+async fn load_current_manifest_tables<'a, S: ObjectStore + ?Sized>(
+    store: &'a S,
+    namespace_id: &NamespaceId,
+) -> Result<Option<VerifiedMetadataTables<'a, S>>> {
+    let Some(root) = read_metadata_root_object_if_present(store, namespace_id)
+        .await
+        .map_err(CoreError::load_head)?
+        .map(|loaded| loaded.envelope.state)
+    else {
+        return Ok(None);
+    };
+    load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
+        .await
+        .map(Some)
+        .map_err(manifest_load_failure)
+}
+
+/// The object keys the spec's runs hold for its group, or `None` when the
+/// manifest no longer references one of those runs at all.
+///
+/// Segments are immutable and their keys are generated, so two manifests
+/// agreeing on this set agree on every row the job read. Runs the manifest
+/// gained meanwhile are not in it — the job never read them, and they survive
+/// the publication untouched.
+pub(super) fn snapshot_segment_keys<S: ObjectStore + ?Sized>(
+    tables: &VerifiedMetadataTables<'_, S>,
+    spec: &MetadataCompactionSpec,
+) -> Option<BTreeSet<String>> {
+    let mut keys = BTreeSet::new();
+    for (run_seq, level) in spec.inputs() {
+        let run = tables
+            .scan_runs
+            .iter()
+            .find(|run| run.run_seq == *run_seq && run.level == *level)?;
+        keys.extend(
+            group_run_descriptors(run, spec.group())
+                .map(|descriptor| descriptor.object_key.clone()),
+        );
+    }
+    Some(keys)
 }
 
 /// One set of families the job merges and judges together, and how it groups
@@ -370,6 +686,8 @@ struct CompactionJob<'a, S: ObjectStore + ?Sized> {
     result: MetadataCompactionResult,
     canonical_digest: RowDigest,
     index_digest: RowDigest,
+    /// The read count the next progress line is owed at.
+    next_progress_rows: u64,
 }
 
 impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
@@ -426,6 +744,7 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
                 .or_default()
                 .push(iterators[next].take_head());
             self.result.rows_read += 1;
+            self.report_progress();
         }
         self.flush_locality(cluster, &mut group_rows, &mut writers)
             .await?;
@@ -437,6 +756,28 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
             self.result.output_segments.extend(segments);
         }
         Ok(true)
+    }
+
+    /// Says where a long job has got to, at [`PROGRESS_ROW_INTERVAL`].
+    ///
+    /// A job has no bound on how long it runs, and it publishes nothing until
+    /// it is finished, so without this an operator watching a big namespace
+    /// sees one line at the start and nothing until it lands. The counters are
+    /// the job's own; nothing is measured for this.
+    fn report_progress(&mut self) {
+        if self.result.rows_read < self.next_progress_rows {
+            return;
+        }
+        self.next_progress_rows = self.result.rows_read.saturating_add(PROGRESS_ROW_INTERVAL);
+        tracing::info!(
+            namespace_id = self.namespace_id.as_str(),
+            families = ?self.spec.families(),
+            rows_read = self.result.rows_read,
+            rows_written = self.result.rows_written,
+            input_rows = self.spec.input_rows(),
+            output_segments = self.result.output_segments.len(),
+            "streaming metadata compaction progress"
+        );
     }
 
     /// Fills every iterator that has run out of rows, a bounded wave at a

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -776,7 +776,9 @@ async fn bounded_subset_rebuild_rejects_divergent_revision_index() {
     };
     let mut rebuild_error = None;
     for _unit in 0..8 {
-        match super::reorganize_metadata_step(&store, &namespace_id, &context, fold_policy).await {
+        match super::reorganize_metadata_step(&store, &namespace_id, &context, fold_policy, None)
+            .await
+        {
             Ok(report) => match report.outcome {
                 super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
                 _ => continue,

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -37,6 +37,10 @@ use super::runs::{
 use super::stored_block_cache::{
     StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind,
 };
+use super::streaming_compaction::{
+    run_metadata_compaction_job, MetadataCompactionCancellation, MetadataCompactionJobOutcome,
+    MetadataCompactionSpec,
+};
 use super::{
     block_fetch, create, data_block_load, flush, load, record, reorganize,
     reorganize_metadata_step, row, scan, MetadataReorganizeOutcome,
@@ -240,14 +244,15 @@ async fn drain_reorganization<S: ObjectStore + ?Sized>(
         ..policy
     };
     loop {
-        let report = super::reorganize_metadata_step(store, namespace_id, context, fold_policy)
-            .await
-            .expect("reorganization step");
+        let report =
+            super::reorganize_metadata_step(store, namespace_id, context, fold_policy, None)
+                .await
+                .expect("reorganization step");
         match report.outcome {
             super::MetadataReorganizeOutcome::UnitPublished { .. }
             | super::MetadataReorganizeOutcome::Superseded => continue,
             super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
-            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+            super::MetadataReorganizeOutcome::CompactionPlanned { .. } => {
                 panic!("test reorganization budget should admit a progress-making subset")
             }
         }
@@ -258,6 +263,126 @@ async fn drain_reorganization<S: ObjectStore + ?Sized>(
         .envelope
         .state
         .manifest_id
+}
+
+/// Runs the job a step planned, the way the maintenance runner's background
+/// task runs it — except that this waits for it, which is what makes a test
+/// deterministic.
+async fn run_planned_compaction<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+    spec: &MetadataCompactionSpec,
+) -> MetadataCompactionJobOutcome {
+    run_metadata_compaction_job(
+        store,
+        namespace_id,
+        context,
+        policy,
+        spec,
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    .expect("run the planned streaming compaction")
+}
+
+/// What a reader sees right now: every inode the namespace knows, resolved
+/// the way a read resolves it — visible or not, at what path, at what
+/// revision.
+///
+/// This is the answer that must not move while a fold or a rebuild runs.
+/// Comparing rows would say the opposite of what is wanted: both drop rows
+/// precisely because no read can observe them, so the row set is meant to
+/// change and this is not.
+async fn visible_namespace<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> Vec<CurrentFileState> {
+    let manifest_id = read_metadata_root_object(store, namespace_id)
+        .await
+        .expect("read metadata root")
+        .envelope
+        .state
+        .manifest_id;
+    let materialized =
+        load_manifest_materialization_for_inspection(store, namespace_id, manifest_id)
+            .await
+            .expect("materialize the manifest");
+    let inode_ids: Vec<InodeId> = materialized
+        .metadata_state
+        .inodes()
+        .iter()
+        .map(|inode| inode.inode_id)
+        .collect();
+    let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+        .await
+        .expect("load the read view");
+    resolve_current_files(&view, &inode_ids)
+        .await
+        .expect("resolve every inode the namespace knows")
+}
+
+/// Rebuilds one family group through a streaming compaction and publishes the
+/// swap, answering with the staged object keys the manifest now names.
+///
+/// For a caller that needs a namespace whose manifest references segments
+/// under the compaction staging directory: the collector's tests, which have
+/// to tell a published job's output from an orphan.
+pub(crate) async fn compact_a_family_group_into_staging<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) -> BTreeSet<String> {
+    // One byte admits no run whole, so the group a step selects has no window
+    // that makes progress and is handed to a job.
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
+        ..MetadataLsmPolicy::default()
+    };
+    let report = reorganize_metadata_step(store, namespace_id, context, policy, None)
+        .await
+        .expect("plan a streaming compaction");
+    let MetadataReorganizeOutcome::CompactionPlanned { spec, .. } = report.outcome else {
+        panic!("a budget that admits no run whole must plan a streaming compaction");
+    };
+    publish_planned_compaction(store, namespace_id, context, policy, &spec).await;
+
+    let staging_prefix =
+        loonfs_objectstore::keys::metadata_compaction_staging_prefix(namespace_id.as_str());
+    let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
+    let staged: BTreeSet<String> =
+        load_verified_manifest_tables(store, namespace_id, &manifest_object_id)
+            .await
+            .expect("load the published manifest")
+            .manifest()
+            .payload
+            .metadata_files
+            .iter()
+            .map(|descriptor| descriptor.object_key.clone())
+            .filter(|key| key.starts_with(&staging_prefix))
+            .collect();
+    assert!(
+        !staged.is_empty(),
+        "a published job's output is referenced from the staging directory"
+    );
+    staged
+}
+
+/// The same, where anything but a publication is a test failure.
+async fn publish_planned_compaction<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+    spec: &MetadataCompactionSpec,
+) {
+    let outcome = run_planned_compaction(store, namespace_id, context, policy, spec).await;
+    assert!(
+        matches!(outcome, MetadataCompactionJobOutcome::Published { .. }),
+        "the planned job must publish, got {outcome:?}"
+    );
 }
 
 async fn current_manifest_object_id<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -139,7 +139,7 @@ async fn drain_reorganization_with_count<S: ObjectStore + ?Sized>(
 ) -> (ManifestId, usize) {
     let mut published = 0usize;
     for _ in 0..128 {
-        let report = super::reorganize_metadata_step(store, namespace_id, context, policy)
+        let report = super::reorganize_metadata_step(store, namespace_id, context, policy, None)
             .await
             .expect("reorganization step");
         match report.outcome {
@@ -147,7 +147,7 @@ async fn drain_reorganization_with_count<S: ObjectStore + ?Sized>(
             super::MetadataReorganizeOutcome::Superseded => {
                 panic!("single-writer test must not be superseded")
             }
-            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+            super::MetadataReorganizeOutcome::CompactionPlanned { .. } => {
                 panic!("test budget must admit a progress-making subset")
             }
             super::MetadataReorganizeOutcome::NotNeeded { .. } => {
@@ -790,7 +790,7 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     let mut units = 0usize;
     let mut last_manifest_id = None;
     loop {
-        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
             .await
             .expect("reorganization step");
         match report.outcome {
@@ -805,7 +805,7 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
                 panic!("no concurrent publisher exists in this test")
             }
             super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
-            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+            super::MetadataReorganizeOutcome::CompactionPlanned { .. } => {
                 panic!("test reorganization budget should admit a progress-making subset")
             }
         }
@@ -864,16 +864,17 @@ async fn reorganization_step_honors_run_row_and_decoded_byte_budgets() {
     };
     store.reset();
     let blocked =
-        super::reorganize_metadata_step(&store, &namespace_id, &context, tiny_byte_policy)
+        super::reorganize_metadata_step(&store, &namespace_id, &context, tiny_byte_policy, None)
             .await
             .expect("budgeted step");
-    let super::MetadataReorganizeOutcome::BudgetExhausted { families, .. } = blocked.outcome else {
+    let super::MetadataReorganizeOutcome::CompactionPlanned { families, .. } = blocked.outcome
+    else {
         panic!("one byte must not admit an SST run");
     };
     assert_eq!(
         current_manifest_id(&store, &namespace_id).await,
         root_before,
-        "a budget-blocked step must not publish"
+        "a step that plans a compaction must not publish"
     );
     assert_eq!(store.count(OperationClass::Put), 0);
     assert!(
@@ -889,7 +890,7 @@ async fn reorganization_step_honors_run_row_and_decoded_byte_budgets() {
         ..MetadataLsmPolicy::default()
     };
     store.reset();
-    let published = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+    let published = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
         .await
         .expect("bounded step");
     let super::MetadataReorganizeOutcome::UnitPublished {
@@ -954,10 +955,15 @@ async fn bounded_reorganization_converges_to_unbounded_shape_and_preserves_inter
         max_decoded_input_bytes_per_step: unlimited,
         ..MetadataLsmPolicy::default()
     };
-    let first =
-        super::reorganize_metadata_step(&bounded_store, &namespace_id, &context, bounded_policy)
-            .await
-            .expect("first bounded step");
+    let first = super::reorganize_metadata_step(
+        &bounded_store,
+        &namespace_id,
+        &context,
+        bounded_policy,
+        None,
+    )
+    .await
+    .expect("first bounded step");
     assert!(matches!(
         first.outcome,
         super::MetadataReorganizeOutcome::UnitPublished { input_runs: 2, .. }
@@ -1027,10 +1033,15 @@ async fn bounded_reorganization_converges_to_unbounded_shape_and_preserves_inter
     create_checkpoint(&bounded_store, &namespace_id, &context)
         .await
         .expect("checkpoint later file");
-    let below_trigger =
-        super::reorganize_metadata_step(&bounded_store, &namespace_id, &context, bounded_policy)
-            .await
-            .expect("below-trigger step");
+    let below_trigger = super::reorganize_metadata_step(
+        &bounded_store,
+        &namespace_id,
+        &context,
+        bounded_policy,
+        None,
+    )
+    .await
+    .expect("below-trigger step");
     assert!(matches!(
         below_trigger.outcome,
         super::MetadataReorganizeOutcome::NotNeeded { l0_runs: 1 }
@@ -1247,9 +1258,10 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
 
     // One unit runs, then the process "crashes": nothing is carried over
     // but the published manifest.
-    let first_report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
-        .await
-        .expect("first unit");
+    let first_report =
+        super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
+            .await
+            .expect("first unit");
     let super::MetadataReorganizeOutcome::UnitPublished {
         families: first_families,
         ..
@@ -1265,7 +1277,7 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
     // job, including the delta the interleaved checkpoint added.
     let mut folded_groups = vec![first_families];
     loop {
-        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
             .await
             .expect("resumed unit");
         match report.outcome {
@@ -1276,7 +1288,7 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
                 panic!("no concurrent publisher exists in this test")
             }
             super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
-            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+            super::MetadataReorganizeOutcome::CompactionPlanned { .. } => {
                 panic!("test reorganization budget should admit a progress-making subset")
             }
         }
@@ -1463,6 +1475,7 @@ async fn over_budget_reorganization_aborts_without_publishing() {
         &namespace_id,
         &context,
         fold_everything,
+        None,
         &overrun,
     )
     .await
@@ -1484,6 +1497,7 @@ async fn over_budget_reorganization_aborts_without_publishing() {
         &namespace_id,
         &context,
         fold_everything,
+        None,
     )
     .await
     .expect("in-budget retry folds the unit");
@@ -1507,7 +1521,7 @@ async fn select_reorganization_window<S: ObjectStore + ?Sized>(
     let tables = load_verified_manifest_tables(store, namespace_id, &manifest_object_id)
         .await
         .expect("load manifest tables");
-    let group = super::reorganize::select_family_group(&tables.manifest().payload)
+    let group = super::reorganize::select_family_group(&tables.manifest().payload, None)
         .expect("a family group with L0 rows to fold");
     let frozen_floor_seq = read_floor_seq(store, namespace_id).await;
     let selection =
@@ -1575,11 +1589,12 @@ fn policy_that_cannot_fold_the_base(base_rows: u64) -> MetadataLsmPolicy {
 /// base run here is what hid the over-budget bottom from the report.
 ///
 /// Once the delta runs are down to one the group has nothing left to merge,
-/// and the step reports it blocked. That is honest — the base still cannot
-/// be read in one step — and it is the case the streaming compactor is being
-/// built for.
+/// and the step hands the whole group to a streaming compaction. That job
+/// rebuilds the group under no budget, so the base is folded again, its
+/// segments are replaced, and the group ends in one run. There is no state
+/// where the group is stuck.
 #[tokio::test]
-async fn a_base_run_over_the_step_budget_merges_the_delta_runs_above_it() {
+async fn a_base_run_over_the_step_budget_merges_the_delta_runs_then_compacts_the_group() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1652,13 +1667,14 @@ async fn a_base_run_over_the_step_budget_merges_the_delta_runs_above_it() {
     assert_eq!(bottom.level, CHECKPOINT_BASE_RUN_LEVEL);
     assert_eq!(bottom.rows, base_rows);
 
-    // Repeated steps keep merging what fits. The base run stays exactly where
-    // it is, and stays one run.
+    // Repeated steps keep merging what fits. While they do, the base run
+    // stays exactly where it is, and stays one run.
     let mut published = 0usize;
-    let mut blocked = 0usize;
+    let mut compactions = 0usize;
     let mut group_delta_run_counts = vec![group_delta_runs(&before.manifest, &group).len()];
+    let mut delta_runs_when_the_compaction_was_planned = None;
     for _ in 0..64 {
-        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
             .await
             .expect("reorganization step");
         let current = load_manifest_materialization_for_inspection(
@@ -1674,25 +1690,44 @@ async fn a_base_run_over_the_step_budget_merges_the_delta_runs_above_it() {
             "a merge above the base must not mint a second base run"
         );
         group_delta_run_counts.push(group_delta_runs(&current.manifest, &group).len());
-        match report.outcome {
+        match &report.outcome {
             super::MetadataReorganizeOutcome::UnitPublished { .. } => published += 1,
             super::MetadataReorganizeOutcome::Superseded => {
                 panic!("no concurrent publisher exists in this test")
             }
-            // The group's delta runs are down to one, and merging one run
-            // into itself is not progress. Only a fold of the whole group
-            // moves this on, and that fold does not fit one step.
-            super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
-                blocked += 1;
-                break;
+            // A group whose delta runs are down to one has nothing left to
+            // merge, and merging one run into itself is not progress. Only a
+            // rebuild of the whole group moves it on, and that is the job the
+            // step plans. This budget starves more than one group, so the
+            // others are run too and the loop ends with nothing left to fold.
+            super::MetadataReorganizeOutcome::CompactionPlanned { families, spec } => {
+                if *families == group {
+                    let referenced = run_segment_object_keys(&current.manifest);
+                    assert!(
+                        base_segments
+                            .iter()
+                            .all(|segment| referenced.contains(segment)),
+                        "the base must still be untouched when the job is planned"
+                    );
+                    delta_runs_when_the_compaction_was_planned =
+                        Some(group_delta_runs(&current.manifest, &group).len());
+                    compactions += 1;
+                }
+                publish_planned_compaction(&store, &namespace_id, &context, policy, spec).await;
             }
             super::MetadataReorganizeOutcome::NotNeeded { .. } => break,
         }
     }
     assert!(published > 0, "at least one unit must publish");
     assert_eq!(
-        blocked, 1,
-        "the group must end blocked on the base it cannot read, ran {group_delta_run_counts:?}"
+        compactions, 1,
+        "the group must hand itself to one streaming compaction, ran {group_delta_run_counts:?}"
+    );
+    assert_eq!(
+        delta_runs_when_the_compaction_was_planned,
+        Some(1),
+        "the delta runs must merge down to one before the job takes the group, ran \
+         {group_delta_run_counts:?}"
     );
 
     let after = load_manifest_materialization_for_inspection(
@@ -1702,23 +1737,20 @@ async fn a_base_run_over_the_step_budget_merges_the_delta_runs_above_it() {
     )
     .await
     .expect("load the drained manifest");
+    // The job rebuilt the group, so it is one base run and the frozen base's
+    // segments are gone. That is the whole point: they could not be rewritten
+    // by any step, and a run nothing rewrites is a run nothing reclaims.
     assert_eq!(
-        group_delta_runs(&after.manifest, &group).len(),
+        group_runs(&after.manifest, &group).len(),
         1,
-        "the delta runs must merge down to one, ran {group_delta_run_counts:?}"
+        "the group must end in one run, ran {group_delta_run_counts:?}"
     );
-    // The group's own run count, not the manifest's: a merge only takes this
-    // group's segments out of its input runs, and those runs stay in the
-    // manifest holding the other groups' families.
-    assert!(
-        group_runs(&after.manifest, &group).len() < group_runs(&before.manifest, &group).len(),
-        "the group's run count must fall"
-    );
+    assert_eq!(group_base_runs(&after.manifest, &group).len(), 1);
     let remaining = run_segment_object_keys(&after.manifest);
     for segment in &base_segments {
         assert!(
-            remaining.contains(segment),
-            "the base run this step could not read must stay referenced untouched"
+            !remaining.contains(segment),
+            "the frozen base's segments must be replaced by the rebuilt run"
         );
     }
     let projection = load_current_projection(&store, &namespace_id)
@@ -1840,7 +1872,7 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     assert!(input.runs.len() > 1);
     let base_before = group_base_runs(&before.manifest, &group);
 
-    let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+    let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
         .await
         .expect("reorganization step");
     assert!(
@@ -1987,55 +2019,22 @@ async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
     );
 
     let root_before = current_manifest_id(&store, &namespace_id).await;
-    let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
+    let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
         .await
         .expect("reorganization step");
     assert!(
         matches!(
             report.outcome,
-            super::MetadataReorganizeOutcome::BudgetExhausted { .. }
+            super::MetadataReorganizeOutcome::CompactionPlanned { .. }
         ),
-        "expected a blocked step, got {:?}",
+        "expected a planned compaction, got {:?}",
         report.outcome
     );
     assert_eq!(
         current_manifest_id(&store, &namespace_id).await,
         root_before,
-        "a blocked step must not publish"
+        "a step that plans a compaction must not publish"
     );
-}
-
-/// What a reader sees right now: every inode the namespace knows, resolved
-/// the way a read resolves it — visible or not, at what path, at what
-/// revision.
-///
-/// This is the answer that must not move while folds run. Comparing rows
-/// would say the opposite of what is wanted: a fold drops rows precisely
-/// because no read can observe them, so the row set is meant to change and
-/// this is not.
-async fn visible_namespace(
-    store: &LocalFsStore,
-    namespace_id: &NamespaceId,
-) -> Vec<CurrentFileState> {
-    let materialized = load_manifest_materialization_for_inspection(
-        store,
-        namespace_id,
-        current_manifest_id(store, namespace_id).await,
-    )
-    .await
-    .expect("materialize the manifest");
-    let inode_ids: Vec<InodeId> = materialized
-        .metadata_state
-        .inodes()
-        .iter()
-        .map(|inode| inode.inode_id)
-        .collect();
-    let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
-        .await
-        .expect("load the read view");
-    resolve_current_files(&view, &inode_ids)
-        .await
-        .expect("resolve every inode the namespace knows")
 }
 
 /// The soak's end state, as a test.
@@ -2052,10 +2051,10 @@ async fn visible_namespace(
 ///
 /// What is pinned here is that neither happens. No group's base fragments,
 /// whatever the budgets do; every step leaves reads answering exactly what
-/// they answered before; and a group whose bottom stops fitting one step says
-/// so and stops, rather than minting another base run. Folding such a group
-/// is the streaming compactor's job, and this test gains that half when the
-/// compactor lands.
+/// they answered before; a group whose bottom stops fitting one step is
+/// handed to a streaming compaction rather than minting another base run;
+/// and every cycle settles with nothing left to fold. There is no run of
+/// steps that ends with a group nothing can fold.
 #[tokio::test]
 async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
     let temp_dir = tempdir().expect("tempdir");
@@ -2075,7 +2074,7 @@ async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
     };
 
     let group = group_containing(ApiMetadataTableFamily::DirentryUnbinds);
-    let mut blocked_groups = 0usize;
+    let mut compacted_groups = 0usize;
     for cycle in 0..4u64 {
         for file in 0..4u64 {
             write_file_bytes(
@@ -2113,9 +2112,10 @@ async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
 
         let mut settled = false;
         for _step in 0..512 {
-            let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy)
-                .await
-                .expect("reorganization step");
+            let report =
+                super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
+                    .await
+                    .expect("reorganization step");
             let current = load_manifest_materialization_for_inspection(
                 &store,
                 &namespace_id,
@@ -2140,12 +2140,15 @@ async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
                     break;
                 }
                 // The group's bottom no longer fits one step and its delta
-                // runs are merged down to one. The step says so and mints
-                // nothing; the streaming compactor is what folds it.
-                super::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
-                    blocked_groups += 1;
-                    settled = true;
-                    break;
+                // runs are merged down to one. The step hands the group to a
+                // streaming compaction, which is what folds it. The runner
+                // runs that job in the background; here it runs inline, so
+                // the steps that follow see what they would have seen once it
+                // landed.
+                super::MetadataReorganizeOutcome::CompactionPlanned { spec, .. } => {
+                    publish_planned_compaction(&store, &namespace_id, &context, policy, &spec)
+                        .await;
+                    compacted_groups += 1;
                 }
                 super::MetadataReorganizeOutcome::Superseded => {
                     panic!("no concurrent publisher exists in this test")
@@ -2153,12 +2156,15 @@ async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
                 super::MetadataReorganizeOutcome::UnitPublished { .. } => {}
             }
         }
-        assert!(settled, "cycle {cycle}: reorganization did not settle");
+        assert!(
+            settled,
+            "cycle {cycle}: reorganization did not settle with nothing left to fold"
+        );
     }
 
     assert!(
-        blocked_groups > 0,
-        "a group must have outgrown one step and reported it"
+        compacted_groups > 0,
+        "a group must have outgrown one step and been rebuilt by a streaming compaction"
     );
     let final_manifest = load_manifest_materialization_for_inspection(
         &store,

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -3,17 +3,17 @@
 //! place, restart equivalence, and the resource bounds that make the job
 //! independent of the size of what it rebuilds.
 
-use super::super::reorganize::{
-    select_reorganization_input, write_reorganized_manifest, ReorganizationPlan,
-};
+use super::super::reorganize::{select_reorganization_input, ReorganizationPlan};
 use super::super::row::manifest_row_commit_seq;
 use super::super::runs::MetadataFamilyGroup;
 use super::super::scan::VerifiedMetadataTables;
 use super::super::streaming_compaction::{
-    run_metadata_compaction, MetadataCompactionCancellation, MetadataCompactionOutcome,
-    MetadataCompactionResult, MetadataCompactionSpec,
+    finalize_metadata_compaction, run_metadata_compaction, snapshot_segment_keys, Finalization,
+    MetadataCompactionCancellation, MetadataCompactionOutcome, MetadataCompactionResult,
+    MetadataCompactionSpec,
 };
 use super::*;
+use crate::timing::StdMonotonicTimer;
 use loonfs_objectstore::keys::metadata_compaction_staging_prefix;
 use loonfs_test_support::stores::ConcurrencyWatchStore;
 use std::collections::BTreeMap;
@@ -252,6 +252,50 @@ fn fold_everything_policy() -> MetadataLsmPolicy {
     }
 }
 
+/// A budget one byte wide, which admits no run whole, so the planner has no
+/// window that makes progress and answers with a compaction.
+fn starving_policy() -> MetadataLsmPolicy {
+    MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
+        ..MetadataLsmPolicy::default()
+    }
+}
+
+/// A per-step row budget one row short of what `group`'s base run holds.
+///
+/// That is the production condition: no window over this group makes progress,
+/// so a step hands it to a job, while every other group still folds normally
+/// on the steps around it.
+async fn policy_that_starves_the_group<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
+) -> MetadataLsmPolicy {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    let base_rows: u64 = runs_in_scan_order(&tables.manifest().payload)
+        .iter()
+        .filter(|run| run.level == CHECKPOINT_BASE_RUN_LEVEL)
+        .flat_map(|run| run.tables.iter())
+        .filter(|table| group.contains(table.family))
+        .flat_map(|table| &table.segments)
+        .map(|descriptor| descriptor.row_count)
+        .sum();
+    assert!(
+        base_rows > 1,
+        "the seed must leave this group a base run to starve"
+    );
+    MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        max_decoded_input_rows_per_step: NonZeroUsize::new(
+            usize::try_from(base_rows).expect("test row counts are small") - 1,
+        )
+        .expect("nonzero"),
+        max_rows_per_segment: NonZeroUsize::new(4).expect("nonzero"),
+        ..MetadataLsmPolicy::default()
+    }
+}
+
 /// A budget that rolls many small output segments, so the job's writers are
 /// exercised rather than producing one segment per family.
 fn small_segment_policy() -> MetadataLsmPolicy {
@@ -331,79 +375,52 @@ async fn run_compaction<S: ObjectStore + ?Sized>(
         .expect("run the streaming compaction")
 }
 
-/// The swap a finished job's caller performs, as much of it as this change
-/// owns: reload the current manifest, verify every snapshot run is still
-/// present and unchanged, replace exactly those descriptors with the output
-/// run, and publish through the ordinary manifest path.
+/// The segments the group's snapshot runs hold right now, which is what
+/// finalization compares the manifest against.
+async fn snapshot_keys_now<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+) -> BTreeSet<String> {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    snapshot_segment_keys(&tables, spec).expect("the snapshot must be present")
+}
+
+/// The production finalizer, called the way the job driver calls it.
 ///
-/// The runner productionizes this — the race handling, the reporting, and the
-/// retry are its business. This is the minimum the oracle needs to look at
-/// what the job built through a manifest a reader can load.
+/// The driver runs the rebuild and this together. These tests split the two so
+/// they can assert on what the rebuild produced before it is published, and on
+/// what happens when the manifest moves in between.
 async fn finalize_streaming_compaction<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     spec: &MetadataCompactionSpec,
-    snapshot_at_start: &[MetadataRunManifest],
+    snapshot_keys: &BTreeSet<String>,
+    result: &MetadataCompactionResult,
+) -> Finalization {
+    finalize_metadata_compaction(
+        store,
+        namespace_id,
+        &test_context(),
+        spec,
+        snapshot_keys,
+        result.clone(),
+        &StdMonotonicTimer::default(),
+    )
+    .await
+    .expect("finalize the streaming compaction")
+}
+
+/// The same, for the tests where anything but a publication is a failure.
+async fn publish_streaming_compaction<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+    snapshot_keys: &BTreeSet<String>,
     result: &MetadataCompactionResult,
 ) -> ManifestId {
-    let root = read_metadata_root_object(store, namespace_id)
-        .await
-        .expect("read root")
-        .envelope
-        .state;
-    let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
-        .await
-        .expect("load the current manifest");
-    assert_eq!(
-        snapshot_runs_for_group(tables.manifest(), spec.group()),
-        snapshot_at_start,
-        "the snapshot must still be present and unchanged at finalization"
-    );
-
-    let previous = tables.manifest();
-    let inputs: BTreeSet<(ChangeSeq, u32)> = spec.inputs().iter().copied().collect();
-    let mut metadata_files: Vec<MetadataFileRef> = previous
-        .payload
-        .metadata_files
-        .iter()
-        .filter(|descriptor| {
-            !spec.group().contains(descriptor.family)
-                || !inputs.contains(&(descriptor.run_seq, descriptor.level))
-        })
-        .cloned()
-        .collect();
-    metadata_files.extend(result.output_segments.iter().cloned());
-    let base_seq = metadata_files
-        .iter()
-        .map(|descriptor| descriptor.run_seq)
-        .min()
-        .unwrap_or(previous.payload.base_seq);
-    let retention_floor_seq = previous
-        .payload
-        .retention_floor_seq
-        .max(spec.frozen_floor_seq());
-
-    let manifest = write_reorganized_manifest(
-        store,
-        namespace_id,
-        previous,
-        metadata_files,
-        base_seq,
-        retention_floor_seq,
-    )
-    .await
-    .expect("write the replacement manifest");
-    match publish_metadata_root(
-        store,
-        namespace_id,
-        &manifest,
-        Some(root.manifest_object_id.clone()),
-        test_context().now_ms,
-    )
-    .await
-    .expect("publish the replacement manifest")
-    {
-        ManifestPublicationOutcome::Published(_) => manifest.payload.manifest_id,
+    match finalize_streaming_compaction(store, namespace_id, spec, snapshot_keys, result).await {
+        Finalization::Published(manifest_id) => manifest_id,
         other => panic!("no concurrent publisher exists in this test, got {other:?}"),
     }
 }
@@ -494,6 +511,7 @@ async fn fold_group_whole<S: ObjectStore + ?Sized>(
         namespace_id,
         &test_context(),
         fold_everything_policy(),
+        None,
     )
     .await
     .expect("fold the group whole");
@@ -569,10 +587,10 @@ async fn the_planner_answers_with_a_merge_or_with_a_compaction() {
     );
 }
 
-/// The step reports the same blocked outcome it reported before the compactor
-/// existed. Scheduling the job is the runner's, and lands with it.
+/// A step that plans a compaction publishes nothing and stages nothing: it
+/// hands the plan back, and the runtime starts the job.
 #[tokio::test]
-async fn a_step_that_plans_a_compaction_still_reports_the_group_blocked() {
+async fn a_step_that_plans_a_compaction_publishes_nothing_itself() {
     let temp_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -583,26 +601,102 @@ async fn a_step_that_plans_a_compaction_still_reports_the_group_blocked() {
         &store,
         &namespace_id,
         &test_context(),
-        MetadataLsmPolicy {
-            max_l0_runs: NonZeroUsize::MIN,
-            max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
-            ..MetadataLsmPolicy::default()
-        },
+        starving_policy(),
+        None,
     )
     .await
     .expect("budgeted step");
-    assert!(matches!(
-        report.outcome,
-        MetadataReorganizeOutcome::BudgetExhausted { .. }
-    ));
+    let MetadataReorganizeOutcome::CompactionPlanned { families, spec } = report.outcome else {
+        panic!("a group no window fits must plan a streaming compaction");
+    };
+    assert_eq!(families, MetadataFamilyGroup::Bindings.families());
+    assert!(spec.input_rows() > 0, "the plan must report what it reads");
     assert_eq!(
         current_manifest_object_id(&store, &namespace_id).await,
         before,
-        "a blocked step publishes nothing"
+        "a step that plans a compaction publishes nothing"
     );
     assert!(
         staged_object_keys(&store, &namespace_id).await.is_empty(),
-        "and stages nothing, because no job runs yet"
+        "and stages nothing, because the job has not started"
+    );
+}
+
+/// While a job rebuilds one group, steps leave that group alone and fold the
+/// others. Without this a step would keep re-planning the running job: the
+/// group's L0 rows are frozen in the job's snapshot, so its count never falls
+/// while every other group's does.
+#[tokio::test]
+async fn a_step_leaves_the_group_a_running_job_is_rebuilding_alone() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        ..MetadataLsmPolicy::default()
+    };
+
+    // Same durable state, twice. With no job in flight this group is what a
+    // step takes: it holds the most L0 rows.
+    let fold_dir = tempdir().expect("tempdir");
+    copy_store_tree(temp_dir.path(), fold_dir.path());
+    let fold_store = LocalFsStore::new(fold_dir.path()).expect("store");
+    let without = super::super::reorganize_metadata_step(
+        &fold_store,
+        &namespace_id,
+        &test_context(),
+        policy,
+        None,
+    )
+    .await
+    .expect("step with no job running");
+    let MetadataReorganizeOutcome::UnitPublished { families, .. } = without.outcome else {
+        panic!("expected a merge, got {:?}", without.outcome);
+    };
+    assert_eq!(
+        families,
+        group.families(),
+        "the seed must leave this group the one a step would take"
+    );
+
+    // With the job's plan in hand, every step folds another group and none
+    // touches this one, so the job's input is exactly what it was.
+    let mut other_groups_folded = 0usize;
+    for _ in 0..16 {
+        let report = super::super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &test_context(),
+            policy,
+            Some(&spec),
+        )
+        .await
+        .expect("step with the job running");
+        match report.outcome {
+            MetadataReorganizeOutcome::UnitPublished { families, .. } => {
+                assert_ne!(
+                    families,
+                    group.families(),
+                    "a step must not merge the group a job is rebuilding"
+                );
+                other_groups_folded += 1;
+            }
+            MetadataReorganizeOutcome::NotNeeded { .. } => break,
+            other => panic!("unexpected outcome {other:?}"),
+        }
+    }
+    assert!(
+        other_groups_folded > 0,
+        "ordinary maintenance must keep going while a job runs"
+    );
+    assert_eq!(
+        snapshot_keys_now(&store, &namespace_id, &spec).await,
+        snapshot_keys,
+        "the job's input must be exactly what it was when the job was planned"
     );
 }
 
@@ -633,12 +727,7 @@ async fn a_streaming_compaction_and_a_whole_group_fold_reach_the_same_rows() {
     let folded_state = current_metadata_state(&fold_store, &namespace_id).await;
 
     let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
-    let snapshot = snapshot_runs_for_group(
-        load_current_manifest_tables(&store, &namespace_id)
-            .await
-            .manifest(),
-        group,
-    );
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
     let outcome = run_compaction(
         &store,
         &namespace_id,
@@ -675,7 +764,7 @@ async fn a_streaming_compaction_and_a_whole_group_fold_reach_the_same_rows() {
     );
     assert_eq!(result.unbind_probes, reverse_rows_at_or_below_floor);
 
-    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+    publish_streaming_compaction(&store, &namespace_id, &spec, &snapshot_keys, &result).await;
     let compacted = group_rows_of_current_manifest(&store, &namespace_id, group).await;
 
     assert_eq!(
@@ -770,12 +859,7 @@ async fn a_compaction_that_drops_nothing_fails_the_oracle() {
     let spec = compaction_spec_for_group(&store, &namespace_id, group)
         .await
         .with_frozen_floor_seq(ChangeSeq(0));
-    let snapshot = snapshot_runs_for_group(
-        load_current_manifest_tables(&store, &namespace_id)
-            .await
-            .manifest(),
-        group,
-    );
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
     let MetadataCompactionOutcome::Completed(result) = run_compaction(
         &store,
         &namespace_id,
@@ -788,7 +872,7 @@ async fn a_compaction_that_drops_nothing_fails_the_oracle() {
         panic!("nothing cancelled this job");
     };
     assert_eq!(result.unbind_probes, 0, "a floor of zero covers no row");
-    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+    publish_streaming_compaction(&store, &namespace_id, &spec, &snapshot_keys, &result).await;
 
     let compacted = group_rows_of_current_manifest(&store, &namespace_id, group).await;
     assert_ne!(
@@ -814,12 +898,7 @@ async fn a_compaction_of_the_revisions_group_rewrites_every_row_it_reads() {
     let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
 
     let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
-    let snapshot = snapshot_runs_for_group(
-        load_current_manifest_tables(&store, &namespace_id)
-            .await
-            .manifest(),
-        group,
-    );
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
     let MetadataCompactionOutcome::Completed(result) = run_compaction(
         &store,
         &namespace_id,
@@ -839,7 +918,7 @@ async fn a_compaction_of_the_revisions_group_rewrites_every_row_it_reads() {
         result.unbind_probes, 0,
         "the revisions group has no bind rule, so it reads no unbind"
     );
-    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+    publish_streaming_compaction(&store, &namespace_id, &spec, &snapshot_keys, &result).await;
 
     assert_eq!(
         group_rows_of_current_manifest(&store, &namespace_id, group).await,
@@ -922,12 +1001,7 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
 
     // The uninterrupted run, for the comparison.
     let spec = compaction_spec_for_group(&straight_store, &namespace_id, group).await;
-    let snapshot = snapshot_runs_for_group(
-        load_current_manifest_tables(&straight_store, &namespace_id)
-            .await
-            .manifest(),
-        group,
-    );
+    let snapshot_keys = snapshot_keys_now(&straight_store, &namespace_id, &spec).await;
     let MetadataCompactionOutcome::Completed(straight_result) = run_compaction(
         &straight_store,
         &namespace_id,
@@ -939,11 +1013,11 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
     else {
         panic!("nothing cancelled this job");
     };
-    finalize_streaming_compaction(
+    publish_streaming_compaction(
         &straight_store,
         &namespace_id,
         &spec,
-        &snapshot,
+        &snapshot_keys,
         &straight_result,
     )
     .await;
@@ -1007,12 +1081,7 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
     // The re-run from the same spec, against the same durable state.
     let store = LocalFsStore::new(interrupted_dir.path()).expect("store");
     let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
-    let snapshot = snapshot_runs_for_group(
-        load_current_manifest_tables(&store, &namespace_id)
-            .await
-            .manifest(),
-        group,
-    );
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
     let MetadataCompactionOutcome::Completed(result) = run_compaction(
         &store,
         &namespace_id,
@@ -1038,7 +1107,7 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
         .iter()
         .map(|descriptor| descriptor.object_key.clone())
         .collect();
-    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+    publish_streaming_compaction(&store, &namespace_id, &spec, &snapshot_keys, &result).await;
 
     assert_eq!(
         group_rows_of_current_manifest(&store, &namespace_id, group).await,
@@ -1189,12 +1258,7 @@ async fn one_directory_far_past_the_row_budget_streams_a_slot_at_a_time() {
     );
 
     let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
-    let snapshot = snapshot_runs_for_group(
-        load_current_manifest_tables(&store, &namespace_id)
-            .await
-            .manifest(),
-        group,
-    );
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
     let MetadataCompactionOutcome::Completed(result) = run_compaction(
         &store,
         &namespace_id,
@@ -1212,7 +1276,7 @@ async fn one_directory_far_past_the_row_budget_streams_a_slot_at_a_time() {
         result.peak_locality_rows
     );
 
-    finalize_streaming_compaction(&store, &namespace_id, &spec, &snapshot, &result).await;
+    publish_streaming_compaction(&store, &namespace_id, &spec, &snapshot_keys, &result).await;
     assert_eq!(
         group_rows_of_current_manifest(&store, &namespace_id, group).await,
         folded,
@@ -1230,5 +1294,524 @@ async fn one_directory_far_past_the_row_budget_streams_a_slot_at_a_time() {
         snapshot_runs_for_group(tables.manifest(), group).len(),
         1,
         "the job must leave the group in one run"
+    );
+}
+
+// -------------------------------------------------------------------------
+// The whole arc, through the step the maintenance runner calls
+// -------------------------------------------------------------------------
+
+/// The unbind rows a floor covers, which is the churn a rebuild reclaims.
+fn unbinds_at_or_below(
+    rows: &BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>>,
+    floor_seq: ChangeSeq,
+) -> usize {
+    rows[&ApiMetadataTableFamily::DirentryUnbinds]
+        .iter()
+        .filter(|row| {
+            matches!(row, MetadataRow::DirentryUnbind { unbind_seq, .. } if *unbind_seq <= floor_seq)
+        })
+        .count()
+}
+
+/// The group's segments the manifest holds outside a spec's input runs: the
+/// runs that arrived after the job was planned.
+async fn group_segments_outside_the_job<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+    group: MetadataFamilyGroup,
+) -> BTreeSet<String> {
+    let inputs: BTreeSet<(ChangeSeq, u32)> = spec.inputs().iter().copied().collect();
+    load_current_manifest_tables(store, namespace_id)
+        .await
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| {
+            group.contains(descriptor.family)
+                && !inputs.contains(&(descriptor.run_seq, descriptor.level))
+        })
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect()
+}
+
+/// Every object key the current manifest references.
+async fn referenced_segment_keys<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> BTreeSet<String> {
+    load_current_manifest_tables(store, namespace_id)
+        .await
+        .manifest()
+        .payload
+        .metadata_files
+        .iter()
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect()
+}
+
+/// The whole arc, driven through the entry point the maintenance runner
+/// calls.
+///
+/// A group past the budgets with churn below the floor is handed to a job.
+/// The runner starts that job and goes on stepping; here the steps and the job
+/// run in one task, which is the same interleaving with the timing taken out.
+/// While the job is in flight the other groups keep folding, no step touches
+/// the job's group, a run arrives above the job's snapshot and survives its
+/// publication, the loader accepts the manifest every step leaves, and a read
+/// answers the same thing throughout. The job then publishes, the group ends
+/// in one base run, and the churn the floor covered is gone.
+#[tokio::test]
+async fn an_over_budget_group_is_rebuilt_by_a_job_while_maintenance_carries_on() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
+    let floor_seq = read_floor_seq(&store, &namespace_id).await;
+    let rows_before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    assert!(
+        unbinds_at_or_below(&rows_before, floor_seq) > 0,
+        "the seed must leave churn the floor covers, or a rebuild reclaims nothing"
+    );
+    let mut visible = visible_namespace(&store, &namespace_id).await;
+    assert!(
+        visible.iter().any(|state| state.visible),
+        "the seed must leave something to read"
+    );
+
+    let mut active: Option<MetadataCompactionSpec> = None;
+    let mut steps_with_a_job_running = 0usize;
+    let mut other_groups_folded = 0usize;
+    let mut arrived_keys = BTreeSet::new();
+    let mut published_jobs = 0usize;
+    let mut settled = false;
+
+    for _step in 0..64 {
+        let report = super::super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &context,
+            policy,
+            active.as_ref(),
+        )
+        .await
+        .expect("maintenance step");
+        match report.outcome {
+            MetadataReorganizeOutcome::UnitPublished { ref families, .. } => {
+                if active.is_some() {
+                    assert_ne!(
+                        families.as_slice(),
+                        group.families(),
+                        "no step may merge the group a job is rebuilding"
+                    );
+                    other_groups_folded += 1;
+                }
+            }
+            MetadataReorganizeOutcome::CompactionPlanned {
+                ref families,
+                ref spec,
+            } => {
+                // One job at a time per namespace: a plan that arrives while
+                // one runs is reported and skipped, which is what the runner
+                // does with it.
+                if active.is_none() {
+                    assert_eq!(
+                        families.as_slice(),
+                        group.families(),
+                        "this budget starves this group first"
+                    );
+                    active = Some(spec.clone());
+                    if arrived_keys.is_empty() {
+                        // A run arrives while the first job runs. It is
+                        // outside that job's snapshot, so the job never reads
+                        // it and the publication must land underneath it.
+                        write_file_bytes(
+                            &store,
+                            &namespace_id,
+                            "/arrived-mid-job.txt",
+                            b"arrived while the job ran\n",
+                            &context,
+                            None,
+                        )
+                        .await
+                        .expect("write a file while the job runs");
+                        create_checkpoint(&store, &namespace_id, &context)
+                            .await
+                            .expect("checkpoint it");
+                        arrived_keys =
+                            group_segments_outside_the_job(&store, &namespace_id, spec, group)
+                                .await;
+                        assert!(
+                            !arrived_keys.is_empty(),
+                            "the arriving run must sit outside the job's input"
+                        );
+                        visible = visible_namespace(&store, &namespace_id).await;
+                    }
+                }
+            }
+            MetadataReorganizeOutcome::Superseded => {
+                panic!("no concurrent publisher exists in this test")
+            }
+            MetadataReorganizeOutcome::NotNeeded { .. } if active.is_none() => {
+                settled = true;
+                break;
+            }
+            MetadataReorganizeOutcome::NotNeeded { .. } => {}
+        }
+
+        // Every step leaves a manifest the loader accepts and a read
+        // answering exactly what it answered before.
+        assert_eq!(
+            visible_namespace(&store, &namespace_id).await,
+            visible,
+            "a step changed what a read answers"
+        );
+
+        // The runner has the job running in another task. Waiting a few steps
+        // and then running it here is the same interleaving with the timing
+        // taken out: the steps in between did ordinary work against a
+        // manifest that holds the job's whole input.
+        if let Some(spec) = active.clone() {
+            steps_with_a_job_running += 1;
+            if steps_with_a_job_running % 3 == 0 {
+                publish_planned_compaction(&store, &namespace_id, &context, policy, &spec).await;
+                published_jobs += 1;
+                active = None;
+                if published_jobs == 1 {
+                    let referenced = referenced_segment_keys(&store, &namespace_id).await;
+                    assert!(
+                        arrived_keys.is_subset(&referenced),
+                        "the run that arrived while the job ran must survive its publication"
+                    );
+                }
+                assert_eq!(
+                    visible_namespace(&store, &namespace_id).await,
+                    visible,
+                    "the job's publication changed what a read answers"
+                );
+            }
+        }
+    }
+
+    assert!(published_jobs > 0, "the group must be rebuilt by a job");
+    assert!(
+        other_groups_folded > 0,
+        "ordinary maintenance must keep folding while a job runs"
+    );
+    assert!(settled, "maintenance must settle with nothing left to fold");
+
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let base_runs = snapshot_runs_for_group(tables.manifest(), group)
+        .into_iter()
+        .filter(|run| run.level == CHECKPOINT_BASE_RUN_LEVEL)
+        .count();
+    drop(tables);
+    assert_eq!(base_runs, 1, "the group must end in one base run");
+
+    let rows_after = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    assert_eq!(
+        unbinds_at_or_below(&rows_after, floor_seq),
+        0,
+        "every unbind the floor covered must be gone"
+    );
+    assert!(
+        rows_after.values().map(Vec::len).sum::<usize>()
+            < rows_before.values().map(Vec::len).sum::<usize>(),
+        "the rebuild must reclaim rows"
+    );
+}
+
+/// Runs steps until one hands a group to a job, and answers with that plan.
+///
+/// A step folds the group with the most L0 rows, so the starved group is
+/// reached after the groups that still fit have folded.
+async fn step_until_a_compaction_is_planned<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+    policy: MetadataLsmPolicy,
+) -> MetadataCompactionSpec {
+    for _step in 0..64 {
+        let report =
+            super::super::reorganize_metadata_step(store, namespace_id, context, policy, None)
+                .await
+                .expect("maintenance step");
+        match report.outcome {
+            MetadataReorganizeOutcome::CompactionPlanned { spec, .. } => return spec,
+            MetadataReorganizeOutcome::UnitPublished { .. } => {}
+            other => panic!("expected a plan or a merge, got {other:?}"),
+        }
+    }
+    panic!("no step handed a group to a job")
+}
+
+/// The crash variant of the same arc: the job dies mid-run, and the next step
+/// plans it again.
+///
+/// Nothing durable records that a job was running, so a process that dies —
+/// or a shutdown that cancels — costs the work and nothing else. What a read
+/// answers has not moved, the manifest has not moved, the segments the attempt
+/// wrote are staged and named by nothing, and the step after it plans the
+/// group again and the second attempt finishes.
+#[tokio::test]
+async fn a_job_that_dies_mid_run_leaves_orphans_and_the_next_step_plans_it_again() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_bindings_workload(
+        &LocalFsStore::new(temp_dir.path()).expect("store"),
+        &namespace_id,
+    )
+    .await;
+    let group = MetadataFamilyGroup::Bindings;
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
+
+    let spec = step_until_a_compaction_is_planned(&store, &namespace_id, &context, policy).await;
+    let visible = visible_namespace(&store, &namespace_id).await;
+    let manifest_before = current_manifest_object_id(&store, &namespace_id).await;
+
+    // The attempt dies partway through, which is what a cancellation and a
+    // kill leave behind alike: staged segments and nothing else. The
+    // cancellation lands after a number of reads rather than at a boundary
+    // the test picked, so several thresholds are tried until one lands after
+    // the job has written something.
+    let mut orphans = BTreeSet::new();
+    for reads_before_cancel in [8usize, 16, 24, 32] {
+        let cancellation = MetadataCompactionCancellation::default();
+        let dying_store = CancelAfterReadsStore {
+            inner: LocalFsStore::new(temp_dir.path()).expect("store"),
+            cancellation: cancellation.clone(),
+            reads_before_cancel,
+            reads: AtomicUsize::new(0),
+        };
+        let outcome = run_metadata_compaction_job(
+            &dying_store,
+            &namespace_id,
+            &context,
+            policy,
+            &spec,
+            &cancellation,
+        )
+        .await
+        .expect("run the job");
+        assert_eq!(
+            outcome,
+            MetadataCompactionJobOutcome::Cancelled,
+            "the cancellation must land before the job finishes"
+        );
+        assert_eq!(
+            current_manifest_object_id(&store, &namespace_id).await,
+            manifest_before,
+            "a job that died must publish nothing"
+        );
+        assert_eq!(
+            visible_namespace(&store, &namespace_id).await,
+            visible,
+            "and must leave what a read answers exactly where it was"
+        );
+        orphans.extend(staged_object_keys(&store, &namespace_id).await);
+        if !orphans.is_empty() {
+            break;
+        }
+    }
+    assert!(
+        !orphans.is_empty(),
+        "an attempt must leave the segments it had written staged"
+    );
+    let referenced = referenced_segment_keys(&store, &namespace_id).await;
+    assert!(
+        orphans.is_disjoint(&referenced),
+        "and nothing may reference them"
+    );
+
+    // The next step plans the group again, and the second attempt finishes.
+    let spec = step_until_a_compaction_is_planned(&store, &namespace_id, &context, policy).await;
+    publish_planned_compaction(&store, &namespace_id, &context, policy, &spec).await;
+
+    assert_eq!(
+        visible_namespace(&store, &namespace_id).await,
+        visible,
+        "the rebuild must leave what a read answers where it was"
+    );
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let runs = snapshot_runs_for_group(tables.manifest(), group);
+    drop(tables);
+    assert_eq!(runs.len(), 1, "the group must end in one run");
+    assert_eq!(runs[0].level, CHECKPOINT_BASE_RUN_LEVEL);
+    // The first attempt's segments are still staged and still named by
+    // nothing: orphans for the collector, not state anything reads.
+    let referenced = referenced_segment_keys(&store, &namespace_id).await;
+    let staged_now = staged_object_keys(&store, &namespace_id).await;
+    assert!(orphans.is_subset(&staged_now));
+    assert!(orphans.is_disjoint(&referenced));
+}
+
+/// Publishes a competing manifest the first time the finalizer writes its
+/// replacement manifest object.
+///
+/// That is the window the retry is for: the finalizer has reloaded the root
+/// and decided its swap, and a flush lands before its compare-and-swap does.
+#[derive(Debug)]
+struct FlushDuringFinalizationStore {
+    inner: LocalFsStore,
+    namespace_id: NamespaceId,
+    flushed: AtomicUsize,
+}
+
+#[async_trait]
+impl ObjectStore for FlushDuringFinalizationStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key.ends_with(".manifest.json") && self.flushed.fetch_add(1, Ordering::SeqCst) == 0 {
+            super::super::flush::flush_wal(&self.inner, &self.namespace_id, &test_context())
+                .await
+                .expect("the competing flush must publish");
+        }
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// A flush that lands while a job is finalizing does not cost the job.
+///
+/// The finalizer reloads, checks that its input is still exactly what it read,
+/// and publishes on top of the flush. The flush's own run survives, because it
+/// arrived above the job's snapshot and the swap replaces only what the
+/// snapshot held.
+#[tokio::test]
+async fn a_flush_landing_during_finalization_is_retried_over() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_bindings_workload(
+        &LocalFsStore::new(temp_dir.path()).expect("store"),
+        &namespace_id,
+    )
+    .await;
+    let group = MetadataFamilyGroup::Bindings;
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job");
+    };
+
+    // A write with no checkpoint behind it leaves a WAL tail, which is what
+    // the competing flush publishes.
+    let visible_before = visible_namespace(&store, &namespace_id).await;
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/raced-the-finalizer.txt",
+        b"raced the finalizer\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write a file the flush will publish");
+
+    let racing_store = FlushDuringFinalizationStore {
+        inner: LocalFsStore::new(temp_dir.path()).expect("store"),
+        namespace_id: namespace_id.clone(),
+        flushed: AtomicUsize::new(0),
+    };
+    let manifest_id = match finalize_streaming_compaction(
+        &racing_store,
+        &namespace_id,
+        &spec,
+        &snapshot_keys,
+        &result,
+    )
+    .await
+    {
+        Finalization::Published(manifest_id) => manifest_id,
+        other => panic!("the retry must publish, got {other:?}"),
+    };
+    assert!(
+        racing_store.flushed.load(Ordering::SeqCst) > 1,
+        "the finalizer must have written a replacement manifest more than once"
+    );
+
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    assert_eq!(tables.manifest().payload.manifest_id, manifest_id);
+    let runs = snapshot_runs_for_group(tables.manifest(), group);
+    drop(tables);
+    // Two runs: the base run the job built, and the delta run the flush
+    // published above the job's snapshot. The flush's run survives because
+    // the swap replaces only what the snapshot held.
+    assert_eq!(
+        runs.iter()
+            .filter(|run| run.level == CHECKPOINT_BASE_RUN_LEVEL)
+            .count(),
+        1,
+        "the group must end in one base run"
+    );
+    assert_eq!(
+        runs.iter()
+            .filter(|run| run.level == CHECKPOINT_L0_RUN_LEVEL)
+            .count(),
+        1,
+        "the flush's run must survive the swap"
+    );
+    // Nothing the job rebuilt moved, and the file the flush published is
+    // there: the swap replaced its own snapshot and preserved the rest.
+    let visible_after = visible_namespace(&store, &namespace_id).await;
+    assert_eq!(
+        visible_after.len(),
+        visible_before.len() + 1,
+        "the swap must leave the flush's file and nothing else new"
+    );
+    assert_eq!(
+        &visible_after[..visible_before.len()],
+        visible_before.as_slice(),
+        "the swap must not move anything a read already answered"
+    );
+    assert!(
+        visible_after.last().expect("the flush's file").visible,
+        "the file the flush published must be visible after the swap"
     );
 }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -828,12 +828,47 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     /// calling this from maintenance is what keeps read fan-out bounded.
     /// Repeat until the report says `NotNeeded`; every call re-reads durable
     /// state, so interrupted reorganizations resume from the live manifest.
-    pub async fn reorganize_metadata(&self) -> Result<crate::checkpoint::MetadataReorganizeReport> {
+    ///
+    /// A group whose oldest run no longer fits one unit is reported as
+    /// [`MetadataReorganizeOutcome::CompactionPlanned`] instead. The caller
+    /// runs that plan with [`Self::run_metadata_compaction`] as a background
+    /// job and hands its spec back here as `active_compaction` for as long as
+    /// the job runs, so no unit merges the group underneath it.
+    pub async fn reorganize_metadata(
+        &self,
+        active_compaction: Option<&crate::checkpoint::MetadataCompactionSpec>,
+    ) -> Result<crate::checkpoint::MetadataReorganizeReport> {
         crate::checkpoint::reorganize_metadata_step(
             &self.store,
             &self.namespace_id,
             &self.mutation_context()?,
             crate::checkpoint::MetadataLsmPolicy::default(),
+            active_compaction,
+        )
+        .await
+    }
+
+    /// Rebuilds one family group in a single streaming pass and publishes the
+    /// swap, from a plan [`Self::reorganize_metadata`] produced.
+    ///
+    /// Long-running by design and paced by no budget: it is the caller's
+    /// background work, not a bounded step. `cancellation` stops it between
+    /// block fetches, which is what a graceful shutdown sets. Every ending
+    /// short of a publication costs only the work done — the manifest never
+    /// moved, the segments it wrote are staged and referenced by nothing, and
+    /// a later step plans the group again.
+    pub async fn run_metadata_compaction(
+        &self,
+        spec: &crate::checkpoint::MetadataCompactionSpec,
+        cancellation: &crate::checkpoint::MetadataCompactionCancellation,
+    ) -> Result<crate::checkpoint::MetadataCompactionJobOutcome> {
+        crate::checkpoint::run_metadata_compaction_job(
+            &self.store,
+            &self.namespace_id,
+            &self.mutation_context()?,
+            crate::checkpoint::MetadataLsmPolicy::default(),
+            spec,
+            cancellation,
         )
         .await
     }

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -6,8 +6,8 @@ use loonfs_api::{
     PageCursor,
 };
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_manifest_prefix, metadata_table_prefix, upload_session_prefix,
-    wal_segment_prefix,
+    checkpoint_prefix, metadata_compaction_staging_prefix, metadata_manifest_prefix,
+    metadata_table_prefix, upload_session_prefix, wal_segment_prefix,
 };
 use serde::{Deserialize, Serialize};
 
@@ -16,15 +16,21 @@ use serde::{Deserialize, Serialize};
 pub(super) enum CandidateFamily {
     WalSegments,
     MetadataTables,
+    /// Metadata segments a streaming compaction wrote. Its own family
+    /// because it ages on its own window: a job outlives the ordinary grace
+    /// window, so its output would read as an aged orphan while it was still
+    /// being written.
+    CompactionStaging,
     Manifests,
     Checkpoints,
     UploadSessions,
 }
 
 impl CandidateFamily {
-    pub(super) const ALL: [Self; 5] = [
+    pub(super) const ALL: [Self; 6] = [
         Self::WalSegments,
         Self::MetadataTables,
+        Self::CompactionStaging,
         Self::Manifests,
         Self::Checkpoints,
         Self::UploadSessions,
@@ -42,6 +48,7 @@ impl CandidateFamily {
         match self {
             Self::WalSegments => wal_segment_prefix(namespace_id.as_str()),
             Self::MetadataTables => metadata_table_prefix(namespace_id.as_str()),
+            Self::CompactionStaging => metadata_compaction_staging_prefix(namespace_id.as_str()),
             Self::Manifests => metadata_manifest_prefix(namespace_id.as_str()),
             Self::Checkpoints => checkpoint_prefix(namespace_id.as_str()),
             Self::UploadSessions => upload_session_prefix(namespace_id.as_str()),

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -14,6 +14,7 @@ use super::reap::{
 use super::uploads::{sweep_upload_session, ContentReferences, UploadSessionSweep};
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
+use crate::limits::METADATA_COMPACTION_STAGING_GRACE_MS;
 use crate::namespace::basis::read_head_and_metadata_basis;
 use crate::namespace::control::ControlObjectLoadError;
 use futures::StreamExt;
@@ -246,7 +247,11 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     // immediately before its decision.
     let selected = match family {
         CandidateFamily::WalSegments => !mark.protects_wal_segment(key),
-        CandidateFamily::MetadataTables => !mark.tables.contains(key),
+        // A staged segment a publication landed is named by the manifest like
+        // any other table, so the same root set answers for both families.
+        CandidateFamily::MetadataTables | CandidateFamily::CompactionStaging => {
+            !mark.tables.contains(key)
+        }
         CandidateFamily::Manifests => match manifest_object_id_of(key) {
             Some(Ok(id)) => !mark.manifests.contains(&id),
             // A key that names no readable manifest is reachable from no
@@ -275,17 +280,28 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
         CandidateFamily::WalSegments => {
             if sweep.live.protects_wal_segment(key) {
                 report.retain(RetainedReason::Referenced);
-            } else if sweep_aged(store, key, config, context, sweep, report).await? {
+            } else if sweep_aged(store, key, config.grace_window_ms, context, sweep, report).await?
+            {
                 report.deleted_wal_segments += 1;
             }
         }
-        CandidateFamily::MetadataTables => {
+        // Both families hold metadata segments and both are counted as
+        // metadata tables. What differs is the window an unreferenced one
+        // ages under: a staged segment belongs to a job that publishes
+        // nothing until it finishes, and a job is allowed to run for a long
+        // time, so reaping one on the ordinary window would delete the output
+        // of a job still writing it.
+        CandidateFamily::MetadataTables | CandidateFamily::CompactionStaging => {
+            let grace_window_ms = match family {
+                CandidateFamily::CompactionStaging => METADATA_COMPACTION_STAGING_GRACE_MS,
+                _ => config.grace_window_ms,
+            };
             // Rule 5 is sticky across every re-collection in this pass.
             if sweep.degraded {
                 report.retain(RetainedReason::DegradedRoots);
             } else if sweep.live.tables.contains(key) {
                 report.retain(RetainedReason::Referenced);
-            } else if sweep_aged(store, key, config, context, sweep, report).await? {
+            } else if sweep_aged(store, key, grace_window_ms, context, sweep, report).await? {
                 report.deleted_metadata_tables += 1;
             }
         }
@@ -298,7 +314,9 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
                         report.retain(RetainedReason::Referenced);
                     }
                     Some(Ok(_)) => {
-                        if sweep_aged(store, key, config, context, sweep, report).await? {
+                        if sweep_aged(store, key, config.grace_window_ms, context, sweep, report)
+                            .await?
+                        {
                             report.deleted_manifests += 1;
                         }
                     }
@@ -322,21 +340,26 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
 /// deletions.
 ///
 /// Two things have to hold before the key goes. The object's own write time
-/// has to be a grace window old, which is what protects a publication still
-/// in flight and every object the reference anchor predates. And the
+/// has to be `grace_window_ms` old, which is what protects a publication
+/// still in flight and every object the reference anchor predates. And the
 /// reference anchor has to say the object was already unreferenced when the
 /// window opened, which is what protects a reader still holding an anchor it
 /// pinned inside the window. A pass with no anchor cannot answer the second
 /// question, so it keeps every aged candidate and says so.
+///
+/// The window is a parameter because one family does not use the configured
+/// one: compaction staging holds the output of a job that publishes nothing
+/// until it finishes, and it ages under
+/// [`METADATA_COMPACTION_STAGING_GRACE_MS`] instead.
 async fn sweep_aged<S: ObjectStore + ?Sized>(
     store: &S,
     key: &str,
-    config: &GcConfig,
+    grace_window_ms: u64,
     context: &MutationContext,
     sweep: &SweepVerifier,
     report: &mut GcResponse,
 ) -> Result<bool> {
-    match grace_age(store, key, config.grace_window_ms, context.now_ms)
+    match grace_age(store, key, grace_window_ms, context.now_ms)
         .await
         .map_err(|error| CoreError::store(key, &error))?
     {

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -6,13 +6,15 @@ use super::live_set::{recollect_live_set, LiveSet};
 use super::run::{gc_namespace, gc_namespace_with_reverify_chunk};
 use crate::checkpoint::advance_retention_floor;
 use crate::checkpoint::record::release_checkpoint_record;
-use crate::checkpoint::tests::{create_checkpoint, mutation_context, write_test_file};
+use crate::checkpoint::tests::{
+    compact_a_family_group_into_staging, create_checkpoint, mutation_context, write_test_file,
+};
 use crate::commit_engine::{CommitCandidate, NamespaceCommitEngine};
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::limits::{
     CONTENT_RECLAMATION_GRACE_MS, FORK_CHECKPOINT_LEASE_MS, GC_MIN_GRACE_WINDOW_MS,
-    UPLOAD_SESSION_LEASE_MS,
+    METADATA_COMPACTION_STAGING_GRACE_MS, UPLOAD_SESSION_LEASE_MS,
 };
 use crate::path::write::{CommitRequest, FilesystemOperation};
 use loonfs_api::v0::GcResponse;
@@ -22,8 +24,9 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::{ContentRef, ContentStoreId, NamespaceId, UploadId};
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_manifest_object, metadata_manifest_prefix, metadata_root,
-    metadata_table, metadata_table_prefix, wal_head, wal_segment, wal_segment_prefix,
+    checkpoint_prefix, metadata_compaction_staging_table, metadata_manifest_object,
+    metadata_manifest_prefix, metadata_root, metadata_table, metadata_table_prefix, wal_head,
+    wal_segment, wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
@@ -1866,10 +1869,15 @@ async fn fold_metadata<S: ObjectStore + ?Sized>(
     };
     let mut folded = false;
     for _ in 0..16 {
-        let report =
-            crate::checkpoint::reorganize_metadata_step(store, namespace_id, context, fold_policy)
-                .await
-                .expect("reorganize step");
+        let report = crate::checkpoint::reorganize_metadata_step(
+            store,
+            namespace_id,
+            context,
+            fold_policy,
+            None,
+        )
+        .await
+        .expect("reorganize step");
         if matches!(
             report.outcome,
             crate::checkpoint::MetadataReorganizeOutcome::NotNeeded { .. }
@@ -1959,6 +1967,140 @@ fn reason_total(report: &GcResponse) -> u64 {
         .into_iter()
         .map(|(_, count)| count)
         .sum()
+}
+
+/// A streaming compaction's staged segments age under a window of their own.
+///
+/// The job publishes nothing until it finishes and it has no time budget, so
+/// its output is unreferenced for as long as it runs. Under the ordinary
+/// window the collector would reap a job's segments while it was still writing
+/// them. Under the staging window it reaps them only once no job could still
+/// be alive, and a job that died leaves exactly those orphans.
+#[tokio::test]
+async fn a_staged_compaction_segment_ages_under_the_staging_window() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&inner, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    crate::checkpoint::flush_wal(&inner, &namespace_id, &setup)
+        .await
+        .expect("flush wal");
+
+    // The namespace ages past the window, so the pass has an anchor. The
+    // staged segment below is written after it, the way a job's output is.
+    let published = namespace_key_set(&inner, &namespace_id).await;
+    let store = aged_before_now(inner, published);
+    let staged_key = metadata_compaction_staging_table(
+        namespace_id.as_str(),
+        "tbl_0123456789abcdef0123456789abcdef",
+    );
+    store
+        .put_if_absent(&staged_key, Bytes::from_static(b"staged segment"))
+        .await
+        .expect("write a staged segment");
+
+    // Long past the ordinary window, which is where a job would still be
+    // running and this segment would still be its output.
+    let running =
+        context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
+    let report = gc_namespace(&store, &namespace_id, &config(), &running)
+        .await
+        .expect("gc pass while a job could still be running");
+    assert_eq!(
+        report.deleted_metadata_tables, 0,
+        "a running job's output must not be reaped"
+    );
+    assert_eq!(report.retained.grace_window, 1);
+    assert!(store
+        .head(&staged_key)
+        .await
+        .expect("head the staged segment")
+        .is_some());
+
+    // Past the staging window, where no job can still be alive, the same
+    // object is the orphan a dead job left.
+    let dead = context(
+        now_after_newest_object(
+            store.inner(),
+            &namespace_id,
+            METADATA_COMPACTION_STAGING_GRACE_MS + 1,
+        )
+        .await,
+    );
+    let report = gc_namespace(&store, &namespace_id, &config(), &dead)
+        .await
+        .expect("gc pass once no job could still be running");
+    assert_eq!(
+        report.deleted_metadata_tables, 1,
+        "a dead job's orphan must be reaped"
+    );
+    assert!(store
+        .head(&staged_key)
+        .await
+        .expect("head the staged segment")
+        .is_none());
+}
+
+/// A published job's output is an ordinary referenced table. The manifest
+/// names it where it sits, so the sweep protects it for the same reason it
+/// protects every other table, and no window ever applies to it.
+#[tokio::test]
+async fn a_published_compactions_staged_segments_are_referenced_and_kept() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    for index in 0..4 {
+        write_test_file(
+            &store,
+            &namespace_id,
+            &format!("/docs/{index}.txt"),
+            &format!("gc-body-{index}"),
+            &setup,
+        )
+        .await;
+        // Flushes rather than checkpoints: a checkpoint pins the manifest it
+        // published, and a pinned manifest protects its tables forever, which
+        // would leave this pass nothing to reap and nothing to prove.
+        crate::checkpoint::flush_wal(&store, &namespace_id, &setup)
+            .await
+            .expect("flush wal");
+    }
+    let staged = compact_a_family_group_into_staging(&store, &namespace_id, &setup).await;
+
+    // Far past every window this collector knows, including the staging one.
+    let long_after = context(
+        now_after_newest_object(
+            &store,
+            &namespace_id,
+            METADATA_COMPACTION_STAGING_GRACE_MS * 4,
+        )
+        .await,
+    );
+    let report = gc_namespace(&store, &namespace_id, &config(), &long_after)
+        .await
+        .expect("gc pass long after the job published");
+    assert!(
+        report.deleted_metadata_tables > 0,
+        "the pass must have reaped the runs the job replaced, or it proves nothing"
+    );
+    for key in &staged {
+        assert!(
+            store
+                .head(key)
+                .await
+                .expect("head a staged segment")
+                .is_some(),
+            "a published job's segment must survive every window"
+        );
+    }
 }
 
 /// The write-time arm is what covers an object the reference manifest
@@ -2380,10 +2522,15 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
         ..Default::default()
     };
     for _ in 0..16 {
-        let report =
-            crate::checkpoint::reorganize_metadata_step(&store, &namespace_id, &setup, fold_policy)
-                .await
-                .expect("reorganize step");
+        let report = crate::checkpoint::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &setup,
+            fold_policy,
+            None,
+        )
+        .await
+        .expect("reorganize step");
         if matches!(
             report.outcome,
             crate::checkpoint::MetadataReorganizeOutcome::NotNeeded { .. }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -177,7 +177,8 @@ pub mod publish {
 // `MetadataReorganizeReport` has no caller that names it; it stays public
 // because it is the return type of `NamespaceEngine::reorganize_metadata`.
 pub use checkpoint::{
-    CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, MetadataReorganizeOutcome,
+    CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, MetadataCompactionCancellation,
+    MetadataCompactionJobOutcome, MetadataCompactionSpec, MetadataReorganizeOutcome,
     MetadataReorganizeReport,
 };
 pub use context::MutationContext;

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -107,6 +107,26 @@ pub const GC_SAFETY_MARGIN_MS: u64 = 3 * 60 * 1000;
 /// Default candidate budget for one step-driven garbage-collection pass.
 pub const DEFAULT_GC_MAX_OBJECTS: u64 = 1024;
 
+/// Grace a streaming compaction's staged segments get before garbage
+/// collection may reap one as an orphan (format spec, "Garbage collection",
+/// rule 12).
+///
+/// A staged segment is unreferenced for as long as its job runs, and the job
+/// has no time budget at all: it rebuilds a whole family group, which is the
+/// work no per-step budget could hold. The ordinary grace window only has to
+/// cover a publication in flight, so it is far too short here — a pass would
+/// reap the output of a job still writing it.
+///
+/// This window is a liveness bound and not a correctness one. A job that
+/// publishes leaves its segments named by the manifest, and a referenced
+/// object is live wherever it sits, so nothing this window protects is
+/// needed once the publication lands. Being generous costs storage for
+/// orphans a crash left behind; being tight costs a job that was nearly done.
+/// So it is one day, spelled as the number of metadata publication budgets
+/// that fit in one: a job that has not finished within that many is not one a
+/// restart is going to shorten.
+pub const METADATA_COMPACTION_STAGING_GRACE_MS: u64 = 96 * METADATA_PUBLICATION_BUDGET_MS;
+
 const fn max_u64(left: u64, right: u64) -> u64 {
     if left > right {
         left
@@ -293,6 +313,19 @@ mod tests {
                     METADATA_PUBLICATION_BUDGET_MS,
                 ) + PROVIDER_OPERATION_DEADLINE_MS,
             "the floor keeps a margin above budget plus provider deadline"
+        );
+    }
+
+    /// The staging window has to outlast a job, and a job is allowed to be
+    /// long. Anything near the ordinary window would reap a job's output
+    /// while it was still writing it.
+    #[test]
+    fn the_compaction_staging_grace_is_a_day_of_publication_budgets() {
+        assert_eq!(METADATA_COMPACTION_STAGING_GRACE_MS, 24 * 60 * 60 * 1000);
+        assert!(
+            METADATA_COMPACTION_STAGING_GRACE_MS
+                > 10 * max_u64(GC_MIN_GRACE_WINDOW_MS, GcConfig::default().grace_window_ms),
+            "an orphan's window must be nothing like the window that covers a publication"
         );
     }
 }

--- a/crates/loonfs-core/tests/it/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/it/visibility_equivalence.rs
@@ -875,7 +875,7 @@ async fn drain_reorganization(
     for _ in 0..16 {
         let report = harness
             .engine
-            .reorganize_metadata()
+            .reorganize_metadata(None)
             .await
             .expect("reorganize metadata");
         match report.outcome {
@@ -893,7 +893,7 @@ async fn drain_reorganization(
             MetadataReorganizeOutcome::Superseded => {
                 panic!("single-writer test must not supersede reorganization")
             }
-            MetadataReorganizeOutcome::BudgetExhausted { .. } => {
+            MetadataReorganizeOutcome::CompactionPlanned { .. } => {
                 panic!("default budget must admit the visibility scenario")
             }
         }

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -26,8 +26,9 @@ use loonfs_grep::{
     GrepReorganizeOutcome, GrepService, GrepWorker, GREP_GC_GRACE_WINDOW_MS,
 };
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, checkpoint_record, metadata_manifest_object, metadata_manifest_prefix,
-    metadata_table_prefix, upload_session_prefix, wal_segment_prefix,
+    checkpoint_prefix, checkpoint_record, metadata_compaction_staging_prefix,
+    metadata_manifest_object, metadata_manifest_prefix, metadata_table_prefix,
+    upload_session_prefix, wal_segment_prefix,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
@@ -1911,6 +1912,7 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
             metadata_manifest_prefix(live_namespace.as_str()),
             wal_segment_prefix(live_namespace.as_str()),
             metadata_table_prefix(live_namespace.as_str()),
+            metadata_compaction_staging_prefix(live_namespace.as_str()),
             metadata_manifest_prefix(live_namespace.as_str()),
             checkpoint_prefix(live_namespace.as_str()),
             upload_session_prefix(live_namespace.as_str()),

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -380,6 +380,56 @@ all. Any other value fails the process rather than being guessed at.
 and leaves the rest alone. `LOONFS_TRACE=off` silences the output whatever
 `RUST_LOG` says.
 
+### Metadata rebuilds that run in the background
+
+Background maintenance rewrites a namespace's metadata into fewer files as it
+goes. It does that one group of metadata at a time, and one maintenance step
+reads a whole group. A group that has grown past what one step may read is
+handled differently, and it logs a few lines worth knowing.
+
+The first is a warning saying that the oldest metadata run in a family group
+no longer fits one reorganization step. It names the group, the run, how many
+rows and bytes that run holds, and the two per-step budgets it did not fit. It
+means the namespace has grown, not that anything is wrong.
+
+What follows it is `a family group outgrew one reorganization step; a
+streaming metadata compaction is rebuilding it`. That is a background job the
+server starts and does not wait for. It reads every file the group holds,
+writes the rebuilt group as it goes, and publishes the result in one step at
+the end. A large group can keep it busy for a long time, and it logs
+`streaming metadata compaction progress` as it works so you can see it moving.
+`streaming metadata compaction rebuilt a family group` is the line that says
+it landed.
+
+Nothing needs doing about any of this. While the job runs, ordinary
+maintenance carries on: the WAL still flushes, the other groups still fold,
+and reads answer exactly the same thing from the first line to the last. One
+job runs at a time per namespace, so a second group in the same state waits
+its turn and says so.
+
+A restart during a rebuild loses that rebuild's work, and this is expected.
+Nothing durable records that a job was running: the published metadata never
+moved, the files the job had written are referenced by nothing, and the next
+maintenance step starts the job again from what the namespace holds by then.
+The abandoned files sit under
+`namespaces/{namespace}/metadata/compaction-staging/` and garbage collection
+reclaims them a day later, which is a deliberately generous wait so that a
+collection pass can never delete the output of a job that is still running.
+The same is true of a graceful shutdown, which cancels a running job rather
+than waiting for it.
+
+Two lines mean the job did not land and will be run again: `streaming metadata
+compaction abandoned` (something else rewrote the group underneath it) and
+`streaming metadata compaction superseded` (writes kept landing during its
+final publication). Both are safe and both are self-correcting. `streaming
+metadata compaction failed` carries the error and is worth reading; the next
+step still tries again.
+
+This build does not expose the per-step budgets in the config, so the lever for
+everything a step does — flushing, folding, collecting — remains how often
+maintenance runs, not how much each run may do. The rebuild above is the one
+piece of upkeep that lever does not pace, because it is not paced at all.
+
 ## The optional local cache
 
 The server can keep encoded metadata blocks on this machine's disk, in front

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -365,6 +365,12 @@ async fn build_handles(
         // populating a second, default-sized cache.
         .runtime_cache(config.runtime_cache_config())
         .shared_metadata_table_cache(&writer)
+        // A maintenance step this server runs on request may plan a
+        // background streaming compaction. Sharing the writer's runner is
+        // what lets it start one, makes the operator's step and the writer's
+        // own steps agree that a namespace runs one job at a time, and puts
+        // the job under the shutdown that settles the writer.
+        .background_maintenance(&writer)
         .trace_mode(TraceMode::Remote)
         .trace_store_kind(trace_store_kind)
         .metrics_recorder(metrics.recorder());

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -5,6 +5,7 @@
 //! builds and collects its own state through this handle's public
 //! checkpoint calls, and its hosts drive it.
 
+use crate::maintenance_runner::CompactionStart;
 use crate::FsAdmin;
 use crate::NamespaceStatusResponse;
 use crate::{
@@ -28,7 +29,7 @@ impl FsAdmin {
     /// Drops everything this runtime caches for a namespace: the read
     /// caches, and — when this handle runs over a writer's runtime — the
     /// rebuildable half of that namespace's publisher state.
-    fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
+    pub(crate) fn invalidate_namespace(&self, namespace_id: &NamespaceId) {
         self.core.invalidate_namespace_read_cache(namespace_id);
         if let Some(publisher) = &self.publisher {
             publisher.invalidate_projection(namespace_id);
@@ -192,18 +193,7 @@ impl FsAdmin {
         } else {
             WalFlushStepOutcome::NotNeeded
         };
-        let reorganize = match self.run_reorganization(namespace_id).await? {
-            loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. } => {
-                ReorganizeStepOutcome::NotNeeded
-            }
-            loonfs_core::MetadataReorganizeOutcome::UnitPublished { .. } => {
-                ReorganizeStepOutcome::UnitPublished
-            }
-            loonfs_core::MetadataReorganizeOutcome::BudgetExhausted { .. } => {
-                ReorganizeStepOutcome::BudgetExhausted
-            }
-            loonfs_core::MetadataReorganizeOutcome::Superseded => ReorganizeStepOutcome::Superseded,
-        };
+        let reorganize = self.run_reorganization(namespace_id).await?;
         Ok(MetadataMaintenanceResponse {
             wal_flush,
             reorganize,
@@ -215,17 +205,29 @@ impl FsAdmin {
     /// `loonfs-core`'s `reorganize_metadata`). Explicit steps stay bounded at
     /// one unit per call; the returned outcome lets writer-scheduled
     /// background work keep folding until nothing is left.
+    ///
+    /// A family group whose oldest run no longer fits one unit is rebuilt by
+    /// a streaming compaction instead, which this step starts as background
+    /// work and does not wait for. While that job runs its group is left
+    /// alone and the step folds the other groups; the plan it carries is what
+    /// tells the planner which group that is.
     async fn run_reorganization(
         &self,
         namespace_id: &NamespaceId,
-    ) -> Result<loonfs_core::MetadataReorganizeOutcome> {
+    ) -> Result<ReorganizeStepOutcome> {
+        let active = self
+            .compactions
+            .as_ref()
+            .and_then(|compactions| compactions.active_spec(namespace_id));
         let report = self
             .engine(namespace_id)
-            .reorganize_metadata()
+            .reorganize_metadata(active.as_ref())
             .await
             .map_err(RuntimeError::Core)?;
-        match &report.outcome {
-            loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. } => {}
+        match report.outcome {
+            loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. } => {
+                Ok(ReorganizeStepOutcome::NotNeeded)
+            }
             loonfs_core::MetadataReorganizeOutcome::UnitPublished {
                 families,
                 folded_l0_rows,
@@ -243,18 +245,112 @@ impl FsAdmin {
                     decoded_input_bytes,
                     "metadata reorganization unit published"
                 );
+                Ok(ReorganizeStepOutcome::UnitPublished)
             }
-            loonfs_core::MetadataReorganizeOutcome::BudgetExhausted { families, .. } => {
-                tracing::warn!(
-                    families = ?families,
-                    "metadata reorganization input does not fit the per-step budget"
-                );
+            loonfs_core::MetadataReorganizeOutcome::CompactionPlanned { spec, .. } => {
+                Ok(self.start_streaming_compaction(namespace_id, spec))
             }
             loonfs_core::MetadataReorganizeOutcome::Superseded => {
                 tracing::info!("metadata reorganization unit superseded; will retry");
+                Ok(ReorganizeStepOutcome::Superseded)
             }
         }
-        Ok(report.outcome)
+    }
+
+    /// Starts the job a step planned, unless something already owns the
+    /// namespace's one slot or this handle schedules no background work.
+    fn start_streaming_compaction(
+        &self,
+        namespace_id: &NamespaceId,
+        spec: loonfs_core::MetadataCompactionSpec,
+    ) -> ReorganizeStepOutcome {
+        let families = spec.families();
+        let input_runs = spec.input_runs();
+        let input_rows = spec.input_rows();
+        let started = match &self.compactions {
+            Some(compactions) => compactions.start(self, namespace_id, spec),
+            None => CompactionStart::NoRunner,
+        };
+        match started {
+            CompactionStart::Started => {
+                tracing::info!(
+                    families = ?families,
+                    input_runs,
+                    input_rows,
+                    "a family group outgrew one reorganization step; a streaming metadata \
+                     compaction is rebuilding it"
+                );
+                ReorganizeStepOutcome::CompactionStarted
+            }
+            CompactionStart::AlreadyRunning => {
+                tracing::info!(
+                    families = ?families,
+                    "a streaming metadata compaction is already running for this namespace; this \
+                     group waits for it to finish"
+                );
+                ReorganizeStepOutcome::CompactionPending
+            }
+            CompactionStart::NoRunner => {
+                tracing::warn!(
+                    families = ?families,
+                    "a family group needs a streaming metadata compaction, and this handle \
+                     schedules no background work; the group is unchanged"
+                );
+                ReorganizeStepOutcome::CompactionPending
+            }
+        }
+    }
+
+    /// Runs one streaming compaction to its end and says what that end was.
+    ///
+    /// The maintenance runner spawns this; nothing awaits it. Every ending
+    /// short of a publication leaves the manifest where it was and the
+    /// segments the job wrote unreferenced, so there is nothing to undo and
+    /// nothing to retry here — a later step plans the group again.
+    pub(crate) async fn run_streaming_compaction(
+        &self,
+        namespace_id: &NamespaceId,
+        spec: &loonfs_core::MetadataCompactionSpec,
+        cancellation: &loonfs_core::MetadataCompactionCancellation,
+    ) {
+        match self
+            .engine(namespace_id)
+            .run_metadata_compaction(spec, cancellation)
+            .await
+        {
+            Ok(loonfs_core::MetadataCompactionJobOutcome::Published {
+                manifest_id,
+                rows_read,
+                rows_written,
+                output_segments,
+            }) => {
+                // The manifest moved, so every cached view of this namespace
+                // is one manifest behind.
+                self.invalidate_namespace(namespace_id);
+                tracing::info!(
+                    namespace_id = %namespace_id,
+                    families = ?spec.families(),
+                    rows_read,
+                    rows_written,
+                    output_segments,
+                    manifest_id = manifest_id.0,
+                    "streaming metadata compaction rebuilt a family group"
+                );
+            }
+            Ok(outcome) => tracing::info!(
+                namespace_id = %namespace_id,
+                families = ?spec.families(),
+                outcome = ?outcome,
+                "streaming metadata compaction ended without publishing; a later step plans it \
+                 again"
+            ),
+            Err(error) => tracing::warn!(
+                namespace_id = %namespace_id,
+                families = ?spec.families(),
+                error = %error,
+                "streaming metadata compaction failed; a later step plans it again"
+            ),
+        }
     }
 
     /// Runs the v1 mark-and-sweep garbage collector for one namespace.

--- a/crates/loonfs/src/handle/admin.rs
+++ b/crates/loonfs/src/handle/admin.rs
@@ -2,6 +2,7 @@
 
 use super::HandleBuilderCore;
 use crate::fs::{ReadCore, WriterIdentity};
+use crate::maintenance_runner::BackgroundCompactions;
 use crate::metrics::{MetricsRecorder, ObjectStoreMetricsRecorder};
 use crate::publisher::PublisherRegistry;
 use crate::{
@@ -28,6 +29,14 @@ pub struct FsAdmin {
     /// writer's runtime for background maintenance holds that writer's
     /// registry.
     pub(crate) publisher: Option<PublisherRegistry>,
+    /// The streaming metadata compactions a writer's maintenance runner is
+    /// running, when this handle has a writer behind it.
+    ///
+    /// A maintenance step consults it twice: to leave alone the group a job
+    /// is rebuilding, and to start a job when it plans one. A handle with no
+    /// writer behind it holds `None`, schedules no background work of any
+    /// kind, and reports the plan instead of starting it.
+    pub(crate) compactions: Option<BackgroundCompactions>,
 }
 
 impl FsAdmin {
@@ -55,11 +64,13 @@ impl FsAdmin {
         core: ReadCore,
         actor: WriterIdentity,
         publisher: PublisherRegistry,
+        compactions: BackgroundCompactions,
     ) -> Self {
         Self {
             core,
             actor,
             publisher: Some(publisher),
+            compactions: Some(compactions),
         }
     }
 
@@ -76,6 +87,7 @@ impl FsAdmin {
 pub struct FsAdminBuilder {
     core: HandleBuilderCore,
     actor_id: Option<String>,
+    compactions: Option<BackgroundCompactions>,
 }
 
 impl FsAdminBuilder {
@@ -83,6 +95,7 @@ impl FsAdminBuilder {
         Self {
             core,
             actor_id: None,
+            compactions: None,
         }
     }
 
@@ -108,6 +121,25 @@ impl FsAdminBuilder {
     /// handle's other caches, but its decoded-block budget goes unused.
     pub fn shared_metadata_table_cache(mut self, writer: &super::FsWriter) -> Self {
         self.core.shared_metadata_table_cache = Some(writer.metadata_table_cache());
+        self
+    }
+
+    /// Lets this handle's maintenance steps start background work on
+    /// `writer`'s maintenance runner instead of declining it.
+    ///
+    /// One kind of upkeep does not fit in a step: a family group that has
+    /// outgrown one step's budgets is rebuilt by a streaming compaction that
+    /// runs for as long as it takes and publishes once at the end. Without
+    /// this, an explicit step reports that the group needs one and starts
+    /// nothing, because a handle that owns no background work has nowhere to
+    /// run it. With it, an operator's step starts the same job the writer's
+    /// own steps start, the two share the one-job-per-namespace rule, and
+    /// `writer`'s shutdown cancels and drains it.
+    ///
+    /// Only for a writer in the same runtime ownership domain, like
+    /// [`Self::shared_metadata_table_cache`].
+    pub fn background_maintenance(mut self, writer: &super::FsWriter) -> Self {
+        self.compactions = Some(writer.background_compactions());
         self
     }
 
@@ -157,6 +189,7 @@ impl FsAdminBuilder {
             core: self.core.open_read_core()?,
             actor,
             publisher: None,
+            compactions: self.compactions,
         })
     }
 }

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -72,6 +72,14 @@ impl FsWriter {
         self.core.metadata_table_cache()
     }
 
+    /// The streaming metadata compactions this writer's runner is running,
+    /// for a handle built to share them.
+    pub(crate) fn background_compactions(
+        &self,
+    ) -> crate::maintenance_runner::BackgroundCompactions {
+        self.bits.maintenance.compactions()
+    }
+
     /// This writer's object-store client, instrumented exactly as the
     /// handle's own traffic is.
     ///
@@ -167,6 +175,12 @@ impl FsWriter {
     /// so a step is never torn down mid-flight; a long-lived host calls it
     /// to read durable state a step was about to leave. Callers await their
     /// own publications, so a quiet runner is a quiet writer.
+    ///
+    /// One task this waits for is not a bounded step. A family group that has
+    /// outgrown one step is rebuilt by a streaming compaction paced by no
+    /// budget, and this waits for that to finish rather than stopping it.
+    /// [`Self::shutdown`] cancels it instead, which is what makes a shutdown
+    /// short.
     pub async fn flush_background(&self) -> Result<()> {
         self.bits.maintenance.drain().await
     }
@@ -192,6 +206,14 @@ impl FsWriter {
     /// pass deletes provider objects, an index step writes segments, all
     /// after the process was asked to stop, and all of it the drain then
     /// has to sit through. Closing first leaves the window empty.
+    ///
+    /// Closing maintenance admission also cancels every streaming metadata
+    /// compaction this writer is running. Such a job is background work with
+    /// no budget pacing it, so the drain below would otherwise wait for a
+    /// whole family group to be rebuilt. The job checks its token between
+    /// block fetches and stops, and it costs the work it had done and nothing
+    /// else: it publishes only at the end, so the metadata it was rebuilding
+    /// never moved and a later step plans the group again.
     ///
     /// Nor can the order wedge, for a reason worth stating because it is
     /// not the obvious one: no maintenance step submits to the publication

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -38,6 +38,7 @@
 //! schedule nothing.
 
 mod admission;
+mod compaction;
 mod jobs;
 #[cfg(test)]
 mod tests;
@@ -45,6 +46,7 @@ mod tests;
 use crate::metrics::RuntimeInstruments;
 use crate::{NamespaceId, Result, RuntimeError};
 use admission::{Admission, MaintenanceDispatch, MaintenanceKey, StepOutcome};
+pub(crate) use compaction::{BackgroundCompactions, CompactionStart};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::future::Future;
@@ -438,7 +440,7 @@ impl RunnerCounters {
     }
 }
 
-struct RunnerInner {
+pub(crate) struct RunnerInner {
     policy: FsBackgroundWork,
     /// Runtime that owns spawned work. Handle builders pin the runtime they
     /// were opened on; `None` resolves the runtime driving the triggering
@@ -458,6 +460,12 @@ struct RunnerInner {
     /// number on an existing trace answers for a reader with no metrics
     /// pipeline at all.
     instruments: Arc<RuntimeInstruments>,
+    /// The streaming metadata compactions running under this runner, one per
+    /// namespace at most. Held here rather than beside the admission book
+    /// because a compaction is not a bounded step: it takes no permit, it
+    /// runs for as long as it needs, and what the runner owes it is a spawn,
+    /// a cancellation at shutdown, and the drain every spawned task gets.
+    compactions: Arc<Mutex<BTreeMap<NamespaceId, compaction::ActiveCompaction>>>,
 }
 
 struct RunnerState {
@@ -509,6 +517,7 @@ impl MaintenanceRunner {
                 wake: Arc::new(Notify::new()),
                 counters: RunnerCounters::default(),
                 instruments,
+                compactions: Arc::new(Mutex::new(BTreeMap::new())),
             }),
         }
     }
@@ -519,6 +528,15 @@ impl MaintenanceRunner {
         MaintenanceHandle {
             inner: Arc::downgrade(&self.inner),
         }
+    }
+
+    /// A cloneable view of the streaming compactions this runner is running.
+    ///
+    /// Every handle whose maintenance steps may plan one holds this, which is
+    /// what makes the runner's own steps and an operator's explicit step see
+    /// the same jobs.
+    pub(crate) fn compactions(&self) -> BackgroundCompactions {
+        BackgroundCompactions::new(Arc::clone(&self.inner.compactions), &self.inner)
     }
 
     /// The executor registered under `id`.
@@ -549,13 +567,18 @@ impl MaintenanceRunner {
     }
 
     /// Rejects further scheduling and discards work still waiting for a
-    /// permit. Running steps stay visible to [`Self::drain`].
+    /// permit, and tells every running streaming compaction to stop. Running
+    /// steps and cancelled compactions stay visible to [`Self::drain`].
     ///
     /// Synchronous on purpose: a shutdown has to close admission before its
     /// first await, or a step finishing during the publication drain hands
-    /// its slot to work the shutdown already decided to drop.
+    /// its slot to work the shutdown already decided to drop. Cancelling the
+    /// compactions here rather than in the drain is the same reasoning — a
+    /// job checks its token between block fetches, so the earlier it is set
+    /// the less of the drain it spends finishing work nobody will publish.
     pub(crate) fn close_admission(&self) {
         self.inner.lock_state().admission.close();
+        self.compactions().cancel_all();
         self.inner.wake.notify_one();
     }
 
@@ -701,7 +724,7 @@ impl RunnerInner {
     /// refuses after a shutdown. Dropping the future without running it must
     /// release whatever it holds, so both refusals here clean up by
     /// dropping.
-    fn spawn(&self, future: impl Future<Output = ()> + Send + 'static) {
+    pub(super) fn spawn(&self, future: impl Future<Output = ()> + Send + 'static) {
         let Some(runtime) = self.runtime() else {
             return;
         };

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -1,0 +1,148 @@
+//! The streaming metadata compactions this process is running.
+//!
+//! A maintenance step that plans one starts it here. The job is a background
+//! task the runner owns — it takes no admission permit, because it is not a
+//! bounded step and holding one for hours would starve every key behind it —
+//! and it is registered for the same drain every other spawned task is, so a
+//! shutdown cancels it and then waits for it.
+//!
+//! What this holds is a map from namespace to the one job running for it: the
+//! plan, so the steps that follow know not to merge the group underneath it,
+//! and the cancellation token, so a shutdown can stop it. There is no
+//! lifecycle beyond present and absent. The entry goes when the job ends,
+//! however it ends, because the guard that holds it is dropped with the task.
+
+use super::RunnerInner;
+use crate::{FsAdmin, NamespaceId};
+use loonfs_core::{MetadataCompactionCancellation, MetadataCompactionSpec};
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, Weak};
+
+/// The one job a namespace may have running.
+pub(super) struct ActiveCompaction {
+    spec: MetadataCompactionSpec,
+    cancellation: MetadataCompactionCancellation,
+}
+
+/// A handle on this process's running compactions, cloned into every handle
+/// whose maintenance steps may start one.
+///
+/// The map is held strongly and the runner weakly, which is the same shape
+/// [`super::MaintenanceHandle`] has and for the same reason: a step may
+/// consult the map at any time, and a step that outlives the writer that owns
+/// the runner starts nothing.
+#[derive(Clone)]
+pub(crate) struct BackgroundCompactions {
+    active: Arc<Mutex<BTreeMap<NamespaceId, ActiveCompaction>>>,
+    runner: Weak<RunnerInner>,
+}
+
+/// What a step's plan met when it tried to start a job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompactionStart {
+    /// The job is running now.
+    Started,
+    /// A job is already running for this namespace, so this plan was not
+    /// started. One job at a time per namespace is a process-level fact; a
+    /// later step plans this group again.
+    AlreadyRunning,
+    /// The writer that owned the runner is gone, so there is nothing left to
+    /// spawn on. Indistinguishable, to the step, from a handle that never had
+    /// background work at all.
+    NoRunner,
+}
+
+impl BackgroundCompactions {
+    pub(super) fn new(
+        active: Arc<Mutex<BTreeMap<NamespaceId, ActiveCompaction>>>,
+        runner: &Arc<RunnerInner>,
+    ) -> Self {
+        Self {
+            active,
+            runner: Arc::downgrade(runner),
+        }
+    }
+
+    /// The plan of the job running for `namespace_id`, for the step that has
+    /// to leave its group alone.
+    pub(crate) fn active_spec(&self, namespace_id: &NamespaceId) -> Option<MetadataCompactionSpec> {
+        self.lock()
+            .get(namespace_id)
+            .map(|active| active.spec.clone())
+    }
+
+    /// Starts `spec` as a background job under `admin`'s identity, unless a
+    /// job already holds the namespace's one slot.
+    pub(crate) fn start(
+        &self,
+        admin: &FsAdmin,
+        namespace_id: &NamespaceId,
+        spec: MetadataCompactionSpec,
+    ) -> CompactionStart {
+        let Some(runner) = self.runner.upgrade() else {
+            return CompactionStart::NoRunner;
+        };
+        let cancellation = MetadataCompactionCancellation::default();
+        {
+            let mut active = self.lock();
+            if active.contains_key(namespace_id) {
+                return CompactionStart::AlreadyRunning;
+            }
+            active.insert(
+                namespace_id.clone(),
+                ActiveCompaction {
+                    spec: spec.clone(),
+                    cancellation: cancellation.clone(),
+                },
+            );
+        }
+        // The guard is built before the future so the future owns it from the
+        // moment it exists. A spawn a shutdown refuses drops the future
+        // without polling it, and that drop is what gives the slot back.
+        let guard = CompactionSlot {
+            active: Arc::clone(&self.active),
+            namespace_id: namespace_id.clone(),
+        };
+        let admin = admin.clone();
+        let namespace_id = namespace_id.clone();
+        runner.spawn(async move {
+            let _slot = guard;
+            admin
+                .run_streaming_compaction(&namespace_id, &spec, &cancellation)
+                .await;
+        });
+        CompactionStart::Started
+    }
+
+    /// Cancels every running job. The tasks themselves are joined by the
+    /// runner's drain; this is what makes that wait short.
+    pub(super) fn cancel_all(&self) {
+        for active in self.lock().values() {
+            active.cancellation.cancel();
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<NamespaceId, ActiveCompaction>> {
+        self.active
+            .lock()
+            .expect("background compaction lock poisoned")
+    }
+}
+
+/// Holds a namespace's compaction slot and gives it back exactly once.
+///
+/// Dropping is the only way the slot is released — on a normal finish, on a
+/// panic, and on a task discarded with its runtime — so no namespace is ever
+/// left claiming a job that is not running.
+struct CompactionSlot {
+    active: Arc<Mutex<BTreeMap<NamespaceId, ActiveCompaction>>>,
+    namespace_id: NamespaceId,
+}
+
+impl Drop for CompactionSlot {
+    fn drop(&mut self) {
+        if let Ok(mut active) = self.active.lock() {
+            active.remove(&self.namespace_id);
+        }
+    }
+}

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -11,8 +11,8 @@
 //! explicit call with no scheduler behind it.
 
 use super::{
-    MaintenanceJob, MaintenanceJobId, MaintenanceProbe, MaintenanceStepConclusion,
-    MaintenanceStepResult,
+    BackgroundCompactions, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,
+    MaintenanceStepConclusion, MaintenanceStepResult,
 };
 use crate::fs::{ReadCore, WriterBits};
 use crate::publisher::PublisherRegistry;
@@ -38,6 +38,7 @@ pub(crate) fn register_core_jobs(
         core: core.clone(),
         bits: Arc::downgrade(bits),
         publisher: publisher.clone(),
+        compactions: runner.compactions(),
     };
     runner.register(Arc::new(MetadataJob { context: context() }))?;
     runner.register(Arc::new(GcJob { context: context() }))?;
@@ -81,6 +82,9 @@ struct StepContext {
     core: ReadCore,
     bits: Weak<WriterBits>,
     publisher: PublisherRegistry,
+    /// Held strongly: it is a map and a weak reference to the runner, so it
+    /// keeps nothing alive that a dropped writer should have taken with it.
+    compactions: BackgroundCompactions,
 }
 
 impl StepContext {
@@ -90,6 +94,7 @@ impl StepContext {
             self.core.clone(),
             bits.identity.clone(),
             self.publisher.clone(),
+            self.compactions.clone(),
         );
         Some((bits, admin))
     }
@@ -278,6 +283,12 @@ fn metadata_has_nothing_to_maintain(error: &RuntimeError) -> bool {
 /// and then failed to fit a fold unit did move durable state and should run
 /// again; a step that only lost a race should take that race again; a step
 /// that only failed to fit has nothing to gain from an immediate retry.
+///
+/// Starting a streaming compaction is progress of the useful kind: the step
+/// that started it did no folding, and the steps behind it now have the
+/// group's peers to fold while the job runs. A group waiting on a job that is
+/// already running is a block — there is work and this step cannot make it —
+/// so the key parks and comes back on the next nudge or sweep.
 fn metadata_conclusion(step: &MetadataMaintenanceResponse) -> MaintenanceStepConclusion {
     let flush = match step.wal_flush {
         WalFlushStepOutcome::Flushed { .. } => Some(MaintenanceStepConclusion::Progressed),
@@ -287,9 +298,11 @@ fn metadata_conclusion(step: &MetadataMaintenanceResponse) -> MaintenanceStepCon
         WalFlushStepOutcome::NotNeeded => None,
     };
     let reorganize = match step.reorganize {
-        ReorganizeStepOutcome::UnitPublished => Some(MaintenanceStepConclusion::Progressed),
+        ReorganizeStepOutcome::UnitPublished | ReorganizeStepOutcome::CompactionStarted => {
+            Some(MaintenanceStepConclusion::Progressed)
+        }
         ReorganizeStepOutcome::Superseded => Some(MaintenanceStepConclusion::Superseded),
-        ReorganizeStepOutcome::BudgetExhausted => Some(MaintenanceStepConclusion::Blocked),
+        ReorganizeStepOutcome::CompactionPending => Some(MaintenanceStepConclusion::Blocked),
         ReorganizeStepOutcome::NotNeeded => None,
     };
     [flush, reorganize]
@@ -450,11 +463,35 @@ mod tests {
         );
         let blocked = step_response(
             WalFlushStepOutcome::NotNeeded,
-            ReorganizeStepOutcome::BudgetExhausted,
+            ReorganizeStepOutcome::CompactionPending,
         );
         assert_eq!(
             metadata_conclusion(&blocked),
             MaintenanceStepConclusion::Blocked
+        );
+    }
+
+    /// Starting a background rebuild is progress: the step that started it
+    /// folded nothing, and the steps behind it have the group's peers to fold
+    /// while the job runs.
+    #[test]
+    fn starting_a_compaction_progresses_and_waiting_on_one_blocks() {
+        let started = step_response(
+            WalFlushStepOutcome::NotNeeded,
+            ReorganizeStepOutcome::CompactionStarted,
+        );
+        assert_eq!(
+            metadata_conclusion(&started),
+            MaintenanceStepConclusion::Progressed
+        );
+        let waiting = step_response(
+            WalFlushStepOutcome::NotNeeded,
+            ReorganizeStepOutcome::CompactionPending,
+        );
+        assert_eq!(
+            metadata_conclusion(&waiting),
+            MaintenanceStepConclusion::Blocked,
+            "a group waiting on a job already running has nothing to gain from an immediate retry"
         );
     }
 
@@ -464,7 +501,7 @@ mod tests {
             WalFlushStepOutcome::Flushed {
                 manifest_head_seq: ChangeSeq(7),
             },
-            ReorganizeStepOutcome::BudgetExhausted,
+            ReorganizeStepOutcome::CompactionPending,
         );
         assert_eq!(
             metadata_conclusion(&step),

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -683,6 +683,15 @@ reclaimable state is collected; naming anything else is refused with
 `namespace_deleted`, because a tombstone has nothing to flush, reorganize,
 or retain.
 
+One reorganize outcome describes work the step did not do itself. A family
+group that has outgrown one step is rebuilt by a background streaming
+compaction, and `reorganize.kind` reports `compaction_started` when the step
+started that job. The step publishes nothing in that case: the job publishes
+once, when it finishes. `compaction_pending` says the group needs one and
+this step started none, because a job is already running for the namespace —
+one runs at a time — or because the process serving the request schedules no
+background work. The server log says which.
+
 Inside `metadata`, `max_wal_tail_segments` overrides the flush threshold;
 zero, and any value above the write-rejection threshold, are rejected as
 `invalid_request`. Nothing surrenders replay history unless

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -2186,8 +2186,9 @@ does not exist, so there is nothing to collect and nothing to ignore.
 
 v1 GC is listing mark-and-sweep. Its inputs are `wal/head.json`,
 `wal/floor.json`, `metadata/root.json`, and the `metadata/manifests/`,
-`metadata/tables/`, `checkpoints/`, and `wal/segments/` collections. A live
-manifest roots every object key its `metadata_files` list names. The pass also
+`metadata/tables/`, `metadata/compaction-staging/`, `checkpoints/`, and
+`wal/segments/` collections. A live manifest roots every object key its
+`metadata_files` list names, wherever that key sits. The pass also
 sweeps `uploads/`, and that sweep owns content reclamation as well; the two
 halves are split at the completed line and described in rule 11.
 Core GC never recognizes, lists specifically, or deletes any object below a
@@ -2358,6 +2359,19 @@ publishing CAS) — under these rules:
    reading through a pinned basis; a same-content-store copy across
    namespaces (section 2.8) would have to root the reference on the source
    side the way a fork does.
+12. **Compaction staging ages under a window of its own.** A streaming
+   compaction ("Compaction") publishes nothing until it finishes and is paced
+   by no budget, so its output is unreferenced for as long as the job runs.
+   `T` only has to cover a publication in flight, so a sweep applying it to
+   `metadata/compaction-staging/` would delete the output of a job still
+   writing it. Unreferenced staged segments therefore age under
+   `METADATA_COMPACTION_STAGING_GRACE`, a generous bound on job duration
+   rather than a correctness window: nothing is unsafe about a shorter one
+   except that a job would have to run again. A published job's segments are
+   named by the manifest, and a referenced object is live wherever it sits,
+   so this window never applies to them. Every other rule — the reference
+   anchor, delete-time re-verification, degraded roots — applies here exactly
+   as it applies to `metadata/tables/`.
 
 Deletion proceeds data first, records last, so a crash mid-sweep leaves
 orphaned data for the next pass rather than a record whose data vanished.

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -5595,7 +5595,21 @@
               "kind": {
                 "type": "string",
                 "enum": [
-                  "budget_exhausted"
+                  "compaction_started"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "compaction_pending"
                 ]
               }
             }


### PR DESCRIPTION
This change connects the streaming compaction executor to metadata maintenance. When the planner determines that a family group cannot make progress through a bounded merge, the maintenance step starts a background compaction and returns without publishing metadata itself.

The maintenance runner keeps one active compaction per namespace. While the job is running, later maintenance steps exclude its family group from ordinary merges and may continue working on other groups. The background task does not hold a bounded-step admission permit. It is included in runner shutdown, and graceful shutdown requests cancellation before waiting for the task to finish.

After the executor finishes, finalization reloads the current root and manifest and verifies that the selected input segment set is unchanged. It removes only those inputs, adds the staged output segments, preserves runs created while the job was running, and publishes through the normal manifest compare-and-swap. An unrelated publication causes a reload and retry, up to four attempts. A changed input causes the result to be abandoned without publication.

Garbage collection now recognizes the metadata compaction staging prefix. Referenced staged segments remain live after publication, while unreferenced segments are eligible for collection after the fixed 24-hour staging grace period.

The maintenance API replaces the previous budget-exhausted result with `compaction_started` and `compaction_pending`. The first reports that this step launched a job. The second reports that the group needs a compaction but no new job was started because another job already owns the namespace slot or the current handle cannot schedule background work. Logs and the self-hosting guide describe start, progress, publication, cancellation, abandonment, supersession, failure, and restart behavior.

End-to-end tests cover starting a job from the maintenance path, keeping reads stable while it runs, preserving a newer run during final publication, restarting after cancellation, retrying finalization across a concurrent flush, and collecting staged output. The workspace test suite, Clippy, formatting, OpenAPI checks, and existing golden files all pass.
