### PR TITLE
fix(checkpoint): a compaction's outputs are leased, its trigger is bounded, and its retention state is constant

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -6,8 +6,8 @@ use crate::envelope::EnvelopeCodecError;
 use crate::WriterEpoch;
 use crate::{
     ChangeSeq, CheckpointId, ChecksumAlgorithm, CommitId, ContentId, ContentRef, ContentRefKind,
-    ContentStoreId, InodeId, ManifestId, ManifestObjectId, NamespaceId, StorageChecksum, UploadId,
-    WalSegmentId, ROOT_INODE_ID,
+    ContentStoreId, InodeId, ManifestId, ManifestObjectId, MetadataCompactionId, NamespaceId,
+    StorageChecksum, UploadId, WalSegmentId, ROOT_INODE_ID,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -30,16 +30,20 @@ pub enum ControlObjectKind {
     CheckpointRecord,
     /// Tracks staged content through upload completion or cleanup.
     UploadSession,
+    /// Marks one streaming metadata compaction's output as owned by a job
+    /// that is still running.
+    CompactionLease,
 }
 
 impl ControlObjectKind {
     /// Lists every registered control-object family in stable registry order.
-    pub const ALL: [Self; 5] = [
+    pub const ALL: [Self; 6] = [
         Self::WalHead,
         Self::WalFloor,
         Self::MetadataRoot,
         Self::CheckpointRecord,
         Self::UploadSession,
+        Self::CompactionLease,
     ];
 
     /// Durable format version for this control object kind.
@@ -55,6 +59,7 @@ impl ControlObjectKind {
             Self::MetadataRoot => 1,
             Self::CheckpointRecord => 1,
             Self::UploadSession => 1,
+            Self::CompactionLease => 1,
         }
     }
 
@@ -66,6 +71,7 @@ impl ControlObjectKind {
             Self::MetadataRoot => "metadata_root",
             Self::CheckpointRecord => "checkpoint_record",
             Self::UploadSession => "upload_session",
+            Self::CompactionLease => "compaction_lease",
         }
     }
 
@@ -119,6 +125,34 @@ pub struct MetadataRootState {
     pub manifest_payload_checksum: String,
     /// Unix-millisecond wall-clock stamp for observability and GC grace policy, not ordering.
     pub updated_at_ms: u64,
+}
+
+/// Says that one streaming metadata compaction is still running, so the
+/// objects under its job prefix belong to it.
+///
+/// The lease carries lifecycle ownership and nothing else: no cursor, no
+/// output descriptor, no offset, no progress. Its only reader is garbage
+/// collection, which retains a job prefix whose lease was refreshed recently
+/// and reclaims one whose lease is stale or gone (format spec, "Garbage
+/// collection", rule 12). Nothing about a job's correctness depends on it —
+/// a job that loses its lease loses its output to a later pass and runs
+/// again, which is what every other way a job can end already costs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetadataCompactionLeaseState {
+    /// Job this lease belongs to, which is also the prefix its output sits
+    /// under.
+    pub job_id: MetadataCompactionId,
+    /// Namespace whose family group the job is rebuilding.
+    pub namespace_id: NamespaceId,
+    /// Writer identity the job runs under, for an operator reading the
+    /// object.
+    pub owner_id: String,
+    /// Unix-millisecond stamp of the job's first lease write.
+    pub started_at_ms: u64,
+    /// Unix-millisecond stamp of the most recent lease write, and the only
+    /// input to whether the job still owns its prefix.
+    pub heartbeat_at_ms: u64,
 }
 
 /// Lifecycle of a durable checkpoint record: monotonic, with exactly two
@@ -1068,6 +1102,9 @@ pub type MetadataRootEnvelope = ControlObjectEnvelope<MetadataRootState>;
 pub type WalFloorEnvelope = ControlObjectEnvelope<WalFloorState>;
 /// Specializes a control envelope for a durable manifest pin.
 pub type CheckpointRecordEnvelope = ControlObjectEnvelope<CheckpointRecordState>;
+/// Specializes a control envelope for a running compaction's ownership of
+/// its staged output.
+pub type MetadataCompactionLeaseEnvelope = ControlObjectEnvelope<MetadataCompactionLeaseState>;
 
 /// Computes the checksum stored beside canonical JSON for a control state.
 ///

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -522,6 +522,16 @@ string_id! {
 }
 
 string_id! {
+    /// Durable id for one streaming metadata compaction job.
+    ///
+    /// The job's staged output and its lease live under one prefix named by
+    /// this id, so a collector can tell one job's output from another's
+    /// without reading anything.
+    MetadataCompactionId,
+    prefix = "cmp"
+}
+
+string_id! {
     /// Durable id for one derived-index segment file.
     IndexSegmentId,
     prefix = "idx"

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -124,9 +124,9 @@ pub use ids::{
     generated_id, manifest_object_id_manifest_id, wal_segment_id_start_seq, ChangeSeq,
     CheckpointId, CommitId, CommitIdValidationError, ContentId, ContentStoreId,
     GeneratedIdValidationError, IndexSegmentId, InodeId, InodeKind, ManifestId, ManifestObjectId,
-    MetadataTableId, NameKey, NameKeyValidationError, NamespaceId, NamespaceIdValidationError,
-    RevisionNo, UploadId, WalSegmentId, WriterEpoch, MAX_ID_BYTES, MAX_NAME_KEY_BYTES,
-    ROOT_INODE_ID,
+    MetadataCompactionId, MetadataTableId, NameKey, NameKeyValidationError, NamespaceId,
+    NamespaceIdValidationError, RevisionNo, UploadId, WalSegmentId, WriterEpoch, MAX_ID_BYTES,
+    MAX_NAME_KEY_BYTES, ROOT_INODE_ID,
 };
 pub use name_policy::name_key_for_display_name;
 pub use pagination::{

--- a/crates/loonfs-api/tests/golden/control_compaction_lease.v1.json
+++ b/crates/loonfs-api/tests/golden/control_compaction_lease.v1.json
@@ -1,0 +1,1 @@
+{"kind":"compaction_lease","format_version":1,"payload_checksum":"sha256:f4be765aa5e02c3aebb404f1ef389a05cbdaca305883a074531127eef800e169","payload":{"job_id":"cmp_0123456789abcdef0123456789abcdef","namespace_id":"demo","owner_id":"writer-1","started_at_ms":1000,"heartbeat_at_ms":3000}}

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -21,8 +21,8 @@
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, CheckpointOwner, CheckpointRecordLifecycle,
     CheckpointRecordState, ControlObjectEnvelope, ControlObjectKind, ForkBasis, HeadState,
-    MetadataRootState, NamespaceState, UploadSessionLifecycle, UploadSessionState,
-    UploadSessionTransport, WalFloorState, WalSegmentPointer, WriterBlock,
+    MetadataCompactionLeaseState, MetadataRootState, NamespaceState, UploadSessionLifecycle,
+    UploadSessionState, UploadSessionTransport, WalFloorState, WalSegmentPointer, WriterBlock,
 };
 use loonfs_api::wire::envelope::EnvelopeCodecError;
 use loonfs_api::wire::manifest::{
@@ -37,8 +37,9 @@ use loonfs_api::wire::wal::{
 use loonfs_api::{
     sha256_digest, AttributeKey, AttributeRevisionNo, AttributeValue, Attributes, ChangeSeq,
     CheckpointId, ChecksumAlgorithm, CommitId, ContentId, ContentRef, ContentRefKind,
-    ContentStoreId, InodeId, InodeKind, ManifestId, ManifestObjectId, MetadataTableId, NameKey,
-    NamespaceId, RevisionNo, StorageChecksum, UploadId, WalSegmentId, WriterEpoch,
+    ContentStoreId, InodeId, InodeKind, ManifestId, ManifestObjectId, MetadataCompactionId,
+    MetadataTableId, NameKey, NamespaceId, RevisionNo, StorageChecksum, UploadId, WalSegmentId,
+    WriterEpoch,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -600,6 +601,22 @@ fn control_objects_match_golden_bytes() {
                 target_namespace_id: NamespaceId::parse("clone").expect("valid namespace id"),
             },
             state: CheckpointRecordLifecycle::Active {},
+        },
+    );
+    // The lease is a control object of its own family, and the only thing
+    // that reads it is garbage collection. Its bytes are pinned like every
+    // other family's so a field rename cannot silently change what a
+    // collector reads a running job's claim out of.
+    check_control_golden(
+        "control_compaction_lease.v1.json",
+        ControlObjectKind::CompactionLease,
+        MetadataCompactionLeaseState {
+            job_id: MetadataCompactionId::parse("cmp_0123456789abcdef0123456789abcdef")
+                .expect("valid compaction id"),
+            namespace_id: namespace_id(),
+            owner_id: "writer-1".to_owned(),
+            started_at_ms: 1_000,
+            heartbeat_at_ms: 3_000,
         },
     );
     check_control_golden(

--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -1,0 +1,218 @@
+//! The lease one streaming metadata compaction holds over its own output.
+//!
+//! A job writes every output segment under `metadata/compactions/{job_id}/`
+//! and writes this object beside them. It carries lifecycle ownership and
+//! nothing else — job, namespace, owner, start, last heartbeat — because the
+//! one question it answers is whether the objects under its prefix belong to
+//! a job that is still running. There is no cursor here, no output
+//! descriptor, no offset, and no progress: a crashed job still loses its
+//! work, exactly as the design says it does.
+//!
+//! Garbage collection is the only reader. It retains a prefix whose lease was
+//! refreshed within [`METADATA_COMPACTION_LEASE_EXPIRY_MS`] and lets a prefix
+//! with a stale or missing lease age out as ordinary orphans (format spec,
+//! "Garbage collection", rule 12). Nothing else loads it, so a lease that
+//! does not decode is treated as missing and logged: a corrupt lease must not
+//! keep a prefix alive forever, and it must not stop anything else from
+//! working either.
+
+use crate::error::{CoreError, Result};
+use crate::limits::{
+    METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS, METADATA_COMPACTION_LEASE_EXPIRY_MS,
+};
+use crate::timing::MonotonicTimer;
+use loonfs_api::wire::control::{
+    decode_control_object, encode_control_object, ControlObjectKind,
+    MetadataCompactionLeaseEnvelope, MetadataCompactionLeaseState,
+};
+use loonfs_api::{MetadataCompactionId, NamespaceId};
+use loonfs_objectstore::keys::metadata_compaction_lease;
+use loonfs_objectstore::{ObjectStore, PutMode};
+
+/// What a job's lease says about the objects under that job's prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompactionLeaseState {
+    /// The lease was refreshed recently enough that the job may still be
+    /// running, so everything under its prefix belongs to it.
+    Held,
+    /// There is no lease, or it does not decode, or its last heartbeat is
+    /// older than the expiry. Whatever sits under the prefix is an ordinary
+    /// unreferenced orphan.
+    Gone,
+}
+
+/// Reads the lease of one job and says whether that job still owns its
+/// prefix.
+///
+/// `job_id` is the path component, not a parsed identity: a collector reads
+/// it off the key it is deciding. A lease naming a different job or a
+/// different namespace is not this prefix's lease, so it is read as absent
+/// whatever else it is.
+pub(crate) async fn read_compaction_lease_state<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    job_id: &str,
+    now_ms: u64,
+) -> Result<CompactionLeaseState> {
+    let object_key = metadata_compaction_lease(namespace_id.as_str(), job_id);
+    let Some(bytes) = store
+        .get(&object_key, None)
+        .await
+        .map_err(|error| CoreError::store(&object_key, &error))?
+    else {
+        return Ok(CompactionLeaseState::Gone);
+    };
+    let decoded = decode_control_object::<MetadataCompactionLeaseState>(
+        &bytes,
+        ControlObjectKind::CompactionLease,
+    );
+    let state = match decoded {
+        Ok(envelope) => envelope.state,
+        Err(error) => {
+            // Loud, because nothing else will ever say it: no read path
+            // touches this object, so a corrupt one would otherwise sit under
+            // its prefix in silence. Treated as missing, because the
+            // alternative — believing it — would keep a prefix alive forever.
+            tracing::warn!(
+                namespace_id = namespace_id.as_str(),
+                object_key = object_key.as_str(),
+                error = %error,
+                "a streaming metadata compaction lease does not decode; its prefix is collected \
+                 as an orphan"
+            );
+            return Ok(CompactionLeaseState::Gone);
+        }
+    };
+    if state.namespace_id != *namespace_id || state.job_id.as_str() != job_id {
+        tracing::warn!(
+            namespace_id = namespace_id.as_str(),
+            object_key = object_key.as_str(),
+            lease_namespace_id = state.namespace_id.as_str(),
+            lease_job_id = state.job_id.as_str(),
+            "a streaming metadata compaction lease names another job; its prefix is collected as \
+             an orphan"
+        );
+        return Ok(CompactionLeaseState::Gone);
+    }
+    Ok(
+        if now_ms
+            <= state
+                .heartbeat_at_ms
+                .saturating_add(METADATA_COMPACTION_LEASE_EXPIRY_MS)
+        {
+            CompactionLeaseState::Held
+        } else {
+            CompactionLeaseState::Gone
+        },
+    )
+}
+
+/// One running job's claim on its own prefix.
+///
+/// The wall clock is read once, when the job starts; every later heartbeat
+/// stamps that instant plus local monotonic elapsed time, so nothing here
+/// depends on a clock that can move. That is the same posture every
+/// self-enforced budget in the system takes.
+pub(super) struct CompactionLease<'a> {
+    object_key: String,
+    state: MetadataCompactionLeaseState,
+    timer: &'a dyn MonotonicTimer,
+    started_monotonic_ms: u64,
+    next_heartbeat_monotonic_ms: u64,
+}
+
+impl<'a> CompactionLease<'a> {
+    pub(super) fn new(
+        namespace_id: &NamespaceId,
+        job_id: &MetadataCompactionId,
+        owner_id: &str,
+        started_at_ms: u64,
+        timer: &'a dyn MonotonicTimer,
+    ) -> Self {
+        let started_monotonic_ms = timer.monotonic_now_ms();
+        Self {
+            object_key: metadata_compaction_lease(namespace_id.as_str(), job_id.as_str()),
+            state: MetadataCompactionLeaseState {
+                job_id: job_id.clone(),
+                namespace_id: namespace_id.clone(),
+                owner_id: owner_id.to_owned(),
+                started_at_ms,
+                heartbeat_at_ms: started_at_ms,
+            },
+            timer,
+            started_monotonic_ms,
+            next_heartbeat_monotonic_ms: started_monotonic_ms,
+        }
+    }
+
+    /// The clock the job paces itself by. One clock for the job's heartbeat
+    /// and its publication budget, because they measure the same span.
+    pub(super) fn timer(&self) -> &'a dyn MonotonicTimer {
+        self.timer
+    }
+
+    /// Rewrites the lease when the interval has passed since the last write.
+    ///
+    /// Called where cancellation is checked, so the cost is one small
+    /// overwrite every [`METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS`] however
+    /// many rows the job reads in between.
+    pub(super) async fn heartbeat_if_due<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+    ) -> Result<()> {
+        if self.timer.monotonic_now_ms() < self.next_heartbeat_monotonic_ms {
+            return Ok(());
+        }
+        self.heartbeat(store).await
+    }
+
+    /// Rewrites the lease now, whatever the interval says.
+    ///
+    /// Finalization uses this: the span from a heartbeat to the root
+    /// compare-and-swap that makes the output referenced is what the lease has
+    /// to cover, and that span opens at the top of every attempt.
+    pub(super) async fn heartbeat<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
+        let elapsed_ms = self
+            .timer
+            .monotonic_now_ms()
+            .saturating_sub(self.started_monotonic_ms);
+        self.state.heartbeat_at_ms = self.state.started_at_ms.saturating_add(elapsed_ms);
+        let envelope = MetadataCompactionLeaseEnvelope::from_state(
+            ControlObjectKind::CompactionLease,
+            self.state.clone(),
+        )
+        .map_err(|error| {
+            CoreError::Internal(format!("failed to build a compaction lease: {error}"))
+        })?;
+        let bytes = encode_control_object(&envelope).map_err(|error| {
+            CoreError::Internal(format!("failed to encode a compaction lease: {error}"))
+        })?;
+        store
+            .put(&self.object_key, bytes.into(), PutMode::Overwrite)
+            .await
+            .map_err(|error| CoreError::store(&self.object_key, &error))?;
+        self.next_heartbeat_monotonic_ms = self
+            .timer
+            .monotonic_now_ms()
+            .saturating_add(METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS);
+        Ok(())
+    }
+
+    /// Drops the claim after the job's output has been published.
+    ///
+    /// Best effort: the published segments are named by the manifest and live
+    /// wherever they sit, so a lease that survives protects an empty prefix
+    /// until it expires and is then collected like any other orphan. Failing
+    /// the job over it would throw away work that already landed.
+    pub(super) async fn release<S: ObjectStore + ?Sized>(&self, store: &S) {
+        if let Err(error) = store.delete(&self.object_key).await {
+            tracing::info!(
+                namespace_id = self.state.namespace_id.as_str(),
+                object_key = self.object_key.as_str(),
+                error = %error,
+                "a published streaming metadata compaction could not delete its own lease; it \
+                 expires on its own"
+            );
+        }
+    }
+}

