### PR TITLE
chore(checkpoint): one merge engine drives both reorganization paths

### DIFF
--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -39,6 +39,11 @@ pub(super) async fn build_manifest_tables<S: ObjectStore + ?Sized>(
     .await
 }
 
+/// The layout invariant manifest load enforces for real, checked eagerly on a
+/// run a test just built. Production merges write through
+/// [`super::compaction_output::MergeSegmentWriter`], which never holds a run's
+/// tables in this shape.
+#[cfg(test)]
 pub(super) fn debug_assert_manifest_table_segments_do_not_overlap(
     _tables: &[MetadataTableManifest],
 ) {
@@ -208,7 +213,7 @@ impl<'a> MetadataSstWriteRequest<'a> {
 /// otherwise fetch one filter block per run to rule out — while keeping big
 /// base-segment filters (which range pruning already narrows to one
 /// candidate) out of the manifest.
-const INLINE_SEGMENT_FILTER_MAX_BYTES: u32 = 1024;
+pub(super) const INLINE_SEGMENT_FILTER_MAX_BYTES: u32 = 1024;
 
 pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
     store: &S,

--- a/crates/loonfs-core/src/checkpoint/compaction_merge.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_merge.rs
@@ -1,8 +1,8 @@
-//! Reading a streaming compaction's input: one iterator per run per family,
-//! merged in row-key order, refilled a bounded wave at a time.
+//! Reading a merge's input: one iterator per run per family, merged in row-key
+//! order, refilled a bounded wave at a time.
 //!
-//! This is what makes the job's input residency a fixed number rather than a
-//! function of the group it rebuilds. An iterator holds the blocks it has not
+//! This is what makes a merge's input residency a fixed number rather than a
+//! function of what it merges. An iterator holds the blocks it has not
 //! consumed and nothing else, a refill wave is bounded, and the selection
 //! that decides which iterator goes next compares borrowed key slices.
 
@@ -19,11 +19,11 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 /// Decoded data blocks one iterator holds at a time. An iterator refills only
-/// when it has none left, so this is also the most it ever holds, and the
-/// job's input residency is this times the number of open iterators.
+/// when it has none left, so this is also the most it ever holds, and a
+/// merge's input residency is this times the number of open iterators.
 const BLOCKS_PER_ITERATOR_FETCH: usize = 2;
 
-/// Iterators refilled in one wave. Refills are the job's only bulk reads, so
+/// Iterators refilled in one wave. Refills are a merge's only bulk reads, so
 /// this is the width of its fan-out at the store.
 const ITERATOR_FETCH_CONCURRENCY: usize = 8;
 
@@ -188,7 +188,7 @@ impl SegmentRowIterator {
             let descriptor = &self.segments[self.next_segment - 1];
             let end = (self.next_block + BLOCKS_PER_ITERATOR_FETCH).min(index.len());
             // Blocks are decoded into this iterator alone: no table cache and
-            // a memo that dies with the call, so nothing the job reads is
+            // a memo that dies with the call, so nothing the merge reads is
             // retained anywhere but here.
             let blocks = load_segment_data_block_span(
                 store,

--- a/crates/loonfs-core/src/checkpoint/compaction_output.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_output.rs
@@ -1,34 +1,73 @@
-//! Writing a streaming compaction's output: one segment builder per family,
-//! rolled to the store every time the segment row budget fills.
+//! Writing a merge's output: one segment builder per family, rolled to the
+//! store every time the segment row budget fills.
 //!
-//! Segments go to the job's own prefix rather than to `metadata/tables/`
-//! (format spec, "Compaction"), and nothing references them until the job's
-//! one manifest publication names them. What a builder holds is one segment's
-//! worth of rows, so the job's output residency is the segment row budget and
-//! not the size of the group it rebuilds.
+//! Both reorganization paths write through this. What a builder holds is one
+//! segment's worth of rows, so output residency is the segment row budget and
+//! not the size of the group being merged.
+//!
+//! The paths differ in one thing, and [`MergeOutput`] is it: the key a segment
+//! lands under. A background job's segments are written long before the
+//! manifest that names them, so they go under the job's own prefix where a
+//! lease speaks for them (format spec, "Compaction"). A merge that runs inside
+//! a maintenance step publishes in that same step, so its segments go to
+//! `metadata/tables/` like any other freshly written run and are covered by
+//! the ordinary write-time grace.
 
 use super::build::{write_manifest_segment, MetadataSstWriteRequest};
+use super::reorganize::MergePlacement;
 use super::runs::MetadataLsmPolicy;
-use super::streaming_compaction::MetadataCompactionSpec;
 use crate::error::Result;
 use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
-use loonfs_api::{MetadataTableId, NamespaceId};
-use loonfs_objectstore::keys::metadata_compaction_table;
+use loonfs_api::{MetadataCompactionId, MetadataTableId, NamespaceId};
+use loonfs_objectstore::keys::{metadata_compaction_table, metadata_table};
 use loonfs_objectstore::ObjectStore;
+
+/// Where a merge's output segments are written.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum MergeOutput<'a> {
+    /// Under the job's own prefix, for a merge whose publication comes much
+    /// later. The lease beside the segments is what tells garbage collection
+    /// that objects far older than any grace window still have an owner.
+    JobPrefix(&'a MetadataCompactionId),
+    /// At ordinary table keys, for a merge that publishes inside the step that
+    /// ran it. Its segments are seconds old when the manifest names them, so
+    /// the ordinary write-time grace already covers them and there is nothing
+    /// for a lease to say.
+    Tables,
+}
+
+impl MergeOutput<'_> {
+    fn object_key(&self, namespace_id: &NamespaceId, table_id: &MetadataTableId) -> String {
+        match self {
+            Self::JobPrefix(job_id) => {
+                metadata_compaction_table(namespace_id.as_str(), job_id.as_str(), table_id.as_str())
+            }
+            Self::Tables => metadata_table(namespace_id.as_str(), table_id.as_str()),
+        }
+    }
+}
 
 /// Accumulates one family's surviving rows and uploads a segment every time
 /// the segment row budget fills.
-pub(super) struct StagedSegmentWriter {
+pub(super) struct MergeSegmentWriter<'a> {
     family: MetadataTableFamily,
+    output: MergeOutput<'a>,
+    placement: MergePlacement,
     rows: Vec<MetadataRow>,
     next_segment_index: u32,
     segments: Vec<MetadataFileRef>,
 }
 
-impl StagedSegmentWriter {
-    pub(super) fn new(family: MetadataTableFamily) -> Self {
+impl<'a> MergeSegmentWriter<'a> {
+    pub(super) fn new(
+        family: MetadataTableFamily,
+        output: MergeOutput<'a>,
+        placement: MergePlacement,
+    ) -> Self {
         Self {
             family,
+            output,
+            placement,
             rows: Vec::new(),
             next_segment_index: 0,
             segments: Vec::new(),
@@ -43,14 +82,13 @@ impl StagedSegmentWriter {
         &mut self,
         store: &S,
         namespace_id: &NamespaceId,
-        spec: &MetadataCompactionSpec,
         policy: MetadataLsmPolicy,
     ) -> Result<()> {
         let max_rows = policy.max_rows_per_segment.get();
         while self.rows.len() >= max_rows {
             let rest = self.rows.split_off(max_rows);
             let full = std::mem::replace(&mut self.rows, rest);
-            self.write_segment(store, namespace_id, spec, full).await?;
+            self.write_segment(store, namespace_id, full).await?;
         }
         Ok(())
     }
@@ -59,11 +97,10 @@ impl StagedSegmentWriter {
         mut self,
         store: &S,
         namespace_id: &NamespaceId,
-        spec: &MetadataCompactionSpec,
     ) -> Result<Vec<MetadataFileRef>> {
         let rest = std::mem::take(&mut self.rows);
         if !rest.is_empty() {
-            self.write_segment(store, namespace_id, spec, rest).await?;
+            self.write_segment(store, namespace_id, rest).await?;
         }
         Ok(self.segments)
     }
@@ -72,23 +109,18 @@ impl StagedSegmentWriter {
         &mut self,
         store: &S,
         namespace_id: &NamespaceId,
-        spec: &MetadataCompactionSpec,
         rows: Vec<MetadataRow>,
     ) -> Result<()> {
         let table_id = MetadataTableId::generate();
-        let object_key = metadata_compaction_table(
-            namespace_id.as_str(),
-            spec.job_id().as_str(),
-            table_id.as_str(),
-        );
+        let object_key = self.output.object_key(namespace_id, &table_id);
         let descriptor = write_manifest_segment(
             store,
             MetadataSstWriteRequest::new(
                 namespace_id,
                 table_id,
                 object_key,
-                spec.placement().output_seq(),
-                spec.placement().output_level(),
+                self.placement.output_seq(),
+                self.placement.output_level(),
                 self.family,
                 self.next_segment_index,
                 rows,

--- a/crates/loonfs-core/src/checkpoint/compaction_retention.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_retention.rs
@@ -1,13 +1,12 @@
 //! The frozen floor's rules as streaming operators: one row in, at most one
 //! row out, and a fixed amount of state in between.
 //!
-//! A whole-group fold holds every row of a family and decides them together
-//! ([`super::reorganize::drop_rows_below_retention_floor`]). A streaming
-//! compaction cannot: one inode may hold any number of attribute revisions
-//! and one parent-and-name slot any number of binding generations, so holding
-//! "the rows a rule reads together" is holding an unbounded set. These
-//! operators hold the *answer* a rule is building instead, which is a fixed
-//! number of fields per family and at most one row.
+//! Holding every row of a family and deciding them together is not available
+//! to a merge: one inode may hold any number of attribute revisions and one
+//! parent-and-name slot any number of binding generations, so holding "the
+//! rows a rule reads together" is holding an unbounded set. These operators
+//! hold the *answer* a rule is building instead, which is a fixed number of
+//! fields per family and at most one row.
 //!
 //! What makes that possible is the row-key grammar. Rows arrive in row-key
 //! order, and every rule reads neighbours that share a key prefix, so the rows
@@ -21,7 +20,7 @@
 //!
 //! The reverse bind index is the one family no grouping can serve: it is
 //! keyed by child while the unbind that retires a bind is keyed by parent, so
-//! its rows are decided one at a time by a point read into the job's snapshot
+//! its rows are decided one at a time by a point read into the merge's snapshot
 //! ([`super::streaming_compaction`]) and it holds no state here at all.
 
 use super::frozen_floor::{bind_survives_frozen_floor, BindingGeneration};
@@ -53,7 +52,7 @@ pub(super) enum RetentionRule {
     /// A bind and the unbinds of its own generation, decided together.
     ForwardBindings,
     /// Reverse bind rows, each decided by a point read into the snapshot.
-    /// The operator holds nothing; the job does the reading.
+    /// The operator holds nothing; the merge does the reading.
     ReverseBindProbe,
 }
 
@@ -69,16 +68,16 @@ impl RetentionRule {
             Self::ForwardBindings => {
                 RetentionOperator::ForwardBindings(BindingRetention::default())
             }
-            // The reverse index is decided one row at a time by the job,
+            // The reverse index is decided one row at a time by the merge,
             // which is the only thing that can read the snapshot, so this
-            // rule has no state of its own to run. The job still opens and
+            // rule has no state of its own to run. The merge still opens and
             // closes groups over it, and both are nothing to do.
             Self::ReverseBindProbe => RetentionOperator::KeepEveryRow,
         }
     }
 }
 
-/// The state one cluster's rule holds while the job streams through it.
+/// The state one cluster's rule holds while a merge streams through it.
 #[derive(Debug)]
 pub(super) enum RetentionOperator {
     KeepEveryRow,
@@ -131,7 +130,7 @@ impl RetentionOperator {
 
     /// How many rows this operator is holding right now.
     ///
-    /// This is the number the job's peak counter tracks, and the thing the
+    /// This is the number the merge's peak counter tracks, and the thing the
     /// resource tests assert stays small however many revisions one inode has
     /// or however many generations one name slot has.
     pub(super) fn held_rows(&self) -> usize {
@@ -191,7 +190,7 @@ impl AttributeRetention {
         // without gaps or repeats, so "the newest at or below the floor"
         // names exactly one row. Two rows sharing a number would make the
         // choice arbitrary and the drop unsafe; refuse to compact state that
-        // violates it, exactly as the whole-group fold does.
+        // violates it.
         if self.previous_at_floor == Some(*attributes_revision_no) {
             return Err(CoreError::NamespaceCorrupt(format!(
                 "inode `{inode_id}` has two attribute rows at revision \
@@ -267,7 +266,7 @@ pub(super) struct BindingRetention {
     held_bind: Option<MetadataRow>,
     /// The generations this group's unbinds retired at or below the floor.
     /// One entry at most — every unbind in the group names the same
-    /// generation — and it is the same set a whole-group fold builds, so both
+    /// generation — and it is the set both bind families are judged against, so
     /// bind families reach `bind_survives_frozen_floor` by the same route.
     unbound_at_floor: BTreeSet<BindingGeneration>,
     /// The one bind at or below the floor in this slot that nothing retired,
@@ -449,7 +448,7 @@ mod tests {
     }
 
     /// The rule refuses a history where "the newest at the floor" is
-    /// ambiguous, exactly as the whole-group fold does.
+    /// ambiguous.
     #[test]
     fn two_attribute_rows_at_one_revision_below_the_floor_are_refused() {
         let mut operator = RetentionRule::Attributes.operator();

--- a/crates/loonfs-core/src/checkpoint/frozen_floor.rs
+++ b/crates/loonfs-core/src/checkpoint/frozen_floor.rs
@@ -1,13 +1,12 @@
 //! The frozen floor's shared rules: what a binding generation is, which ones
 //! an unbind retires, and whether a bind row survives.
 //!
-//! Two things fold rows below the retention floor, and they are peers. A
-//! bounded merge holds every row of its window and decides them together
-//! ([`super::reorganize`]). A streaming compaction cannot hold them and runs
-//! the same rules as streaming operators instead
-//! ([`super::compaction_retention`]). Neither owns the policy, so it lives
-//! here, and the equivalence oracle in the tests is what says the two reach
-//! the same rows.
+//! One engine folds rows below the retention floor
+//! ([`super::streaming_compaction`]), and it reaches these rules by two routes.
+//! A forward bind row is decided against the unbinds of its own locality group
+//! ([`super::compaction_retention`]); a reverse bind row is keyed by child, so
+//! its unbinds are point-read out of the same snapshot instead. Neither route
+//! owns the policy, so it lives here and both call it.
 
 use loonfs_api::wire::manifest::MetadataRow;
 use loonfs_api::{ChangeSeq, InodeId, NameKey};
@@ -24,8 +23,7 @@ pub(super) type BindingGeneration = (InodeId, NameKey, ChangeSeq, u32);
 /// The binding generations an unbind at or below `retention_floor_seq`
 /// retires.
 ///
-/// A whole-group fold builds this from every unbind row it merged. A
-/// streaming compaction builds it one binding generation at a time, from that
+/// The merge builds this one binding generation at a time, from that
 /// generation's own unbinds: a bind's row key is its generation and an
 /// unbind's key leads with the generation it retires, so the rows of one
 /// generation hold both halves of the pair.
@@ -33,37 +31,50 @@ pub(super) fn unbindings_at_or_below_floor(
     unbind_rows: &[MetadataRow],
     retention_floor_seq: ChangeSeq,
 ) -> BTreeSet<BindingGeneration> {
-    let mut unbound_at_floor = BTreeSet::new();
-    for row in unbind_rows {
-        if let MetadataRow::DirentryUnbind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            unbind_seq,
-            ..
-        } = row
-        {
-            if *unbind_seq <= retention_floor_seq {
-                unbound_at_floor.insert((
-                    *parent_inode_id,
-                    name_key.clone(),
-                    *bind_seq,
-                    *bind_delta_index,
-                ));
-            }
-        }
-    }
-    unbound_at_floor
+    unbind_rows
+        .iter()
+        .filter_map(|row| unbinding_at_or_below_floor(row, retention_floor_seq))
+        .collect()
+}
+
+/// The binding generation this row retires at or below `retention_floor_seq`,
+/// or `None` when it retires none.
+///
+/// The per-row half of [`unbindings_at_or_below_floor`], for a caller that
+/// meets unbind rows one at a time in a merged stream rather than holding a
+/// slice of them. Both spellings of the set are this one rule.
+pub(super) fn unbinding_at_or_below_floor(
+    row: &MetadataRow,
+    retention_floor_seq: ChangeSeq,
+) -> Option<BindingGeneration> {
+    let MetadataRow::DirentryUnbind {
+        parent_inode_id,
+        name_key,
+        bind_seq,
+        bind_delta_index,
+        unbind_seq,
+        ..
+    } = row
+    else {
+        return None;
+    };
+    (*unbind_seq <= retention_floor_seq).then(|| {
+        (
+            *parent_inode_id,
+            name_key.clone(),
+            *bind_seq,
+            *bind_delta_index,
+        )
+    })
 }
 
 /// Whether one bind row survives the frozen floor.
 ///
 /// A bind above the floor always survives. At or below it the bind survives
 /// exactly when nothing retired it, because a bind is only ever superseded by
-/// an operation that also unbinds it — the writer invariant
-/// `refuse_superseded_bind_without_unbind` in [`super::reorganize`] refuses to
-/// compact without.
+/// an operation that also unbinds it — the forward binding operator refuses to
+/// compact a slot where that does not hold
+/// (`super::compaction_retention::BindingRetention::check_the_slot_invariant`).
 ///
 /// Both bind families read this same rule, which is what keeps them dropping
 /// in lockstep: the format gives every bind row exactly one reverse row, and a

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -46,9 +46,6 @@ pub(crate) use super::tests::inspection_materialization::{
     load_manifest_materialization_for_inspection,
     load_manifest_metadata_state_for_inspection_from_manifest,
 };
-pub(super) use super::validate::{
-    validate_direntry_child_bind_index, validate_revision_by_inode_desc_index,
-};
 
 pub(super) fn ensure_root_matches_manifest(
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -12,6 +12,13 @@
 //! read each other; revisions travel with their descending index so index
 //! parity holds within every unit.
 //!
+//! The merging itself is not here. A step drives the same engine a background
+//! compaction drives ([`super::streaming_compaction`]), synchronously and with
+//! nothing around it: no lease, no job, no registry, no admission, and output
+//! written at ordinary table keys because the publication that names it is the
+//! step's own. What the step owns is choosing the window, publishing the
+//! result, and reporting what it did.
+//!
 //! A merge writes a base-tier run when, and only when, its window starts at
 //! the group's oldest run. That is the same condition retention dropping
 //! needs, so the level a run carries and the rules that produced it say the
@@ -52,42 +59,28 @@
 //! either reporting that the namespace needs one or running it.
 
 use super::block_fetch::load_segment_index_for_reorganization;
-use super::build::{
-    build_manifest_tables_from_rows, debug_assert_manifest_table_segments_do_not_overlap,
-    MetadataTableSegmentation,
-};
 use super::error::ManifestLoadError;
 use super::flush::{ensure_metadata_publication_budget, next_manifest_id_after};
-use super::frozen_floor::{
-    bind_survives_frozen_floor, unbindings_at_or_below_floor, BindingGeneration,
-};
-use super::load::{
-    load_verified_manifest_tables, validate_direntry_child_bind_index,
-    validate_revision_by_inode_desc_index,
-};
+use super::load::load_verified_manifest_tables;
 use super::publish::{
     manifest_write_failure, publish_metadata_root, write_namespace_manifest,
     ManifestPublicationOutcome,
 };
 use super::runs::{
-    flatten_manifest_tables, l0_run_count, MetadataFamilyGroup, MetadataLsmPolicy,
-    MetadataRunManifest, CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL,
-    REORGANIZE_FAMILY_GROUPS,
+    l0_run_count, MetadataFamilyGroup, MetadataLsmPolicy, MetadataRunManifest,
+    CHECKPOINT_BASE_RUN_LEVEL, CHECKPOINT_L0_RUN_LEVEL, REORGANIZE_FAMILY_GROUPS,
 };
 use super::scan::VerifiedMetadataTables;
-use super::streaming_compaction::MetadataCompactionSpec;
+use super::streaming_compaction::{merge_group_in_step, MetadataCompactionSpec};
 use crate::context::MutationContext;
 use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::{read_head_object, read_metadata_root_object_if_present};
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::wire::manifest::{
-    ActiveDeletionRowAction, MetadataFileRef, MetadataRow, MetadataTableFamily,
-    NamespaceManifestEnvelope, NamespaceManifestPayload,
+    MetadataFileRef, NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
-use loonfs_api::{
-    AttributeRevisionNo, ChangeSeq, InodeId, ManifestId, ManifestObjectId, NamespaceId,
-};
+use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -344,69 +337,22 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         }
     };
 
-    // Merge only the selected complete runs. The scan reads exactly the
-    // manifest's tables — never the WAL tail — and the unselected
-    // descriptors remain in the replacement manifest unchanged.
-    let mut rows_by_family = BTreeMap::<MetadataTableFamily, Vec<MetadataRow>>::new();
-    for family in group.families() {
-        let rows = tables
-            .scan_prefix_in_runs(&input.runs, *family, "")
-            .await
-            .map_err(|error| {
-                CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-            })?;
-        rows_by_family.insert(*family, rows);
-    }
-    // The paired groups exist to preserve index parity; verify it on the
-    // selected complete runs before writing anything.
-    if group.contains(MetadataTableFamily::DirentryBinds) {
-        validate_direntry_child_bind_index(
-            root.manifest_object_id.as_ref(),
-            rows_by_family
-                .get(&MetadataTableFamily::DirentryBinds)
-                .map_or(&[], Vec::as_slice),
-            rows_by_family
-                .get(&MetadataTableFamily::DirentryChildBinds)
-                .map_or(&[], Vec::as_slice),
-        )
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-        })?;
-    }
-    if group.contains(MetadataTableFamily::Revisions) {
-        validate_revision_by_inode_desc_index(
-            root.manifest_object_id.as_ref(),
-            rows_by_family
-                .get(&MetadataTableFamily::Revisions)
-                .map_or(&[], Vec::as_slice),
-            rows_by_family
-                .get(&MetadataTableFamily::RevisionsByInodeDesc)
-                .map_or(&[], Vec::as_slice),
-        )
-        .map_err(|error| {
-            CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(error))
-        })?;
-    }
-    // Dropping is only visibility-preserving over a merge that starts at the
-    // group's oldest run, which is what the placement records. A window that
-    // had to skip older runs merges them exactly as they are, so its output
-    // holds every row its inputs held.
-    if input.placement.may_drop_rows_below_the_retention_floor() {
-        drop_rows_below_retention_floor(&mut rows_by_family, floor_seq)?;
-    }
-
-    let run_tables = build_manifest_tables_from_rows(
+    // Merge only the selected complete runs, through the one engine both
+    // reorganization paths run ([`super::streaming_compaction`]). It reads
+    // exactly the manifest's tables — never the WAL tail — and the unselected
+    // descriptors remain in the replacement manifest unchanged. Whether it
+    // drops rows follows from the placement, and its segments go to ordinary
+    // table keys because this step publishes them below.
+    let merged = merge_group_in_step(
         store,
         namespace_id,
-        input.placement.output_seq(),
-        input.placement.output_level(),
-        |family| rows_by_family.remove(&family).unwrap_or_default(),
-        MetadataTableSegmentation::Base {
-            max_rows_per_segment: policy.max_rows_per_segment,
-        },
+        group,
+        &input.runs,
+        input.placement,
+        floor_seq,
+        policy,
     )
     .await?;
-    debug_assert_manifest_table_segments_do_not_overlap(&run_tables);
 
     let mut metadata_files: Vec<_> = previous
         .payload
@@ -420,7 +366,7 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         })
         .cloned()
         .collect();
-    metadata_files.extend(flatten_manifest_tables(run_tables));
+    metadata_files.extend(merged.output_segments);
     // `base_seq` is the manifest's oldest-run marker: every referenced run
     // must sit at or above it, including L0 runs other groups have not
     // folded yet.
@@ -1018,252 +964,4 @@ pub(super) async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
         .await
         .map_err(manifest_write_failure)?;
     Ok(manifest)
-}
-
-/// Drops rows that no retained sequence can observe (format spec,
-/// "Compaction"). Conservative subset: superseded or unbound bindings and
-/// spent unbind markers at or below the retention floor, and cancelled
-/// active-deletion pairs. Revision rows are never dropped — file history is
-/// durable data retained independently of the replay floor — and tombstone
-/// and inode rows are always retained until reachability-based dropping is
-/// designed.
-///
-/// A bounded merge holds every row of its window, so this reads them all at
-/// once. A streaming compaction cannot hold them, and runs the same rules as
-/// streaming operators instead ([`super::compaction_retention`]); the
-/// equivalence oracle in the tests is what says the two reach the same rows.
-pub(super) fn drop_rows_below_retention_floor(
-    rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
-    retention_floor_seq: ChangeSeq,
-) -> Result<()> {
-    let unbound_at_floor = unbindings_at_or_below_floor(
-        rows_by_family
-            .get(&MetadataTableFamily::DirentryUnbinds)
-            .map_or(&[], Vec::as_slice),
-        retention_floor_seq,
-    );
-    drop_rows_below_frozen_floor(rows_by_family, retention_floor_seq, &unbound_at_floor)
-}
-
-/// [`drop_rows_below_retention_floor`] against an unbind set the caller
-/// already built, so the retention floor and the unbind set that goes with it
-/// are stated once for the whole window.
-fn drop_rows_below_frozen_floor(
-    rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
-    retention_floor_seq: ChangeSeq,
-    unbound_at_floor: &BTreeSet<BindingGeneration>,
-) -> Result<()> {
-    refuse_superseded_bind_without_unbind(
-        rows_by_family
-            .get(&MetadataTableFamily::DirentryBinds)
-            .map_or(&[], Vec::as_slice),
-        retention_floor_seq,
-        unbound_at_floor,
-    )?;
-    for family in [
-        MetadataTableFamily::DirentryBinds,
-        MetadataTableFamily::DirentryChildBinds,
-    ] {
-        if let Some(rows) = rows_by_family.get_mut(&family) {
-            rows.retain(|row| {
-                bind_survives_frozen_floor(row, retention_floor_seq, unbound_at_floor)
-            });
-        }
-    }
-    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::DirentryUnbinds) {
-        rows.retain(|row| match row {
-            MetadataRow::DirentryUnbind { unbind_seq, .. } => *unbind_seq > retention_floor_seq,
-            _ => true,
-        });
-    }
-
-    // Active deletions are current state, not history, so the retention
-    // floor has NO say over them: a deletion stays listed and recoverable
-    // however far the floor advances — that is the product promise, and
-    // dropping a row at the floor would silently retire a recoverable
-    // deletion. The only rows that go are the pairs that cancelled each
-    // other. A removal marker's listed row is always in the same merged set:
-    // the deletion commits before the undelete, runs merge oldest-first, and
-    // the selected subset is a prefix of that order, so a marker can never
-    // outlive the row it names. A streaming compaction groups the family by
-    // deletion identity, which is the pair's shared key prefix, so the pair
-    // lands in one group there too.
-    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::ActiveDeletions) {
-        let revoked: BTreeSet<(ChangeSeq, InodeId)> = rows
-            .iter()
-            .filter_map(|row| match row {
-                MetadataRow::ActiveDeletion {
-                    root_inode_id,
-                    deleted_at_seq,
-                    action: ActiveDeletionRowAction::Removed { .. },
-                } => Some((*deleted_at_seq, *root_inode_id)),
-                _ => None,
-            })
-            .collect();
-        rows.retain(|row| match row {
-            MetadataRow::ActiveDeletion {
-                root_inode_id,
-                deleted_at_seq,
-                action,
-            } => match action {
-                ActiveDeletionRowAction::Removed { .. } => false,
-                ActiveDeletionRowAction::Listed { .. } => {
-                    !revoked.contains(&(*deleted_at_seq, *root_inode_id))
-                }
-            },
-            _ => true,
-        });
-    }
-
-    // The idempotency horizon is the retention floor: a receipt dropped
-    // here makes its id indistinguishable from one never used, so a commit
-    // retried from below the floor commits AGAIN as a new mutation (format
-    // spec §3.3; pinned by `a_retry_past_the_receipt_horizon_commits_again`).
-    // Replay is guaranteed exactly as long as retained history.
-    if let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::CommitReceipts) {
-        rows.retain(|row| match row {
-            MetadataRow::CommitReceipt { committed_seq, .. } => {
-                *committed_seq >= retention_floor_seq
-            }
-            _ => true,
-        });
-    }
-
-    drop_superseded_attribute_revisions(rows_by_family, retention_floor_seq)?;
-    Ok(())
-}
-
-/// Refuses to compact bind rows that break the writer invariant the drop
-/// rests on.
-///
-/// At the floor only the latest bind per (parent, name) slot is visible, and a
-/// bind is only ever superseded by an operation that also unbinds it. So every
-/// non-latest bind at or below the floor must have a matching unbind at or
-/// below the floor. Where that does not hold, dropping by
-/// [`bind_survives_frozen_floor`] would keep a bind no read can reach and call
-/// it live, so the compaction stops instead.
-fn refuse_superseded_bind_without_unbind(
-    bind_rows: &[MetadataRow],
-    retention_floor_seq: ChangeSeq,
-    unbound_at_floor: &BTreeSet<BindingGeneration>,
-) -> Result<()> {
-    let mut latest_bind_at_floor = BTreeMap::new();
-    for row in bind_rows {
-        if let MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            ..
-        } = row
-        {
-            if *bind_seq <= retention_floor_seq {
-                let candidate = (*bind_seq, *bind_delta_index);
-                let latest = latest_bind_at_floor
-                    .entry((*parent_inode_id, name_key.clone()))
-                    .or_insert(candidate);
-                if candidate > *latest {
-                    *latest = candidate;
-                }
-            }
-        }
-    }
-    for row in bind_rows {
-        if let MetadataRow::DirentryBind {
-            parent_inode_id,
-            name_key,
-            bind_seq,
-            bind_delta_index,
-            ..
-        } = row
-        {
-            if *bind_seq <= retention_floor_seq
-                && latest_bind_at_floor.get(&(*parent_inode_id, name_key.clone()))
-                    != Some(&(*bind_seq, *bind_delta_index))
-                && !unbound_at_floor.contains(&(
-                    *parent_inode_id,
-                    name_key.clone(),
-                    *bind_seq,
-                    *bind_delta_index,
-                ))
-            {
-                return Err(CoreError::NamespaceCorrupt(format!(
-                    "bind at seq `{bind_seq}` delta {bind_delta_index} for parent `{parent_inode_id}` is superseded at or below the retention floor without an unbind; refusing to drop rows"
-                )));
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Keeps every attribute revision above the retention floor, plus the newest
-/// revision at or below it per inode, and drops the rest.
-///
-/// An attribute revision is current state, not history: the newest one for an
-/// inode is what every read answers with, and no retained sequence can
-/// observe an older one once a newer one is at or below the floor. The
-/// newest-at-floor row is kept even when its map is empty, because an empty
-/// map is the cleared state — dropping it would let an older non-empty map
-/// become the newest row and resurrect attributes a caller cleared.
-///
-/// Attributes are never dropped for being unreachable. A deleted inode keeps
-/// its rows, the same posture inode and tombstone rows take, and that is what
-/// makes an undelete give back the map the inode had.
-///
-/// The rule reads one inode's rows and no others, and reads them newest
-/// first, so a streaming compaction reaches the same answer holding two
-/// fields instead of the inode's history.
-fn drop_superseded_attribute_revisions(
-    rows_by_family: &mut BTreeMap<MetadataTableFamily, Vec<MetadataRow>>,
-    retention_floor_seq: ChangeSeq,
-) -> Result<()> {
-    let Some(rows) = rows_by_family.get_mut(&MetadataTableFamily::Attributes) else {
-        return Ok(());
-    };
-    // Writer invariant: one inode's attribute revisions are
-    // numbered without gaps or repeats, so "the newest at or below the floor"
-    // names exactly one row. Two rows sharing a number would make the choice
-    // arbitrary and the drop unsafe; refuse to compact state that violates
-    // it.
-    let mut newest_at_floor = BTreeMap::<InodeId, AttributeRevisionNo>::new();
-    let mut seen_at_floor = BTreeSet::<(InodeId, AttributeRevisionNo)>::new();
-    for row in rows.iter() {
-        let MetadataRow::AttributesRevision {
-            inode_id,
-            attributes_revision_no,
-            committed_seq,
-            ..
-        } = row
-        else {
-            continue;
-        };
-        if *committed_seq > retention_floor_seq {
-            continue;
-        }
-        if !seen_at_floor.insert((*inode_id, *attributes_revision_no)) {
-            return Err(CoreError::NamespaceCorrupt(format!(
-                "inode `{inode_id}` has two attribute rows at revision `{attributes_revision_no}` at or below the retention floor; refusing to drop rows"
-            )));
-        }
-        let newest = newest_at_floor
-            .entry(*inode_id)
-            .or_insert(*attributes_revision_no);
-        if attributes_revision_no > newest {
-            *newest = *attributes_revision_no;
-        }
-    }
-
-    rows.retain(|row| match row {
-        MetadataRow::AttributesRevision {
-            inode_id,
-            attributes_revision_no,
-            committed_seq,
-            ..
-        } => {
-            *committed_seq > retention_floor_seq
-                || newest_at_floor.get(inode_id) == Some(attributes_revision_no)
-        }
-        _ => true,
-    });
-    Ok(())
 }

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -36,8 +36,8 @@ pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 10] = [
 /// One set of families whose rows merge in one reorganization unit.
 ///
 /// Families that read each other's rows to decide what to drop (see
-/// `super::reorganize::drop_rows_below_retention_floor`) must compact
-/// together, and a secondary index always travels with its canonical family.
+/// `super::compaction_retention`) must compact together, and a secondary index
+/// always travels with its canonical family.
 ///
 /// This is a closed enum rather than a list of family slices because every
 /// caller wants the group itself, not a slice it has to recognize by

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -111,20 +111,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         ))
     }
 
-    /// Scans only `runs`, for a reorganization unit that is replacing that
-    /// complete run subset while leaving every other descriptor untouched.
-    pub(super) async fn scan_prefix_in_runs(
-        &self,
-        runs: &[MetadataRunManifest],
-        family: MetadataTableFamily,
-        prefix: &str,
-    ) -> Result<Vec<MetadataRow>, ManifestLoadError> {
-        Ok(strip_row_keys(
-            self.scan_prefix_rows_in_runs(runs, family, prefix, None, Readahead::Disabled)
-                .await?,
-        ))
-    }
-
     /// [`Self::scan_prefix`] for a point lookup: `filter_probe` is the
     /// family's exact filter key for the value being looked up, so each
     /// candidate segment's bloom filter is consulted before its index or
@@ -170,7 +156,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
             return Ok(Vec::new());
         }
         self.scan_range_page_rows(
-            self.scan_runs.as_ref(),
             family,
             lower_bound,
             upper_bound,
@@ -196,7 +181,6 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         }
         Ok(strip_row_keys(
             self.scan_range_page_rows(
-                self.scan_runs.as_ref(),
                 family,
                 lower_bound,
                 upper_bound,
@@ -217,27 +201,8 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         filter_probe: Option<&str>,
         readahead: Readahead,
     ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
-        self.scan_prefix_rows_in_runs(
-            self.scan_runs.as_ref(),
-            family,
-            prefix,
-            filter_probe,
-            readahead,
-        )
-        .await
-    }
-
-    async fn scan_prefix_rows_in_runs(
-        &self,
-        runs: &[MetadataRunManifest],
-        family: MetadataTableFamily,
-        prefix: &str,
-        filter_probe: Option<&str>,
-        readahead: Readahead,
-    ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
         let upper_bound = string_prefix_upper_bound(prefix);
         self.scan_range_page_rows(
-            runs,
             family,
             prefix,
             upper_bound.as_deref(),
@@ -278,10 +243,8 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn scan_range_page_rows(
         &self,
-        runs: &[MetadataRunManifest],
         family: MetadataTableFamily,
         lower_bound: &str,
         upper_bound: Option<&str>,
@@ -290,7 +253,7 @@ impl<S: ObjectStore + ?Sized> VerifiedMetadataTables<'_, S> {
         readahead: Readahead,
     ) -> Result<Vec<(String, MetadataRow)>, ManifestLoadError> {
         let mut candidates = Vec::new();
-        for run in runs {
+        for run in self.scan_runs.iter() {
             let table = manifest_table_for_family(&self.manifest_object_key, &run.tables, family)?;
             candidates.extend(table.segments.iter().filter(|descriptor| {
                 descriptor_may_intersect_range(descriptor, lower_bound, upper_bound)

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -1,39 +1,44 @@
-//! Rebuilding one family group in a single streaming job.
+//! The merge engine both reorganization paths run, and the background job
+//! that is one of them.
 //!
-//! A bounded merge reads every row of its window into memory, so a group
-//! whose bottom-anchored window no longer fits one step's budgets can never
-//! fold from its bottom again: its base is frozen and its retention stops
-//! ([`super::reorganize`] reports that, loudly). Such a group is rebuilt
-//! here instead, by one job that reads every run it holds and is paced by no
-//! budget at all.
+//! [`GroupMerge`] merges one family group. It opens one iterator per run per
+//! family and merges them in row-key order ([`super::compaction_merge`]),
+//! feeds the merged rows through streaming retention operators
+//! ([`super::compaction_retention`]), and writes each output segment as it
+//! fills ([`super::compaction_output`]). What it holds at any instant is a
+//! fixed number of decoded input blocks per iterator, the fixed state of one
+//! retention operator, and one segment builder per family of the group. No
+//! family, no partition, no directory, no inode's history, and no name slot's
+//! generations are ever collected whole, so nothing it holds follows the size
+//! of what it merges.
 //!
-//! Nothing about the job follows the size of the group. It opens one iterator
-//! per run per family and merges them in row-key order
-//! ([`super::compaction_merge`]), feeds the merged rows through streaming
-//! retention operators ([`super::compaction_retention`]), and writes each
-//! output segment as it fills ([`super::compaction_output`]). What it holds at
-//! any instant is a fixed number of decoded input blocks per iterator, the
-//! fixed state of one retention operator, and one segment builder per family
-//! of the group. No family, no partition, no directory, no inode's history,
-//! and no name slot's generations are ever collected whole.
+//! Rows are dropped when, and only when, the merge's [`MergePlacement`] is
+//! `Base`. That is the placement rule already: a window that starts at the
+//! group's oldest run holds every row a drop could need to read, and a window
+//! above the base does not, so a merge above the base is a pure rewrite.
 //!
-//! What is left here is the job itself: the plan, the loop that drives those
-//! three, and the one publication that swaps the rebuilt run in.
+//! Two callers drive the engine, and they differ in orchestration rather than
+//! in merging.
 //!
-//! Output segments go to the job's own prefix rather than to
-//! `metadata/tables/` (format spec, "Compaction"): a job outlives the
+//! [`merge_group_in_step`] runs it synchronously inside one maintenance step.
+//! The step's budgets chose the window and the step publishes the result, so
+//! the segments go to `metadata/tables/` and there is no lease, no job, no
+//! registry, and no admission.
+//!
+//! [`run_metadata_compaction_job`] runs it as a background task the
+//! maintenance runner owns, for a group whose bottom-anchored window no longer
+//! fits one step's budgets — a group whose base is frozen and whose retention
+//! has stopped ([`super::reorganize`] reports that, loudly). Nothing paces that
+//! work, so it needs everything the step-contained merge does not: admission, a
+//! staging prefix, and a lease over what it writes there. Its segments go to
+//! the job's own prefix (format spec, "Compaction") because a job outlives the
 //! collector's grace window, so its output would otherwise look exactly like
-//! the unreferenced aged objects the collector reaps. What tells the collector
-//! the difference is the lease beside them ([`super::compaction_lease`]),
-//! which the job rewrites while it runs. The executor publishes nothing
-//! itself. It returns the descriptors it wrote, and
-//! [`run_metadata_compaction_job`] swaps them in with one manifest
-//! publication; a cancelled or crashed job leaves staged objects nothing
-//! references and the old manifest still valid.
-//!
-//! The job runs as a background task the maintenance runner owns. The step
-//! that plans it starts it and returns; the runner cancels it on shutdown and
-//! joins it with the rest of its background work.
+//! the unreferenced aged objects the collector reaps; the lease beside them
+//! ([`super::compaction_lease`]) is what tells the collector the difference. It
+//! publishes nothing until it is finished, and a cancelled or crashed job
+//! leaves staged objects nothing references and the old manifest still valid.
+//! The step that plans it starts it and returns; the runner cancels it on
+//! shutdown and joins it with the rest of its background work.
 
 use super::block_fetch::load_segment_filter;
 use super::block_load::SessionBlockMemo;
@@ -42,11 +47,14 @@ use super::compaction_lease::{CompactionLease, LeaseHold};
 use super::compaction_merge::{
     locality_of, refill_iterators, select_next_iterator, LocalityGrouping, SegmentRowIterator,
 };
-use super::compaction_output::StagedSegmentWriter;
+use super::compaction_output::{MergeOutput, MergeSegmentWriter};
 use super::compaction_retention::{KeptRow, RetentionRule};
 use super::error::ManifestLoadError;
 use super::flush::ensure_metadata_publication_budget;
-use super::frozen_floor::{bind_survives_frozen_floor, unbindings_at_or_below_floor};
+use super::frozen_floor::{
+    bind_survives_frozen_floor, unbinding_at_or_below_floor, unbindings_at_or_below_floor,
+    BindingGeneration,
+};
 use super::load::{
     load_manifest_segment_rows_in_key_range_with_cache, load_verified_manifest_tables,
 };
@@ -171,12 +179,6 @@ impl MetadataCompactionSpec {
         &self.inputs
     }
 
-    /// Where this job's output stands in the group, which decides the level
-    /// and sequence every segment it writes carries.
-    pub(super) fn placement(&self) -> MergePlacement {
-        self.placement
-    }
-
     pub(super) fn frozen_floor_seq(&self) -> ChangeSeq {
         self.frozen_floor_seq
     }
@@ -261,7 +263,7 @@ impl MetadataCompactionCancellation {
 /// How a job ended.
 #[derive(Debug)]
 pub(super) enum MetadataCompactionOutcome {
-    Completed(MetadataCompactionResult),
+    Completed(MetadataMergeResult),
     /// The cancellation token was set. Whatever the job had written stays
     /// staged and unreferenced.
     Cancelled,
@@ -271,23 +273,84 @@ pub(super) enum MetadataCompactionOutcome {
     Fenced,
 }
 
-/// What one finished job built, held in memory until the caller publishes it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct MetadataCompactionResult {
-    /// The output run's segment descriptors, naming their staged object keys.
+/// What one finished merge built, held in memory until the caller publishes
+/// it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct MetadataMergeResult {
+    /// The output run's segment descriptors, naming the object keys the merge
+    /// wrote them to.
     pub(super) output_segments: Vec<MetadataFileRef>,
     pub(super) rows_read: u64,
     pub(super) rows_written: u64,
     pub(super) rows_written_by_family: BTreeMap<MetadataTableFamily, u64>,
     /// Point reads into the snapshot's unbind family, one per reverse bind
-    /// row at or below the frozen floor.
+    /// row at or below the frozen floor. Zero for a merge that resolves the
+    /// reverse index from what it streamed
+    /// ([`ReverseBindResolution::CollectedUnbinds`]).
     pub(super) unbind_probes: u64,
-    /// The most decoded input blocks the job's iterators held at once, and
+    /// Generation identities such a merge collected, which is what its reverse
+    /// resolution holds instead of making those reads. Bounded by the below-
+    /// floor unbind rows in the window, and therefore by the step's budgets.
+    pub(super) collected_unbind_generations: usize,
+    /// The most decoded input blocks the merge's iterators held at once, and
     /// the most rows one retention operator held. These are what bound the
-    /// job's memory, so tests assert they do not follow the size of the
+    /// merge's memory, so tests assert they do not follow the size of the
     /// group, of one inode's history, or of one name slot's generations.
     pub(super) peak_resident_blocks: usize,
     pub(super) peak_operator_rows: usize,
+}
+
+/// Merges one window of complete runs inside the maintenance step that
+/// selected it.
+///
+/// The engine is the job's engine. What this leaves out is everything the job
+/// needs because it outlives its step: there is no lease, no staging prefix,
+/// no registry entry, and no admission, and the segments are written at
+/// ordinary table keys because the step publishes them itself a moment later.
+///
+/// `runs` is the window the step's budgets chose, and `placement` is where its
+/// output stands in the group — which is also what decides whether rows may be
+/// dropped.
+pub(super) async fn merge_group_in_step<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
+    runs: &[MetadataRunManifest],
+    placement: MergePlacement,
+    frozen_floor_seq: ChangeSeq,
+    policy: MetadataLsmPolicy,
+) -> Result<MetadataMergeResult> {
+    // A step-contained merge has nothing to cancel it: it holds the step, and
+    // a shutdown waits for the step it is in.
+    let cancellation = MetadataCompactionCancellation::default();
+    let merge = GroupMerge::new(
+        store,
+        namespace_id,
+        group,
+        placement,
+        frozen_floor_seq,
+        MergeOutput::Tables,
+        policy,
+        &cancellation,
+        runs.to_vec(),
+        // The window is capped by the step's budgets, so the set of below-floor
+        // unbound generations is capped with it and costs no store reads.
+        ReverseBindResolution::CollectedUnbinds(BTreeSet::new()),
+        // A step-contained merge is bounded by the step's input budgets and
+        // ends in the step's own publication, so it has nothing to report
+        // progress about.
+        None,
+    );
+    match merge.run(None).await? {
+        MetadataCompactionOutcome::Completed(result) => Ok(result),
+        // Neither ending is reachable without a token to set and a lease to
+        // lose, and this merge has neither.
+        MetadataCompactionOutcome::Cancelled | MetadataCompactionOutcome::Fenced => {
+            Err(CoreError::Internal(
+                "a step-contained metadata merge cannot be cancelled or fenced".to_owned(),
+            ))
+        }
+    }
 }
 
 /// Rebuilds `spec`'s group from `spec`'s runs.
@@ -303,40 +366,23 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
     cancellation: &MetadataCompactionCancellation,
     lease: &mut CompactionLease<'_>,
 ) -> Result<MetadataCompactionOutcome> {
-    let snapshot = resolve_snapshot_runs(tables, spec)?;
-    let mut job = CompactionJob {
-        store: tables.store,
+    let merge = GroupMerge::new(
+        tables.store,
         namespace_id,
-        spec,
+        spec.group,
+        spec.placement,
+        spec.frozen_floor_seq,
+        MergeOutput::JobPrefix(spec.job_id()),
         policy,
         cancellation,
-        snapshot,
-        probe_cache: MetadataTableCache::new(MetadataTableCacheConfig {
-            max_decoded_bytes: PROBE_CACHE_DECODED_BYTES,
-        }),
-        result: MetadataCompactionResult {
-            output_segments: Vec::new(),
-            rows_read: 0,
-            rows_written: 0,
-            rows_written_by_family: BTreeMap::new(),
-            unbind_probes: 0,
-            peak_resident_blocks: 0,
-            peak_operator_rows: 0,
-        },
-        canonical_digest: RowDigest::default(),
-        index_digest: RowDigest::default(),
-        next_progress_rows: PROGRESS_ROW_INTERVAL,
-    };
-
-    for cluster in retention_clusters(spec.group) {
-        match job.run_cluster(cluster, lease).await? {
-            ClusterEnd::Merged => {}
-            ClusterEnd::Cancelled => return Ok(MetadataCompactionOutcome::Cancelled),
-            ClusterEnd::Fenced => return Ok(MetadataCompactionOutcome::Fenced),
-        }
-    }
-    job.refuse_a_run_whose_index_disagrees()?;
-    Ok(MetadataCompactionOutcome::Completed(job.result))
+        resolve_snapshot_runs(tables, spec)?,
+        // A job has no bound on the group it rebuilds, so it reads the
+        // snapshot per reverse row rather than holding a set that would follow
+        // the group's size.
+        ReverseBindResolution::PointProbeSnapshot,
+        Some(spec.input_rows()),
+    );
+    merge.run(Some(lease)).await
 }
 
 /// How one cluster's merge ended.
@@ -572,7 +618,7 @@ pub(super) async fn finalize_metadata_compaction<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     spec: &MetadataCompactionSpec,
     snapshot_keys: &BTreeSet<String>,
-    result: MetadataCompactionResult,
+    result: MetadataMergeResult,
     cancellation: &MetadataCompactionCancellation,
     lease: &mut CompactionLease<'_>,
 ) -> Result<Finalization> {
@@ -727,18 +773,65 @@ pub(super) fn snapshot_segment_keys<S: ObjectStore + ?Sized>(
     Some(keys)
 }
 
-/// One set of families the job merges and judges together, and how it groups
-/// their rows while doing it.
-struct RetentionCluster {
-    families: &'static [MetadataTableFamily],
-    locality: LocalityGrouping,
-    rule: RetentionRule,
+/// How a merge decides whether a reverse bind row survives the frozen floor.
+///
+/// The reverse index is keyed by child while the unbind that retires a bind is
+/// keyed by parent, so no grouping of the merged stream holds a reverse row
+/// together with its unbind. Both answers below come from the same rule
+/// ([`bind_survives_frozen_floor`]) against the same set
+/// ([`unbinding_at_or_below_floor`]); they differ only in where the set comes
+/// from, because the two orchestrations have different resource contracts.
+///
+/// This parameterizes the lookup and nothing else. Iteration, retention,
+/// segment writing, parity, and publication are the same code either way.
+enum ReverseBindResolution {
+    /// Read the unbinds of one binding out of the snapshot, one probe per
+    /// reverse row at or below the floor.
+    ///
+    /// What a background job uses. A job has no bound on the group it
+    /// rebuilds, so it must not hold a set that follows the group's size; a
+    /// bounded cache in front of the reads is the most it can keep.
+    PointProbeSnapshot,
+    /// Consult the below-floor unbound generations the forward cluster already
+    /// streamed past.
+    ///
+    /// What a merge inside a maintenance step uses. Its input is capped by the
+    /// step's row and decoded-byte budgets, so this set is capped by the same
+    /// budgets — it holds one generation identity per below-floor unbind in
+    /// the window, and never more than the window itself.
+    ///
+    /// The alternative costs one store round trip per reverse row once the
+    /// probe cache can no longer hold the window's unbind family. The row
+    /// budget admits about 43,000 unbind rows, which reaches the 16 MiB cache
+    /// at an ordinary name length, and the decoded-byte budget allows four
+    /// times that. Measured on a window whose unbind family just fills the
+    /// cache, with the reverse index walking it out of order: 65,536 reverse
+    /// rows cost 27,427 data reads and 309 MB transferred for 16 MB of priced
+    /// input, and doubling the family doubled both. This set is also the
+    /// smaller resident structure — one identity per below-floor unbind, well
+    /// under the cache it replaces.
+    ///
+    /// This is filled by the forward cluster, which
+    /// [`BINDINGS_CLUSTERS`] runs first for exactly that reason.
+    CollectedUnbinds(BTreeSet<BindingGeneration>),
+}
+
+/// One set of families the engine merges and judges together, and how it
+/// groups their rows while doing it.
+pub(super) struct RetentionCluster {
+    pub(super) families: &'static [MetadataTableFamily],
+    pub(super) locality: LocalityGrouping,
+    pub(super) rule: RetentionRule,
 }
 
 /// The bindings group merges its two forward families together, because an
 /// unbind retires the bind of its generation. The reverse index is keyed by
 /// child, so it shares no group with the rows it indexes and streams on its
 /// own.
+///
+/// The forward cluster is first, and must stay first: a merge resolving
+/// reverse rows from [`ReverseBindResolution::CollectedUnbinds`] fills that set
+/// while streaming the unbind family here.
 const BINDINGS_CLUSTERS: [RetentionCluster; 2] = [
     RetentionCluster {
         families: &[
@@ -789,7 +882,7 @@ const ATTRIBUTE_CLUSTERS: [RetentionCluster; 1] = [RetentionCluster {
     rule: RetentionRule::Attributes,
 }];
 
-fn retention_clusters(group: MetadataFamilyGroup) -> &'static [RetentionCluster] {
+pub(super) fn retention_clusters(group: MetadataFamilyGroup) -> &'static [RetentionCluster] {
     match group {
         MetadataFamilyGroup::Bindings => &BINDINGS_CLUSTERS,
         MetadataFamilyGroup::Revisions => &REVISION_CLUSTERS,
@@ -801,35 +894,167 @@ fn retention_clusters(group: MetadataFamilyGroup) -> &'static [RetentionCluster]
     }
 }
 
-struct CompactionJob<'a, S: ObjectStore + ?Sized> {
+/// Merging one family group: the shared engine, whatever is driving it.
+struct GroupMerge<'a, S: ObjectStore + ?Sized> {
     store: &'a S,
     namespace_id: &'a NamespaceId,
-    spec: &'a MetadataCompactionSpec,
+    group: MetadataFamilyGroup,
+    /// Where the output stands in the group, which decides the level and
+    /// sequence every segment carries and whether rows may be dropped at all.
+    placement: MergePlacement,
+    frozen_floor_seq: ChangeSeq,
+    output: MergeOutput<'a>,
     policy: MetadataLsmPolicy,
     cancellation: &'a MetadataCompactionCancellation,
     snapshot: Vec<MetadataRunManifest>,
+    reverse_binds: ReverseBindResolution,
     probe_cache: MetadataTableCache,
-    result: MetadataCompactionResult,
+    result: MetadataMergeResult,
     canonical_digest: RowDigest,
     index_digest: RowDigest,
-    /// The read count the next progress line is owed at.
-    next_progress_rows: u64,
+    /// The last input row key seen in each family, which is what lets the merge
+    /// refuse a family that holds one row key twice. One string per family.
+    last_input_key_by_family: BTreeMap<MetadataTableFamily, String>,
+    /// The rows the input runs hold, and the read count the next progress line
+    /// is owed at. `None` for a merge short enough to have nothing to report.
+    input_rows: Option<u64>,
+    next_progress_rows: Option<u64>,
 }
 
-impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
+impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        store: &'a S,
+        namespace_id: &'a NamespaceId,
+        group: MetadataFamilyGroup,
+        placement: MergePlacement,
+        frozen_floor_seq: ChangeSeq,
+        output: MergeOutput<'a>,
+        policy: MetadataLsmPolicy,
+        cancellation: &'a MetadataCompactionCancellation,
+        snapshot: Vec<MetadataRunManifest>,
+        reverse_binds: ReverseBindResolution,
+        input_rows: Option<u64>,
+    ) -> Self {
+        Self {
+            store,
+            namespace_id,
+            group,
+            placement,
+            frozen_floor_seq,
+            output,
+            policy,
+            cancellation,
+            snapshot,
+            reverse_binds,
+            probe_cache: MetadataTableCache::new(MetadataTableCacheConfig {
+                max_decoded_bytes: PROBE_CACHE_DECODED_BYTES,
+            }),
+            result: MetadataMergeResult::default(),
+            canonical_digest: RowDigest::default(),
+            index_digest: RowDigest::default(),
+            last_input_key_by_family: BTreeMap::new(),
+            input_rows,
+            next_progress_rows: input_rows.map(|_| PROGRESS_ROW_INTERVAL),
+        }
+    }
+
+    /// Merges every cluster of the group, in order.
+    ///
+    /// `lease` is the claim a caller that stages its output holds over it. A
+    /// merge that publishes inside its own step has none, and passes `None`.
+    async fn run(
+        mut self,
+        mut lease: Option<&mut CompactionLease<'_>>,
+    ) -> Result<MetadataCompactionOutcome> {
+        for cluster in retention_clusters(self.group) {
+            match self.run_cluster(cluster, lease.as_deref_mut()).await? {
+                ClusterEnd::Merged => {}
+                ClusterEnd::Cancelled => return Ok(MetadataCompactionOutcome::Cancelled),
+                ClusterEnd::Fenced => return Ok(MetadataCompactionOutcome::Fenced),
+            }
+        }
+        self.refuse_a_run_whose_index_disagrees()?;
+        Ok(MetadataCompactionOutcome::Completed(self.result))
+    }
+
+    /// Refuses a family that hands the merge one row key twice, and refuses a
+    /// merge that hands itself a family out of order.
+    ///
+    /// A metadata row key identifies one row. Nothing downstream re-checks
+    /// that: reads concatenate runs rather than deduplicating them, and the
+    /// segment builder rejects only a descending key, so two equal adjacent
+    /// keys travel into a published run and make the same logical event
+    /// answerable twice.
+    ///
+    /// This runs over the merge's input rather than its output, which is what
+    /// makes it see a duplicate retention would otherwise drop, a duplicate
+    /// split across two runs, and a duplicate split across two segments.
+    ///
+    /// It stands beside the output digests
+    /// ([`Self::refuse_a_run_whose_index_disagrees`]) because the two prove
+    /// different things. The digests say the two families of an index pair hold
+    /// the same rows as each other; a duplicate present on both sides passes
+    /// them, because both multisets still match. This says no family holds one
+    /// row key twice, whatever the other family holds.
+    ///
+    /// A key that goes backwards is not corruption in the store — the k-way
+    /// merge emits one family in row-key order — so that case is an internal
+    /// error against the merge itself.
+    fn refuse_a_repeated_input_key(
+        &mut self,
+        family: MetadataTableFamily,
+        row_key: &str,
+    ) -> Result<()> {
+        if let Some(previous) = self.last_input_key_by_family.get(&family) {
+            match row_key.cmp(previous.as_str()) {
+                std::cmp::Ordering::Greater => {}
+                std::cmp::Ordering::Equal => {
+                    return Err(CoreError::NamespaceCorrupt(format!(
+                        "metadata family `{family:?}` contains duplicate row key `{row_key}`; \
+                         refusing to merge it into a run"
+                    )));
+                }
+                std::cmp::Ordering::Less => {
+                    return Err(CoreError::Internal(format!(
+                        "metadata merge read row key `{row_key}` after `{previous}` in family \
+                         `{family:?}`"
+                    )));
+                }
+            }
+        }
+        self.last_input_key_by_family
+            .insert(family, row_key.to_owned());
+        Ok(())
+    }
+
+    /// Which rule decides this cluster's rows.
+    ///
+    /// Dropping is only visibility-preserving over a window that starts at the
+    /// group's oldest run, and the placement is what records that
+    /// ([`MergePlacement`]). A merge above the base merges its window exactly
+    /// as it stands, so every cluster keeps every row.
+    fn rule_for(&self, cluster: &RetentionCluster) -> RetentionRule {
+        if self.placement.may_drop_rows_below_the_retention_floor() {
+            cluster.rule
+        } else {
+            RetentionRule::KeepEveryRow
+        }
+    }
+
     /// Merges one cluster end to end.
     async fn run_cluster(
         &mut self,
         cluster: &RetentionCluster,
-        lease: &mut CompactionLease<'_>,
+        mut lease: Option<&mut CompactionLease<'_>>,
     ) -> Result<ClusterEnd> {
         // The descriptors are cloned out of the snapshot rather than borrowed
-        // from it: an iterator outlives every other borrow the job takes, and
+        // from it: an iterator outlives every other borrow the merge takes, and
         // a cluster opens one per run per family, which is a handful.
         let mut iterators = Vec::new();
         for run in &self.snapshot {
             for family in cluster.families {
-                let segments: Vec<MetadataFileRef> = group_run_descriptors(run, self.spec.group)
+                let segments: Vec<MetadataFileRef> = group_run_descriptors(run, self.group)
                     .filter(|descriptor| descriptor.family == *family)
                     .cloned()
                     .collect();
@@ -838,26 +1063,34 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
                 }
             }
         }
-        let mut writers: BTreeMap<MetadataTableFamily, StagedSegmentWriter> = cluster
+        let mut writers: BTreeMap<MetadataTableFamily, MergeSegmentWriter> = cluster
             .families
             .iter()
-            .map(|family| (*family, StagedSegmentWriter::new(*family)))
+            .map(|family| {
+                (
+                    *family,
+                    MergeSegmentWriter::new(*family, self.output, self.placement),
+                )
+            })
             .collect();
 
-        let floor_seq = self.spec.frozen_floor_seq;
-        let mut operator = cluster.rule.operator();
+        let floor_seq = self.frozen_floor_seq;
+        let rule = self.rule_for(cluster);
+        let mut operator = rule.operator();
         let mut locality: Option<String> = None;
         loop {
             if self.cancellation.is_cancelled() {
                 return Ok(ClusterEnd::Cancelled);
             }
-            // The claim on the job's prefix is refreshed where the job checks
+            // The claim on a staged merge's prefix is refreshed where it checks
             // whether it should stop, which is the one place it is guaranteed
-            // to reach however long a merge runs. Losing it is one more way
-            // the job has to stop: the segments it has written belong to the
+            // to reach however long a merge runs. Losing it is one more way the
+            // merge has to stop: the segments it has written belong to the
             // collector now.
-            if lease.heartbeat_if_due(self.store).await? == LeaseHold::Fenced {
-                return Ok(ClusterEnd::Fenced);
+            if let Some(lease) = lease.as_deref_mut() {
+                if lease.heartbeat_if_due(self.store).await? == LeaseHold::Fenced {
+                    return Ok(ClusterEnd::Fenced);
+                }
             }
             self.refill(&mut iterators).await?;
             let Some(next) = select_next_iterator(&iterators, cluster.locality) else {
@@ -869,7 +1102,9 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
             let opened = {
                 let iterator = &iterators[next];
                 let (row_key, _) = iterator.head().expect("the selected iterator has a row");
-                let row_locality = locality_of(iterator.family, row_key, cluster.locality);
+                let family = iterator.family;
+                self.refuse_a_repeated_input_key(family, row_key)?;
+                let row_locality = locality_of(family, row_key, cluster.locality);
                 (locality.as_deref() != Some(row_locality)).then(|| row_locality.to_owned())
             };
             if opened.is_some() {
@@ -882,9 +1117,10 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
             let row = iterators[next].take_head();
             self.result.rows_read += 1;
             self.report_progress();
-            let kept = match cluster.rule {
+            self.collect_unbinding(&row);
+            let kept = match rule {
                 // The reverse index is the one family no grouping can decide,
-                // so the job reads the snapshot for it rather than holding
+                // so the merge reads the snapshot for it rather than holding
                 // state.
                 RetentionRule::ReverseBindProbe => self
                     .reverse_bind_survives(&row)
@@ -903,9 +1139,7 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
         }
 
         for writer in writers.into_values() {
-            let segments = writer
-                .finish(self.store, self.namespace_id, self.spec)
-                .await?;
+            let segments = writer.finish(self.store, self.namespace_id).await?;
             self.result.output_segments.extend(segments);
         }
         Ok(ClusterEnd::Merged)
@@ -915,25 +1149,32 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
     ///
     /// A job has no bound on how long it runs, and it publishes nothing until
     /// it is finished, so without this an operator watching a big namespace
-    /// sees one line at the start and nothing until it lands. The counters are
-    /// the job's own; nothing is measured for this.
+    /// sees one line at the start and nothing until it lands. A merge that runs
+    /// inside a maintenance step reports nothing: its input is capped by the
+    /// step's budgets and the step publishes it. The counters are the merge's
+    /// own; nothing is measured for this.
     fn report_progress(&mut self) {
-        if self.result.rows_read < self.next_progress_rows {
+        let (Some(next_progress_rows), Some(input_rows)) =
+            (self.next_progress_rows, self.input_rows)
+        else {
+            return;
+        };
+        if self.result.rows_read < next_progress_rows {
             return;
         }
-        self.next_progress_rows = self.result.rows_read.saturating_add(PROGRESS_ROW_INTERVAL);
+        self.next_progress_rows = Some(self.result.rows_read.saturating_add(PROGRESS_ROW_INTERVAL));
         tracing::info!(
             namespace_id = self.namespace_id.as_str(),
-            families = ?self.spec.families(),
+            families = ?self.group.families(),
             rows_read = self.result.rows_read,
             rows_written = self.result.rows_written,
-            input_rows = self.spec.input_rows(),
+            input_rows,
             output_segments = self.result.output_segments.len(),
             "streaming metadata compaction progress"
         );
     }
 
-    /// Fills every iterator that has run out of rows and records what the job
+    /// Fills every iterator that has run out of rows and records what the merge
     /// then holds.
     async fn refill(&mut self, iterators: &mut [SegmentRowIterator]) -> Result<()> {
         let resident = refill_iterators(self.store, iterators).await?;
@@ -946,7 +1187,7 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
     async fn write_row(
         &mut self,
         (family, row): KeptRow,
-        writers: &mut BTreeMap<MetadataTableFamily, StagedSegmentWriter>,
+        writers: &mut BTreeMap<MetadataTableFamily, MergeSegmentWriter<'_>>,
     ) -> Result<()> {
         self.fold_into_index_digests(family, &row)?;
         *self
@@ -960,26 +1201,45 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
             .expect("a cluster writes only the families it merges");
         writer.push(row);
         writer
-            .roll_full_segments(self.store, self.namespace_id, self.spec, self.policy)
+            .roll_full_segments(self.store, self.namespace_id, self.policy)
             .await
     }
 
-    /// Whether one reverse bind row survives the frozen floor, decided by
-    /// reading the snapshot for the unbinds of its own binding.
+    /// Remembers a below-floor unbind for the reverse pass, when the merge is
+    /// resolving reverse rows from what it streamed rather than from the store.
+    ///
+    /// Every unbind row of the snapshot goes through here, because the forward
+    /// cluster streams the whole unbind family before the reverse cluster
+    /// starts. That is what makes the collected set answer exactly what a
+    /// point read into the same snapshot would answer.
+    fn collect_unbinding(&mut self, row: &MetadataRow) {
+        let ReverseBindResolution::CollectedUnbinds(unbound_at_floor) = &mut self.reverse_binds
+        else {
+            return;
+        };
+        if let Some(generation) = unbinding_at_or_below_floor(row, self.frozen_floor_seq) {
+            unbound_at_floor.insert(generation);
+            self.result.collected_unbind_generations = unbound_at_floor.len();
+        }
+    }
+
+    /// Whether one reverse bind row survives the frozen floor.
     ///
     /// The reverse index is keyed by child and the unbind family by parent, so
     /// no grouping of the merged stream can hold a reverse row together with
-    /// the unbind that retires it. The point read closes that: it runs
-    /// [`unbindings_at_or_below_floor`] and [`bind_survives_frozen_floor`]
-    /// over unbind rows from the same immutable snapshot against the same
-    /// frozen floor as the forward pass, so the two bind families drop in
-    /// lockstep — which they must, because the format gives every bind row
-    /// exactly one reverse row and a run whose two counts disagree does not
-    /// load.
+    /// the unbind that retires it. Both resolutions close that the same way:
+    /// they run [`bind_survives_frozen_floor`] against the generations
+    /// [`unbinding_at_or_below_floor`] retired, out of the same immutable
+    /// snapshot and against the same frozen floor as the forward pass. So the
+    /// two bind families drop in lockstep — which they must, because the format
+    /// gives every bind row exactly one reverse row and a run whose two counts
+    /// disagree does not load.
     ///
-    /// Only rows at or below the floor cost a read: a bind above the floor
-    /// survives whatever retired it later. Each read returns the unbinds of
-    /// one binding generation, which is zero rows or one.
+    /// They differ only in where the set comes from
+    /// ([`ReverseBindResolution`]). A collected set answers with no read at
+    /// all. A probe reads the unbinds of one binding, and only rows at or
+    /// below the floor cost one: a bind above the floor survives whatever
+    /// retired it later.
     async fn reverse_bind_survives(&mut self, row: &MetadataRow) -> Result<bool> {
         let MetadataRow::DirentryBind {
             parent_inode_id,
@@ -991,8 +1251,15 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
         else {
             return Ok(true);
         };
-        if *bind_seq > self.spec.frozen_floor_seq {
+        if *bind_seq > self.frozen_floor_seq {
             return Ok(true);
+        }
+        if let ReverseBindResolution::CollectedUnbinds(unbound_at_floor) = &self.reverse_binds {
+            return Ok(bind_survives_frozen_floor(
+                row,
+                self.frozen_floor_seq,
+                unbound_at_floor,
+            ));
         }
         let unbind_rows = self
             .read_unbinds_of_binding(
@@ -1006,11 +1273,10 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
             )
             .await?;
         self.result.unbind_probes += 1;
-        let unbound_at_floor =
-            unbindings_at_or_below_floor(&unbind_rows, self.spec.frozen_floor_seq);
+        let unbound_at_floor = unbindings_at_or_below_floor(&unbind_rows, self.frozen_floor_seq);
         Ok(bind_survives_frozen_floor(
             row,
-            self.spec.frozen_floor_seq,
+            self.frozen_floor_seq,
             &unbound_at_floor,
         ))
     }
@@ -1021,9 +1287,9 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
     /// prefix selects the unbinds of that one binding and nothing else. The
     /// bloom filter is keyed by parent and name, so a binding no operation
     /// ever retired misses it outright and costs no index or data fetch.
-    /// Decoded sections land in the job's own bounded cache, and the per-read
+    /// Decoded sections land in the merge's own bounded cache, and the per-read
     /// memo is dropped with the read, so what these reads hold is the cache's
-    /// byte budget however many of them the job makes.
+    /// byte budget however many of them the merge makes.
     async fn read_unbinds_of_binding(
         &self,
         prefix: &str,
@@ -1032,7 +1298,7 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
         let upper_bound = string_prefix_upper_bound(prefix);
         let mut rows = Vec::new();
         for run in &self.snapshot {
-            for descriptor in group_run_descriptors(run, self.spec.group)
+            for descriptor in group_run_descriptors(run, self.group)
                 .filter(|descriptor| descriptor.family == MetadataTableFamily::DirentryUnbinds)
             {
                 if !descriptor_may_intersect_range(descriptor, prefix, upper_bound.as_deref()) {
@@ -1074,7 +1340,7 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
         family: MetadataTableFamily,
         row: &MetadataRow,
     ) -> Result<()> {
-        let Some((canonical, index)) = index_pair(self.spec.group) else {
+        let Some((canonical, index)) = index_pair(self.group) else {
             return Ok(());
         };
         if family == canonical {
@@ -1088,25 +1354,30 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
     /// Refuses to hand back a run whose secondary index does not hold the same
     /// rows as its canonical family.
     ///
-    /// A whole-group fold compares the two families outright, over rows it
-    /// holds all of. A streaming job cannot: the reverse bind index is keyed
-    /// by child, so no grouping ever holds a bind row and the reverse row that
-    /// indexes it, and the two are decided in different passes. The digests
-    /// stand in — each pass folds the rows it wrote into one, order does not
-    /// matter, and the two agree at the end exactly when the job wrote the two
-    /// families the same rows.
+    /// This is the only index-parity check a merge makes, whichever path is
+    /// driving it. Comparing the two families outright is not available to a
+    /// merge that never holds them: the reverse bind index is keyed by child,
+    /// so no grouping ever holds a bind row and the reverse row that indexes
+    /// it, and the two are decided in different passes. The digests stand in —
+    /// each pass folds the rows it wrote into one, order does not matter, and
+    /// the two agree at the end exactly when the merge wrote the two families
+    /// the same rows.
+    ///
+    /// The check covers what the merge wrote rather than what it read, which is
+    /// the stronger claim: it says the two families dropped in lockstep, not
+    /// only that their inputs matched.
     fn refuse_a_run_whose_index_disagrees(&self) -> Result<()> {
-        let Some((canonical, index)) = index_pair(self.spec.group) else {
+        let Some((canonical, index)) = index_pair(self.group) else {
             return Ok(());
         };
         if self.canonical_digest == self.index_digest {
             return Ok(());
         }
         Err(CoreError::NamespaceCorrupt(format!(
-            "a streaming compaction of {:?} wrote {} `{canonical:?}` rows digesting to `{}` and \
+            "a metadata merge of {:?} wrote {} `{canonical:?}` rows digesting to `{}` and \
              {} `{index:?}` rows digesting to `{}`; the two families must hold the same rows, so \
              the run it built is not publishable",
-            self.spec.group.families(),
+            self.group.families(),
             self.canonical_digest.rows,
             self.canonical_digest.spell(),
             self.index_digest.rows,
@@ -1121,8 +1392,8 @@ impl<S: ObjectStore + ?Sized> CompactionJob<'_, S> {
 /// rows and not on the order they were written in — which is the point,
 /// because the two families of an index pair are written in different orders
 /// and, for the bind pair, in different passes. This is corruption detection,
-/// not a signature: what it has to catch is a job that wrote a secondary index
-/// rows its canonical family does not hold, including a row differing in one
+/// not a signature: what it has to catch is a merge that wrote a secondary
+/// index rows its canonical family does not hold, including a row differing in one
 /// field. Nothing durable carries it, so the input is the row's serde
 /// encoding.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -170,8 +170,12 @@ fn the_fold_drops_cancelled_pairs_and_keeps_every_live_deletion() {
         manifest_rows_for_family(&state, ApiMetadataTableFamily::ActiveDeletions),
     )]);
     // Far above every row: the floor must not touch this family.
-    reorganize::drop_rows_below_retention_floor(&mut rows_by_family, ChangeSeq(10_000))
-        .expect("fold active deletions");
+    fold_rows_with_retention(
+        MetadataFamilyGroup::ActiveDeletions,
+        &mut rows_by_family,
+        ChangeSeq(10_000),
+    )
+    .expect("fold active deletions");
 
     let kept = rows_by_family
         .remove(&ApiMetadataTableFamily::ActiveDeletions)

--- a/crates/loonfs-core/src/checkpoint/tests/attributes.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/attributes.rs
@@ -97,8 +97,12 @@ fn the_fold_keeps_every_revision_above_the_floor_and_the_newest_at_it() {
     ]);
     let mut rows_by_family = attribute_rows(&state);
 
-    reorganize::drop_rows_below_retention_floor(&mut rows_by_family, ChangeSeq(6))
-        .expect("fold attributes");
+    fold_rows_with_retention(
+        MetadataFamilyGroup::Attributes,
+        &mut rows_by_family,
+        ChangeSeq(6),
+    )
+    .expect("fold attributes");
 
     assert_eq!(
         kept_revisions(&rows_by_family),
@@ -125,8 +129,12 @@ fn the_fold_keeps_a_latest_empty_revision() {
     ]);
     let mut rows_by_family = attribute_rows(&state);
 
-    reorganize::drop_rows_below_retention_floor(&mut rows_by_family, ChangeSeq(9))
-        .expect("fold attributes");
+    fold_rows_with_retention(
+        MetadataFamilyGroup::Attributes,
+        &mut rows_by_family,
+        ChangeSeq(9),
+    )
+    .expect("fold attributes");
 
     let kept = rows_by_family
         .remove(&ApiMetadataTableFamily::Attributes)
@@ -157,8 +165,12 @@ fn the_fold_never_drops_attributes_for_being_unreachable() {
     let mut rows_by_family = attribute_rows(&state);
     // No inode or bind rows travel with the attribute group, so nothing here
     // could establish reachability even if the rule wanted to.
-    reorganize::drop_rows_below_retention_floor(&mut rows_by_family, ChangeSeq(10_000))
-        .expect("fold attributes");
+    fold_rows_with_retention(
+        MetadataFamilyGroup::Attributes,
+        &mut rows_by_family,
+        ChangeSeq(10_000),
+    )
+    .expect("fold attributes");
 
     assert_eq!(kept_revisions(&rows_by_family), vec![(7, 1)]);
 }
@@ -175,8 +187,12 @@ fn the_fold_refuses_to_compact_repeated_revision_numbers() {
     ]);
     let mut rows_by_family = attribute_rows(&state);
 
-    let error = reorganize::drop_rows_below_retention_floor(&mut rows_by_family, ChangeSeq(9))
-        .expect_err("repeated revision numbers are corruption");
+    let error = fold_rows_with_retention(
+        MetadataFamilyGroup::Attributes,
+        &mut rows_by_family,
+        ChangeSeq(9),
+    )
+    .expect_err("repeated revision numbers are corruption");
 
     assert!(
         matches!(&error, CoreError::NamespaceCorrupt(_)),

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -3,7 +3,7 @@
 use super::*;
 use loonfs_api::{ContentId, StorageChecksum};
 
-async fn rewrite_manifest_segment(
+pub(super) async fn rewrite_manifest_segment(
     store: &LocalFsStore,
     _namespace_id: &NamespaceId,
     _run_seq: ChangeSeq,
@@ -30,6 +30,17 @@ async fn rewrite_manifest_segment(
     descriptor.min_key = built.min_key;
     descriptor.max_key = built.max_key;
     descriptor.index_block = built.index;
+    // A rewritten segment's filter changes size, and a descriptor that inlines
+    // a filter must inline the one it actually has: manifest load compares the
+    // two. Derived exactly as `write_manifest_segment` derives it.
+    descriptor.filter_inline = (built.filter.stored_len
+        <= super::super::build::INLINE_SEGMENT_FILTER_MAX_BYTES)
+        .then(|| {
+            let start = built.filter.offset as usize;
+            loonfs_api::wire::hex::hex_encode_bytes(
+                &built.bytes[start..start + built.filter.stored_len as usize],
+            )
+        });
     descriptor.filter_block = built.filter;
     descriptor.payload_checksum = loonfs_api::sha256_digest(&built.bytes);
 }
@@ -102,7 +113,7 @@ fn default_target_block_bytes() -> NonZeroUsize {
     NonZeroUsize::new(DEFAULT_TARGET_BLOCK_BYTES).expect("the default target is positive")
 }
 
-async fn overwrite_manifest(
+pub(super) async fn overwrite_manifest(
     store: &LocalFsStore,
     namespace_id: &NamespaceId,
     manifest: NamespaceManifestEnvelope,
@@ -389,7 +400,7 @@ fn drop_pass_keeps_the_floor_visible_binding_across_a_later_rename() {
         vec![unbind(1, 0, 2)],
     );
 
-    super::reorganize::drop_rows_below_retention_floor(&mut rows, ChangeSeq(1)).expect("drop");
+    fold_rows_with_retention(MetadataFamilyGroup::Bindings, &mut rows, ChangeSeq(1)).expect("drop");
 
     assert_eq!(rows[&ApiMetadataTableFamily::DirentryBinds].len(), 2);
     assert_eq!(rows[&ApiMetadataTableFamily::DirentryChildBinds].len(), 2);
@@ -428,7 +439,7 @@ fn drop_pass_resolves_same_seq_rebinds_by_delta_index() {
     );
     rows.insert(ApiMetadataTableFamily::DirentryUnbinds, vec![unbind]);
 
-    super::reorganize::drop_rows_below_retention_floor(&mut rows, ChangeSeq(1)).expect("drop");
+    fold_rows_with_retention(MetadataFamilyGroup::Bindings, &mut rows, ChangeSeq(1)).expect("drop");
 
     // Only the delta-2 rebind (the slot's latest) survives; the superseded
     // delta-0 bind and its spent unbind marker are gone from both families.
@@ -466,7 +477,7 @@ fn drop_pass_refuses_superseded_bind_without_unbind() {
         vec![bind(0), bind(1)],
     );
 
-    let error = super::reorganize::drop_rows_below_retention_floor(&mut rows, ChangeSeq(1))
+    let error = fold_rows_with_retention(MetadataFamilyGroup::Bindings, &mut rows, ChangeSeq(1))
         .expect_err("superseded live bind must refuse the drop");
     assert!(matches!(error, CoreError::NamespaceCorrupt(_)));
 }
@@ -795,10 +806,17 @@ async fn bounded_subset_rebuild_rejects_divergent_revision_index() {
             }
         }
     }
+    // The merge digests the rows it writes into each family of the pair and
+    // compares the two, which is the one index-parity check either
+    // reorganization path makes.
     match rebuild_error.expect("reorganization should reject the divergent index") {
-        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(
-            ManifestLoadError::RevisionIndexMismatch { .. },
-        )) => {}
+        CoreError::NamespaceCorrupt(message) => {
+            assert!(
+                message.contains("RevisionsByInodeDesc")
+                    && message.contains("must hold the same rows"),
+                "expected a revision index mismatch, got: {message}"
+            );
+        }
         other => panic!("expected revision index mismatch, got {other:?}"),
     }
 }

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -18,8 +18,11 @@ use super::build::{
     build_manifest_tables, build_manifest_tables_from_rows, MetadataTableSegmentation,
 };
 use super::cache::{MetadataTableBlockKind, MetadataTableCache, MetadataTableCacheConfig};
+use super::compaction_merge::locality_of;
+use super::compaction_retention::RetentionRule;
 use super::create::load_checkpoint_projection_metadata_state;
 use super::error::ManifestLoadError;
+use super::frozen_floor::{bind_survives_frozen_floor, unbindings_at_or_below_floor};
 use super::load::load_verified_manifest_tables_with_cache;
 use super::load::{
     head_from_manifest, load_manifest_materialization_for_inspection,
@@ -38,8 +41,8 @@ use super::stored_block_cache::{
     StoredMetadataBlockCache, StoredMetadataBlockKey, StoredMetadataBlockKind,
 };
 use super::streaming_compaction::{
-    run_metadata_compaction_job, MetadataCompactionCancellation, MetadataCompactionJobOutcome,
-    MetadataCompactionSpec,
+    retention_clusters, run_metadata_compaction_job, MetadataCompactionCancellation,
+    MetadataCompactionJobOutcome, MetadataCompactionSpec,
 };
 use super::{
     block_fetch, create, data_block_load, flush, load, record, reorganize,
@@ -93,7 +96,7 @@ use loonfs_objectstore::{
 use loonfs_test_support::stores::{
     CountingStore, FailStore, InjectedError, KeyPredicate, OperationClass,
 };
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
@@ -229,6 +232,81 @@ async fn checkpoint_then_reorganize<S: ObjectStore + ?Sized>(
         .await
         .expect("create checkpoint");
     drain_reorganization(store, namespace_id, context, policy).await
+}
+
+/// Runs the merge engine's retention operators over rows a test holds in
+/// memory, so a rule test can state a handful of rows and a floor and assert
+/// what survives without a namespace, a manifest, or segments.
+///
+/// It is a harness, not a second implementation: the clusters, the locality
+/// grouping, and the operators are the engine's own. The one thing it does
+/// differently is the reverse bind index, which a merge decides by point-reading
+/// the unbinds of one binding out of its snapshot. Here the whole unbind family
+/// is in hand, so the shared rules are applied to it directly — which is what
+/// the point read does with the rows it fetched.
+fn fold_rows_with_retention(
+    group: MetadataFamilyGroup,
+    rows_by_family: &mut BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>>,
+    floor_seq: ChangeSeq,
+) -> crate::error::Result<()> {
+    // Built from the input rows, before any cluster replaces them: a merge's
+    // point reads go to its immutable snapshot, never to what it has written.
+    let unbound_at_floor = unbindings_at_or_below_floor(
+        rows_by_family
+            .get(&ApiMetadataTableFamily::DirentryUnbinds)
+            .map_or(&[][..], Vec::as_slice),
+        floor_seq,
+    );
+    for cluster in retention_clusters(group) {
+        // The stream a merge sees: the cluster's rows by locality, then family,
+        // then row key.
+        let mut merged: Vec<(ApiMetadataTableFamily, String, MetadataRow)> = Vec::new();
+        for family in cluster.families {
+            for row in rows_by_family.get(family).map_or(&[][..], Vec::as_slice) {
+                merged.push((*family, row.row_key_for_family(*family), row.clone()));
+            }
+        }
+        merged.sort_by(|left, right| {
+            locality_of(left.0, &left.1, cluster.locality)
+                .cmp(locality_of(right.0, &right.1, cluster.locality))
+                .then(left.0.cmp(&right.0))
+                .then(left.1.cmp(&right.1))
+        });
+
+        let mut kept: BTreeMap<ApiMetadataTableFamily, Vec<MetadataRow>> = cluster
+            .families
+            .iter()
+            .map(|family| (*family, Vec::new()))
+            .collect();
+        let mut operator = cluster.rule.operator();
+        let mut locality: Option<String> = None;
+        for (family, row_key, row) in merged {
+            let row_locality = locality_of(family, &row_key, cluster.locality);
+            if locality.as_deref() != Some(row_locality) {
+                if let Some((family, row)) = operator.close_group(floor_seq)? {
+                    kept.entry(family).or_default().push(row);
+                }
+                locality = Some(row_locality.to_owned());
+            }
+            let survivor = match cluster.rule {
+                RetentionRule::ReverseBindProbe => {
+                    bind_survives_frozen_floor(&row, floor_seq, &unbound_at_floor)
+                        .then_some((family, row))
+                }
+                _ => operator.push(family, row, floor_seq)?,
+            };
+            if let Some((family, row)) = survivor {
+                kept.entry(family).or_default().push(row);
+            }
+        }
+        if let Some((family, row)) = operator.close_group(floor_seq)? {
+            kept.entry(family).or_default().push(row);
+        }
+        for (family, rows) in kept {
+            rows_by_family.insert(family, rows);
+        }
+    }
+    Ok(())
 }
 
 /// Runs reorganization units until nothing is left to fold, with the

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -1,22 +1,21 @@
-//! Rebuilding a family group in one streaming job: the plan split, the
-//! oracle that says a streaming job and a whole-group fold reach the same
-//! place, restart equivalence, and the resource bounds that make the job
-//! independent of the size of what it rebuilds.
+//! Rebuilding a family group in one background job: the plan split, the
+//! oracle that says the job's orchestration and a maintenance step's reach the
+//! same place, restart equivalence, and the resource bounds that make a merge
+//! independent of the size of what it merges.
 
 use super::super::compaction_lease::{
     claim_compaction_prefix, CompactionLease, CompactionPrefixOwner, LeaseHold,
 };
 use super::super::reorganize::{
-    drop_rows_below_retention_floor, select_reorganization_input, FrozenBasePolicy,
-    ReorganizationPlan,
+    group_run_descriptors, select_reorganization_input, FrozenBasePolicy, ReorganizationPlan,
 };
 use super::super::row::manifest_row_commit_seq;
 use super::super::runs::MetadataFamilyGroup;
 use super::super::scan::VerifiedMetadataTables;
 use super::super::streaming_compaction::{
-    finalize_metadata_compaction, run_metadata_compaction, snapshot_segment_keys, Finalization,
-    MetadataCompactionCancellation, MetadataCompactionOutcome, MetadataCompactionResult,
-    MetadataCompactionSpec,
+    finalize_metadata_compaction, merge_group_in_step, run_metadata_compaction,
+    snapshot_segment_keys, Finalization, MetadataCompactionCancellation, MetadataCompactionOutcome,
+    MetadataCompactionSpec, MetadataMergeResult,
 };
 use super::*;
 use crate::limits::METADATA_COMPACTION_LEASE_EXPIRY_MS;
@@ -676,7 +675,7 @@ async fn finalize_streaming_compaction<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     spec: &MetadataCompactionSpec,
     snapshot_keys: &BTreeSet<String>,
-    result: &MetadataCompactionResult,
+    result: &MetadataMergeResult,
 ) -> Finalization {
     finalize_streaming_compaction_under(
         store,
@@ -695,7 +694,7 @@ async fn finalize_streaming_compaction_under<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     spec: &MetadataCompactionSpec,
     snapshot_keys: &BTreeSet<String>,
-    result: &MetadataCompactionResult,
+    result: &MetadataMergeResult,
     cancellation: &MetadataCompactionCancellation,
 ) -> Finalization {
     let timer = StdMonotonicTimer::default();
@@ -719,7 +718,7 @@ async fn publish_streaming_compaction<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     spec: &MetadataCompactionSpec,
     snapshot_keys: &BTreeSet<String>,
-    result: &MetadataCompactionResult,
+    result: &MetadataMergeResult,
 ) -> ManifestId {
     match finalize_streaming_compaction(store, namespace_id, spec, snapshot_keys, result).await {
         Finalization::Published(manifest_id) => manifest_id,
@@ -801,8 +800,8 @@ async fn staged_object_keys<S: ObjectStore + ?Sized>(
         .await
 }
 
-/// Runs the whole-group fold with the budgets raised, which is the other way
-/// of doing what the streaming job does.
+/// Merges the group inside one maintenance step with the budgets raised, which
+/// is the other way of running the same engine.
 async fn fold_group_whole<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -1183,12 +1182,21 @@ async fn small_delta_batches_are_consolidated_by_merges_rather_than_by_jobs() {
 // The oracle
 // -------------------------------------------------------------------------
 
-/// A streaming compaction and a whole-group fold with the budgets raised are
-/// two ways of doing the same thing, so they must land in the same place: the
-/// same surviving rows in every family of the group, the same materialized
-/// namespace, and the same rows dropped.
+/// A background compaction and a synchronous merge inside a maintenance step
+/// with the budgets raised must land in the same place: the same surviving rows
+/// in every family of the group, the same materialized namespace, and the same
+/// rows dropped.
+///
+/// Both paths run one engine, so this no longer bridges two implementations of
+/// the merge. What it guards now is the orchestration split. The background job
+/// resolves its input from a spec captured before it started, stages its output
+/// under its own prefix behind a lease, and swaps it in with a separate
+/// publication much later; the step chooses its window from the manifest it
+/// just read, writes at ordinary table keys, and publishes in the same step.
+/// Those are different enough that a change to either one can move the rows a
+/// reader ends up with, and this is what says it did not.
 #[tokio::test]
-async fn a_streaming_compaction_and_a_whole_group_fold_reach_the_same_rows() {
+async fn a_background_compaction_and_a_step_contained_merge_reach_the_same_rows() {
     let job_dir = tempdir().expect("tempdir");
     let store = LocalFsStore::new(job_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -1248,7 +1256,7 @@ async fn a_streaming_compaction_and_a_whole_group_fold_reach_the_same_rows() {
 
     assert_eq!(
         compacted, folded,
-        "a streaming compaction and a whole-group fold must keep the same rows"
+        "a background compaction and a step-contained merge must keep the same rows"
     );
     assert!(
         metadata_states_equivalent(
@@ -1318,9 +1326,9 @@ async fn a_streaming_compaction_and_a_whole_group_fold_reach_the_same_rows() {
     }
 }
 
-/// The oracle has teeth only if the retention operators are what make the two
+/// The oracle has teeth only if the retention rules are what make the two
 /// rebuilds agree. A floor of zero is above nothing, so every rule that reads
-/// the floor keeps every row, and the job must then disagree with the fold.
+/// the floor keeps every row, and the job must then disagree with the step.
 #[tokio::test]
 async fn a_compaction_that_drops_nothing_fails_the_oracle() {
     let job_dir = tempdir().expect("tempdir");
@@ -1356,12 +1364,12 @@ async fn a_compaction_that_drops_nothing_fails_the_oracle() {
     let compacted = group_rows_of_current_manifest(&store, &namespace_id, group).await;
     assert_ne!(
         compacted, folded,
-        "with the floor rules keeping everything, the job must not reach the fold's rows"
+        "with the floor rules keeping everything, the job must not reach the step's rows"
     );
     assert!(
         compacted.values().map(Vec::len).sum::<usize>()
             > folded.values().map(Vec::len).sum::<usize>(),
-        "and must keep strictly more rows than the fold kept"
+        "and must keep strictly more rows than the step kept"
     );
 }
 
@@ -1403,6 +1411,622 @@ async fn a_compaction_of_the_revisions_group_rewrites_every_row_it_reads() {
         group_rows_of_current_manifest(&store, &namespace_id, group).await,
         before,
         "revision rows are durable history and are never dropped"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Duplicate row keys
+// -------------------------------------------------------------------------
+
+/// The object keys the current manifest holds for `group`.
+async fn group_segment_keys<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    group: MetadataFamilyGroup,
+) -> BTreeSet<String> {
+    let tables = load_current_manifest_tables(store, namespace_id).await;
+    snapshot_runs_for_group(tables.manifest(), group)
+        .iter()
+        .flat_map(|run| group_run_descriptors(run, group))
+        .map(|descriptor| descriptor.object_key.clone())
+        .collect()
+}
+
+/// Rewrites the group's base-run segment for `family` with `rows`, updating
+/// the descriptor in `manifest` to match.
+async fn rewrite_base_segment(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    manifest: &mut NamespaceManifestEnvelope,
+    family: ApiMetadataTableFamily,
+    mut rows: Vec<MetadataRow>,
+) {
+    rows.sort_by_key(|row| row.row_key_for_family(family));
+    let head_seq = manifest.payload.head_seq;
+    let descriptor = manifest
+        .payload
+        .metadata_files
+        .iter_mut()
+        .find(|metadata_file| {
+            metadata_file.level == CHECKPOINT_BASE_RUN_LEVEL && metadata_file.family == family
+        })
+        .expect("the folded base run holds this family");
+    super::index_parity::rewrite_manifest_segment(
+        store,
+        namespace_id,
+        head_seq,
+        family,
+        descriptor,
+        rows,
+        NonZeroUsize::new(DEFAULT_TARGET_BLOCK_BYTES).expect("the default target is positive"),
+    )
+    .await;
+}
+
+/// A run whose canonical family and secondary index both hold the same row
+/// twice is refused by both orchestration paths, and neither publishes.
+///
+/// The duplicate has to be on both sides. The output digests compare the two
+/// families against each other, so a one-sided duplicate only re-proves what
+/// the digests already catch; a duplicate present on both sides leaves both
+/// multisets equal and passes them. The segment builder does not catch it
+/// either — it refuses a descending row key, not a repeated one — so without
+/// the input-key guard the duplicate reaches a published run, where reads that
+/// concatenate runs would answer the same revision twice.
+#[tokio::test]
+async fn a_row_key_repeated_in_both_families_of_an_index_pair_is_refused() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    seed_bindings_workload(&store, &namespace_id).await;
+    let group = MetadataFamilyGroup::Revisions;
+
+    // Fold everything into one base run, then repeat one revision inside both
+    // families of the pair.
+    drain_reorganization(&store, &namespace_id, &context, fold_everything_policy()).await;
+    let mut manifest = load_current_manifest_tables(&store, &namespace_id)
+        .await
+        .manifest()
+        .clone();
+    let rows = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+    let repeated = rows[&ApiMetadataTableFamily::Revisions]
+        .first()
+        .expect("the namespace has revisions")
+        .clone();
+    let duplicated_key = repeated.row_key_for_family(ApiMetadataTableFamily::Revisions);
+    for family in [
+        ApiMetadataTableFamily::Revisions,
+        ApiMetadataTableFamily::RevisionsByInodeDesc,
+    ] {
+        let mut family_rows = rows[&family].clone();
+        family_rows.push(repeated.clone());
+        rewrite_base_segment(&store, &namespace_id, &mut manifest, family, family_rows).await;
+    }
+    super::index_parity::overwrite_manifest(&store, &namespace_id, manifest).await;
+    // One delta run above the doctored base, so a bottom-anchored window makes
+    // progress and the merge reads the base.
+    write_file_bytes(
+        &store,
+        &namespace_id,
+        "/late.txt",
+        b"late\n",
+        &context,
+        None,
+    )
+    .await
+    .expect("write a late file");
+    create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect("checkpoint the late write");
+
+    // A doctored run still loads: the two families hold the same rows as each
+    // other, so descriptor counts and the digests agree.
+    let keys_before = group_segment_keys(&store, &namespace_id, group).await;
+    let floor_seq = read_floor_seq(&store, &namespace_id).await;
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let Some(ReorganizationPlan::BoundedMerge(input)) = select_reorganization_input(
+        &tables,
+        group,
+        fold_everything_policy(),
+        floor_seq,
+        &FrozenBasePolicy::default(),
+    )
+    .await
+    .expect("plan the group")
+    .plan
+    else {
+        panic!("raised budgets must admit a bounded merge");
+    };
+    drop(tables);
+
+    let step_error = merge_group_in_step(
+        &store,
+        &namespace_id,
+        group,
+        &input.runs,
+        input.placement,
+        floor_seq,
+        fold_everything_policy(),
+    )
+    .await
+    .expect_err("a step-contained merge must refuse the duplicate");
+    assert_duplicate_row_key(&step_error, &duplicated_key);
+
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let timer = StdMonotonicTimer::default();
+    let mut lease = test_lease(&store, &namespace_id, &spec, &timer).await;
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let job_error = run_metadata_compaction(
+        &tables,
+        &namespace_id,
+        &spec,
+        fold_everything_policy(),
+        &MetadataCompactionCancellation::default(),
+        &mut lease,
+    )
+    .await
+    .expect_err("a background compaction must refuse the duplicate");
+    assert_duplicate_row_key(&job_error, &duplicated_key);
+    drop(tables);
+
+    assert_eq!(
+        group_segment_keys(&store, &namespace_id, group).await,
+        keys_before,
+        "neither path may publish a run built from a duplicated key"
+    );
+}
+
+fn assert_duplicate_row_key(error: &CoreError, duplicated_key: &str) {
+    let CoreError::NamespaceCorrupt(message) = error else {
+        panic!("a duplicate row key is namespace corruption, got {error:?}");
+    };
+    assert!(
+        message.contains("Revisions") && message.contains(duplicated_key),
+        "the error must name the family and the duplicated key, got: {message}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Reverse-bind resolution cost
+// -------------------------------------------------------------------------
+
+/// Records every ranged read so a test can classify it against the manifest's
+/// descriptors: a read at a segment's filter offset is a filter read, one at
+/// its index offset is an index read, and anything else is data.
+#[derive(Debug)]
+struct ReadRecorderStore {
+    inner: LocalFsStore,
+    reads: Mutex<Vec<(String, u64, u64)>>,
+}
+
+impl ReadRecorderStore {
+    fn new(inner: LocalFsStore) -> Self {
+        Self {
+            inner,
+            reads: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn take_reads(&self) -> Vec<(String, u64, u64)> {
+        std::mem::take(&mut self.reads.lock().expect("read log"))
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ReadRecorderStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let result = self.inner.get(key, range.clone()).await;
+        if let Ok(Some(bytes)) = &result {
+            let start = range.as_ref().map_or(0, |range| range.start_inclusive);
+            self.reads
+                .lock()
+                .expect("read log")
+                .push((key.to_owned(), start, bytes.len() as u64));
+        }
+        result
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        let result = self.inner.get_with_metadata(key).await;
+        if let Ok(Some(body)) = &result {
+            self.reads
+                .lock()
+                .expect("read log")
+                .push((key.to_owned(), 0, body.bytes.len() as u64));
+        }
+        result
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
+
+/// What one merge cost the store, by section.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct ReadProfile {
+    filter_reads: usize,
+    index_reads: usize,
+    data_reads: usize,
+    other_reads: usize,
+    stored_bytes: u64,
+}
+
+impl ReadProfile {
+    fn requests(&self) -> usize {
+        self.filter_reads + self.index_reads + self.data_reads + self.other_reads
+    }
+}
+
+/// Classifies a read log against the segment descriptors it touched.
+fn classify_reads(reads: &[(String, u64, u64)], descriptors: &[MetadataFileRef]) -> ReadProfile {
+    let mut profile = ReadProfile::default();
+    for (key, start, bytes) in reads {
+        profile.stored_bytes += bytes;
+        let Some(descriptor) = descriptors
+            .iter()
+            .find(|descriptor| descriptor.object_key == *key)
+        else {
+            profile.other_reads += 1;
+            continue;
+        };
+        if *start == descriptor.filter_block.offset {
+            profile.filter_reads += 1;
+        } else if *start == descriptor.index_block.offset {
+            profile.index_reads += 1;
+        } else {
+            profile.data_reads += 1;
+        }
+    }
+    profile
+}
+
+/// A namespace whose reverse-bind index walks the unbind keyspace out of
+/// order.
+///
+/// Files are created round-robin across many parents, so child inode ids
+/// ascend across parents rather than within one. The reverse index is keyed by
+/// child and the unbind family by parent, so reading the reverse index in its
+/// own key order jumps between parents on every row. Every file is then
+/// deleted and the floor advanced past the deletions, which is what makes each
+/// reverse row cost a probe.
+async fn seed_reverse_binds_that_jump_the_unbind_keyspace(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    parents: u64,
+    rounds: u64,
+) {
+    let context = test_context();
+    bootstrap_namespace(store, namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    for round in 0..rounds {
+        for parent in 0..parents {
+            write_file_bytes(
+                store,
+                namespace_id,
+                &format!("/d{parent}/f{round}.txt"),
+                b"body\n",
+                &context,
+                None,
+            )
+            .await
+            .expect("write file");
+        }
+        // The WAL tail is capped, so each round is checkpointed as it is made.
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint the writes");
+    }
+    for round in 0..rounds {
+        for parent in 0..parents {
+            delete_path(
+                store,
+                namespace_id,
+                &format!("/d{parent}/f{round}.txt"),
+                &context,
+                None,
+            )
+            .await
+            .expect("delete file");
+        }
+        create_checkpoint(store, namespace_id, &context)
+            .await
+            .expect("checkpoint the deletions");
+    }
+    // Small segments, so the unbind family spans many segments and a probe
+    // that jumps parents lands in a different one.
+    drain_reorganization(
+        store,
+        namespace_id,
+        &context,
+        MetadataLsmPolicy {
+            max_rows_per_segment: NonZeroUsize::new(16).expect("nonzero"),
+            ..fold_everything_policy()
+        },
+    )
+    .await;
+    advance_retention_floor(store, namespace_id, &context)
+        .await
+        .expect("advance the floor past the deletions");
+    write_file_bytes(store, namespace_id, "/late.txt", b"late\n", &context, None)
+        .await
+        .expect("write a late file");
+    create_checkpoint(store, namespace_id, &context)
+        .await
+        .expect("checkpoint the late write");
+}
+
+/// Replaces the bindings families of the namespace's base run with `count`
+/// synthetic generations, each bound and unbound below the retention floor.
+///
+/// The point is the ordering. The reverse index is keyed by child and the
+/// unbind family by parent and name, so a generation's name is scrambled
+/// against its child id: reading the reverse index in its own order walks the
+/// unbind keyspace in a pseudo-random permutation, which is the worst case for
+/// a cache that holds a bounded slice of it. `count` must be a power of two,
+/// which makes the odd multiplier below a bijection.
+///
+/// Going through the write path for a working set this size would take hours,
+/// and the merge only ever sees durable segments, so they are built directly.
+async fn install_synthetic_bindings_base(
+    store: &LocalFsStore,
+    namespace_id: &NamespaceId,
+    count: u64,
+    rows_per_segment: NonZeroUsize,
+) -> u64 {
+    assert!(
+        count.is_power_of_two(),
+        "the scrambling multiplier is only a permutation over a power of two"
+    );
+    let mut binds = Vec::with_capacity(count as usize);
+    let mut unbinds = Vec::with_capacity(count as usize);
+    for index in 0..count {
+        let parent = InodeId(1_000);
+        // Odd multiplier, power-of-two modulus: a bijection, so every name is
+        // distinct and the name order is scattered against the child order.
+        let scrambled = index.wrapping_mul(2_654_435_761) % count;
+        let name = format!("g{scrambled:012}");
+        let delta = u32::try_from(index).expect("test generation counts are small");
+        binds.push(MetadataRow::DirentryBind {
+            parent_inode_id: parent,
+            name_key: NameKey::parse(&name).expect("name key"),
+            display_name: loonfs_api::DisplayName::parse(&name).expect("display name"),
+            child_inode_id: InodeId(100_000 + index),
+            bind_seq: ChangeSeq(1),
+            bind_delta_index: delta,
+        });
+        unbinds.push(MetadataRow::DirentryUnbind {
+            parent_inode_id: parent,
+            name_key: NameKey::parse(&name).expect("name key"),
+            display_name: loonfs_api::DisplayName::parse(&name).expect("display name"),
+            child_inode_id: InodeId(100_000 + index),
+            bind_seq: ChangeSeq(1),
+            bind_delta_index: delta,
+            unbind_seq: ChangeSeq(2),
+            unbind_delta_index: delta,
+        });
+    }
+
+    let mut manifest = load_current_manifest_tables(store, namespace_id)
+        .await
+        .manifest()
+        .clone();
+    let base_run_seq = manifest
+        .payload
+        .metadata_files
+        .iter()
+        .find(|descriptor| descriptor.level == CHECKPOINT_BASE_RUN_LEVEL)
+        .expect("the namespace has been folded into a base run")
+        .run_seq;
+    let mut rows_by_family = BTreeMap::from([
+        (ApiMetadataTableFamily::DirentryBinds, binds.clone()),
+        (ApiMetadataTableFamily::DirentryChildBinds, binds),
+        (ApiMetadataTableFamily::DirentryUnbinds, unbinds),
+    ]);
+    let run_tables = build_manifest_tables_from_rows(
+        store,
+        namespace_id,
+        base_run_seq,
+        CHECKPOINT_BASE_RUN_LEVEL,
+        |family| {
+            let mut rows = rows_by_family.remove(&family).unwrap_or_default();
+            rows.sort_by_key(|row| row.row_key_for_family(family));
+            rows
+        },
+        MetadataTableSegmentation::Base {
+            max_rows_per_segment: rows_per_segment,
+        },
+    )
+    .await
+    .expect("build the synthetic bindings run");
+
+    // Only the base tier is replaced: the delta run above it is what gives a
+    // bottom-anchored window something to fold.
+    manifest.payload.metadata_files.retain(|descriptor| {
+        !MetadataFamilyGroup::Bindings.contains(descriptor.family)
+            || descriptor.level != CHECKPOINT_BASE_RUN_LEVEL
+    });
+    manifest
+        .payload
+        .metadata_files
+        .extend(flatten_manifest_tables(run_tables));
+    // What the probe cache would have to hold to serve every probe without
+    // refetching: the decoded data blocks of the unbind family.
+    let mut unbind_decoded_bytes = 0u64;
+    for descriptor in manifest
+        .payload
+        .metadata_files
+        .iter()
+        .filter(|descriptor| descriptor.family == ApiMetadataTableFamily::DirentryUnbinds)
+    {
+        let index = block_fetch::load_segment_index_for_reorganization(
+            store,
+            None,
+            &Default::default(),
+            descriptor,
+        )
+        .await
+        .expect("load a synthetic segment index");
+        unbind_decoded_bytes += index
+            .iter()
+            .map(|entry| u64::from(entry.block.decoded_len))
+            .sum::<u64>();
+    }
+    super::index_parity::overwrite_manifest(store, namespace_id, manifest).await;
+    unbind_decoded_bytes
+}
+
+/// A merge inside a maintenance step reads its window once, whatever order the
+/// reverse index walks the unbind keyspace in.
+///
+/// This is the total-work half of the resource contract. The other resource
+/// tests bound what a merge holds and how wide it fans out at any instant;
+/// neither of them sees a merge that reads the same block over and over.
+///
+/// The window here is the shape that used to cost the most: every reverse bind
+/// row is below the floor, so every one needs a verdict, and the names are
+/// scrambled against the child ids so consecutive reverse rows land in
+/// unrelated parts of the parent-ordered unbind family. Resolving those from
+/// the store costs one round trip per row once the probe cache can no longer
+/// hold the window's unbind family, which the step's budgets allow. Measured on
+/// a window whose unbind family just fills the cache, 65,536 reverse rows cost
+/// 27,427 data reads and 309 MB transferred against 16 MB of priced input, and
+/// doubling the family doubled both; the same window resolved from the
+/// collected set costs 386 data reads and 3.7 MB.
+///
+/// So the assertion is the contract rather than a number: the step reads each
+/// segment's index once and its data once, and makes no probe at all. A
+/// background job keeps the probes, because its memory must not follow the
+/// group it rebuilds, and this pins that split too.
+#[tokio::test]
+async fn a_step_contained_merge_reads_its_window_once() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    seed_reverse_binds_that_jump_the_unbind_keyspace(&inner, &namespace_id, 4, 2).await;
+    let generations = 4_096;
+    install_synthetic_bindings_base(
+        &inner,
+        &namespace_id,
+        generations,
+        NonZeroUsize::new(512).expect("nonzero"),
+    )
+    .await;
+
+    let store = ReadRecorderStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+    let group = MetadataFamilyGroup::Bindings;
+    let floor_seq = read_floor_seq(&store, &namespace_id).await;
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let descriptors: Vec<MetadataFileRef> = tables.manifest().payload.metadata_files.clone();
+    let Some(ReorganizationPlan::BoundedMerge(input)) = select_reorganization_input(
+        &tables,
+        group,
+        fold_everything_policy(),
+        floor_seq,
+        &FrozenBasePolicy::default(),
+    )
+    .await
+    .expect("plan the group")
+    .plan
+    else {
+        panic!("raised budgets must admit a bounded merge");
+    };
+    drop(tables);
+    let window_segments = input
+        .runs
+        .iter()
+        .flat_map(|run| group_run_descriptors(run, group))
+        .count();
+    let unbinds_below_floor = descriptors
+        .iter()
+        .filter(|descriptor| descriptor.family == ApiMetadataTableFamily::DirentryUnbinds)
+        .map(|descriptor| descriptor.row_count)
+        .sum::<u64>();
+    let _ = store.take_reads();
+
+    let merged = merge_group_in_step(
+        &store,
+        &namespace_id,
+        group,
+        &input.runs,
+        input.placement,
+        floor_seq,
+        fold_everything_policy(),
+    )
+    .await
+    .expect("merge the window");
+    let profile = classify_reads(&store.take_reads(), &descriptors);
+
+    assert_eq!(
+        merged.unbind_probes, 0,
+        "a step-contained merge resolves the reverse index from what it streamed"
+    );
+    assert_eq!(
+        merged.collected_unbind_generations as u64, unbinds_below_floor,
+        "the collected set holds one identity per below-floor unbind in the window, and no more"
+    );
+    // One index read and one span of data reads per segment. Data blocks are
+    // fetched two at a time, so a segment costs at most its block count; the
+    // bound that matters is that neither follows the row count.
+    assert!(
+        profile.index_reads <= window_segments,
+        "the merge read {} indexes for {window_segments} segments",
+        profile.index_reads
+    );
+    assert!(
+        profile.requests() < merged.rows_read as usize / 8,
+        "total work must follow the window's segments, not its rows: {} requests for {} rows",
+        profile.requests(),
+        merged.rows_read
+    );
+
+    // The background job keeps the probe, because it has no budget capping
+    // what it would otherwise collect.
+    let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
+    let MetadataCompactionOutcome::Completed(job) = run_compaction(
+        &store,
+        &namespace_id,
+        &spec,
+        fold_everything_policy(),
+        &MetadataCompactionCancellation::default(),
+    )
+    .await
+    else {
+        panic!("nothing cancelled this job");
+    };
+    assert_eq!(
+        job.unbind_probes, unbinds_below_floor,
+        "a background compaction probes once per reverse row the floor covers"
+    );
+    assert_eq!(
+        job.collected_unbind_generations, 0,
+        "and collects nothing, so its memory does not follow the group"
     );
 }
 
@@ -1892,10 +2516,11 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
 // Resource discipline
 // -------------------------------------------------------------------------
 
-/// The job's reads never overlap wider than its fetch bound, and the decoded
-/// blocks it holds never follow the size of what it is rebuilding.
+/// A merge's reads never overlap wider than its fetch bound, and the decoded
+/// blocks it holds never follow the size of what it is merging. Both hold for
+/// the background job and for the same engine run inside a maintenance step.
 #[tokio::test]
-async fn a_compaction_keeps_its_reads_and_its_decoded_blocks_bounded() {
+async fn a_merge_keeps_its_reads_and_its_decoded_blocks_bounded() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = ConcurrencyWatchStore::new(
@@ -1957,6 +2582,61 @@ async fn a_compaction_keeps_its_reads_and_its_decoded_blocks_bounded() {
         result.peak_operator_rows <= 1,
         "a retention operator held {} rows",
         result.peak_operator_rows
+    );
+
+    // The same bounds hold for the same engine run inside a maintenance step.
+    // The step's input budgets cap what a window may hold, but they say nothing
+    // about what merging it costs, and the old path read every row of the
+    // window into vectors.
+    let store = ConcurrencyWatchStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        KeyPredicate::metadata_table(),
+    );
+    let floor_seq = read_floor_seq(&store, &namespace_id).await;
+    let tables = load_current_manifest_tables(&store, &namespace_id).await;
+    let Some(ReorganizationPlan::BoundedMerge(input)) = select_reorganization_input(
+        &tables,
+        group,
+        small_segment_policy(),
+        floor_seq,
+        &FrozenBasePolicy::default(),
+    )
+    .await
+    .expect("plan the group")
+    .plan
+    else {
+        panic!("raised budgets must admit a bounded merge");
+    };
+    drop(tables);
+    let merged = merge_group_in_step(
+        &store,
+        &namespace_id,
+        group,
+        &input.runs,
+        input.placement,
+        floor_seq,
+        small_segment_policy(),
+    )
+    .await
+    .expect("merge the window inside a step");
+    assert!(
+        store.reads().peak_in_flight <= 8,
+        "the step's merge overlapped {} reads at once",
+        store.reads().peak_in_flight
+    );
+    assert!(
+        merged.peak_resident_blocks <= input.runs.len() * 2 * 2,
+        "the step's merge held {} decoded blocks at once",
+        merged.peak_resident_blocks
+    );
+    assert!(
+        merged.peak_operator_rows <= 1,
+        "a retention operator held {} rows in the step's merge",
+        merged.peak_operator_rows
+    );
+    assert_eq!(
+        merged.rows_read, result.rows_read,
+        "both paths read the same window"
     );
 }
 
@@ -2049,7 +2729,8 @@ async fn one_directory_far_past_the_row_budget_streams_a_row_at_a_time() {
 }
 
 /// Every group of a namespace whose churn all lands on one hot locality
-/// rebuilds to the fold's rows while its operators hold at most one row.
+/// rebuilds to the same rows a step-contained merge reaches, while its
+/// operators hold at most one row.
 ///
 /// The wide-directory case above proves that distinct localities do not
 /// accumulate together. This proves the other half: one inode's attribute
@@ -2067,26 +2748,31 @@ async fn one_hot_locality_of_each_kind_rebuilds_with_fixed_operator_state() {
     copy_store_tree(job_dir.path(), fold_dir.path());
     let fold_store = LocalFsStore::new(fold_dir.path()).expect("store");
 
+    // What both stores hold before either of them rebuilds anything. The trees
+    // are byte-identical here, so one read stands for both.
+    let mut rows_before = BTreeMap::new();
     for group in REORGANIZE_FAMILY_GROUPS {
-        let before = group_rows_of_current_manifest(&store, &namespace_id, group).await;
+        rows_before.insert(
+            group,
+            group_rows_of_current_manifest(&store, &namespace_id, group).await,
+        );
+    }
+    // The same durable bytes, rebuilt the other way: synchronous merges inside
+    // maintenance steps, with the budgets raised so each group folds whole.
+    drain_reorganization(
+        &fold_store,
+        &namespace_id,
+        &test_context(),
+        fold_everything_policy(),
+    )
+    .await;
+
+    for group in REORGANIZE_FAMILY_GROUPS {
+        let before = rows_before[&group].clone();
         if before.values().all(Vec::is_empty) {
             continue;
         }
-        // The same durable bytes, folded the ordinary way.
-        let folded_before = group_rows_of_current_manifest(&fold_store, &namespace_id, group).await;
-        assert_eq!(
-            folded_before, before,
-            "both rebuilds must start from the same rows"
-        );
-        let mut folded = folded_before.clone();
-        for family in group.families() {
-            folded.entry(*family).or_default();
-        }
-        drop_rows_below_retention_floor(&mut folded, frozen_floor_seq)
-            .expect("fold the group whole");
-        for (family, rows) in &mut folded {
-            rows.sort_by_key(|row| row.row_key_for_family(*family));
-        }
+        let folded = group_rows_of_current_manifest(&fold_store, &namespace_id, group).await;
 
         let spec = compaction_spec_for_group(&store, &namespace_id, group).await;
         let snapshot_keys = snapshot_keys_now(&store, &namespace_id, &spec).await;
@@ -2111,7 +2797,7 @@ async fn one_hot_locality_of_each_kind_rebuilds_with_fixed_operator_state() {
         let compacted = group_rows_of_current_manifest(&store, &namespace_id, group).await;
         assert_eq!(
             compacted, folded,
-            "a streaming rebuild of {group:?} must keep the rows a whole-group fold keeps"
+            "a background rebuild of {group:?} must keep the rows a step-contained merge keeps"
         );
         // Nothing above the floor may go, whatever the rules dropped below it.
         for (family, rows) in &before {

--- a/crates/loonfs-core/src/checkpoint/validate.rs
+++ b/crates/loonfs-core/src/checkpoint/validate.rs
@@ -3,12 +3,15 @@
 
 use super::error::ManifestLoadError;
 use super::row::manifest_row_commit_seq;
+#[cfg(test)]
+use loonfs_api::wire::manifest::MetadataTableFamily;
 use loonfs_api::wire::manifest::{
-    MetadataRow, MetadataTableFamily, NamespaceManifestEnvelope, NamespaceManifestPayload,
+    MetadataRow, NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
 use loonfs_api::{
     manifest_object_id_manifest_id, ChangeSeq, ManifestId, ManifestObjectId, NamespaceId,
 };
+#[cfg(test)]
 use std::collections::BTreeSet;
 
 pub(super) fn validate_namespace_manifest(
@@ -144,6 +147,14 @@ pub(super) fn validate_manifest_row_seq_range<'a>(
     Ok(())
 }
 
+/// Compares a bind family against its reverse index outright, over rows a
+/// caller holds all of.
+///
+/// Only the test-only inspection materialization holds a whole family, so only
+/// it can afford this. A merge never holds one and checks parity by digesting
+/// the rows it writes instead
+/// (`super::streaming_compaction::GroupMerge::refuse_a_run_whose_index_disagrees`).
+#[cfg(test)]
 pub(super) fn validate_direntry_child_bind_index(
     object_key: &str,
     direntry_bind_rows: &[MetadataRow],
@@ -167,6 +178,9 @@ pub(super) fn validate_direntry_child_bind_index(
     Ok(())
 }
 
+/// [`validate_direntry_child_bind_index`] for the revision pair, and
+/// test-only for the same reason.
+#[cfg(test)]
 pub(super) fn validate_revision_by_inode_desc_index(
     object_key: &str,
     revision_rows: &[MetadataRow],
@@ -197,6 +211,7 @@ pub(super) fn validate_revision_by_inode_desc_index(
     Ok(())
 }
 
+#[cfg(test)]
 fn validate_revision_rows_have_unique_keys(
     object_key: &str,
     family: MetadataTableFamily,
@@ -216,6 +231,7 @@ fn validate_revision_rows_have_unique_keys(
     Ok(())
 }
 
+#[cfg(test)]
 fn revision_logical_key(row: &MetadataRow) -> String {
     row.row_key_for_family(MetadataTableFamily::Revisions)
 }

--- a/docs/design/metadata-streaming-compaction.md
+++ b/docs/design/metadata-streaming-compaction.md
@@ -37,6 +37,16 @@ Merges above the base can continue reducing delta-run count, but they cannot app
 - Changes to the metadata segment format.
 - Configurable process-wide concurrency. The maintenance runner uses a fixed limit of two concurrent jobs.
 
+## One engine, two orchestrations
+
+Both reorganization paths merge with the same code. A maintenance step runs it synchronously over the window its budgets selected, and a background job runs it over every run a group holds. The merge itself does not know which one is driving it: it reads sorted iterators, applies the retention operators, writes segments, and reports what it wrote. Rows are dropped when, and only when, the merge placement is base-tier, which is the same rule that decides the output level.
+
+The two orchestrations exist because the work has two shapes. A step-contained merge is the frequent small case. It is bounded by the step's input budgets, it publishes inside the step that ran it, and paying for a lease, a staging prefix, a registry entry, and an admission permit on every one of them would be pure overhead. It also preserves the step contract that `ManualOnly` deployments drive: one call does one unit of work and either publishes it or reports that there was nothing to do.
+
+The background job exists because work of unbounded duration cannot be done that way. A job may run for minutes or hours, so its output has to be staged where a lease can speak for it, its concurrency has to be admitted, and its publication has to revalidate the input it read. Those costs buy nothing for a merge that finishes inside its own step.
+
+One thing inside the merge follows the same split, and only one: how a reverse bind row is resolved. The two resource contracts genuinely differ there, and the section on reverse-index resolution below says how. Everything else — iteration, retention, segment writing, index parity, and what the merge reports — is the same code for both.
+
 ## Compaction flow
 
 Normal bounded merges remain the preferred path. Streaming compaction is selected when a family group has repeatedly required work while its bottom-anchored merge cannot fit within one maintenance step.
@@ -90,9 +100,9 @@ Runs published after the snapshot was captured are not part of the compaction in
 
 ## Streaming executor
 
-Each family is read through a sorted iterator over its selected runs. A k-way merge selects the next row in family key order. Completed output segments are written as soon as they reach the normal segment target size.
+This is the engine both paths run. Each family is read through a sorted iterator over its selected runs. A k-way merge selects the next row in family key order. Completed output segments are written as soon as they reach the normal segment target size. A background job writes them under its own prefix; a step-contained merge writes them at ordinary table keys, because the publication that names them lands in the same step and the ordinary write-time grace already covers them.
 
-The following resources have explicit limits:
+The following resources have explicit limits, and they bound both paths:
 
 - Decoded input blocks held by each iterator.
 - Concurrent object-store fetches.
@@ -113,11 +123,29 @@ Rows are processed as follows:
 - Attribute rows arrive newest first for each inode. The operator tracks whether it has retained the newest row at or below the floor and detects repeated revision numbers without retaining the complete history.
 - Active-deletion rows are ordered so a removal marker arrives before the row it removes. One flag is enough to remove the pair together.
 - Forward binding rows are grouped by binding generation. The operator holds at most one bind row until the matching unbind rows arrive, and it retains one generation identity to validate the parent-and-name slot.
-- Reverse child-binding rows use bloom-filtered point lookups against the snapshot's unbind rows because their key order differs from the forward binding table.
+- Reverse child-binding rows are resolved against the same below-floor unbound generations, reached by one of two routes because their key order differs from the forward binding table. The next section says which route and why.
 
-Bindings and revisions have secondary indexes that must remain equivalent to their canonical families. The executor computes order-independent digests for the canonical and index rows selected for output. A mismatch fails the job before publication.
+Bindings and revisions have secondary indexes that must remain equivalent to their canonical families. The executor computes order-independent digests for the canonical and index rows selected for output, and a mismatch fails the merge before publication. This is the only index-parity check either path makes. It covers the rows a merge wrote rather than the rows it read, so it states that the two families dropped in lockstep and not only that their inputs matched.
+
+Every metadata row key identifies one row, and nothing downstream re-establishes that: reads concatenate runs rather than deduplicating them, and the segment writer rejects a descending key but not a repeated one. The executor therefore holds the last input row key it saw for each family and requires the next one to be strictly greater. An equal key is namespace corruption and names the family and the key; a smaller key is an internal error against the merge itself. The check runs over the merge's input, so it sees a duplicate that retention would have dropped, one split across two runs, and one split across two segments. It is separate from the digests and catches a different fault: a duplicate present in both families of an index pair leaves both multisets equal, so the digests pass it.
 
 The executor reports its peak retained-row count. Resource tests use heavily reused inodes and binding slots to verify that this value remains constant.
+
+## Reverse-index resolution
+
+A reverse child-binding row is keyed by child while the unbind that retires its binding is keyed by parent, so no grouping of the merged stream holds the two together. Both paths decide such a row with the same rule against the same set of below-floor unbound generations. They build that set differently, because their resource contracts differ.
+
+A background job reads the unbinds of one binding out of its snapshot, one bloom-filtered point lookup per reverse row at or below the floor, behind a bounded decoded-block cache. A job has no bound on the group it rebuilds, so it must not hold a set that grows with that group.
+
+A merge inside a maintenance step collects the below-floor unbound generations while the forward binding cluster streams the unbind family, and the reverse cluster consults that set. The set holds one generation identity per below-floor unbind row in the window, so it is capped by the same row and decoded-byte budgets that capped the window, and it costs no reads at all.
+
+The step does not use point lookups because their cost is not bounded by those budgets. The lookups are one per reverse row, and each becomes a separate round trip once the cache can no longer hold the window's unbind family. The step's row budget admits about 43,000 unbind rows in a bindings window, so that family reaches the 16 MiB cache at roughly 380 bytes a row, which is an ordinary name length; the decoded-byte budget is four times the cache and allows more still.
+
+Measured on a window whose unbind family just fills the cache, with the reverse index walking it out of order, 65,536 reverse rows cost 27,427 data-block reads and 309 MB transferred against 16 MB of priced input. Doubling the family to twice the cache doubled it again: 131,072 reverse rows, 54,819 data-block reads, 707 MB. The cost per reverse row does not settle, because each row is decided on its own.
+
+The same 65,536-row window resolved from the collected set costs 386 data-block reads and 3.7 MB, which is the window read once. The collected set is also the smaller resident structure: one generation identity per below-floor unbind is well under the 16 MiB cache it replaces.
+
+Step budgets therefore price the selected logical input, and a step-contained merge reads exactly that: each selected segment's index once and its data once. Reverse resolution adds no store work to it.
 
 ## Job leases and garbage collection
 
@@ -159,7 +187,10 @@ Lifecycle logging covers job selection, start, progress, publication, cancellati
 
 The implementation is validated with the following tests:
 
-- Compare streaming output with a whole-group fold over the same snapshot.
+- Compare a background job's output with a synchronous merge in a maintenance step over the same snapshot. Both run the same engine, so this test guards the orchestration split rather than two merge implementations.
+- Confirm that a step-contained merge holds the same bounded input blocks, fetch width, and retention state the background job holds.
+- Confirm that a step-contained merge reads each selected segment's index once and its data once, and makes no reverse-index lookup, while a background job over the same window makes one lookup per reverse row the floor covers.
+- Reject a row key repeated in both families of a secondary-index pair, on both paths, without publishing.
 - Confirm that new runs published during execution survive finalization.
 - Confirm that changed input causes abandonment without publication.
 - Exercise compare-and-swap retries after unrelated manifest updates.
@@ -174,6 +205,7 @@ The implementation is validated with the following tests:
 - Verify that explicit compaction and maintenance without a background runner select full compaction immediately for a frozen base.
 - Process large attribute histories and heavily reused binding slots while holding at most one row in retention state.
 - Reject canonical-family and secondary-index mismatches before publication.
+- Reject a metadata family whose merge input repeats a row key.
 - Load a published manifest whose descriptors still use compaction-prefix object keys.
 
 ## Deferred work


### PR DESCRIPTION
This change makes bounded maintenance-step merges and background streaming compactions use one merge engine. Both paths share sorted iterators, retention operators, segment writing, input-order validation, and output index-parity checks. This reduces duplicate logic while preserving the existing maintenance and publication behavior.

The caller still controls orchestration. A maintenance step selects a budgeted window, runs the engine synchronously, writes to normal metadata table keys, and publishes before returning. It does not need a lease, staging prefix, background registry entry, or admission permit. A background compaction runs the engine over a complete oversized family group and keeps its existing job prefix, lease, admission, cancellation, input revalidation, and final publication logic.

Merge placement determines retention behavior. A base-tier merge may remove rows below the retention floor because its input starts with the oldest run. A delta-tier merge keeps every input row because related history may remain in the base. Both paths therefore derive output level and row-removal behavior from the same placement value.

Each family’s input keys must now be strictly increasing. The engine retains only the previous key for each family and rejects repeated or descending keys, including duplicates split across runs or segments and duplicates that retention would otherwise remove. This check is separate from index parity because matching duplicates in both sides of an index pair can produce equal digests.

Canonical families and their secondary indexes use one parity check. The engine builds order-independent digests from the rows actually written and compares each canonical/index pair before returning the run. Validating output rather than input confirms that retention removed corresponding rows from both families.

Reverse-binding retention uses the execution path’s memory constraints. Background compaction continues to point-read matching unbind rows so memory does not grow with the full group. A budgeted maintenance step collects below-floor unbound generations while it streams the forward families, avoiding thousands of out-of-order point reads. In the measured 65,536-row window, this reduced data-block reads from 27,427 to 386 and transferred data from 309 MB to 3.7 MB. At 131,072 rows, the point-read path required 54,819 reads and 707 MB, so keeping it off the bounded path avoids work that scales linearly with the window.

The change removes the vector-based bounded merge, whole-window row materialization, duplicate retention pass, separate merge-time parity checks, and the scan helper used only by that implementation. Tests compare both orchestration paths over identical durable state, verify their resource bounds and reverse-binding results, and cover duplicate keys across rows, runs, segments, and retention boundaries. Formatting, Clippy, the workspace suite, OpenAPI checks, packaging checks, and distribution checks pass. No golden-format files change.
