### PR TITLE
feat(maintenance): compaction admission, lifecycle outcomes, and the manual path

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -966,11 +966,18 @@ pub enum ReorganizeStepOutcome {
     /// streaming compaction that rebuilds it. The step published nothing;
     /// the job publishes once, when it finishes.
     CompactionStarted,
-    /// A group needs a streaming compaction and this step did not start one,
-    /// because one is already running for this namespace or because the
-    /// handle this step ran through schedules no background work. The server
-    /// log says which.
-    CompactionPending,
+    /// A job for this namespace is already running, so this step started
+    /// none. One runs at a time per namespace; a later step plans this group
+    /// again.
+    CompactionRunning,
+    /// This step's job holds the namespace's slot and is waiting for a
+    /// process compaction permit. It starts when one frees; nothing is
+    /// needed to make it.
+    CompactionAtCapacity,
+    /// A group needs a streaming compaction and this handle schedules no
+    /// background work, so nothing will run one until an operator does. The
+    /// self-hosting guide names the call.
+    CompactionRequired,
     /// Another publisher advanced the root first; a later step retries.
     Superseded,
 }

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -470,8 +470,16 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                         ReorganizeStepOutcome::CompactionStarted => {
                             "started a background compaction of one family group"
                         }
-                        ReorganizeStepOutcome::CompactionPending => {
+                        ReorganizeStepOutcome::CompactionAtCapacity => {
+                            "queued a background compaction of one family group behind the \
+                             server's compaction limit"
+                        }
+                        ReorganizeStepOutcome::CompactionRunning => {
                             "one family group is waiting on a background compaction"
+                        }
+                        ReorganizeStepOutcome::CompactionRequired => {
+                            "one family group needs a compaction this server will not run on its \
+                             own"
                         }
                         ReorganizeStepOutcome::Superseded => "reorganize superseded",
                     }

--- a/crates/loonfs-core/src/checkpoint/compaction_merge.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_merge.rs
@@ -1,0 +1,384 @@
+//! Reading a streaming compaction's input: one iterator per run per family,
+//! merged in row-key order, refilled a bounded wave at a time.
+//!
+//! This is what makes the job's input residency a fixed number rather than a
+//! function of the group it rebuilds. An iterator holds the blocks it has not
+//! consumed and nothing else, a refill wave is bounded, and the selection
+//! that decides which iterator goes next compares borrowed key slices.
+
+use super::block_fetch::load_segment_index_for_reorganization;
+use super::block_load::SessionBlockMemo;
+use super::data_block_load::load_segment_data_block_span;
+use super::streaming_compaction::manifest_load_failure;
+use super::validate::validate_manifest_row_seq_range;
+use crate::error::Result;
+use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
+use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentIndexEntry};
+use loonfs_objectstore::ObjectStore;
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+/// Decoded data blocks one iterator holds at a time. An iterator refills only
+/// when it has none left, so this is also the most it ever holds, and the
+/// job's input residency is this times the number of open iterators.
+const BLOCKS_PER_ITERATOR_FETCH: usize = 2;
+
+/// Iterators refilled in one wave. Refills are the job's only bulk reads, so
+/// this is the width of its fan-out at the store.
+const ITERATOR_FETCH_CONCURRENCY: usize = 8;
+
+/// Which rows a retention rule has to see together, and therefore how the
+/// merge interleaves the families of one cluster.
+///
+/// The rules that drop a row read its neighbours, and every one of them reads
+/// neighbours that share a row-key prefix: an unbind cancels the bind of its
+/// own generation, a removal marker repeats its deletion's sequence and root,
+/// and an attribute revision supersedes revisions of its own inode. So the
+/// grouping is read straight off the row-key grammar in
+/// `MetadataRow::row_key_for_family`, and it is the shortest prefix each rule
+/// needs rather than the whole partition the rows happen to share:
+///
+/// | families | grouped by | key components after the family prefix |
+/// | --- | --- | --- |
+/// | binds, unbinds | one binding generation | `{parent}-{name}-{bind_seq}-{bind_delta}` |
+/// | active deletions | one deletion | `{deleted_at_seq}-{root}` |
+/// | attributes | one inode | `{inode}` |
+/// | everything else | one row | — |
+///
+/// A generation rather than a name slot is what keeps the bindings group
+/// bounded: a slot has no limit on how many times a name is created and
+/// deleted, and a generation holds one bind and the unbind that retires it.
+/// A bind's whole row key *is* its generation, and an unbind's key leads with
+/// the generation it retires, so both families name the same group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LocalityGrouping {
+    /// Every row is judged on its own.
+    Row,
+    /// Rows sharing the first `n` hyphen-separated components after their
+    /// family's row-key prefix are judged together. Every component of the
+    /// grammar is digits or lowercase hex, and a hyphen sorts below both, so
+    /// rows of one grouping are contiguous in row-key order and grouping
+    /// order is row-key order.
+    LeadingKeyComponents(usize),
+}
+
+/// The locality group a row key belongs to, as a slice of the key itself.
+///
+/// The family's own prefix is stripped, so two families of one cluster name
+/// the same group with the same string: a bind's `direntry-{parent}-{name}`
+/// and its unbind's `direntry-unbind-{parent}-{name}` both read as
+/// `{parent}-{name}`.
+pub(super) fn locality_of(
+    family: MetadataTableFamily,
+    row_key: &str,
+    locality: LocalityGrouping,
+) -> &str {
+    let prefix_len = family.row_key_prefix().len();
+    let tail = row_key.get(prefix_len..).unwrap_or(row_key);
+    let LocalityGrouping::LeadingKeyComponents(components) = locality else {
+        return tail;
+    };
+    let mut end = 0;
+    for component in 0..components {
+        if component > 0 {
+            end += 1;
+        }
+        match tail[end..].find('-') {
+            Some(offset) => end += offset,
+            None => return tail,
+        }
+    }
+    &tail[..end]
+}
+
+/// Reads one family's rows out of one run, one bounded span of data blocks at
+/// a time.
+///
+/// A run's segments for one family are ascending and non-overlapping (manifest
+/// load enforces it), so walking them in index order walks the run's rows in
+/// row-key order. Only the current segment's index is held, and only the
+/// blocks not yet consumed.
+pub(super) struct SegmentRowIterator {
+    pub(super) family: MetadataTableFamily,
+    segments: Vec<MetadataFileRef>,
+    next_segment: usize,
+    index: Option<Arc<Vec<SegmentIndexEntry>>>,
+    next_block: usize,
+    blocks: VecDeque<Arc<DecodedDataBlock>>,
+    row: usize,
+}
+
+impl SegmentRowIterator {
+    pub(super) fn new(family: MetadataTableFamily, mut segments: Vec<MetadataFileRef>) -> Self {
+        segments.sort_by_key(|descriptor| descriptor.segment_index);
+        Self {
+            family,
+            segments,
+            next_segment: 0,
+            index: None,
+            next_block: 0,
+            blocks: VecDeque::new(),
+            row: 0,
+        }
+    }
+
+    pub(super) fn head(&self) -> Option<(&str, &MetadataRow)> {
+        let block = self.blocks.front()?;
+        Some((block.row_keys[self.row].as_str(), &block.rows[self.row]))
+    }
+
+    pub(super) fn take_head(&mut self) -> MetadataRow {
+        let row = self.blocks.front().expect("a head to take").rows[self.row].clone();
+        self.row += 1;
+        while self
+            .blocks
+            .front()
+            .is_some_and(|block| self.row >= block.rows.len())
+        {
+            self.blocks.pop_front();
+            self.row = 0;
+        }
+        row
+    }
+
+    fn needs_fill(&self) -> bool {
+        self.blocks.is_empty() && !self.is_exhausted()
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.blocks.is_empty()
+            && self.next_segment >= self.segments.len()
+            && self
+                .index
+                .as_ref()
+                .is_none_or(|index| self.next_block >= index.len())
+    }
+
+    fn resident_blocks(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Fetches the next span of data blocks, opening the next segment first
+    /// when the current one is spent. A segment with no rows left is closed
+    /// and its index dropped before the next one is read, so one iterator
+    /// holds one index at a time.
+    async fn fill<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
+        while self.blocks.is_empty() {
+            let index = match &self.index {
+                Some(index) if self.next_block < index.len() => Arc::clone(index),
+                _ => {
+                    self.index = None;
+                    let Some(descriptor) = self.segments.get(self.next_segment) else {
+                        return Ok(());
+                    };
+                    self.next_segment += 1;
+                    self.next_block = 0;
+                    let index = load_segment_index_for_reorganization(
+                        store,
+                        None,
+                        &SessionBlockMemo::default(),
+                        descriptor,
+                    )
+                    .await
+                    .map_err(manifest_load_failure)?;
+                    self.index = Some(Arc::clone(&index));
+                    index
+                }
+            };
+            let descriptor = &self.segments[self.next_segment - 1];
+            let end = (self.next_block + BLOCKS_PER_ITERATOR_FETCH).min(index.len());
+            // Blocks are decoded into this iterator alone: no table cache and
+            // a memo that dies with the call, so nothing the job reads is
+            // retained anywhere but here.
+            let blocks = load_segment_data_block_span(
+                store,
+                None,
+                &SessionBlockMemo::default(),
+                descriptor,
+                &index[self.next_block..end],
+            )
+            .await
+            .map_err(manifest_load_failure)?;
+            self.next_block = end;
+            validate_manifest_row_seq_range(
+                &descriptor.object_key,
+                blocks.iter().flat_map(|block| block.rows.iter()),
+                descriptor.run_seq,
+            )
+            .map_err(manifest_load_failure)?;
+            self.row = 0;
+            self.blocks
+                .extend(blocks.into_iter().filter(|block| !block.rows.is_empty()));
+        }
+        Ok(())
+    }
+}
+
+/// Fills every iterator that has run out of rows, a bounded wave at a time,
+/// and answers with the decoded blocks they then hold together.
+pub(super) async fn refill_iterators<S: ObjectStore + ?Sized>(
+    store: &S,
+    iterators: &mut [SegmentRowIterator],
+) -> Result<usize> {
+    let mut hungry: Vec<&mut SegmentRowIterator> = iterators
+        .iter_mut()
+        .filter(|iterator| iterator.needs_fill())
+        .collect();
+    for wave in hungry.chunks_mut(ITERATOR_FETCH_CONCURRENCY) {
+        futures::future::try_join_all(
+            wave.iter_mut()
+                .map(|iterator| Box::pin(iterator.fill(store))),
+        )
+        .await?;
+    }
+    Ok(iterators
+        .iter()
+        .map(SegmentRowIterator::resident_blocks)
+        .sum())
+}
+
+/// The iterator whose next row sorts first, or `None` when every iterator is
+/// spent.
+///
+/// A linear scan rather than a heap: an iterator is opened per run per family
+/// of one cluster, which is a handful, and the scan compares borrowed key
+/// slices while a heap would have to own them.
+pub(super) fn select_next_iterator(
+    iterators: &[SegmentRowIterator],
+    locality: LocalityGrouping,
+) -> Option<usize> {
+    let mut best: Option<(usize, &str, &str)> = None;
+    for (position, iterator) in iterators.iter().enumerate() {
+        let Some((row_key, _)) = iterator.head() else {
+            continue;
+        };
+        let candidate = locality_of(iterator.family, row_key, locality);
+        let take = match best {
+            // Locality first so a group's rows arrive together whatever
+            // family they come from, then family, then key: within one
+            // family that is row-key order, which is the order a segment
+            // builder demands.
+            Some((best_position, best_locality, best_key)) => {
+                (candidate, iterators[position].family, row_key)
+                    < (best_locality, iterators[best_position].family, best_key)
+            }
+            None => true,
+        };
+        if take {
+            best = Some((position, candidate, row_key));
+        }
+    }
+    best.map(|(position, _, _)| position)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{locality_of, LocalityGrouping};
+    use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
+    use loonfs_api::{ChangeSeq, DisplayName, InodeId, NameKey};
+
+    fn bind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
+        MetadataRow::DirentryBind {
+            parent_inode_id: InodeId(parent),
+            name_key: NameKey::parse(name).expect("name key"),
+            display_name: DisplayName::parse(name).expect("display name"),
+            child_inode_id: InodeId(42),
+            bind_seq: ChangeSeq(bind_seq),
+            bind_delta_index: 0,
+        }
+    }
+
+    fn unbind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
+        MetadataRow::DirentryUnbind {
+            parent_inode_id: InodeId(parent),
+            name_key: NameKey::parse(name).expect("name key"),
+            display_name: DisplayName::parse(name).expect("display name"),
+            child_inode_id: InodeId(42),
+            bind_seq: ChangeSeq(bind_seq),
+            bind_delta_index: 0,
+            unbind_seq: ChangeSeq(bind_seq + 1),
+            unbind_delta_index: 0,
+        }
+    }
+
+    /// The grouping the bindings cluster merges by.
+    const GENERATION: LocalityGrouping = LocalityGrouping::LeadingKeyComponents(4);
+
+    /// A bind and the unbind that retires it must name the same locality
+    /// group, because the drop rule reads one from the other. They live in
+    /// different families with different row-key prefixes, so this holds only
+    /// because the grouping is read behind the prefix.
+    #[test]
+    fn a_bind_and_its_unbind_name_one_locality_group() {
+        let bound = bind(7, "report.txt", 11);
+        let retired = unbind(7, "report.txt", 11);
+        let bind_key = bound.row_key_for_family(MetadataTableFamily::DirentryBinds);
+        let unbind_key = retired.row_key_for_family(MetadataTableFamily::DirentryUnbinds);
+
+        assert_eq!(
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
+            locality_of(
+                MetadataTableFamily::DirentryUnbinds,
+                &unbind_key,
+                GENERATION
+            ),
+        );
+        // Another generation of the same name is a different group, which is
+        // what keeps a slot with any number of generations bounded.
+        let regenerated =
+            bind(7, "report.txt", 12).row_key_for_family(MetadataTableFamily::DirentryBinds);
+        assert_ne!(
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
+            locality_of(MetadataTableFamily::DirentryBinds, &regenerated, GENERATION),
+        );
+        // Another name under the same parent is a different group: the rules
+        // read one binding, not one directory.
+        let other = bind(7, "other.txt", 11).row_key_for_family(MetadataTableFamily::DirentryBinds);
+        assert_ne!(
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
+            locality_of(MetadataTableFamily::DirentryBinds, &other, GENERATION),
+        );
+        // And so is the same name under another parent.
+        let elsewhere =
+            bind(8, "report.txt", 11).row_key_for_family(MetadataTableFamily::DirentryBinds);
+        assert_ne!(
+            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
+            locality_of(MetadataTableFamily::DirentryBinds, &elsewhere, GENERATION),
+        );
+    }
+
+    /// Rows of one locality group are contiguous in row-key order, and
+    /// grouping order is row-key order. Without both, a merge would reopen a
+    /// group it had already judged and written.
+    #[test]
+    fn locality_order_follows_row_key_order() {
+        let mut keys: Vec<String> = ["a", "ab", "b", "a-b"]
+            .into_iter()
+            .flat_map(|name| {
+                [11u64, 12].map(|seq| {
+                    bind(7, name, seq).row_key_for_family(MetadataTableFamily::DirentryBinds)
+                })
+            })
+            .collect();
+        keys.sort();
+
+        let localities: Vec<&str> = keys
+            .iter()
+            .map(|key| locality_of(MetadataTableFamily::DirentryBinds, key, GENERATION))
+            .collect();
+        let mut runs = localities.clone();
+        runs.dedup();
+        let mut distinct = runs.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(
+            runs.len(),
+            distinct.len(),
+            "a group must not reappear after another group began: {localities:?}"
+        );
+        assert!(
+            runs.windows(2).all(|pair| pair[0] < pair[1]),
+            "grouping order must be row-key order: {runs:?}"
+        );
+    }
+}