--- a/crates/loonfs-core/src/checkpoint/compaction_retention.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_retention.rs
@@ -1,0 +1,606 @@
+//! The frozen floor's rules as streaming operators: one row in, at most one
+//! row out, and a fixed amount of state in between.
+//!
+//! A whole-group fold holds every row of a family and decides them together
+//! ([`super::reorganize::drop_rows_below_retention_floor`]). A streaming
+//! compaction cannot: one inode may hold any number of attribute revisions
+//! and one parent-and-name slot any number of binding generations, so holding
+//! "the rows a rule reads together" is holding an unbounded set. These
+//! operators hold the *answer* a rule is building instead, which is a fixed
+//! number of fields per family and at most one row.
+//!
+//! What makes that possible is the row-key grammar. Rows arrive in row-key
+//! order, and every rule reads neighbours that share a key prefix, so the rows
+//! a rule needs arrive together and in the order the rule wants them:
+//!
+//! | family | grouped by | arrives |
+//! | --- | --- | --- |
+//! | attributes | one inode | newest revision first |
+//! | active deletions | one deletion | the removal before the row it removes |
+//! | binds, unbinds | one binding generation | the bind before its unbinds |
+//!
+//! The reverse bind index is the one family no grouping can serve: it is
+//! keyed by child while the unbind that retires a bind is keyed by parent, so
+//! its rows are decided one at a time by a point read into the job's snapshot
+//! ([`super::streaming_compaction`]) and it holds no state here at all.
+
+use super::reorganize::{bind_survives_frozen_floor, BindingGeneration};
+use crate::error::{CoreError, Result};
+use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow, MetadataTableFamily};
+use loonfs_api::{AttributeRevisionNo, ChangeSeq};
+use std::collections::BTreeSet;
+
+/// One row a retention operator kept, and the family it belongs to.
+pub(super) type KeptRow = (MetadataTableFamily, MetadataRow);
+
+/// Which rule decides a cluster's rows, as the cluster table names it.
+///
+/// The table is `const`, so it names the rule; [`Self::operator`] is what
+/// turns one into the state that runs it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RetentionRule {
+    /// Nothing is ever dropped: revision history, inode rows, and tombstone
+    /// rows are retained whatever the floor says.
+    KeepEveryRow,
+    /// A receipt is decided by its own sequence against the floor.
+    Receipts,
+    /// Every revision above the floor, plus the newest at or below it, per
+    /// inode.
+    Attributes,
+    /// A cancelled deletion's pair leaves together; a live listing stays
+    /// however far the floor advances.
+    ActiveDeletions,
+    /// A bind and the unbinds of its own generation, decided together.
+    ForwardBindings,
+    /// Reverse bind rows, each decided by a point read into the snapshot.
+    /// The operator holds nothing; the job does the reading.
+    ReverseBindProbe,
+}
+
+impl RetentionRule {
+    pub(super) fn operator(self) -> RetentionOperator {
+        match self {
+            Self::KeepEveryRow => RetentionOperator::KeepEveryRow,
+            Self::Receipts => RetentionOperator::Receipts,
+            Self::Attributes => RetentionOperator::Attributes(AttributeRetention::default()),
+            Self::ActiveDeletions => {
+                RetentionOperator::ActiveDeletions(ActiveDeletionRetention::default())
+            }
+            Self::ForwardBindings => {
+                RetentionOperator::ForwardBindings(BindingRetention::default())
+            }
+            // The reverse index is decided one row at a time by the job,
+            // which is the only thing that can read the snapshot, so this
+            // rule has no state of its own to run. The job still opens and
+            // closes groups over it, and both are nothing to do.
+            Self::ReverseBindProbe => RetentionOperator::KeepEveryRow,
+        }
+    }
+}
+
+/// The state one cluster's rule holds while the job streams through it.
+#[derive(Debug)]
+pub(super) enum RetentionOperator {
+    KeepEveryRow,
+    Receipts,
+    Attributes(AttributeRetention),
+    ActiveDeletions(ActiveDeletionRetention),
+    ForwardBindings(BindingRetention),
+}
+
+impl RetentionOperator {
+    /// Judges one row and answers with what survives it.
+    ///
+    /// A `None` means the row was dropped or is being held for a verdict the
+    /// rest of its group has not delivered yet; [`Self::close_group`] is where
+    /// anything held comes back.
+    pub(super) fn push(
+        &mut self,
+        family: MetadataTableFamily,
+        row: MetadataRow,
+        floor_seq: ChangeSeq,
+    ) -> Result<Option<KeptRow>> {
+        let kept = match self {
+            Self::KeepEveryRow => Some(row),
+            Self::Receipts => keep_receipt(row, floor_seq),
+            Self::Attributes(state) => state.push(row, floor_seq)?,
+            Self::ActiveDeletions(state) => state.push(row),
+            Self::ForwardBindings(state) => state.push(row, floor_seq),
+        };
+        Ok(kept.map(|row| (family, row)))
+    }
+
+    /// Closes the locality group that just ended and answers with the row it
+    /// was holding, if it was holding one.
+    pub(super) fn close_group(&mut self, floor_seq: ChangeSeq) -> Result<Option<KeptRow>> {
+        match self {
+            Self::KeepEveryRow | Self::Receipts => Ok(None),
+            Self::Attributes(state) => {
+                state.close_group();
+                Ok(None)
+            }
+            Self::ActiveDeletions(state) => {
+                state.close_group();
+                Ok(None)
+            }
+            Self::ForwardBindings(state) => Ok(state
+                .close_group(floor_seq)?
+                .map(|row| (MetadataTableFamily::DirentryBinds, row))),
+        }
+    }
+
+    /// How many rows this operator is holding right now.
+    ///
+    /// This is the number the job's peak counter tracks, and the thing the
+    /// resource tests assert stays small however many revisions one inode has
+    /// or however many generations one name slot has.
+    pub(super) fn held_rows(&self) -> usize {
+        match self {
+            Self::KeepEveryRow
+            | Self::Receipts
+            | Self::Attributes(_)
+            | Self::ActiveDeletions(_) => 0,
+            Self::ForwardBindings(state) => usize::from(state.held_bind.is_some()),
+        }
+    }
+}
+
+/// A receipt below the floor is indistinguishable from one never used, which
+/// is the idempotency horizon (format spec, section 3.3).
+fn keep_receipt(row: MetadataRow, floor_seq: ChangeSeq) -> Option<MetadataRow> {
+    match &row {
+        MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq < floor_seq => None,
+        _ => Some(row),
+    }
+}
+
+/// Attribute rows, one inode at a time.
+///
+/// Ascending row-key order within one inode is descending revision order:
+/// `lookup_keys::attributes_row_key` inverts the revision number, the commit
+/// sequence, and the delta index, which is what makes a prefix read answer
+/// with the newest state first. So the first row at or below the floor is the
+/// newest at or below it — the one row the rule keeps — and every later row of
+/// that inode is older and goes. The whole history is never held.
+#[derive(Debug, Default)]
+pub(super) struct AttributeRetention {
+    /// Whether this inode has already kept its newest row at or below the
+    /// floor.
+    kept_at_floor: bool,
+    /// The revision of the previous row at or below the floor, which is what
+    /// catches two rows sharing one revision number. Descending revision
+    /// order puts any such pair next to each other, so one field sees them.
+    previous_at_floor: Option<AttributeRevisionNo>,
+}
+
+impl AttributeRetention {
+    fn push(&mut self, row: MetadataRow, floor_seq: ChangeSeq) -> Result<Option<MetadataRow>> {
+        let MetadataRow::AttributesRevision {
+            inode_id,
+            attributes_revision_no,
+            committed_seq,
+            ..
+        } = &row
+        else {
+            return Ok(Some(row));
+        };
+        if *committed_seq > floor_seq {
+            return Ok(Some(row));
+        }
+        // Writer invariant: one inode's attribute revisions are numbered
+        // without gaps or repeats, so "the newest at or below the floor"
+        // names exactly one row. Two rows sharing a number would make the
+        // choice arbitrary and the drop unsafe; refuse to compact state that
+        // violates it, exactly as the whole-group fold does.
+        if self.previous_at_floor == Some(*attributes_revision_no) {
+            return Err(CoreError::NamespaceCorrupt(format!(
+                "inode `{inode_id}` has two attribute rows at revision \
+                 `{attributes_revision_no}` at or below the retention floor; refusing to drop rows"
+            )));
+        }
+        self.previous_at_floor = Some(*attributes_revision_no);
+        if self.kept_at_floor {
+            return Ok(None);
+        }
+        self.kept_at_floor = true;
+        Ok(Some(row))
+    }
+
+    fn close_group(&mut self) {
+        self.kept_at_floor = false;
+        self.previous_at_floor = None;
+    }
+}
+
+/// Active-deletion rows, one deletion identity at a time.
+///
+/// The family holds current state, not history, so the floor has no say over
+/// it: a listed deletion stays recoverable however far the floor advances.
+/// The only rows that go are the pairs that cancelled each other, and the row
+/// key ranks the removal marker below the row it removes, so the marker
+/// always arrives first and one flag decides the pair.
+#[derive(Debug, Default)]
+pub(super) struct ActiveDeletionRetention {
+    /// Whether this deletion's removal marker has already arrived.
+    revoked: bool,
+}
+
+impl ActiveDeletionRetention {
+    fn push(&mut self, row: MetadataRow) -> Option<MetadataRow> {
+        let MetadataRow::ActiveDeletion { action, .. } = &row else {
+            return Some(row);
+        };
+        match action {
+            // Every removal marker goes; what it is here to decide is whether
+            // the listed row goes with it.
+            ActiveDeletionRowAction::Removed { .. } => {
+                self.revoked = true;
+                None
+            }
+            ActiveDeletionRowAction::Listed { .. } if self.revoked => None,
+            ActiveDeletionRowAction::Listed { .. } => Some(row),
+        }
+    }
+
+    fn close_group(&mut self) {
+        self.revoked = false;
+    }
+}
+
+/// Forward bind rows and the unbinds that retire them, one binding generation
+/// at a time.
+///
+/// A bind's row key *is* its generation — `direntry-{parent}-{name}-{bind_seq}
+/// -{bind_delta}` — and an unbind's key leads with the generation it retires,
+/// so a locality group of four key components holds one bind and the unbinds
+/// of that one bind. The bind arrives first, because its family sorts first,
+/// and the verdict on it is delivered when the group closes.
+///
+/// The one thing that outlives a generation is the slot invariant below: at
+/// or below the floor only the latest bind in a slot may stand un-retired, and
+/// that is a property of the whole parent-and-name slot rather than of one
+/// generation. It costs one generation identity, not one row per generation.
+#[derive(Debug, Default)]
+pub(super) struct BindingRetention {
+    /// The bind row of the generation being read, held until its unbinds have
+    /// arrived. One row: a generation has one bind.
+    held_bind: Option<MetadataRow>,
+    /// The generations this group's unbinds retired at or below the floor.
+    /// One entry at most — every unbind in the group names the same
+    /// generation — and it is the same set a whole-group fold builds, so both
+    /// bind families reach `bind_survives_frozen_floor` by the same route.
+    unbound_at_floor: BTreeSet<BindingGeneration>,
+    /// The one bind at or below the floor in this slot that nothing retired,
+    /// or `None` while the slot has none. A second one means the first was
+    /// superseded without an unbind.
+    unretired_at_floor: Option<BindingGeneration>,
+}
+
+impl BindingRetention {
+    fn push(&mut self, row: MetadataRow, floor_seq: ChangeSeq) -> Option<MetadataRow> {
+        match &row {
+            MetadataRow::DirentryUnbind {
+                parent_inode_id,
+                name_key,
+                bind_seq,
+                bind_delta_index,
+                unbind_seq,
+                ..
+            } => {
+                if *unbind_seq > floor_seq {
+                    return Some(row);
+                }
+                // A spent marker: the floor covers it, so nothing can observe
+                // the binding it retired, and it retires that binding for the
+                // bind row held above.
+                self.unbound_at_floor.insert((
+                    *parent_inode_id,
+                    name_key.clone(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ));
+                None
+            }
+            // A bind above the floor survives whatever retired it later, so
+            // it needs no verdict and is written straight through.
+            MetadataRow::DirentryBind { bind_seq, .. } if *bind_seq > floor_seq => Some(row),
+            MetadataRow::DirentryBind { .. } => {
+                self.held_bind = Some(row);
+                None
+            }
+            _ => Some(row),
+        }
+    }
+
+    fn close_group(&mut self, floor_seq: ChangeSeq) -> Result<Option<MetadataRow>> {
+        let unbound_at_floor = std::mem::take(&mut self.unbound_at_floor);
+        let Some(row) = self.held_bind.take() else {
+            return Ok(None);
+        };
+        let MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } = &row
+        else {
+            return Ok(Some(row));
+        };
+        let generation = (
+            *parent_inode_id,
+            name_key.clone(),
+            *bind_seq,
+            *bind_delta_index,
+        );
+        self.check_the_slot_invariant(&generation)?;
+        let survives = bind_survives_frozen_floor(&row, floor_seq, &unbound_at_floor);
+        self.unretired_at_floor = survives.then_some(generation);
+        Ok(survives.then_some(row))
+    }
+
+    /// Refuses a slot whose binds break the writer invariant the drop rests
+    /// on.
+    ///
+    /// At the floor only the latest bind per slot is visible, and a bind is
+    /// only ever superseded by an operation that also unbinds it. So every
+    /// bind at or below the floor except the slot's latest must have been
+    /// retired. Generations arrive in ascending order, so a bind at or below
+    /// the floor arriving while an earlier un-retired one still stands proves
+    /// that earlier one was superseded without an unbind — and dropping by
+    /// [`bind_survives_frozen_floor`] would then keep a bind no read can
+    /// reach and call it live.
+    fn check_the_slot_invariant(&mut self, generation: &BindingGeneration) -> Result<()> {
+        let Some(previous) = self.unretired_at_floor.take() else {
+            return Ok(());
+        };
+        if (&previous.0, &previous.1) != (&generation.0, &generation.1) {
+            // A different parent-and-name slot: the previous slot's latest
+            // bind was its latest, which is exactly what the invariant
+            // allows.
+            return Ok(());
+        }
+        Err(CoreError::NamespaceCorrupt(format!(
+            "bind at seq `{}` delta {} for parent `{}` is superseded at or below the retention \
+             floor without an unbind; refusing to drop rows",
+            previous.2, previous.3, previous.0
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loonfs_api::{DisplayName, InodeId, NameKey};
+
+    fn floor() -> ChangeSeq {
+        ChangeSeq(100)
+    }
+
+    fn attribute_row(inode: u64, revision: u64, committed_seq: u64) -> MetadataRow {
+        MetadataRow::AttributesRevision {
+            inode_id: InodeId(inode),
+            attributes_revision_no: AttributeRevisionNo(revision),
+            committed_seq: ChangeSeq(committed_seq),
+            delta_index: 0,
+            attributes: Default::default(),
+        }
+    }
+
+    fn bind_row(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
+        MetadataRow::DirentryBind {
+            parent_inode_id: InodeId(parent),
+            name_key: NameKey::parse(name).expect("name key"),
+            display_name: DisplayName::parse(name).expect("display name"),
+            child_inode_id: InodeId(42),
+            bind_seq: ChangeSeq(bind_seq),
+            bind_delta_index: 0,
+        }
+    }
+
+    fn unbind_row(parent: u64, name: &str, bind_seq: u64, unbind_seq: u64) -> MetadataRow {
+        MetadataRow::DirentryUnbind {
+            parent_inode_id: InodeId(parent),
+            name_key: NameKey::parse(name).expect("name key"),
+            display_name: DisplayName::parse(name).expect("display name"),
+            child_inode_id: InodeId(42),
+            bind_seq: ChangeSeq(bind_seq),
+            bind_delta_index: 0,
+            unbind_seq: ChangeSeq(unbind_seq),
+            unbind_delta_index: 0,
+        }
+    }
+
+    /// One inode's revisions arrive newest first, so the operator keeps
+    /// everything above the floor plus the first row at or below it, and its
+    /// state never grows with the history.
+    #[test]
+    fn one_inode_keeps_the_newest_row_at_the_floor_and_holds_nothing() {
+        let mut operator = RetentionRule::Attributes.operator();
+        let mut kept = Vec::new();
+        // Newest first: two above the floor, then a hundred thousand below.
+        for (revision, committed_seq) in [(100_002u64, 102u64), (100_001, 101)] {
+            if let Some((_, row)) = operator
+                .push(
+                    MetadataTableFamily::Attributes,
+                    attribute_row(7, revision, committed_seq),
+                    floor(),
+                )
+                .expect("push")
+            {
+                kept.push(row);
+            }
+        }
+        for revision in (1..=100_000u64).rev() {
+            let pushed = operator
+                .push(
+                    MetadataTableFamily::Attributes,
+                    attribute_row(7, revision, 50),
+                    floor(),
+                )
+                .expect("push");
+            if let Some((_, row)) = pushed {
+                kept.push(row);
+            }
+            assert_eq!(operator.held_rows(), 0);
+        }
+        assert_eq!(kept.len(), 3, "two above the floor and the newest below it");
+        assert_eq!(kept[2], attribute_row(7, 100_000, 50));
+    }
+
+    /// The rule refuses a history where "the newest at the floor" is
+    /// ambiguous, exactly as the whole-group fold does.
+    #[test]
+    fn two_attribute_rows_at_one_revision_below_the_floor_are_refused() {
+        let mut operator = RetentionRule::Attributes.operator();
+        operator
+            .push(
+                MetadataTableFamily::Attributes,
+                attribute_row(7, 5, 50),
+                floor(),
+            )
+            .expect("the first row at the floor is kept");
+        let error = operator
+            .push(
+                MetadataTableFamily::Attributes,
+                attribute_row(7, 5, 49),
+                floor(),
+            )
+            .expect_err("a repeated revision at the floor is refused");
+        assert!(error.to_string().contains("two attribute rows at revision"));
+    }
+
+    /// A cancelled deletion's pair leaves together, and a live one stays
+    /// whatever the floor says.
+    #[test]
+    fn a_cancelled_deletion_leaves_and_a_live_one_stays() {
+        let mut operator = RetentionRule::ActiveDeletions.operator();
+        let removed = MetadataRow::ActiveDeletion {
+            root_inode_id: InodeId(9),
+            deleted_at_seq: ChangeSeq(3),
+            action: ActiveDeletionRowAction::Removed {
+                revoked_at_seq: ChangeSeq(4),
+            },
+        };
+        let listed = MetadataRow::ActiveDeletion {
+            root_inode_id: InodeId(9),
+            deleted_at_seq: ChangeSeq(3),
+            action: ActiveDeletionRowAction::Listed {
+                deleted_at_ms: 1_000,
+                deleted_direntry: None,
+            },
+        };
+        assert!(operator
+            .push(
+                MetadataTableFamily::ActiveDeletions,
+                removed.clone(),
+                floor()
+            )
+            .expect("push")
+            .is_none());
+        assert!(operator
+            .push(
+                MetadataTableFamily::ActiveDeletions,
+                listed.clone(),
+                floor()
+            )
+            .expect("push")
+            .is_none());
+        assert_eq!(operator.held_rows(), 0);
+
+        operator.close_group(floor()).expect("close");
+        assert!(
+            operator
+                .push(MetadataTableFamily::ActiveDeletions, listed, floor())
+                .expect("push")
+                .is_some(),
+            "the next deletion is decided on its own markers, not the previous one's"
+        );
+    }
+
+    /// One name slot with a hundred thousand generations streams through
+    /// holding at most one row.
+    #[test]
+    fn one_name_slot_of_many_generations_holds_at_most_one_row() {
+        let mut operator = RetentionRule::ForwardBindings.operator();
+        let mut kept = Vec::new();
+        let mut peak = 0usize;
+        for generation in 1..=100_000u64 {
+            // Every generation is bound and then unbound below the floor,
+            // which is the shape a repeatedly recreated name leaves.
+            operator
+                .push(
+                    MetadataTableFamily::DirentryBinds,
+                    bind_row(7, "hot.txt", generation),
+                    ChangeSeq(200_000),
+                )
+                .expect("push");
+            peak = peak.max(operator.held_rows());
+            operator
+                .push(
+                    MetadataTableFamily::DirentryUnbinds,
+                    unbind_row(7, "hot.txt", generation, generation + 1),
+                    ChangeSeq(200_000),
+                )
+                .expect("push");
+            peak = peak.max(operator.held_rows());
+            if let Some((_, row)) = operator.close_group(ChangeSeq(200_000)).expect("close") {
+                kept.push(row);
+            }
+        }
+        assert_eq!(peak, 1, "the operator holds one bind row and no more");
+        assert!(
+            kept.is_empty(),
+            "every generation was unbound below the floor, so every bind goes"
+        );
+    }
+
+    /// A bind that survives the floor is remembered by identity alone, and a
+    /// second surviving bind in the same slot is the invariant violation the
+    /// rule refuses.
+    #[test]
+    fn a_second_unretired_bind_in_one_slot_is_refused() {
+        let mut operator = RetentionRule::ForwardBindings.operator();
+        operator
+            .push(
+                MetadataTableFamily::DirentryBinds,
+                bind_row(7, "a.txt", 10),
+                floor(),
+            )
+            .expect("push");
+        assert!(operator
+            .close_group(floor())
+            .expect("close")
+            .is_some_and(|(family, _)| family == MetadataTableFamily::DirentryBinds));
+
+        // The next slot is unaffected by the one before it: the bind left
+        // standing in `a.txt` is that slot's latest, which is what the
+        // invariant allows.
+        operator
+            .push(
+                MetadataTableFamily::DirentryBinds,
+                bind_row(7, "b.txt", 11),
+                floor(),
+            )
+            .expect("push");
+        operator.close_group(floor()).expect("close");
+
+        // A second generation in that same slot with nothing retiring the
+        // first is the state the drop rule may not act on.
+        operator
+            .push(
+                MetadataTableFamily::DirentryBinds,
+                bind_row(7, "b.txt", 12),
+                floor(),
+            )
+            .expect("push");
+        let error = operator
+            .close_group(floor())
+            .expect_err("a superseded bind with no unbind is refused");
+        assert!(
+            error.to_string().contains("seq `11`"),
+            "the error must name the bind that was superseded, got: {error}"
+        );
+        assert!(error.to_string().contains("superseded at or below"));
+    }
+}

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -28,7 +28,8 @@ use loonfs_api::wire::manifest::{
 };
 use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId, WriterEpoch};
 use loonfs_objectstore::keys::{
-    metadata_compaction_staging_table, metadata_manifest_object, metadata_table,
+    metadata_compaction_job_id_from_key, metadata_compaction_table, metadata_manifest_object,
+    metadata_table,
 };
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
@@ -576,22 +577,27 @@ pub(super) fn metadata_file_object_key(descriptor: &MetadataFileRef) -> String {
 /// identity may live at.
 ///
 /// The ordinary key is the metadata-table key its owner and table id build.
-/// The other is the staging directory a streaming compaction writes to: a
-/// compaction writes its output before any manifest names it, so its segments
-/// must sit outside the listing a collector sweeps for unreferenced tables
-/// (format spec, "Compaction"). Publication moves no bytes, so the manifest
-/// that swaps a compaction's output in names the staged keys. The segment is
-/// an ordinary one either way — same encoding, same descriptor — and the
-/// table id still makes the key its producer's alone.
+/// The other is one streaming compaction job's own prefix: a compaction
+/// writes its output before any manifest names it, so its segments must sit
+/// outside the listing a collector sweeps for unreferenced tables (format
+/// spec, "Compaction"). Publication moves no bytes, so the manifest that swaps
+/// a compaction's output in names the staged keys. The segment is an ordinary
+/// one either way — same encoding, same descriptor — and the table id still
+/// makes the key its producer's alone. The job id is read back out of the key
+/// rather than carried on the descriptor, because which job wrote a segment
+/// stops mattering the moment a manifest names it.
 pub(super) fn ensure_segment_object_key(
     descriptor: &MetadataFileRef,
 ) -> Result<(), ManifestLoadError> {
     let expected = metadata_file_object_key(descriptor);
-    let staged = metadata_compaction_staging_table(
-        descriptor.owner_namespace_id.as_str(),
-        descriptor.table_id.as_str(),
-    );
-    if descriptor.object_key == expected || descriptor.object_key == staged {
+    let staged = metadata_compaction_job_id_from_key(&descriptor.object_key).map(|job_id| {
+        metadata_compaction_table(
+            descriptor.owner_namespace_id.as_str(),
+            job_id,
+            descriptor.table_id.as_str(),
+        )
+    });
+    if descriptor.object_key == expected || staged.as_deref() == Some(&descriptor.object_key) {
         return Ok(());
     }
     Err(ManifestLoadError::SegmentObjectKeyMismatch {

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -22,7 +22,9 @@
 //!   [`row`] handles manifest-row encoding.
 //! - [`reorganize`] compacts bounded family groups into new base runs, and
 //!   [`streaming_compaction`] rebuilds a group whose bottom-anchored window
-//!   no longer fits one of those steps.
+//!   no longer fits one of those steps — with [`compaction_retention`]
+//!   holding the frozen floor's rules as streaming state and
+//!   [`compaction_lease`] holding the running job's claim on its own output.
 //! - [`retention`] advances the retention floor behind verified progress.
 //! - [`runs`] models the LSM run layout shared by all of the above,
 //!   [`cache`] holds decoded SST blocks keyed by content digest, and
@@ -33,6 +35,8 @@ mod block_fetch;
 mod block_load;
 mod build;
 mod cache;
+mod compaction_lease;
+mod compaction_retention;
 mod create;
 mod data_block_load;
 mod error;
@@ -62,7 +66,9 @@ pub use self::cache::{
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
-pub use self::reorganize::{MetadataReorganizeOutcome, MetadataReorganizeReport};
+pub use self::reorganize::{
+    MetadataCompactionView, MetadataReorganizeOutcome, MetadataReorganizeReport,
+};
 pub(crate) use self::runs::MetadataLsmPolicy;
 pub use self::stored_block_cache::{
     StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey,
@@ -72,6 +78,7 @@ pub use self::streaming_compaction::{
     MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,
 };
 
+pub(crate) use self::compaction_lease::{read_compaction_lease_state, CompactionLeaseState};
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::files::list_checkpoint_files_page;
 pub(crate) use self::flush::flush_wal;

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -38,6 +38,18 @@
 //! job: it reports the plan, and the runtime starts the job in the
 //! background and hands its spec back to every step that follows, which is
 //! how a step knows to leave that group alone while it runs.
+//!
+//! One step cannot see whether a group is stuck. A group whose
+//! bottom-anchored window is blocked still has delta runs to merge, and under
+//! sustained writes there is always another pair of them, so a planner
+//! deciding from one step's view alone would take the delta merge every time
+//! and never start the job — the base would stay frozen and the group's
+//! retention would stay stopped. The runtime therefore counts, per group, the
+//! engagements that planned work while the bottom-anchored window was
+//! blocked, and hands that count back through
+//! [`MetadataCompactionView`]. At
+//! [`DELTA_MERGES_OVER_A_FROZEN_BASE`] the planner stops taking the merge and
+//! starts the job.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::build::{
@@ -76,6 +88,47 @@ use loonfs_api::{
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
+/// Maintenance engagements that may plan a delta merge over a frozen base
+/// before the planner insists on the job that unfreezes it.
+///
+/// Delta merges between jobs are how a stuck group amortizes: a job rereads
+/// the whole group, so running one for every eight delta runs would reread
+/// megabytes to fold in a sliver. Two engagements is the smallest count that
+/// still lets the ordinary merge do that work, and it bounds how long
+/// retention for the group can stay stopped — the job starts within two
+/// maintenance engagements of the block, whatever the write rate is.
+pub(super) const DELTA_MERGES_OVER_A_FROZEN_BASE: u32 = 2;
+
+/// What the process running maintenance knows about one namespace's
+/// streaming compactions, which one step's read of durable state cannot see.
+///
+/// Both fields are in-memory process state, and both are safe to lose: a
+/// restart forgets the active job (a later step plans it again) and forgets
+/// the engagement counts (the next two engagements rebuild them, delaying one
+/// cycle).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MetadataCompactionView<'a> {
+    /// The plan of the job running for this namespace, or `None` when it is
+    /// running none. The step leaves that job's group alone and folds
+    /// another, because every run of that group is in the job's snapshot and
+    /// merging one would waste the whole job at finalization.
+    pub active: Option<&'a MetadataCompactionSpec>,
+    /// Per family group, how many maintenance engagements have planned work
+    /// for it while its bottom-anchored merge was blocked, since that group's
+    /// last completed job. Keyed by the group's families, which is the
+    /// group's identity outside this crate.
+    pub blocked_engagements: &'a [(&'a [MetadataTableFamily], u32)],
+}
+
+impl MetadataCompactionView<'_> {
+    fn engagements(&self, group: MetadataFamilyGroup) -> u32 {
+        self.blocked_engagements
+            .iter()
+            .find(|(families, _)| *families == group.families())
+            .map_or(0, |(_, engagements)| *engagements)
+    }
+}
+
 /// What one reorganization step did.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MetadataReorganizeOutcome {
@@ -93,6 +146,14 @@ pub enum MetadataReorganizeOutcome {
         decoded_input_rows: u64,
         decoded_input_bytes: u64,
         manifest_id: ManifestId,
+        /// True when the window starting at the group's oldest run could not
+        /// reach an L0 run, so this merge ran above a frozen base and the
+        /// group's retention is still stopped. The runtime counts these per
+        /// group and hands the count back through
+        /// [`MetadataCompactionView::blocked_engagements`], which is what
+        /// decides when the planner stops merging deltas over that base and
+        /// starts the job that unfreezes it.
+        bottom_anchored_merge_blocked: bool,
     },
     /// No oldest-first subset that would make progress fits the hard
     /// per-step input budgets, so the group is rebuilt by a streaming
@@ -119,10 +180,9 @@ pub struct MetadataReorganizeReport {
 /// call re-reads durable state, so any two calls compose — including across
 /// process restarts.
 ///
-/// `active_compaction` is the plan of the streaming compaction this process
-/// is running for the namespace, or `None` when it is running none. The step
-/// leaves that job's group alone and works on another; see
-/// [`select_family_group`].
+/// `compactions` is what this process knows about the namespace's streaming
+/// compactions: which group a job is rebuilding right now, and how long each
+/// group has been merging deltas over a frozen base.
 #[tracing::instrument(
     level = "info",
     name = "loonfs.phase",
@@ -135,18 +195,11 @@ pub(crate) async fn reorganize_metadata_step<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     context: &MutationContext,
     policy: MetadataLsmPolicy,
-    active_compaction: Option<&MetadataCompactionSpec>,
+    compactions: MetadataCompactionView<'_>,
 ) -> Result<MetadataReorganizeReport> {
     let timer = StdMonotonicTimer::default();
-    reorganize_metadata_step_with_timer(
-        store,
-        namespace_id,
-        context,
-        policy,
-        active_compaction,
-        &timer,
-    )
-    .await
+    reorganize_metadata_step_with_timer(store, namespace_id, context, policy, compactions, &timer)
+        .await
 }
 
 pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>(
@@ -154,7 +207,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     namespace_id: &NamespaceId,
     context: &MutationContext,
     policy: MetadataLsmPolicy,
-    active_compaction: Option<&MetadataCompactionSpec>,
+    compactions: MetadataCompactionView<'_>,
     timer: &dyn MonotonicTimer,
 ) -> Result<MetadataReorganizeReport> {
     // The publication budget covers the whole unit: measurement starts
@@ -191,7 +244,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     }
     let Some(group) = select_family_group(
         &previous.payload,
-        active_compaction.map(MetadataCompactionSpec::group),
+        compactions.active.map(MetadataCompactionSpec::group),
     ) else {
         // L0 runs exist but hold no rows (empty families), or the only group
         // with rows is the one a job is rebuilding; nothing to fold here.
@@ -212,14 +265,21 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let floor_seq = resolve_retention_floor_seq(store, &head)
         .await
         .map_err(CoreError::load_head)?;
-    let selection = select_reorganization_input(&tables, group, policy, floor_seq)
-        .await
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-        })?;
+    let selection = select_reorganization_input(
+        &tables,
+        group,
+        policy,
+        floor_seq,
+        compactions.engagements(group) >= DELTA_MERGES_OVER_A_FROZEN_BASE,
+    )
+    .await
+    .map_err(|error| {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
+    })?;
     if let Some(bottom) = selection.group_bottom_over_budget {
         report_group_bottom_over_budget(namespace_id, group, &bottom, policy);
     }
+    let bottom_anchored_merge_blocked = selection.bottom_anchored_merge_blocked;
     let input = match selection.plan {
         Some(ReorganizationPlan::BoundedMerge(input)) => input,
         Some(ReorganizationPlan::FullCompaction(spec)) => {
@@ -356,6 +416,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
                 decoded_input_rows: input.decoded_rows,
                 decoded_input_bytes: input.decoded_bytes,
                 manifest_id: manifest.payload.manifest_id,
+                bottom_anchored_merge_blocked,
             },
         }),
         ManifestPublicationOutcome::Superseded(_) | ManifestPublicationOutcome::RootCasRaceLost => {
@@ -498,6 +559,11 @@ pub(super) struct ReorganizationSelection {
     /// all and there is nothing to do either way.
     pub(super) plan: Option<ReorganizationPlan>,
     pub(super) group_bottom_over_budget: Option<OverBudgetRun>,
+    /// True when the window starting at the group's oldest run could not
+    /// reach an L0 run inside the budgets. The group's base is frozen while
+    /// that holds, and only a streaming compaction unfreezes it, so this is
+    /// what the runtime counts to decide when to stop merging deltas over it.
+    pub(super) bottom_anchored_merge_blocked: bool,
 }
 
 /// A run that does not fit one step's budgets on its own.
@@ -555,11 +621,18 @@ pub(super) struct OverBudgetRun {
 /// `frozen_floor_seq` is the live retention floor. A bounded merge reads it
 /// again at drop time; a compaction spec carries it, because the floor a job
 /// judges every row against is fixed when the job is planned.
+///
+/// `compact_a_frozen_base` is the runtime's answer to the one thing this
+/// function cannot see: how long this group has already been merging deltas
+/// over a base no window can reach. When it is set, a blocked bottom-anchored
+/// window goes straight to the job rather than taking the delta merge above
+/// it — the merge would make progress, but not the progress the group needs.
 pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     group: MetadataFamilyGroup,
     policy: MetadataLsmPolicy,
     frozen_floor_seq: ChangeSeq,
+    compact_a_frozen_base: bool,
 ) -> std::result::Result<ReorganizationSelection, ManifestLoadError> {
     let mut candidates = tables
         .scan_runs
@@ -595,8 +668,19 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
     // candidate's total is read at most once however many windows weigh it.
     let mut decoded_bytes_by_candidate = vec![None::<u64>; candidate_count];
     let mut group_bottom_over_budget = None;
+    let mut bottom_anchored_merge_blocked = false;
 
     for window_start in std::iter::once(0).chain(delta_only_start) {
+        // Reaching a window above the bottom means the bottom-anchored one
+        // made no progress, so the group's base is frozen and its retention
+        // has stopped. A delta merge still helps — it keeps the run count
+        // down while the base waits — but only the job unfreezes the base, and
+        // under sustained writes there is always another pair of delta runs to
+        // merge. So after the runtime has watched this group take that merge
+        // enough times, the planner stops taking it.
+        if window_start > 0 && compact_a_frozen_base {
+            break;
+        }
         let mut runs = Vec::new();
         let mut decoded_rows = 0u64;
         let mut decoded_bytes = 0u64;
@@ -666,6 +750,7 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
             runs.len() > 1
         };
         if !makes_progress {
+            bottom_anchored_merge_blocked |= bottom_anchored;
             continue;
         }
         let run_ids = runs.iter().map(|run| (run.run_seq, run.level)).collect();
@@ -680,17 +765,19 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 placement,
             })),
             group_bottom_over_budget,
+            bottom_anchored_merge_blocked,
         });
     }
 
-    // No window makes progress inside the budgets. That is the whole of the
-    // stuck case: the bottom-anchored window cannot reach an L0 run, so
-    // retention for the group has stopped, and the delta runs above the
-    // bottom are down to one or blocked as well, so nothing shrinks the run
-    // count either. A streaming compaction takes the whole group. Its input
-    // is every run the group holds, which is bottom-anchored by
-    // construction, so its output is the group's base run and it may drop
-    // what the floor allows.
+    // Nothing above got taken. Either no window makes progress inside the
+    // budgets — the bottom-anchored window cannot reach an L0 run, so
+    // retention for the group has stopped, and the delta runs above the bottom
+    // are down to one or blocked as well — or the delta merge was available
+    // and the runtime said this group has taken enough of them. Both end the
+    // same way: a streaming compaction takes the whole group. Its input is
+    // every run the group holds, which is bottom-anchored by construction, so
+    // its output is the group's base run and it may drop what the floor
+    // allows.
     let spec = (!candidates.is_empty()).then(|| {
         MetadataCompactionSpec::new(
             group,
@@ -712,6 +799,7 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
     Ok(ReorganizationSelection {
         plan: spec.map(ReorganizationPlan::FullCompaction),
         group_bottom_over_budget,
+        bottom_anchored_merge_blocked,
     })
 }
 
@@ -895,6 +983,11 @@ pub(super) async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
 /// durable data retained independently of the replay floor — and tombstone
 /// and inode rows are always retained until reachability-based dropping is
 /// designed.
+///
+/// A bounded merge holds every row of its window, so this reads them all at
+/// once. A streaming compaction cannot hold them, and runs the same rules as
+/// streaming operators instead ([`super::compaction_retention`]); the
+/// equivalence oracle in the tests is what says the two reach the same rows.
 pub(super) fn drop_rows_below_retention_floor(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,
@@ -920,9 +1013,10 @@ pub(super) type BindingGeneration = (InodeId, NameKey, ChangeSeq, u32);
 /// retires.
 ///
 /// A whole-group fold builds this from every unbind row it merged. A
-/// streaming compaction builds it per slot, from the unbind rows of that one
-/// (parent, name) slot: an unbind and the bind it cancels share a slot, so
-/// the rows of one slot hold both halves of every pair they belong to.
+/// streaming compaction builds it one binding generation at a time, from that
+/// generation's own unbinds: a bind's row key is its generation and an
+/// unbind's key leads with the generation it retires, so the rows of one
+/// generation hold both halves of the pair.
 pub(super) fn unbindings_at_or_below_floor(
     unbind_rows: &[MetadataRow],
     retention_floor_seq: ChangeSeq,
@@ -961,8 +1055,9 @@ pub(super) fn unbindings_at_or_below_floor(
 /// Both bind families read this same rule, which is what keeps them dropping
 /// in lockstep: the format gives every bind row exactly one reverse row, and a
 /// run whose two counts disagree does not load. They reach the rule by
-/// different routes — the forward row's unbinds share its slot, the reverse
-/// row's do not — but the rule is one function and the answer is one answer.
+/// different routes — the forward row's unbinds arrive in its own locality
+/// group, the reverse row's do not and are point-read instead — but the rule
+/// is one function and the answer is one answer.
 pub(super) fn bind_survives_frozen_floor(
     row: &MetadataRow,
     retention_floor_seq: ChangeSeq,
@@ -987,17 +1082,10 @@ pub(super) fn bind_survives_frozen_floor(
         ))
 }
 
-/// [`drop_rows_below_retention_floor`] against a floor and an unbind set the
-/// caller froze, rather than against rows it can see right now.
-///
-/// A streaming compaction calls this per locality group: the floor is fixed
-/// for the whole job, so every group and every attempt decides identically.
-/// Families the caller leaves out of `rows_by_family` are untouched, which is
-/// how a compaction keeps the reverse bind index out of this pass — its rows
-/// are keyed by child, so the group holding one does not hold the forward
-/// binds the invariant check below reads, and the compaction decides those
-/// rows with a point read instead.
-pub(super) fn drop_rows_below_frozen_floor(
+/// [`drop_rows_below_retention_floor`] against an unbind set the caller
+/// already built, so the retention floor and the unbind set that goes with it
+/// are stated once for the whole window.
+fn drop_rows_below_frozen_floor(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,
     unbound_at_floor: &BTreeSet<BindingGeneration>,
@@ -1035,7 +1123,7 @@ pub(super) fn drop_rows_below_frozen_floor(
     // the deletion commits before the undelete, runs merge oldest-first, and
     // the selected subset is a prefix of that order, so a marker can never
     // outlive the row it names. A streaming compaction groups the family by
-    // deletion generation, which is the pair's shared key prefix, so the pair
+    // deletion identity, which is the pair's shared key prefix, so the pair
     // lands in one group there too.
     if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::ActiveDeletions) {
         let revoked: BTreeSet<(ChangeSeq, InodeId)> = rows
@@ -1159,8 +1247,9 @@ fn refuse_superseded_bind_without_unbind(
 /// its rows, the same posture inode and tombstone rows take, and that is what
 /// makes an undelete give back the map the inode had.
 ///
-/// The rule reads one inode's rows and no others, so a streaming compaction
-/// runs it over one inode's rows at a time and reaches the same answer.
+/// The rule reads one inode's rows and no others, and reads them newest
+/// first, so a streaming compaction reaches the same answer holding two
+/// fields instead of the inode's history.
 fn drop_superseded_attribute_revisions(
     rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
     retention_floor_seq: ChangeSeq,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -9,17 +9,20 @@
 //!
 //! Nothing about the job follows the size of the group. It opens one iterator
 //! per run per family, merges them in row-key order, feeds the merged rows
-//! through the retention rules a locality group at a time, and writes each
-//! output segment as it fills. What it holds at any instant is a fixed number
-//! of decoded input blocks per iterator, the rows of one locality group, and
-//! one segment builder per family of the group. No family, no partition, and
-//! no directory is ever collected whole.
+//! through streaming retention operators ([`super::compaction_retention`]),
+//! and writes each output segment as it fills. What it holds at any instant is
+//! a fixed number of decoded input blocks per iterator, the fixed state of one
+//! retention operator, and one segment builder per family of the group. No
+//! family, no partition, no directory, no inode's history, and no name slot's
+//! generations are ever collected whole.
 //!
-//! Output segments go to the staging directory rather than to
+//! Output segments go to the job's own prefix rather than to
 //! `metadata/tables/` (format spec, "Compaction"): a job outlives the
 //! collector's grace window, so its output would otherwise look exactly like
-//! the unreferenced aged objects the collector reaps. The executor publishes
-//! nothing itself. It returns the descriptors it wrote, and
+//! the unreferenced aged objects the collector reaps. What tells the collector
+//! the difference is the lease beside them ([`super::compaction_lease`]),
+//! which the job rewrites while it runs. The executor publishes nothing
+//! itself. It returns the descriptors it wrote, and
 //! [`run_metadata_compaction_job`] swaps them in with one manifest
 //! publication; a cancelled or crashed job leaves staged objects nothing
 //! references and the old manifest still valid.
@@ -32,6 +35,8 @@ use super::block_fetch::{load_segment_filter, load_segment_index_for_reorganizat
 use super::block_load::SessionBlockMemo;
 use super::build::{write_manifest_segment, MetadataSstWriteRequest};
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
+use super::compaction_lease::CompactionLease;
+use super::compaction_retention::{KeptRow, RetentionRule};
 use super::data_block_load::load_segment_data_block_span;
 use super::error::ManifestLoadError;
 use super::flush::ensure_metadata_publication_budget;
@@ -40,8 +45,8 @@ use super::load::{
 };
 use super::publish::{publish_metadata_root, ManifestPublicationOutcome};
 use super::reorganize::{
-    bind_survives_frozen_floor, drop_rows_below_frozen_floor, group_run_descriptors,
-    unbindings_at_or_below_floor, write_reorganized_manifest, MergePlacement,
+    bind_survives_frozen_floor, group_run_descriptors, unbindings_at_or_below_floor,
+    write_reorganized_manifest, MergePlacement,
 };
 use super::runs::{MetadataFamilyGroup, MetadataLsmPolicy, MetadataRunManifest};
 use super::scan::{descriptor_may_intersect_range, Readahead, VerifiedMetadataTables};
@@ -49,13 +54,13 @@ use super::validate::validate_manifest_row_seq_range;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::control::read_metadata_root_object_if_present;
-use crate::timing::{MonotonicTimer, StdMonotonicTimer};
+use crate::timing::StdMonotonicTimer;
 use loonfs_api::wire::manifest::{lookup_keys, MetadataFileRef, MetadataRow, MetadataTableFamily};
 use loonfs_api::wire::sst_blocks::{
     string_prefix_upper_bound, DecodedDataBlock, SegmentIndexEntry,
 };
-use loonfs_api::{ChangeSeq, ManifestId, MetadataTableId, NamespaceId};
-use loonfs_objectstore::keys::metadata_compaction_staging_table;
+use loonfs_api::{ChangeSeq, ManifestId, MetadataCompactionId, MetadataTableId, NamespaceId};
+use loonfs_objectstore::keys::metadata_compaction_table;
 use loonfs_objectstore::ObjectStore;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -107,6 +112,10 @@ const MAX_FINALIZATION_ATTEMPTS: usize = 4;
 /// merge the group a job is rebuilding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataCompactionSpec {
+    /// This job's identity, and the prefix its output and its lease live
+    /// under. Generated with the plan, so two plans for one group never write
+    /// into each other's prefix.
+    job_id: MetadataCompactionId,
     group: MetadataFamilyGroup,
     /// Every run the group held when the plan was made, by sequence and
     /// level. That is bottom-anchored by construction — a run the group holds
@@ -130,6 +139,7 @@ impl MetadataCompactionSpec {
         frozen_floor_seq: ChangeSeq,
     ) -> Self {
         Self {
+            job_id: MetadataCompactionId::generate(),
             group,
             inputs,
             input_rows,
@@ -140,6 +150,11 @@ impl MetadataCompactionSpec {
 
     pub(super) fn group(&self) -> MetadataFamilyGroup {
         self.group
+    }
+
+    /// The job's identity, which names the prefix its output sits under.
+    pub fn job_id(&self) -> &MetadataCompactionId {
+        &self.job_id
     }
 
     /// The families this job rebuilds, for a caller reporting what it started.
@@ -213,10 +228,11 @@ pub(super) struct MetadataCompactionResult {
     /// row at or below the frozen floor.
     pub(super) unbind_probes: u64,
     /// The most decoded input blocks the job's iterators held at once, and
-    /// the most rows one locality group held. These are what bound the job's
-    /// memory, so tests assert they do not follow the size of the group.
+    /// the most rows one retention operator held. These are what bound the
+    /// job's memory, so tests assert they do not follow the size of the
+    /// group, of one inode's history, or of one name slot's generations.
     pub(super) peak_resident_blocks: usize,
-    pub(super) peak_locality_rows: usize,
+    pub(super) peak_operator_rows: usize,
 }
 
 /// Rebuilds `spec`'s group from `spec`'s runs.
@@ -230,6 +246,7 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
     spec: &MetadataCompactionSpec,
     policy: MetadataLsmPolicy,
     cancellation: &MetadataCompactionCancellation,
+    lease: &mut CompactionLease<'_>,
 ) -> Result<MetadataCompactionOutcome> {
     let snapshot = resolve_snapshot_runs(tables, spec)?;
     let mut job = CompactionJob {
@@ -249,7 +266,7 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
             rows_written_by_family: BTreeMap::new(),
             unbind_probes: 0,
             peak_resident_blocks: 0,
-            peak_locality_rows: 0,
+            peak_operator_rows: 0,
         },
         canonical_digest: RowDigest::default(),
         index_digest: RowDigest::default(),
@@ -257,7 +274,7 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
     };
 
     for cluster in retention_clusters(spec.group) {
-        if !job.run_cluster(cluster).await? {
+        if !job.run_cluster(cluster, lease).await? {
             return Ok(MetadataCompactionOutcome::Cancelled);
         }
     }
@@ -323,8 +340,19 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
     let Some(snapshot_keys) = snapshot_segment_keys(&tables, spec) else {
         return Ok(MetadataCompactionJobOutcome::Abandoned);
     };
+    // The lease is written before the first output object, so no object under
+    // the job's prefix is ever unclaimed.
+    let mut lease = CompactionLease::new(
+        namespace_id,
+        spec.job_id(),
+        &context.writer_id,
+        context.now_ms,
+        &timer,
+    );
+    lease.heartbeat(store).await?;
     tracing::info!(
         namespace_id = namespace_id.as_str(),
+        job_id = spec.job_id().as_str(),
         families = ?spec.families(),
         input_runs = spec.input_runs(),
         input_rows = spec.input_rows(),
@@ -332,21 +360,32 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
         "streaming metadata compaction started"
     );
 
-    let result =
-        match run_metadata_compaction(&tables, namespace_id, spec, policy, cancellation).await? {
-            MetadataCompactionOutcome::Completed(result) => result,
-            MetadataCompactionOutcome::Cancelled => {
-                // The executor stops between block fetches, so what it wrote is
-                // whatever segments had already filled. They are staged and named
-                // by nothing.
-                tracing::info!(
-                    namespace_id = namespace_id.as_str(),
-                    families = ?spec.families(),
-                    "streaming metadata compaction cancelled"
-                );
-                return Ok(MetadataCompactionJobOutcome::Cancelled);
-            }
-        };
+    let result = match run_metadata_compaction(
+        &tables,
+        namespace_id,
+        spec,
+        policy,
+        cancellation,
+        &mut lease,
+    )
+    .await?
+    {
+        MetadataCompactionOutcome::Completed(result) => result,
+        MetadataCompactionOutcome::Cancelled => {
+            // The executor stops between block fetches, so what it wrote is
+            // whatever segments had already filled. They are staged and named
+            // by nothing. The lease is left where it is: it expires on its
+            // own, and a pass that arrives before it does keeps a dead job's
+            // orphans a while longer, which costs storage and nothing else.
+            tracing::info!(
+                namespace_id = namespace_id.as_str(),
+                job_id = spec.job_id().as_str(),
+                families = ?spec.families(),
+                "streaming metadata compaction cancelled"
+            );
+            return Ok(MetadataCompactionJobOutcome::Cancelled);
+        }
+    };
     drop(tables);
 
     let rows_read = result.rows_read;
@@ -359,13 +398,18 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
         spec,
         &snapshot_keys,
         result,
-        &timer,
+        &mut lease,
     )
     .await?
     {
         Finalization::Published(manifest_id) => {
+            // The manifest names the staged segments now, and a referenced
+            // object is live wherever it sits, so the claim has nothing left
+            // to protect.
+            lease.release(store).await;
             tracing::info!(
                 namespace_id = namespace_id.as_str(),
+                job_id = spec.job_id().as_str(),
                 families = ?spec.families(),
                 rows_read,
                 rows_written,
@@ -398,7 +442,9 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
 /// The publication budget covers this publication and not the job: what it
 /// protects against is a root compare-and-swap landing after the objects it
 /// names could have aged into the collector's window, which is a property of
-/// the last few seconds and not of however long the rebuild took.
+/// the last few seconds and not of however long the rebuild took. That is the
+/// same span the lease has to cover, so both are measured off the lease's own
+/// clock.
 pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -406,9 +452,15 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
     spec: &MetadataCompactionSpec,
     snapshot_keys: &BTreeSet<String>,
     result: MetadataCompactionResult,
-    timer: &dyn MonotonicTimer,
+    lease: &mut CompactionLease<'_>,
 ) -> Result<Finalization> {
+    let timer = lease.timer();
     for attempt in 1..=MAX_FINALIZATION_ATTEMPTS {
+        // The span from here to the compare-and-swap below is one publication
+        // budget, and a lease outlasts one publication, so refreshing the
+        // claim once per attempt keeps the output claimed until the manifest
+        // names it (`limits::METADATA_COMPACTION_LEASE_EXPIRY_MS`).
+        lease.heartbeat(store).await?;
         let publication_started_ms = timer.monotonic_now_ms();
         let Some(root) = read_metadata_root_object_if_present(store, namespace_id)
             .await
@@ -542,28 +594,32 @@ pub(super) fn snapshot_segment_keys<S: ObjectStore + ?Sized>(
 struct RetentionCluster {
     families: &'static [MetadataTableFamily],
     locality: LocalityGrouping,
-    operator: RetentionOperator,
+    rule: RetentionRule,
 }
 
-/// How many rows the retention rules need to see at once.
+/// Which rows a retention rule has to see together, and therefore how the
+/// merge interleaves the families of one cluster.
 ///
 /// The rules that drop a row read its neighbours, and every one of them reads
-/// neighbours that share a row-key prefix: an unbind cancels the bind under
-/// the same parent and name, a removal marker repeats its deletion's sequence
-/// and root, and an attribute revision supersedes revisions of its own inode.
-/// So the grouping is read straight off the row-key grammar in
+/// neighbours that share a row-key prefix: an unbind cancels the bind of its
+/// own generation, a removal marker repeats its deletion's sequence and root,
+/// and an attribute revision supersedes revisions of its own inode. So the
+/// grouping is read straight off the row-key grammar in
 /// `MetadataRow::row_key_for_family`, and it is the shortest prefix each rule
 /// needs rather than the whole partition the rows happen to share:
 ///
 /// | families | grouped by | key components after the family prefix |
 /// | --- | --- | --- |
-/// | binds, unbinds | one name slot | `{parent}-{name}` |
+/// | binds, unbinds | one binding generation | `{parent}-{name}-{bind_seq}-{bind_delta}` |
 /// | active deletions | one deletion | `{deleted_at_seq}-{root}` |
 /// | attributes | one inode | `{inode}` |
 /// | everything else | one row | — |
 ///
-/// A slot rather than a directory is what keeps the bindings group bounded:
-/// a directory has no size limit, and a slot holds one binding's generations.
+/// A generation rather than a name slot is what keeps the bindings group
+/// bounded: a slot has no limit on how many times a name is created and
+/// deleted, and a generation holds one bind and the unbind that retires it.
+/// A bind's whole row key *is* its generation, and an unbind's key leads with
+/// the generation it retires, so both families name the same group.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LocalityGrouping {
     /// Every row is judged on its own.
@@ -576,43 +632,32 @@ enum LocalityGrouping {
     LeadingKeyComponents(usize),
 }
 
-/// Which rule decides the rows of a cluster.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RetentionOperator {
-    /// The frozen floor's rules over one locality group's rows, which is the
-    /// same function a whole-group fold runs over a whole family.
-    FrozenFloor,
-    /// Reverse bind rows, each decided by a point read into the snapshot for
-    /// the unbinds of its own binding.
-    ReverseBindProbe,
-}
-
 /// The bindings group merges its two forward families together, because an
-/// unbind retires the bind in its slot. The reverse index is keyed by child,
-/// so it shares no slot with the rows it indexes and streams on its own.
+/// unbind retires the bind of its generation. The reverse index is keyed by
+/// child, so it shares no group with the rows it indexes and streams on its
+/// own.
 const BINDINGS_CLUSTERS: [RetentionCluster; 2] = [
     RetentionCluster {
         families: &[
             MetadataTableFamily::DirentryBinds,
             MetadataTableFamily::DirentryUnbinds,
         ],
-        locality: LocalityGrouping::LeadingKeyComponents(2),
-        operator: RetentionOperator::FrozenFloor,
+        locality: LocalityGrouping::LeadingKeyComponents(4),
+        rule: RetentionRule::ForwardBindings,
     },
     RetentionCluster {
         families: &[MetadataTableFamily::DirentryChildBinds],
         locality: LocalityGrouping::Row,
-        operator: RetentionOperator::ReverseBindProbe,
+        rule: RetentionRule::ReverseBindProbe,
     },
 ];
 
-/// A family whose rows are each decided on their own — either because no rule
-/// drops them at all, or because the rule reads nothing but the row.
+/// A family no rule ever drops a row from, rewritten in key order.
 const fn row_cluster(families: &'static [MetadataTableFamily]) -> RetentionCluster {
     RetentionCluster {
         families,
         locality: LocalityGrouping::Row,
-        operator: RetentionOperator::FrozenFloor,
+        rule: RetentionRule::KeepEveryRow,
     }
 }
 
@@ -625,17 +670,20 @@ const REVISION_CLUSTERS: [RetentionCluster; 2] = [
 const INODE_CLUSTERS: [RetentionCluster; 1] = [row_cluster(&[MetadataTableFamily::Inodes])];
 const TOMBSTONE_CLUSTERS: [RetentionCluster; 1] = [row_cluster(&[MetadataTableFamily::Tombstones])];
 /// A receipt is kept or dropped by its own sequence against the floor.
-const RECEIPT_CLUSTERS: [RetentionCluster; 1] =
-    [row_cluster(&[MetadataTableFamily::CommitReceipts])];
+const RECEIPT_CLUSTERS: [RetentionCluster; 1] = [RetentionCluster {
+    families: &[MetadataTableFamily::CommitReceipts],
+    locality: LocalityGrouping::Row,
+    rule: RetentionRule::Receipts,
+}];
 const ACTIVE_DELETION_CLUSTERS: [RetentionCluster; 1] = [RetentionCluster {
     families: &[MetadataTableFamily::ActiveDeletions],
     locality: LocalityGrouping::LeadingKeyComponents(2),
-    operator: RetentionOperator::FrozenFloor,
+    rule: RetentionRule::ActiveDeletions,
 }];
 const ATTRIBUTE_CLUSTERS: [RetentionCluster; 1] = [RetentionCluster {
     families: &[MetadataTableFamily::Attributes],
     locality: LocalityGrouping::LeadingKeyComponents(1),
-    operator: RetentionOperator::FrozenFloor,
+    rule: RetentionRule::Attributes,
 }];
 
 fn retention_clusters(group: MetadataFamilyGroup) -> &'static [RetentionCluster] {
@@ -692,7 +740,11 @@ struct CompactionJob<'a, S: ObjectStore + ?Sized> {
 
 impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
     /// Merges one cluster end to end. `false` means the job was cancelled.
-    async fn run_cluster(&mut self, cluster: &RetentionCluster) -> Result<bool> {
+    async fn run_cluster(
+        &mut self,
+        cluster: &RetentionCluster,
+        lease: &mut CompactionLease<'_>,
+    ) -> Result<bool> {
         // The descriptors are cloned out of the snapshot rather than borrowed
         // from it: an iterator outlives every other borrow the job takes, and
         // a cluster opens one per run per family, which is a handful.
@@ -714,12 +766,17 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
             .map(|family| (*family, StagedSegmentWriter::new(*family)))
             .collect();
 
+        let floor_seq = self.spec.frozen_floor_seq;
+        let mut operator = cluster.rule.operator();
         let mut locality: Option<String> = None;
-        let mut group_rows: BTreeMap<MetadataTableFamily, Vec<MetadataRow>> = BTreeMap::new();
         loop {
             if self.cancellation.is_cancelled() {
                 return Ok(false);
             }
+            // The claim on the job's prefix is refreshed where the job checks
+            // whether it should stop, which is the one place it is guaranteed
+            // to reach however long a merge runs.
+            lease.heartbeat_if_due(self.store).await?;
             self.refill(&mut iterators).await?;
             let Some(next) = select_next_iterator(&iterators, cluster.locality) else {
                 break;
@@ -733,21 +790,35 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
                 let row_locality = locality_of(iterator.family, row_key, cluster.locality);
                 (locality.as_deref() != Some(row_locality)).then(|| row_locality.to_owned())
             };
-            if let Some(opened) = opened {
-                self.flush_locality(cluster, &mut group_rows, &mut writers)
-                    .await?;
-                locality = Some(opened);
+            if opened.is_some() {
+                if let Some(kept) = operator.close_group(floor_seq)? {
+                    self.write_row(kept, &mut writers).await?;
+                }
+                locality = opened;
             }
             let family = iterators[next].family;
-            group_rows
-                .entry(family)
-                .or_default()
-                .push(iterators[next].take_head());
+            let row = iterators[next].take_head();
             self.result.rows_read += 1;
             self.report_progress();
+            let kept = match cluster.rule {
+                // The reverse index is the one family no grouping can decide,
+                // so the job reads the snapshot for it rather than holding
+                // state.
+                RetentionRule::ReverseBindProbe => self
+                    .reverse_bind_survives(&row)
+                    .await?
+                    .then_some((family, row)),
+                _ => operator.push(family, row, floor_seq)?,
+            };
+            self.result.peak_operator_rows =
+                self.result.peak_operator_rows.max(operator.held_rows());
+            if let Some(kept) = kept {
+                self.write_row(kept, &mut writers).await?;
+            }
         }
-        self.flush_locality(cluster, &mut group_rows, &mut writers)
-            .await?;
+        if let Some(kept) = operator.close_group(floor_seq)? {
+            self.write_row(kept, &mut writers).await?;
+        }
 
         for writer in writers.into_values() {
             let segments = writer
@@ -802,63 +873,31 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
         Ok(())
     }
 
-    /// Judges one locality group and writes what survives.
-    async fn flush_locality(
+    /// Writes one row a retention operator kept, rolling a segment when its
+    /// family's builder fills.
+    async fn write_row(
         &mut self,
-        cluster: &RetentionCluster,
-        group_rows: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
+        (family, row): KeptRow,
         writers: &mut BTreeMap<MetadataTableFamily, StagedSegmentWriter>,
     ) -> Result<()> {
-        let held: usize = group_rows.values().map(Vec::len).sum();
-        if held == 0 {
-            return Ok(());
-        }
-        self.result.peak_locality_rows = self.result.peak_locality_rows.max(held);
-
-        match cluster.operator {
-            RetentionOperator::FrozenFloor => {
-                // A locality group holds every unbind that can retire the
-                // binds it holds, because a bind and its unbind share a slot.
-                let unbound_at_floor = unbindings_at_or_below_floor(
-                    group_rows
-                        .get(&MetadataTableFamily::DirentryUnbinds)
-                        .map_or(&[], Vec::as_slice),
-                    self.spec.frozen_floor_seq,
-                );
-                drop_rows_below_frozen_floor(
-                    group_rows,
-                    self.spec.frozen_floor_seq,
-                    &unbound_at_floor,
-                )?;
-            }
-            RetentionOperator::ReverseBindProbe => {
-                self.retain_reverse_binds(group_rows).await?;
-            }
-        }
-
-        for (family, rows) in std::mem::take(group_rows) {
-            let writer = writers
-                .get_mut(&family)
-                .expect("a cluster writes only the families it merges");
-            for row in rows {
-                self.fold_into_index_digests(family, &row)?;
-                *self
-                    .result
-                    .rows_written_by_family
-                    .entry(family)
-                    .or_default() += 1;
-                self.result.rows_written += 1;
-                writer.push(row);
-            }
-            writer
-                .roll_full_segments(self.store, self.namespace_id, self.spec, self.policy)
-                .await?;
-        }
-        Ok(())
+        self.fold_into_index_digests(family, &row)?;
+        *self
+            .result
+            .rows_written_by_family
+            .entry(family)
+            .or_default() += 1;
+        self.result.rows_written += 1;
+        let writer = writers
+            .get_mut(&family)
+            .expect("a cluster writes only the families it merges");
+        writer.push(row);
+        writer
+            .roll_full_segments(self.store, self.namespace_id, self.spec, self.policy)
+            .await
     }
 
-    /// Keeps the reverse bind rows the frozen floor still covers, deciding
-    /// each one by reading the snapshot for the unbinds of its own binding.
+    /// Whether one reverse bind row survives the frozen floor, decided by
+    /// reading the snapshot for the unbinds of its own binding.
     ///
     /// The reverse index is keyed by child and the unbind family by parent, so
     /// no grouping of the merged stream can hold a reverse row together with
@@ -873,50 +912,39 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
     /// Only rows at or below the floor cost a read: a bind above the floor
     /// survives whatever retired it later. Each read returns the unbinds of
     /// one binding generation, which is zero rows or one.
-    async fn retain_reverse_binds(
-        &mut self,
-        group_rows: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
-    ) -> Result<()> {
-        let Some(rows) = group_rows.get_mut(&MetadataTableFamily::DirentryChildBinds) else {
-            return Ok(());
+    async fn reverse_bind_survives(&mut self, row: &MetadataRow) -> Result<bool> {
+        let MetadataRow::DirentryBind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            ..
+        } = row
+        else {
+            return Ok(true);
         };
-        let mut kept = Vec::with_capacity(rows.len());
-        for row in std::mem::take(rows) {
-            let MetadataRow::DirentryBind {
-                parent_inode_id,
-                name_key,
-                bind_seq,
-                bind_delta_index,
-                ..
-            } = &row
-            else {
-                kept.push(row);
-                continue;
-            };
-            if *bind_seq > self.spec.frozen_floor_seq {
-                kept.push(row);
-                continue;
-            }
-            let unbind_rows = self
-                .read_unbinds_of_binding(
-                    &lookup_keys::direntry_unbind_binding_prefix(
-                        *parent_inode_id,
-                        name_key.as_str(),
-                        *bind_seq,
-                        *bind_delta_index,
-                    ),
-                    &lookup_keys::direntry_unbind_probe(*parent_inode_id, name_key.as_str()),
-                )
-                .await?;
-            self.result.unbind_probes += 1;
-            let unbound_at_floor =
-                unbindings_at_or_below_floor(&unbind_rows, self.spec.frozen_floor_seq);
-            if bind_survives_frozen_floor(&row, self.spec.frozen_floor_seq, &unbound_at_floor) {
-                kept.push(row);
-            }
+        if *bind_seq > self.spec.frozen_floor_seq {
+            return Ok(true);
         }
-        *rows = kept;
-        Ok(())
+        let unbind_rows = self
+            .read_unbinds_of_binding(
+                &lookup_keys::direntry_unbind_binding_prefix(
+                    *parent_inode_id,
+                    name_key.as_str(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ),
+                &lookup_keys::direntry_unbind_probe(*parent_inode_id, name_key.as_str()),
+            )
+            .await?;
+        self.result.unbind_probes += 1;
+        let unbound_at_floor =
+            unbindings_at_or_below_floor(&unbind_rows, self.spec.frozen_floor_seq);
+        Ok(bind_survives_frozen_floor(
+            row,
+            self.spec.frozen_floor_seq,
+            &unbound_at_floor,
+        ))
     }
 
     /// One point read into the snapshot's unbind family.
@@ -1236,8 +1264,11 @@ impl StagedSegmentWriter {
         rows: Vec<MetadataRow>,
     ) -> Result<()> {
         let table_id = MetadataTableId::generate();
-        let object_key =
-            metadata_compaction_staging_table(namespace_id.as_str(), table_id.as_str());
+        let object_key = metadata_compaction_table(
+            namespace_id.as_str(),
+            spec.job_id().as_str(),
+            table_id.as_str(),
+        );
         let descriptor = write_manifest_segment(
             store,
             MetadataSstWriteRequest::new(
@@ -1366,35 +1397,49 @@ mod tests {
         }
     }
 
+    /// The grouping the bindings cluster merges by.
+    const GENERATION: LocalityGrouping = LocalityGrouping::LeadingKeyComponents(4);
+
     /// A bind and the unbind that retires it must name the same locality
     /// group, because the drop rule reads one from the other. They live in
     /// different families with different row-key prefixes, so this holds only
     /// because the grouping is read behind the prefix.
     #[test]
     fn a_bind_and_its_unbind_name_one_locality_group() {
-        let slot = LocalityGrouping::LeadingKeyComponents(2);
         let bound = bind(7, "report.txt", 11);
         let retired = unbind(7, "report.txt", 11);
         let bind_key = bound.row_key_for_family(MetadataTableFamily::DirentryBinds);
         let unbind_key = retired.row_key_for_family(MetadataTableFamily::DirentryUnbinds);
 
         assert_eq!(
-            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, slot),
-            locality_of(MetadataTableFamily::DirentryUnbinds, &unbind_key, slot),
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
+            locality_of(
+                MetadataTableFamily::DirentryUnbinds,
+                &unbind_key,
+                GENERATION
+            ),
+        );
+        // Another generation of the same name is a different group, which is
+        // what keeps a slot with any number of generations bounded.
+        let regenerated =
+            bind(7, "report.txt", 12).row_key_for_family(MetadataTableFamily::DirentryBinds);
+        assert_ne!(
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
+            locality_of(MetadataTableFamily::DirentryBinds, &regenerated, GENERATION),
         );
         // Another name under the same parent is a different group: the rules
-        // read one slot, not one directory.
+        // read one binding, not one directory.
         let other = bind(7, "other.txt", 11).row_key_for_family(MetadataTableFamily::DirentryBinds);
         assert_ne!(
-            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, slot),
-            locality_of(MetadataTableFamily::DirentryBinds, &other, slot),
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
+            locality_of(MetadataTableFamily::DirentryBinds, &other, GENERATION),
         );
         // And so is the same name under another parent.
         let elsewhere =
             bind(8, "report.txt", 11).row_key_for_family(MetadataTableFamily::DirentryBinds);
         assert_ne!(
-            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, slot),
-            locality_of(MetadataTableFamily::DirentryBinds, &elsewhere, slot),
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
+            locality_of(MetadataTableFamily::DirentryBinds, &elsewhere, GENERATION),
         );
     }
 
@@ -1403,7 +1448,6 @@ mod tests {
     /// group it had already judged and written.
     #[test]
     fn locality_order_follows_row_key_order() {
-        let slot = LocalityGrouping::LeadingKeyComponents(2);
         let mut keys: Vec<String> = ["a", "ab", "b", "a-b"]
             .into_iter()
             .flat_map(|name| {
@@ -1416,7 +1460,7 @@ mod tests {
 
         let localities: Vec<&str> = keys
             .iter()
-            .map(|key| locality_of(MetadataTableFamily::DirentryBinds, key, slot))
+            .map(|key| locality_of(MetadataTableFamily::DirentryBinds, key, GENERATION))
             .collect();
         let mut runs = localities.clone();
         runs.dedup();

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -776,8 +776,14 @@ async fn bounded_subset_rebuild_rejects_divergent_revision_index() {
     };
     let mut rebuild_error = None;
     for _unit in 0..8 {
-        match super::reorganize_metadata_step(&store, &namespace_id, &context, fold_policy, None)
-            .await
+        match super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &context,
+            fold_policy,
+            MetadataCompactionView::default(),
+        )
+        .await
         {
             Ok(report) => match report.outcome {
                 super::MetadataReorganizeOutcome::NotNeeded { .. } => break,

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -43,7 +43,7 @@ use super::streaming_compaction::{
 };
 use super::{
     block_fetch, create, data_block_load, flush, load, record, reorganize,
-    reorganize_metadata_step, row, scan, MetadataReorganizeOutcome,
+    reorganize_metadata_step, row, scan, MetadataCompactionView, MetadataReorganizeOutcome,
 };
 use crate::error::{CoreError, ErrorCode, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
@@ -244,10 +244,15 @@ async fn drain_reorganization<S: ObjectStore + ?Sized>(
         ..policy
     };
     loop {
-        let report =
-            super::reorganize_metadata_step(store, namespace_id, context, fold_policy, None)
-                .await
-                .expect("reorganization step");
+        let report = super::reorganize_metadata_step(
+            store,
+            namespace_id,
+            context,
+            fold_policy,
+            MetadataCompactionView::default(),
+        )
+        .await
+        .expect("reorganization step");
         match report.outcome {
             super::MetadataReorganizeOutcome::UnitPublished { .. }
             | super::MetadataReorganizeOutcome::Superseded => continue,
@@ -341,16 +346,22 @@ pub(crate) async fn compact_a_family_group_into_staging<S: ObjectStore + ?Sized>
         max_decoded_input_bytes_per_step: NonZeroUsize::MIN,
         ..MetadataLsmPolicy::default()
     };
-    let report = reorganize_metadata_step(store, namespace_id, context, policy, None)
-        .await
-        .expect("plan a streaming compaction");
+    let report = reorganize_metadata_step(
+        store,
+        namespace_id,
+        context,
+        policy,
+        MetadataCompactionView::default(),
+    )
+    .await
+    .expect("plan a streaming compaction");
     let MetadataReorganizeOutcome::CompactionPlanned { spec, .. } = report.outcome else {
         panic!("a budget that admits no run whole must plan a streaming compaction");
     };
     publish_planned_compaction(store, namespace_id, context, policy, &spec).await;
 
     let staging_prefix =
-        loonfs_objectstore::keys::metadata_compaction_staging_prefix(namespace_id.as_str());
+        loonfs_objectstore::keys::metadata_compaction_prefix(namespace_id.as_str());
     let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
     let staged: BTreeSet<String> =
         load_verified_manifest_tables(store, namespace_id, &manifest_object_id)

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -139,9 +139,15 @@ async fn drain_reorganization_with_count<S: ObjectStore + ?Sized>(
 ) -> (ManifestId, usize) {
     let mut published = 0usize;
     for _ in 0..128 {
-        let report = super::reorganize_metadata_step(store, namespace_id, context, policy, None)
-            .await
-            .expect("reorganization step");
+        let report = super::reorganize_metadata_step(
+            store,
+            namespace_id,
+            context,
+            policy,
+            MetadataCompactionView::default(),
+        )
+        .await
+        .expect("reorganization step");
         match report.outcome {
             super::MetadataReorganizeOutcome::UnitPublished { .. } => published += 1,
             super::MetadataReorganizeOutcome::Superseded => {
@@ -790,9 +796,15 @@ async fn checkpoints_append_past_the_threshold_and_reorganization_drains() {
     let mut units = 0usize;
     let mut last_manifest_id = None;
     loop {
-        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
-            .await
-            .expect("reorganization step");
+        let report = super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &context,
+            policy,
+            MetadataCompactionView::default(),
+        )
+        .await
+        .expect("reorganization step");
         match report.outcome {
             super::MetadataReorganizeOutcome::UnitPublished { manifest_id, .. } => {
                 units += 1;
@@ -863,10 +875,15 @@ async fn reorganization_step_honors_run_row_and_decoded_byte_budgets() {
         ..MetadataLsmPolicy::default()
     };
     store.reset();
-    let blocked =
-        super::reorganize_metadata_step(&store, &namespace_id, &context, tiny_byte_policy, None)
-            .await
-            .expect("budgeted step");
+    let blocked = super::reorganize_metadata_step(
+        &store,
+        &namespace_id,
+        &context,
+        tiny_byte_policy,
+        MetadataCompactionView::default(),
+    )
+    .await
+    .expect("budgeted step");
     let super::MetadataReorganizeOutcome::CompactionPlanned { families, .. } = blocked.outcome
     else {
         panic!("one byte must not admit an SST run");
@@ -890,9 +907,15 @@ async fn reorganization_step_honors_run_row_and_decoded_byte_budgets() {
         ..MetadataLsmPolicy::default()
     };
     store.reset();
-    let published = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
-        .await
-        .expect("bounded step");
+    let published = super::reorganize_metadata_step(
+        &store,
+        &namespace_id,
+        &context,
+        policy,
+        MetadataCompactionView::default(),
+    )
+    .await
+    .expect("bounded step");
     let super::MetadataReorganizeOutcome::UnitPublished {
         families,
         input_runs,
@@ -960,7 +983,7 @@ async fn bounded_reorganization_converges_to_unbounded_shape_and_preserves_inter
         &namespace_id,
         &context,
         bounded_policy,
-        None,
+        MetadataCompactionView::default(),
     )
     .await
     .expect("first bounded step");
@@ -1038,7 +1061,7 @@ async fn bounded_reorganization_converges_to_unbounded_shape_and_preserves_inter
         &namespace_id,
         &context,
         bounded_policy,
-        None,
+        MetadataCompactionView::default(),
     )
     .await
     .expect("below-trigger step");
@@ -1258,10 +1281,15 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
 
     // One unit runs, then the process "crashes": nothing is carried over
     // but the published manifest.
-    let first_report =
-        super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
-            .await
-            .expect("first unit");
+    let first_report = super::reorganize_metadata_step(
+        &store,
+        &namespace_id,
+        &context,
+        policy,
+        MetadataCompactionView::default(),
+    )
+    .await
+    .expect("first unit");
     let super::MetadataReorganizeOutcome::UnitPublished {
         families: first_families,
         ..
@@ -1277,9 +1305,15 @@ async fn reorganization_resumes_from_the_manifest_after_interruption() {
     // job, including the delta the interleaved checkpoint added.
     let mut folded_groups = vec![first_families];
     loop {
-        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
-            .await
-            .expect("resumed unit");
+        let report = super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &context,
+            policy,
+            MetadataCompactionView::default(),
+        )
+        .await
+        .expect("resumed unit");
         match report.outcome {
             super::MetadataReorganizeOutcome::UnitPublished { families, .. } => {
                 folded_groups.push(families);
@@ -1475,7 +1509,7 @@ async fn over_budget_reorganization_aborts_without_publishing() {
         &namespace_id,
         &context,
         fold_everything,
-        None,
+        MetadataCompactionView::default(),
         &overrun,
     )
     .await
@@ -1497,7 +1531,7 @@ async fn over_budget_reorganization_aborts_without_publishing() {
         &namespace_id,
         &context,
         fold_everything,
-        None,
+        MetadataCompactionView::default(),
     )
     .await
     .expect("in-budget retry folds the unit");
@@ -1524,10 +1558,15 @@ async fn select_reorganization_window<S: ObjectStore + ?Sized>(
     let group = super::reorganize::select_family_group(&tables.manifest().payload, None)
         .expect("a family group with L0 rows to fold");
     let frozen_floor_seq = read_floor_seq(store, namespace_id).await;
-    let selection =
-        super::reorganize::select_reorganization_input(&tables, group, policy, frozen_floor_seq)
-            .await
-            .expect("select a reorganization input");
+    let selection = super::reorganize::select_reorganization_input(
+        &tables,
+        group,
+        policy,
+        frozen_floor_seq,
+        false,
+    )
+    .await
+    .expect("select a reorganization input");
     (group.families().to_vec(), selection)
 }
 
@@ -1674,9 +1713,15 @@ async fn a_base_run_over_the_step_budget_merges_the_delta_runs_then_compacts_the
     let mut group_delta_run_counts = vec![group_delta_runs(&before.manifest, &group).len()];
     let mut delta_runs_when_the_compaction_was_planned = None;
     for _ in 0..64 {
-        let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
-            .await
-            .expect("reorganization step");
+        let report = super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &context,
+            policy,
+            MetadataCompactionView::default(),
+        )
+        .await
+        .expect("reorganization step");
         let current = load_manifest_materialization_for_inspection(
             &store,
             &namespace_id,
@@ -1872,9 +1917,15 @@ async fn a_merge_above_the_base_keeps_the_rows_that_shadow_it() {
     assert!(input.runs.len() > 1);
     let base_before = group_base_runs(&before.manifest, &group);
 
-    let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
-        .await
-        .expect("reorganization step");
+    let report = super::reorganize_metadata_step(
+        &store,
+        &namespace_id,
+        &context,
+        policy,
+        MetadataCompactionView::default(),
+    )
+    .await
+    .expect("reorganization step");
     assert!(
         matches!(
             report.outcome,
@@ -2019,9 +2070,15 @@ async fn a_run_in_the_middle_over_the_budget_stops_the_window() {
     );
 
     let root_before = current_manifest_id(&store, &namespace_id).await;
-    let report = super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
-        .await
-        .expect("reorganization step");
+    let report = super::reorganize_metadata_step(
+        &store,
+        &namespace_id,
+        &context,
+        policy,
+        MetadataCompactionView::default(),
+    )
+    .await
+    .expect("reorganization step");
     assert!(
         matches!(
             report.outcome,
@@ -2112,10 +2169,15 @@ async fn repeated_churn_under_small_budgets_leaves_one_base_run_per_group() {
 
         let mut settled = false;
         for _step in 0..512 {
-            let report =
-                super::reorganize_metadata_step(&store, &namespace_id, &context, policy, None)
-                    .await
-                    .expect("reorganization step");
+            let report = super::reorganize_metadata_step(
+                &store,
+                &namespace_id,
+                &context,
+                policy,
+                MetadataCompactionView::default(),
+            )
+            .await
+            .expect("reorganization step");
             let current = load_manifest_materialization_for_inspection(
                 &store,
                 &namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -3,7 +3,10 @@
 //! place, restart equivalence, and the resource bounds that make the job
 //! independent of the size of what it rebuilds.
 
-use super::super::reorganize::{select_reorganization_input, ReorganizationPlan};
+use super::super::compaction_lease::CompactionLease;
+use super::super::reorganize::{
+    drop_rows_below_retention_floor, select_reorganization_input, ReorganizationPlan,
+};
 use super::super::row::manifest_row_commit_seq;
 use super::super::runs::MetadataFamilyGroup;
 use super::super::scan::VerifiedMetadataTables;
@@ -14,7 +17,8 @@ use super::super::streaming_compaction::{
 };
 use super::*;
 use crate::timing::StdMonotonicTimer;
-use loonfs_objectstore::keys::metadata_compaction_staging_prefix;
+use loonfs_api::wire::manifest::ActiveDeletionRowAction;
+use loonfs_objectstore::keys::{metadata_compaction_lease, metadata_compaction_prefix};
 use loonfs_test_support::stores::ConcurrencyWatchStore;
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -236,9 +240,236 @@ async fn seed_one_wide_directory(store: &LocalFsStore, namespace_id: &NamespaceI
         .expect("checkpoint the late write");
 }
 
+/// A namespace whose churn all lands on one locality of each kind: one
+/// inode's attribute history, one parent-and-name slot's binding
+/// generations, and one path deleted and undeleted over and over.
+///
+/// This is the shape the wide-directory seed does not produce. Many distinct
+/// names prove that distinct localities do not accumulate together; only one
+/// hot locality proves that the rules inside one do not accumulate either.
+async fn seed_one_hot_locality_of_each_kind(store: &LocalFsStore, namespace_id: &NamespaceId) {
+    let context = test_context();
+    bootstrap_namespace(store, namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    write_file_bytes(
+        store,
+        namespace_id,
+        "/hot/annotated.txt",
+        b"body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write the annotated file");
+    // One inode, many attribute revisions. Every one supersedes the last, so
+    // the whole history below the floor collapses to one row. The tail is
+    // flushed along the way because a namespace may only carry so many
+    // unpublished WAL segments.
+    for revision in 0..48u64 {
+        update_attributes(
+            store,
+            namespace_id,
+            "/hot/annotated.txt",
+            "loon.round",
+            &revision.to_string(),
+            &context,
+        )
+        .await;
+        if revision % 16 == 15 {
+            flush::flush_wal(store, namespace_id, &context)
+                .await
+                .expect("flush the tail");
+        }
+    }
+    // One parent-and-name slot, many binding generations: the same path
+    // created and deleted over and over.
+    for round in 0..48u64 {
+        write_file_bytes(
+            store,
+            namespace_id,
+            "/hot/recreated.txt",
+            b"body\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("recreate the file");
+        delete_path(store, namespace_id, "/hot/recreated.txt", &context, None)
+            .await
+            .expect("delete the file");
+        if round % 8 == 7 {
+            flush::flush_wal(store, namespace_id, &context)
+                .await
+                .expect("flush the tail");
+        }
+    }
+    // One deletion generation cancelled by an undelete, which is the pair the
+    // active-deletion rule drops together.
+    write_file_bytes(
+        store,
+        namespace_id,
+        "/hot/undeleted.txt",
+        b"body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write the undeleted file");
+    delete_path(store, namespace_id, "/hot/undeleted.txt", &context, None)
+        .await
+        .expect("delete the file to undelete");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the deletion so its listed row is readable");
+    undelete_newest_deletion(store, namespace_id, &context).await;
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the churn");
+    drain_reorganization(
+        store,
+        namespace_id,
+        &context,
+        MetadataLsmPolicy {
+            max_rows_per_segment: NonZeroUsize::new(4).expect("nonzero"),
+            ..MetadataLsmPolicy::default()
+        },
+    )
+    .await;
+    advance_retention_floor(store, namespace_id, &context)
+        .await
+        .expect("advance the floor past the churn");
+
+    // A little above the floor, so the job has rows it may not drop.
+    write_file_bytes(
+        store,
+        namespace_id,
+        "/hot/late.txt",
+        b"late body\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write a late file");
+    update_attributes(
+        store,
+        namespace_id,
+        "/hot/annotated.txt",
+        "loon.round",
+        "late",
+        &context,
+    )
+    .await;
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the late writes");
+}
+
+/// Publishes one attribute update, which is one more revision for the
+/// inode the path resolves to.
+async fn update_attributes<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    path: &str,
+    key: &str,
+    value: &str,
+    context: &MutationContext,
+) {
+    publish_one_operation(
+        store,
+        namespace_id,
+        FilesystemOperation::UpdateAttributes {
+            path: AbsolutePath::parse(path).expect("path"),
+            set: [(
+                loonfs_api::AttributeKey::parse(key).expect("attribute key"),
+                loonfs_api::AttributeValue::String {
+                    value: value.to_owned(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+            remove: Vec::new(),
+            expected_inode_id: None,
+            expected_attributes_revision_no: None,
+        },
+        context,
+    )
+    .await;
+}
+
+/// Cancels the namespace's newest recoverable deletion, which writes the
+/// removal marker the active-deletion rule pairs with the listed row.
+///
+/// The deletion is read back out of the manifest rather than remembered from
+/// the commit response, because the row is what names the generation the
+/// undelete has to cancel.
+async fn undelete_newest_deletion<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    context: &MutationContext,
+) {
+    let rows =
+        group_rows_of_current_manifest(store, namespace_id, MetadataFamilyGroup::ActiveDeletions)
+            .await;
+    let (root_inode_id, deleted_at_seq) = rows[&ApiMetadataTableFamily::ActiveDeletions]
+        .iter()
+        .filter_map(|row| match row {
+            MetadataRow::ActiveDeletion {
+                root_inode_id,
+                deleted_at_seq,
+                action: ActiveDeletionRowAction::Listed { .. },
+            } => Some((*root_inode_id, *deleted_at_seq)),
+            _ => None,
+        })
+        .max_by_key(|(_, deleted_at_seq)| *deleted_at_seq)
+        .expect("the namespace holds a recoverable deletion");
+    publish_one_operation(
+        store,
+        namespace_id,
+        FilesystemOperation::Undelete {
+            inode_id: root_inode_id,
+            deleted_at_seq,
+            path: None,
+        },
+        context,
+    )
+    .await;
+}
+
+async fn publish_one_operation<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    operation: FilesystemOperation,
+    context: &MutationContext,
+) {
+    NamespaceCommitEngine::new(namespace_id.clone())
+        .publish_batch(
+            store,
+            vec![CommitCandidate::prepared(
+                CommitRequest::single(CommitId::generate(), None, operation),
+                Vec::new(),
+            )],
+            context,
+            &PublishTailOptions::default(),
+        )
+        .await
+        .results
+        .pop()
+        .expect("one result")
+        .expect("publish the operation");
+}
+
 // -------------------------------------------------------------------------
 // Driving a job
 // -------------------------------------------------------------------------
+
+/// The view a step sees while `spec`'s job is rebuilding its group.
+fn rebuilding(spec: &MetadataCompactionSpec) -> MetadataCompactionView<'_> {
+    MetadataCompactionView {
+        active: Some(spec),
+        blocked_engagements: &[],
+    }
+}
 
 /// A budget that admits the whole group in one step, so the ordinary fold can
 /// rebuild in one unit whatever the streaming job did incrementally.
@@ -353,6 +584,7 @@ async fn compaction_spec_for_group<S: ObjectStore + ?Sized>(
             ..MetadataLsmPolicy::default()
         },
         frozen_floor_seq,
+        false,
     )
     .await
     .expect("plan the group");
@@ -360,6 +592,24 @@ async fn compaction_spec_for_group<S: ObjectStore + ?Sized>(
         Some(ReorganizationPlan::FullCompaction(spec)) => spec,
         _ => panic!("a group no budget admits must plan as a streaming compaction"),
     }
+}
+
+/// The claim a job holds while it runs, built the way the job driver builds
+/// it. These tests split the rebuild from the driver, so they open the claim
+/// themselves.
+fn test_lease<'a>(
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+    timer: &'a StdMonotonicTimer,
+) -> CompactionLease<'a> {
+    let context = test_context();
+    CompactionLease::new(
+        namespace_id,
+        spec.job_id(),
+        &context.writer_id,
+        context.now_ms,
+        timer,
+    )
 }
 
 async fn run_compaction<S: ObjectStore + ?Sized>(
@@ -370,9 +620,18 @@ async fn run_compaction<S: ObjectStore + ?Sized>(
     cancellation: &MetadataCompactionCancellation,
 ) -> MetadataCompactionOutcome {
     let tables = load_current_manifest_tables(store, namespace_id).await;
-    run_metadata_compaction(&tables, namespace_id, spec, policy, cancellation)
-        .await
-        .expect("run the streaming compaction")
+    let timer = StdMonotonicTimer::default();
+    let mut lease = test_lease(namespace_id, spec, &timer);
+    run_metadata_compaction(
+        &tables,
+        namespace_id,
+        spec,
+        policy,
+        cancellation,
+        &mut lease,
+    )
+    .await
+    .expect("run the streaming compaction")
 }
 
 /// The segments the group's snapshot runs hold right now, which is what
@@ -398,6 +657,8 @@ async fn finalize_streaming_compaction<S: ObjectStore + ?Sized>(
     snapshot_keys: &BTreeSet<String>,
     result: &MetadataCompactionResult,
 ) -> Finalization {
+    let timer = StdMonotonicTimer::default();
+    let mut lease = test_lease(namespace_id, spec, &timer);
     finalize_metadata_compaction(
         store,
         namespace_id,
@@ -405,7 +666,7 @@ async fn finalize_streaming_compaction<S: ObjectStore + ?Sized>(
         spec,
         snapshot_keys,
         result.clone(),
-        &StdMonotonicTimer::default(),
+        &mut lease,
     )
     .await
     .expect("finalize the streaming compaction")
@@ -493,7 +754,7 @@ async fn staged_object_keys<S: ObjectStore + ?Sized>(
 ) -> BTreeSet<String> {
     use futures::StreamExt;
     store
-        .list_prefix_stream(&metadata_compaction_staging_prefix(namespace_id.as_str()))
+        .list_prefix_stream(&metadata_compaction_prefix(namespace_id.as_str()))
         .map(|key| key.expect("list staged objects"))
         .collect()
         .await
@@ -511,7 +772,7 @@ async fn fold_group_whole<S: ObjectStore + ?Sized>(
         namespace_id,
         &test_context(),
         fold_everything_policy(),
-        None,
+        MetadataCompactionView::default(),
     )
     .await
     .expect("fold the group whole");
@@ -542,9 +803,10 @@ async fn the_planner_answers_with_a_merge_or_with_a_compaction() {
     let floor_seq = read_floor_seq(&store, &namespace_id).await;
     let tables = load_current_manifest_tables(&store, &namespace_id).await;
 
-    let generous = select_reorganization_input(&tables, group, fold_everything_policy(), floor_seq)
-        .await
-        .expect("plan under generous budgets");
+    let generous =
+        select_reorganization_input(&tables, group, fold_everything_policy(), floor_seq, false)
+            .await
+            .expect("plan under generous budgets");
     assert!(
         matches!(generous.plan, Some(ReorganizationPlan::BoundedMerge(_))),
         "a window that fits is a bounded merge"
@@ -560,6 +822,7 @@ async fn the_planner_answers_with_a_merge_or_with_a_compaction() {
             ..MetadataLsmPolicy::default()
         },
         floor_seq,
+        false,
     )
     .await
     .expect("plan under budgets nothing fits");
@@ -602,7 +865,7 @@ async fn a_step_that_plans_a_compaction_publishes_nothing_itself() {
         &namespace_id,
         &test_context(),
         starving_policy(),
-        None,
+        MetadataCompactionView::default(),
     )
     .await
     .expect("budgeted step");
@@ -650,7 +913,7 @@ async fn a_step_leaves_the_group_a_running_job_is_rebuilding_alone() {
         &namespace_id,
         &test_context(),
         policy,
-        None,
+        MetadataCompactionView::default(),
     )
     .await
     .expect("step with no job running");
@@ -672,7 +935,7 @@ async fn a_step_leaves_the_group_a_running_job_is_rebuilding_alone() {
             &namespace_id,
             &test_context(),
             policy,
-            Some(&spec),
+            rebuilding(&spec),
         )
         .await
         .expect("step with the job running");
@@ -698,6 +961,182 @@ async fn a_step_leaves_the_group_a_running_job_is_rebuilding_alone() {
         snapshot_keys,
         "the job's input must be exactly what it was when the job was planned"
     );
+}
+
+/// A group whose bottom-anchored window is blocked still merges the delta
+/// runs above the frozen base — and under sustained writes there is always
+/// another pair of them, so a planner reading one step's view alone would take
+/// that merge forever and never start the job.
+///
+/// The runtime counts those engagements, and after
+/// `DELTA_MERGES_OVER_A_FROZEN_BASE` of them the planner starts the job
+/// regardless of what delta window is available. Here every step publishes a
+/// fresh delta run before the next one plans, which is the write pattern that
+/// used to postpone the job indefinitely.
+#[tokio::test]
+async fn sustained_delta_runs_cannot_postpone_a_blocked_groups_job() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_one_wide_directory(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
+
+    let mut engagements = 0u32;
+    let mut delta_merges_over_the_frozen_base = 0usize;
+    let mut planned: Option<MetadataCompactionSpec> = None;
+    for round in 0..16u64 {
+        // A new delta run before every step, so the planner always has two
+        // runs above the base to merge.
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/wide/arrival-{round}.txt"),
+            b"arrival\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write a file");
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("checkpoint the write");
+
+        let blocked = [(group.families(), engagements)];
+        let report = super::super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &context,
+            policy,
+            MetadataCompactionView {
+                active: None,
+                blocked_engagements: &blocked,
+            },
+        )
+        .await
+        .expect("maintenance step");
+        match report.outcome {
+            MetadataReorganizeOutcome::CompactionPlanned { ref families, .. } => {
+                assert_eq!(families.as_slice(), group.families());
+                planned = match report.outcome {
+                    MetadataReorganizeOutcome::CompactionPlanned { spec, .. } => Some(spec),
+                    _ => unreachable!(),
+                };
+                break;
+            }
+            MetadataReorganizeOutcome::UnitPublished {
+                ref families,
+                bottom_anchored_merge_blocked,
+                ..
+            } if families.as_slice() == group.families() => {
+                assert!(
+                    bottom_anchored_merge_blocked,
+                    "this budget starves the group's base, so every merge of it runs above one"
+                );
+                engagements += 1;
+                delta_merges_over_the_frozen_base += 1;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        planned.is_some(),
+        "the job must start while delta runs keep arriving"
+    );
+    assert_eq!(
+        delta_merges_over_the_frozen_base,
+        super::super::reorganize::DELTA_MERGES_OVER_A_FROZEN_BASE as usize,
+        "the group merges deltas over its frozen base exactly that many times before the job"
+    );
+}
+
+/// Between jobs, the ordinary delta merge is what consolidates new runs.
+///
+/// Starting a job for every batch of delta runs would reread the whole group
+/// to fold in a sliver, which is the amortization the counter exists to keep.
+/// A group whose base is not frozen never counts an engagement at all, and a
+/// group whose base is frozen spends its budget on merges first.
+#[tokio::test]
+async fn small_delta_batches_are_consolidated_by_merges_rather_than_by_jobs() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let policy = MetadataLsmPolicy {
+        max_l0_runs: NonZeroUsize::MIN,
+        ..MetadataLsmPolicy::default()
+    };
+
+    // Budgets this group fits: every merge starts at the group's oldest run,
+    // so nothing is ever blocked and no engagement is ever counted.
+    let mut merges = 0usize;
+    for _ in 0..16 {
+        let report = super::super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &context,
+            policy,
+            MetadataCompactionView::default(),
+        )
+        .await
+        .expect("maintenance step");
+        match report.outcome {
+            MetadataReorganizeOutcome::UnitPublished {
+                ref families,
+                bottom_anchored_merge_blocked,
+                ..
+            } => {
+                if families.as_slice() == group.families() {
+                    assert!(
+                        !bottom_anchored_merge_blocked,
+                        "a group whose window fits is never merging over a frozen base"
+                    );
+                    merges += 1;
+                }
+            }
+            MetadataReorganizeOutcome::NotNeeded { .. } => break,
+            other => panic!("unexpected outcome {other:?}"),
+        }
+    }
+    assert!(merges > 0, "the ordinary merge must do this group's work");
+
+    // A fresh delta batch arrives. It folds through the ordinary merge, and
+    // the planner never reaches for a job.
+    for round in 0..3u64 {
+        write_file_bytes(
+            &store,
+            &namespace_id,
+            &format!("/steady-{round}.txt"),
+            b"steady\n",
+            &context,
+            None,
+        )
+        .await
+        .expect("write a file");
+        create_checkpoint(&store, &namespace_id, &context)
+            .await
+            .expect("checkpoint the write");
+    }
+    for _ in 0..16 {
+        let report = super::super::reorganize_metadata_step(
+            &store,
+            &namespace_id,
+            &context,
+            policy,
+            MetadataCompactionView::default(),
+        )
+        .await
+        .expect("maintenance step");
+        match report.outcome {
+            MetadataReorganizeOutcome::UnitPublished { .. } => {}
+            MetadataReorganizeOutcome::NotNeeded { .. } => break,
+            other => panic!("a group whose window fits must never plan a job, got {other:?}"),
+        }
+    }
 }
 
 // -------------------------------------------------------------------------
@@ -747,7 +1186,7 @@ async fn a_streaming_compaction_and_a_whole_group_fold_reach_the_same_rows() {
     assert!(
         result.output_segments.iter().all(|descriptor| descriptor
             .object_key
-            .starts_with(&metadata_compaction_staging_prefix(namespace_id.as_str()))),
+            .starts_with(&metadata_compaction_prefix(namespace_id.as_str()))),
         "every output segment is written to the staging directory"
     );
     // Every reverse row the floor covers costs one point read, and no other
@@ -1139,6 +1578,118 @@ async fn a_cancelled_compaction_leaves_orphans_and_the_rerun_lands_where_it_woul
 }
 
 // -------------------------------------------------------------------------
+// The job's claim on its own output
+// -------------------------------------------------------------------------
+
+/// A job writes its lease before its first output object and deletes it after
+/// publishing, and the segments it published stay where they are.
+///
+/// The lease is what tells a collector that an unreferenced staged object
+/// belongs to a job that is still running. Once the manifest names those
+/// objects they are live wherever they sit, so the claim has nothing left to
+/// protect.
+#[tokio::test]
+async fn a_job_claims_its_prefix_while_it_runs_and_drops_the_claim_when_it_publishes() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Bindings;
+    let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
+    let spec = step_until_a_compaction_is_planned(&store, &namespace_id, &context, policy).await;
+    let lease_key = metadata_compaction_lease(namespace_id.as_str(), spec.job_id().as_str());
+
+    let outcome = run_metadata_compaction_job(
+        &store,
+        &namespace_id,
+        &context,
+        policy,
+        &spec,
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    .expect("run the job");
+    assert!(matches!(
+        outcome,
+        MetadataCompactionJobOutcome::Published { .. }
+    ));
+
+    // Every object the job wrote sits under its own prefix, and the manifest
+    // now names the segments.
+    let staged = staged_object_keys(&store, &namespace_id).await;
+    let referenced = referenced_segment_keys(&store, &namespace_id).await;
+    let job_prefix = format!(
+        "{}{}/",
+        metadata_compaction_prefix(namespace_id.as_str()),
+        spec.job_id().as_str()
+    );
+    assert!(
+        staged.iter().all(|key| key.starts_with(&job_prefix)),
+        "every object a job writes belongs to that job's prefix: {staged:?}"
+    );
+    assert!(
+        !staged.is_empty() && staged.iter().all(|key| referenced.contains(key)),
+        "the manifest must name the segments the job published"
+    );
+    assert!(
+        !staged.contains(&lease_key),
+        "a published job deletes its own lease"
+    );
+    assert!(store
+        .head(&lease_key)
+        .await
+        .expect("head the lease")
+        .is_none());
+}
+
+/// A cancelled job leaves its lease behind, which is what keeps a collector
+/// off the segments it had written until the lease expires.
+#[tokio::test]
+async fn a_cancelled_job_leaves_its_claim_standing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_bindings_workload(
+        &LocalFsStore::new(temp_dir.path()).expect("store"),
+        &namespace_id,
+    )
+    .await;
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let group = MetadataFamilyGroup::Bindings;
+    let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
+    let spec = step_until_a_compaction_is_planned(&store, &namespace_id, &context, policy).await;
+    let lease_key = metadata_compaction_lease(namespace_id.as_str(), spec.job_id().as_str());
+
+    let cancellation = MetadataCompactionCancellation::default();
+    let dying_store = CancelAfterReadsStore {
+        inner: LocalFsStore::new(temp_dir.path()).expect("store"),
+        cancellation: cancellation.clone(),
+        reads_before_cancel: 8,
+        reads: AtomicUsize::new(0),
+    };
+    let outcome = run_metadata_compaction_job(
+        &dying_store,
+        &namespace_id,
+        &context,
+        policy,
+        &spec,
+        &cancellation,
+    )
+    .await
+    .expect("run the job");
+    assert_eq!(outcome, MetadataCompactionJobOutcome::Cancelled);
+    assert!(
+        store
+            .head(&lease_key)
+            .await
+            .expect("head the lease")
+            .is_some(),
+        "a cancelled job's claim stands until it expires"
+    );
+}
+
+// -------------------------------------------------------------------------
 // Resource discipline
 // -------------------------------------------------------------------------
 
@@ -1200,21 +1751,22 @@ async fn a_compaction_keeps_its_reads_and_its_decoded_blocks_bounded() {
         result.rows_read > (rows_in_group / 2) as u64,
         "this assertion means nothing unless the job read most of the group"
     );
-    // No locality group is a family: the rules read one name slot, and a slot
-    // holds the generations of one binding.
+    // The retention operators hold answers, not rows. The bindings operator
+    // holds one bind row until its generation's unbinds have arrived, and no
+    // other operator holds a row at all.
     assert!(
-        result.peak_locality_rows <= 8,
-        "one locality group held {} rows",
-        result.peak_locality_rows
+        result.peak_operator_rows <= 1,
+        "a retention operator held {} rows",
+        result.peak_operator_rows
     );
 }
 
 /// One directory far past the old per-step row budget streams through with
 /// the same bounded state. The case that needed a durable offset inside a
-/// partition needs nothing now: the rules read one name slot, so the peak
-/// tracks a slot's rows and not the directory's.
+/// partition needs nothing now: the operators hold one row at most, whatever
+/// the directory holds.
 #[tokio::test]
-async fn one_directory_far_past_the_row_budget_streams_a_slot_at_a_time() {
+async fn one_directory_far_past_the_row_budget_streams_a_row_at_a_time() {
     let job_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(job_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1271,9 +1823,9 @@ async fn one_directory_far_past_the_row_budget_streams_a_slot_at_a_time() {
         panic!("nothing cancelled this job");
     };
     assert!(
-        result.peak_locality_rows * 4 < widest,
-        "the peak locality held {} rows against a directory of {widest}",
-        result.peak_locality_rows
+        result.peak_operator_rows <= 1,
+        "a retention operator held {} rows against a directory of {widest}",
+        result.peak_operator_rows
     );
 
     publish_streaming_compaction(&store, &namespace_id, &spec, &snapshot_keys, &result).await;
@@ -1294,6 +1846,111 @@ async fn one_directory_far_past_the_row_budget_streams_a_slot_at_a_time() {
         snapshot_runs_for_group(tables.manifest(), group).len(),
         1,
         "the job must leave the group in one run"
+    );
+}
+
+/// Every group of a namespace whose churn all lands on one hot locality
+/// rebuilds to the fold's rows while its operators hold at most one row.
+///
+/// The wide-directory case above proves that distinct localities do not
+/// accumulate together. This proves the other half: one inode's attribute
+/// history, one name slot's binding generations, and one deletion's markers
+/// are each decided by fixed state rather than by holding the locality.
+#[tokio::test]
+async fn one_hot_locality_of_each_kind_rebuilds_with_fixed_operator_state() {
+    let job_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(job_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    seed_one_hot_locality_of_each_kind(&store, &namespace_id).await;
+    let frozen_floor_seq = read_floor_seq(&store, &namespace_id).await;
+
+    let fold_dir = tempdir().expect("tempdir");
+    copy_store_tree(job_dir.path(), fold_dir.path());
+    let fold_store = LocalFsStore::new(fold_dir.path()).expect("store");
+
+    for group in REORGANIZE_FAMILY_GROUPS {
+        let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+        if before.values().all(Vec::is_empty) {
+            continue;
+        }
+        // The same durable bytes, folded the ordinary way.
+        let folded_before = group_rows_of_current_manifest(&fold_store, &namespace_id, group).await;
+        assert_eq!(
+            folded_before, before,
+            "both rebuilds must start from the same rows"
+        );
+        let mut folded = folded_before.clone();
+        for family in group.families() {
+            folded.entry(*family).or_default();
+        }
+        drop_rows_below_retention_floor(&mut folded, frozen_floor_seq)
+            .expect("fold the group whole");
+        for (family, rows) in &mut folded {
+            rows.sort_by_key(|row| row.row_key_for_family(*family));
+        }
+
+        let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+        let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
+        let MetadataCompactionOutcome::Completed(result) = run_compaction(
+            &store,
+            &namespace_id,
+            &spec,
+            small_segment_policy(),
+            &MetadataCompactionCancellation::default(),
+        )
+        .await
+        else {
+            panic!("nothing cancelled this job");
+        };
+        assert!(
+            result.peak_operator_rows <= 1,
+            "a {group:?} retention operator held {} rows",
+            result.peak_operator_rows
+        );
+        publish_streaming_compaction(&store, &namespace_id, &spec, &snapshot_keys, &result).await;
+
+        let compacted = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+        assert_eq!(
+            compacted, folded,
+            "a streaming rebuild of {group:?} must keep the rows a whole-group fold keeps"
+        );
+        // Nothing above the floor may go, whatever the rules dropped below it.
+        for (family, rows) in &before {
+            let survivors: BTreeSet<String> = compacted[family]
+                .iter()
+                .map(|row| row.row_key_for_family(*family))
+                .collect();
+            for row in rows {
+                if manifest_row_commit_seq(row) > frozen_floor_seq {
+                    assert!(
+                        survivors.contains(&row.row_key_for_family(*family)),
+                        "the job dropped a {family:?} row above the retention floor"
+                    );
+                }
+            }
+        }
+    }
+
+    // The hot localities really did collapse: the group with an attribute
+    // history and the group with a name slot both hold fewer rows than they
+    // did, and the two bind families stayed in lockstep.
+    let attributes =
+        group_rows_of_current_manifest(&store, &namespace_id, MetadataFamilyGroup::Attributes)
+            .await;
+    assert_eq!(
+        attributes[&ApiMetadataTableFamily::Attributes].len(),
+        2,
+        "one inode's history must collapse to the newest row at the floor plus the late one"
+    );
+    let bindings =
+        group_rows_of_current_manifest(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    assert_eq!(
+        bindings[&ApiMetadataTableFamily::DirentryBinds].len(),
+        bindings[&ApiMetadataTableFamily::DirentryChildBinds].len(),
+    );
+    assert!(
+        bindings[&ApiMetadataTableFamily::DirentryUnbinds].is_empty(),
+        "every unbind the floor covered must be gone"
     );
 }
 
@@ -1397,7 +2054,10 @@ async fn an_over_budget_group_is_rebuilt_by_a_job_while_maintenance_carries_on()
             &namespace_id,
             &context,
             policy,
-            active.as_ref(),
+            active.as_ref().map_or_else(
+                MetadataCompactionView::default,
+                |spec: &MetadataCompactionSpec| rebuilding(spec),
+            ),
         )
         .await
         .expect("maintenance step");
@@ -1537,10 +2197,15 @@ async fn step_until_a_compaction_is_planned<S: ObjectStore + ?Sized>(
     policy: MetadataLsmPolicy,
 ) -> MetadataCompactionSpec {
     for _step in 0..64 {
-        let report =
-            super::super::reorganize_metadata_step(store, namespace_id, context, policy, None)
-                .await
-                .expect("maintenance step");
+        let report = super::super::reorganize_metadata_step(
+            store,
+            namespace_id,
+            context,
+            policy,
+            MetadataCompactionView::default(),
+        )
+        .await
+        .expect("maintenance step");
         match report.outcome {
             MetadataReorganizeOutcome::CompactionPlanned { spec, .. } => return spec,
             MetadataReorganizeOutcome::UnitPublished { .. } => {}

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -832,18 +832,21 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     /// A group whose oldest run no longer fits one unit is reported as
     /// [`MetadataReorganizeOutcome::CompactionPlanned`] instead. The caller
     /// runs that plan with [`Self::run_metadata_compaction`] as a background
-    /// job and hands its spec back here as `active_compaction` for as long as
-    /// the job runs, so no unit merges the group underneath it.
+    /// job and hands its spec back here in `compactions` for as long as the
+    /// job runs, so no unit merges the group underneath it. `compactions`
+    /// also carries how long each group has been merging deltas over a base
+    /// no window can reach, which is what decides when the planner stops
+    /// taking that merge and starts the job.
     pub async fn reorganize_metadata(
         &self,
-        active_compaction: Option<&crate::checkpoint::MetadataCompactionSpec>,
+        compactions: crate::checkpoint::MetadataCompactionView<'_>,
     ) -> Result<crate::checkpoint::MetadataReorganizeReport> {
         crate::checkpoint::reorganize_metadata_step(
             &self.store,
             &self.namespace_id,
             &self.mutation_context()?,
             crate::checkpoint::MetadataLsmPolicy::default(),
-            active_compaction,
+            compactions,
         )
         .await
     }

--- a/crates/loonfs-core/src/gc/compaction_staging.rs
+++ b/crates/loonfs-core/src/gc/compaction_staging.rs
@@ -1,0 +1,70 @@
+//! Deciding one streaming compaction's objects: the lease says whether the
+//! job that wrote them still owns them.
+//!
+//! A job writes its output under `metadata/compactions/{job_id}/` and rewrites
+//! its lease beside it while it runs (format spec, "Garbage collection", rule
+//! 12). A pass sweeping that prefix therefore asks one question per object:
+//! does the job that owns this key still hold its lease? A fresh lease retains
+//! the whole prefix however old the objects under it are, and a stale or
+//! missing one leaves them to ordinary orphan collection.
+//!
+//! The lease of a job sorts before that job's `tables/` directory and a job's
+//! objects are contiguous, so remembering the answer for the job being walked
+//! turns one lease read per object into one lease read per job. The memo is
+//! not authority: a resumed pass simply reads the lease again.
+
+use crate::checkpoint::{read_compaction_lease_state, CompactionLeaseState};
+use crate::error::Result;
+use loonfs_api::NamespaceId;
+use loonfs_objectstore::keys::metadata_compaction_job_id_from_key;
+use loonfs_objectstore::ObjectStore;
+
+/// What one pass has learned about the compaction job it is walking.
+#[derive(Debug, Default)]
+pub(super) struct CompactionLeases {
+    /// The job this pass last read a lease for, and what that lease said.
+    last_read: Option<(String, CompactionLeaseState)>,
+}
+
+/// What the sweep should do with one key under the compaction prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StagedObject {
+    /// A live job owns it. Nothing about its age matters.
+    OwnedByALiveJob,
+    /// No job owns it: it belongs to a job that finished, died, or never
+    /// wrote a lease. It ages out as an ordinary unreferenced orphan.
+    Orphaned,
+    /// The key is under the prefix but is neither a job's lease nor one of
+    /// its staged segments, so this pass cannot tell what wrote it and
+    /// retains it.
+    UnrecognizedKey,
+}
+
+impl CompactionLeases {
+    /// Reads `key`'s owning job, and the lease of that job unless this pass
+    /// has already read it.
+    pub(super) async fn owner_of<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        key: &str,
+        now_ms: u64,
+    ) -> Result<StagedObject> {
+        let Some(job_id) = metadata_compaction_job_id_from_key(key) else {
+            return Ok(StagedObject::UnrecognizedKey);
+        };
+        let state = match &self.last_read {
+            Some((read_job_id, state)) if read_job_id == job_id => *state,
+            _ => {
+                let state =
+                    read_compaction_lease_state(store, namespace_id, job_id, now_ms).await?;
+                self.last_read = Some((job_id.to_owned(), state));
+                state
+            }
+        };
+        Ok(match state {
+            CompactionLeaseState::Held => StagedObject::OwnedByALiveJob,
+            CompactionLeaseState::Gone => StagedObject::Orphaned,
+        })
+    }
+}

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -6,8 +6,8 @@ use loonfs_api::{
     PageCursor,
 };
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_compaction_staging_prefix, metadata_manifest_prefix,
-    metadata_table_prefix, upload_session_prefix, wal_segment_prefix,
+    checkpoint_prefix, metadata_compaction_prefix, metadata_manifest_prefix, metadata_table_prefix,
+    upload_session_prefix, wal_segment_prefix,
 };
 use serde::{Deserialize, Serialize};
 
@@ -16,10 +16,11 @@ use serde::{Deserialize, Serialize};
 pub(super) enum CandidateFamily {
     WalSegments,
     MetadataTables,
-    /// Metadata segments a streaming compaction wrote. Its own family
-    /// because it ages on its own window: a job outlives the ordinary grace
-    /// window, so its output would read as an aged orphan while it was still
-    /// being written.
+    /// Everything one streaming compaction job owns: the segments it wrote
+    /// and the lease that says it is still running. Its own family because
+    /// its objects are decided by that lease rather than by age alone — a job
+    /// outlives the ordinary grace window, so its output would otherwise read
+    /// as an aged orphan while it was still being written.
     CompactionStaging,
     Manifests,
     Checkpoints,
@@ -48,7 +49,7 @@ impl CandidateFamily {
         match self {
             Self::WalSegments => wal_segment_prefix(namespace_id.as_str()),
             Self::MetadataTables => metadata_table_prefix(namespace_id.as_str()),
-            Self::CompactionStaging => metadata_compaction_staging_prefix(namespace_id.as_str()),
+            Self::CompactionStaging => metadata_compaction_prefix(namespace_id.as_str()),
             Self::Manifests => metadata_manifest_prefix(namespace_id.as_str()),
             Self::Checkpoints => checkpoint_prefix(namespace_id.as_str()),
             Self::UploadSessions => upload_session_prefix(namespace_id.as_str()),

--- a/crates/loonfs-core/src/gc/mod.rs
+++ b/crates/loonfs-core/src/gc/mod.rs
@@ -15,6 +15,7 @@
 //! anchor in `live_set.rs` is what dates that moment.
 
 mod budget;
+mod compaction_staging;
 mod config;
 mod cursor;
 mod fork_checkpoints;

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -2,6 +2,7 @@
 //! and the bounded, resumable sweep.
 
 use super::budget::PassBudget;
+use super::compaction_staging::{CompactionLeases, StagedObject};
 use super::config::GcConfig;
 use super::cursor::{CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
@@ -106,6 +107,9 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     // overrunning — the sessions waiting on it are retained and the sweep
     // continues.
     let mut references = ContentReferences::over(&mark);
+    // What this pass has learned about the compaction job whose objects it is
+    // walking. One lease read per job rather than one per object.
+    let mut leases = CompactionLeases::default();
     // The position this pass walked to, or `None` while it has decided
     // nothing and has no progress of its own to report.
     let mut position: Option<GcCursor> = None;
@@ -144,6 +148,7 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
                 &mark,
                 &mut sweep,
                 &mut references,
+                &mut leases,
                 &mut budget,
                 &mut report,
             )
@@ -206,6 +211,7 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
     mark: &LiveSet,
     sweep: &mut SweepVerifier,
     references: &mut ContentReferences<'_>,
+    leases: &mut CompactionLeases,
     budget: &mut PassBudget,
     report: &mut GcResponse,
 ) -> Result<SweepStep> {
@@ -285,24 +291,57 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
                 report.deleted_wal_segments += 1;
             }
         }
-        // Both families hold metadata segments and both are counted as
-        // metadata tables. What differs is the window an unreferenced one
-        // ages under: a staged segment belongs to a job that publishes
-        // nothing until it finishes, and a job is allowed to run for a long
-        // time, so reaping one on the ordinary window would delete the output
-        // of a job still writing it.
-        CandidateFamily::MetadataTables | CandidateFamily::CompactionStaging => {
-            let grace_window_ms = match family {
-                CandidateFamily::CompactionStaging => METADATA_COMPACTION_STAGING_GRACE_MS,
-                _ => config.grace_window_ms,
-            };
+        CandidateFamily::MetadataTables => {
             // Rule 5 is sticky across every re-collection in this pass.
             if sweep.degraded {
                 report.retain(RetainedReason::DegradedRoots);
             } else if sweep.live.tables.contains(key) {
                 report.retain(RetainedReason::Referenced);
-            } else if sweep_aged(store, key, grace_window_ms, context, sweep, report).await? {
+            } else if sweep_aged(store, key, config.grace_window_ms, context, sweep, report).await?
+            {
                 report.deleted_metadata_tables += 1;
+            }
+        }
+        // A compaction job's prefix holds the segments it has written and the
+        // lease that says it is still running. A published segment is named by
+        // the manifest and is live like any other table; everything else is
+        // decided by the lease, because a job outlives the ordinary grace
+        // window and its output would otherwise read as an aged orphan while
+        // it was still being written. Only the segments are counted as
+        // metadata tables — a lease is a control object, and a pass that
+        // reclaims one reclaims that job's segments in the same walk.
+        CandidateFamily::CompactionStaging => {
+            if sweep.degraded {
+                report.retain(RetainedReason::DegradedRoots);
+            } else if sweep.live.tables.contains(key) {
+                report.retain(RetainedReason::Referenced);
+            } else {
+                match leases
+                    .owner_of(store, namespace_id, key, context.now_ms)
+                    .await?
+                {
+                    // The same reason an object inside its window is kept:
+                    // something that has not run out yet still protects it.
+                    StagedObject::OwnedByALiveJob => report.retain(RetainedReason::GraceWindow),
+                    StagedObject::UnrecognizedKey => {
+                        report.retain(RetainedReason::UnrecognizedKey);
+                    }
+                    StagedObject::Orphaned => {
+                        if sweep_aged(
+                            store,
+                            key,
+                            METADATA_COMPACTION_STAGING_GRACE_MS,
+                            context,
+                            sweep,
+                            report,
+                        )
+                        .await?
+                            && key.ends_with(".sst.zst")
+                        {
+                            report.deleted_metadata_tables += 1;
+                        }
+                    }
+                }
             }
         }
         CandidateFamily::Manifests => {
@@ -348,9 +387,10 @@ async fn process_candidate<S: ObjectStore + ?Sized>(
 /// question, so it keeps every aged candidate and says so.
 ///
 /// The window is a parameter because one family does not use the configured
-/// one: compaction staging holds the output of a job that publishes nothing
-/// until it finishes, and it ages under
-/// [`METADATA_COMPACTION_STAGING_GRACE_MS`] instead.
+/// one: an object under a compaction job's prefix whose lease is stale or
+/// gone ages under [`METADATA_COMPACTION_STAGING_GRACE_MS`], which covers the
+/// lease's own expiry plus the publication that could still be naming the
+/// object.
 async fn sweep_aged<S: ObjectStore + ?Sized>(
     store: &S,
     key: &str,

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -9,12 +9,14 @@ use crate::checkpoint::record::release_checkpoint_record;
 use crate::checkpoint::tests::{
     compact_a_family_group_into_staging, create_checkpoint, mutation_context, write_test_file,
 };
+use crate::checkpoint::MetadataCompactionView;
 use crate::commit_engine::{CommitCandidate, NamespaceCommitEngine};
 use crate::context::MutationContext;
 use crate::error::CoreError;
 use crate::limits::{
     CONTENT_RECLAMATION_GRACE_MS, FORK_CHECKPOINT_LEASE_MS, GC_MIN_GRACE_WINDOW_MS,
-    METADATA_COMPACTION_STAGING_GRACE_MS, UPLOAD_SESSION_LEASE_MS,
+    METADATA_COMPACTION_LEASE_EXPIRY_MS, METADATA_COMPACTION_STAGING_GRACE_MS,
+    UPLOAD_SESSION_LEASE_MS,
 };
 use crate::path::write::{CommitRequest, FilesystemOperation};
 use loonfs_api::v0::GcResponse;
@@ -24,9 +26,9 @@ use loonfs_api::wire::control::{
 };
 use loonfs_api::{ContentRef, ContentStoreId, NamespaceId, UploadId};
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, metadata_compaction_staging_table, metadata_manifest_object,
-    metadata_manifest_prefix, metadata_root, metadata_table, metadata_table_prefix, wal_head,
-    wal_segment, wal_segment_prefix,
+    checkpoint_prefix, metadata_compaction_lease, metadata_compaction_table,
+    metadata_manifest_object, metadata_manifest_prefix, metadata_root, metadata_table,
+    metadata_table_prefix, wal_head, wal_segment, wal_segment_prefix,
 };
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
@@ -1874,7 +1876,7 @@ async fn fold_metadata<S: ObjectStore + ?Sized>(
             namespace_id,
             context,
             fold_policy,
-            None,
+            MetadataCompactionView::default(),
         )
         .await
         .expect("reorganize step");
@@ -1969,80 +1971,226 @@ fn reason_total(report: &GcResponse) -> u64 {
         .sum()
 }
 
-/// A streaming compaction's staged segments age under a window of their own.
-///
-/// The job publishes nothing until it finishes and it has no time budget, so
-/// its output is unreferenced for as long as it runs. Under the ordinary
-/// window the collector would reap a job's segments while it was still writing
-/// them. Under the staging window it reaps them only once no job could still
-/// be alive, and a job that died leaves exactly those orphans.
-#[tokio::test]
-async fn a_staged_compaction_segment_ages_under_the_staging_window() {
-    let temp_dir = tempdir().expect("tempdir");
+/// A namespace with one staged segment under `job_id`, aged so the pass has a
+/// reference anchor, and the lease key that job would hold.
+async fn namespace_with_staged_output(
+    temp_dir: &tempfile::TempDir,
+    namespace_id: &NamespaceId,
+    job_id: &str,
+) -> (MetadataMapStore<LocalFsStore>, String, String) {
     let inner = LocalFsStore::new(temp_dir.path()).expect("store");
-    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let setup = context(1_000);
-    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+    bootstrap_namespace(&inner, namespace_id, &setup, false)
         .await
         .expect("bootstrap");
-    write_test_file(&inner, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
-    crate::checkpoint::flush_wal(&inner, &namespace_id, &setup)
+    write_test_file(&inner, namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    crate::checkpoint::flush_wal(&inner, namespace_id, &setup)
         .await
         .expect("flush wal");
 
     // The namespace ages past the window, so the pass has an anchor. The
     // staged segment below is written after it, the way a job's output is.
-    let published = namespace_key_set(&inner, &namespace_id).await;
+    let published = namespace_key_set(&inner, namespace_id).await;
     let store = aged_before_now(inner, published);
-    let staged_key = metadata_compaction_staging_table(
+    let staged_key = metadata_compaction_table(
         namespace_id.as_str(),
+        job_id,
         "tbl_0123456789abcdef0123456789abcdef",
     );
     store
         .put_if_absent(&staged_key, Bytes::from_static(b"staged segment"))
         .await
         .expect("write a staged segment");
+    let lease_key = metadata_compaction_lease(namespace_id.as_str(), job_id);
+    (store, staged_key, lease_key)
+}
 
-    // Long past the ordinary window, which is where a job would still be
-    // running and this segment would still be its output.
-    let running =
-        context(now_after_newest_object(store.inner(), &namespace_id, GRACE_MS + 1).await);
-    let report = gc_namespace(&store, &namespace_id, &config(), &running)
+/// Writes the lease a job holding `job_id` would have written at
+/// `heartbeat_at_ms`.
+async fn write_compaction_lease<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    job_id: &str,
+    heartbeat_at_ms: u64,
+) {
+    let envelope = loonfs_api::wire::control::MetadataCompactionLeaseEnvelope::from_state(
+        loonfs_api::wire::control::ControlObjectKind::CompactionLease,
+        loonfs_api::wire::control::MetadataCompactionLeaseState {
+            job_id: loonfs_api::MetadataCompactionId::parse(job_id).expect("job id"),
+            namespace_id: namespace_id.clone(),
+            owner_id: "writer".to_owned(),
+            started_at_ms: 1_000,
+            heartbeat_at_ms,
+        },
+    )
+    .expect("build a lease");
+    let bytes =
+        loonfs_api::wire::control::encode_control_object(&envelope).expect("encode a lease");
+    store
+        .put(
+            &metadata_compaction_lease(namespace_id.as_str(), job_id),
+            Bytes::from(bytes),
+            PutMode::Overwrite,
+        )
         .await
-        .expect("gc pass while a job could still be running");
+        .expect("write a lease");
+}
+
+const TEST_JOB_ID: &str = "cmp_0123456789abcdef0123456789abcdef";
+
+/// A running job's output survives however old it is, because its lease says
+/// the job that wrote it is still running.
+///
+/// This is the case a fixed window could not express: a job publishes nothing
+/// until it finishes and is paced by no budget, so its first segment can be
+/// arbitrarily older than any window a collector applies to it.
+#[tokio::test]
+async fn a_live_jobs_staged_output_survives_however_old_it_is() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let (store, staged_key, lease_key) =
+        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+
+    // A day past the window the design used to apply here, with the job's
+    // lease refreshed a moment ago.
+    let now_ms = now_after_newest_object(store.inner(), &namespace_id, 24 * 60 * 60 * 1000).await;
+    write_compaction_lease(&store, &namespace_id, TEST_JOB_ID, now_ms).await;
+
+    let report = gc_namespace(&store, &namespace_id, &config(), &context(now_ms))
+        .await
+        .expect("gc pass while the job holds its lease");
     assert_eq!(
         report.deleted_metadata_tables, 0,
         "a running job's output must not be reaped"
     );
-    assert_eq!(report.retained.grace_window, 1);
+    assert_eq!(
+        report.retained.grace_window, 2,
+        "the segment and the lease are both retained by the lease"
+    );
+    for key in [&staged_key, &lease_key] {
+        assert!(store
+            .head(key)
+            .await
+            .expect("head a staged object")
+            .is_some());
+    }
+}
+
+/// A job whose lease went stale loses its prefix: the segments and the lease
+/// are ordinary orphans once the staging window has passed on them.
+#[tokio::test]
+async fn a_dead_jobs_staged_output_is_reclaimed_after_the_staging_window() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let (store, staged_key, lease_key) =
+        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+
+    // The job's last heartbeat, and then a pass one lease expiry later. The
+    // lease is stale, but the objects are still inside the staging window.
+    let died_at_ms = now_after_newest_object(store.inner(), &namespace_id, 0).await;
+    write_compaction_lease(&store, &namespace_id, TEST_JOB_ID, died_at_ms).await;
+    let expired_ms = died_at_ms + METADATA_COMPACTION_LEASE_EXPIRY_MS + 1;
+    let report = gc_namespace(&store, &namespace_id, &config(), &context(expired_ms))
+        .await
+        .expect("gc pass once the lease expired");
+    assert_eq!(
+        report.deleted_metadata_tables, 0,
+        "an expired lease still leaves the objects their own window"
+    );
     assert!(store
         .head(&staged_key)
         .await
         .expect("head the staged segment")
         .is_some());
 
-    // Past the staging window, where no job can still be alive, the same
-    // object is the orphan a dead job left.
-    let dead = context(
-        now_after_newest_object(
-            store.inner(),
-            &namespace_id,
-            METADATA_COMPACTION_STAGING_GRACE_MS + 1,
-        )
-        .await,
-    );
-    let report = gc_namespace(&store, &namespace_id, &config(), &dead)
+    // Past the staging window, the same objects are the orphans a dead job
+    // left. Only the segment counts as a metadata table; the lease is a
+    // control object.
+    let reclaimable_ms = now_after_newest_object(
+        store.inner(),
+        &namespace_id,
+        METADATA_COMPACTION_STAGING_GRACE_MS + 1,
+    )
+    .await;
+    let report = gc_namespace(&store, &namespace_id, &config(), &context(reclaimable_ms))
         .await
         .expect("gc pass once no job could still be running");
     assert_eq!(
         report.deleted_metadata_tables, 1,
         "a dead job's orphan must be reaped"
     );
+    for key in [&staged_key, &lease_key] {
+        assert!(store
+            .head(key)
+            .await
+            .expect("head a staged object")
+            .is_none());
+    }
+}
+
+/// A job that died before writing a lease at all leaves output no lease
+/// claims, and the same window reclaims it.
+#[tokio::test]
+async fn staged_output_with_no_lease_at_all_is_reclaimed() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let (store, staged_key, _) =
+        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+
+    let reclaimable_ms = now_after_newest_object(
+        store.inner(),
+        &namespace_id,
+        METADATA_COMPACTION_STAGING_GRACE_MS + 1,
+    )
+    .await;
+    let report = gc_namespace(&store, &namespace_id, &config(), &context(reclaimable_ms))
+        .await
+        .expect("gc pass over an unclaimed prefix");
+    assert_eq!(report.deleted_metadata_tables, 1);
     assert!(store
         .head(&staged_key)
         .await
         .expect("head the staged segment")
         .is_none());
+}
+
+/// A lease that does not decode is treated as missing.
+///
+/// Nothing else reads this object, so believing a corrupt one would keep its
+/// prefix alive forever and nothing would ever say why. It is said out loud
+/// instead, and the prefix is collected like any other unclaimed one.
+#[tokio::test]
+async fn a_lease_that_does_not_decode_does_not_immortalize_its_prefix() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let (store, staged_key, lease_key) =
+        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+    store
+        .put(
+            &lease_key,
+            Bytes::from_static(b"{\"kind\":\"compaction_lease\",\"payload\":"),
+            PutMode::Overwrite,
+        )
+        .await
+        .expect("write a corrupt lease");
+
+    let reclaimable_ms = now_after_newest_object(
+        store.inner(),
+        &namespace_id,
+        METADATA_COMPACTION_STAGING_GRACE_MS + 1,
+    )
+    .await;
+    let report = gc_namespace(&store, &namespace_id, &config(), &context(reclaimable_ms))
+        .await
+        .expect("a corrupt lease must not fail the pass");
+    assert_eq!(report.deleted_metadata_tables, 1);
+    for key in [&staged_key, &lease_key] {
+        assert!(store
+            .head(key)
+            .await
+            .expect("head a staged object")
+            .is_none());
+    }
 }
 
 /// A published job's output is an ordinary referenced table. The manifest
@@ -2527,7 +2675,7 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
             &namespace_id,
             &setup,
             fold_policy,
-            None,
+            MetadataCompactionView::default(),
         )
         .await
         .expect("reorganize step");

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -178,8 +178,8 @@ pub mod publish {
 // because it is the return type of `NamespaceEngine::reorganize_metadata`.
 pub use checkpoint::{
     CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, MetadataCompactionCancellation,
-    MetadataCompactionJobOutcome, MetadataCompactionSpec, MetadataReorganizeOutcome,
-    MetadataReorganizeReport,
+    MetadataCompactionJobOutcome, MetadataCompactionSpec, MetadataCompactionView,
+    MetadataReorganizeOutcome, MetadataReorganizeReport,
 };
 pub use context::MutationContext;
 pub use engine::RuntimeReadContext;

--- a/crates/loonfs-core/src/limits.rs
+++ b/crates/loonfs-core/src/limits.rs
@@ -107,25 +107,86 @@ pub const GC_SAFETY_MARGIN_MS: u64 = 3 * 60 * 1000;
 /// Default candidate budget for one step-driven garbage-collection pass.
 pub const DEFAULT_GC_MAX_OBJECTS: u64 = 1024;
 
-/// Grace a streaming compaction's staged segments get before garbage
-/// collection may reap one as an orphan (format spec, "Garbage collection",
-/// rule 12).
+/// How often a running streaming compaction rewrites its lease (format spec,
+/// "Garbage collection", rule 12).
 ///
-/// A staged segment is unreferenced for as long as its job runs, and the job
-/// has no time budget at all: it rebuilds a whole family group, which is the
-/// work no per-step budget could hold. The ordinary grace window only has to
-/// cover a publication in flight, so it is far too short here — a pass would
-/// reap the output of a job still writing it.
+/// A job's staged output is unreferenced for as long as the job runs, and a
+/// job has no time budget at all, so the collector cannot tell a running
+/// job's output from a dead one's by age. The lease is what tells it: the
+/// job rewrites it on this interval, and a prefix whose lease is fresh is
+/// retained whole.
 ///
-/// This window is a liveness bound and not a correctness one. A job that
-/// publishes leaves its segments named by the manifest, and a referenced
-/// object is live wherever it sits, so nothing this window protects is
-/// needed once the publication lands. Being generous costs storage for
-/// orphans a crash left behind; being tight costs a job that was nearly done.
-/// So it is one day, spelled as the number of metadata publication budgets
-/// that fit in one: a job that has not finished within that many is not one a
-/// restart is going to shorten.
-pub const METADATA_COMPACTION_STAGING_GRACE_MS: u64 = 96 * METADATA_PUBLICATION_BUDGET_MS;
+/// One small overwrite per interval is nothing beside the reads the job is
+/// already making, so the interval is set by the other side of the trade:
+/// it has to be long enough that a heartbeat spending its whole provider
+/// budget still lands before the next one is due, and short enough that a
+/// dead job's output is reclaimable in a sensible time. Five minutes is
+/// twice the provider bound below it and leaves the reclamation window
+/// under an hour.
+pub const METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS: u64 = 5 * 60 * 1000;
+
+/// Heartbeats a lease may miss before the collector reads its job as gone.
+pub const METADATA_COMPACTION_LEASE_MISSED_HEARTBEATS: u64 = 5;
+
+/// How long after its last heartbeat a lease still says its job owns its
+/// prefix.
+///
+/// Two things have to fit inside it. A running job must never lose its
+/// prefix, so the window covers several missed heartbeats rather than one.
+/// And a job's last heartbeat before it publishes is at the top of a
+/// finalization attempt, so the window must also outlast one publication:
+/// `GC_MIN_GRACE_WINDOW_MS` is the bound on the span from a publication's
+/// first object write to its root compare-and-swap, and the assertion below
+/// holds the lease above it.
+pub const METADATA_COMPACTION_LEASE_EXPIRY_MS: u64 =
+    METADATA_COMPACTION_LEASE_MISSED_HEARTBEATS * METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS;
+
+/// Grace a streaming compaction's staged segments get, once their job's
+/// lease is stale or gone, before garbage collection may reap one as an
+/// orphan (format spec, "Garbage collection", rule 12).
+///
+/// Derived, not tuned. A job owns its prefix while its lease is fresh, so
+/// what remains to cover is the gap between the last heartbeat and the moment
+/// the objects become referenced: the lease's own expiry, plus the bound on
+/// the publication that names them, which is what `GC_MIN_GRACE_WINDOW_MS`
+/// bounds for every other publication in the system.
+///
+/// This is the window that replaced a fixed day. A day was a guess at how
+/// long a job might run, which is exactly the thing the streaming design
+/// refuses to bound; the lease measures it instead, and this window only has
+/// to cover what happens after a lease stops being refreshed.
+pub const METADATA_COMPACTION_STAGING_GRACE_MS: u64 =
+    METADATA_COMPACTION_LEASE_EXPIRY_MS + GC_MIN_GRACE_WINDOW_MS;
+
+/// The heartbeat's inequality, shared by the compile-time assertion below
+/// and the test that proves the assertion has teeth.
+const fn heartbeats_land_before_the_next_one_is_due(interval_ms: u64) -> bool {
+    interval_ms > PROVIDER_OPERATION_DEADLINE_MS + PROVIDER_ATTEMPT_TIMEOUT_MS
+}
+
+// A heartbeat is one small overwrite, and one provider operation's total wall
+// time is its deadline plus one attempt timeout. An interval below that would
+// make a healthy job fall behind its own lease under nothing worse than a
+// slow provider, so the two constants have to move together.
+const _: () = assert!(
+    heartbeats_land_before_the_next_one_is_due(METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS),
+    "a heartbeat that spends its whole provider budget must still land before the next is due"
+);
+
+/// The lease's inequality, shared by the compile-time assertion below and the
+/// test that proves the assertion has teeth.
+const fn outlasts_one_publication(expiry_ms: u64) -> bool {
+    expiry_ms >= GC_MIN_GRACE_WINDOW_MS
+}
+
+// A job's last heartbeat before its output becomes referenced is at the top
+// of a finalization attempt, and that attempt's compare-and-swap lands within
+// one publication bound of it. A lease shorter than that bound would expire
+// while the publication naming its output was still in flight.
+const _: () = assert!(
+    outlasts_one_publication(METADATA_COMPACTION_LEASE_EXPIRY_MS),
+    "a compaction lease must outlast the publication that ends the job holding it"
+);
 
 const fn max_u64(left: u64, right: u64) -> u64 {
     if left > right {
@@ -316,16 +377,39 @@ mod tests {
         );
     }
 
-    /// The staging window has to outlast a job, and a job is allowed to be
-    /// long. Anything near the ordinary window would reap a job's output
-    /// while it was still writing it.
+    /// The staging window is derived from the lease, not from a guess at how
+    /// long a job runs. A running job holds its prefix through its lease, so
+    /// this window only has to cover what follows the last heartbeat.
     #[test]
-    fn the_compaction_staging_grace_is_a_day_of_publication_budgets() {
-        assert_eq!(METADATA_COMPACTION_STAGING_GRACE_MS, 24 * 60 * 60 * 1000);
-        assert!(
-            METADATA_COMPACTION_STAGING_GRACE_MS
-                > 10 * max_u64(GC_MIN_GRACE_WINDOW_MS, GcConfig::default().grace_window_ms),
-            "an orphan's window must be nothing like the window that covers a publication"
+    fn the_compaction_staging_grace_is_the_lease_plus_one_publication() {
+        // 25 minutes of lease + 20.5 minutes of publication.
+        assert_eq!(METADATA_COMPACTION_LEASE_EXPIRY_MS, 25 * 60 * 1000);
+        assert_eq!(METADATA_COMPACTION_STAGING_GRACE_MS, 1_500_000 + 1_230_000);
+        assert_eq!(
+            METADATA_COMPACTION_STAGING_GRACE_MS,
+            METADATA_COMPACTION_LEASE_EXPIRY_MS + GC_MIN_GRACE_WINDOW_MS
+        );
+        // Same bargain as every other derived floor here: the compile-time
+        // assertion is only worth having if its predicate can fail.
+        assert!(outlasts_one_publication(
+            METADATA_COMPACTION_LEASE_EXPIRY_MS
+        ));
+        assert!(!outlasts_one_publication(GC_MIN_GRACE_WINDOW_MS - 1));
+    }
+
+    /// Same bargain as the other derived floors: the heartbeat assertion is
+    /// only worth having if its predicate can fail.
+    #[test]
+    fn the_heartbeat_interval_floor_rejects_an_interval_one_provider_bound_short() {
+        assert!(heartbeats_land_before_the_next_one_is_due(
+            METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS
+        ));
+        assert!(!heartbeats_land_before_the_next_one_is_due(
+            PROVIDER_OPERATION_DEADLINE_MS + PROVIDER_ATTEMPT_TIMEOUT_MS
+        ));
+        assert_eq!(
+            METADATA_COMPACTION_LEASE_EXPIRY_MS,
+            METADATA_COMPACTION_LEASE_MISSED_HEARTBEATS * METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS
         );
     }
 }

--- a/crates/loonfs-core/tests/it/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/it/visibility_equivalence.rs
@@ -875,7 +875,7 @@ async fn drain_reorganization(
     for _ in 0..16 {
         let report = harness
             .engine
-            .reorganize_metadata(None)
+            .reorganize_metadata(loonfs_core::MetadataCompactionView::default())
             .await
             .expect("reorganize metadata");
         match report.outcome {

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -26,9 +26,8 @@ use loonfs_grep::{
     GrepReorganizeOutcome, GrepService, GrepWorker, GREP_GC_GRACE_WINDOW_MS,
 };
 use loonfs_objectstore::keys::{
-    checkpoint_prefix, checkpoint_record, metadata_compaction_staging_prefix,
-    metadata_manifest_object, metadata_manifest_prefix, metadata_table_prefix,
-    upload_session_prefix, wal_segment_prefix,
+    checkpoint_prefix, checkpoint_record, metadata_compaction_prefix, metadata_manifest_object,
+    metadata_manifest_prefix, metadata_table_prefix, upload_session_prefix, wal_segment_prefix,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
@@ -1912,7 +1911,7 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
             metadata_manifest_prefix(live_namespace.as_str()),
             wal_segment_prefix(live_namespace.as_str()),
             metadata_table_prefix(live_namespace.as_str()),
-            metadata_compaction_staging_prefix(live_namespace.as_str()),
+            metadata_compaction_prefix(live_namespace.as_str()),
             metadata_manifest_prefix(live_namespace.as_str()),
             checkpoint_prefix(live_namespace.as_str()),
             upload_session_prefix(live_namespace.as_str()),

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -81,19 +81,37 @@ pub fn metadata_table(namespace: &str, table_id: &str) -> String {
     ObjectLayout::new().metadata_table(namespace, table_id)
 }
 
-/// Builds the immutable staging key a streaming compaction writes one
+/// Builds the immutable staging key one streaming compaction job writes a
 /// metadata segment to before any manifest references it.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_compaction_staging_table(namespace: &str, table_id: &str) -> String {
-    ObjectLayout::new().metadata_compaction_staging_table(namespace, table_id)
+pub fn metadata_compaction_table(namespace: &str, job_id: &str, table_id: &str) -> String {
+    ObjectLayout::new().metadata_compaction_table(namespace, job_id, table_id)
 }
 
-/// Builds the listing prefix containing staged compaction segments for one namespace.
+/// Builds the mutable lease key one streaming compaction job holds over its
+/// own prefix.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_compaction_staging_prefix(namespace: &str) -> String {
-    ObjectLayout::new().metadata_compaction_staging_prefix(namespace)
+pub fn metadata_compaction_lease(namespace: &str, job_id: &str) -> String {
+    ObjectLayout::new().metadata_compaction_lease(namespace, job_id)
+}
+
+/// Builds the listing prefix containing every streaming compaction job's
+/// objects for one namespace.
+///
+/// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+pub fn metadata_compaction_prefix(namespace: &str) -> String {
+    ObjectLayout::new().metadata_compaction_prefix(namespace)
+}
+
+/// Extracts the job id from a key under one namespace's compaction prefix.
+///
+/// Returns `None` for a key under the prefix that is neither a job's lease
+/// nor one of its staged segments. See
+/// [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+pub fn metadata_compaction_job_id_from_key(key: &str) -> Option<&str> {
+    ObjectLayout::new().metadata_compaction_job_id_from_key(key)
 }
 
 /// Builds the mutable lifecycle key for one checkpoint record.
@@ -134,8 +152,8 @@ pub fn content_blob(content_store: &str, content_id: &ContentId) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        checkpoint_record, content_blob, metadata_compaction_staging_prefix,
-        metadata_compaction_staging_table, metadata_manifest_object, metadata_root, metadata_table,
+        checkpoint_record, content_blob, metadata_compaction_lease, metadata_compaction_prefix,
+        metadata_compaction_table, metadata_manifest_object, metadata_root, metadata_table,
         namespace_prefix, upload_session, wal_floor, wal_head, wal_segment,
         wal_segment_id_from_key, wal_segment_prefix,
     };
@@ -210,6 +228,7 @@ mod tests {
                     "00000000000000000400-0123456789abcdef",
                 )
                 .replace("{checkpoint_id}", "chk-1")
+                .replace("{job_id}", "cmp-1")
                 .replace("{table_id}", "tbl-1")
                 .replace("{upload_id}", "up-1")
                 .replace("{content_id[4..6]}", &CONTENT_ID[4..6])
@@ -235,7 +254,11 @@ mod tests {
             ("Metadata tables", metadata_table("ns-1", "tbl-1")),
             (
                 "Compaction staging",
-                metadata_compaction_staging_table("ns-1", "tbl-1"),
+                metadata_compaction_table("ns-1", "cmp-1", "tbl-1"),
+            ),
+            (
+                "Compaction leases",
+                metadata_compaction_lease("ns-1", "cmp-1"),
             ),
             ("Upload sessions", upload_session("ns-1", "up-1")),
             ("Metadata root", metadata_root("ns-1")),
@@ -294,12 +317,20 @@ mod tests {
             "namespaces/ns-1/metadata/tables/tbl_00000000000000000000000000000001.sst.zst"
         );
         assert_eq!(
-            metadata_compaction_staging_prefix("ns-1"),
-            "namespaces/ns-1/metadata/compaction-staging/"
+            metadata_compaction_prefix("ns-1"),
+            "namespaces/ns-1/metadata/compactions/"
         );
         assert_eq!(
-            metadata_compaction_staging_table("ns-1", "tbl_00000000000000000000000000000001"),
-            "namespaces/ns-1/metadata/compaction-staging/tbl_00000000000000000000000000000001.sst.zst"
+            metadata_compaction_table(
+                "ns-1",
+                "cmp_00000000000000000000000000000001",
+                "tbl_00000000000000000000000000000001"
+            ),
+            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/tables/tbl_00000000000000000000000000000001.sst.zst"
+        );
+        assert_eq!(
+            metadata_compaction_lease("ns-1", "cmp_00000000000000000000000000000001"),
+            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/lease.json"
         );
         assert_eq!(
             checkpoint_record("ns-1", "chk_00000000000000000000000000000001"),

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -40,6 +40,11 @@ pub enum DurableObjectFamily {
     ///
     /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
     MetadataCompactionStaging,
+    /// Classifies the mutable lease one streaming compaction holds over its
+    /// own staged output.
+    ///
+    /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
+    MetadataCompactionLease,
     /// Classifies a mutable checkpoint lifecycle record.
     ///
     /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
@@ -150,16 +155,46 @@ impl ObjectLayout {
     /// references yet. The object is an ordinary metadata segment; only the
     /// directory differs, which is what keeps a running job's output out of
     /// the sweep that reaps unreferenced table keys.
-    pub(crate) fn metadata_compaction_staging_table(
+    ///
+    /// The job id in the middle is what groups one job's output together, so
+    /// a collector can decide a whole job's objects from that job's lease
+    /// rather than one object at a time.
+    pub(crate) fn metadata_compaction_table(
         &self,
         namespace: &str,
+        job_id: &str,
         table_id: &str,
     ) -> String {
-        format!("namespaces/{namespace}/metadata/compaction-staging/{table_id}.sst.zst")
+        format!("namespaces/{namespace}/metadata/compactions/{job_id}/tables/{table_id}.sst.zst")
     }
 
-    pub(crate) fn metadata_compaction_staging_prefix(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/metadata/compaction-staging/")
+    /// The lease one job holds over its own prefix. It sorts before that
+    /// job's `tables/` directory, so an ascending listing of the compaction
+    /// prefix reads a job's lease before the objects it protects.
+    pub(crate) fn metadata_compaction_lease(&self, namespace: &str, job_id: &str) -> String {
+        format!("namespaces/{namespace}/metadata/compactions/{job_id}/lease.json")
+    }
+
+    pub(crate) fn metadata_compaction_prefix(&self, namespace: &str) -> String {
+        format!("namespaces/{namespace}/metadata/compactions/")
+    }
+
+    /// The job id of a key under one namespace's compaction prefix, for the
+    /// collector that has to find the lease owning a staged object.
+    ///
+    /// Returns `None` for a key under the prefix that is neither a job's
+    /// lease nor one of its staged segments; such a key belongs to no job and
+    /// the collector refuses to decide it.
+    pub(crate) fn metadata_compaction_job_id_from_key<'a>(&self, key: &'a str) -> Option<&'a str> {
+        match key.split('/').collect::<Vec<_>>().as_slice() {
+            ["namespaces", _, "metadata", "compactions", job_id, "lease.json"] => Some(job_id),
+            ["namespaces", _, "metadata", "compactions", job_id, "tables", table]
+                if table.ends_with(".sst.zst") =>
+            {
+                Some(job_id)
+            }
+            _ => None,
+        }
     }
 
     /// Durable stable-view pin to a metadata manifest.
@@ -220,7 +255,7 @@ pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
         ["namespaces", namespace, "metadata", "tables", table] if table.ends_with(".sst.zst") => {
             parsed(DurableObjectFamily::MetadataTable, Some(namespace))
         }
-        ["namespaces", namespace, "metadata", "compaction-staging", table]
+        ["namespaces", namespace, "metadata", "compactions", _job_id, "tables", table]
             if table.ends_with(".sst.zst") =>
         {
             parsed(
@@ -228,6 +263,10 @@ pub fn parse_object_key(key: &str) -> Option<ParsedObjectKey<'_>> {
                 Some(namespace),
             )
         }
+        ["namespaces", namespace, "metadata", "compactions", _job_id, "lease.json"] => parsed(
+            DurableObjectFamily::MetadataCompactionLease,
+            Some(namespace),
+        ),
         ["namespaces", namespace, "checkpoints", checkpoint] if checkpoint.ends_with(".json") => {
             parsed(DurableObjectFamily::CheckpointRecord, Some(namespace))
         }
@@ -296,9 +335,19 @@ mod tests {
         );
         assert_eq!(
             layout
-                .metadata_compaction_staging_table("ns-1", "tbl_00000000000000000000000000000001")
+                .metadata_compaction_table(
+                    "ns-1",
+                    "cmp_00000000000000000000000000000001",
+                    "tbl_00000000000000000000000000000001"
+                )
                 .as_str(),
-            "namespaces/ns-1/metadata/compaction-staging/tbl_00000000000000000000000000000001.sst.zst"
+            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/tables/tbl_00000000000000000000000000000001.sst.zst"
+        );
+        assert_eq!(
+            layout
+                .metadata_compaction_lease("ns-1", "cmp_00000000000000000000000000000001")
+                .as_str(),
+            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/lease.json"
         );
         assert_eq!(
             layout
@@ -341,18 +390,61 @@ mod tests {
     fn staged_compaction_segments_live_outside_the_table_listing_prefix() {
         let layout = ObjectLayout::new();
         let tables = layout.metadata_table_prefix("ns-1");
-        let staging = layout.metadata_compaction_staging_prefix("ns-1");
+        let staging = layout.metadata_compaction_prefix("ns-1");
 
         assert!(!staging.starts_with(&tables));
         assert!(!layout
-            .metadata_compaction_staging_table("ns-1", "tbl_abc")
+            .metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc")
             .starts_with(&tables));
         assert!(layout
-            .metadata_compaction_staging_table("ns-1", "tbl_abc")
+            .metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc")
+            .starts_with(&staging));
+        assert!(layout
+            .metadata_compaction_lease("ns-1", "cmp_abc")
             .starts_with(&staging));
         assert!(!layout
             .metadata_table("ns-1", "tbl_abc")
             .starts_with(&staging));
+    }
+
+    /// A collector reads a job's lease before the objects the lease protects,
+    /// which is what lets one lease read decide a whole job's output.
+    #[test]
+    fn a_jobs_lease_sorts_before_its_staged_segments() {
+        let layout = ObjectLayout::new();
+        let lease = layout.metadata_compaction_lease("ns-1", "cmp_abc");
+        let table = layout.metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc");
+        assert!(lease < table);
+        // And one job's objects are contiguous: the next job's lease sorts
+        // above every object of the job before it.
+        assert!(table < layout.metadata_compaction_lease("ns-1", "cmp_abd"));
+    }
+
+    /// Both key shapes under the compaction prefix name their job; anything
+    /// else under it names none, and the collector refuses to decide it.
+    #[test]
+    fn compaction_keys_report_the_job_that_owns_them() {
+        let layout = ObjectLayout::new();
+        assert_eq!(
+            layout.metadata_compaction_job_id_from_key(
+                &layout.metadata_compaction_lease("ns-1", "cmp_abc")
+            ),
+            Some("cmp_abc")
+        );
+        assert_eq!(
+            layout.metadata_compaction_job_id_from_key(
+                &layout.metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc")
+            ),
+            Some("cmp_abc")
+        );
+        for foreign in [
+            "namespaces/ns-1/metadata/compactions/cmp_abc/tables/tbl_abc.tmp",
+            "namespaces/ns-1/metadata/compactions/cmp_abc/notes.json",
+            "namespaces/ns-1/metadata/compactions/stray.json",
+            "namespaces/ns-1/metadata/tables/tbl_abc.sst.zst",
+        ] {
+            assert_eq!(layout.metadata_compaction_job_id_from_key(foreign), None);
+        }
     }
 
     #[test]
@@ -382,8 +474,12 @@ mod tests {
                 DurableObjectFamily::MetadataTable,
             ),
             (
-                layout.metadata_compaction_staging_table("ns-1", "tbl_abc"),
+                layout.metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc"),
                 DurableObjectFamily::MetadataCompactionStaging,
+            ),
+            (
+                layout.metadata_compaction_lease("ns-1", "cmp_abc"),
+                DurableObjectFamily::MetadataCompactionLease,
             ),
             (
                 layout.checkpoint_record("ns-1", "chk_00000000000000000000000000000001"),
@@ -414,6 +510,7 @@ mod tests {
             "namespaces/ns-1/gc/manifest.boundary.json",
             "namespaces/ns-1/gc/pins/pin_00000000000000000000000000000001.json",
             "namespaces/ns-1/pins/pin_00000000000000000000000000000001.json",
+            "namespaces/ns-1/metadata/compaction-staging/tbl_abc.sst.zst",
         ] {
             assert!(
                 parse_object_key(old).is_none(),

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -725,9 +725,9 @@ fn classify_key(key: &str) -> KeyClass {
         DurableObjectFamily::MetadataTable | DurableObjectFamily::MetadataCompactionStaging => {
             KeyClass::MetadataSst
         }
-        DurableObjectFamily::CheckpointRecord | DurableObjectFamily::WalFloor => {
-            KeyClass::GcControl
-        }
+        DurableObjectFamily::CheckpointRecord
+        | DurableObjectFamily::WalFloor
+        | DurableObjectFamily::MetadataCompactionLease => KeyClass::GcControl,
         DurableObjectFamily::MetadataRoot => KeyClass::NamespaceManifest,
         DurableObjectFamily::UploadSession => KeyClass::Metadata,
     }

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -392,9 +392,15 @@ no longer fits one reorganization step. It names the group, the run, how many
 rows and bytes that run holds, and the two per-step budgets it did not fit. It
 means the namespace has grown, not that anything is wrong.
 
-What follows it is `a family group outgrew one reorganization step; a
-streaming metadata compaction is rebuilding it`. That is a background job the
-server starts and does not wait for. It reads every file the group holds,
+The warning may repeat once or twice before the rebuild starts. A group in
+this state still has newer metadata files above the frozen ones, and folding
+those together is cheaper than rebuilding the whole group, so maintenance does
+that first. After a couple of rounds it stops waiting and starts the rebuild,
+whether or not more files have arrived meanwhile.
+
+What follows is `a family group outgrew one reorganization step; a streaming
+metadata compaction is rebuilding it`. That is a background job the server
+starts and does not wait for. It reads every file the group holds,
 writes the rebuilt group as it goes, and publishes the result in one step at
 the end. A large group can keep it busy for a long time, and it logs
 `streaming metadata compaction progress` as it works so you can see it moving.
@@ -408,15 +414,21 @@ job runs at a time per namespace, so a second group in the same state waits
 its turn and says so.
 
 A restart during a rebuild loses that rebuild's work, and this is expected.
-Nothing durable records that a job was running: the published metadata never
+Nothing durable records the rebuild's progress: the published metadata never
 moved, the files the job had written are referenced by nothing, and the next
 maintenance step starts the job again from what the namespace holds by then.
-The abandoned files sit under
-`namespaces/{namespace}/metadata/compaction-staging/` and garbage collection
-reclaims them a day later, which is a deliberately generous wait so that a
-collection pass can never delete the output of a job that is still running.
 The same is true of a graceful shutdown, which cancels a running job rather
 than waiting for it.
+
+Each job writes its files under
+`namespaces/{namespace}/metadata/compactions/{job}/tables/` and keeps a small
+`lease.json` beside them that it rewrites every few minutes while it runs.
+That lease is how a collection pass tells a job that is still writing from
+one that died: a job holding its lease keeps its files however old they are,
+and a job whose lease has gone stale leaves them to be reclaimed within the
+hour. The lease says only who owns the files and when the job last touched
+them; it records nothing about the rebuild's progress, so it cannot make a
+restart resume anything.
 
 Two lines mean the job did not land and will be run again: `streaming metadata
 compaction abandoned` (something else rewrote the group underneath it) and

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -61,6 +61,7 @@ pub async fn summarize_namespace_objects<S: ObjectStore + ?Sized>(
                 DurableObjectFamily::WalFloor
                 | DurableObjectFamily::MetadataRoot
                 | DurableObjectFamily::CheckpointRecord
+                | DurableObjectFamily::MetadataCompactionLease
                 | DurableObjectFamily::UploadSession
                 | DurableObjectFamily::ContentBlob => {}
             }

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -215,13 +215,18 @@ impl FsAdmin {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<ReorganizeStepOutcome> {
-        let active = self
+        // A handle with no runner has no jobs and no counts, which reads to
+        // the planner exactly as a namespace nothing is stuck on. It could
+        // not start a job either way.
+        let pressure = self
             .compactions
             .as_ref()
-            .and_then(|compactions| compactions.active_spec(namespace_id));
+            .map(|compactions| compactions.pressure(namespace_id))
+            .unwrap_or_default();
+        let engagements = pressure.engagements();
         let report = self
             .engine(namespace_id)
-            .reorganize_metadata(active.as_ref())
+            .reorganize_metadata(pressure.view(&engagements))
             .await
             .map_err(RuntimeError::Core)?;
         match report.outcome {
@@ -234,15 +239,25 @@ impl FsAdmin {
                 input_runs,
                 decoded_input_rows,
                 decoded_input_bytes,
+                bottom_anchored_merge_blocked,
                 ..
             } => {
                 self.invalidate_namespace(namespace_id);
+                // A merge that had to start above the group's base leaves the
+                // base frozen and the group's retention stopped. One step
+                // cannot see how long that has been true, so the count that
+                // decides when to stop merging deltas and start the job lives
+                // here.
+                if let Some(background) = &self.compactions {
+                    background.record_merge(namespace_id, &families, bottom_anchored_merge_blocked);
+                }
                 tracing::info!(
                     families = ?families,
                     folded_l0_rows,
                     input_runs,
                     decoded_input_rows,
                     decoded_input_bytes,
+                    bottom_anchored_merge_blocked,
                     "metadata reorganization unit published"
                 );
                 Ok(ReorganizeStepOutcome::UnitPublished)
@@ -327,6 +342,12 @@ impl FsAdmin {
                 // The manifest moved, so every cached view of this namespace
                 // is one manifest behind.
                 self.invalidate_namespace(namespace_id);
+                // The group's base is no longer frozen, so the engagements it
+                // spent merging deltas over that base are spent. It starts
+                // counting again from nothing.
+                if let Some(background) = &self.compactions {
+                    background.clear_engagements(namespace_id, spec.families());
+                }
                 tracing::info!(
                     namespace_id = %namespace_id,
                     families = ?spec.families(),

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -461,11 +461,12 @@ pub(crate) struct RunnerInner {
     /// pipeline at all.
     instruments: Arc<RuntimeInstruments>,
     /// The streaming metadata compactions running under this runner, one per
-    /// namespace at most. Held here rather than beside the admission book
-    /// because a compaction is not a bounded step: it takes no permit, it
-    /// runs for as long as it needs, and what the runner owes it is a spawn,
-    /// a cancellation at shutdown, and the drain every spawned task gets.
-    compactions: Arc<Mutex<BTreeMap<NamespaceId, compaction::ActiveCompaction>>>,
+    /// namespace at most, and the pressure that decides when one has to
+    /// start. Held here rather than beside the admission book because a
+    /// compaction is not a bounded step: it takes no permit, it runs for as
+    /// long as it needs, and what the runner owes it is a spawn, a
+    /// cancellation at shutdown, and the drain every spawned task gets.
+    compactions: Arc<Mutex<BTreeMap<NamespaceId, compaction::NamespaceCompactions>>>,
 }
 
 struct RunnerState {

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -1,4 +1,5 @@
-//! The streaming metadata compactions this process is running.
+//! The streaming metadata compactions this process is running, and the
+//! pressure that decides when one has to start.
 //!
 //! A maintenance step that plans one starts it here. The job is a background
 //! task the runner owns — it takes no admission permit, because it is not a
@@ -6,14 +7,24 @@
 //! and it is registered for the same drain every other spawned task is, so a
 //! shutdown cancels it and then waits for it.
 //!
-//! What this holds is a map from namespace to the one job running for it: the
-//! plan, so the steps that follow know not to merge the group underneath it,
-//! and the cancellation token, so a shutdown can stop it. There is no
-//! lifecycle beyond present and absent. The entry goes when the job ends,
-//! however it ends, because the guard that holds it is dropped with the task.
+//! What this holds, per namespace, is two things. The one job running for it:
+//! the plan, so the steps that follow know not to merge the group underneath
+//! it, and the cancellation token, so a shutdown can stop it. And a count per
+//! family group of the maintenance engagements that planned work for that
+//! group while its bottom-anchored merge was blocked, which is the one thing
+//! a single step cannot see: under sustained writes there is always another
+//! pair of delta runs to merge, so a planner deciding from one step's view
+//! would take that merge forever and never start the job that unfreezes the
+//! group's base.
+//!
+//! Both are in-memory and single-writer, and both are safe to lose. A restart
+//! forgets the running job, and a later step plans it again. A restart
+//! forgets the counts, and the next two engagements rebuild them, which
+//! delays one cycle and nothing else.
 
 use super::RunnerInner;
 use crate::{FsAdmin, NamespaceId};
+use loonfs_api::wire::manifest::MetadataTableFamily;
 use loonfs_core::{MetadataCompactionCancellation, MetadataCompactionSpec};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, Weak};
@@ -22,6 +33,23 @@ use std::sync::{Arc, Mutex, Weak};
 pub(super) struct ActiveCompaction {
     spec: MetadataCompactionSpec,
     cancellation: MetadataCompactionCancellation,
+}
+
+/// What this process knows about one namespace's compactions.
+#[derive(Default)]
+pub(super) struct NamespaceCompactions {
+    active: Option<ActiveCompaction>,
+    /// Engagements that planned work for a family group while its
+    /// bottom-anchored merge was blocked, since that group's last completed
+    /// job. A group is listed here only while it is blocked, so the map holds
+    /// the groups that are stuck and nothing else.
+    blocked_engagements: BTreeMap<Vec<MetadataTableFamily>, u32>,
+}
+
+impl NamespaceCompactions {
+    fn is_empty(&self) -> bool {
+        self.active.is_none() && self.blocked_engagements.is_empty()
+    }
 }
 
 /// A handle on this process's running compactions, cloned into every handle
@@ -33,7 +61,7 @@ pub(super) struct ActiveCompaction {
 /// the runner starts nothing.
 #[derive(Clone)]
 pub(crate) struct BackgroundCompactions {
-    active: Arc<Mutex<BTreeMap<NamespaceId, ActiveCompaction>>>,
+    namespaces: Arc<Mutex<BTreeMap<NamespaceId, NamespaceCompactions>>>,
     runner: Weak<RunnerInner>,
 }
 
@@ -52,23 +80,116 @@ pub(crate) enum CompactionStart {
     NoRunner,
 }
 
+/// What one namespace's planner needs to know, in the shape
+/// [`loonfs_core::MetadataCompactionView`] borrows from.
+///
+/// Owned rather than borrowed because the lock is released before the step
+/// runs: a step reads durable state and publishes, which is far too long to
+/// hold a map every other step consults. The default is what a namespace
+/// nothing is running for reads as.
+#[derive(Default)]
+pub(crate) struct CompactionPressure {
+    active: Option<MetadataCompactionSpec>,
+    blocked_engagements: Vec<(Vec<MetadataTableFamily>, u32)>,
+}
+
+impl CompactionPressure {
+    /// Borrows this as the view a maintenance step reads.
+    pub(crate) fn view<'a>(
+        &'a self,
+        families: &'a [(&'a [MetadataTableFamily], u32)],
+    ) -> loonfs_core::MetadataCompactionView<'a> {
+        loonfs_core::MetadataCompactionView {
+            active: self.active.as_ref(),
+            blocked_engagements: families,
+        }
+    }
+
+    /// The engagement counts as borrowed slices, which is what
+    /// [`Self::view`] needs and what the caller has to keep alive around it.
+    pub(crate) fn engagements(&self) -> Vec<(&[MetadataTableFamily], u32)> {
+        self.blocked_engagements
+            .iter()
+            .map(|(families, engagements)| (families.as_slice(), *engagements))
+            .collect()
+    }
+}
+
 impl BackgroundCompactions {
     pub(super) fn new(
-        active: Arc<Mutex<BTreeMap<NamespaceId, ActiveCompaction>>>,
+        namespaces: Arc<Mutex<BTreeMap<NamespaceId, NamespaceCompactions>>>,
         runner: &Arc<RunnerInner>,
     ) -> Self {
         Self {
-            active,
+            namespaces,
             runner: Arc::downgrade(runner),
         }
     }
 
-    /// The plan of the job running for `namespace_id`, for the step that has
-    /// to leave its group alone.
-    pub(crate) fn active_spec(&self, namespace_id: &NamespaceId) -> Option<MetadataCompactionSpec> {
-        self.lock()
-            .get(namespace_id)
-            .map(|active| active.spec.clone())
+    /// Everything a step's planner needs about this namespace: the job it
+    /// must leave alone, and how long each group has been stuck.
+    pub(crate) fn pressure(&self, namespace_id: &NamespaceId) -> CompactionPressure {
+        let namespaces = self.lock();
+        let Some(entry) = namespaces.get(namespace_id) else {
+            return CompactionPressure::default();
+        };
+        CompactionPressure {
+            active: entry.active.as_ref().map(|active| active.spec.clone()),
+            blocked_engagements: entry
+                .blocked_engagements
+                .iter()
+                .map(|(families, engagements)| (families.clone(), *engagements))
+                .collect(),
+        }
+    }
+
+    /// Records what one published merge unit said about its group.
+    ///
+    /// A merge that ran above a frozen base is one more engagement the group
+    /// spent without its retention restarting; a merge that started at the
+    /// group's oldest run means the base is not frozen, so the count goes.
+    pub(crate) fn record_merge(
+        &self,
+        namespace_id: &NamespaceId,
+        families: &[MetadataTableFamily],
+        bottom_anchored_merge_blocked: bool,
+    ) {
+        let mut namespaces = self.lock();
+        if !bottom_anchored_merge_blocked {
+            let Some(entry) = namespaces.get_mut(namespace_id) else {
+                return;
+            };
+            entry.blocked_engagements.remove(families);
+            if entry.is_empty() {
+                namespaces.remove(namespace_id);
+            }
+            return;
+        }
+        *namespaces
+            .entry(namespace_id.clone())
+            .or_default()
+            .blocked_engagements
+            .entry(families.to_vec())
+            .or_default() += 1;
+    }
+
+    /// Clears a group's engagement count after a job rebuilt it.
+    ///
+    /// The base is no longer frozen, so the group starts counting again from
+    /// nothing.
+    pub(crate) fn clear_engagements(
+        &self,
+        namespace_id: &NamespaceId,
+        families: &[MetadataTableFamily],
+    ) {
+        let mut namespaces = self.lock();
+        let Some(entry) = namespaces.get_mut(namespace_id) else {
+            return;
+        };
+        entry.blocked_engagements.remove(families);
+        if entry.is_empty() {
+            namespaces.remove(namespace_id);
+        }
     }
 
     /// Starts `spec` as a background job under `admin`'s identity, unless a
@@ -84,23 +205,21 @@ impl BackgroundCompactions {
         };
         let cancellation = MetadataCompactionCancellation::default();
         {
-            let mut active = self.lock();
-            if active.contains_key(namespace_id) {
+            let mut namespaces = self.lock();
+            let entry = namespaces.entry(namespace_id.clone()).or_default();
+            if entry.active.is_some() {
                 return CompactionStart::AlreadyRunning;
             }
-            active.insert(
-                namespace_id.clone(),
-                ActiveCompaction {
-                    spec: spec.clone(),
-                    cancellation: cancellation.clone(),
-                },
-            );
+            entry.active = Some(ActiveCompaction {
+                spec: spec.clone(),
+                cancellation: cancellation.clone(),
+            });
         }
         // The guard is built before the future so the future owns it from the
         // moment it exists. A spawn a shutdown refuses drops the future
         // without polling it, and that drop is what gives the slot back.
         let guard = CompactionSlot {
-            active: Arc::clone(&self.active),
+            namespaces: Arc::clone(&self.namespaces),
             namespace_id: namespace_id.clone(),
         };
         let admin = admin.clone();
@@ -117,13 +236,15 @@ impl BackgroundCompactions {
     /// Cancels every running job. The tasks themselves are joined by the
     /// runner's drain; this is what makes that wait short.
     pub(super) fn cancel_all(&self) {
-        for active in self.lock().values() {
-            active.cancellation.cancel();
+        for entry in self.lock().values() {
+            if let Some(active) = &entry.active {
+                active.cancellation.cancel();
+            }
         }
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<NamespaceId, ActiveCompaction>> {
-        self.active
+    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<NamespaceId, NamespaceCompactions>> {
+        self.namespaces
             .lock()
             .expect("background compaction lock poisoned")
     }
@@ -135,14 +256,21 @@ impl BackgroundCompactions {
 /// panic, and on a task discarded with its runtime — so no namespace is ever
 /// left claiming a job that is not running.
 struct CompactionSlot {
-    active: Arc<Mutex<BTreeMap<NamespaceId, ActiveCompaction>>>,
+    namespaces: Arc<Mutex<BTreeMap<NamespaceId, NamespaceCompactions>>>,
     namespace_id: NamespaceId,
 }
 
 impl Drop for CompactionSlot {
     fn drop(&mut self) {
-        if let Ok(mut active) = self.active.lock() {
-            active.remove(&self.namespace_id);
+        let Ok(mut namespaces) = self.namespaces.lock() else {
+            return;
+        };
+        let Some(entry) = namespaces.get_mut(&self.namespace_id) else {
+            return;
+        };
+        entry.active = None;
+        if entry.is_empty() {
+            namespaces.remove(&self.namespace_id);
         }
     }
 }

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -6,7 +6,7 @@ Status: accepted
 
 LoonFS stores namespace metadata in immutable runs. The oldest data is stored in a base run, and checkpoints add newer delta runs. Routine maintenance merges complete runs within a fixed per-step budget, but a family group can eventually become larger than that budget. Once this happens, ordinary maintenance can reduce the number of delta runs but cannot rebuild the base run or apply retention across the complete group.
 
-This design adds a background streaming compaction for oversized metadata family groups. The job reads a fixed snapshot of the selected runs and captures a retention floor, which is the sequence number below which obsolete history may be removed. It applies that floor throughout the job, writes output segments to a staging prefix, and publishes the result with one manifest update. Readers continue using the existing manifest until that final update succeeds.
+This design adds a background streaming compaction for oversized metadata family groups. The job reads a fixed snapshot of the selected runs and captures a retention floor, which is the sequence number below which obsolete history may be removed. It applies that floor throughout the job, writes output segments under a job-specific prefix, and publishes the result with one manifest update. Readers continue using the existing manifest until that final update succeeds.
 
 ## Problem
 
@@ -23,6 +23,8 @@ Merges above the base can continue reducing delta-run count, but they cannot app
 - Apply one retention floor consistently across the complete job.
 - Preserve runs created after the job starts.
 - Bound input buffering, fetch concurrency, decoded-block caching, output buffering, and retention working memory.
+- Ensure that a group starts compaction even when new delta runs arrive continuously.
+- Avoid rebuilding a large base after every small batch of delta runs.
 - Allow cancellation without publishing a partial result.
 - Prevent garbage collection from deleting output that belongs to an active job.
 - Reclaim unreferenced output after failed, cancelled, or superseded jobs.
@@ -33,16 +35,17 @@ Merges above the base can continue reducing delta-run count, but they cannot app
 - More than one active metadata compaction per namespace.
 - A fixed wall-clock limit for the complete job.
 - Changes to the metadata segment format.
+- A process-wide limit on the number of namespaces compacting at once.
 
 ## Compaction flow
 
-Normal bounded merges remain the preferred path. Streaming compaction is selected only when a family group needs bottom-anchored work and no valid bounded merge can make progress.
+Normal bounded merges remain the preferred path. Streaming compaction is selected when a family group has repeatedly required work while its bottom-anchored merge cannot fit within one maintenance step.
 
 The complete operation has five stages:
 
-1. Capture an immutable compaction specification containing the family group, selected input runs, output identity, and retention floor.
-2. Open sorted iterators over the selected runs and merge their rows in key order.
-3. Apply the retention rules and write completed output segments under the metadata compaction staging prefix.
+1. Capture an immutable compaction specification containing a generated job ID, the family group, selected input runs, output identity, and retention floor.
+2. Create the job lease, open sorted iterators over the selected runs, and merge their rows in key order.
+3. Apply the retention rules and write completed output segments under `metadata/compactions/{job_id}/tables/`.
 4. Reload the current manifest and confirm that every selected input is still present and unchanged.
 5. Publish one manifest update that removes the selected inputs and adds the completed output.
 
@@ -51,7 +54,7 @@ The manifest remains unchanged during stages 1 through 4. A crash, cancellation,
 ```text
 fixed input runs -> sorted iterators -> retention -> staged output segments
 
-current manifest + verified inputs + verified output -> one manifest publication
+current manifest + verified inputs + staged output -> one manifest publication
 ```
 
 ## Merge placement
@@ -69,11 +72,17 @@ Manifest validation enforces the resulting layout:
 - Segment indexes for one family and run start at zero and contain no gaps or duplicates.
 - Segment key ranges are strictly ordered and do not overlap.
 
-## Planning and coordination
+## Planning and scheduling
 
-Planning produces either a bounded merge or a `MetadataCompactionSpec`. The compaction specification records the family group as an enum value, along with the exact input descriptors, output identity, and retention floor. These values do not change during the job.
+Planning produces either a bounded merge or a `MetadataCompactionSpec`. The compaction specification records the job ID, family group, exact input descriptors, output identity, and retention floor. These values do not change during the job.
 
-The maintenance runner keeps one active compaction slot per namespace. While a job is active, its family group is excluded from bounded merges. Maintenance may continue processing unrelated groups in the same namespace.
+A group with an oversized base may still have delta runs that fit within a bounded merge. Always choosing that merge can prevent full compaction when writes continuously create more delta runs. Starting full compaction as soon as the base exceeds the budget would cause the opposite problem: the complete base would be reread for every small batch of delta runs.
+
+The maintenance runner balances these cases by recording how many maintenance engagements planned work for a family group while its bottom-anchored merge was blocked. The first two engagements may use bounded delta merges. After two such engagements, planning selects full compaction even when another delta merge is available.
+
+The count is stored in process memory for each namespace and family group. It is cleared after successful full compaction or after a bottom-anchored merge becomes possible. A restart loses the count, so at most two more engagements are required before full compaction is selected again.
+
+The maintenance runner also keeps one active compaction slot per namespace. While a job is active, its family group is excluded from bounded merges. Maintenance may continue processing unrelated groups in the same namespace.
 
 Runs published after the snapshot was captured are not part of the compaction input. Final publication preserves those runs.
 
@@ -87,61 +96,58 @@ The following resources have explicit limits:
 - Concurrent object-store fetches.
 - The decoded-block cache used by reverse-index point lookups.
 - Buffered output rows for each family.
-- In-memory rows held for one retention locality.
+- State held by each retention operator.
 
-A retention locality is the set of rows that must be considered together before any of them can be removed. One inode may have a long attribute history, and one parent-and-name slot may be reused many times. The implementation must not collect an unlimited number of locality rows in memory. An operator that needs the complete locality must either process it incrementally or spill after reaching a configured byte limit.
-
-This requirement bounds memory independently of the total family-group size and of the number of revisions associated with one logical key.
+Retention is implemented by family-specific streaming operators. Each operator keeps a fixed number of fields and at most one complete row. Memory use therefore does not increase with the total family-group size, one inode's attribute history, or the number of binding generations associated with one name.
 
 ## Retention and index consistency
 
 Retention uses the floor captured in the compaction specification. The same floor applies to every input row, even when the namespace advances while the job is running.
 
-Rows are processed according to the locality required by each rule:
+Rows are processed as follows:
 
-- Revisions pass through without removal.
-- Receipt rows are evaluated independently.
-- Attribute rows are grouped by inode.
-- Active-deletion rows are grouped by deletion identity.
-- Bind and unbind rows are grouped by parent and name slot so related rows are removed together.
+- Revisions, inodes, and tombstones pass through without removal.
+- Receipt rows are evaluated independently against the retention floor.
+- Attribute rows arrive newest first for each inode. The operator tracks whether it has retained the newest row at or below the floor and detects repeated revision numbers without retaining the complete history.
+- Active-deletion rows are ordered so a removal marker arrives before the row it removes. One flag is enough to remove the pair together.
+- Forward binding rows are grouped by binding generation. The operator holds at most one bind row until the matching unbind rows arrive, and it retains one generation identity to validate the parent-and-name slot.
 - Reverse child-binding rows use bloom-filtered point lookups against the snapshot's unbind rows because their key order differs from the forward binding table.
 
 Bindings and revisions have secondary indexes that must remain equivalent to their canonical families. The executor computes order-independent digests for the canonical and index rows selected for output. A mismatch fails the job before publication.
 
-## Staging and visibility
+The executor reports its peak retained-row count. Resource tests use heavily reused inodes and binding slots to verify that this value remains constant.
 
-Output segments are written under a metadata compaction staging prefix. Their object keys are not referenced by the manifest while the job is running, so readers cannot observe them.
+## Job leases and garbage collection
 
-Published descriptors may continue to reference objects under the staging prefix. Metadata loading and descriptor validation must therefore accept valid staged object keys after publication. Moving or copying the objects is not required.
+Each job owns `metadata/compactions/{job_id}/`. Output segments are stored in its `tables/` subdirectory, and lifecycle ownership is recorded in `lease.json` beside that directory.
 
-The output must remain protected from garbage collection until finalization succeeds or the job is abandoned. This protection cannot depend only on an estimated job duration because the design does not impose a wall-clock limit. Garbage collection needs an active-job lease or another durable root that covers every staged output object through publication.
+The lease records the job ID, namespace ID, owner ID, start time, and most recent heartbeat. It does not contain a cursor, output descriptors, offsets, or progress, so it cannot be used to resume a failed job.
 
-After publication, the manifest is the durable root for the output. After cancellation, failure, or supersession, the active-job protection is released and the ordinary staging grace period may be used before deleting the unreferenced objects.
+The lease is written before the first output segment and refreshed every five minutes while the job runs. It is also refreshed at the start of every finalization attempt. A lease remains valid for 25 minutes after its last heartbeat, which covers missed heartbeats and the complete manifest-publication budget.
+
+Garbage collection reads at most one lease per job prefix during a pass. A fresh lease keeps the complete prefix regardless of object age. A stale, missing, or invalid lease makes unreferenced objects eligible for collection after a staging grace period derived from the lease expiry and the normal publication grace. Unrecognized keys under the compaction prefix are retained because ownership cannot be established safely.
+
+After publication, the manifest is the durable reference for the output segments. Lease deletion is best effort because an undeleted lease expires without affecting the published data. After cancellation, failure, or supersession, the lease stops receiving heartbeats and the unreferenced output is eventually collected.
 
 ## Finalization
 
-Finalization reloads the current root and manifest. Publication is allowed only when all of the following conditions hold:
-
-- Every selected input descriptor is still present and unchanged.
-- Every output object exists and remains protected from garbage collection.
-- Canonical-family and secondary-index validation succeeded.
-- The retention floor in the result matches the captured specification.
+Finalization refreshes the lease, then reloads the current root and manifest. Publication is allowed only when every selected input descriptor is still present and unchanged and canonical-family and secondary-index validation succeeded.
 
 The new manifest removes exactly the selected input descriptors, adds the output descriptors, and preserves every newer or unrelated run.
 
-Publication uses the normal manifest compare-and-swap. If an unrelated publication wins the race, finalization reloads the manifest and retries. If any selected input changed, the compaction result is abandoned because it no longer represents the current snapshot.
+Publication uses the normal manifest compare-and-swap. If an unrelated publication wins the race, finalization refreshes the lease, reloads the manifest, and retries. If any selected input changed, the compaction result is abandoned because it no longer represents the current snapshot.
 
 ## Cancellation and recovery
 
 The executor checks a cancellation token during input processing, object-store work, retention processing, and output writing. Graceful shutdown requests cancellation before waiting for background tasks to drain.
 
-Cancellation never publishes a partial result. A process restart does not resume completed segments; maintenance starts a new compaction from the current manifest. This repeats work but does not require durable progress state in the namespace manifest.
+Cancellation never publishes a partial result. A process restart does not resume completed segments; maintenance starts a new compaction from the current manifest. This repeats work but does not require durable progress state in the namespace manifest or lease.
 
 ## Maintenance results and observability
 
 The maintenance API reports `compaction_started` when a step launches a background job. It reports `compaction_pending` when the group requires streaming compaction but the current step cannot start one, such as when the namespace already has an active job.
 
-Lifecycle logging covers job selection, start, progress, publication, cancellation, abandonment, supersession, and failure. Progress records include the namespace, family group, input-run count, rows processed, output-segment count, elapsed time, and final outcome.
+Lifecycle logging covers job selection, start, progress, publication, cancellation, abandonment, supersession, and failure. Progress records include the namespace, family group, input-run count, rows processed, output-segment count, peak retention rows, elapsed time, and final outcome.
 
 ## Validation
 
@@ -152,14 +158,16 @@ The implementation is validated with the following tests:
 - Confirm that changed input causes abandonment without publication.
 - Exercise compare-and-swap retries after unrelated manifest updates.
 - Cancel jobs during reading, retention, writing, and finalization and verify that readers continue using the original manifest.
-- Keep active staged output live beyond the normal garbage-collection grace period.
-- Reclaim staged output after failed and cancelled jobs release their protection.
-- Force one retention locality beyond the in-memory limit and verify incremental processing or spill behavior.
+- Keep all objects under a fresh job lease live beyond the normal garbage-collection grace period.
+- Reclaim staged output after a lease expires or is missing.
+- Reject malformed and mismatched leases as job ownership records.
+- Exercise continuous delta creation and verify that full compaction starts after the bounded engagement count.
+- Process large attribute histories and heavily reused binding slots while holding at most one row in retention state.
 - Reject canonical-family and secondary-index mismatches before publication.
-- Load a published manifest whose descriptors still use staging-prefix object keys.
+- Load a published manifest whose descriptors still use compaction-prefix object keys.
 
 ## Deferred work
 
-Durable resume may be added later if measured restart cost justifies the additional state. Resume state would be owned by the compactor and would record completed segment boundaries without changing the reader-visible namespace manifest.
+Durable resume may be added later if measured restart cost justifies the additional state. Resume state would be owned by the compactor and would record completed segment boundaries without changing the reader-visible namespace manifest. The job lease is not resume state and never records progress.
 
-Support for multiple concurrent compactions in one namespace is also deferred. It would require explicit scheduling and resource-sharing rules beyond the single active-job model described here.
+Support for multiple concurrent compactions in one namespace and a process-wide concurrency cap are also deferred. Both require scheduling and resource-sharing rules beyond the current single-job-per-namespace model.

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -79,7 +79,8 @@ The required durable object families and standard key patterns are:
 | **Namespace manifests** | Immutable | Record one namespace file-set version: its metadata table references and a head summary. Table references carry their own owner, so a fork target's manifest names source-owned tables without recording anything about the fork. | `namespaces/{namespace_id}/metadata/manifests/{manifest_object_id}.manifest.json` |
 | **Checkpoint records** | Mutable lifecycle | Durable stable-view pins to a metadata manifest, each carrying a required owner (user or fork target). The lifecycle is monotonic: a record is created active under a generated id, released once by compare-and-swap, and deleted a grace window after that release. | `namespaces/{namespace_id}/checkpoints/{checkpoint_id}.json` |
 | **Metadata tables** | Immutable | Store metadata rows referenced by manifests. Files may be owned by the namespace itself or by a fork source namespace. | `namespaces/{owner_namespace_id}/metadata/tables/{table_id}.sst.zst` |
-| **Compaction staging** | Immutable | Hold metadata segments a streaming compaction has written before any manifest references them ("Compaction"). The object is an ordinary metadata segment; only the directory differs. | `namespaces/{owner_namespace_id}/metadata/compaction-staging/{table_id}.sst.zst` |
+| **Compaction staging** | Immutable | Hold metadata segments one streaming compaction job has written before any manifest references them ("Compaction"). The object is an ordinary metadata segment; only the directory differs. | `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/tables/{table_id}.sst.zst` |
+| **Compaction leases** | Mutable | Say that one streaming compaction job is still running, so the objects under its prefix belong to it. Carries lifecycle ownership only — job, namespace, owner, start, and last heartbeat — and is rewritten on a heartbeat interval and deleted after publication. | `namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/lease.json` |
 | **Upload sessions** | Mutable lifecycle | Track one staged-content upload. The lifecycle is monotonic: a session is created `open` under a lease, and moves once to `completed` or `aborted`, both terminal. | `namespaces/{namespace_id}/uploads/{upload_id}.json` |
 | **Metadata root** | Mutable | Cold pointer to the best known materialized metadata root; monotonic CAS. | `namespaces/{namespace_id}/metadata/root.json` |
 | **WAL floor** | Mutable | Cold lower bound of retained WAL/change history; monotonic CAS. | `namespaces/{namespace_id}/wal/floor.json` |
@@ -314,14 +315,15 @@ Small mutable objects such as the namespace head must use compare-and-swap
 semantics. These objects must remain small enough that guarded rewrite is
 practical.
 
-Five control-object kinds are registered: `wal_head`, `wal_floor`,
-`metadata_root`, `checkpoint_record`, and `upload_session`. A control-object
-envelope carrying any other kind string is rejected, not skipped.
+Six control-object kinds are registered: `wal_head`, `wal_floor`,
+`metadata_root`, `checkpoint_record`, `upload_session`, and
+`compaction_lease`. A control-object envelope carrying any other kind string
+is rejected, not skipped.
 
 Mutable control-object decoders reject unknown fields in both the envelope and
 the complete nested payload. Otherwise, an older binary could tolerate a
 newer field, erase it during read-modify-write, and still report a successful
-guarded update. All five registered kinds use that strict decoder; immutable
+guarded update. All six registered kinds use that strict decoder; immutable
 WAL segments, metadata segments, namespace manifests, grep segments, and grep
 manifests remain tolerant of additive fields.
 
@@ -1819,6 +1821,7 @@ Two rules make these envelopes evolvable:
 | Control objects (head, metadata root, WAL floor) | per-kind snake_case names | JSON, uncompressed | 1 (tracked per kind) |
 | Checkpoint record | `checkpoint_record` | JSON, uncompressed | 1 |
 | Upload session | `upload_session` | JSON, uncompressed | 1 |
+| Compaction lease | `compaction_lease` | JSON, uncompressed | 1 |
 
 JSON families keep their payload inline as raw JSON so manifests and control
 objects stay directly readable with generic tooling; CBOR families carry the
@@ -2133,16 +2136,28 @@ A rebuild whose bottom-anchored window cannot fit one step's budget is run as
 a streaming compaction instead: it merges every run of the group in one job
 and writes each finished output segment as it fills, so nothing about the job
 follows the size of the group. Those segments are written under
-`namespaces/{owner_namespace_id}/metadata/compaction-staging/{table_id}.sst.zst`
+`namespaces/{owner_namespace_id}/metadata/compactions/{job_id}/tables/{table_id}.sst.zst`
 rather than under `metadata/tables/`. The object is an ordinary metadata
 segment — same encoding, same descriptor, same reads — and only its directory
 differs. The directory is what keeps a running job's output out of the
 listing that enumerates metadata tables: a job outlives the collector's grace
 window, so its segments would otherwise read as unreferenced objects aged
-past grace, which is the class the collector reaps. Nothing loads or
-validates the staging directory, and a manifest may reference a staged key
-directly: a completed publication moves no bytes, because a referenced object
-is live wherever it sits.
+past grace, which is the class the collector reaps. The job id groups one
+job's output together so a collector can decide all of it from that job's
+lease ("Garbage collection", rule 12). Nothing loads or validates the
+compaction directory, and a manifest may reference a staged key directly: a
+completed publication moves no bytes, because a referenced object is live
+wherever it sits.
+
+The rules a rebuild applies are the same however it runs them. A bounded
+merge holds every row of its window and decides them together. A streaming
+compaction cannot, because one inode's attribute history and one
+parent-and-name slot's binding generations have no size limit, so it runs
+each rule as a streaming operator holding a fixed number of fields and at
+most one row. The row-key grammar is what makes the two agree: attribute rows
+of one inode arrive newest first, a deletion's removal marker arrives before
+the row it removes, and a bind arrives before the unbinds of its own binding
+generation.
 
 Invariants:
 
@@ -2186,7 +2201,7 @@ does not exist, so there is nothing to collect and nothing to ignore.
 
 v1 GC is listing mark-and-sweep. Its inputs are `wal/head.json`,
 `wal/floor.json`, `metadata/root.json`, and the `metadata/manifests/`,
-`metadata/tables/`, `metadata/compaction-staging/`, `checkpoints/`, and
+`metadata/tables/`, `metadata/compactions/`, `checkpoints/`, and
 `wal/segments/` collections. A live manifest roots every object key its
 `metadata_files` list names, wherever that key sits. The pass also
 sweeps `uploads/`, and that sweep owns content reclamation as well; the two
@@ -2359,19 +2374,49 @@ publishing CAS) — under these rules:
    reading through a pinned basis; a same-content-store copy across
    namespaces (section 2.8) would have to root the reference on the source
    side the way a fork does.
-12. **Compaction staging ages under a window of its own.** A streaming
+12. **A compaction job's objects are decided by its lease.** A streaming
    compaction ("Compaction") publishes nothing until it finishes and is paced
    by no budget, so its output is unreferenced for as long as the job runs.
    `T` only has to cover a publication in flight, so a sweep applying it to
-   `metadata/compaction-staging/` would delete the output of a job still
-   writing it. Unreferenced staged segments therefore age under
-   `METADATA_COMPACTION_STAGING_GRACE`, a generous bound on job duration
-   rather than a correctness window: nothing is unsafe about a shorter one
-   except that a job would have to run again. A published job's segments are
-   named by the manifest, and a referenced object is live wherever it sits,
-   so this window never applies to them. Every other rule — the reference
-   anchor, delete-time re-verification, degraded roots — applies here exactly
-   as it applies to `metadata/tables/`.
+   `metadata/compactions/` would delete the output of a job still writing it,
+   and no fixed window can replace it: any such window is a guess at how long
+   a job may run, which is exactly what the design refuses to bound.
+
+   The job says so instead. Every job owns the prefix
+   `namespaces/{namespace_id}/metadata/compactions/{job_id}/`, writes its
+   output under `tables/` inside it, and holds a lease at `lease.json` beside
+   that directory. The lease carries lifecycle ownership only — job,
+   namespace, owner, `started_at_ms`, `heartbeat_at_ms` — and never a cursor,
+   an output descriptor, an offset, or resumable progress. The job writes it
+   before its first output object, rewrites it every
+   `METADATA_COMPACTION_HEARTBEAT_INTERVAL` while it runs and at the top of
+   every finalization attempt, and deletes it after publishing.
+
+   A pass decides one of the prefix's objects as follows. An object the
+   manifest references is live, like every other referenced object. Otherwise,
+   if the owning job's lease decodes and its `heartbeat_at_ms` is within
+   `METADATA_COMPACTION_LEASE_EXPIRY`, the object is retained whatever its
+   age. Otherwise it ages as an ordinary unreferenced orphan under
+   `METADATA_COMPACTION_STAGING_GRACE`, which is derived rather than tuned:
+
+   ```
+   METADATA_COMPACTION_STAGING_GRACE
+       >= METADATA_COMPACTION_LEASE_EXPIRY   (a job's claim outliving its last heartbeat)
+          + T                                (rule 1: the publication that may still name it)
+   ```
+
+   `METADATA_COMPACTION_LEASE_EXPIRY` is a small multiple of the heartbeat
+   interval, and it must itself be at least `T`: a job's last heartbeat before
+   its output becomes referenced is at the top of a finalization attempt, and
+   that attempt's compare-and-swap lands within one publication bound of it.
+
+   The lease is a mutable control object and decodes strictly like every
+   other. A lease that does not decode, or that names another job or another
+   namespace, is treated as missing and reported: nothing else reads the
+   object, so believing a corrupt one would keep its prefix alive forever and
+   nothing would ever say why. Every other rule — the reference anchor,
+   delete-time re-verification, degraded roots — applies here exactly as it
+   applies to `metadata/tables/`.
 
 Deletion proceeds data first, records last, so a crash mid-sweep leaves
 orphaned data for the next pass rather than a record whose data vanished.


### PR DESCRIPTION
This change strengthens streaming metadata compaction in three areas: staged-output lifetime, scheduling under sustained writes, and retention memory usage.

Each compaction now gets a unique `metadata/compactions/{job_id}/` prefix containing its staged tables and a small `lease.json` control object. The lease records the job, namespace, owner, start time, and latest heartbeat, but no progress or resume state. It is written before output, refreshed every five minutes while the job runs and before each finalization attempt, and allowed to expire after 25 minutes without a heartbeat.

Garbage collection reads the lease once per job prefix. A fresh lease protects every object in that prefix regardless of age. A stale, missing, or invalid lease allows unreferenced objects to age out after a grace period derived from the lease expiry and the normal publication window. Published segments remain protected by their manifest references. This removes the fixed 24-hour assumption that could allow a long-running job's earlier output to be deleted before publication.

The maintenance runner now records how many bounded merges have run above an oversized base for each namespace and family group. The first two engagements may consolidate delta runs normally. After two engagements, the next plan selects full compaction even if another delta merge is available. This prevents continuous writes from postponing base compaction indefinitely without rebuilding the complete base for every small batch of deltas. The counters are process-local and reset after successful compaction or bottom-anchored work.

Retention no longer collects every row in one locality before deciding what to keep. Family-specific streaming operators now retain a fixed amount of state and at most one complete row. Attribute histories are processed newest first with two fields per inode, active deletions use one flag, and forward bindings hold one bind row until its matching unbinds arrive. Reverse binding-index rows continue to use point reads against the fixed snapshot. Peak retention state is reported and tested against large single-inode and single-name workloads.

The change also adds the compaction lease control format, job-specific object-key parsing, garbage-collection handling, updated format and design documentation, and tests for live, expired, missing, malformed, and published leases; sustained-write scheduling; fixed retention state; cancellation; and publication races.

Formatting, Clippy, the full locked workspace test suite, and the OpenAPI checks pass. One new golden file records the lease control object; existing golden files are unchanged.