--- a/crates/loonfs-core/src/checkpoint/compaction_output.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_output.rs
@@ -1,0 +1,102 @@
+//! Writing a streaming compaction's output: one segment builder per family,
+//! rolled to the store every time the segment row budget fills.
+//!
+//! Segments go to the job's own prefix rather than to `metadata/tables/`
+//! (format spec, "Compaction"), and nothing references them until the job's
+//! one manifest publication names them. What a builder holds is one segment's
+//! worth of rows, so the job's output residency is the segment row budget and
+//! not the size of the group it rebuilds.
+
+use super::build::{write_manifest_segment, MetadataSstWriteRequest};
+use super::runs::MetadataLsmPolicy;
+use super::streaming_compaction::MetadataCompactionSpec;
+use crate::error::Result;
+use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
+use loonfs_api::{MetadataTableId, NamespaceId};
+use loonfs_objectstore::keys::metadata_compaction_table;
+use loonfs_objectstore::ObjectStore;
+
+/// Accumulates one family's surviving rows and uploads a segment every time
+/// the segment row budget fills.
+pub(super) struct StagedSegmentWriter {
+    family: MetadataTableFamily,
+    rows: Vec<MetadataRow>,
+    next_segment_index: u32,
+    segments: Vec<MetadataFileRef>,
+}
+
+impl StagedSegmentWriter {
+    pub(super) fn new(family: MetadataTableFamily) -> Self {
+        Self {
+            family,
+            rows: Vec::new(),
+            next_segment_index: 0,
+            segments: Vec::new(),
+        }
+    }
+
+    pub(super) fn push(&mut self, row: MetadataRow) {
+        self.rows.push(row);
+    }
+
+    pub(super) async fn roll_full_segments<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        spec: &MetadataCompactionSpec,
+        policy: MetadataLsmPolicy,
+    ) -> Result<()> {
+        let max_rows = policy.max_rows_per_segment.get();
+        while self.rows.len() >= max_rows {
+            let rest = self.rows.split_off(max_rows);
+            let full = std::mem::replace(&mut self.rows, rest);
+            self.write_segment(store, namespace_id, spec, full).await?;
+        }
+        Ok(())
+    }
+
+    pub(super) async fn finish<S: ObjectStore + ?Sized>(
+        mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        spec: &MetadataCompactionSpec,
+    ) -> Result<Vec<MetadataFileRef>> {
+        let rest = std::mem::take(&mut self.rows);
+        if !rest.is_empty() {
+            self.write_segment(store, namespace_id, spec, rest).await?;
+        }
+        Ok(self.segments)
+    }
+
+    async fn write_segment<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+        namespace_id: &NamespaceId,
+        spec: &MetadataCompactionSpec,
+        rows: Vec<MetadataRow>,
+    ) -> Result<()> {
+        let table_id = MetadataTableId::generate();
+        let object_key = metadata_compaction_table(
+            namespace_id.as_str(),
+            spec.job_id().as_str(),
+            table_id.as_str(),
+        );
+        let descriptor = write_manifest_segment(
+            store,
+            MetadataSstWriteRequest::new(
+                namespace_id,
+                table_id,
+                object_key,
+                spec.placement().output_seq(),
+                spec.placement().output_level(),
+                self.family,
+                self.next_segment_index,
+                rows,
+            ),
+        )
+        .await?;
+        self.next_segment_index += 1;
+        self.segments.push(descriptor);
+        Ok(())
+    }
+}

--- a/crates/loonfs-core/src/checkpoint/compaction_retention.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_retention.rs
@@ -24,7 +24,7 @@
 //! its rows are decided one at a time by a point read into the job's snapshot
 //! ([`super::streaming_compaction`]) and it holds no state here at all.
 
-use super::reorganize::{bind_survives_frozen_floor, BindingGeneration};
+use super::frozen_floor::{bind_survives_frozen_floor, BindingGeneration};
 use crate::error::{CoreError, Result};
 use loonfs_api::wire::manifest::{ActiveDeletionRowAction, MetadataRow, MetadataTableFamily};
 use loonfs_api::{AttributeRevisionNo, ChangeSeq};

--- a/crates/loonfs-core/src/checkpoint/frozen_floor.rs
+++ b/crates/loonfs-core/src/checkpoint/frozen_floor.rs
@@ -1,0 +1,96 @@
+//! The frozen floor's shared rules: what a binding generation is, which ones
+//! an unbind retires, and whether a bind row survives.
+//!
+//! Two things fold rows below the retention floor, and they are peers. A
+//! bounded merge holds every row of its window and decides them together
+//! ([`super::reorganize`]). A streaming compaction cannot hold them and runs
+//! the same rules as streaming operators instead
+//! ([`super::compaction_retention`]). Neither owns the policy, so it lives
+//! here, and the equivalence oracle in the tests is what says the two reach
+//! the same rows.
+
+use loonfs_api::wire::manifest::MetadataRow;
+use loonfs_api::{ChangeSeq, InodeId, NameKey};
+use std::collections::BTreeSet;
+
+/// Identifies one binding generation, which is what an unbind names and what
+/// the bind drop matches on.
+///
+/// Identity here omits `child_inode_id` (the read path also matches it); the
+/// 4-tuple is already unique for writer-produced rows, so the predicates
+/// agree on every legal history.
+pub(super) type BindingGeneration = (InodeId, NameKey, ChangeSeq, u32);
+
+/// The binding generations an unbind at or below `retention_floor_seq`
+/// retires.
+///
+/// A whole-group fold builds this from every unbind row it merged. A
+/// streaming compaction builds it one binding generation at a time, from that
+/// generation's own unbinds: a bind's row key is its generation and an
+/// unbind's key leads with the generation it retires, so the rows of one
+/// generation hold both halves of the pair.
+pub(super) fn unbindings_at_or_below_floor(
+    unbind_rows: &[MetadataRow],
+    retention_floor_seq: ChangeSeq,
+) -> BTreeSet<BindingGeneration> {
+    let mut unbound_at_floor = BTreeSet::new();
+    for row in unbind_rows {
+        if let MetadataRow::DirentryUnbind {
+            parent_inode_id,
+            name_key,
+            bind_seq,
+            bind_delta_index,
+            unbind_seq,
+            ..
+        } = row
+        {
+            if *unbind_seq <= retention_floor_seq {
+                unbound_at_floor.insert((
+                    *parent_inode_id,
+                    name_key.clone(),
+                    *bind_seq,
+                    *bind_delta_index,
+                ));
+            }
+        }
+    }
+    unbound_at_floor
+}
+
+/// Whether one bind row survives the frozen floor.
+///
+/// A bind above the floor always survives. At or below it the bind survives
+/// exactly when nothing retired it, because a bind is only ever superseded by
+/// an operation that also unbinds it — the writer invariant
+/// `refuse_superseded_bind_without_unbind` in [`super::reorganize`] refuses to
+/// compact without.
+///
+/// Both bind families read this same rule, which is what keeps them dropping
+/// in lockstep: the format gives every bind row exactly one reverse row, and a
+/// run whose two counts disagree does not load. They reach the rule by
+/// different routes — the forward row's unbinds arrive in its own locality
+/// group, the reverse row's do not and are point-read instead — but the rule
+/// is one function and the answer is one answer.
+pub(super) fn bind_survives_frozen_floor(
+    row: &MetadataRow,
+    retention_floor_seq: ChangeSeq,
+    unbound_at_floor: &BTreeSet<BindingGeneration>,
+) -> bool {
+    let MetadataRow::DirentryBind {
+        parent_inode_id,
+        name_key,
+        bind_seq,
+        bind_delta_index,
+        ..
+    } = row
+    else {
+        return true;
+    };
+    *bind_seq > retention_floor_seq
+        || !unbound_at_floor.contains(&(
+            *parent_inode_id,
+            name_key.clone(),
+            *bind_seq,
+            *bind_delta_index,
+        ))
+}

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -22,9 +22,13 @@
 //!   [`row`] handles manifest-row encoding.
 //! - [`reorganize`] compacts bounded family groups into new base runs, and
 //!   [`streaming_compaction`] rebuilds a group whose bottom-anchored window
-//!   no longer fits one of those steps — with [`compaction_retention`]
-//!   holding the frozen floor's rules as streaming state and
-//!   [`compaction_lease`] holding the running job's claim on its own output.
+//!   no longer fits one of those steps. The job's own parts are split by what
+//!   they do: [`compaction_merge`] reads its input, [`compaction_retention`]
+//!   holds the frozen floor's rules as streaming state,
+//!   [`compaction_output`] writes its segments, and [`compaction_lease`]
+//!   holds its claim on them. [`frozen_floor`] holds the drop rules the
+//!   bounded merge and the streaming job both read, because neither owns
+//!   them.
 //! - [`retention`] advances the retention floor behind verified progress.
 //! - [`runs`] models the LSM run layout shared by all of the above,
 //!   [`cache`] holds decoded SST blocks keyed by content digest, and
@@ -36,12 +40,15 @@ mod block_load;
 mod build;
 mod cache;
 mod compaction_lease;
+mod compaction_merge;
+mod compaction_output;
 mod compaction_retention;
 mod create;
 mod data_block_load;
 mod error;
 mod files;
 mod flush;
+mod frozen_floor;
 mod list;
 mod load;
 mod publish;

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -58,6 +58,9 @@ use super::build::{
 };
 use super::error::ManifestLoadError;
 use super::flush::{ensure_metadata_publication_budget, next_manifest_id_after};
+use super::frozen_floor::{
+    bind_survives_frozen_floor, unbindings_at_or_below_floor, BindingGeneration,
+};
 use super::load::{
     load_verified_manifest_tables, validate_direntry_child_bind_index,
     validate_revision_by_inode_desc_index,
@@ -83,7 +86,7 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
 use loonfs_api::{
-    AttributeRevisionNo, ChangeSeq, InodeId, ManifestId, ManifestObjectId, NameKey, NamespaceId,
+    AttributeRevisionNo, ChangeSeq, InodeId, ManifestId, ManifestObjectId, NamespaceId,
 };
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
@@ -999,87 +1002,6 @@ pub(super) fn drop_rows_below_retention_floor(
         retention_floor_seq,
     );
     drop_rows_below_frozen_floor(rows_by_family, retention_floor_seq, &unbound_at_floor)
-}
-
-/// Identifies one binding generation, which is what an unbind names and what
-/// the bind drop matches on.
-///
-/// Identity here omits `child_inode_id` (the read path also matches it); the
-/// 4-tuple is already unique for writer-produced rows, so the predicates
-/// agree on every legal history.
-pub(super) type BindingGeneration = (InodeId, NameKey, ChangeSeq, u32);
-
-/// The binding generations an unbind at or below `retention_floor_seq`
-/// retires.
-///
-/// A whole-group fold builds this from every unbind row it merged. A
-/// streaming compaction builds it one binding generation at a time, from that
-/// generation's own unbinds: a bind's row key is its generation and an
-/// unbind's key leads with the generation it retires, so the rows of one
-/// generation hold both halves of the pair.
-pub(super) fn unbindings_at_or_below_floor(
-    unbind_rows: &[MetadataRow],
-    retention_floor_seq: ChangeSeq,
-) -> BTreeSet<BindingGeneration> {
-    let mut unbound_at_floor = BTreeSet::new();
-    for row in unbind_rows {
-        if let MetadataRow::DirentryUnbind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            unbind_seq,
-            ..
-        } = row
-        {
-            if *unbind_seq <= retention_floor_seq {
-                unbound_at_floor.insert((
-                    *parent_inode_id,
-                    name_key.clone(),
-                    *bind_seq,
-                    *bind_delta_index,
-                ));
-            }
-        }
-    }
-    unbound_at_floor
-}
-
-/// Whether one bind row survives the frozen floor.
-///
-/// A bind above the floor always survives. At or below it the bind survives
-/// exactly when nothing retired it, because a bind is only ever superseded by
-/// an operation that also unbinds it — the writer invariant
-/// [`refuse_superseded_bind_without_unbind`] refuses to compact without.
-///
-/// Both bind families read this same rule, which is what keeps them dropping
-/// in lockstep: the format gives every bind row exactly one reverse row, and a
-/// run whose two counts disagree does not load. They reach the rule by
-/// different routes — the forward row's unbinds arrive in its own locality
-/// group, the reverse row's do not and are point-read instead — but the rule
-/// is one function and the answer is one answer.
-pub(super) fn bind_survives_frozen_floor(
-    row: &MetadataRow,
-    retention_floor_seq: ChangeSeq,
-    unbound_at_floor: &BTreeSet<BindingGeneration>,
-) -> bool {
-    let MetadataRow::DirentryBind {
-        parent_inode_id,
-        name_key,
-        bind_seq,
-        bind_delta_index,
-        ..
-    } = row
-    else {
-        return true;
-    };
-    *bind_seq > retention_floor_seq
-        || !unbound_at_floor.contains(&(
-            *parent_inode_id,
-            name_key.clone(),
-            *bind_seq,
-            *bind_delta_index,
-        ))
 }
 
 /// [`drop_rows_below_retention_floor`] against an unbind set the caller

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -8,13 +8,17 @@
 //! budget at all.
 //!
 //! Nothing about the job follows the size of the group. It opens one iterator
-//! per run per family, merges them in row-key order, feeds the merged rows
-//! through streaming retention operators ([`super::compaction_retention`]),
-//! and writes each output segment as it fills. What it holds at any instant is
-//! a fixed number of decoded input blocks per iterator, the fixed state of one
-//! retention operator, and one segment builder per family of the group. No
-//! family, no partition, no directory, no inode's history, and no name slot's
-//! generations are ever collected whole.
+//! per run per family and merges them in row-key order
+//! ([`super::compaction_merge`]), feeds the merged rows through streaming
+//! retention operators ([`super::compaction_retention`]), and writes each
+//! output segment as it fills ([`super::compaction_output`]). What it holds at
+//! any instant is a fixed number of decoded input blocks per iterator, the
+//! fixed state of one retention operator, and one segment builder per family
+//! of the group. No family, no partition, no directory, no inode's history,
+//! and no name slot's generations are ever collected whole.
+//!
+//! What is left here is the job itself: the plan, the loop that drives those
+//! three, and the one publication that swaps the rebuilt run in.
 //!
 //! Output segments go to the job's own prefix rather than to
 //! `metadata/tables/` (format spec, "Compaction"): a job outlives the
@@ -31,50 +35,39 @@
 //! that plans it starts it and returns; the runner cancels it on shutdown and
 //! joins it with the rest of its background work.
 
-use super::block_fetch::{load_segment_filter, load_segment_index_for_reorganization};
+use super::block_fetch::load_segment_filter;
 use super::block_load::SessionBlockMemo;
-use super::build::{write_manifest_segment, MetadataSstWriteRequest};
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
 use super::compaction_lease::CompactionLease;
+use super::compaction_merge::{
+    locality_of, refill_iterators, select_next_iterator, LocalityGrouping, SegmentRowIterator,
+};
+use super::compaction_output::StagedSegmentWriter;
 use super::compaction_retention::{KeptRow, RetentionRule};
-use super::data_block_load::load_segment_data_block_span;
 use super::error::ManifestLoadError;
 use super::flush::ensure_metadata_publication_budget;
+use super::frozen_floor::{bind_survives_frozen_floor, unbindings_at_or_below_floor};
 use super::load::{
     load_manifest_segment_rows_in_key_range_with_cache, load_verified_manifest_tables,
 };
 use super::publish::{publish_metadata_root, ManifestPublicationOutcome};
-use super::reorganize::{
-    bind_survives_frozen_floor, group_run_descriptors, unbindings_at_or_below_floor,
-    write_reorganized_manifest, MergePlacement,
-};
+use super::reorganize::{group_run_descriptors, write_reorganized_manifest, MergePlacement};
 use super::runs::{MetadataFamilyGroup, MetadataLsmPolicy, MetadataRunManifest};
 use super::scan::{descriptor_may_intersect_range, Readahead, VerifiedMetadataTables};
-use super::validate::validate_manifest_row_seq_range;
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::control::read_metadata_root_object_if_present;
+use crate::time::current_time_ms;
 use crate::timing::StdMonotonicTimer;
 use loonfs_api::wire::manifest::{lookup_keys, MetadataFileRef, MetadataRow, MetadataTableFamily};
-use loonfs_api::wire::sst_blocks::{
-    string_prefix_upper_bound, DecodedDataBlock, SegmentIndexEntry,
-};
-use loonfs_api::{ChangeSeq, ManifestId, MetadataCompactionId, MetadataTableId, NamespaceId};
-use loonfs_objectstore::keys::metadata_compaction_table;
+use loonfs_api::wire::sst_blocks::string_prefix_upper_bound;
+use loonfs_api::{ChangeSeq, ManifestId, MetadataCompactionId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-
-/// Decoded data blocks one iterator holds at a time. An iterator refills only
-/// when it has none left, so this is also the most it ever holds, and the
-/// job's input residency is this times the number of open iterators.
-const BLOCKS_PER_ITERATOR_FETCH: usize = 2;
-
-/// Iterators refilled in one wave. Refills are the job's only bulk reads, so
-/// this is the width of its fan-out at the store.
-const ITERATOR_FETCH_CONCURRENCY: usize = 8;
+use tokio::sync::Notify;
 
 /// Decoded-byte budget for the cache the reverse-index point reads share.
 ///
@@ -176,6 +169,12 @@ impl MetadataCompactionSpec {
         &self.inputs
     }
 
+    /// Where this job's output stands in the group, which decides the level
+    /// and sequence every segment it writes carries.
+    pub(super) fn placement(&self) -> MergePlacement {
+        self.placement
+    }
+
     pub(super) fn frozen_floor_seq(&self) -> ChangeSeq {
         self.frozen_floor_seq
     }
@@ -187,23 +186,73 @@ impl MetadataCompactionSpec {
             ..self.clone()
         }
     }
+
+    /// A plan over no runs at all, for tests that drive how a runtime admits
+    /// jobs rather than what a job reads.
+    ///
+    /// Running one rebuilds nothing, which is the point: the tests that build
+    /// these assert on slots, permits, and cancellation, and a plan naming
+    /// runs would make them seed a namespace to say so.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn planned_over_no_runs() -> Self {
+        Self::new(
+            MetadataFamilyGroup::Bindings,
+            Vec::new(),
+            0,
+            MergePlacement::Base {
+                output_seq: ChangeSeq(0),
+            },
+            ChangeSeq(0),
+        )
+    }
 }
 
-/// Stops a running job between block fetches.
+/// Stops a job between block fetches, between finalization attempts, and
+/// while it waits for whatever admission its runtime puts in front of it.
 ///
 /// Cancelling costs the work done so far and nothing else: the staged
 /// segments are unreferenced, the manifest never moved, and a later job runs
 /// the same spec again.
 #[derive(Debug, Clone, Default)]
-pub struct MetadataCompactionCancellation(Arc<AtomicBool>);
+pub struct MetadataCompactionCancellation(Arc<Cancellation>);
+
+#[derive(Debug, Default)]
+struct Cancellation {
+    cancelled: AtomicBool,
+    /// Wakes whoever is waiting rather than reading rows. A job queued behind
+    /// its runtime's admission has no block fetch to check the flag between,
+    /// so a shutdown would otherwise have to wait for a permit it is trying
+    /// to stop needing.
+    woken: Notify,
+}
 
 impl MetadataCompactionCancellation {
     pub fn cancel(&self) {
-        self.0.store(true, Ordering::SeqCst);
+        self.0.cancelled.store(true, Ordering::SeqCst);
+        self.0.woken.notify_waiters();
     }
 
-    fn is_cancelled(&self) -> bool {
-        self.0.load(Ordering::SeqCst)
+    /// Whether the token has been set. What a job reads between block
+    /// fetches, and what a caller about to start work reads first.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.cancelled.load(Ordering::SeqCst)
+    }
+
+    /// Resolves once the token is set, and stays pending while it is not.
+    ///
+    /// For a caller waiting on something else — a permit, a queue — that has
+    /// to stop waiting when the job is cancelled.
+    pub async fn cancelled(&self) {
+        let woken = self.0.woken.notified();
+        tokio::pin!(woken);
+        // Registered before the flag is read, which is what closes the race
+        // with a `cancel` landing between the read and the await: the notify
+        // then wakes this waiter rather than passing it by.
+        woken.as_mut().enable();
+        if self.is_cancelled() {
+            return;
+        }
+        woken.await;
     }
 }
 
@@ -311,6 +360,10 @@ pub(super) enum Finalization {
     Published(ManifestId),
     Abandoned,
     Superseded,
+    /// The cancellation token was set before this finalization published.
+    /// Nothing was swapped in, so the ending is the executor's: staged output
+    /// nothing references, and the manifest where it was.
+    Cancelled,
 }
 
 /// Runs one streaming compaction end to end: rebuild the group, then swap the
@@ -370,8 +423,11 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
     )
     .await?
     {
-        MetadataCompactionOutcome::Completed(result) => result,
-        MetadataCompactionOutcome::Cancelled => {
+        MetadataCompactionOutcome::Completed(result) if !cancellation.is_cancelled() => result,
+        // A token set after the last row still costs the job. Checked here so
+        // a shutdown does not spend the drain building a manifest and taking
+        // races for a publication it has already decided against.
+        MetadataCompactionOutcome::Completed(_) | MetadataCompactionOutcome::Cancelled => {
             // The executor stops between block fetches, so what it wrote is
             // whatever segments had already filled. They are staged and named
             // by nothing. The lease is left where it is: it expires on its
@@ -394,10 +450,10 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
     match finalize_metadata_compaction(
         store,
         namespace_id,
-        context,
         spec,
         &snapshot_keys,
         result,
+        cancellation,
         &mut lease,
     )
     .await?
@@ -426,6 +482,15 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
         }
         Finalization::Abandoned => Ok(MetadataCompactionJobOutcome::Abandoned),
         Finalization::Superseded => Ok(MetadataCompactionJobOutcome::Superseded),
+        Finalization::Cancelled => {
+            tracing::info!(
+                namespace_id = namespace_id.as_str(),
+                job_id = spec.job_id().as_str(),
+                families = ?spec.families(),
+                "streaming metadata compaction cancelled while finalizing"
+            );
+            Ok(MetadataCompactionJobOutcome::Cancelled)
+        }
     }
 }
 
@@ -445,17 +510,30 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
 /// the last few seconds and not of however long the rebuild took. That is the
 /// same span the lease has to cover, so both are measured off the lease's own
 /// clock.
+///
+/// The root is stamped with the wall clock each attempt reads rather than the
+/// one the job started under. A job that ran for hours would otherwise stamp
+/// the root with its start time, and a job rebasing over a newer flush would
+/// move the root's `updated_at_ms` backwards. The job's identity is the other
+/// half of what a publication carries, and that stays frozen: the writer this
+/// job runs as is the writer that planned it.
 pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    context: &MutationContext,
     spec: &MetadataCompactionSpec,
     snapshot_keys: &BTreeSet<String>,
     result: MetadataCompactionResult,
+    cancellation: &MetadataCompactionCancellation,
     lease: &mut CompactionLease<'_>,
 ) -> Result<Finalization> {
     let timer = lease.timer();
     for attempt in 1..=MAX_FINALIZATION_ATTEMPTS {
+        // Checked at the top of every attempt, not only the first: the
+        // attempts after a lost race are exactly the wait a shutdown must not
+        // sit through.
+        if cancellation.is_cancelled() {
+            return Ok(Finalization::Cancelled);
+        }
         // The span from here to the compare-and-swap below is one publication
         // budget, and a lease outlasts one publication, so refreshing the
         // claim once per attempt keeps the output claimed until the manifest
@@ -508,13 +586,18 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
         )
         .await?;
 
+        // The last check before the swap that makes this output reader
+        // truth. Everything above it is reads and objects nothing references.
+        if cancellation.is_cancelled() {
+            return Ok(Finalization::Cancelled);
+        }
         ensure_metadata_publication_budget(timer, publication_started_ms, namespace_id)?;
         let published = publish_metadata_root(
             store,
             namespace_id,
             &manifest,
             Some(root.manifest_object_id.clone()),
-            context.now_ms,
+            current_time_ms()?,
         )
         .await?;
         drop(tables);
@@ -597,41 +680,6 @@ struct RetentionCluster {
     rule: RetentionRule,
 }
 
-/// Which rows a retention rule has to see together, and therefore how the
-/// merge interleaves the families of one cluster.
-///
-/// The rules that drop a row read its neighbours, and every one of them reads
-/// neighbours that share a row-key prefix: an unbind cancels the bind of its
-/// own generation, a removal marker repeats its deletion's sequence and root,
-/// and an attribute revision supersedes revisions of its own inode. So the
-/// grouping is read straight off the row-key grammar in
-/// `MetadataRow::row_key_for_family`, and it is the shortest prefix each rule
-/// needs rather than the whole partition the rows happen to share:
-///
-/// | families | grouped by | key components after the family prefix |
-/// | --- | --- | --- |
-/// | binds, unbinds | one binding generation | `{parent}-{name}-{bind_seq}-{bind_delta}` |
-/// | active deletions | one deletion | `{deleted_at_seq}-{root}` |
-/// | attributes | one inode | `{inode}` |
-/// | everything else | one row | — |
-///
-/// A generation rather than a name slot is what keeps the bindings group
-/// bounded: a slot has no limit on how many times a name is created and
-/// deleted, and a generation holds one bind and the unbind that retires it.
-/// A bind's whole row key *is* its generation, and an unbind's key leads with
-/// the generation it retires, so both families name the same group.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LocalityGrouping {
-    /// Every row is judged on its own.
-    Row,
-    /// Rows sharing the first `n` hyphen-separated components after their
-    /// family's row-key prefix are judged together. Every component of the
-    /// grammar is digits or lowercase hex, and a hyphen sorts below both, so
-    /// rows of one grouping are contiguous in row-key order and grouping
-    /// order is row-key order.
-    LeadingKeyComponents(usize),
-}
-
 /// The bindings group merges its two forward families together, because an
 /// unbind retires the bind of its generation. The reverse index is keyed by
 /// child, so it shares no group with the rows it indexes and streams on its
@@ -696,31 +744,6 @@ fn retention_clusters(group: MetadataFamilyGroup) -> &'static [RetentionCluster]
         MetadataFamilyGroup::CommitReceipts => &RECEIPT_CLUSTERS,
         MetadataFamilyGroup::Attributes => &ATTRIBUTE_CLUSTERS,
     }
-}
-
-/// The locality group a row key belongs to, as a slice of the key itself.
-///
-/// The family's own prefix is stripped, so two families of one cluster name
-/// the same group with the same string: a bind's `direntry-{parent}-{name}`
-/// and its unbind's `direntry-unbind-{parent}-{name}` both read as
-/// `{parent}-{name}`.
-fn locality_of(family: MetadataTableFamily, row_key: &str, locality: LocalityGrouping) -> &str {
-    let prefix_len = family.row_key_prefix().len();
-    let tail = row_key.get(prefix_len..).unwrap_or(row_key);
-    let LocalityGrouping::LeadingKeyComponents(components) = locality else {
-        return tail;
-    };
-    let mut end = 0;
-    for component in 0..components {
-        if component > 0 {
-            end += 1;
-        }
-        match tail[end..].find('-') {
-            Some(offset) => end += offset,
-            None => return tail,
-        }
-    }
-    &tail[..end]
 }
 
 struct CompactionJob<'a, S: ObjectStore + ?Sized> {
@@ -851,24 +874,10 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
         );
     }
 
-    /// Fills every iterator that has run out of rows, a bounded wave at a
-    /// time, and records what the job then holds.
+    /// Fills every iterator that has run out of rows and records what the job
+    /// then holds.
     async fn refill(&mut self, iterators: &mut [SegmentRowIterator]) -> Result<()> {
-        let mut hungry: Vec<&mut SegmentRowIterator> = iterators
-            .iter_mut()
-            .filter(|iterator| iterator.needs_fill())
-            .collect();
-        for wave in hungry.chunks_mut(ITERATOR_FETCH_CONCURRENCY) {
-            futures::future::try_join_all(
-                wave.iter_mut()
-                    .map(|iterator| Box::pin(iterator.fill(self.store))),
-            )
-            .await?;
-        }
-        let resident = iterators
-            .iter()
-            .map(SegmentRowIterator::resident_blocks)
-            .sum();
+        let resident = refill_iterators(self.store, iterators).await?;
         self.result.peak_resident_blocks = self.result.peak_resident_blocks.max(resident);
         Ok(())
     }
@@ -1047,248 +1056,6 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
     }
 }
 
-/// Reads one family's rows out of one run, one bounded span of data blocks at
-/// a time.
-///
-/// A run's segments for one family are ascending and non-overlapping (manifest
-/// load enforces it), so walking them in index order walks the run's rows in
-/// row-key order. Only the current segment's index is held, and only the
-/// blocks not yet consumed.
-struct SegmentRowIterator {
-    family: MetadataTableFamily,
-    segments: Vec<MetadataFileRef>,
-    next_segment: usize,
-    index: Option<Arc<Vec<SegmentIndexEntry>>>,
-    next_block: usize,
-    blocks: VecDeque<Arc<DecodedDataBlock>>,
-    row: usize,
-}
-
-impl SegmentRowIterator {
-    fn new(family: MetadataTableFamily, mut segments: Vec<MetadataFileRef>) -> Self {
-        segments.sort_by_key(|descriptor| descriptor.segment_index);
-        Self {
-            family,
-            segments,
-            next_segment: 0,
-            index: None,
-            next_block: 0,
-            blocks: VecDeque::new(),
-            row: 0,
-        }
-    }
-
-    fn head(&self) -> Option<(&str, &MetadataRow)> {
-        let block = self.blocks.front()?;
-        Some((block.row_keys[self.row].as_str(), &block.rows[self.row]))
-    }
-
-    fn take_head(&mut self) -> MetadataRow {
-        let row = self.blocks.front().expect("a head to take").rows[self.row].clone();
-        self.row += 1;
-        while self
-            .blocks
-            .front()
-            .is_some_and(|block| self.row >= block.rows.len())
-        {
-            self.blocks.pop_front();
-            self.row = 0;
-        }
-        row
-    }
-
-    fn needs_fill(&self) -> bool {
-        self.blocks.is_empty() && !self.is_exhausted()
-    }
-
-    fn is_exhausted(&self) -> bool {
-        self.blocks.is_empty()
-            && self.next_segment >= self.segments.len()
-            && self
-                .index
-                .as_ref()
-                .is_none_or(|index| self.next_block >= index.len())
-    }
-
-    fn resident_blocks(&self) -> usize {
-        self.blocks.len()
-    }
-
-    /// Fetches the next span of data blocks, opening the next segment first
-    /// when the current one is spent. A segment with no rows left is closed
-    /// and its index dropped before the next one is read, so one iterator
-    /// holds one index at a time.
-    async fn fill<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
-        while self.blocks.is_empty() {
-            let index = match &self.index {
-                Some(index) if self.next_block < index.len() => Arc::clone(index),
-                _ => {
-                    self.index = None;
-                    let Some(descriptor) = self.segments.get(self.next_segment) else {
-                        return Ok(());
-                    };
-                    self.next_segment += 1;
-                    self.next_block = 0;
-                    let index = load_segment_index_for_reorganization(
-                        store,
-                        None,
-                        &SessionBlockMemo::default(),
-                        descriptor,
-                    )
-                    .await
-                    .map_err(manifest_load_failure)?;
-                    self.index = Some(Arc::clone(&index));
-                    index
-                }
-            };
-            let descriptor = &self.segments[self.next_segment - 1];
-            let end = (self.next_block + BLOCKS_PER_ITERATOR_FETCH).min(index.len());
-            // Blocks are decoded into this iterator alone: no table cache and
-            // a memo that dies with the call, so nothing the job reads is
-            // retained anywhere but here.
-            let blocks = load_segment_data_block_span(
-                store,
-                None,
-                &SessionBlockMemo::default(),
-                descriptor,
-                &index[self.next_block..end],
-            )
-            .await
-            .map_err(manifest_load_failure)?;
-            self.next_block = end;
-            validate_manifest_row_seq_range(
-                &descriptor.object_key,
-                blocks.iter().flat_map(|block| block.rows.iter()),
-                descriptor.run_seq,
-            )
-            .map_err(manifest_load_failure)?;
-            self.row = 0;
-            self.blocks
-                .extend(blocks.into_iter().filter(|block| !block.rows.is_empty()));
-        }
-        Ok(())
-    }
-}
-
-/// The iterator whose next row sorts first, or `None` when every iterator is
-/// spent.
-///
-/// A linear scan rather than a heap: an iterator is opened per run per family
-/// of one cluster, which is a handful, and the scan compares borrowed key
-/// slices while a heap would have to own them.
-fn select_next_iterator(
-    iterators: &[SegmentRowIterator],
-    locality: LocalityGrouping,
-) -> Option<usize> {
-    let mut best: Option<(usize, &str, &str)> = None;
-    for (position, iterator) in iterators.iter().enumerate() {
-        let Some((row_key, _)) = iterator.head() else {
-            continue;
-        };
-        let candidate = locality_of(iterator.family, row_key, locality);
-        let take = match best {
-            // Locality first so a group's rows arrive together whatever
-            // family they come from, then family, then key: within one
-            // family that is row-key order, which is the order a segment
-            // builder demands.
-            Some((best_position, best_locality, best_key)) => {
-                (candidate, iterators[position].family, row_key)
-                    < (best_locality, iterators[best_position].family, best_key)
-            }
-            None => true,
-        };
-        if take {
-            best = Some((position, candidate, row_key));
-        }
-    }
-    best.map(|(position, _, _)| position)
-}
-
-/// Accumulates one family's surviving rows and uploads a segment every time
-/// the segment row budget fills.
-struct StagedSegmentWriter {
-    family: MetadataTableFamily,
-    rows: Vec<MetadataRow>,
-    next_segment_index: u32,
-    segments: Vec<MetadataFileRef>,
-}
-
-impl StagedSegmentWriter {
-    fn new(family: MetadataTableFamily) -> Self {
-        Self {
-            family,
-            rows: Vec::new(),
-            next_segment_index: 0,
-            segments: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, row: MetadataRow) {
-        self.rows.push(row);
-    }
-
-    async fn roll_full_segments<S: ObjectStore + ?Sized>(
-        &mut self,
-        store: &S,
-        namespace_id: &NamespaceId,
-        spec: &MetadataCompactionSpec,
-        policy: MetadataLsmPolicy,
-    ) -> Result<()> {
-        let max_rows = policy.max_rows_per_segment.get();
-        while self.rows.len() >= max_rows {
-            let rest = self.rows.split_off(max_rows);
-            let full = std::mem::replace(&mut self.rows, rest);
-            self.write_segment(store, namespace_id, spec, full).await?;
-        }
-        Ok(())
-    }
-
-    async fn finish<S: ObjectStore + ?Sized>(
-        mut self,
-        store: &S,
-        namespace_id: &NamespaceId,
-        spec: &MetadataCompactionSpec,
-    ) -> Result<Vec<MetadataFileRef>> {
-        let rest = std::mem::take(&mut self.rows);
-        if !rest.is_empty() {
-            self.write_segment(store, namespace_id, spec, rest).await?;
-        }
-        Ok(self.segments)
-    }
-
-    async fn write_segment<S: ObjectStore + ?Sized>(
-        &mut self,
-        store: &S,
-        namespace_id: &NamespaceId,
-        spec: &MetadataCompactionSpec,
-        rows: Vec<MetadataRow>,
-    ) -> Result<()> {
-        let table_id = MetadataTableId::generate();
-        let object_key = metadata_compaction_table(
-            namespace_id.as_str(),
-            spec.job_id().as_str(),
-            table_id.as_str(),
-        );
-        let descriptor = write_manifest_segment(
-            store,
-            MetadataSstWriteRequest::new(
-                namespace_id,
-                table_id,
-                object_key,
-                spec.placement.output_seq(),
-                spec.placement.output_level(),
-                self.family,
-                self.next_segment_index,
-                rows,
-            ),
-        )
-        .await?;
-        self.next_segment_index += 1;
-        self.segments.push(descriptor);
-        Ok(())
-    }
-}
-
 /// An order-independent digest of the rows one family was written.
 ///
 /// The combiner is wrapping addition, so the digest depends on the multiset of
@@ -1363,14 +1130,16 @@ fn resolve_snapshot_runs<S: ObjectStore + ?Sized>(
         .collect()
 }
 
-fn manifest_load_failure(error: ManifestLoadError) -> CoreError {
+/// The one mapper the compaction modules share: a manifest load failure is a
+/// metadata projection failure wherever it is read.
+pub(super) fn manifest_load_failure(error: ManifestLoadError) -> CoreError {
     CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{locality_of, LocalityGrouping, RowDigest};
-    use loonfs_api::wire::manifest::{MetadataRow, MetadataTableFamily};
+    use super::RowDigest;
+    use loonfs_api::wire::manifest::MetadataRow;
     use loonfs_api::{ChangeSeq, DisplayName, InodeId, NameKey};
 
     fn bind(parent: u64, name: &str, bind_seq: u64) -> MetadataRow {
@@ -1395,87 +1164,6 @@ mod tests {
             unbind_seq: ChangeSeq(bind_seq + 1),
             unbind_delta_index: 0,
         }
-    }
-
-    /// The grouping the bindings cluster merges by.
-    const GENERATION: LocalityGrouping = LocalityGrouping::LeadingKeyComponents(4);
-
-    /// A bind and the unbind that retires it must name the same locality
-    /// group, because the drop rule reads one from the other. They live in
-    /// different families with different row-key prefixes, so this holds only
-    /// because the grouping is read behind the prefix.
-    #[test]
-    fn a_bind_and_its_unbind_name_one_locality_group() {
-        let bound = bind(7, "report.txt", 11);
-        let retired = unbind(7, "report.txt", 11);
-        let bind_key = bound.row_key_for_family(MetadataTableFamily::DirentryBinds);
-        let unbind_key = retired.row_key_for_family(MetadataTableFamily::DirentryUnbinds);
-
-        assert_eq!(
-            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
-            locality_of(
-                MetadataTableFamily::DirentryUnbinds,
-                &unbind_key,
-                GENERATION
-            ),
-        );
-        // Another generation of the same name is a different group, which is
-        // what keeps a slot with any number of generations bounded.
-        let regenerated =
-            bind(7, "report.txt", 12).row_key_for_family(MetadataTableFamily::DirentryBinds);
-        assert_ne!(
-            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
-            locality_of(MetadataTableFamily::DirentryBinds, &regenerated, GENERATION),
-        );
-        // Another name under the same parent is a different group: the rules
-        // read one binding, not one directory.
-        let other = bind(7, "other.txt", 11).row_key_for_family(MetadataTableFamily::DirentryBinds);
-        assert_ne!(
-            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
-            locality_of(MetadataTableFamily::DirentryBinds, &other, GENERATION),
-        );
-        // And so is the same name under another parent.
-        let elsewhere =
-            bind(8, "report.txt", 11).row_key_for_family(MetadataTableFamily::DirentryBinds);
-        assert_ne!(
-            locality_of(MetadataTableFamily::DirentryBinds, &bind_key, GENERATION),
-            locality_of(MetadataTableFamily::DirentryBinds, &elsewhere, GENERATION),
-        );
-    }
-
-    /// Rows of one locality group are contiguous in row-key order, and
-    /// grouping order is row-key order. Without both, a merge would reopen a
-    /// group it had already judged and written.
-    #[test]
-    fn locality_order_follows_row_key_order() {
-        let mut keys: Vec<String> = ["a", "ab", "b", "a-b"]
-            .into_iter()
-            .flat_map(|name| {
-                [11u64, 12].map(|seq| {
-                    bind(7, name, seq).row_key_for_family(MetadataTableFamily::DirentryBinds)
-                })
-            })
-            .collect();
-        keys.sort();
-
-        let localities: Vec<&str> = keys
-            .iter()
-            .map(|key| locality_of(MetadataTableFamily::DirentryBinds, key, GENERATION))
-            .collect();
-        let mut runs = localities.clone();
-        runs.dedup();
-        let mut distinct = runs.clone();
-        distinct.sort_unstable();
-        distinct.dedup();
-        assert_eq!(
-            runs.len(),
-            distinct.len(),
-            "a group must not reappear after another group began: {localities:?}"
-        );
-        assert!(
-            runs.windows(2).all(|pair| pair[0] < pair[1]),
-            "grouping order must be row-key order: {runs:?}"
-        );
     }
 
     /// The digest compares two families written in different orders and, for

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -657,15 +657,35 @@ async fn finalize_streaming_compaction<S: ObjectStore + ?Sized>(
     snapshot_keys: &BTreeSet<String>,
     result: &MetadataCompactionResult,
 ) -> Finalization {
+    finalize_streaming_compaction_under(
+        store,
+        namespace_id,
+        spec,
+        snapshot_keys,
+        result,
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+}
+
+/// The same, with the token the tests that cancel a finalization set.
+async fn finalize_streaming_compaction_under<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    spec: &MetadataCompactionSpec,
+    snapshot_keys: &BTreeSet<String>,
+    result: &MetadataCompactionResult,
+    cancellation: &MetadataCompactionCancellation,
+) -> Finalization {
     let timer = StdMonotonicTimer::default();
     let mut lease = test_lease(namespace_id, spec, &timer);
     finalize_metadata_compaction(
         store,
         namespace_id,
-        &test_context(),
         spec,
         snapshot_keys,
         result.clone(),
+        cancellation,
         &mut lease,
     )
     .await
@@ -2478,5 +2498,266 @@ async fn a_flush_landing_during_finalization_is_retried_over() {
     assert!(
         visible_after.last().expect("the flush's file").visible,
         "the file the flush published must be visible after the swap"
+    );
+}
+
+/// When the namespace's root was last published.
+async fn root_updated_at_ms<S: ObjectStore + ?Sized>(store: &S, namespace_id: &NamespaceId) -> u64 {
+    read_metadata_root_object(store, namespace_id)
+        .await
+        .expect("read metadata root")
+        .envelope
+        .state
+        .updated_at_ms
+}
+
+/// The root's timestamp says when the publication landed, not when the job
+/// that produced it started.
+///
+/// A job holds its writer identity for as long as it runs, and a long one
+/// finishes hours after the context it was planned under was built. Stamping
+/// the root with that context would make a job that rebases over a newer
+/// flush move the namespace's `updated_at_ms` backwards.
+#[tokio::test]
+async fn a_rebased_publication_never_moves_the_root_timestamp_backward() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let spec =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job");
+    };
+
+    // A flush lands while the job runs, stamping the root a minute past the
+    // context the job carries.
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/landed-while-the-job-ran.txt",
+        b"landed while the job ran\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write a file the flush will publish");
+    let later = mutation_context(&context.writer_id, context.now_ms + 60_000);
+    flush::flush_wal(&store, &namespace_id, &later)
+        .await
+        .expect("the flush must publish");
+    let flushed_at_ms = root_updated_at_ms(&store, &namespace_id).await;
+    assert!(
+        flushed_at_ms >= later.now_ms,
+        "the flush must stamp the root with its own time"
+    );
+
+    publish_streaming_compaction(&store, &namespace_id, &spec, &snapshot_keys, &result).await;
+
+    let published_at_ms = root_updated_at_ms(&store, &namespace_id).await;
+    assert!(
+        published_at_ms > context.now_ms,
+        "the root must carry publication time, not the time the job was planned at"
+    );
+    assert!(
+        published_at_ms >= flushed_at_ms,
+        "a job rebased over a newer flush must not move the root's timestamp backwards"
+    );
+}
+
+/// A token set after the last row costs the job its publication.
+///
+/// The executor finished, so there is a whole rebuilt group in memory and
+/// staged output on the store. None of it lands: the manifest stays where it
+/// was, and the staged segments stay orphans a later pass reclaims.
+#[tokio::test]
+async fn a_cancellation_after_the_last_row_publishes_nothing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let spec =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
+    let cancellation = MetadataCompactionCancellation::default();
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &cancellation,
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job while it read");
+    };
+    let manifest_before = current_manifest_object_id(&store, &namespace_id).await;
+    let visible_before = visible_namespace(&store, &namespace_id).await;
+
+    cancellation.cancel();
+    let finalization = finalize_streaming_compaction_under(
+        &store,
+        &namespace_id,
+        &spec,
+        &snapshot_keys,
+        &result,
+        &cancellation,
+    )
+    .await;
+
+    assert!(
+        matches!(finalization, Finalization::Cancelled),
+        "a cancelled finalization must publish nothing, got {finalization:?}"
+    );
+    assert_eq!(
+        current_manifest_object_id(&store, &namespace_id).await,
+        manifest_before,
+        "the manifest must be where the job found it"
+    );
+    assert_eq!(
+        visible_namespace(&store, &namespace_id).await,
+        visible_before,
+        "and a read must answer exactly what it answered before"
+    );
+    let staged = staged_object_keys(&store, &namespace_id).await;
+    let referenced = referenced_segment_keys(&store, &namespace_id).await;
+    assert!(
+        !staged.is_empty(),
+        "the job wrote segments before it was cancelled"
+    );
+    assert!(
+        staged.is_disjoint(&referenced),
+        "and nothing may reference them"
+    );
+}
+
+/// Fails every root compare-and-swap, and cancels the job the first time it
+/// tries one.
+///
+/// That is the shape a shutdown takes during finalization: attempts are still
+/// available, the races are still there to take, and the job must stop taking
+/// them.
+#[derive(Debug)]
+struct CancelAtTheFirstPublicationStore {
+    inner: LocalFsStore,
+    cancellation: MetadataCompactionCancellation,
+    manifests: AtomicUsize,
+}
+
+#[async_trait]
+impl ObjectStore for CancelAtTheFirstPublicationStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        if key.ends_with(".manifest.json") {
+            self.manifests.fetch_add(1, Ordering::SeqCst);
+        }
+        if matches!(mode, PutMode::CompareAndSwap { .. }) {
+            self.cancellation.cancel();
+            return Err(ObjectStoreError::PreconditionFailed {
+                object_key: key.to_owned(),
+            });
+        }
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// A shutdown during finalization does not wait out the attempts it has left.
+///
+/// The first attempt loses its race and the token is set while it does. The
+/// attempts after it are exactly the wait a shutdown must not sit through, so
+/// the job stops at the top of the next one rather than building three more
+/// manifests to lose three more races with.
+#[tokio::test]
+async fn a_cancelled_finalization_does_not_take_the_races_it_has_left() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    seed_bindings_workload(&store, &namespace_id).await;
+    let spec =
+        compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
+    let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
+    let cancellation = MetadataCompactionCancellation::default();
+    let MetadataCompactionOutcome::Completed(result) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        small_segment_policy(),
+        &cancellation,
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job while it read");
+    };
+    let manifest_before = current_manifest_object_id(&store, &namespace_id).await;
+
+    let cancelling_store = CancelAtTheFirstPublicationStore {
+        inner: LocalFsStore::new(temp_dir.path()).expect("store"),
+        cancellation: cancellation.clone(),
+        manifests: AtomicUsize::new(0),
+    };
+    let finalization = finalize_streaming_compaction_under(
+        &cancelling_store,
+        &namespace_id,
+        &spec,
+        &snapshot_keys,
+        &result,
+        &cancellation,
+    )
+    .await;
+
+    assert!(
+        matches!(finalization, Finalization::Cancelled),
+        "the cancelled attempt must not be retried, got {finalization:?}"
+    );
+    assert_eq!(
+        cancelling_store.manifests.load(Ordering::SeqCst),
+        1,
+        "only the attempt that was running when the token was set may build a manifest"
+    );
+    assert_eq!(
+        current_manifest_object_id(&store, &namespace_id).await,
+        manifest_before,
+        "and nothing may be published"
     );
 }

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -411,7 +411,34 @@ Nothing needs doing about any of this. While the job runs, ordinary
 maintenance carries on: the WAL still flushes, the other groups still fold,
 and reads answer exactly the same thing from the first line to the last. One
 job runs at a time per namespace, so a second group in the same state waits
-its turn and says so.
+its turn and says so. The server also runs at most two of these jobs at once
+across every namespace it serves, so a third namespace that needs one waits
+for a permit. That wait is not a stall: the group is claimed from the moment
+it is planned, so nothing re-plans it and nothing rewrites it underneath, and
+the job starts as soon as a permit frees.
+
+A maintenance step reports which of those four states its group is in, so a
+step run by hand answers the question too:
+
+| `reorganize.kind` | What it means | What to do |
+| --- | --- | --- |
+| `compaction_started` | This step started the rebuild. | Nothing. Watch for the progress lines. |
+| `compaction_at_capacity` | The rebuild is waiting for one of the server's two compaction permits. | Nothing. It starts when a running job finishes. |
+| `compaction_running` | A rebuild is already running for this namespace. | Nothing. This group's turn comes when that one lands. |
+| `compaction_required` | The group needs a rebuild and the handle that ran the step has no background work behind it. | Run one explicitly. Nothing else will. |
+
+The last row is the only one that asks anything of you, and this server does
+not report it: its admin handle shares the writer's background work, so a step
+you run by hand starts the job itself even with `maintenance = "manual"`.
+It is for embedded deployments whose admin handle has no writer behind it.
+Those call `FsAdmin::compact_metadata`, which runs one rebuild in the caller's
+own task and returns when it lands; cancelling it is dropping the future.
+
+Two metrics say what the limit is doing:
+`loonfs.maintenance.compactions_running` and
+`loonfs.maintenance.compactions_queued`. A queue that never empties is a
+process serving more namespaces than two concurrent rebuilds can keep up
+with.
 
 A restart during a rebuild loses that rebuild's work, and this is expected.
 Nothing durable records the rebuild's progress: the published metadata never
@@ -435,12 +462,13 @@ compaction abandoned` (something else rewrote the group underneath it) and
 `streaming metadata compaction superseded` (writes kept landing during its
 final publication). Both are safe and both are self-correcting. `streaming
 metadata compaction failed` carries the error and is worth reading; the next
-step still tries again.
+step still tries again, about a minute later.
 
-This build does not expose the per-step budgets in the config, so the lever for
-everything a step does — flushing, folding, collecting — remains how often
-maintenance runs, not how much each run may do. The rebuild above is the one
-piece of upkeep that lever does not pace, because it is not paced at all.
+This build does not expose the per-step budgets in the config, and it does not
+expose the two-job limit either, so the lever for everything a step does —
+flushing, folding, collecting — remains how often maintenance runs, not how
+much each run may do. The rebuild above is the one piece of upkeep that lever
+does not pace, because it is not paced at all.
 
 ## The optional local cache
 

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -17,6 +17,34 @@ use crate::{
 use crate::{ChangeSeq, Result, RuntimeError};
 use loonfs_core::cache::{load_namespace_fold_basis, load_namespace_head_summary};
 
+/// What one explicit [`FsAdmin::compact_metadata`] call did.
+///
+/// The job's own endings are [`loonfs_core::MetadataCompactionJobOutcome`],
+/// unchanged from what background work reports for the same job. The two
+/// variants beside it are the two ways a call runs no job at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MetadataCompactionOutcome {
+    /// The planner found no family group that has outgrown a bounded
+    /// reorganization step, so this call ran no job. It may have folded one
+    /// bounded unit instead, or lost the race for one, exactly as an ordinary
+    /// maintenance step does.
+    NotNeeded,
+    /// A job already holds this namespace's compaction slot. One runs at a
+    /// time per namespace, so this call ran none.
+    AlreadyRunning,
+    /// A job ran here, and this is how it ended.
+    Ran(loonfs_core::MetadataCompactionJobOutcome),
+}
+
+/// What one reorganization unit left for its caller.
+enum ReorganizationStep {
+    /// The unit is finished, and this is what it did.
+    Concluded(ReorganizeStepOutcome),
+    /// A family group has outgrown a bounded step. The caller starts the job
+    /// as background work, or runs it in its own task.
+    CompactionPlanned(loonfs_core::MetadataCompactionSpec),
+}
+
 impl FsAdmin {
     /// A mutating engine under this handle's actor identity.
     fn engine(
@@ -215,6 +243,23 @@ impl FsAdmin {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<ReorganizeStepOutcome> {
+        Ok(match self.reorganize_once(namespace_id).await? {
+            ReorganizationStep::Concluded(outcome) => outcome,
+            ReorganizationStep::CompactionPlanned(spec) => {
+                self.start_streaming_compaction(namespace_id, spec)
+            }
+        })
+    }
+
+    /// The one reorganization unit both paths run, and what it left for its
+    /// caller.
+    ///
+    /// A step starts the planned job as background work; an explicit
+    /// [`Self::compact_metadata`] runs it here. Everything before that point
+    /// is the same call, so the bookkeeping a published unit leaves behind —
+    /// the cache invalidation, the engagement count — happens once, whichever
+    /// path asked.
+    async fn reorganize_once(&self, namespace_id: &NamespaceId) -> Result<ReorganizationStep> {
         // A handle with no runner has no jobs and no counts, which reads to
         // the planner exactly as a namespace nothing is stuck on. It could
         // not start a job either way.
@@ -229,9 +274,9 @@ impl FsAdmin {
             .reorganize_metadata(pressure.view(&engagements))
             .await
             .map_err(RuntimeError::Core)?;
-        match report.outcome {
+        Ok(ReorganizationStep::Concluded(match report.outcome {
             loonfs_core::MetadataReorganizeOutcome::NotNeeded { .. } => {
-                Ok(ReorganizeStepOutcome::NotNeeded)
+                ReorganizeStepOutcome::NotNeeded
             }
             loonfs_core::MetadataReorganizeOutcome::UnitPublished {
                 families,
@@ -260,16 +305,16 @@ impl FsAdmin {
                     bottom_anchored_merge_blocked,
                     "metadata reorganization unit published"
                 );
-                Ok(ReorganizeStepOutcome::UnitPublished)
+                ReorganizeStepOutcome::UnitPublished
             }
             loonfs_core::MetadataReorganizeOutcome::CompactionPlanned { spec, .. } => {
-                Ok(self.start_streaming_compaction(namespace_id, spec))
+                return Ok(ReorganizationStep::CompactionPlanned(spec))
             }
             loonfs_core::MetadataReorganizeOutcome::Superseded => {
                 tracing::info!("metadata reorganization unit superseded; will retry");
-                Ok(ReorganizeStepOutcome::Superseded)
+                ReorganizeStepOutcome::Superseded
             }
-        }
+        }))
     }
 
     /// Starts the job a step planned, unless something already owns the
@@ -297,42 +342,110 @@ impl FsAdmin {
                 );
                 ReorganizeStepOutcome::CompactionStarted
             }
+            CompactionStart::Queued => {
+                tracing::info!(
+                    families = ?families,
+                    input_runs,
+                    input_rows,
+                    "a family group outgrew one reorganization step; its streaming metadata \
+                     compaction is waiting for a process compaction permit"
+                );
+                ReorganizeStepOutcome::CompactionAtCapacity
+            }
             CompactionStart::AlreadyRunning => {
                 tracing::info!(
                     families = ?families,
                     "a streaming metadata compaction is already running for this namespace; this \
                      group waits for it to finish"
                 );
-                ReorganizeStepOutcome::CompactionPending
+                ReorganizeStepOutcome::CompactionRunning
             }
             CompactionStart::NoRunner => {
                 tracing::warn!(
                     families = ?families,
                     "a family group needs a streaming metadata compaction, and this handle \
-                     schedules no background work; the group is unchanged"
+                     schedules no background work; run `FsAdmin::compact_metadata` to rebuild it"
                 );
-                ReorganizeStepOutcome::CompactionPending
+                ReorganizeStepOutcome::CompactionRequired
             }
         }
     }
 
+    /// Runs one planned streaming metadata compaction to its end, in the
+    /// caller's own task.
+    ///
+    /// This is the whole of metadata maintenance for a deployment that
+    /// schedules none: bounded steps run through
+    /// [`Self::maintenance_step_namespace`], and the one piece of upkeep that
+    /// does not fit a step runs here. It plans exactly as a step does, so a
+    /// step reporting [`ReorganizeStepOutcome::CompactionRequired`] is what
+    /// says a call here has work to do.
+    ///
+    /// The job is the same one background work runs: the same executor, the
+    /// same finalizer, and no durable record that it is running. Dropping the
+    /// returned future stops it, at the cost of the work it had done. A
+    /// handle attached to a writer's background work shares that writer's
+    /// namespace slots and compaction permits, so this waits its turn beside
+    /// the writer's own jobs and is cancelled by that writer's shutdown. A
+    /// standalone handle has neither, and the caller's own call rate is the
+    /// only limit on how many of these run at once.
+    pub async fn compact_metadata(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<MetadataCompactionOutcome> {
+        let ReorganizationStep::CompactionPlanned(spec) =
+            self.reorganize_once(namespace_id).await?
+        else {
+            return Ok(MetadataCompactionOutcome::NotNeeded);
+        };
+        let Some(compactions) = &self.compactions else {
+            // No runner behind this handle, so there is no slot to claim and
+            // no permit to wait for.
+            let cancellation = loonfs_core::MetadataCompactionCancellation::default();
+            return Ok(MetadataCompactionOutcome::Ran(
+                self.run_streaming_compaction(namespace_id, &spec, &cancellation)
+                    .await?,
+            ));
+        };
+        let Some(mut claim) = compactions.claim(namespace_id, &spec) else {
+            return Ok(MetadataCompactionOutcome::AlreadyRunning);
+        };
+        if !claim.admitted().await {
+            return Ok(MetadataCompactionOutcome::Ran(
+                loonfs_core::MetadataCompactionJobOutcome::Cancelled,
+            ));
+        }
+        let outcome = self
+            .run_streaming_compaction(namespace_id, &spec, claim.cancellation())
+            .await;
+        claim.finished(matches!(
+            outcome,
+            Ok(loonfs_core::MetadataCompactionJobOutcome::Published { .. })
+        ));
+        Ok(MetadataCompactionOutcome::Ran(outcome?))
+    }
+
     /// Runs one streaming compaction to its end and says what that end was.
     ///
-    /// The maintenance runner spawns this; nothing awaits it. Every ending
-    /// short of a publication leaves the manifest where it was and the
-    /// segments the job wrote unreferenced, so there is nothing to undo and
-    /// nothing to retry here — a later step plans the group again.
+    /// Both paths reach this: the background task the maintenance runner
+    /// spawns, which awaits nothing and reads the ending from the log, and
+    /// [`Self::compact_metadata`], which hands the ending to its caller.
+    /// Every ending short of a publication leaves the manifest where it was
+    /// and the segments the job wrote unreferenced, so there is nothing to
+    /// undo here — the caller gives its claim back and a later step plans the
+    /// group again.
     pub(crate) async fn run_streaming_compaction(
         &self,
         namespace_id: &NamespaceId,
         spec: &loonfs_core::MetadataCompactionSpec,
         cancellation: &loonfs_core::MetadataCompactionCancellation,
-    ) {
-        match self
+    ) -> Result<loonfs_core::MetadataCompactionJobOutcome> {
+        let outcome = self
             .engine(namespace_id)
             .run_metadata_compaction(spec, cancellation)
             .await
-        {
+            .map_err(RuntimeError::Core);
+        match &outcome {
             Ok(loonfs_core::MetadataCompactionJobOutcome::Published {
                 manifest_id,
                 rows_read,
@@ -372,6 +485,7 @@ impl FsAdmin {
                 "streaming metadata compaction failed; a later step plans it again"
             ),
         }
+        outcome
     }
 
     /// Runs the v1 mark-and-sweep garbage collector for one namespace.

--- a/crates/loonfs/src/fs/mod.rs
+++ b/crates/loonfs/src/fs/mod.rs
@@ -11,6 +11,8 @@ mod tests;
 mod uploads;
 mod writes;
 
+pub use maintenance::MetadataCompactionOutcome;
+
 pub(crate) use core::{should_invalidate_after_result, ReadCore, WriterBits, WriterIdentity};
 pub(crate) use namespaces::delete_namespace_with_engine;
 pub(crate) use writes::publish_batch_with_engine;

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -80,8 +80,9 @@ pub use loonfs_core::time::current_time_ms;
 pub use loonfs_core::{
     delete_if_aged, AgedSweep, BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage,
     CheckpointFilesPageCursor, CurrentFileState, DeleteNamespaceOptions, Error as CoreError,
-    ErrorCode, ErrorKind, FileContentStream, GcConfig, MetadataViewError, PassBudget,
-    StoreFailureClass, WriterFence, CONTENT_READ_CHUNK_BYTES, MAX_RESOLVE_CURRENT_FILES,
+    ErrorCode, ErrorKind, FileContentStream, GcConfig, MetadataCompactionJobOutcome,
+    MetadataViewError, PassBudget, StoreFailureClass, WriterFence, CONTENT_READ_CHUNK_BYTES,
+    MAX_RESOLVE_CURRENT_FILES,
 };
 pub use publisher::PublishObserver;
 
@@ -155,6 +156,7 @@ pub use loonfs_objectstore::{
 
 pub use cache::RuntimeCacheStats;
 pub use config::{RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE};
+pub use fs::MetadataCompactionOutcome;
 pub use handle::{FsAdmin, FsAdminBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder};
 pub use maintenance_runner::{
     FsBackgroundWork, MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -463,10 +463,14 @@ pub(crate) struct RunnerInner {
     /// The streaming metadata compactions running under this runner, one per
     /// namespace at most, and the pressure that decides when one has to
     /// start. Held here rather than beside the admission book because a
-    /// compaction is not a bounded step: it takes no permit, it runs for as
-    /// long as it needs, and what the runner owes it is a spawn, a
-    /// cancellation at shutdown, and the drain every spawned task gets.
+    /// compaction is not a bounded step: it takes no admission permit, it
+    /// runs for as long as it needs, and what the runner owes it is a spawn,
+    /// a cancellation at shutdown, and the drain every spawned task gets.
     compactions: Arc<Mutex<BTreeMap<NamespaceId, compaction::NamespaceCompactions>>>,
+    /// What caps compactions across every namespace this process serves. The
+    /// map above stops two jobs sharing a namespace; this stops one process
+    /// holding a job's worth of memory per namespace it has touched.
+    compaction_permits: Arc<tokio::sync::Semaphore>,
 }
 
 struct RunnerState {
@@ -519,6 +523,9 @@ impl MaintenanceRunner {
                 counters: RunnerCounters::default(),
                 instruments,
                 compactions: Arc::new(Mutex::new(BTreeMap::new())),
+                compaction_permits: Arc::new(tokio::sync::Semaphore::new(
+                    compaction::MAX_CONCURRENT_COMPACTIONS,
+                )),
             }),
         }
     }
@@ -535,9 +542,9 @@ impl MaintenanceRunner {
     ///
     /// Every handle whose maintenance steps may plan one holds this, which is
     /// what makes the runner's own steps and an operator's explicit step see
-    /// the same jobs.
+    /// the same jobs and share the same permits.
     pub(crate) fn compactions(&self) -> BackgroundCompactions {
-        BackgroundCompactions::new(Arc::clone(&self.inner.compactions), &self.inner)
+        BackgroundCompactions::new(&self.inner)
     }
 
     /// The executor registered under `id`.

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -7,12 +7,25 @@
 //! and it is registered for the same drain every other spawned task is, so a
 //! shutdown cancels it and then waits for it.
 //!
-//! What this holds, per namespace, is two things. The one job running for it:
+//! Two things admit a job, and they answer different questions. A namespace
+//! slot stops two jobs rebuilding one namespace at once, which would waste
+//! one of them at finalization. A process-wide semaphore stops this process
+//! running one job per namespace it serves: each job holds a probe cache,
+//! decoded blocks for its iterators, and a segment builder per family, so the
+//! aggregate is what has to be capped whatever the per-namespace rule says. A
+//! job claims its slot first and then waits for a permit, and it is queued
+//! rather than refused while it waits.
+//!
+//! What this holds, per namespace, is two things. The one job claiming it:
 //! the plan, so the steps that follow know not to merge the group underneath
-//! it, and the cancellation token, so a shutdown can stop it. And a count per
-//! family group of the maintenance engagements that planned work for that
-//! group while its bottom-anchored merge was blocked, which is the one thing
-//! a single step cannot see: under sustained writes there is always another
+//! it, and the cancellation token, so a shutdown can stop it. The plan is
+//! recorded when the slot is claimed rather than when the job starts reading,
+//! so a queued job's group is left alone exactly as a running job's is — and
+//! because it is left alone, no merge is published for it, so the count below
+//! neither climbs nor resets while the job waits. And a count per family
+//! group of the maintenance engagements that planned work for that group
+//! while its bottom-anchored merge was blocked, which is the one thing a
+//! single step cannot see: under sustained writes there is always another
 //! pair of delta runs to merge, so a planner deciding from one step's view
 //! would take that merge forever and never start the job that unfreezes the
 //! group's base.
@@ -22,15 +35,31 @@
 //! forgets the counts, and the next two engagements rebuild them, which
 //! delays one cycle and nothing else.
 
-use super::RunnerInner;
+use super::{MaintenanceJobId, RunnerInner};
 use crate::{FsAdmin, NamespaceId};
 use loonfs_api::wire::manifest::MetadataTableFamily;
-use loonfs_core::{MetadataCompactionCancellation, MetadataCompactionSpec};
+use loonfs_core::{
+    MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,
+};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, Weak};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-/// The one job a namespace may have running.
-pub(super) struct ActiveCompaction {
+/// Streaming compactions this process runs at once, across every namespace it
+/// serves.
+///
+/// Small and fixed. A job is unpaced by design and holds real memory while it
+/// runs, so the useful question is how many of them a process may hold at
+/// once, and two is enough to keep one namespace's job from stalling every
+/// other namespace while still bounding the total. It is deliberately not a
+/// configuration knob: an operator's lever over maintenance is how often it
+/// runs, and a second concurrency number would only let a deployment raise
+/// this one until its memory answered for it.
+pub(crate) const MAX_CONCURRENT_COMPACTIONS: usize = 2;
+
+/// The one job a namespace may have, from the moment it claims the slot to
+/// the moment it ends — including the time it spends waiting for a permit.
+struct ActiveCompaction {
     spec: MetadataCompactionSpec,
     cancellation: MetadataCompactionCancellation,
 }
@@ -55,13 +84,14 @@ impl NamespaceCompactions {
 /// A handle on this process's running compactions, cloned into every handle
 /// whose maintenance steps may start one.
 ///
-/// The map is held strongly and the runner weakly, which is the same shape
-/// [`super::MaintenanceHandle`] has and for the same reason: a step may
-/// consult the map at any time, and a step that outlives the writer that owns
-/// the runner starts nothing.
+/// The map and the permits are held strongly and the runner weakly, which is
+/// the same shape [`super::MaintenanceHandle`] has and for the same reason: a
+/// step may consult the map at any time, and a step that outlives the writer
+/// that owns the runner starts nothing.
 #[derive(Clone)]
 pub(crate) struct BackgroundCompactions {
     namespaces: Arc<Mutex<BTreeMap<NamespaceId, NamespaceCompactions>>>,
+    permits: Arc<Semaphore>,
     runner: Weak<RunnerInner>,
 }
 
@@ -70,9 +100,12 @@ pub(crate) struct BackgroundCompactions {
 pub(crate) enum CompactionStart {
     /// The job is running now.
     Started,
-    /// A job is already running for this namespace, so this plan was not
-    /// started. One job at a time per namespace is a process-level fact; a
-    /// later step plans this group again.
+    /// The job holds the namespace's slot and is waiting for a process
+    /// permit. It starts when one frees, and its group is already left alone.
+    Queued,
+    /// A job is already running or queued for this namespace, so this plan
+    /// was not started. One job at a time per namespace is a process-level
+    /// fact; a later step plans this group again.
     AlreadyRunning,
     /// The writer that owned the runner is gone, so there is nothing left to
     /// spawn on. Indistinguishable, to the step, from a handle that never had
@@ -116,12 +149,10 @@ impl CompactionPressure {
 }
 
 impl BackgroundCompactions {
-    pub(super) fn new(
-        namespaces: Arc<Mutex<BTreeMap<NamespaceId, NamespaceCompactions>>>,
-        runner: &Arc<RunnerInner>,
-    ) -> Self {
+    pub(super) fn new(runner: &Arc<RunnerInner>) -> Self {
         Self {
-            namespaces,
+            namespaces: Arc::clone(&runner.compactions),
+            permits: Arc::clone(&runner.compaction_permits),
             runner: Arc::downgrade(runner),
         }
     }
@@ -192,6 +223,47 @@ impl BackgroundCompactions {
         }
     }
 
+    /// Claims the namespace's compaction slot for `spec`, or `None` when a
+    /// job already holds it.
+    ///
+    /// The claim carries a process permit when one was free. When none was,
+    /// the claim is queued and [`CompactionClaim::admitted`] is what waits
+    /// for one. Either way the plan is in the map from here on, so the next
+    /// step leaves this group alone.
+    pub(crate) fn claim(
+        &self,
+        namespace_id: &NamespaceId,
+        spec: &MetadataCompactionSpec,
+    ) -> Option<CompactionClaim> {
+        let cancellation = MetadataCompactionCancellation::default();
+        {
+            let mut namespaces = self.lock();
+            let entry = namespaces.entry(namespace_id.clone()).or_default();
+            if entry.active.is_some() {
+                return None;
+            }
+            entry.active = Some(ActiveCompaction {
+                spec: spec.clone(),
+                cancellation: cancellation.clone(),
+            });
+        }
+        let claim = CompactionClaim {
+            // Taken without waiting: whether a permit was free is what tells
+            // the step that planned this job apart from a step that queued
+            // one, and a claim that waited here would hold the step.
+            permit: Arc::clone(&self.permits).try_acquire_owned().ok(),
+            slot: CompactionSlot {
+                namespaces: Arc::clone(&self.namespaces),
+                permits: Arc::clone(&self.permits),
+                runner: Weak::clone(&self.runner),
+                namespace_id: namespace_id.clone(),
+            },
+            cancellation,
+        };
+        claim.slot.report_counts();
+        Some(claim)
+    }
+
     /// Starts `spec` as a background job under `admin`'s identity, unless a
     /// job already holds the namespace's one slot.
     pub(crate) fn start(
@@ -203,38 +275,40 @@ impl BackgroundCompactions {
         let Some(runner) = self.runner.upgrade() else {
             return CompactionStart::NoRunner;
         };
-        let cancellation = MetadataCompactionCancellation::default();
-        {
-            let mut namespaces = self.lock();
-            let entry = namespaces.entry(namespace_id.clone()).or_default();
-            if entry.active.is_some() {
-                return CompactionStart::AlreadyRunning;
-            }
-            entry.active = Some(ActiveCompaction {
-                spec: spec.clone(),
-                cancellation: cancellation.clone(),
-            });
-        }
-        // The guard is built before the future so the future owns it from the
-        // moment it exists. A spawn a shutdown refuses drops the future
-        // without polling it, and that drop is what gives the slot back.
-        let guard = CompactionSlot {
-            namespaces: Arc::clone(&self.namespaces),
-            namespace_id: namespace_id.clone(),
+        let Some(mut claim) = self.claim(namespace_id, &spec) else {
+            return CompactionStart::AlreadyRunning;
         };
+        let queued = claim.is_queued();
+        // The claim is moved into the future so the future owns it from the
+        // moment it exists. A spawn a shutdown refuses drops the future
+        // without polling it, and that drop is what gives the slot and the
+        // permit back.
         let admin = admin.clone();
         let namespace_id = namespace_id.clone();
         runner.spawn(async move {
-            let _slot = guard;
-            admin
-                .run_streaming_compaction(&namespace_id, &spec, &cancellation)
-                .await;
+            if !claim.admitted().await {
+                return;
+            }
+            // Every ending is logged inside, including the error one, so what
+            // a task nobody awaits needs from it is only what to do next.
+            let published = matches!(
+                admin
+                    .run_streaming_compaction(&namespace_id, &spec, claim.cancellation())
+                    .await,
+                Ok(MetadataCompactionJobOutcome::Published { .. })
+            );
+            claim.finished(published);
         });
-        CompactionStart::Started
+        if queued {
+            CompactionStart::Queued
+        } else {
+            CompactionStart::Started
+        }
     }
 
-    /// Cancels every running job. The tasks themselves are joined by the
-    /// runner's drain; this is what makes that wait short.
+    /// Cancels every job this process holds a slot for, running or queued.
+    /// The tasks themselves are joined by the runner's drain; this is what
+    /// makes that wait short.
     pub(super) fn cancel_all(&self) {
         for entry in self.lock().values() {
             if let Some(active) = &entry.active {
@@ -250,6 +324,84 @@ impl BackgroundCompactions {
     }
 }
 
+/// One job's claim on a namespace's compaction slot and on a process permit.
+pub(crate) struct CompactionClaim {
+    /// Declared before the slot, so it is dropped before the slot is: the
+    /// counts the slot reports on its way out then already exclude this job.
+    permit: Option<OwnedSemaphorePermit>,
+    slot: CompactionSlot,
+    cancellation: MetadataCompactionCancellation,
+}
+
+impl CompactionClaim {
+    /// Whether this claim is waiting for a process permit rather than holding
+    /// one.
+    pub(crate) fn is_queued(&self) -> bool {
+        self.permit.is_none()
+    }
+
+    /// The token that stops this job, whether it is queued or running.
+    pub(crate) fn cancellation(&self) -> &MetadataCompactionCancellation {
+        &self.cancellation
+    }
+
+    /// Gives the claim back and puts the namespace's metadata maintenance
+    /// back in the queue, which is what a job ending is: the moment the
+    /// condition that blocked that maintenance changed.
+    ///
+    /// A publication means the group is rebuilt and whatever arrived while
+    /// the job ran can fold now, so the key is nudged at once. Any other
+    /// ending means the job is to be planned again, and immediately would
+    /// only start the same long job again, so the key waits one
+    /// reconciliation interval. The sweep remains the net under both: these
+    /// nudges are hints like every other, and a lost one costs the delay to
+    /// the next sweep.
+    ///
+    /// The claim goes back before the nudge, and that order is the whole
+    /// reason this is one call. A step that reached the planner while the
+    /// slot was still held would leave alone the very group the job just
+    /// rebuilt, and then park.
+    pub(crate) fn finished(self, published: bool) {
+        let runner = Weak::clone(&self.slot.runner);
+        let namespace_id = self.slot.namespace_id.clone();
+        drop(self);
+        let Some(runner) = runner.upgrade() else {
+            return;
+        };
+        let not_before_ms = (!published).then(|| {
+            runner
+                .clock
+                .now_ms()
+                .saturating_add(super::RECONCILE_INTERVAL_MS)
+        });
+        super::nudge_key(
+            &runner,
+            MaintenanceJobId::METADATA,
+            &namespace_id,
+            not_before_ms,
+        );
+    }
+
+    /// Resolves once this job may run. `false` means it was cancelled while
+    /// it waited and must not run at all.
+    ///
+    /// Waiting is what makes a queued job free: it holds its namespace slot,
+    /// so its group is left alone, and it holds nothing else until a permit
+    /// frees.
+    pub(crate) async fn admitted(&mut self) -> bool {
+        if self.permit.is_none() {
+            let permits = Arc::clone(&self.slot.permits);
+            let cancellation = self.cancellation.clone();
+            self.permit = tokio::select! {
+                permit = permits.acquire_owned() => permit.ok(),
+                () = cancellation.cancelled() => None,
+            };
+            self.slot.report_counts();
+        }
+        self.permit.is_some() && !self.cancellation.is_cancelled()
+    }
+}
+
 /// Holds a namespace's compaction slot and gives it back exactly once.
 ///
 /// Dropping is the only way the slot is released — on a normal finish, on a
@@ -257,20 +409,50 @@ impl BackgroundCompactions {
 /// left claiming a job that is not running.
 struct CompactionSlot {
     namespaces: Arc<Mutex<BTreeMap<NamespaceId, NamespaceCompactions>>>,
+    permits: Arc<Semaphore>,
+    runner: Weak<RunnerInner>,
     namespace_id: NamespaceId,
+}
+
+impl CompactionSlot {
+    /// Reports how many jobs are running and how many are waiting for a
+    /// permit, from the two facts that decide it: the slots claimed, and the
+    /// permits taken.
+    fn report_counts(&self) {
+        let Some(runner) = self.runner.upgrade() else {
+            return;
+        };
+        let claimed = self
+            .namespaces
+            .lock()
+            .map(|namespaces| {
+                namespaces
+                    .values()
+                    .filter(|entry| entry.active.is_some())
+                    .count()
+            })
+            .unwrap_or(0);
+        let running = MAX_CONCURRENT_COMPACTIONS.saturating_sub(self.permits.available_permits());
+        runner
+            .instruments
+            .compactions(running, claimed.saturating_sub(running));
+    }
 }
 
 impl Drop for CompactionSlot {
     fn drop(&mut self) {
-        let Ok(mut namespaces) = self.namespaces.lock() else {
-            return;
-        };
-        let Some(entry) = namespaces.get_mut(&self.namespace_id) else {
-            return;
-        };
-        entry.active = None;
-        if entry.is_empty() {
-            namespaces.remove(&self.namespace_id);
+        {
+            let Ok(mut namespaces) = self.namespaces.lock() else {
+                return;
+            };
+            let Some(entry) = namespaces.get_mut(&self.namespace_id) else {
+                return;
+            };
+            entry.active = None;
+            if entry.is_empty() {
+                namespaces.remove(&self.namespace_id);
+            }
         }
+        self.report_counts();
     }
 }

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -286,9 +286,13 @@ fn metadata_has_nothing_to_maintain(error: &RuntimeError) -> bool {
 ///
 /// Starting a streaming compaction is progress of the useful kind: the step
 /// that started it did no folding, and the steps behind it now have the
-/// group's peers to fold while the job runs. A group waiting on a job that is
-/// already running is a block — there is work and this step cannot make it —
-/// so the key parks and comes back on the next nudge or sweep.
+/// group's peers to fold while the job runs. A job queued behind the process
+/// compaction limit reads the same way — the group is claimed, so the steps
+/// behind it have the same peers to fold, and nothing is needed to make the
+/// job run. A group waiting on a job already running, and a group needing one
+/// this handle cannot run at all, are blocks: there is work and this step
+/// cannot make it, so the key parks and comes back on the next nudge or
+/// sweep. The job's own ending nudges the key back when it lands.
 fn metadata_conclusion(step: &MetadataMaintenanceResponse) -> MaintenanceStepConclusion {
     let flush = match step.wal_flush {
         WalFlushStepOutcome::Flushed { .. } => Some(MaintenanceStepConclusion::Progressed),
@@ -298,11 +302,15 @@ fn metadata_conclusion(step: &MetadataMaintenanceResponse) -> MaintenanceStepCon
         WalFlushStepOutcome::NotNeeded => None,
     };
     let reorganize = match step.reorganize {
-        ReorganizeStepOutcome::UnitPublished | ReorganizeStepOutcome::CompactionStarted => {
+        ReorganizeStepOutcome::UnitPublished
+        | ReorganizeStepOutcome::CompactionStarted
+        | ReorganizeStepOutcome::CompactionAtCapacity => {
             Some(MaintenanceStepConclusion::Progressed)
         }
         ReorganizeStepOutcome::Superseded => Some(MaintenanceStepConclusion::Superseded),
-        ReorganizeStepOutcome::CompactionPending => Some(MaintenanceStepConclusion::Blocked),
+        ReorganizeStepOutcome::CompactionRunning | ReorganizeStepOutcome::CompactionRequired => {
+            Some(MaintenanceStepConclusion::Blocked)
+        }
         ReorganizeStepOutcome::NotNeeded => None,
     };
     [flush, reorganize]
@@ -463,7 +471,7 @@ mod tests {
         );
         let blocked = step_response(
             WalFlushStepOutcome::NotNeeded,
-            ReorganizeStepOutcome::CompactionPending,
+            ReorganizeStepOutcome::CompactionRunning,
         );
         assert_eq!(
             metadata_conclusion(&blocked),
@@ -473,9 +481,10 @@ mod tests {
 
     /// Starting a background rebuild is progress: the step that started it
     /// folded nothing, and the steps behind it have the group's peers to fold
-    /// while the job runs.
+    /// while the job runs. A job queued behind the process limit reads the
+    /// same way, because the group is claimed either way.
     #[test]
-    fn starting_a_compaction_progresses_and_waiting_on_one_blocks() {
+    fn a_started_or_queued_compaction_progresses_and_the_other_two_block() {
         let started = step_response(
             WalFlushStepOutcome::NotNeeded,
             ReorganizeStepOutcome::CompactionStarted,
@@ -484,14 +493,32 @@ mod tests {
             metadata_conclusion(&started),
             MaintenanceStepConclusion::Progressed
         );
+        let queued = step_response(
+            WalFlushStepOutcome::NotNeeded,
+            ReorganizeStepOutcome::CompactionAtCapacity,
+        );
+        assert_eq!(
+            metadata_conclusion(&queued),
+            MaintenanceStepConclusion::Progressed,
+            "a queued job owns its group already, so the step behind it folds the peers"
+        );
         let waiting = step_response(
             WalFlushStepOutcome::NotNeeded,
-            ReorganizeStepOutcome::CompactionPending,
+            ReorganizeStepOutcome::CompactionRunning,
         );
         assert_eq!(
             metadata_conclusion(&waiting),
             MaintenanceStepConclusion::Blocked,
             "a group waiting on a job already running has nothing to gain from an immediate retry"
+        );
+        let unschedulable = step_response(
+            WalFlushStepOutcome::NotNeeded,
+            ReorganizeStepOutcome::CompactionRequired,
+        );
+        assert_eq!(
+            metadata_conclusion(&unschedulable),
+            MaintenanceStepConclusion::Blocked,
+            "a handle that cannot run the job gains nothing from being asked again at once"
         );
     }
 
@@ -501,7 +528,7 @@ mod tests {
             WalFlushStepOutcome::Flushed {
                 manifest_head_seq: ChangeSeq(7),
             },
-            ReorganizeStepOutcome::CompactionPending,
+            ReorganizeStepOutcome::CompactionRunning,
         );
         assert_eq!(
             metadata_conclusion(&step),

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -947,3 +947,219 @@ async fn the_runtime_registers_its_metadata_and_gc_jobs() {
         "an id may only be registered once"
     );
 }
+
+/// A plan for a job these tests never let read anything: what they assert on
+/// is the slot, the permit, and the token.
+fn compaction_plan() -> loonfs_core::MetadataCompactionSpec {
+    loonfs_core::MetadataCompactionSpec::planned_over_no_runs()
+}
+
+/// Claims the compaction slots of `count` namespaces named `job-0`, `job-1`,
+/// and so on, in order.
+fn claim_all(
+    compactions: &BackgroundCompactions,
+    count: usize,
+) -> Vec<compaction::CompactionClaim> {
+    (0..count)
+        .map(|index| {
+            compactions
+                .claim(&namespace_id(&format!("job-{index}")), &compaction_plan())
+                .expect("each namespace claims its own slot")
+        })
+        .collect()
+}
+
+/// The process limit is what bounds compactions, not the namespace count.
+///
+/// Every namespace that plans one claims its own slot, so the map cannot
+/// bound them: a process serving a hundred namespaces would run a hundred
+/// jobs. The permits are what stop that, and a job that cannot have one is
+/// queued rather than refused — its group is claimed either way, so nothing
+/// re-plans it and nothing merges it underneath.
+#[tokio::test]
+async fn at_most_the_process_limit_of_compactions_run_however_many_namespaces_plan_one() {
+    let runner = enabled_runner(TestJob::idle());
+    let compactions = runner.compactions();
+    let claims = claim_all(&compactions, compaction::MAX_CONCURRENT_COMPACTIONS + 2);
+
+    assert_eq!(
+        claims.iter().filter(|claim| !claim.is_queued()).count(),
+        compaction::MAX_CONCURRENT_COMPACTIONS,
+        "the permits are what decide how many run"
+    );
+
+    // The queued claims wait, and each one starts as a permit frees.
+    let mut claims = claims.into_iter();
+    let running: Vec<_> = claims
+        .by_ref()
+        .take(compaction::MAX_CONCURRENT_COMPACTIONS)
+        .collect();
+    let admitted = Arc::new(AtomicU64::new(0));
+    let waiting: Vec<_> = claims
+        .map(|mut claim| {
+            let admitted = Arc::clone(&admitted);
+            tokio::spawn(async move {
+                assert!(claim.admitted().await, "a freed permit admits this job");
+                admitted.fetch_add(1, Ordering::SeqCst);
+            })
+        })
+        .collect();
+    tokio::task::yield_now().await;
+    assert_eq!(
+        admitted.load(Ordering::SeqCst),
+        0,
+        "a queued job runs nothing while every permit is held"
+    );
+
+    for (freed, claim) in running.into_iter().enumerate() {
+        drop(claim);
+        wait_for(
+            || admitted.load(Ordering::SeqCst) as usize > freed,
+            "the next queued compaction to start",
+        )
+        .await;
+    }
+    for task in waiting {
+        task.await.expect("the queued jobs settle");
+    }
+}
+
+/// One namespace, one job — whether the job is running or still queued.
+///
+/// The plan is in the map from the claim, which is also what leaves the
+/// group alone: a step that read a queued job's group and merged it would
+/// waste that job at finalization.
+#[tokio::test]
+async fn a_queued_job_still_holds_its_namespace_and_still_excludes_its_group() {
+    let runner = enabled_runner(TestJob::idle());
+    let compactions = runner.compactions();
+    let _running = claim_all(&compactions, compaction::MAX_CONCURRENT_COMPACTIONS);
+
+    let queued_namespace = namespace_id("queued");
+    let queued = compactions
+        .claim(&queued_namespace, &compaction_plan())
+        .expect("a namespace with no job claims its slot");
+    assert!(queued.is_queued(), "every permit is held");
+    assert!(
+        compactions
+            .claim(&queued_namespace, &compaction_plan())
+            .is_none(),
+        "a second job for one namespace is refused while the first waits"
+    );
+
+    let pressure = compactions.pressure(&queued_namespace);
+    let engagements = pressure.engagements();
+    assert!(
+        pressure.view(&engagements).active.is_some(),
+        "a queued job's group is left alone exactly as a running job's is"
+    );
+
+    drop(queued);
+    let pressure = compactions.pressure(&queued_namespace);
+    let engagements = pressure.engagements();
+    assert!(
+        pressure.view(&engagements).active.is_none(),
+        "and the slot goes back when the claim does"
+    );
+}
+
+/// A shutdown stops a job that is waiting for a permit, not only one that is
+/// reading rows.
+///
+/// A queued job has no block fetch to check its token between, so without
+/// this the drain would wait for a permit it is trying to stop needing.
+#[tokio::test]
+async fn cancellation_reaches_a_job_that_is_still_waiting_for_a_permit() {
+    let runner = enabled_runner(TestJob::idle());
+    let compactions = runner.compactions();
+    let _running = claim_all(&compactions, compaction::MAX_CONCURRENT_COMPACTIONS);
+    let mut queued = compactions
+        .claim(&namespace_id("queued"), &compaction_plan())
+        .expect("a namespace with no job claims its slot");
+    assert!(queued.is_queued());
+
+    let ran = Arc::new(AtomicU64::new(0));
+    let waiting = tokio::spawn({
+        let ran = Arc::clone(&ran);
+        async move {
+            let admitted = queued.admitted().await;
+            if admitted {
+                ran.fetch_add(1, Ordering::SeqCst);
+            }
+            admitted
+        }
+    });
+    tokio::task::yield_now().await;
+
+    compactions.cancel_all();
+
+    assert!(
+        !waiting.await.expect("the queued job settles"),
+        "a cancelled job must not be admitted by a permit that frees later"
+    );
+    assert_eq!(
+        ran.load(Ordering::SeqCst),
+        0,
+        "and it must run nothing, so it stages nothing"
+    );
+}
+
+/// A published job puts its namespace's metadata maintenance back in the
+/// queue at once, and gives its slot back first.
+///
+/// A delta run that arrived while the job ran is exactly what a group blocked
+/// behind that job could not fold. Nothing durable reports that it can now,
+/// so without this nudge the fold waits for the next reconciliation sweep —
+/// and a nudge that arrived while the slot was still held would wake a step
+/// that leaves that group alone. A job that ended without publishing is
+/// planned again instead, and waits a sweep's worth of time so it does not
+/// start the same long job at once.
+#[tokio::test]
+async fn a_job_that_ends_frees_its_slot_and_requeues_its_namespace() {
+    let job = TestJob::gated([], StepAnswer::Conclude(MaintenanceStepConclusion::Idle));
+    let clock = ManualClock::at(1_700_000_000_000);
+    let runner = runner_with(FsBackgroundWork::Enabled, clock.clone(), job.clone());
+    let compactions = runner.compactions();
+    // The one admission permit is held by a step that never finishes, so a
+    // nudged key stays where the nudge put it.
+    runner
+        .handle()
+        .nudge(TEST_JOB, &namespace_id("holds-the-permit"));
+    job.gate().wait_entered(1).await;
+
+    let published = namespace_id("published");
+    compactions
+        .claim(&published, &compaction_plan())
+        .expect("the namespace claims its slot")
+        .finished(true);
+    assert!(
+        runner.is_pending(MaintenanceJobId::METADATA, &published),
+        "a published job hands the namespace straight back to metadata maintenance"
+    );
+    assert_eq!(
+        runner.not_before_ms(MaintenanceJobId::METADATA, &published),
+        None,
+        "and it waits for nothing"
+    );
+    let pressure = compactions.pressure(&published);
+    let engagements = pressure.engagements();
+    assert!(
+        pressure.view(&engagements).active.is_none(),
+        "the slot is back before the nudge, so the step it wakes may fold the rebuilt group"
+    );
+
+    let abandoned = namespace_id("abandoned");
+    compactions
+        .claim(&abandoned, &compaction_plan())
+        .expect("the namespace claims its slot")
+        .finished(false);
+    assert_eq!(
+        runner.not_before_ms(MaintenanceJobId::METADATA, &abandoned),
+        Some(clock.now_ms() + RECONCILE_INTERVAL_MS),
+        "a job that published nothing is planned again after a backoff, not at once"
+    );
+
+    job.gate().release(8);
+    runner.close_admission();
+    runner.drain().await.expect("the held step settles");
+}

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -57,6 +57,7 @@ struct Installed {
     recorder: Arc<dyn MetricsRecorder>,
     object_store: Mutex<HashMap<&'static str, ObjectStoreOperationInstruments>>,
     maintenance: Mutex<HashMap<&'static str, MaintenanceJobInstruments>>,
+    compactions: CompactionInstruments,
     publisher: PublisherInstruments,
     gc: GcInstruments,
 }
@@ -67,6 +68,7 @@ impl RuntimeInstruments {
     pub(crate) fn new(recorder: Option<Arc<dyn MetricsRecorder>>) -> Arc<Self> {
         Arc::new(Self {
             installed: recorder.map(|recorder| Installed {
+                compactions: CompactionInstruments::register(recorder.as_ref()),
                 publisher: PublisherInstruments::register(recorder.as_ref()),
                 gc: GcInstruments::register(recorder.as_ref()),
                 object_store: Mutex::new(HashMap::new()),
@@ -127,6 +129,26 @@ impl RuntimeInstruments {
             return;
         };
         installed.maintenance_job(job).probe_failures.increment(1);
+    }
+
+    /// Reports the streaming metadata compactions this process is running and
+    /// the ones holding a namespace slot while they wait for a permit.
+    ///
+    /// Queued is the number that matters on its own: jobs take as long as
+    /// they take, so a queue that never empties is a process serving more
+    /// namespaces than its compaction limit admits.
+    pub(crate) fn compactions(&self, running: usize, queued: usize) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        installed
+            .compactions
+            .running
+            .set(i64::try_from(running).unwrap_or(i64::MAX));
+        installed
+            .compactions
+            .queued
+            .set(i64::try_from(queued).unwrap_or(i64::MAX));
     }
 
     /// Reports the candidates a namespace has admitted but not yet taken.
@@ -419,6 +441,31 @@ impl MaintenanceJobInstruments {
             MaintenanceStepConclusion::Blocked => &self.blocked,
             MaintenanceStepConclusion::Superseded => &self.superseded,
             MaintenanceStepConclusion::NotEnabled => &self.not_enabled,
+        }
+    }
+}
+
+/// The two numbers that describe this process's streaming metadata
+/// compactions: how many are running, and how many are waiting to.
+struct CompactionInstruments {
+    running: Arc<dyn GaugeHandle>,
+    queued: Arc<dyn GaugeHandle>,
+}
+
+impl CompactionInstruments {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        Self {
+            running: recorder.register_gauge(
+                "loonfs.maintenance.compactions_running",
+                "Streaming metadata compactions this process is running",
+                &[],
+            ),
+            queued: recorder.register_gauge(
+                "loonfs.maintenance.compactions_queued",
+                "Streaming metadata compactions holding a namespace slot while they wait for a \
+                 process permit",
+                &[],
+            ),
         }
     }
 }

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -7,8 +7,8 @@ use crate::common::*;
 use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
 use loonfs::{
     ChangeSeq, CommitId, CreateNamespaceOptions, ErrorCode, MaintenancePlan, ManifestId,
-    NamespaceId, PutFileOptions, ReorganizeStepOutcome, RuntimeError, SharedObjectStore,
-    WalFlushStepOutcome,
+    MetadataCompactionOutcome, NamespaceId, PutFileOptions, ReorganizeStepOutcome, RuntimeError,
+    SharedObjectStore, WalFlushStepOutcome,
 };
 use loonfs_api::wire::control::{
     decode_control_object, encode_control_object, ControlObjectEnvelope, ControlObjectKind,
@@ -560,6 +560,61 @@ fn maintenance_step_after_existing_manifest_writes_l0_manifest() {
     assert!(l0_files
         .iter()
         .any(|metadata_file| metadata_file.run_seq == ChangeSeq(2)));
+}
+
+/// A handle with no background work behind it can still run the one piece of
+/// upkeep a bounded step cannot do itself.
+///
+/// This is the manual deployment story: an operator drives bounded steps and
+/// then drives this, and neither needs a scheduler. The call plans exactly as
+/// a step does — including folding one bounded unit when that is what the
+/// namespace needs — and reports what it ran.
+#[test]
+fn a_standalone_admin_drives_metadata_compaction_itself() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "manual-compaction-test");
+    let namespace_id = namespace_id("demo");
+
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    // A namespace that has published no manifest has no runs to rebuild.
+    assert_eq!(
+        block_on(fs.admin.compact_metadata(&namespace_id)).expect("compact an empty namespace"),
+        MetadataCompactionOutcome::NotNeeded
+    );
+
+    // Enough flushes to put the manifest's L0 run count over the fold
+    // trigger, which is what makes the planner select a group at all.
+    for index in 0..9 {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            &format!("/docs/file-{index}.txt"),
+            format!("file {index}").as_bytes(),
+            PutFileOptions::default(),
+        )
+        .expect("put a file");
+        fs.flush_wal_blocking(&namespace_id)
+            .expect("flush the tail");
+    }
+    let manifest_before = fs
+        .namespace_status_blocking(&namespace_id)
+        .expect("status before the call")
+        .current_manifest_id;
+
+    // Nothing here has outgrown a bounded step, so the plan is a merge and
+    // this call reports that it ran no job — having folded the unit the
+    // planner chose, exactly as the next maintenance step would have.
+    assert_eq!(
+        block_on(fs.admin.compact_metadata(&namespace_id)).expect("plan a compaction"),
+        MetadataCompactionOutcome::NotNeeded
+    );
+    assert_ne!(
+        fs.namespace_status_blocking(&namespace_id)
+            .expect("status after the call")
+            .current_manifest_id,
+        manifest_before,
+        "the call must run the same planner a maintenance step runs, and publish what it chose"
+    );
 }
 
 fn create_directory_request(commit_id: &str, absolute_path: &str) -> CommitRequest {

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -683,14 +683,20 @@ reclaimable state is collected; naming anything else is refused with
 `namespace_deleted`, because a tombstone has nothing to flush, reorganize,
 or retain.
 
-One reorganize outcome describes work the step did not do itself. A family
+Four reorganize outcomes describe work the step did not do itself. A family
 group that has outgrown one step is rebuilt by a background streaming
-compaction, and `reorganize.kind` reports `compaction_started` when the step
-started that job. The step publishes nothing in that case: the job publishes
-once, when it finishes. `compaction_pending` says the group needs one and
-this step started none, because a job is already running for the namespace —
-one runs at a time — or because the process serving the request schedules no
-background work. The server log says which.
+compaction, and the step publishes nothing in that case: the job publishes
+once, when it finishes. `reorganize.kind` says what became of that job.
+
+`compaction_started` means this step started one. `compaction_at_capacity`
+means this step's job claimed the namespace but is waiting for a process
+compaction permit, because the process is already running its limit of them;
+it starts when one frees. `compaction_running` means a job was already
+running for this namespace, which runs one at a time, so this step started
+none and a later step plans the group again. `compaction_required` means the
+group needs a job and the handle serving the request has no background work
+behind it at all, so nothing will run one until an operator does; the
+self-hosting guide names the call.
 
 Inside `metadata`, `max_wal_tail_segments` overrides the flush threshold;
 zero, and any value above the write-rejection threshold, are rejected as

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -5609,7 +5609,35 @@
               "kind": {
                 "type": "string",
                 "enum": [
-                  "compaction_pending"
+                  "compaction_running"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "compaction_at_capacity"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "compaction_required"
                 ]
               }
             }


### PR DESCRIPTION
This change adds the operational controls needed to run streaming metadata compaction safely in both background and manual-maintenance deployments.

The maintenance runner now allows at most two streaming metadata compactions to run in one process, while continuing to allow only one job per namespace. When both process permits are in use, the runner reserves the new job's namespace and queues the job instead of rejecting it. Reserving the namespace before waiting prevents regular maintenance from modifying the family group that the queued job plans to rebuild. Shutdown now cancels jobs that are waiting for a permit as well as jobs already running.

When a job ends, the runner releases its namespace reservation and schedules metadata maintenance again. A successful publication triggers an immediate check so any runs that arrived during compaction can be merged. Cancellation, failure, abandonment, or repeated publication conflicts schedule the retry after one reconciliation interval, which avoids immediately repeating the same expensive work. The new `loonfs.maintenance.compactions_running` and `loonfs.maintenance.compactions_queued` gauges expose current usage of the process limit.

The finalization path now checks for cancellation before it starts, before every retry, and immediately before the root compare-and-swap. A shutdown after the last output row therefore publishes nothing. Each publication attempt also reads the current wall clock before updating the root, so a long-running job cannot replace a newer root timestamp with the older time captured when the job was planned.

The maintenance API now reports the reason a compaction did not start with separate outcomes. `compaction_running` means this namespace already has a job, `compaction_at_capacity` means this job is waiting for a process permit, and `compaction_required` means the current handle has no background runner and an operator must run the work explicitly. The CLI, API documentation, OpenAPI schema, logs, and self-hosting guide use these states consistently.

`FsAdmin::compact_metadata` provides that explicit path. It uses the same planner, executor, finalizer, cache invalidation, and scheduling rules as background maintenance, but runs one planned compaction in the caller's task and returns its outcome. A handle attached to a writer shares the writer's namespace reservations and process permits. A standalone handle has no background admission layer, so the caller determines concurrency by how many calls it starts. Dropping the future stops work before publication and leaves staged output unreferenced for normal cleanup.

The input merge logic, staged output writer, and retention-floor rules now live in focused modules instead of the compaction orchestration file. Tests cover process-wide admission, queued-job isolation and cancellation, post-job scheduling, manual execution, cancellation during finalization, and timestamp monotonicity.

Formatting, Clippy, the full locked workspace test suite, and the OpenAPI checks pass. No golden-format bytes change; the generated OpenAPI document reflects the new maintenance outcomes.
