### PR TITLE
docs: clarify code comments across the workspace

### DIFF
--- a/crates/loonfs-api/src/content.rs
+++ b/crates/loonfs-api/src/content.rs
@@ -64,20 +64,12 @@ impl<'de> Deserialize<'de> for ContentRefKind {
     }
 }
 
-/// Algorithm of a stored full-object checksum.
+/// Supported algorithms for full-object checksums.
 ///
-/// Every algorithm here covers the complete object. There is deliberately no
-/// checksum-*type* field: full-object coverage is an invariant of this
-/// format, established when the object is written, never read back from a
-/// provider. (Cloudflare R2 never reports `x-amz-checksum-type` at all, so a
-/// type read back would be unavailable exactly where it would matter.)
-///
-/// Every algorithm here is producible by this build, and the vocabulary is
-/// closed: an algorithm spelling this build does not know fails to decode
-/// rather than decoding into a value nothing can recompute. So a
-/// `ChecksumAlgorithm` in hand always names evidence that can be checked,
-/// and the read, retry, and resume paths never have to carry a "cannot
-/// tell" answer. Adding a variant is therefore adding a producer for it.
+/// Full-object coverage is part of the LoonFS format, so no separate checksum
+/// type is stored. Unknown algorithms fail to decode because every in-memory
+/// `ChecksumAlgorithm` must be recomputable by this build. Adding a variant
+/// also requires adding its implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
@@ -163,13 +155,10 @@ impl StorageChecksum {
     }
 }
 
-/// One full-object checksum folded over a payload delivered in pieces.
+/// Incremental full-object checksum for streamed reads and writes.
 ///
-/// This is the streaming form of [`StorageChecksum::matches`], for a reader
-/// that verifies an object it never holds whole. Both cover the whole
-/// vocabulary, so a checksum a buffered read would judge is one a streaming
-/// read can fold — the two can never disagree about whether an object is
-/// checkable, only about what it hashes to.
+/// It supports every [`ChecksumAlgorithm`] used by buffered verification, so
+/// buffered and streaming paths differ only in how bytes are supplied.
 #[derive(Debug)]
 pub enum StreamingChecksum {
     /// SHA-256 folded over the payload.
@@ -252,14 +241,11 @@ impl fmt::Debug for Crc64Nvme {
     }
 }
 
-/// CRC-32C (Castagnoli) over a payload delivered in pieces.
+/// Incremental CRC-32C (Castagnoli) checksum.
 ///
-/// This is the full-object checksum Google Cloud Storage computes and
-/// reports, so a transfer that never passes through LoonFS is described by
-/// it and nothing else. A CRC folds forward from a running value, so the
-/// same digest serves a whole-object read and a resumed one: the prefix
-/// already on disk goes in first, the fetched remainder after it, and the
-/// closed value covers the object either way.
+/// Google Cloud Storage reports this checksum for direct transfers. Resumed
+/// reads first add the retained prefix and then the fetched remainder, which
+/// produces the same full-object checksum as an uninterrupted read.
 #[derive(Default)]
 pub struct Crc32c {
     crc: u32,
@@ -403,13 +389,11 @@ impl ContentRef {
         }
     }
 
-    /// Builds a reference from a digest folded over the payload as it was
-    /// written, for a write that never held the whole payload at once.
+    /// Builds a content reference from a SHA-256 computed while streaming the
+    /// payload.
     ///
-    /// Taking the digest itself rather than a checksum value is what keeps
-    /// the provenance rule structural: the only way to reach this
-    /// constructor is to have hashed the bytes here, on the LoonFS write
-    /// path, which is exactly what `whole_file_sha256` claims.
+    /// Accepting the digest object, rather than an arbitrary checksum string,
+    /// ensures that `whole_file_sha256` came from the LoonFS write path.
     pub fn blob_v1_streamed(content_id: ContentId, size_bytes: u64, digest: Sha256) -> Self {
         let storage_checksum = digest.finish();
         Self {
@@ -421,14 +405,11 @@ impl ContentRef {
         }
     }
 
-    /// The checksum this reference holds its bytes to.
+    /// Returns the checksum used to verify this content reference.
     ///
-    /// The trusted whole-file digest when one exists, and otherwise the
-    /// reference's own storage checksum — which for an object a provider
-    /// assembled or a client wrote directly is the only full-object evidence
-    /// there is. Reads, resumed reads, and retry reconciliation all judge
-    /// against this one answer, so no two of them can hold the same
-    /// reference to different evidence.
+    /// A trusted whole-file SHA-256 is preferred when present. Otherwise the
+    /// provider's full-object storage checksum is used. All verification paths
+    /// call this method so they use the same evidence.
     pub fn verifiable_checksum(&self) -> StorageChecksum {
         match &self.whole_file_sha256 {
             Some(digest) => StorageChecksum {
@@ -557,17 +538,12 @@ mod tests {
         }
     }
 
-    /// An algorithm spelling this build does not know is rejected at decode
-    /// rather than kept as an unknown value, unlike
-    /// [`ContentRefKind::Unsupported`], which exists so a relaying reader
-    /// cannot destroy a newer kind.
+    /// Unknown checksum algorithms are rejected during decoding.
     ///
-    /// The asymmetry is deliberate and load-bearing: nothing here relays a
-    /// checksum it did not verify, so an algorithm that survived decoding
-    /// would be evidence nothing could check. Rejecting at the boundary is
-    /// what makes every `ChecksumAlgorithm` value in memory recomputable,
-    /// and therefore what lets reads, retries, and resumes have no "cannot
-    /// tell" answer to carry.
+    /// Content kinds may be preserved by readers without interpretation, but a
+    /// checksum is accepted only when this build can verify it. This guarantees
+    /// that every decoded `ChecksumAlgorithm` is supported by buffered, streamed,
+    /// and resumed verification.
     #[test]
     fn an_unknown_checksum_algorithm_fails_to_decode() {
         assert!(serde_json::from_str::<ChecksumAlgorithm>("\"md5\"").is_err());

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -81,15 +81,12 @@ impl ControlObjectKind {
     }
 }
 
-/// Lower bound of retained WAL/change history: the symmetrical pair to
-/// `wal/head.json`.
+/// Earliest sequence for which incremental WAL history is retained.
 ///
-/// Updated only by monotonic compare-and-swap on its own etag; never
-/// consulted for live commit visibility. Missing, stale, or unverifiable
-/// floors mean "retain more history", never less. The floor is necessary
-/// but not sufficient for deletion: below-floor objects are candidates,
-/// and actual deletion additionally requires delete-time re-verification
-/// (format spec, "Garbage collection").
+/// The floor advances monotonically by compare-and-swap and does not control
+/// live visibility. Missing or unverifiable floor state must retain more
+/// history. Objects below the floor are only deletion candidates; garbage
+/// collection still revalidates them before removal.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WalFloorState {
@@ -191,16 +188,12 @@ pub struct MetadataCompactionLeaseState {
     pub heartbeat_at_ms: u64,
 }
 
-/// Lifecycle of a durable checkpoint record: monotonic, with exactly two
-/// states and one transition.
+/// Monotonic lifecycle of a durable checkpoint record.
 ///
-/// A record is born `active` under a freshly generated id and pins its basis
-/// until something moves it to `released` by compare-and-swap — the owner
-/// asking for it, or garbage collection observing that its `expires_at_ms`
-/// passed. `released` is terminal: nothing returns a record to `active`, so
-/// a released record protects nothing and answers no read. Garbage
-/// collection deletes it once `released_at_ms` is a grace window old. A new
-/// pin is a new record under a new id, never a revival of this one.
+/// A new record starts active and pins its basis. Explicit release or expiry
+/// moves it to the terminal released state by compare-and-swap. Released
+/// records serve no reads and are deleted after the release grace period.
+/// Creating another pin always creates a new record id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CheckpointRecordLifecycle {
@@ -309,14 +302,12 @@ struct StrictCheckpointRecordState {
 }
 
 impl<'de> Deserialize<'de> for CheckpointRecordState {
-    /// Reads one checkpoint record and proves the one relationship its shape
-    /// cannot: that a fork-owned pin carries the lease bounding it.
+    /// Decodes a checkpoint record and validates that every fork-owned record
+    /// has an expiry.
     ///
-    /// The lease is the only thing that ever releases an attempt whose
-    /// target head was never installed — nothing else can tell that attempt
-    /// from one still running — so a fork record without one pins its basis
-    /// forever, and no pass can decide otherwise. It is refused at load like
-    /// any other corruption.
+    /// The expiry bounds an abandoned fork attempt whose target head was never
+    /// installed. Without it, the source basis could remain pinned forever, so
+    /// such a record is rejected as corrupt.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -534,15 +525,12 @@ impl From<StrictWalSegmentPointer> for WalSegmentPointer {
 }
 
 impl<'de> Deserialize<'de> for HeadState {
-    /// Reads one head and proves the one relationship its shape cannot: that
-    /// the replay accelerator begins at the visible WAL tip.
+    /// Decodes a namespace head and validates the WAL hint list.
     ///
-    /// Every publisher writes `visible_wal_tip` and `recent_segments` in the
-    /// same compare-and-swap. A namespace before its first commit has
-    /// neither, and every namespace after it has the tip as the
-    /// accelerator's first entry. Readers count the visible WAL tail from a
-    /// hint run that starts at the tip, so a head that disagrees with itself
-    /// is refused at load like any other corruption.
+    /// Before the first commit, both `visible_wal_tip` and `recent_segments` are
+    /// empty. Afterward, the first recent segment must equal the visible tip
+    /// because both are written in the same compare-and-swap. A mismatch is
+    /// rejected as corrupt state.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -658,13 +646,10 @@ impl HeadState {
     }
 }
 
-/// How one upload session moves its bytes into object storage, and
-/// everything that choice settles before any byte moves.
+/// Transport selected when an upload session is created.
 ///
-/// A session's transport is fixed when it opens and never changes. Each
-/// variant carries exactly what its own path needs, so a session cannot
-/// hold a provider upload it will never use, or a promise it was never
-/// given.
+/// The transport never changes, and each variant stores only the state
+/// required by that upload path.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum UploadSessionTransport {
@@ -672,11 +657,10 @@ pub enum UploadSessionTransport {
     /// so it learns size and digest from the bytes as they pass and has
     /// nothing to record here.
     ///
-    /// The empty braces are load-bearing: serde lets a *unit* variant of a
-    /// tagged enum swallow whatever else the object carried, so spelling
-    /// this as `ServiceProxied` would read a record holding a provider
-    /// upload as a proxied session and drop the handle that cleans it up.
-    /// A variant with no fields refuses it as the corruption it is.
+    /// Empty braces force serde to reject fields from another transport.
+    ///
+    /// A unit variant would silently ignore unexpected fields, which could drop
+    /// a provider upload id needed for cleanup.
     ServiceProxied {},
     /// The client writes the whole object through one presigned request.
     DirectPut {
@@ -689,16 +673,12 @@ pub enum UploadSessionTransport {
         /// reference rather than believing it.
         promised_content: ContentRef,
     },
-    /// The client writes the object in parts through presigned part
-    /// uploads, and the provider assembles it.
+    /// The client uploads parts and the provider assembles the object.
     ///
-    /// There is deliberately no content promise here. A session that had to
-    /// declare its length and digest up front would make a one-pass
-    /// uploader read its payload twice, and a client reading from a pipe
-    /// could not start at all — so a multipart upload claims what it wrote
-    /// at completion, which is where it was always verified rather than
-    /// believed. This variant carrying no reference is what makes an
-    /// up-front multipart claim unrepresentable.
+    /// Multipart sessions do not store a content reference at creation because
+    /// one-pass and streaming clients may not know the final size or checksum.
+    /// The client supplies those values at completion, when LoonFS verifies the
+    /// assembled object.
     DirectMultipart {
         /// The provider-side upload the parts assemble through, and the
         /// only provider handle LoonFS keeps: parts are the client's
@@ -725,17 +705,12 @@ impl UploadSessionTransport {
     }
 }
 
-/// Lifecycle of a durable upload session: one live state and two terminal
-/// ones, with no way back.
+/// Monotonic lifecycle of a durable upload session.
 ///
-/// A session opens with a lease and either completes or is aborted. The
-/// compare-and-swap that makes one of those two land is the serialization
-/// point for the whole upload — provider state follows the durable
-/// transition, never the other way around — so whichever transition wins is
-/// simply what happened, and the loser reports a terminal error rather than
-/// undoing anything. Nothing returns a session to `open`: a client that
-/// wants another try begins another session, which mints its own content
-/// identity.
+/// A session starts open and ends either completed or aborted. The
+/// compare-and-swap that writes the terminal state decides which transition
+/// won; provider cleanup happens afterward. Terminal sessions never reopen,
+/// so another attempt requires a new session and content id.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum UploadSessionLifecycle {
@@ -757,22 +732,13 @@ pub enum UploadSessionLifecycle {
         /// completed one names its content once, below.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         staged_content: Option<ContentRef>,
-        /// Unix-millisecond stamp of the staging request currently writing
-        /// the content object, or `None` when no request holds the slot.
+        /// Time at which the current staging request claimed exclusive access,
+        /// or `None` when no request is staging.
         ///
-        /// The claim is what makes staging exclusive. A service-proxied
-        /// session writes one object key, and a provider cannot make the
-        /// create-only condition on a multipart write part of the write, so
-        /// two requests that both found the key absent would both assemble
-        /// over it and only one of them would record its digest. Taking this
-        /// claim is a compare-and-swap, so exactly one request writes at a
-        /// time and the recorded reference always describes the object.
-        ///
-        /// It carries no expiry of its own. The claim is honoured only while
-        /// the session is open, so `expires_at_ms` above bounds it: a request
-        /// that is cancelled while holding the claim leaves the session
-        /// unable to stage until its lease passes, and garbage collection
-        /// aborts the session at exactly that point.
+        /// The claim is acquired by compare-and-swap so only one request can write
+        /// the session's content object at a time. It has no separate expiry; the
+        /// upload session lease bounds a claim left behind by cancellation, after
+        /// which garbage collection aborts the session.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         staging_claimed_at_ms: Option<u64>,
     },

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -59,11 +59,10 @@ pub enum MetadataTableFamily {
     ActiveDeletions,
     /// Preserves commit idempotency evidence independently of retained WAL history.
     CommitReceipts,
-    /// Stores inode attribute revisions newest-first per inode.
+    /// Stores inode attribute revisions newest-first.
     ///
-    /// The family stands alone: it has no ascending twin, because nothing
-    /// reads attributes in any other order than newest first for one inode.
-    /// So no cross-family index-parity validator applies to it.
+    /// Attributes are read only in this order, so the family has no secondary
+    /// index and requires no cross-family parity check.
     Attributes,
 }
 
@@ -92,9 +91,9 @@ pub struct MetadataFileRef {
     pub min_key: String,
     /// Inclusive greatest durable row key; range planning skips disjoint segments.
     pub max_key: String,
-    /// Where the segment's index block lives and how to verify it. The
-    /// descriptor is the only entry point into a segment object — there is
-    /// no footer — so a reader starts here.
+    /// Location and verification data for the segment index block.
+    ///
+    /// Segments have no footer, so readers begin with this handle.
     pub index_block: BlockHandle,
     /// Where the segment's bloom filter block lives and how to verify it.
     pub filter_block: BlockHandle,
@@ -191,12 +190,11 @@ pub enum MetadataRow {
         /// every `committed_at_ms`.
         deleted_at_ms: u64,
     },
-    /// Names one deletion generation in the derived active-deletions family.
+    /// Derived row used to list currently recoverable deletions.
     ///
-    /// The row is not a new event: the materializer derives it from the
-    /// tombstone family, adding a `listed` row for each `set` and a `removed`
-    /// row for each `revoke`, so the trash listing is a range scan instead of
-    /// a walk over every deletion the namespace ever recorded.
+    /// Materialization writes `listed` for each tombstone set and `removed` for
+    /// each revoke. This lets trash listing use an ordered range scan instead of
+    /// replaying all historical deletion events.
     ActiveDeletion {
         /// Subtree root the deletion covers. With `deleted_at_seq` this is
         /// exactly the handle `undelete` addresses.
@@ -263,12 +261,10 @@ pub struct TombstoneGeneration {
     pub delta_index: u32,
 }
 
-/// The directory binding a path delete removed, described whole.
+/// Directory binding removed by a path deletion.
 ///
-/// Tombstone rows are immortal, so this is where a deleted name survives
-/// after the unbind row ages out — and where undelete reads the binding it
-/// restores. The three fields describe one binding, so they travel as one:
-/// a tombstone either recorded a binding or it did not.
+/// Tombstones retain this binding after the corresponding unbind row may be
+/// collected. Undelete uses it to restore the original parent and name.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeletedDirentry {
@@ -316,15 +312,12 @@ pub enum TombstoneRowAction {
     },
 }
 
-/// Active-deletion row vocabulary (format spec, "Tombstones and deletion").
+/// Current-state rows for recoverable deletions.
 ///
-/// The family holds current state, not history: a `listed` row means the
-/// deletion is recoverable and the trash lists it, and a `removed` row is the
-/// undelete's compensating marker that hides it. The two rows for one
-/// deletion share a key prefix and `removed` sorts first, so an ascending
-/// scan always sees the removal before the row it removes; reorganization
-/// then drops the pair, because a cancelled deletion is not state anyone can
-/// still observe.
+/// `Listed` exposes a deletion in trash; `Removed` hides it after undelete.
+/// Both rows share a key prefix, with `Removed` sorting first, so scans can
+/// suppress restored entries. Reorganization later removes the cancelled
+/// pair.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ActiveDeletionRowAction {

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -40,14 +40,11 @@ pub struct ApiError {
     pub details: Option<Box<ErrorDetails>>,
 }
 
-/// Structured, machine-readable context accompanying an [`ApiError`].
+/// Optional machine-readable details for an [`ApiError`].
 ///
-/// Every field is optional: a code populates the fields that apply to it
-/// (API spec, "Standard error contract"), and clients must tolerate absent
-/// fields exactly as they tolerate unknown codes. Retry decisions still key
-/// off the code; these fields carry the identity a caller needs to act —
-/// which commit to resubmit, which epoch displaced it, which revision the
-/// precondition saw.
+/// Clients make retry decisions from the error code and use these fields for
+/// relevant identifiers such as commit ids, writer epochs, and revisions.
+/// Fields may be absent and clients must ignore fields they do not use.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ErrorDetails {
@@ -209,16 +206,10 @@ pub enum DeleteDirectoryBehavior {
 
 /// One path-oriented filesystem operation.
 ///
-/// Unknown fields are rejected because every optimistic-concurrency guard
-/// below is an optional field. A misspelled `expected_revision_no` or
-/// `expected_inode_id` would otherwise decode to `None`, and the write would
-/// apply unguarded and answer 200 — a lost update reported as a success. A
-/// guard the server never saw must fail the request, not the precondition.
-///
-/// Every variant here carries fields. A variant that carries none must still
-/// be spelled with empty braces, because serde lets a *unit* variant of a
-/// tagged enum swallow whatever else the body held; `BeginUploadRequest` in
-/// [`super::uploads`] shows the same rule.
+/// Unknown fields are rejected because concurrency guards are optional. A
+/// misspelled guard must fail decoding instead of silently becoming `None`
+/// and allowing an unguarded write. Any future fieldless variant must use
+/// empty braces so serde also rejects unexpected fields for that variant.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
@@ -297,13 +288,12 @@ pub enum FilesystemOperation {
         inode_id: InodeId,
         /// Observed deletion sequence, which prevents cancelling a newer tombstone generation.
         deleted_at_seq: ChangeSeq,
-        /// Absolute destination path whose parent must be visible and whose
-        /// name must be absent. Absent means restore in place: re-bind
-        /// under the parent and name the deletion recorded, anchored on
-        /// the parent's identity rather than any remembered spelling, so
-        /// the entry lands correctly even when ancestors were renamed
-        /// since. A deletion that recorded no binding needs the explicit
-        /// path.
+        /// Optional destination for the restored inode.
+        ///
+        /// When absent, the inode is rebound to the parent and name recorded by the
+        /// deletion. Parent identity, rather than an old path string, keeps this
+        /// correct after ancestor renames. An explicit path is required when the
+        /// deletion recorded no binding.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         path: Option<AbsolutePath>,
     },
@@ -325,9 +315,10 @@ pub enum FilesystemOperation {
         /// not name are left alone.
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         set: BTreeMap<AttributeKey, AttributeValue>,
-        /// Keys to remove. A list rather than a set so a repeated key is
-        /// rejected with a message that names it, instead of being folded
-        /// away as if the caller had asked once.
+        /// Attribute keys to remove.
+        ///
+        /// A list preserves duplicate entries so validation can report them instead
+        /// of silently deduplicating the request.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         remove: Vec<AttributeKey>,
         /// When set, the update applies only if the path still resolves to

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -30,20 +30,12 @@ pub struct DirectPutContentClaim {
     pub storage_checksum: StorageChecksum,
 }
 
-/// What a `direct_multipart` client says about the object it finished
-/// writing, supplied at completion rather than at begin.
+/// Final size and checksum claimed for a direct multipart upload.
 ///
-/// The claim arrives last because that is the only place a one-pass
-/// uploader can produce it: a client that had to declare the length and
-/// digest up front would have to read its payload twice, and a client
-/// reading from a pipe could not start at all. Nothing is lost by waiting —
-/// the claim was never trusted, only verified, and verification happens at
-/// completion either way.
-///
-/// The digest is CRC-64/NVME rather than SHA-256 because that is the
-/// checksum an S3-compatible provider computes over a multipart object: it
-/// is the only full-object evidence the provider will ever be able to show
-/// back, so it is the only thing worth claiming at all.
+/// The claim is supplied at completion so one-pass and streaming uploaders do
+/// not need to read the payload twice. LoonFS verifies the claim rather than
+/// trusting it. CRC-64/NVME is used because S3-compatible providers report it
+/// for the assembled full object.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
@@ -91,23 +83,16 @@ pub enum UploadMode {
     DirectMultipart,
 }
 
-/// Request for starting an upload session, tagged by the transport it asks
-/// for.
+/// Request to start an upload session, tagged by transport mode.
 ///
-/// Each transport carries only what it needs, so the combinations a flat
-/// request could spell — a proxied begin carrying multipart geometry, a
-/// direct put with no claim to sign — are refused when the body is decoded
-/// rather than by a handler reading them back. `mode` is required: a
-/// request that does not say how it intends to move its bytes is not a
-/// request this API can answer.
+/// Each variant contains only fields valid for that transport, so invalid
+/// combinations are rejected during decoding. The `mode` field is required.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
 pub enum BeginUploadRequest {
-    // The empty braces are load-bearing: serde lets a *unit* variant of a
-    // tagged enum swallow whatever else the body carried, so spelling this
-    // as `ServiceProxied` would quietly accept a proxied begin holding
-    // another transport's fields. A variant with no fields refuses them.
+    // Empty braces make serde reject fields from another transport. A unit
+    // variant would silently ignore them.
     /// Send the bytes to the service, which writes the content object.
     #[cfg_attr(feature = "openapi", schema(title = "BeginUploadServiceProxied"))]
     ServiceProxied {},
@@ -176,16 +161,11 @@ pub struct DirectPutUpload {
     pub access: ObjectTransferAccess,
 }
 
-/// Direct multipart upload details: the geometry a client cuts its payload
-/// into parts with, and nothing else.
+/// Part geometry returned for a direct multipart upload.
 ///
-/// There is no content reference here, and no part count. The session has
-/// not been told what it is about to receive, so there is no identity to
-/// echo and no arithmetic to do — the server mints the content object
-/// behind the session and names it in the completion response. The
-/// provider's upload id is absent for the same reason it always was: a
-/// client asks this server for part URLs by part number and never talks to
-/// the provider's multipart API in its own words.
+/// The begin response does not include a content reference or part count
+/// because the final payload is not known yet. The server owns the provider
+/// upload id and returns the content reference only after completion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DirectMultipartUpload {
@@ -270,14 +250,10 @@ pub struct ValidatedContentToken {
     pub token: String,
 }
 
-/// Response for starting an upload session, tagged by the transport the
-/// server settled on.
+/// Response to starting an upload session, tagged by transport mode.
 ///
-/// Each transport carries what its client needs next and nothing else, so
-/// the combinations a flat response could spell — a proxied session holding
-/// presigned access, a direct put with no capability to write through — are
-/// not values this type can hold. Unlike the request, unknown fields are
-/// accepted: a response reader tolerates what a later server adds.
+/// Each variant contains only the fields needed by that transport. Unknown
+/// response fields are accepted for forward compatibility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "mode", rename_all = "snake_case")]

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -1,5 +1,6 @@
-//! The embedded arm of the CLI's backend seam: an in-process `loonfs`
-//! runtime behind the same method set the remote arm answers.
+//! Embedded CLI backend implemented by an in-process `loonfs` runtime.
+//!
+//! It implements the same operations as the remote backend.
 
 use crate::backend_error::{
     map_namespace_scoped_grep_error, map_namespace_scoped_runtime_error, map_runtime_error,

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -1,18 +1,10 @@
-//! The backend seam: one logical LoonFS API over two transports.
+//! Unified CLI operations for embedded and remote profiles.
 //!
-//! [`ResolvedTarget`] is what every CLI command programs against. A resolved
-//! profile decides which arm answers — [`EmbeddedBackend`] drives an
-//! in-process `loonfs` runtime, the remote arm drives a `loonfs-client` over
-//! HTTP — and the commands above this seam cannot tell which they got.
-//!
-//! The seam is private to this crate on purpose. It exists so `loonfs` can run
-//! its features against either transport, not as an extension point: an
-//! application embedding LoonFS programs against `loonfs` (runtime) or
-//! `loonfs-client` (HTTP) directly, and neither needs a seam between.
-//!
-//! The methods are async so the CLI drives both transports from its own
-//! runtime. [`loonfs_client::Client`] is itself async, so the remote arms are
-//! direct calls that map the client's error type onto [`BackendError`].
+//! Commands call [`ResolvedTarget`] without depending on the selected
+//! transport. Embedded profiles use the in-process `loonfs` runtime; remote
+//! profiles use `loonfs-client` over HTTP. This private abstraction is for
+//! CLI parity, not application extension. All methods are async and normalize
+//! transport errors as [`BackendError`].
 
 mod embedded;
 
@@ -55,13 +47,10 @@ use loonfs::{
 /// budgets, not by how fast it polls.
 const REMOTE_STATUS_POLL_INTERVAL_MS: u64 = 250;
 
-/// What a caller will spend driving bounded steps toward something.
+/// Optional step-count and elapsed-time limits for iterative commands.
 ///
-/// What one step is depends on what is being driven: one bounded index step
-/// where an embedded profile waits for the index, one status check where a
-/// remote one does, one bounded maintenance step where `admin run` drains an
-/// assignment. The accounting is the same in every case, and both bounds are
-/// optional — an unbudgeted caller runs until the work settles.
+/// A step may be an index update, a remote status check, or a maintenance
+/// operation. Commands without either limit continue until the work settles.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct StepBudget {
     pub max_steps: Option<u64>,
@@ -77,12 +66,11 @@ impl StepBudget {
     }
 }
 
-/// One file's content, in the pieces the transport that opened it delivers.
+/// File content returned by either CLI transport.
 ///
-/// The arms exist because the transports genuinely differ, not because the
-/// commands above want to know which they got: all are consumed by the
-/// same [`FileDownload::next_chunk`] loop, so a download is written to disk
-/// or to standard output the same way whichever profile served it.
+/// Embedded and remote profiles expose different stream types, while small
+/// reads may already be buffered. [`FileDownload::next_chunk`] gives command
+/// code one common iteration model.
 pub(crate) enum FileDownload {
     /// The embedded runtime's bounded stream. Boxed because a stream carries
     /// its object key, reference, and running digest, and the whole arm is a
@@ -103,12 +91,11 @@ pub(crate) enum FileDownload {
 }
 
 impl FileDownload {
-    /// The next piece of the file, or `None` at a verified end.
+    /// Returns the next chunk, or `None` after full verification.
     ///
-    /// A streamed download verifies size and digest on the call that reports
-    /// the end, so a caller that drives this to `None` has verified content
-    /// and a caller that stops early does not. Held bytes were verified
-    /// before they were handed over and answer in one piece.
+    /// Streamed downloads verify length and checksum when the final call reaches
+    /// the end. Stopping early does not complete verification. Buffered bytes
+    /// were verified before this method receives them.
     pub(crate) async fn next_chunk(&mut self) -> Result<Option<Bytes>, BackendError> {
         match self {
             Self::Streamed {
@@ -211,13 +198,11 @@ impl MaintenanceDrainProgress {
     }
 }
 
-/// Refuses a maintenance host to a profile that has no runtime to host it
-/// in. Remote profiles are served by a server that runs its own runner;
-/// stepping one from here would be a second scheduler over the same
-/// namespaces, and there is no remote step to drive anyway.
-/// Refuses upload-session bookkeeping to a profile that has no sessions.
-/// An embedded profile stages content through its own runtime, so there is
-/// no session to ask after and nothing an interrupted upload could rejoin.
+/// Errors used when a command requires the other profile type.
+///
+/// Remote profiles cannot host local maintenance because the server already
+/// schedules it. Embedded profiles do not expose upload sessions because
+/// they stage content directly in-process.
 fn upload_sessions_need_a_remote_profile() -> BackendError {
     BackendError::new(
         loonfs_api::ErrorCode::NotSupported.as_str(),
@@ -255,15 +240,11 @@ async fn rest_between_status_checks() {
     .await;
 }
 
-/// One logical LoonFS API over two transports.
+/// Implements the same CLI operation set for embedded and remote targets.
 ///
-/// Every method below is an exhaustive `match self` with no catch-all arm,
-/// and that exhaustiveness *is* the parity statement this seam used to make
-/// with a trait and two named implementations: neither transport can quietly
-/// go missing from a method, and both must report the same registry error
-/// code for the same failure, so a command renders identical outcomes
-/// regardless of which transport a profile selects (this crate's two-mode
-/// parity tests hold that line).
+/// Each method exhaustively matches both variants, so adding an operation or
+/// target requires handling both transports. Both paths normalize failures to
+/// the same error-code registry, which keeps command output consistent.
 impl ResolvedTarget {
     /// Creates a new empty namespace.
     pub(crate) async fn create_namespace(

--- a/crates/loonfs-cli/src/backend_error.rs
+++ b/crates/loonfs-cli/src/backend_error.rs
@@ -6,21 +6,13 @@ use loonfs_client::ClientError;
 use loonfs_grep::GrepError;
 use thiserror::Error;
 
-/// Failure surfaced by the backend seam ([`crate::resolve::ResolvedTarget`]),
-/// as a `(code, message)` pair.
+/// Normalized error returned by either CLI backend.
 ///
-/// `code` draws from exactly two namespaces:
-///
-/// - **Registry codes** ([`loonfs_api::ErrorCode`]) pass through verbatim
-///   from whichever transport produced them, so embedded and remote backends
-///   surface the same code for the same failure. Never restate a registry
-///   code as a string literal; use `ErrorCode::X.as_str()` or an error's
-///   `code()`.
-/// - **Backend-local codes** cover failures that never produce a registry
-///   code — a server cannot see a caller's local profile or store
-///   configuration, so these deliberately live outside the registry. The
-///   complete list, each owned by a constructor below, is: `invalid_config`,
-///   `invalid_input`, `client_error`, `io_error`, and `runtime_error`.
+/// `code` is either a shared [`loonfs_api::ErrorCode`] string or one of the
+/// local codes created below: `invalid_config`, `invalid_input`,
+/// `client_error`, `io_error`, or `runtime_error`. Shared codes must come
+/// from the registry rather than duplicated string literals so embedded and
+/// remote profiles report the same condition consistently.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("{code}: {message}")]
 pub(crate) struct BackendError {
@@ -107,13 +99,9 @@ impl From<ClientError> for BackendError {
                 details,
             },
             ClientError::Io(message) => Self::io_error(format!("i/o error: {message}")),
-            // Every variant `loonfs-client` defines today has an explicit arm
-            // above, so this one is unreachable and the mapping is unchanged
-            // from when it lived inside that crate. It is required because
-            // `ClientError` is `#[non_exhaustive]`, which only binds across a
-            // crate boundary — a variant added later lands here as a generic
-            // transport failure instead of failing this build. Give any new
-            // variant its own arm rather than letting it fall through.
+            // `ClientError` is non-exhaustive across crate boundaries, so future
+            // variants map to a generic transport failure. Add an explicit arm when a
+            // new variant needs a more specific CLI code.
             other => Self::client_error(other.to_string()),
         }
     }

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -24,11 +24,10 @@ const XDG_CONFIG_SUBDIR: &str = "loonfs";
 /// Directory under `$HOME`, where installs predating XDG support live.
 const LEGACY_CONFIG_SUBDIR: &str = ".loonfs";
 
-/// The way past a config file this build will not accept. Every failure to
-/// load the resolved file ends with it, because strict decoding is only
-/// safe while a rejected file can always be stepped around — otherwise one
-/// unknown key bricks every command, `loonfs init` included. The
-/// environment variable named here is [`CONFIG_PATH_ENV`].
+/// Recovery instructions appended to config-load errors.
+///
+/// Strict decoding is safe only when users can select or create another
+/// config file, including when the default file is unreadable.
 const CONFIG_REMEDY: &str = "fix that file, or run against a different one with `--config <path>` \
      or `LOONFS_CONFIG=<path>`; `loonfs config path` prints the file in use, and \
      `loonfs init --config <path>` writes a fresh one";
@@ -255,13 +254,12 @@ impl ConfigLocation {
     }
 }
 
-/// Resolves the config file for this invocation: `--config` beats
-/// `LOONFS_CONFIG` beats the default location.
+/// Resolves the config path in this order: `--config`,
+/// `LOONFS_CONFIG`, then the default location.
 ///
-/// The explicit forms win by being spelled, never by the named file
-/// existing — a path that is not there yet is still the path this
-/// invocation uses, which is what makes `loonfs init --config <path>` a way
-/// out of an unreadable default file.
+/// An explicit path is selected even when the file does not exist, allowing
+/// commands such as `loonfs init --config <path>` to create a replacement
+/// for an invalid default config.
 pub(crate) fn resolve_config_location(flag: Option<&Path>) -> Result<ConfigLocation, CliError> {
     if let Some(path) = flag {
         return Ok(ConfigLocation::at(path.to_path_buf(), ConfigSource::Flag));
@@ -272,13 +270,11 @@ pub(crate) fn resolve_config_location(flag: Option<&Path>) -> Result<ConfigLocat
     default_config_location()
 }
 
-/// The default location: `$XDG_CONFIG_HOME/loonfs/config.toml` when that
-/// variable names an absolute directory, and `~/.loonfs/config.toml`
-/// otherwise.
+/// Returns the default config location.
 ///
-/// Existence decides exactly one thing here, and only for the migration:
-/// an install that predates XDG support keeps reading its `~/.loonfs` file
-/// until a config exists at the preferred path.
+/// An absolute `XDG_CONFIG_HOME` selects the XDG path. Otherwise the legacy
+/// `~/.loonfs/config.toml` path is used. During migration, an existing legacy
+/// file remains active until a file exists at the XDG path.
 fn default_config_location() -> Result<ConfigLocation, CliError> {
     let legacy = legacy_config_path();
     let Some(xdg_dir) = xdg_config_home() else {
@@ -332,9 +328,10 @@ pub(crate) fn load_config(path: &Path) -> Result<CliConfig, CliError> {
     decode_config_source(path, &source.text)
 }
 
-/// A config load for the repair commands. When the strict decode rejects the
-/// file, they get the loose TOML table instead, so a typo in one profile
-/// never bricks the commands that would fix it.
+/// Config result used by repair commands.
+///
+/// When strict decoding fails, repair commands receive the raw TOML table so
+/// they can edit the invalid file.
 pub(crate) enum ConfigLoad {
     Valid(CliConfig),
     Degraded {

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 ///   the same code for the same failure. Never restate a registry code as a
 ///   string literal; use `ErrorCode::X.as_str()` or an error's `code()`.
 /// - **Backend-local codes** ([`crate::backend_error::BackendError`]) pass
-///   through verbatim from the backend seam: `invalid_config`,
+///   through verbatim from the backend: `invalid_config`,
 ///   `invalid_input`, `client_error`, `io_error`, and `runtime_error`.
 /// - **CLI-local codes** cover failures that never reach a backend. The
 ///   complete list, each owned by a constructor below, is: `invalid_config`,
@@ -20,10 +20,9 @@ use serde::{Deserialize, Serialize};
 ///   `config_already_exists`, `destination_exists`,
 ///   `non_interactive_input_required`, `json_not_supported_for_streaming`,
 ///   `invalid_usage`, `io_error`, and `cancelled`. Overlaps with
-///   backend-local codes are
-///   deliberate: the same string means the same thing on both sides of the
-///   seam — a local configuration failure is `invalid_config` whether the
-///   CLI or the backend seam caught it, and the registry codes are reserved
+///   backend-local codes are deliberate: the same string means the same thing
+///   in both layers. A local configuration failure is `invalid_config`
+///   whether the CLI or backend detects it, and registry codes are reserved
 ///   for failures a server could also produce.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CliError {
@@ -39,9 +38,9 @@ pub(crate) struct CliError {
 }
 
 impl From<crate::backend_error::BackendError> for CliError {
-    /// Backend failures pass through verbatim: the seam already carries the
-    /// registry or backend-local code, message, and any server diagnostics
-    /// this CLI reports.
+    /// Backend failures pass through verbatim because the value already
+    /// carries the registry or backend-local code, message, and any server
+    /// diagnostics this CLI reports.
     fn from(error: crate::backend_error::BackendError) -> Self {
         Self {
             code: error.code,

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -149,10 +149,9 @@ impl EmbeddedTarget {
 
     /// Opens the runtime handles over a store the caller already holds.
     ///
-    /// [`Self::new`] opens the profile's configured store and hands it here.
-    /// It is a seam rather than an extension point: it exists so a caller
-    /// that has to watch what crosses the store boundary can hand in a store
-    /// it wrapped.
+    /// [`Self::new`] opens the profile's configured store and passes it here.
+    /// Callers that need to observe store operations may provide a wrapped
+    /// store directly.
     pub(crate) async fn over_store(
         store: SharedObjectStore,
         writer_id: Option<&str>,

--- a/crates/loonfs-client/src/download_tests.rs
+++ b/crates/loonfs-client/src/download_tests.rs
@@ -222,8 +222,8 @@ async fn a_resumed_crc32c_download_folds_the_prefix_into_the_same_verdict() {
     );
 }
 
-/// The happy path over the same seam: the declared length and digest both
-/// hold, every byte reaches the sink, and the count comes back.
+/// The successful path through the same transport: the declared length and
+/// digest both hold, every byte reaches the sink, and the count comes back.
 #[tokio::test]
 async fn a_streamed_read_writes_the_granted_object_and_reports_its_length() {
     let payload = b"exactly the bytes the grant described".to_vec();

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -64,14 +64,11 @@ const DIRECT_MULTIPART_PARTS_IN_FLIGHT: usize = 4;
 /// its signature.
 const DIRECT_MULTIPART_PART_ATTEMPTS: usize = 3;
 
-/// What a retry can still say about the payload it just uploaded.
+/// Evidence retained for comparing a new upload with an earlier commit.
 ///
-/// A buffered put can answer any question about its bytes by hashing them
-/// again. A one-pass put cannot: its payload went by once and is gone, and
-/// what it kept instead is the verified description the server gave back.
-/// Both are evidence about the same bytes; they differ only in which
-/// questions they can answer, and a question neither can answer is reported
-/// as such rather than guessed at.
+/// Buffered bytes can be hashed with any supported algorithm. A one-pass
+/// upload retains only the verified content reference returned by the
+/// server, so unavailable checksum algorithms cannot be compared.
 #[derive(Debug, Clone, Copy)]
 enum UploadedContent<'a> {
     /// The payload itself, which can produce any digest this build knows.
@@ -288,15 +285,12 @@ impl DirectDownloadStream {
     }
 }
 
-/// What a caller keeps so an interrupted direct multipart upload can pick
-/// up rather than start over.
+/// State required to resume an interrupted direct multipart upload.
 ///
-/// The parts are the caller's own bookkeeping, deliberately: an upload
-/// session records the geometry it was opened with and nothing per part, so
-/// the only account of which parts landed is the one the uploading client
-/// kept. Resuming with fewer parts than actually landed re-sends them,
-/// which is harmless; resuming with parts that did not land fails the
-/// completion, which is the assembly refusing to be wrong.
+/// The server records session geometry but not completed parts, so the
+/// client retains the upload id, part size, and accepted part metadata.
+/// Missing entries are safely re-uploaded; incorrect entries cause completion
+/// to fail.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MultipartUploadResume {
     pub upload_id: UploadId,
@@ -335,12 +329,11 @@ struct StagedContent {
     validated_content_token: Option<ValidatedContentToken>,
 }
 
-/// The transport one payload takes to object storage.
+/// Upload path selected from the server capability document.
 ///
-/// Which of these a deployment can offer is its own answer, read from the
-/// capability document: the two direct arms are independent of each other,
-/// so a provider that signs whole-object writes but has no multipart API to
-/// open is spelled by [`Self::DirectPut`] alone.
+/// Direct PUT and direct multipart are independent capabilities; a
+/// deployment may support either one without the other. Proxied upload is
+/// used when no suitable direct path is available.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UploadTransport {
     /// Parts, straight to object storage, retried one at a time.

--- a/crates/loonfs-client/src/payload.rs
+++ b/crates/loonfs-client/src/payload.rs
@@ -1,9 +1,8 @@
-//! Where a streaming put reads its bytes, and how it cuts them into parts.
+//! Streaming payload sources and multipart chunking.
 //!
-//! A [`PayloadSource`] is read exactly once, forward, in pieces. That is the
-//! whole contract: it is what lets one put serve a file on disk and a pipe
-//! with no length equally well, and what keeps the memory a large put costs
-//! independent of how large it is.
+//! [`PayloadSource`] yields bytes once, in order, without requiring a known
+//! length. This supports files, pipes, and sockets while keeping memory use
+//! independent of total payload size.
 
 use bytes::{Bytes, BytesMut};
 use futures::stream::{BoxStream, StreamExt};
@@ -105,15 +104,11 @@ impl PayloadSource {
         (self.stream, self.size_bytes)
     }
 
-    /// Wraps the stream while keeping everything the source knows about
-    /// itself.
+    /// Replaces the byte stream while preserving length and rewind metadata.
     ///
-    /// A wrapper that only watches bytes go past — counting them for a
-    /// progress bar, say — has not changed which payload this is or where it
-    /// came from. Rebuilding the source instead would throw that away, and
-    /// with it the free second pass a file-backed payload gets: an upload
-    /// that has to read the bytes twice would copy them to a spool rather
-    /// than re-open a file that was there all along.
+    /// Wrappers such as progress reporters do not change the payload source.
+    /// Preserving `rewind` lets file-backed uploads reopen the file instead of
+    /// copying it to a temporary spool for a second pass.
     pub fn map_stream(self, wrap: impl FnOnce(PayloadStream) -> PayloadStream) -> Self {
         Self {
             stream: wrap(self.stream),
@@ -122,20 +117,13 @@ impl PayloadSource {
         }
     }
 
-    /// Reads the source to its end, folding `digest` and counting bytes, and
-    /// hands back a payload that can be read again.
+    /// Measures and hashes the source, then returns a payload that can be read
+    /// again.
     ///
-    /// This is the price of a transport that states the payload's digest
-    /// before it may write: the digest must be complete before the first
-    /// body byte, and one forward pass cannot do both. What it must not cost
-    /// is memory. A source opened from a file is not copied at all — the
-    /// second pass re-opens it. Any other source is spooled to a temporary
-    /// file as it is read, chunk by chunk, and the spool is deleted when the
-    /// result is dropped. Nothing here ever holds the payload whole.
-    ///
-    /// The length it returns is measured, not the hint the source declared:
-    /// a source that delivers a different number of bytes is measured as it
-    /// actually is, and that is what may be claimed and what may refuse.
+    /// Transports that sign a checksum before upload require a complete first
+    /// pass. File-backed sources are reopened for the second pass; other sources
+    /// are copied incrementally to a temporary file. The returned length is the
+    /// number of bytes actually read, not the source's optional length hint.
     pub(crate) async fn measure(
         self,
         digest: &mut StreamingChecksum,

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -22,11 +22,10 @@ pub(crate) const MAX_TRANSIENT_RETRY_DELAY: Duration = Duration::from_secs(2);
 /// the caller forever.
 pub(crate) const IO_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// One outbound request, described rather than built.
+/// Reusable description of an outbound request.
 ///
-/// A retry must resend byte-identical content, and a `reqwest::RequestBuilder`
-/// is consumed by sending. Keeping the description lets every attempt build a
-/// fresh builder from the same parts.
+/// `reqwest::RequestBuilder` is consumed when sent. Storing the method, URL,
+/// and headers lets each retry build a fresh request with identical bytes.
 pub(crate) struct WireRequest {
     method: Method,
     url: String,
@@ -158,14 +157,11 @@ impl Client {
             .map_err(|attempt| attempt.error)
     }
 
-    /// Sends one request whose body arrives in pieces, and never resends it.
+    /// Sends a streaming request body exactly once.
     ///
-    /// A stream is consumed by the attempt that reads it, so there is no
-    /// second attempt to make: this is the one call whose failure is always
-    /// the caller's to handle. `size_bytes` declares the length when the
-    /// source knows it, and its absence is what puts the request on chunked
-    /// transfer encoding — which is the honest framing for a payload whose
-    /// length nobody knows yet.
+    /// A stream cannot be replayed after an attempt consumes it, so failures are
+    /// returned to the caller without retry. `size_bytes` sets `Content-Length`;
+    /// when absent, the request uses chunked transfer encoding.
     pub(crate) async fn call_streamed_once(
         &self,
         request: &WireRequest,
@@ -178,14 +174,11 @@ impl Client {
             .map_err(|attempt| attempt.error)
     }
 
-    /// Sends one request and hands its response body back as a stream, so
-    /// the answer is never held whole.
+    /// Sends one request and returns a streamed response body.
     ///
-    /// This is the read counterpart of [`Self::call_streamed_once`], and it
-    /// does not retry for the same reason: the caller consumes what arrives
-    /// as it arrives, so only the caller knows what it already did with the
-    /// first half. A non-success status is read and mapped here instead —
-    /// an error body is small, and it is the one response worth holding.
+    /// The method does not retry because the caller may already have consumed
+    /// part of the response. Non-success responses are buffered only long enough
+    /// to decode the small error body.
     pub(crate) async fn call_for_response_stream(
         &self,
         request: &WireRequest,
@@ -225,19 +218,14 @@ impl Client {
             .boxed())
     }
 
-    /// Sends one request, resending on quick-clearing transient failures —
-    /// the retryable-unavailability codes (`server_busy`,
-    /// `commit_queue_full`, `shutting_down`) and network-level transport
-    /// errors — with doubling backoff, bounded by
-    /// [`MAX_TRANSIENT_ATTEMPTS`]. Call sites opt into this path only for
-    /// reads, commits (which carry a durable replay identity), and operations whose
-    /// repeat semantics are idempotent. Lifecycle mutations and upload
-    /// session creation use [`Self::call_once`] so ambiguous success remains
-    /// visible to the caller. Other unavailability codes are excluded on
-    /// purpose — `maintenance_required` and `index_lagging` clear on a
-    /// maintenance step, not on a resend — and a served status with a
-    /// non-envelope body is not retried: only failures the network layer
-    /// itself reported count as transport.
+    /// Retries transient transport failures and selected temporary server
+    /// errors with bounded exponential backoff.
+    ///
+    /// Callers use this only for reads, replay-safe commits, and idempotent
+    /// operations. Lifecycle changes and upload-session creation use
+    /// [`Self::call_once`] so an ambiguous success is visible. Conditions that
+    /// require maintenance, such as `maintenance_required` or `index_lagging`,
+    /// are not retried.
     pub(crate) async fn call_with_transient_retry(
         &self,
         request: &WireRequest,
@@ -557,7 +545,8 @@ pub(crate) mod test_transport {
 
     // A thread-local is sound here because client tests run on the default
     // current-thread runtime: the future is polled only on the thread that
-    // installed the seam, so no attempt can observe another test's script.
+    // installed the scripted transport, so no attempt can observe another
+    // test's script.
     thread_local! {
         static STATE: RefCell<Option<State>> = const { RefCell::new(None) };
     }

--- a/crates/loonfs-core/src/checkpoint/compaction_retention.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_retention.rs
@@ -144,8 +144,11 @@ impl RetentionOperator {
     }
 }
 
-/// A receipt below the floor is indistinguishable from one never used, which
-/// is the idempotency horizon (format spec, section 3.3).
+/// Keeps commit receipts at or above the retention floor.
+///
+/// A commit ID is idempotent only while its receipt is retained. After a
+/// receipt below the floor is removed, retrying that commit ID creates a new
+/// mutation (format spec, section 3.3).
 fn keep_receipt(row: MetadataRow, floor_seq: ChangeSeq) -> Option<MetadataRow> {
     match &row {
         MetadataRow::CommitReceipt { committed_seq, .. } if *committed_seq < floor_seq => None,
@@ -153,14 +156,15 @@ fn keep_receipt(row: MetadataRow, floor_seq: ChangeSeq) -> Option<MetadataRow> {
     }
 }
 
-/// Attribute rows, one inode at a time.
+/// Retains all attribute revisions above the floor and the newest revision at
+/// or below the floor for each inode.
 ///
-/// Ascending row-key order within one inode is descending revision order:
-/// `lookup_keys::attributes_row_key` inverts the revision number, the commit
-/// sequence, and the delta index, which is what makes a prefix read answer
-/// with the newest state first. So the first row at or below the floor is the
-/// newest at or below it — the one row the rule keeps — and every later row of
-/// that inode is older and goes. The whole history is never held.
+/// Attribute row keys sort each inode's revisions newest first. The first row
+/// at or below the floor represents current state, including an empty map that
+/// records cleared attributes. Older revisions cannot be observed and may be
+/// removed. Deleted inodes keep their attribute rows so an undelete restores
+/// the prior attributes. The operator processes this order without retaining
+/// the complete history.
 #[derive(Debug, Default)]
 pub(super) struct AttributeRetention {
     /// Whether this inode has already kept its newest row at or below the
@@ -211,13 +215,12 @@ impl AttributeRetention {
     }
 }
 
-/// Active-deletion rows, one deletion identity at a time.
+/// Processes active-deletion rows one deletion identity at a time.
 ///
-/// The family holds current state, not history, so the floor has no say over
-/// it: a listed deletion stays recoverable however far the floor advances.
-/// The only rows that go are the pairs that cancelled each other, and the row
-/// key ranks the removal marker below the row it removes, so the marker
-/// always arrives first and one flag decides the pair.
+/// Active deletions represent current recoverable state, so the retention
+/// floor does not remove a listed deletion. The operator removes only a
+/// listed row paired with its removal marker. Row-key order places the marker
+/// first, allowing one flag to determine whether the listed row is retained.
 #[derive(Debug, Default)]
 pub(super) struct ActiveDeletionRetention {
     /// Whether this deletion's removal marker has already arrived.
@@ -338,17 +341,13 @@ impl BindingRetention {
         Ok(survives.then_some(row))
     }
 
-    /// Refuses a slot whose binds break the writer invariant the drop rests
-    /// on.
+    /// Verifies the writer invariant required for binding cleanup.
     ///
-    /// At the floor only the latest bind per slot is visible, and a bind is
-    /// only ever superseded by an operation that also unbinds it. So every
-    /// bind at or below the floor except the slot's latest must have been
-    /// retired. Generations arrive in ascending order, so a bind at or below
-    /// the floor arriving while an earlier un-retired one still stands proves
-    /// that earlier one was superseded without an unbind — and dropping by
-    /// [`bind_survives_frozen_floor`] would then keep a bind no read can
-    /// reach and call it live.
+    /// Superseding a bind also writes its unbind. Therefore every non-current
+    /// bind at or below the retention floor must have a matching unbind.
+    /// Generations arrive in ascending order, so a second unretired bind in
+    /// the same slot proves that the earlier bind was superseded without an
+    /// unbind. Cleanup is rejected when that occurs.
     fn check_the_slot_invariant(&mut self, generation: &BindingGeneration) -> Result<()> {
         let Some(previous) = self.unretired_at_floor.take() else {
             return Ok(());

--- a/crates/loonfs-core/src/checkpoint/frozen_floor.rs
+++ b/crates/loonfs-core/src/checkpoint/frozen_floor.rs
@@ -68,20 +68,12 @@ pub(super) fn unbinding_at_or_below_floor(
     })
 }
 
-/// Whether one bind row survives the frozen floor.
+/// Returns whether a bind row remains visible at the frozen retention floor.
 ///
-/// A bind above the floor always survives. At or below it the bind survives
-/// exactly when nothing retired it, because a bind is only ever superseded by
-/// an operation that also unbinds it — the forward binding operator refuses to
-/// compact a slot where that does not hold
-/// (`super::compaction_retention::BindingRetention::check_the_slot_invariant`).
-///
-/// Both bind families read this same rule, which is what keeps them dropping
-/// in lockstep: the format gives every bind row exactly one reverse row, and a
-/// run whose two counts disagree does not load. They reach the rule by
-/// different routes — the forward row's unbinds arrive in its own locality
-/// group, the reverse row's do not and are point-read instead — but the rule
-/// is one function and the answer is one answer.
+/// Binds above the floor are always retained. A bind at or below the floor is
+/// removed only when a matching unbind is also at or below the floor. The
+/// forward and reverse bind families both use this rule so their corresponding
+/// rows are retained or removed together.
 pub(super) fn bind_survives_frozen_floor(
     row: &MetadataRow,
     retention_floor_seq: ChangeSeq,

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -1,39 +1,23 @@
 //! Checkpoints, namespace manifests, and metadata SSTs.
 //!
-//! A namespace manifest names the immutable metadata SST runs that
-//! materialize one namespace file-set version; a checkpoint pins one manifest
-//! version for retention, forks, stable reads, and restore. Submodules follow
-//! the manifest lifecycle:
+//! A namespace manifest references the immutable metadata SST runs for one
+//! namespace state. A checkpoint pins a manifest for retention, forks, stable
+//! reads, or restore.
 //!
-//! - [`flush`] folds the visible WAL tail into metadata tables and
-//!   advances `metadata/root.json` — the record-less latest-state
-//!   maintenance path.
-//! - [`create`] orchestrates checkpoint creation: flush, then pin
-//!   the resulting manifest under one durable record.
-//! - [`build`] segments metadata rows and writes the immutable SST objects.
-//! - [`publish`] writes manifest objects and advances `metadata/root.json`
-//!   by compare-and-swap.
-//! - [`record`], [`list`], and [`release`] manage durable checkpoint
-//!   records, and [`files`] enumerates the files a record's manifest pins.
-//! - [`load`] and [`validate`] provide envelope-only loading and
-//!   descriptor-only table verification (full-row inspection
-//!   materialization is test-only).
-//! - [`scan`] answers verified row scans over loaded manifest tables, while
-//!   [`row`] handles manifest-row encoding.
-//! - [`reorganize`] compacts bounded family groups into new base runs, and
-//!   [`streaming_compaction`] rebuilds a group whose bottom-anchored window
-//!   no longer fits one of those steps. The job's own parts are split by what
-//!   they do: [`compaction_merge`] reads its input, [`compaction_retention`]
-//!   holds the frozen floor's rules as streaming state,
-//!   [`compaction_output`] writes its segments, and [`compaction_lease`]
-//!   holds its claim on them. [`frozen_floor`] holds the drop rules the
-//!   bounded merge and the streaming job both read, because neither owns
-//!   them.
-//! - [`retention`] advances the retention floor behind verified progress.
-//! - [`runs`] models the LSM run layout shared by all of the above,
-//!   [`cache`] holds decoded SST blocks keyed by content digest, and
-//!   [`stored_block_cache`] defines the seam a node-local cache of the same
-//!   blocks in their encoded form plugs into.
+//! The submodules cover these areas:
+//! - Building and publishing manifests: [`build`], [`flush`], [`create`], and
+//!   [`publish`].
+//! - Managing checkpoint records: [`record`], [`list`], [`release`], and
+//!   [`files`].
+//! - Loading, validating, and scanning metadata: [`load`], [`validate`],
+//!   [`scan`], and [`row`].
+//! - Planning and running metadata merges: [`reorganize`],
+//!   [`streaming_compaction`], [`compaction_merge`],
+//!   [`compaction_retention`], [`compaction_output`], [`compaction_lease`],
+//!   and [`frozen_floor`].
+//! - Advancing the retention floor: [`retention`].
+//! - Describing run layout and caching: [`runs`], [`cache`], and
+//!   [`stored_block_cache`].
 
 mod block_fetch;
 mod block_load;

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -1,62 +1,28 @@
-//! Bounded metadata reorganization: the background half of the
-//! checkpoint/compaction split.
+//! Plans and publishes bounded metadata merges.
 //!
-//! Checkpoint publication only ever appends an L0 delta run, so its cost
-//! follows the WAL delta, never the namespace. Folding those L0 runs into
-//! the base happens here instead, one **family group** at a time: the
-//! group's rows are merged from an oldest-first, budgeted subset of complete
-//! runs, rows no retained sequence can observe are dropped, new segments are
-//! written, and a manifest publishes that swaps just those references.
-//! Families whose rows must stay mutually consistent compact together —
-//! bind, child bind, and unbind rows form one group because their drop rules
-//! read each other; revisions travel with their descending index so index
-//! parity holds within every unit.
+//! Checkpoint publication appends L0 delta runs. Each maintenance step selects
+//! one metadata family group and either merges a budgeted, contiguous set of
+//! complete runs or returns a plan for a background compaction of the entire
+//! group. Bounded steps and background jobs use the same merge engine.
 //!
-//! The merging itself is not here. A step drives the same engine a background
-//! compaction drives ([`super::streaming_compaction`]), synchronously and with
-//! nothing around it: no lease, no job, no registry, no admission, and output
-//! written at ordinary table keys because the publication that names it is the
-//! step's own. What the step owns is choosing the window, publishing the
-//! result, and reporting what it did.
+//! A merge that includes the group's oldest run writes a base-tier run and may
+//! remove rows below the retention floor. A merge that starts above the base
+//! writes a delta-tier run at its newest input sequence and preserves every
+//! row. These rules keep at most one base run per family group and preserve
+//! run ordering.
 //!
-//! A merge writes a base-tier run when, and only when, its window starts at
-//! the group's oldest run. That is the same condition retention dropping
-//! needs, so the level a run carries and the rules that produced it say the
-//! same thing: a base run is a run some fold was allowed to drop rows from,
-//! a delta run is a run nothing has dropped from yet ([`MergePlacement`]). A
-//! merge that had to start above the group's base therefore writes a bigger
-//! delta run rather than a second base run, and a family group holds at most
-//! one base run at any time (manifest load refuses a manifest that says
-//! otherwise).
+//! Each bounded merge publishes a durable manifest, so no separate progress
+//! record is required. After interruption, the next step reloads the current
+//! manifest and selects another group. If a concurrent publication wins the
+//! root compare-and-swap, the merge output remains unreferenced for garbage
+//! collection and a later step retries from the new manifest.
 //!
-//! There is no progress record: each unit ends in a durable manifest, so a
-//! crashed or interrupted reorganization resumes by reading the live
-//! manifest and picking the next group that still has L0 rows. Unit
-//! selection is deterministic (most L0 rows first, then group order). A
-//! concurrent checkpoint racing a unit wins at the root compare-and-swap;
-//! the unit's segments are left unreferenced for garbage collection and the
-//! next step retries against the fresh manifest.
-//!
-//! The planner answers with one of two plans ([`ReorganizationPlan`]). A
-//! group with a window that fits the budgets and makes progress gets that
-//! window. A group with no such window gets a streaming compaction over
-//! every run it holds ([`super::streaming_compaction`]), which is what takes
-//! a frozen base off the step budgets entirely. The step does not run that
-//! job: it reports the plan, and the runtime starts the job in the
-//! background and hands its spec back to every step that follows, which is
-//! how a step knows to leave that group alone while it runs.
-//!
-//! One step cannot see whether a group is stuck. A group whose
-//! bottom-anchored window is blocked still has delta runs to merge, and under
-//! sustained writes there is always another pair of them, so a planner
-//! deciding from one step's view alone would take the delta merge every time
-//! and never start the job — the base would stay frozen and the group's
-//! retention would stay stopped. The caller therefore states a
-//! [`FrozenBasePolicy`]. A writer's own maintenance amortizes: it counts, per
-//! group, the delta merges it has published over that frozen base, and at
-//! [`DELTA_MERGES_OVER_A_FROZEN_BASE`] the planner stops taking the merge and
-//! plans the job. Everyone else asks for the job outright, because they are
-//! either reporting that the namespace needs one or running it.
+//! When the oldest run prevents a useful bounded merge, [`FrozenBasePolicy`]
+//! determines whether the step may merge newer delta runs or must request a
+//! full compaction. Writer maintenance permits a limited number of delta
+//! merges before requesting the background job. Explicit compaction requests
+//! select the job immediately. [`MetadataCompactionView`] identifies any group
+//! already being compacted so a bounded step does not select it again.
 
 use super::block_fetch::load_segment_index_for_reorganization;
 use super::error::ManifestLoadError;
@@ -104,7 +70,7 @@ pub(super) const DELTA_MERGES_OVER_A_FROZEN_BASE: u32 = 2;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FrozenBasePolicy {
     /// Amortize the rebuild: keep taking the delta merge above the frozen
-    /// base until [`DELTA_MERGES_OVER_A_FROZEN_BASE`] of them have published
+    /// base until `DELTA_MERGES_OVER_A_FROZEN_BASE` of them have published
     /// for the group, then plan the job. This is what a writer's own
     /// maintenance runs under, because upkeep that rebuilt the whole group
     /// for every eight delta runs would reread megabytes to fold in a sliver.
@@ -219,10 +185,9 @@ pub struct MetadataReorganizeReport {
     pub outcome: MetadataReorganizeOutcome,
 }
 
-/// Runs at most one reorganization unit against the namespace's current
-/// manifest. Callers (the maintenance step) invoke this repeatedly; each
-/// call re-reads durable state, so any two calls compose — including across
-/// process restarts.
+/// Runs at most one reorganization step against the current manifest. Each
+/// call reloads durable state, so callers may repeat it safely across process
+/// restarts.
 ///
 /// `compactions` is what this process knows about the namespace's streaming
 /// compactions: which group a job is rebuilding right now, and how long each
@@ -444,55 +409,22 @@ pub(super) struct ReorganizationInput {
     pub(super) placement: MergePlacement,
 }
 
-/// Where a merge's output stands in its family group.
+/// Determines a merge's output level, sequence, and retention behavior.
 ///
-/// **A merge's output is base-tier if and only if its window starts at the
-/// group's oldest run.** Base-tier means "rows a fold was allowed to drop
-/// from", so the level a run carries and the rules that produced it say the
-/// same thing. Both the output level and the right to drop rows are read off
-/// this one value; there is no separate flag either can disagree with.
+/// A merge that includes the group's oldest run writes a base-tier run at the
+/// manifest head. Its input includes the previous base run and all older rows
+/// needed by retention rules, so it may remove rows below the retention floor.
+/// Replacing the previous base leaves the group with at most one base run.
 ///
-/// A bottom-anchored merge writes the group's base run, stamped at the
-/// manifest head. Base-tier runs sort below every delta run whatever sequence
-/// they carry, so the output lands at the bottom where its inputs were, and
-/// the sequence is free to be the head's — which is also what keeps a file at
-/// `head_seq` in the manifest when the merge consumed the group's whole top.
-/// It replaces the group's previous base run, because a bottom-anchored
-/// window always contains it, so the group is left with exactly one.
-///
-/// A merge that had to start above the group's base rewrites delta runs into
-/// one bigger delta run. Two things follow from writing it at the delta level
-/// rather than the base level. It cannot mint a second base run, so a group's
-/// base never fragments and nothing ever hides an over-budget bottom behind
-/// fragments that each fit. And its rows stay counted as delta pressure, so
-/// the L0 run count reports what is really waiting.
-///
-/// Its sequence is its newest input's, not the manifest head's, so the output
-/// stands exactly where that run stood: above every run the window left below
-/// it and below every run it left above. The head would put it above runs the
-/// window never reached, and moving merged rows above newer runs is what a
-/// later bottom-anchored fold must never see — it could then drop an unbind
-/// whose bind had moved out of the window and put a deleted file back. The
-/// head is also shared by consecutive maintenance steps on a quiet namespace,
-/// so head-stamped outputs of different merges collide at one identity.
-///
-/// Nothing else in the manifest already holds that identity for these
-/// families: the newest input run's segments for this group leave
-/// `metadata_files` in the same publication the output's enter it. Segments
-/// of other families at that identity stay where they are, which is ordinary
-/// — a run is a set of families, and each family in it has one producer.
+/// A merge that starts above the base writes a delta-tier run and preserves
+/// every input row. The output uses its newest input sequence so it remains in
+/// the same position relative to runs outside the selected window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum MergePlacement {
-    /// The window started at the group's oldest run. The output is the
-    /// group's base run at the manifest head, and retention may drop rows.
-    ///
-    /// Retention dropping reads across the merged rows: an unbind cancels the
-    /// bind it names, and a removal marker cancels the listed deletion it
-    /// repeats. Dropping one half of such a pair is only visibility-preserving
-    /// when the other half is in the same merge, and what guarantees that is
-    /// starting the merge at the group's oldest run — the cancelling row is
-    /// always the newer of the two, so every row it can cancel is already in
-    /// the window (format spec, "Compaction").
+    /// The window includes the group's oldest run. The output is the base run,
+    /// and retention may remove related row pairs because both the older row
+    /// and its newer cancellation row are included (format spec,
+    /// "Compaction").
     Base { output_seq: ChangeSeq },
     /// The window started above the group's oldest run. The output is a delta
     /// run at the newest input's sequence, and nothing is dropped.
@@ -537,12 +469,10 @@ fn merge_placement(
     }
 }
 
-/// What one selection attempt found.
+/// Result of selecting input runs for one reorganization step.
 ///
-/// The saturation record travels beside the input because the caller
-/// reports it on both paths: a group whose oldest run has outgrown one
-/// step's budget still folds its newer runs, and that is exactly when an
-/// operator needs to hear that the run underneath them is frozen.
+/// `group_bottom_over_budget` is reported for status and logging even when the
+/// plan can merge newer delta runs or start a full compaction.
 pub(super) struct ReorganizationSelection {
     /// What the step should do, or `None` when the group holds no runs at
     /// all and there is nothing to do either way.
@@ -566,57 +496,24 @@ pub(super) struct OverBudgetRun {
     pub(super) decoded_bytes: Option<u64>,
 }
 
-/// Selects a contiguous window of complete runs to merge, oldest-first.
+/// Selects bounded merge input or plans a full compaction for one family
+/// group.
 ///
-/// **The order.** The comparator below is the group's recency order, oldest
-/// first. Base-tier runs hold rows an earlier fold already absorbed, so they
-/// sit under every L0 run whatever their `run_seq` says: a bottom-anchored
-/// fold stamps its output at the manifest head, which can leave a base run
-/// carrying a higher `run_seq` than an L0 run some other group has not folded
-/// yet (see [`manifest_has_partial_reorganization`]). Within one tier the
-/// lower `run_seq` is the older run.
+/// Runs are ordered oldest first. Base-tier runs sort before delta-tier runs
+/// regardless of `run_seq`; within a tier, lower sequences are older. The
+/// selector first tries a contiguous window beginning at the oldest run. If
+/// that cannot make progress, it may try a window beginning at the oldest
+/// delta run. It never skips a delta run.
 ///
-/// **The invariant.** A merge writes its inputs back as one run standing
-/// where the window stood: at the bottom of the group when the window is
-/// bottom-anchored, and at its newest input's identity otherwise
-/// ([`MergePlacement`]). Either way the output may not carry a row newer than
-/// a run it left above the window — otherwise a later fold could drop a row
-/// while the row it cancels sits outside that fold's window. What keeps that
-/// true is that the window is a *contiguous* slice of the order: every run it
-/// leaves out sits wholly below it or wholly above it, never interleaved, so
-/// the output can stand in for the whole window without moving any row past
-/// any other. When the window starts at the very bottom nothing is left out
-/// below it at all, and that is the stronger property retention dropping
-/// needs — see [`MergePlacement::Base`].
+/// A bottom-anchored merge makes progress when it moves at least one delta run
+/// into the base tier. A delta-only merge must combine at least two runs. If
+/// neither bounded window works, or `frozen_base` requires a full compaction,
+/// the result contains a plan covering every run in the group.
 ///
-/// **There are two windows to try.** A manifest holds at most one base-tier
-/// run per family group, so the search is short: the window starting at the
-/// group's oldest run, and — when a base run blocks that one — the window
-/// starting at the oldest delta run above it. A delta run is never stepped
-/// over.
-///
-/// **The budgets pace the work; they never end it.** When no window starting
-/// at the group's oldest run can fit the budgets, the start moves past the
-/// base run that blocks it and the step merges the L0 runs above it on their
-/// own. The group keeps shedding runs even while the run at its bottom stays
-/// too large to fold. When not even that is left — no window at all makes
-/// progress inside the budgets — the group is handed to a streaming
-/// compaction, which merges every run it holds and is paced by nothing.
-///
-/// Index sections are read before row payloads so the decoded-byte budget is
-/// known exactly from each data block's durable `decoded_len`; a run that
-/// would cross a budget is not decoded or partially included.
-///
-/// `frozen_floor_seq` is the live retention floor. A bounded merge reads it
-/// again at drop time; a compaction spec carries it, because the floor a job
-/// judges every row against is fixed when the job is planned.
-///
-/// `frozen_base` is the caller's answer to the one thing this function cannot
-/// see: whether the delta merge above a base no window can reach is still the
-/// work this group needs. When the policy says it is not, a blocked
-/// bottom-anchored window goes straight to the job rather than taking that
-/// merge — the merge would make progress, but not the progress the group
-/// needs.
+/// Block indexes are read before row data so the row and decoded-byte budgets
+/// can be enforced without partially including a run. A bounded merge resolves
+/// the current retention floor before applying retention. A full-compaction
+/// plan records `frozen_floor_seq` so the background job uses one fixed floor.
 pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
     tables: &VerifiedMetadataTables<'_, S>,
     group: MetadataFamilyGroup,
@@ -721,18 +618,9 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
             runs.push(run.clone());
         }
 
-        // A merge must leave the group with less to fold than it found, or
-        // the same window would be chosen again forever. What counts as less
-        // follows from where the output lands.
-        //
-        // A bottom-anchored merge writes a base run, so every L0 run it takes
-        // leaves L0 for good: one L0 run in the window is enough, and a
-        // window holding none would only rewrite base rows where they stand.
-        //
-        // A merge above the base writes another delta run, so it only gains
-        // by merging two or more into one. A single-run window there would
-        // rewrite that run as itself, at its own identity, having read and
-        // written every row for nothing.
+        // A bottom-anchored merge makes progress when it moves at least one
+        // L0 run into the base tier. A delta-only merge must combine at least
+        // two runs; rewriting one delta run would not reduce pending work.
         let bottom_anchored = window_start == 0;
         let makes_progress = if bottom_anchored {
             runs.iter().any(|run| run.level == CHECKPOINT_L0_RUN_LEVEL)
@@ -793,21 +681,13 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Says out loud that a family group's oldest run no longer fits one
-/// reorganization step.
+/// Reports that the oldest run in a family group exceeds one step's input
+/// budget.
 ///
-/// Nothing is corrupt when this fires and no work stops. Steps keep merging
-/// the newer runs above the run named here, into one bigger delta run each
-/// time. Once that merge has nothing left to take, the group has no window
-/// that makes progress, and the step hands the whole group to a background
-/// streaming compaction that rebuilds it in one pass under no budget at all.
-/// The group's rows are reclaimed when that job publishes. So this line says
-/// what a namespace has grown into, and that the rebuild of the group has
-/// moved off the step; there is nothing for an operator to do about it.
-///
-/// One line per step until the job starts: a step is already the unit
-/// maintenance schedules, so the cadence of the warning is the cadence of
-/// maintenance.
+/// Bounded steps may continue merging newer delta runs. When no bounded merge
+/// can make the required progress, maintenance plans a streaming compaction
+/// of the complete group. The warning is emitted once per step until that job
+/// starts.
 fn report_group_bottom_over_budget(
     namespace_id: &NamespaceId,
     group: MetadataFamilyGroup,

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -33,20 +33,16 @@ pub(super) const CHECKPOINT_TABLE_FAMILIES: [MetadataTableFamily; 10] = [
     MetadataTableFamily::Attributes,
 ];
 
-/// One set of families whose rows merge in one reorganization unit.
+/// Metadata families merged together as one consistency unit.
 ///
-/// Families that read each other's rows to decide what to drop (see
-/// `super::compaction_retention`) must compact together, and a secondary index
-/// always travels with its canonical family.
+/// Families whose retention rules depend on each other are grouped, and each
+/// secondary index is grouped with its canonical family. The closed enum lets
+/// planning and validation use the group identity directly. Manifest loading
+/// also enforces the layout rule that each group has at most one base-tier
+/// run.
 ///
-/// This is a closed enum rather than a list of family slices because every
-/// caller wants the group itself, not a slice it has to recognize by
-/// comparing it against a table. The grouping is layout policy, not
-/// reorganization's alone: manifest load checks a per-group invariant — at
-/// most one base-tier run per group — so the loader reads it too.
-///
-/// Declaration order is group order, which is what resolves ties when two
-/// groups have equally much to fold.
+/// Declaration order determines which group is selected when multiple groups
+/// have the same amount of pending work.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MetadataFamilyGroup {
     /// A directory binding, the reverse index that finds it by child, and the

--- a/crates/loonfs-core/src/checkpoint/stored_block_cache.rs
+++ b/crates/loonfs-core/src/checkpoint/stored_block_cache.rs
@@ -1,9 +1,8 @@
-//! The seam a node-local cache of encoded metadata SST blocks plugs into.
+//! Interface for a node-local cache of encoded metadata SST blocks.
 //!
-//! This tier sits beneath the decoded [`MetadataTableCache`] and above
-//! object storage. It holds stored section bytes — the same bytes the
-//! segment object holds — so a hit still has to be decoded and verified
-//! before any caller sees a row.
+//! This cache sits between the decoded [`MetadataTableCache`] and object
+//! storage. It stores the original encoded section bytes, which are decoded
+//! and verified before any rows are returned.
 //!
 //! [`MetadataTableCache`]: super::MetadataTableCache
 
@@ -13,22 +12,15 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;
 
-/// Identifies one encoded stored section of one metadata SST segment.
+/// Identifies one encoded section of an immutable metadata SST segment.
 ///
-/// The identity mirrors the decoded cache's. `payload_checksum` is the
-/// segment's `sha256:<hex>` digest, which names immutable bytes, so an entry
-/// can never go stale; `kind` and `offset` locate the section inside that
-/// segment, so sections of one segment cannot collide.
+/// `payload_checksum` identifies the segment bytes. `kind` and `offset`
+/// identify the section within that segment. Lengths and CRCs are validated by
+/// the decoder and therefore are not part of the cache key.
 ///
-/// Nothing else belongs in the identity. Stored lengths and CRCs are
-/// validation inputs carried by the segment's block handles, and the decoder
-/// checks them whether the bytes came from this tier or from the store.
-/// There is no version field either: an implementation versions its own
-/// on-disk directory instead.
-///
-/// Namespace manifests are deliberately not representable. The decoded cache
-/// keys them by object key rather than by content digest, and they stay out
-/// of this tier.
+/// Implementations may version their own on-disk format. Namespace manifests
+/// are excluded because they are keyed by object path rather than content
+/// digest.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct StoredMetadataBlockKey {
     pub payload_checksum: String,
@@ -44,11 +36,8 @@ pub enum StoredMetadataBlockKind {
     Filter,
 }
 
-/// A cache that failed to shut down cleanly.
-///
-/// Shutdown is the one operation whose failure a caller can observe. The
-/// bytes are a cache, so nothing durable is lost, but a host draining on its
-/// way out should still be able to report why.
+/// Error returned when the cache cannot shut down cleanly. Cached bytes are
+/// rebuildable, but the host may report this failure during shutdown.
 #[derive(Debug, Error)]
 #[error("stored metadata block cache failed to close: {0}")]
 pub struct StoredMetadataBlockCacheCloseError(String);
@@ -60,21 +49,15 @@ impl StoredMetadataBlockCacheCloseError {
     }
 }
 
-/// A node-local cache of encoded, stored metadata SST sections.
+/// Node-local cache of encoded metadata SST sections.
 ///
-/// Object storage remains the only authority. This tier holds a copy of
-/// bytes the store already holds, addressed by [`StoredMetadataBlockKey`],
-/// and every hit is decoded and verified by the ordinary segment decoder
-/// before a caller sees a row. A hit is therefore evidence that the bytes
-/// were available locally and nothing more.
+/// Object storage remains authoritative. Every cache hit is decoded and
+/// verified before rows are returned. Cache operations are best effort:
+/// lookup failures return `None`, and insert failures are ignored, so the
+/// system falls back to object-storage reads.
 ///
-/// Lookups and inserts are best effort. An implementation records its own
-/// failures and answers a failed lookup with `None` and a failed insert by
-/// doing nothing, so a full, broken, or unreachable cache degrades to plain
-/// object-store reads.
-///
-/// After [`close`](Self::close) the cache is inert: `get` returns `None`,
-/// and `insert` and `invalidate` do nothing. `close` is idempotent.
+/// After [`close`](Self::close), `get` returns `None` and mutation methods do
+/// nothing. Calling `close` more than once is allowed.
 #[async_trait]
 pub trait StoredMetadataBlockCache: Send + Sync + Debug {
     /// Returns the stored bytes held for `key`, or `None` on a miss.

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -1,6 +1,6 @@
-//! [`NamespaceCommitEngine`]: publishes batches of classified mutation
-//! candidates — one WAL segment, one head compare-and-swap, one result per
-//! candidate.
+//! [`NamespaceCommitEngine`] publishes a batch of validated mutation
+//! candidates as one WAL segment and one head compare-and-swap, then returns
+//! one result per candidate.
 
 use crate::checkpoint::MetadataTableCache;
 use crate::commit::CommitFingerprint;
@@ -46,13 +46,9 @@ pub enum ContentPreparation {
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum ContentPreparationError {
-    /// Every wire token the request supplied was rejected before
-    /// publication, each paired with the content ref it was supplied for.
-    ///
-    /// One request may carry one token per ref, so all of the rejections
-    /// travel together: a caller that has to mint new tokens needs to know
-    /// which refs failed and why, not just that one of them did. The list is
-    /// never empty — a rejection exists because a token was refused.
+    /// Tokens rejected before publication, paired with their content IDs. The
+    /// list is non-empty and includes every rejection so the caller can replace
+    /// the correct tokens.
     #[error("content tokens were rejected: {}", rejected_token_reasons(.0))]
     ContentToken(Vec<(ContentId, ContentTokenError)>),
     /// No prepared proof covers the referenced content.
@@ -60,7 +56,7 @@ pub enum ContentPreparationError {
     ContentNotPrepared { content_id: ContentId },
 }
 
-/// Every rejected token as one message: each content ref beside its reason.
+/// Formats all token rejections as one message, pairing each content ID with its reason.
 fn rejected_token_reasons(rejections: &[(ContentId, ContentTokenError)]) -> String {
     rejections
         .iter()
@@ -119,8 +115,8 @@ impl CommitCandidate {
     }
 
     pub(crate) fn validate_request_limits(&self) -> Result<()> {
-        // The ceilings apply to the request as a whole: a batch occupies the
-        // serialized publisher for as long as all of its operations take.
+        // Apply limits to the complete request because the serialized publisher
+        // processes every operation before releasing the write path.
         if self.request.operations.len() > crate::limits::MAX_COMMIT_OPERATIONS {
             return Err(CoreError::InvalidCommitRequest(format!(
                 "mutation has {} operations; maximum is {}",
@@ -167,21 +163,18 @@ impl CommitCandidate {
     }
 }
 
-/// The WAL-tail maintenance policy: one authority for "when do we
-/// checkpoint?" and "when do we stop accepting writes?", so the two
-/// thresholds cannot drift apart.
+/// Defines the WAL-tail thresholds for checkpointing and write rejection.
+/// Keeping both values in one policy prevents inconsistent configuration.
 ///
-/// Reads never gate on tail length; the rejection only asks writers to wait
-/// for the maintenance a deployment failed to run (format spec,
-/// "Maintenance operations").
+/// Reads do not depend on tail length. Writes are rejected only when
+/// maintenance has fallen behind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WalTailPolicy {
     /// Visible WAL-tail length, in segments, at which a maintenance step
     /// publishes a checkpoint. The step fires at or past this length.
     pub checkpoint_at_segments: u64,
-    /// Visible WAL-tail length at which (at or past) every publish surface
-    /// rejects with `maintenance_required`, so a landed publication never
-    /// leaves a longer tail behind.
+    /// WAL-tail length at which all publish operations return
+    /// `maintenance_required` before adding another segment.
     pub reject_writes_at_segments: u64,
 }
 
@@ -200,8 +193,8 @@ impl Default for WalTailPolicy {
     }
 }
 
-// The ordering invariant `0 < checkpoint < reject` holds by construction:
-// a step must be able to relieve backpressure before writes stop.
+// Checkpointing must begin before the write-rejection threshold so
+// maintenance can reduce the tail before writes are blocked.
 const _: () = assert!(
     0 < WalTailPolicy::DEFAULT.checkpoint_at_segments
         && WalTailPolicy::DEFAULT.checkpoint_at_segments
@@ -214,9 +207,8 @@ pub struct NamespaceCommitEnginePublishResult {
     /// WAL tail length observed by this publish, for opportunistic
     /// maintenance scheduling. Zero when no projection was loaded.
     pub wal_tail_segments: u64,
-    /// The read state this publish produced, present when the head CAS
-    /// landed unambiguously: callers can seed read caches with it instead
-    /// of invalidating them and rebuilding from the store.
+    /// Read state produced by a successful, unambiguous head CAS. Callers can
+    /// use it to update read caches without reloading from object storage.
     pub resulting_read_state: Option<ResultingReadState>,
 }
 
@@ -225,37 +217,32 @@ pub struct NamespaceCommitEnginePublishResult {
 pub struct ResultingReadState {
     pub head: HeadState,
     pub head_etag: String,
-    /// Basis the publish replayed over; the landed head still resolves to
-    /// it, so a seeded anchor pins the same pair the next read would.
+    /// Metadata basis used for replay. The published head still references this
+    /// basis, so a seeded read cache matches the next store-backed read.
     pub basis: MetadataBasis,
     pub manifest_id: ManifestId,
     pub manifest_head_seq: ChangeSeq,
     pub tail_rows: Arc<MetadataState>,
 }
 
-/// Writer-session state for one namespace: never acquired, holding the epoch
-/// this session acquired, or terminally fenced.
+/// Tracks writer state for one namespace session: unacquired, acquired, or
+/// permanently fenced.
 ///
-/// This is authoritative session state, not a cache of durable state —
-/// nothing in the store can rebuild "this session was fenced". Runtimes keep
-/// one shared instance per namespace in a registry that outlives every
-/// rebuildable cache (invalidation, LRU eviction, cache-disabled
-/// configurations) and hand it to each engine they build for the namespace.
-/// An engine built without one gets private state, which keeps the
-/// documented one-shot semantics: each one-shot commit is its own
-/// acquisition decision.
+/// Object storage cannot reconstruct whether the current session was fenced.
+/// Runtimes should therefore share one instance across engines for the same
+/// namespace and keep it outside rebuildable caches. An engine without shared
+/// state treats each one-shot commit as a separate session.
 #[derive(Debug, Default)]
 pub enum WriterSessionState {
     /// No epoch yet: the session's first publish acquires one.
     #[default]
     Unacquired,
-    /// Epoch acquired lazily on this session's first publish and reused for
-    /// its lifetime; no per-publish acquisition CAS.
+    /// Writer epoch acquired on the first publish and reused for the rest of
+    /// the session.
     Acquired(AcquiredWriter),
-    /// Terminal fencing record. Once another session supersedes our epoch,
-    /// every later publish fails with `writer_fenced` without touching the
-    /// store; the session never reacquires on its own. Reacquisition is an
-    /// explicit caller decision, left to a future takeover API.
+    /// Permanent fencing record for this session. Later publishes return
+    /// `writer_fenced` without accessing the store. Acquiring a new writer epoch
+    /// requires an explicit caller action.
     Fenced(WriterFence),
 }
 
@@ -271,9 +258,9 @@ pub struct NamespaceCommitEngine {
     session: SharedWriterSessionState,
     /// Local monotonic source for the self-enforced publish budget.
     timer: Arc<dyn MonotonicTimer>,
-    /// Shared decoded-block cache for publish-view table reads. Blocks are
-    /// content-addressed by segment digest, so cached entries can never
-    /// serve stale state; freshness stays enforced by the head etag check.
+    /// Shared cache of decoded blocks used by publish-view reads. Blocks are
+    /// keyed by segment digest, while the head ETag check verifies that the view
+    /// is current.
     table_cache: Option<Arc<MetadataTableCache>>,
 }
 
@@ -288,17 +275,16 @@ impl NamespaceCommitEngine {
         }
     }
 
-    /// Attaches the runtime's session state for this namespace, so the
-    /// acquired epoch and fencing outlive this engine instance.
+    /// Uses runtime-managed session state so the writer epoch and fenced status
+    /// persist across engine instances.
     pub fn writer_session(mut self, session: SharedWriterSessionState) -> Self {
         self.session = session;
         self
     }
 
     fn lock_session(&self) -> std::sync::MutexGuard<'_, WriterSessionState> {
-        // Poisoning is propagated as a panic: every critical section is a
-        // plain field read or write, so a poisoned lock means another
-        // thread panicked mid-update.
+        // Treat a poisoned lock as fatal because another thread panicked while
+        // updating the session state.
         self.session
             .lock()
             .expect("writer session state lock should not be poisoned")
@@ -315,31 +301,24 @@ impl NamespaceCommitEngine {
         self
     }
 
-    /// Drops the rebuildable tail projection and nothing else. The acquired
-    /// epoch and fencing are session state, not cached state: the epoch's
-    /// validity is re-checked against the head on every publish view load,
-    /// and a fenced session stays fenced.
+    /// Clears only the rebuildable tail projection. Writer epoch and fencing
+    /// remain in session state and are not reset by cache invalidation.
     pub fn invalidate_projection(&mut self) {
         self.publish_tail_projection = None;
     }
 
-    /// What the tail projection this engine retains weighs, or `None` when
-    /// it retains none.
-    ///
-    /// A runtime holding one engine per namespace bounds its total retention
-    /// with this; the per-projection ceiling in [`PublishTailOptions`] only
-    /// bounds one.
+    /// Returns the retained tail projection's memory weight, or `None` when no
+    /// projection is cached. Runtimes can sum this value across namespace engines
+    /// to enforce a global cache limit.
     pub fn retained_tail_weight(&self) -> Option<PublishTailWeight> {
         self.publish_tail_projection
             .as_ref()
             .map(PublishTailProjection::weight)
     }
 
-    /// This session's writer epoch for the namespace, acquired on first use
-    /// and reused afterwards.
-    ///
-    /// Fencing is checked first and answered terminally: a superseded session
-    /// never touches the store again, and never reacquires on its own.
+    /// Returns the session's writer epoch, acquiring it on first use. A fenced
+    /// session fails immediately without accessing the store or acquiring a new
+    /// epoch.
     async fn session_writer_epoch<S: ObjectStore + ?Sized>(
         &self,
         store: &S,
@@ -360,22 +339,21 @@ impl NamespaceCommitEngine {
             .map_err(CoreError::WriterEpoch)?;
         let mut session = self.lock_session();
         if let WriterSessionState::Fenced(fence) = &*session {
-            // Another engine sharing this session observed fencing while we
-            // were acquiring; the session stays fenced.
+            // Another engine fenced the shared session while this engine was acquiring
+            // the epoch. Preserve the fenced state.
             return Err(CoreError::WriterFenced(fence.clone()));
         }
         *session = WriterSessionState::Acquired(acquired_writer.clone());
         Ok(acquired_writer)
     }
 
-    /// Deletes the namespace through this session (format spec, "Tombstones
-    /// and deletion").
+    /// Deletes the namespace using this writer session (format spec,
+    /// "Tombstones and deletion").
     ///
-    /// Deletion is a head-advancing write, so it takes the same session gate
-    /// as [`Self::publish_batch`]: a fenced session is refused terminally
-    /// without touching the store, and the epoch acquired for publishing is
-    /// the epoch the tombstone swap is fenced by. A takeover observed by the
-    /// swap fences this session for good.
+    /// Deletion advances the head, so it uses the same writer-session checks as
+    /// [`Self::publish_batch`]. Fenced sessions fail before accessing the store,
+    /// and a takeover detected during the tombstone CAS permanently fences the
+    /// session.
     pub async fn delete_namespace<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -14,9 +14,8 @@ use loonfs_objectstore::{ObjectMetadata, ObjectStore, ObjectStoreError};
 use std::future::Future;
 use thiserror::Error;
 
-/// The head a closure wants installed, plus what the caller receives once
-/// the compare-and-swap lands. Every head update replaces: a closure that
-/// must not write errors instead.
+/// Replacement head state and the value returned after its CAS succeeds.
+/// An update that should not write must return an error instead.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct HeadReplacement<T> {
     pub(crate) next: Box<HeadState>,
@@ -52,12 +51,10 @@ pub(crate) enum ControlUpdateError {
     RetryExhausted { attempts: usize },
 }
 
-/// Reads the head, lets `update` build the replacement, and publishes it by
-/// compare-and-swap on the loaded etag, retrying the whole
-/// read-decide-swap cycle on CAS conflict. Closure errors propagate
-/// immediately without retrying — that is the fencing hook: a closure that
-/// observes a disqualifying head (newer writer, changed manifest) must error,
-/// never clobber.
+/// Reads the head, asks `update` to build a replacement, and applies it with
+/// a CAS against the loaded ETag. CAS conflicts retry the complete
+/// read-update-CAS cycle. Errors returned by `update` are returned immediately,
+/// which prevents an invalid writer or stale manifest from being overwritten.
 pub(crate) async fn update_head<S, T, E, F>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -206,12 +203,8 @@ fn required_etag_core<'a>(
     })
 }
 
-/// Reads one upload session's durable state without holding an etag.
-///
-/// Callers that only need to know what a session says — status reads, and
-/// the terminal-state check a completion makes before it touches any
-/// provider object — take this instead of opening a compare-and-swap they
-/// may not use.
+/// Reads an upload session without retaining its ETag. Use this for status
+/// checks and other operations that do not need to update the session.
 pub(crate) async fn read_upload_session_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -37,23 +37,18 @@ use std::num::NonZeroU64;
 use std::sync::Arc;
 use thiserror::Error;
 
-/// The pinned inputs the runtime resolves once per read: the head anchored
-/// to its manifest, the shared caches, and (when the runtime has it) the
-/// namespace's immutable catalog pair.
+/// Read context pinned by the runtime for one request. It contains the head,
+/// metadata basis, and shared caches needed to serve every read from the same
+/// namespace snapshot.
 ///
-/// This is the runtime seam: the `loonfs` crate pins one context per
-/// request and fans every read of that request through it, so the whole
-/// request observes a single snapshot and shares the caches. It is a
-/// sanctioned public hook (STYLE, "Harness hooks are sanctioned"), not an
-/// application API — embedded applications use the `loonfs` handles, which
-/// drive this seam internally.
+/// This type supports the `loonfs` runtime. Applications should use the
+/// higher-level `loonfs` reader handles instead.
 #[derive(Debug, Clone)]
 pub struct RuntimeReadContext {
     pub head: HeadState,
     pub head_etag: String,
-    /// The materialized basis the head authorized when the anchor was
-    /// taken. It carries the namespace's own root when it has one, and the
-    /// genesis or fork basis until then.
+    /// Metadata basis referenced by the pinned head. This is the namespace's own
+    /// root after one is published, or its genesis or fork basis before then.
     pub basis: MetadataBasis,
     pub table_cache: Arc<MetadataTableCache>,
     pub tail_cache: Arc<WalTailProjectionCache>,
@@ -84,11 +79,10 @@ pub struct BeginDirectPutUploadTargetResponse {
     pub target: DirectPutUploadTarget,
 }
 
-/// Internal target used by server integrations before they mint part URLs.
+/// Internal multipart target used by the server before signing part URLs.
 ///
-/// There is no content ref: a multipart session is opened before anything
-/// is known about the payload, so identity exists but the reference that
-/// describes it does not yet.
+/// The session has an object identity but no content reference yet because
+/// the payload size and checksum are supplied at completion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectMultipartUploadTarget {
     pub object_key: String,
@@ -228,9 +222,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Deletes this namespace: a fenced, terminal head-state transition.
-    /// Commits acknowledged before the swap stay committed; everything that
-    /// observes the deleted head afterward fails with `namespace_deleted`.
+    /// Deletes the namespace by atomically changing its head to the terminal
+    /// deleted state. Earlier committed changes remain durable, and later
+    /// operations return `namespace_deleted`.
     pub async fn delete_namespace(
         &self,
         options: DeleteNamespaceOptions,
@@ -281,25 +275,15 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
-    /// Opens a bounded streaming read of a file's current content against the
-    /// pinned runtime read context.
+    /// Opens a chunked stream for the file resolved from the pinned read context.
     ///
-    /// The path resolves exactly as it does for [`Self::read_file`]; what
-    /// differs is everything after. The content arrives as `chunk_bytes`
-    /// ranged reads with the verifying digest folded over them, so what the
-    /// read costs in memory is one chunk rather than the file's size, and the
-    /// deployment's buffered-read cap deliberately does not apply — that cap
-    /// bounds what a caller materializes, and this caller materializes a
-    /// chunk.
+    /// The stream fetches `chunk_bytes` at a time, so memory use is bounded by one
+    /// chunk and the buffered-read size limit does not apply. The resolved content
+    /// object is immutable, so later commits cannot change the bytes being read.
     ///
-    /// The pinned context resolves the path; it does not have to survive the
-    /// read. The reference names one immutable object at a random id, so no
-    /// commit landing mid-read can change the bytes under a reader.
-    ///
-    /// `start_offset` skips bytes the caller already holds; the stream still
-    /// verifies the whole object, so those bytes reach it through
-    /// [`FileContentStream::fold_resumed_prefix`] before it fetches
-    /// anything.
+    /// When `start_offset` is nonzero, the caller must pass the skipped prefix to
+    /// [`FileContentStream::fold_resumed_prefix`] before fetching more data. This
+    /// allows the stream to verify the checksum of the complete object.
     pub async fn read_file_stream(
         &self,
         path: impl AsRef<str>,
@@ -329,13 +313,8 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await?)
     }
 
-    /// Resolves a path to the content object a direct read would fetch,
-    /// against the pinned runtime read context.
-    ///
-    /// This reads metadata only. It is the read-side counterpart of
-    /// [`Self::begin_direct_put_upload_target`]: both hand a host the one
-    /// object key it needs in order to sign a transfer, and neither moves
-    /// a byte.
+    /// Resolves a file to the object key needed for a direct download. This
+    /// reads metadata only and does not transfer content bytes.
     pub async fn direct_download_target(
         &self,
         path: impl AsRef<str>,
@@ -368,15 +347,13 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         view.list_trash_page(request).await
     }
 
-    /// Reads one page of the files visible in the state `checkpoint_id`
-    /// pins, in ascending inode-id order.
+    /// Lists files from the manifest pinned by `checkpoint_id`, ordered by inode
+    /// ID.
     ///
-    /// The checkpoint's pinned manifest is the only state enumerated: the
-    /// context's own basis and WAL tail are deliberately not read, so a
-    /// commit landing while a consumer pages through changes nothing it
-    /// sees. Everything after the pinned sequence is the change feed's job.
-    /// The context supplies the namespace's immutable identity and proves
-    /// the namespace is still live.
+    /// The method ignores the current metadata basis and WAL tail, so every page
+    /// comes from the same checkpoint snapshot even when new commits arrive. The
+    /// read context is used only to validate the namespace identity and confirm
+    /// that it has not been deleted.
     pub async fn list_checkpoint_files_page(
         &self,
         checkpoint_id: &CheckpointId,
@@ -395,16 +372,13 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Answers, for each inode id, what it looks like in the namespace's
-    /// current state: whether it is visible, its current revision, and its
-    /// current path.
+    /// Resolves the current visibility, revision, and path for each inode ID.
     ///
-    /// One pinned read serves the whole batch, so every answer describes the
-    /// same state, and answers come back in input order. Ids that name
-    /// nothing are answered as not visible rather than refused — a consumer
-    /// holding ids from an earlier enumeration routinely holds stale ones.
-    /// At most [`MAX_RESOLVE_CURRENT_FILES`](crate::MAX_RESOLVE_CURRENT_FILES)
-    /// ids per call; a larger batch is refused before anything is read.
+    /// All results use the same pinned snapshot and preserve input order. Missing
+    /// inode IDs are returned as not visible because callers may hold IDs from an
+    /// older listing. Requests above
+    /// [`MAX_RESOLVE_CURRENT_FILES`](crate::MAX_RESOLVE_CURRENT_FILES) fail before
+    /// reading metadata.
     pub async fn resolve_current_files(
         &self,
         inode_ids: &[InodeId],
@@ -415,14 +389,11 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         crate::path::read::resolve_current_files(&view, inode_ids).await
     }
 
-    /// Reads one immutable content object by reference.
+    /// Reads and verifies one immutable content object.
     ///
-    /// `max_bytes` is the caller's own budget for this read, checked against
-    /// the reference's declared size before any fetch; it is independent of
-    /// any deployment-wide download limit, so a consumer sizes its own
-    /// buffers. After the fetch the bytes are verified against the
-    /// reference's size and digest, and a mismatch fails the read — there is
-    /// no partial answer and no second attempt against another key.
+    /// `max_bytes` is checked against the declared size before the fetch and is
+    /// independent of deployment-wide download limits. The method returns an
+    /// error if the fetched size or checksum does not match the reference.
     pub async fn read_content_ref(
         &self,
         content_ref: &ContentRef,
@@ -440,11 +411,10 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         Ok(read.bytes)
     }
 
-    /// The namespace's immutable identity, read off the pinned head after
-    /// refusing a head that is not this namespace's or that is a tombstone.
+    /// Returns the namespace catalog derived from the pinned head after checking
+    /// that the head belongs to this namespace and is not deleted.
     ///
-    /// Reads that load a metadata view get both checks from the view load;
-    /// this is for the reads that deliberately do not load one.
+    /// Use this for read paths that do not load a full metadata view.
     fn live_catalog(&self, context: &RuntimeReadContext) -> Result<VerifiedNamespaceCatalogEntry> {
         if context.head.namespace_id != self.namespace_id {
             return Err(crate::error::CoreError::NamespaceCorrupt(format!(
@@ -570,10 +540,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Mints a direct_multipart upload target: a fresh content identity, the
-    /// provider upload that assembles it, and the part geometry the client
-    /// cuts its payload to. What the payload turns out to be is claimed at
-    /// completion.
+    /// Creates a direct multipart upload target with a new object identity,
+    /// provider upload ID, and required part size. The final size and checksum are
+    /// supplied when the upload is completed.
     pub async fn begin_direct_multipart_upload_target(
         &self,
         options: DirectMultipartUploadOptions,
@@ -587,8 +556,8 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Resolves one wave of parts for signing against the session that owns
-    /// them. Nothing durable is written: parts are the client's bookkeeping.
+    /// Validates a group of multipart parts and returns the information needed
+    /// to sign their upload URLs. This method does not write durable state.
     pub async fn direct_multipart_part_targets(
         &self,
         upload_id: &UploadId,
@@ -686,19 +655,13 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Stages bytes this process holds as content a session owns, ready to
-    /// publish here.
+    /// Stores in-process bytes as prepared content and completes the associated
+    /// upload session.
     ///
-    /// This is the whole upload lifecycle for the caller that is also the
-    /// uploader: a session opens, the bytes land under the identity it
-    /// allocated, and the session completes — with no wire step between them
-    /// and no receipt at the end, because the publication happens in this
-    /// process and takes the reference directly. What it does not skip is
-    /// the session record, which is what content garbage collection reads to
-    /// decide an object's fate; without one the bytes would be reachable by
-    /// nothing and reclaimable by nothing.
-    ///
-    /// Two small control writes on top of the content write, in that order.
+    /// This combines session creation, content upload, and completion without a
+    /// network round trip or receipt. It still writes the upload-session record
+    /// required by garbage collection. The content write is followed by two
+    /// small control-object writes.
     pub async fn stage_owned_bytes(
         &self,
         catalog: &VerifiedNamespaceCatalogEntry,
@@ -732,12 +695,8 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Refuses a catalog resolved for some other namespace.
-    ///
-    /// A mismatch is the host's wiring mistake rather than anything a request
-    /// did, so naming the two namespaces says more than naming what was being
-    /// written would — and a multipart completion has no content id to name
-    /// anyway.
+    /// Verifies that a runtime-supplied catalog belongs to this engine's
+    /// namespace. A mismatch indicates an internal integration error.
     fn own_catalog<'c>(
         &self,
         catalog: &'c VerifiedNamespaceCatalogEntry,
@@ -772,8 +731,9 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Reads one upload session, minting a fresh receipt when it is
-    /// completed so a lost commit response never costs a retransfer.
+    /// Reads an upload session. For a completed upload, it also creates a new
+    /// receipt so the caller can retry publication without uploading the content
+    /// again.
     pub async fn read_upload_status(
         &self,
         upload_id: &UploadId,
@@ -793,14 +753,12 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Creates or reuses a named checkpoint pinning the current namespace
-    /// head for the calling user.
+    /// Creates or reuses a named checkpoint for the current namespace head.
     ///
-    /// A checkpoint pins a manifest version for retention/provenance. If the
-    /// current head has no manifest yet, this first publishes one for the
-    /// current durable namespace state; it is not a request to compact
-    /// metadata. `ttl_ms` computes the record's expiry from the engine's
-    /// clock; absent means the pin holds until explicitly released.
+    /// The checkpoint pins a manifest for retention and provenance. If the head
+    /// has no manifest, the method first publishes one without compacting
+    /// metadata. `ttl_ms` sets an expiration time; `None` keeps the checkpoint
+    /// until it is released.
     pub async fn create_checkpoint(
         &self,
         name: String,
@@ -818,11 +776,10 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Lists every active checkpoint record on the namespace, oldest first.
+    /// Lists active checkpoint records from oldest to newest.
     ///
-    /// A read: nothing here releases, expires, or reaps a record. A record
-    /// whose expiry has passed but which no collection pass has released is
-    /// still active and is still listed, with that expiry in the answer.
+    /// This method does not release expired records. A record remains active and
+    /// appears in the result until garbage collection processes it.
     pub async fn list_checkpoints(&self) -> Result<ListCheckpointsResponse> {
         crate::checkpoint::list_checkpoints(&self.store, &self.namespace_id).await
     }
@@ -857,21 +814,21 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
-    /// Runs at most one metadata reorganization unit: folds one family
-    /// group's L0 delta rows into new base segments and publishes a manifest
-    /// swapping that group's references. Checkpoints only append L0 runs, so
-    /// calling this from maintenance is what keeps read fan-out bounded.
-    /// Repeat until the report says `NotNeeded`; every call re-reads durable
-    /// state, so interrupted reorganizations resume from the live manifest.
+    /// Performs at most one metadata reorganization step for one row family.
+    /// It merges L0 delta rows into new base segments and publishes a manifest
+    /// that replaces the old references.
+    ///
+    /// Run this repeatedly until it returns `NotNeeded`. Each call reloads durable
+    /// state, so work can resume safely after interruption.
     ///
     /// A group whose oldest run no longer fits one unit is reported as
-    /// [`MetadataReorganizeOutcome::CompactionPlanned`] instead. The caller
-    /// runs that plan with [`Self::run_metadata_compaction`] as a background
-    /// job and hands its spec back here in `compactions` for as long as the
-    /// job runs, so no unit merges the group underneath it. `compactions`
-    /// also carries how long each group has been merging deltas over a base
-    /// no window can reach, which is what decides when the planner stops
-    /// taking that merge and starts the job.
+    /// [`crate::checkpoint::MetadataReorganizeOutcome::CompactionPlanned`]
+    /// instead. The caller runs that plan with
+    /// [`Self::run_metadata_compaction`] as a background job and includes its
+    /// specification in `compactions` while the job runs. This prevents a
+    /// bounded step from merging the same group concurrently. `compactions`
+    /// also records how many delta merges have run above an oversized base so
+    /// the planner knows when to request the full compaction.
     pub async fn reorganize_metadata(
         &self,
         compactions: crate::checkpoint::MetadataCompactionView<'_>,
@@ -921,12 +878,8 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// The identity every mutation publishes under.
-    ///
-    /// A read-only engine has none, so this fails instead of inventing one.
-    /// Nothing routes that error: the runtime hands read-only engines only to
-    /// read paths, and this exists so a wiring mistake fails honestly rather
-    /// than publishing under a fabricated writer.
+    /// Builds the mutation context for this engine. Read-only engines return an
+    /// internal error because they have no writer identity.
     fn mutation_context(&self) -> Result<MutationContext> {
         let writer = self.writer.as_ref().ok_or_else(|| {
             crate::error::CoreError::Internal(

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -1,9 +1,9 @@
 //! Core error types and their wire-code classification.
 //!
-//! Stringification rule: core errors are `Clone`/serde-constrained, so foreign
-//! causes (object-store, codec, io) are captured as prefixed message strings
-//! next to the object key they are about, not as `#[source]` chains. Crates
-//! without those constraints (server, CLI) prefer `#[source]` chains instead.
+//! Core errors must support `Clone` and serialization. Errors from the object
+//! store, codecs, and I/O are therefore stored as messages with the relevant
+//! object key instead of as `#[source]` chains. The server and CLI use source
+//! chains where these constraints do not apply.
 
 use crate::checkpoint::ManifestLoadError;
 use crate::commit::{CommitHeadPublishError, CommitValidationError};
@@ -28,9 +28,8 @@ use thiserror::Error;
 /// machine-readable reason.
 pub use self::CoreError as Error;
 
-/// Result type used by `loonfs-core` entrypoints. Crate-internal: the alias
-/// is transparent, so public signatures using it still read as
-/// `std::result::Result<T, Error>` from outside.
+/// Internal result alias used by core entry points. Public signatures still
+/// expose this as `std::result::Result<T, Error>`.
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 pub use loonfs_api::{ErrorCode, ErrorKind};
@@ -81,26 +80,24 @@ pub enum CoreError {
         inode_id: InodeId,
         revision_no: RevisionNo,
     },
-    /// A buffered content read was refused before any fetch: the resolved
-    /// content is larger than the caller's read budget allows in memory.
+    /// The content exceeds the caller's in-memory limit. No data was fetched.
     #[error(
         "file content is {size_bytes} bytes, over the {max_bytes}-byte limit \
          this deployment buffers for one read"
     )]
     ContentTooLarge { size_bytes: u64, max_bytes: u64 },
-    /// A batch read asked for more items than one call answers. The caller
-    /// splits the batch; nothing was read.
+    /// The request contains more items than one batch may read. No items were
+    /// read; split the request into smaller batches.
     #[error("asked for {requested} items, over the {max} one batch answers")]
     BatchTooLarge { requested: usize, max: usize },
-    /// A streamed read was asked to start past the end of the content it
-    /// reads, either outright or by being handed more already-held bytes
-    /// than the content has. Nothing was read.
+    /// The requested start offset is past the end of the content. This can also
+    /// happen when the caller supplies more previously read bytes than the
+    /// content contains. No data was read.
     #[error("cannot start a read at offset {start_offset} of {size_bytes}-byte content")]
     ResumeOffsetOutOfRange { start_offset: u64, size_bytes: u64 },
-    /// A streamed read that starts past zero was driven before the bytes it
-    /// skipped were folded into its verification. Verification covers the
-    /// whole object, so it cannot begin until the caller has handed over
-    /// what it already holds. Nothing was read.
+    /// A resumed read cannot continue until the caller supplies all bytes before
+    /// the resume offset for whole-object checksum verification. No data was
+    /// read.
     #[error(
         "a read resumed at offset {start_offset} was given {folded} bytes of what it skipped; \
          verification covers the whole object, so all of them are needed first"
@@ -117,34 +114,29 @@ pub enum CoreError {
     #[error("{}", destination_exists_message(.path, .existing_display_name.as_deref()))]
     DestinationExists {
         path: String,
-        /// Stored spelling of the occupying entry, when the planner had it.
-        /// Rendered when it differs from what the caller typed, because
-        /// sibling names collide after NFC normalization and case folding
-        /// and the two spellings can look identical.
+        /// Stored name of the existing entry, when available. It is included in the
+        /// error when normalization or case folding makes it conflict with the name
+        /// supplied by the caller.
         existing_display_name: Option<String>,
     },
     #[error("commit id conflict for `{commit_id}`")]
     CommitIdReuseConflict {
         commit_id: String,
-        /// Sequence the commit id already landed at, when the conflict was
-        /// decided against a durable receipt — the receipt is what holds
-        /// it. Absent when nothing has committed under the id yet and two
-        /// live requests are claiming it at once, which is the one case a
-        /// caller cannot reconcile by reading the feed.
+        /// Sequence of the commit that already used this ID, when a durable receipt
+        /// exists. This is `None` when two concurrent requests claim the same ID
+        /// before either one commits.
         committed_seq: Option<ChangeSeq>,
-        /// Semantic identity of the mutation that landed under the id, taken
-        /// from the same receipt as `committed_seq` and present exactly when
-        /// it is. Reporting it is what lets a retry prove it is the same
-        /// request by recomputing one value, rather than comparing whichever
-        /// fields it thought to compare.
+        /// Fingerprint of the committed mutation. It is present whenever
+        /// `committed_seq` is present and lets a retry verify that it represents the
+        /// same request.
         committed_fingerprint: Option<String>,
     },
     #[error(transparent)]
     ContentPreparation(#[from] ContentPreparationError),
     #[error("commit queue is full; slow down and retry")]
     CommitQueueFull,
-    /// The serving front-end closed admission for shutdown. New work is
-    /// refused; work admitted earlier still settles.
+    /// The service is shutting down. New requests are rejected, while requests
+    /// accepted earlier may finish.
     #[error("shutting down; new work is not admitted")]
     ShuttingDown,
     #[error("checkpoint unavailable: {0}")]
@@ -206,28 +198,19 @@ pub enum CoreError {
     NamespaceExists { namespace_id: NamespaceId },
     #[error("namespace `{namespace_id}` is deleted")]
     NamespaceDeleted { namespace_id: NamespaceId },
-    /// A caller-supplied `expected_head_seq` did not match the head.
+    /// A caller-supplied `expected_head_seq` did not match the current head.
     ///
-    /// Distinct from the publish path's [`CommitHeadPublishError::StaleHead`],
-    /// which reports a race the caller never asked about: this is a
-    /// precondition the caller wrote, so the rejection owes it both numbers —
-    /// what it asked for and what the namespace was actually at — and a
-    /// caller that meant to delete the current head can retry against the
-    /// sequence it found. Both carry the `stale_head` code.
+    /// Unlike [`CommitHeadPublishError::StaleHead`], this error reports a failed
+    /// explicit precondition. It includes both sequence numbers so the caller can
+    /// decide whether to retry. Both errors use the `stale_head` code.
     #[error("expected head sequence {expected}, found {actual}")]
     StaleHeadPrecondition {
         expected: ChangeSeq,
         actual: ChangeSeq,
     },
-    /// A batch stopped at one of its operations. A mutation commits all of
-    /// its operations or none of them, so this names the operation that
-    /// stopped the request and carries the failure it produced. The wire code
-    /// stays the inner failure's; the position joins the message and the
-    /// structured details.
-    ///
-    /// Only a request with more than one operation is wrapped: a
-    /// single-operation request has one place to fail, so its error stays
-    /// exactly what the operation produced.
+    /// Identifies the operation that caused a multi-operation request to fail.
+    /// The request remains atomic, and the error code is taken from the underlying
+    /// failure. Single-operation requests return the underlying error directly.
     #[error("operation {operation_index}: {source}")]
     FailedOperation {
         operation_index: u32,
@@ -330,9 +313,9 @@ impl From<ImmutableWriteError> for CoreError {
     }
 }
 
-/// What a failed provider operation says about who can fix it, preserved
-/// across the message-flattening seams so the wire code can distinguish
-/// "fix the storage credentials" from "unclassified internal failure".
+/// Classifies a provider failure by the action required to fix it. This
+/// classification is preserved after the original error is converted to a
+/// message so the wire error code remains accurate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum StoreFailureClass {
     /// The provider rejected the deployment's credentials: operator work,
@@ -343,8 +326,7 @@ pub enum StoreFailureClass {
 }
 
 impl StoreFailureClass {
-    /// Classifies a provider error at the seam where its message is
-    /// flattened into a carrier's `message` field.
+    /// Classifies a provider error before converting it to a stored message.
     pub fn of(error: &ObjectStoreError) -> Self {
         match error {
             ObjectStoreError::PermissionDenied { .. } => Self::PermissionDenied,
@@ -506,14 +488,11 @@ impl CoreError {
     }
 }
 
-/// The fencing event a writer session observed: the epoch the session held,
-/// the epoch that displaced it, and — when the head recorded a writer block —
-/// the winner's label and when it acquired.
+/// Describes a writer fencing event: the displaced epoch, the active epoch,
+/// and any available information about the active writer.
 ///
-/// The epochs are what identifies the two parties. Writer labels are process
-/// names, so two local processes can share one (the CLI defaults `writer_id`
-/// to the hostname); the acquisition stamp is what tells those runs apart in
-/// a diagnostic.
+/// Epochs identify the competing sessions. Writer labels may be shared by
+/// multiple processes, so the acquisition timestamp helps distinguish them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriterFence {
     /// Epoch the fenced session held.
@@ -545,9 +524,8 @@ impl std::fmt::Display for WriterFence {
             "epoch {} was fenced by epoch {}",
             self.fenced_epoch, self.active_epoch
         )?;
-        // Both fields come from the head's writer block, so in practice they
-        // are present or absent together; the arms keep the message honest
-        // either way.
+        // These fields normally appear together, but format a useful message when
+        // only one is available.
         match (self.active_writer.as_deref(), self.active_acquired_at_ms) {
             (Some(writer), Some(acquired_at_ms)) => {
                 write!(f, " (writer `{writer}`, acquired at {acquired_at_ms} ms)")

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -1,20 +1,13 @@
-//! Upload and content reclamation, split at the completed line.
+//! Garbage collection for upload sessions and their content.
 //!
-//! Everything before a session completes belongs to upload collection: an
-//! open session whose lease has passed is aborted and the object it was
-//! writing is deleted, and that reasoning is entirely session-local, because
-//! a random content id that was never published can only ever have had one
-//! owner.
+//! Before completion, an expired open session can be aborted and its
+//! unpublished object deleted using only the session record.
 //!
-//! Everything at or after completion belongs to content collection, which is
-//! the harder half: completed content may or may not have been published, and
-//! the only honest way to tell is to look at what the namespace's metadata
-//! actually references. That is decidable — rather than a race against
-//! writers — because a reference can only enter metadata through a receipt,
-//! receipts stop being minted a fixed window after completion, and
-//! `CONTENT_RECLAMATION_GRACE_MS` outlasts that window plus the last
-//! receipt's life plus the publication it could admit. Past the grace, the
-//! set of references to a completed session's content can no longer grow.
+//! After completion, content may already be referenced by metadata. The
+//! collector waits for `CONTENT_RECLAMATION_GRACE_MS`, then scans namespace
+//! metadata before deleting the object. The grace period covers the receipt
+//! lifetime and any publication that receipt can authorize, so no new
+//! reference can appear after the scan becomes eligible.
 
 use super::budget::PassBudget;
 use super::live_set::LiveSet;
@@ -44,13 +37,9 @@ const REVISION_SCAN_WAVE_ROWS: usize = 1024;
 pub(super) enum UploadSessionSweep {
     /// The session key survives this pass. It may have advanced a state.
     Retain {
-        /// When the wait this pass was too early for ends, for the three
-        /// retentions a clock decides: an open session's lease plus the
-        /// grace window, an aborted session's grace, a completed session's
-        /// derived content-reclamation grace. `None` for a retention no
-        /// clock resolves — a lost compare-and-swap, a reference set this
-        /// pass could not establish — where there is no time to come back
-        /// at, only a next pass to look again.
+        /// Earliest time this session may be reconsidered when retention is
+        /// time-based. `None` means the pass must retry later for a non-time-based
+        /// reason, such as a lost CAS or an incomplete reference scan.
         reclaimable_at_ms: Option<u64>,
     },
     /// The session has nothing left to say and its key may be deleted.
@@ -59,22 +48,18 @@ pub(super) enum UploadSessionSweep {
         /// completed and nothing ever published.
         reclaimed_content: bool,
     },
-    /// The pass could not afford the reference collection this session's
-    /// content needs. The session is retained exactly as an undecidable one
-    /// is, completed-content reclamation is off for the rest of the
-    /// invocation, and the sweep goes on to the next candidate: what the
-    /// budget could not pay for is the scan, not the sweep.
+    /// The remaining pass budget was too small to scan content references. Keep
+    /// the session, disable completed-content reclamation for this invocation,
+    /// and continue sweeping other candidates.
     ContentReclamationDeferred,
 }
 
-/// Advances one upload session and reclaims whatever it stops owning.
+/// Advances one upload session and reclaims content it no longer owns.
 ///
-/// Every transition here is a compare-and-swap on exactly the etag inspected
-/// with the state, and a lost swap retains without retrying, so a racing
-/// completion can never be overwritten by a second read. Provider cleanup
-/// always follows the durable transition: a crash in between leaves an
-/// object the next pass deletes from the terminal record, never an object
-/// deleted out from under a session that is still open.
+/// State transitions use a CAS against the ETag that was read with the
+/// session. A CAS conflict keeps the session for a later pass. Provider
+/// cleanup runs only after the durable state transition, so a crash may leave
+/// extra data to clean up but cannot delete data from an open session.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
     store: &S,
@@ -86,9 +71,8 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> Result<UploadSessionSweep> {
-    // Reading first only selects the arm. Nothing here acts on this
-    // observation without re-reading under an etag, so a session that
-    // changes underneath the read is decided correctly anyway.
+    // This read selects the lifecycle branch only. Any state change is applied
+    // through a later CAS using a fresh ETag.
     let state = match read_upload_session_state(store, namespace_id, upload_id).await {
         Ok(state) => state,
         Err(CoreError::UploadNotFound { .. }) => return Ok(retain_undated()),
@@ -112,17 +96,14 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
             if context.now_ms.saturating_sub(aborted_at_ms) < grace_window_ms {
                 return Ok(retain_until(aborted_at_ms.saturating_add(grace_window_ms)));
             }
-            // Repeating the abort's own cleanup is what makes a crash
-            // between the abort swap and its provider work cost nothing.
+            // Repeat provider cleanup so a later pass completes work left by a crash
+            // after the abort CAS.
             AbandonedUpload::of(&state)
                 .release(store, content_store_id)
                 .await;
-            // Not counted as a reclaimed content object: this delete is
-            // unconditional cleanup that runs whether or not the session
-            // ever wrote anything, and it repeats on every pass until the
-            // record ages out. Only the content half's Absent verdict
-            // reports a reclamation, because only it establishes that
-            // there was something to reclaim.
+            // Do not count this as reclaimed content. Abort cleanup runs even when no
+            // object was written. Only a completed session with an `Absent` reference
+            // result proves that a content object was eligible for reclamation.
             Ok(UploadSessionSweep::Delete {
                 reclaimed_content: false,
             })
@@ -142,8 +123,8 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
             {
                 ContentReference::Unknown => Ok(retain_undated()),
                 ContentReference::Deferred => Ok(UploadSessionSweep::ContentReclamationDeferred),
-                // Published content answers to metadata now, not to the
-                // session that uploaded it, so the record is all that goes.
+                // Metadata now owns the published content. Delete only the completed
+                // upload-session record.
                 ContentReference::Referenced => Ok(UploadSessionSweep::Delete {
                     reclaimed_content: false,
                 }),
@@ -177,12 +158,11 @@ fn retain_undated() -> UploadSessionSweep {
     }
 }
 
-/// Aborts one session whose lease has passed, then deletes what it was
-/// writing.
+/// Aborts a session after its lease and grace period expire, then cleans up
+/// its unpublished content.
 ///
-/// The grace on top of the lease is not part of the safety argument — the
-/// compare-and-swap is — it just keeps a completion that arrives moments
-/// late from being a race anyone has to think about.
+/// The CAS provides safety. The additional grace period only reduces races
+/// with completions that arrive shortly after lease expiry.
 async fn abort_expired_session<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -215,8 +195,7 @@ async fn abort_expired_session<S: ObjectStore + ?Sized>(
     )
     .await;
     match aborted {
-        // The record this pass just aborted is retained under the aborted
-        // arm's own grace from here, and that is the next thing it owes.
+        // Keep the newly aborted record until its post-abort grace period expires.
         Ok(UploadSessionCas::Applied(Some(abandoned))) => {
             abandoned.release(store, content_store_id).await;
             Ok(retain_until(context.now_ms.saturating_add(grace_window_ms)))
@@ -256,33 +235,20 @@ enum CollectedReferences {
     /// A root could not be read, so this pass has no reference set at all
     /// (format spec, "Garbage collection", rule 5).
     Unavailable,
-    /// The scan ran out of budget once, which settles it for the whole
-    /// invocation: a later candidate must not pay to start the same scan
-    /// over, and being skipped is a property of the invocation rather than
-    /// of the session that happened to ask first. The ids gathered before
-    /// the budget ran out are dropped, because a partial set is not a
-    /// smaller answer, it is no answer: every id it is missing looks
-    /// unreferenced, so deciding a deletion from one would delete live
-    /// content.
+    /// The reference scan exceeded the pass budget. Do not retry it during this
+    /// invocation, and discard the partial result because missing IDs could make
+    /// live content appear unreferenced.
     Deferred,
     /// Every root was read. The set is complete and may decide deletions.
     Referenced(BTreeSet<ContentId>),
 }
 
-/// Every content id the namespace's live metadata references, collected at
-/// most once per invocation and only when a completed session has actually
-/// aged into reclamation — which in a healthy namespace is never, because
-/// published sessions are swept before their content ever becomes a
-/// question.
+/// Memoized set of content IDs referenced by live namespace metadata.
 ///
-/// The memo lives for one invocation, not one cursor-paged sweep. Carrying
-/// it further would mean putting "already scanned through here, found
-/// nothing" into the cursor, and the cursor is a client-supplied token that
-/// carries enumeration position only and never authorizes a deletion. So a
-/// resumed sweep collects again, and the budget above is what keeps that
-/// honest: the scan pays its own way every time it runs. A verdict of "not
-/// this time" is memoized like any other, which is what keeps one
-/// unaffordable scan from being re-attempted once per aged session.
+/// The set is collected at most once per garbage-collection invocation and
+/// only when an aged completed session needs it. It is not stored in the
+/// pagination cursor because the cursor records position, not permission to
+/// delete. A resumed invocation performs a new budgeted scan.
 pub(super) struct ContentReferences<'a> {
     live: &'a LiveSet,
     collected: CollectedReferences,
@@ -326,15 +292,10 @@ impl<'a> ContentReferences<'a> {
     }
 }
 
-/// Collects every content id the namespace can still reach.
-///
-/// The roots are the same ones the rest of the pass uses: every manifest the
-/// live set protects, which includes each fork basis a fork-owned checkpoint
-/// record pins, plus the retained WAL chain for commits that are durable
-/// but not yet materialized. A fork target can only carry forward references
-/// that were in the basis it forked from, and a commit in any other
-/// namespace can only name content minted by that namespace's own sessions,
-/// so those two sources are the whole reachable set.
+/// Collects every content ID reachable from protected manifests and the
+/// retained WAL chain. Protected manifests include fork bases pinned by
+/// checkpoints. Other namespaces cannot reference these content IDs because
+/// each namespace publishes content created by its own upload sessions.
 ///
 /// Only the manifest half is read here. The chain's references were
 /// harvested off the bodies marking already decoded, so this half is a set

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -55,25 +55,14 @@
 //! );
 //! ```
 
-// Sanctioned consumers of this crate's public surface, in full:
+// This crate has two supported consumers:
+// - `loonfs`, which wraps the core API with runtime caching and batching.
+// - `loonfs-core` integration tests, which inspect durable layout and replay.
 //
-// - **`loonfs`** — the embedded runtime, the only production consumer. It
-//   wraps everything below with caching, batching, and handles, and re-exports
-//   what applications need. Application code depends on `loonfs`, never on
-//   this crate.
-// - **`loonfs-core`'s own integration tests** (`tests/it`) — a white-box
-//   consumer that asserts on durable layout and replay directly. It is why
-//   `metadata` and parts of `commit` are public at all.
-//
-// Nothing else depends on this crate. `loonfs-grep` was extracted and reads
-// filesystem state through `loonfs`; `loonfs-sim`, `loonfs-model`, and
-// `loonfs-test-support` never depended on it; `loonfs-server` and `loonfs-cli`
-// reach the durable control plane through `loonfs::control`.
-//
-// The module list below is grouped by that intent: private modules are engine
-// internals, and each public one names why it is public.
+// Application code should depend on `loonfs`, not `loonfs-core`. Modules are
+// private unless one of these consumers needs them to be public.
 
-// --- engine internals: private, reachable only through the seams below ---
+// Internal engine modules. Public APIs below expose the supported entry points.
 mod checkpoint;
 mod commit_engine;
 mod context;
@@ -89,39 +78,34 @@ mod storage;
 mod timing;
 mod wal;
 
-// --- public seams ---
+// Public modules required by `loonfs` or this crate's integration tests.
 /// Commit planning, validation, and materialization. Consumed by the `loonfs`
 /// publisher and by this crate's commit-validation integration tests.
 pub mod commit;
-/// Content staging and preparation-token minting. Consumed by `loonfs`'s
-/// write path and its server-integration `content_tokens` seam.
+/// Content staging and preparation-token creation used by the `loonfs` write
+/// path and server integration code.
 pub mod content;
 /// Protocol and resource ceilings. Consumed by `loonfs` (re-exported to the
 /// server for request validation) and by layout tests.
 pub mod limits;
-/// Durable metadata state and its row codecs. Public for this crate's
-/// white-box integration tests, which compare projected state against the
-/// reference model; `loonfs` reaches metadata only through the seams above.
+/// Durable metadata state and row codecs. This module is public so
+/// integration tests can compare projected state with the reference model.
 pub mod metadata;
 /// Path parsing and current-state resolution. Consumed by `loonfs`'s write
 /// path (`parse_mutation_path`).
 pub mod path;
-/// Test doubles for this crate's public seams, behind the `test-support`
-/// feature. Consumed by the test targets of crates that implement or install
-/// those seams, and by this crate's own tests; no production build enables
-/// the feature. Doubles live here rather than in `loonfs-test-support`
-/// because that crate is a development dependency of this one and so cannot
-/// depend on these types.
+/// Test doubles for the public core APIs, available through the
+/// `test-support` feature. They remain in this crate because
+/// `loonfs-test-support` is a development dependency and cannot depend on
+/// these types without creating a dependency cycle.
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
-/// The wall-clock boundary durable timestamps are stamped at. Consumed by
-/// `loonfs`, whose mutation contexts and maintenance clock stamp from the
-/// same boundary this crate's own commits do.
+/// Wall-clock access used to assign durable timestamps. Both core commits
+/// and the `loonfs` runtime use this API so they share the same time source.
 pub mod time;
 
-/// Cache types and configuration for runtime read paths. Consumed by
-/// `loonfs`, which owns the runtime's cache configuration and stats, and
-/// which re-exports [`cache::Recency`] for the grep index's own block cache.
+/// Cache types and configuration used by runtime read paths. The `loonfs`
+/// runtime owns these caches and their statistics.
 pub mod cache {
     pub use crate::recency::Recency;
 
@@ -139,10 +123,8 @@ pub mod cache {
     };
 }
 
-/// Typed namespace control-object loaders and verified catalog state.
-/// Consumed by `loonfs`'s cache and write paths, and re-exported as
-/// `loonfs::control` for the white-box layout assertions the server and this
-/// crate's own tests make.
+/// Typed loaders for namespace control objects and verified catalog state.
+/// Used by `loonfs` read and write paths and by layout tests.
 pub mod control {
     pub use crate::namespace::catalog::{
         load_namespace_catalog_entry, NamespaceCatalogLoadError, VerifiedNamespaceCatalogEntry,
@@ -171,11 +153,9 @@ pub mod publish {
     pub use crate::storage::content_admission::PreparedContent;
 }
 
-// Crate-root re-exports. Every name below has a named consumer: `loonfs`
-// unless the comment says otherwise, or reachability through a public
-// signature where noted.
-// `MetadataReorganizeReport` has no caller that names it; it stays public
-// because it is the return type of `NamespaceEngine::reorganize_metadata`.
+// Crate-root re-exports used by `loonfs` or required by public return types.
+// `MetadataReorganizeReport` remains public because
+// `NamespaceEngine::reorganize_metadata` returns it.
 pub use checkpoint::{
     CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, FrozenBasePolicy,
     MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -202,14 +202,11 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         }
     }
 
-    /// A view of exactly one manifest's tables at the sequence they
-    /// materialize, with nothing layered over them.
+    /// Creates a view containing only one manifest at its materialized sequence.
     ///
-    /// [`Self::from_loaded_head`] answers "the namespace as of its live
-    /// head" by replaying the WAL tail over a basis; this answers "the
-    /// namespace exactly as this manifest recorded it". Callers that pin an
-    /// immutable manifest — a checkpoint's basis — read through this, so no
-    /// row committed after the manifest can leak into the answer.
+    /// Unlike [`Self::from_loaded_head`], this view does not replay the current
+    /// WAL tail. It is used for pinned manifests such as checkpoints, so later
+    /// commits cannot affect the result.
     pub(crate) fn over_manifest_tables(
         tables: &'a VerifiedMetadataTables<'store, S>,
         materialized_seq: ChangeSeq,
@@ -249,10 +246,11 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         self.snapshot.visible_seq
     }
 
-    /// Attaches a batch-scoped durable-layer memo. Only attach where every
-    /// composed view's `visible_seq` stays at or above the seq the durable
-    /// layers were loaded at, so memoized durable answers never go stale;
-    /// overlay rows are composed per lookup either way.
+    /// Attaches a cache for durable lookups performed during one batch.
+    ///
+    /// Use it only when every derived view has a `visible_seq` at or after the
+    /// sequence used to load the durable layers. Overlay rows are still applied
+    /// separately for each lookup.
     pub(crate) fn with_durable_cache(
         mut self,
         durable_cache: &'a DurableVisibilityCache,
@@ -287,17 +285,19 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
 }
 
 impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
-    /// Adapter presenting this view's primitive lookups as the
-    /// [`MetadataVisibilityReads`] contract, so the composite rules are
-    /// decided once in [`super::visibility`]. The view is `Copy`, so the
-    /// adapter owns a copy and needs no borrow of `self`.
+    /// Adapts this view to [`MetadataVisibilityReads`] so composite visibility
+    /// rules remain centralized in [`super::visibility`].
+    ///
+    /// `MetadataView` is `Copy`, so the adapter owns a copy instead of borrowing
+    /// `self`.
     fn reads(&self) -> MetadataViewReads<'a, 'store, S> {
         MetadataViewReads { view: *self }
     }
 
-    /// Whether the directory currently has at least one visible child,
-    /// answered by a limit-1 page through a fresh session so the cost stays
-    /// bounded no matter how wide the directory is.
+    /// Returns whether the directory has at least one visible child.
+    ///
+    /// The lookup requests a single-entry page, so its work does not grow with
+    /// the directory's total size.
     pub(crate) async fn has_visible_children(
         &self,
         parent_inode_id: InodeId,

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -31,30 +31,20 @@ pub enum WriterEpochAcquireError {
     RetryExhausted { attempts: usize },
 }
 
-/// Acquires the namespace writer epoch for a writer session.
+/// Acquires the namespace writer epoch for one writer session.
 ///
-/// Lazy by design: sessions call this on their first semantic write, not at
-/// open, and cache the result. Acquisition bumps `writer_epoch` and records
-/// the non-authoritative `writer` block, which fences every other session at
-/// its next publish. There is no lease and no expiry: nothing arbitrates
-/// between two live writers except the epoch itself, so acquisition never
-/// refuses a live caller and contention resolves as deterministic
-/// last-writer-wins. A session that has been fenced must not call this again
-/// on its own; reacquisition is an explicit caller decision.
+/// A session acquires lazily on its first write and caches the result.
+/// Acquisition increments `writer_epoch`; any older session is fenced on its
+/// next publish. There is no lease or expiry, so concurrent acquisitions use
+/// last-writer-wins ordering.
 ///
-/// The one refusal is terminal state: a deleted namespace's head is an
-/// immutable tombstone, so acquisition fails with `NamespaceDeleted` before
-/// any CAS — no attempt may rewrite the tombstone, inflate its epoch, or
-/// name a "current writer" for a dead namespace.
+/// Deleted namespaces reject acquisition before the compare-and-swap. A
+/// fenced session may reacquire only when its caller explicitly starts a new
+/// writer session.
 ///
-/// Every attempt bumps: there is no "this head is already mine" recognition,
-/// because there is no session identity to recognize. That is safe because a
-/// session acquires at most once — the commit engine memoizes the result in
-/// `session_writer_epoch` and never asks again — so a second call only
-/// happens when the first call's outcome was unknown to the caller. Bumping
-/// again then fences an epoch that never published anything, which takeover
-/// already handles as last-writer-wins. The cost is one wasted epoch on a
-/// rare retry path; the benefit is that acquisition needs no identity at all.
+/// Every acquisition attempt increments the epoch, even when the same writer
+/// ID is already recorded. Writer IDs do not identify sessions, and the
+/// commit engine normally calls this only once per session.
 pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -70,9 +60,9 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
         MAX_WRITER_EPOCH_ACQUIRE_ATTEMPTS,
         |loaded_head| {
             let head = &loaded_head.envelope.state;
-            // Terminal-state guard before the bump: no caller, not even the
-            // writer named in the tombstone's block, gets an epoch back for
-            // a deleted namespace.
+            // Check for deletion before incrementing the epoch. A deleted namespace
+            // never grants another writer epoch, including to the writer recorded in
+            // its tombstone.
             if head.state == NamespaceState::Deleted {
                 return Err(WriterEpochAcquireError::NamespaceDeleted {
                     namespace_id: head.namespace_id.clone(),

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -30,17 +30,11 @@ pub(crate) struct PlannedCommit {
     pub(crate) resulting_next_inode_id: InodeId,
 }
 
-/// The semantic identity of one mutation request.
+/// Computes the semantic fingerprint of a mutation request.
 ///
-/// The fingerprint itself is `loonfs-api`'s: the crate that owns the one
-/// operation language owns its identity function, because the HTTP client
-/// has to compute the same value to reconcile a reused-id conflict and does
-/// not depend on this crate. All this adds is core's vocabulary — the
-/// request shape on the way in, `CommitFingerprint` and `CoreError` on the
-/// way out.
-///
-/// The commit id is not an input. It is the key the mutation is filed
-/// under; the fingerprint is what was filed.
+/// `loonfs-api` owns the fingerprint algorithm so clients and the core use
+/// the same definition. The commit ID is excluded: it identifies the request
+/// record, while the fingerprint identifies the requested mutation.
 pub(crate) fn commit_fingerprint(
     namespace_id: &NamespaceId,
     request: &CommitRequest,
@@ -54,20 +48,16 @@ pub(crate) fn commit_fingerprint(
     .map_err(|err| CoreError::Internal(format!("failed to fingerprint mutation: {err}")))
 }
 
-/// Compiles one mutation request into the operations of a single commit.
+/// Compiles a mutation request into one ordered commit plan.
 ///
-/// Operations resolve in order. Operation `k` reads a metadata view that
-/// already carries what operations `0..k` would persist, so a request can
-/// create a directory and write into it, or delete a path and recreate it.
-/// Those effects are computed by the same op validation the commit plan
-/// performs, so resolution and validation cannot disagree about them.
+/// Each operation sees the effects of all earlier operations in the same
+/// request. This allows sequences such as creating a directory and then
+/// writing into it.
 ///
-/// The first operation that fails aborts the whole request, and its error
-/// names the operation's position. Naming the position is why a batch
-/// validates each operation here as well as in the commit plan: the plan
-/// validates the whole operation list at once and has no request-level
-/// position to report. A one-operation request skips the extra pass — it has
-/// one place to fail, and the plan is the only validation it needs.
+/// The first failure aborts the request. Multi-operation requests validate
+/// each operation here so the returned error can include its operation
+/// index. Single-operation requests rely on the final commit-plan
+/// validation.
 pub(crate) async fn plan_commit_against_publish_view<S: ObjectStore + ?Sized>(
     request: &CommitRequest,
     head: &HeadState,
@@ -205,12 +195,11 @@ fn attribute(error: CoreError, index: usize, operation_count: usize) -> CoreErro
     error.at_operation(index)
 }
 
-/// Hands out the inode ids the commit plan will allocate for `ops`, in
-/// operation order, and advances the running counter.
+/// Allocates inode IDs for `ops` in operation order and advances the shared
+/// counter.
 ///
-/// One counter serves the whole request: it is what the planner predicts
-/// parent ids from and what the commit plan re-derives, so the two cannot
-/// number the same creation differently.
+/// The planner and final commit plan use the same ordering so they assign
+/// identical IDs to every created inode.
 fn allocate_inode_ids(ops: &[PlannedOp], next_inode_id: &mut InodeId) -> Result<Vec<InodeId>> {
     let mut allocated = Vec::new();
     for planned in ops {
@@ -227,11 +216,11 @@ fn allocate_inode_ids(ops: &[PlannedOp], next_inode_id: &mut InodeId) -> Result<
     Ok(allocated)
 }
 
-/// Every parent an operation names is either an inode that existed before
-/// this request or one the request has already allocated, so no parent id can
-/// be at or past the running counter. A violation would mean the planner
-/// predicted an id the commit plan never hands out, and the operation would
-/// be parented under nothing.
+/// Verifies that every planned parent inode already exists or was allocated
+/// earlier in this request.
+///
+/// A parent ID at or after `next_inode_id` means the planner referenced an
+/// inode that the commit plan will not create.
 fn debug_assert_parents_are_allocated(ops: &[PlannedOp], next_inode_id: InodeId) {
     debug_assert!(
         ops.iter().all(|planned| {

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -64,12 +64,10 @@ impl Default for PublishTailOptions {
     }
 }
 
-/// What one retained publish-tail projection weighs, in the same two units
-/// [`PublishTailOptions`] bounds.
+/// The row and decoded-byte cost of a retained publish-tail projection.
 ///
-/// Runtimes that retain a projection per namespace bound the total with
-/// these, so the accounting reads the weight the reuse check already
-/// computed instead of walking the state again.
+/// Runtimes use these values to enforce aggregate cache limits without
+/// recounting the projection.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PublishTailWeight {
     pub rows: usize,
@@ -292,15 +290,13 @@ fn ensure_publish_reconstructed_head_matches(
     Ok(())
 }
 
-/// Closes the load by confirming the head has not moved underneath it.
+/// Confirms that the namespace head did not change while the publish view
+/// was loading.
 ///
-/// A moved head is ambiguous on its own: it means either that another
-/// publisher committed (retryable) or that another session took the writer
-/// epoch and fenced this one (terminal). The fence check at the top of the
-/// load only sees the opening snapshot, so a takeover landing mid-load would
-/// otherwise be reported as `stale_head` — telling a permanently fenced
-/// writer to retry. Re-reading the head on the mismatch path resolves which
-/// it was, at the cost of one extra read on a path that already failed.
+/// When the ETag changes, the method distinguishes a normal concurrent
+/// commit from writer fencing. It rereads the head only on this failure path
+/// so a fenced writer receives a terminal error instead of a retryable stale
+/// head error.
 async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -1,19 +1,13 @@
-//! Durable upload sessions: begin, stage, complete, and abort content
-//! uploads, including direct-put targets that move bytes past the server.
+//! Durable upload sessions for starting, staging, completing, and aborting
+//! content uploads, including direct-to-provider transfers.
 //!
-//! A session is `open`, then `completed` or `aborted`, and both of those are
-//! final. The compare-and-swap that lands one of them is the serialization
-//! point for the whole upload: provider state is cleaned strictly after the
-//! durable transition, never before it, so whichever transition wins is what
-//! happened and the loser reports a terminal error instead of undoing
-//! anything.
+//! A session starts open and ends as either completed or aborted. The
+//! compare-and-swap that records a terminal state determines the result.
+//! Provider cleanup runs only after that durable transition.
 //!
-//! Every content object in a namespace is written through a session, whether
-//! its bytes came from a remote peer or from the process doing the
-//! publishing (see [`stage_owned_bytes`]). That is what makes content
-//! collectable: the session record is the only thing that names an object
-//! before metadata does, so an object with no record would be reachable by
-//! nothing and reclaimable by nothing.
+//! Every content object is created through a session. Before metadata
+//! references the object, the session record gives garbage collection a
+//! durable owner and lifecycle state.
 
 use crate::context::MutationContext;
 use crate::control_update::{
@@ -97,13 +91,11 @@ fn upload_mode_name(mode: UploadMode) -> &'static str {
     }
 }
 
-/// Mints the content identity a direct upload will write to, and the
-/// reference that names it.
+/// Creates the object identity and content reference for a direct upload.
 ///
-/// The client declares only what it can know — how many bytes and what they
-/// hash to. Identity is the server's, so a caller can never aim a presigned
-/// write at an object it chose. The reference returned here is the one the
-/// signed write, the completion check, and the later commit all name.
+/// The client supplies the expected size and checksum. The server chooses
+/// the object identity, and the same reference is used for signing,
+/// completion verification, and publication.
 pub(crate) async fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -132,20 +124,12 @@ pub(crate) async fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Mints the content identity a direct multipart upload will assemble into,
-/// and opens the provider upload that will assemble it.
+/// Creates a multipart upload session and the corresponding provider upload.
 ///
-/// Nothing is claimed here. The session is opened for a payload whose
-/// length and digest the client may not know yet — reading from a pipe, or
-/// simply unwilling to read a large file twice — so all that is settled is
-/// the geometry. What the object turns out to be is claimed at completion,
-/// which is where it was always verified.
-///
-/// The provider upload is created before the session record, so the record
-/// is complete from birth and every later step — signing a part, completing,
-/// cleaning up — reads one durable object that already knows everything. A
-/// session record that fails to land takes the provider upload down with it,
-/// so the only thing a failure here can leave behind is nothing.
+/// Size and checksum are supplied at completion because they may be unknown
+/// when streaming begins. The provider upload is created first and then
+/// stored in the session record. If the session record cannot be written,
+/// the provider upload is aborted.
 pub(crate) async fn begin_direct_multipart_upload_target<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -191,13 +175,10 @@ pub(crate) async fn begin_direct_multipart_upload_target<S: ObjectStore + ?Sized
     })
 }
 
-/// Settles the part geometry one multipart session is opened with.
+/// Validates the multipart part size against provider limits.
 ///
-/// The bounds are the providers': no non-final part below 5 MiB, none above
-/// 5 GiB. The size a client picks is also what bounds its object, since a
-/// provider accepts at most [`MAX_MULTIPART_PARTS`] of them. The floor is
-/// well above zero, so what this returns can never be a geometry that cuts
-/// no bytes.
+/// The selected part size also bounds the maximum object size because the
+/// provider accepts at most [`MAX_MULTIPART_PARTS`] parts.
 fn multipart_part_size(requested: Option<u64>) -> Result<NonZeroU64> {
     let part_size_bytes = requested.unwrap_or(PROVIDER_MULTIPART_PART_BYTES);
     NonZeroU64::new(part_size_bytes)
@@ -210,13 +191,10 @@ fn multipart_part_size(requested: Option<u64>) -> Result<NonZeroU64> {
         })
 }
 
-/// Resolves the parts a client asked to be authorized against the session
-/// that owns them.
+/// Validates requested multipart parts and returns the data needed to sign
+/// them.
 ///
-/// The server signs a part, it does not remember one: nothing durable is
-/// written here and nothing is read back later. Part bookkeeping stays with
-/// the client all the way to completion, exactly as it does in the
-/// provider's own multipart API.
+/// Part state remains client-managed. This method writes no durable state.
 pub(crate) async fn direct_multipart_part_targets<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -264,10 +242,9 @@ pub(crate) async fn direct_multipart_part_targets<S: ObjectStore + ?Sized>(
     })
 }
 
-/// The provider upload a multipart session is bound to.
+/// Returns the provider upload ID for a direct multipart session.
 ///
-/// A multipart session always has one — the transport variant carries it —
-/// so the only thing left to say is that some other transport does not.
+/// Other upload modes return an invalid-upload error.
 fn multipart_session_upload(session: &UploadSessionState) -> Result<&str> {
     match &session.transport {
         UploadSessionTransport::DirectMultipart {
@@ -281,14 +258,11 @@ fn multipart_session_upload(session: &UploadSessionState) -> Result<&str> {
     }
 }
 
-/// Turns a client's multipart claim into the reference the assembled object
-/// is bound to.
+/// Builds the content reference for a completed multipart upload.
 ///
-/// There is no `whole_file_sha256`: nobody trustworthy hashes these bytes.
-/// The client's own digest is not evidence, and the provider assembles the
-/// object without ever computing a SHA-256 over it — so the CRC-64/NVME it
-/// does compute is the whole of the reference's evidence, and completion
-/// reads it back rather than believing the claim.
+/// Completion verifies the provider-reported CRC-64/NVME checksum. No
+/// trusted whole-file SHA-256 is available, so `whole_file_sha256` remains
+/// `None`.
 fn direct_multipart_content_ref(
     content_id: ContentId,
     claim: &DirectMultipartContentClaim,
@@ -352,15 +326,11 @@ fn multipart_parts(parts: &[CompletedUploadPart]) -> Result<Vec<MultipartPart>> 
         .collect()
 }
 
-/// Turns a client's claim into the reference the write is bound to.
+/// Builds the content reference for a direct PUT claim.
 ///
-/// The digest is the client's, but it stops being a client claim the moment
-/// it is signed into the provider write: the provider refuses any body that
-/// does not hash to it, and completion re-checks the stored object against
-/// it. That is why the resulting reference may carry `whole_file_sha256`
-/// — but only where the enforced checksum is itself a SHA-256. A provider
-/// that enforces something else has produced no SHA-256 for anyone to
-/// stand behind, and claiming one would be inventing evidence.
+/// The provider enforces the supplied storage checksum, and completion
+/// verifies the stored object against it. `whole_file_sha256` is included
+/// only when the enforced checksum algorithm is SHA-256.
 fn direct_put_content_ref(
     content_id: ContentId,
     claim: &DirectPutContentClaim,
@@ -460,9 +430,10 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
     Ok(upload_id)
 }
 
-/// Admits an upload session only for a namespace that exists and still
-/// serves writes. The head is the whole existence check: absent means the
-/// namespace was never created, and the tombstone refuses.
+/// Verifies that the namespace exists and accepts writes.
+///
+/// A missing head means the namespace was not created. A deleted head
+/// rejects the upload.
 async fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -481,11 +452,8 @@ async fn ensure_upload_namespace_available<S: ObjectStore + ?Sized>(
     Ok(())
 }
 
-/// How a terminal session answers an operation that needed it open.
-///
-/// A completed session is a conflict the caller can reason about; an aborted
-/// one reports the same absence the eventual physical deletion does, because
-/// it will never select content again.
+/// Converts a terminal upload state into the error returned by an operation
+/// that requires an open session.
 fn terminal_session_error(
     state: &UploadSessionLifecycle,
     upload_id: UploadId,
@@ -499,11 +467,10 @@ fn terminal_session_error(
     }
 }
 
-/// The staging slot of a session that may still take bytes.
+/// Returns the staged-content slot for an open session.
 ///
-/// The one state that accepts bytes is the one that holds what was staged,
-/// so asking for the slot and asking whether the session is still live are
-/// the same question, answered once.
+/// Completed and aborted sessions return their corresponding terminal
+/// errors.
 fn open_staging_slot<'a>(
     state: &'a mut UploadSessionLifecycle,
     upload_id: &UploadId,
@@ -650,13 +617,11 @@ fn transport_name(transport: &UploadSessionTransport) -> &'static str {
     }
 }
 
-/// Stages bytes into a service-proxied session.
+/// Stores bytes in a service-proxied upload session.
 ///
-/// The bytes land under the identity the session allocated when it began,
-/// so re-sending the same bytes to the same session writes the same object
-/// rather than minting a second one. Two *different* sessions carrying
-/// identical bytes still get their own objects; sessions are where retry
-/// idempotency lives now, not the key space.
+/// Retries to the same session use the same object identity. Matching bytes
+/// are idempotent; different bytes return a content conflict. Separate
+/// sessions always use separate object identities.
 pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -712,14 +677,13 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
     record_staged_content(store, namespace_id, upload_id, stored.content_ref, false).await
 }
 
-/// Records what a staging write produced and releases the claim it held, in
-/// the one compare-and-swap that makes the staged reference the session's.
+/// Records a staging result and releases its claim in the same
+/// compare-and-swap.
 ///
-/// `already_present` says the store refused to create the object because the
-/// key was occupied. Only this session can name that key, and the claim means
-/// no other request on it was writing, so an occupied key holds bytes from an
-/// earlier attempt of this session that never recorded them. Equal bytes are
-/// that attempt arriving again; different bytes are a conflict.
+/// `already_present` means the create-only object write found an existing
+/// object. The session's claim prevents concurrent writers, so that object
+/// can only come from an earlier attempt that did not record its result.
+/// Matching content is an idempotent retry; different content is a conflict.
 async fn record_staged_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -772,17 +736,14 @@ async fn record_staged_content<S: ObjectStore + ?Sized>(
     .await
 }
 
-/// Stages a streamed payload into a service-proxied session.
+/// Streams content into a service-proxied session while computing its
+/// reference.
 ///
-/// The bytes are hashed as they are forwarded and never held whole, which
-/// is the only difference from [`upload_content`]. That difference forces
-/// the shape: the write cannot happen inside a retried compare-and-swap
-/// closure, because a stream can only be read once. So the session is read,
-/// the payload is written, and only then is the record swapped — and the
-/// swap is where an idempotent re-send is told from a conflicting one, by
-/// comparing the digest this write produced against the one the session
-/// recorded. The store consumes the whole body before it reports a refused
-/// precondition, so that digest exists either way.
+/// The payload is written before the session compare-and-swap because the
+/// stream cannot be replayed inside a retry loop. The compare-and-swap
+/// compares the computed reference with any value already stored in the
+/// session, making an identical retry idempotent and a different payload a
+/// conflict.
 pub(crate) async fn upload_streamed_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -849,13 +810,12 @@ pub(crate) async fn upload_streamed_content<S: ObjectStore + ?Sized>(
     .await
 }
 
-/// Completes an upload: verify the bytes, then make the completion durable.
+/// Completes an upload by verifying the content and then recording the
+/// terminal state.
 ///
-/// The order is the contract. Verification happens before the
-/// compare-and-swap, so nothing is ever recorded as completed on the
-/// strength of a provider response alone; and the terminal states are
-/// checked before any provider call, so a completion arriving after an abort
-/// fails without touching the object the abort is cleaning up.
+/// Verification happens before the compare-and-swap. Terminal session state
+/// is checked before provider access, so a completion cannot race an abort
+/// and read an object being cleaned up.
 pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -918,14 +878,10 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
     .await
 }
 
-/// Freezes a verified reference as one session's final word.
+/// Stores a verified content reference as the session's completed state.
 ///
-/// Every completion lands here, whatever established the reference above it:
-/// a remote peer's bytes proven against the object that came to rest, or an
-/// in-process staging write proven by the write this runtime performed
-/// itself. By this point both hold the same thing, so the transition that
-/// makes content publishable — and, from the other side, collectable — has
-/// one implementation.
+/// All upload modes use this transition. Completion makes the content
+/// eligible for publication and later garbage collection.
 async fn freeze_completed_session<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -991,21 +947,12 @@ struct OwnedStagingSession {
     content_id: ContentId,
 }
 
-/// Stages bytes this runtime holds under a session that owns them.
+/// Stores in-process bytes through an upload session and returns prepared
+/// content.
 ///
-/// The convenience write paths are both ends of an upload at once: the bytes
-/// are already here, so there is no target to hand out, no claim to check,
-/// and no receipt to mint — the publication that follows happens in this
-/// process and takes the reference directly. What they do not skip is the
-/// session, because that is the half of the lifecycle content garbage
-/// collection reads.
-///
-/// The session record is durable before the object exists. That ordering is
-/// the ownership guarantee rather than an optimization: a record written
-/// afterwards leaves a window in which a crash strands bytes nothing names,
-/// which is the exact leak this path exists to close. It costs two small
-/// control writes on top of the content write, and they are sequential for
-/// the same reason.
+/// The session is written before the content object so garbage collection
+/// always has a durable owner for the object. The operation performs one
+/// content write and two sequential control-object writes.
 pub(crate) async fn stage_owned_bytes<S: ObjectStore + ?Sized>(
     store: &S,
     catalog: &VerifiedNamespaceCatalogEntry,
@@ -1067,25 +1014,19 @@ pub(crate) async fn stage_owned_stream<S: ObjectStore + ?Sized>(
     .await
 }
 
-/// Opens the session that will own a content object this runtime is about to
+/// Creates the internal upload session that owns an in-process content
 /// write.
 ///
-/// It is a service-proxied session because that is what it is: the bytes pass
-/// through this process on the way to the store. The upload id is never
-/// handed out, so the record has exactly one later reader — garbage
-/// collection, which learns from it that the object has an owner and what
-/// became of it.
+/// Its ID is not exposed. Garbage collection is its only later reader.
 async fn open_owned_staging_session<S: ObjectStore + ?Sized>(
     store: &S,
     catalog: &VerifiedNamespaceCatalogEntry,
     context: &MutationContext,
 ) -> Result<OwnedStagingSession> {
-    // No availability check, unlike the sessions a remote peer opens. This
-    // caller holds a catalog read off the namespace's own head, and the
-    // publication it is staging for is the admission decision: a namespace
-    // deleted in between refuses there, and a collection pass on a terminal
-    // namespace reaches nothing, so it reclaims this session and the object
-    // it holds like any other completed content nobody references.
+    // Do not recheck namespace availability here. The catalog came from the
+    // namespace head, and publication performs the final admission check. If
+    // the namespace is deleted first, garbage collection removes the
+    // unreferenced completed session and content.
     let session = NewUploadSession::service_proxied();
     let content_id = session.content_id.clone();
     let upload_id = create_upload_session(store, catalog.namespace_id(), session, context).await?;
@@ -1095,18 +1036,12 @@ async fn open_owned_staging_session<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Completes the session an in-process staging write just filled.
+/// Completes an in-process staging session using the content reference
+/// produced by the write.
 ///
-/// Nothing is verified here and nothing needs to be: this runtime wrote the
-/// object and hashed the payload doing it, which is the same evidence a
-/// service-proxied completion accepts from its own staged reference.
-///
-/// A failure before this point leaves an open session whose lease passes and
-/// whose sweep deletes both record and object, so no error path aborts: this
-/// session is unreachable by anyone else, the only way the transition fails
-/// is a store that is not answering, and an abort call is the least likely
-/// thing to get through it. Expiry costs a wait; a second failed write costs
-/// the wait anyway.
+/// No additional verification is needed because this process computed the
+/// checksum while writing. On failure, the open session eventually expires
+/// and garbage collection removes its object.
 async fn complete_owned_staging<S: ObjectStore + ?Sized>(
     store: &S,
     catalog: &VerifiedNamespaceCatalogEntry,
@@ -1126,13 +1061,11 @@ async fn complete_owned_staging<S: ObjectStore + ?Sized>(
     .prepared)
 }
 
-/// Aborts an upload session, then cleans up what it was writing.
+/// Marks an upload session aborted, then cleans up its provider state and
+/// unpublished content.
 ///
-/// The durable transition comes first and the provider work strictly after
-/// it, so a crash in between leaves an object that the next garbage
-/// collection pass reclaims from the aborted record — never an object
-/// deleted out from under a session that is still open. Repeating an abort
-/// is a success that reports the first abort's stamp.
+/// Cleanup starts only after the durable transition. Repeating an abort is
+/// idempotent and returns the original abort timestamp.
 pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -1189,11 +1122,10 @@ pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
     Ok(response)
 }
 
-/// The provider state one terminated session owned.
+/// Provider resources owned by a terminated upload session.
 ///
-/// It travels out of the compare-and-swap that made the session terminal so
-/// cleanup runs strictly after the durable transition — the ordering that
-/// makes a crash in between cost a repeat rather than a lost object.
+/// The compare-and-swap returns this value so cleanup runs only after the
+/// terminal state is durable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AbandonedUpload {
     content_id: ContentId,
@@ -1235,11 +1167,11 @@ impl AbandonedUpload {
     }
 }
 
-/// Reads one session, minting a fresh receipt when it is completed.
+/// Reads an upload session and returns a fresh receipt when the session is
+/// completed.
 ///
-/// This read is the reason a lost commit response is cheap: the completed
-/// session is durable, so the receipt it hands back is as good as the one
-/// the completion returned, and the bytes never move again.
+/// A caller that lost the original completion response can recover the
+/// receipt without uploading the content again.
 pub(crate) async fn read_upload_status<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -1394,12 +1326,11 @@ enum CompletionOutcome {
     Unusable(String),
 }
 
-/// What a completion will do, resolved from the session's transport and the
-/// request together — no provider call, no durable write.
+/// The verification plan derived from the upload transport and completion
+/// request.
 ///
-/// Every arm carries what proving it needs, taken from whichever side knew
-/// it. That is why the step below has nothing left to look up and no case
-/// it cannot handle.
+/// Building the plan performs no provider calls or durable writes. Each
+/// variant contains all data needed for the verification step.
 enum CompletionPlan<'a> {
     /// A proxied session, which wrote and checked its own bytes: what it
     /// recorded staging is the evidence.
@@ -1433,17 +1364,13 @@ impl CompletionPlan<'_> {
     }
 }
 
-/// Matches a completion request against the session it is completing.
+/// Validates a completion request against the upload session's transport.
 ///
-/// Which side names the content depends on which side knew it first. A
-/// proxied or `direct_put` session was handed a reference before any byte
-/// moved, so the request names it back. A `direct_multipart` session was
-/// never told one, so the request carries the claim instead and the
-/// reference is assembled here, over the identity the session has held
-/// since it opened. Either way the client cannot choose the identity.
-///
-/// This is the one thing decoding the request cannot settle: which shape is
-/// right depends on the durable record, which only this server can read.
+/// Proxied and direct-PUT sessions already contain a content reference, so
+/// the request must return that reference. A multipart session receives its
+/// size and checksum claim at completion, while retaining the server-chosen
+/// object identity. The durable session determines which request form is
+/// valid.
 fn completion_plan<'a>(
     session: &'a UploadSessionState,
     request: &'a CompleteUploadRequest,
@@ -1491,15 +1418,13 @@ fn completion_plan<'a>(
     }
 }
 
-/// Establishes the content reference a completion may freeze.
+/// Verifies the uploaded object and returns the content reference that may
+/// be recorded as completed.
 ///
-/// A proxied session already wrote and checked its bytes, so the staged
-/// reference is the answer. A direct session's bytes bypassed the server,
-/// so this is where the server learns what actually landed: it verifies
-/// rather than trusts, because provider enforcement is not uniform across
-/// the family we support and a random object id says nothing about its
-/// contents. One checksum-bearing HEAD settles size and bytes together
-/// without a download.
+/// Proxied uploads use the reference computed while staging. Direct uploads
+/// verify the provider-stored object because the bytes bypassed this server.
+/// A checksum-bearing metadata request verifies size and checksum without
+/// downloading the object.
 async fn completion_outcome<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
@@ -1559,20 +1484,16 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Asks the provider to assemble the parts a client uploaded, then proves
-/// what it assembled.
+/// Asks the provider to assemble the uploaded parts, then verifies the
+/// resulting object.
 ///
-/// The read-back is the load-bearing check, not a formality: AWS S3 treats
-/// the whole-object checksum as a precondition and refuses a wrong one, but
-/// Cloudflare R2 accepts it, assembles the object anyway, and reports the
-/// true checksum instead. One provider enforces, one only witnesses, so
-/// LoonFS witnesses for itself on both.
+/// Provider behavior differs: some reject an incorrect whole-object checksum,
+/// while others assemble the object and report the actual checksum. LoonFS
+/// therefore verifies the stored object after every completion.
 ///
-/// A completion whose response was lost reconciles here too. Replaying the
-/// provider's completion is useless — S3 answers success with no checksum,
-/// R2 answers `NoSuchUpload` while the object sits there correct — so a
-/// consumed upload is not read as failure. The object at the key is the
-/// evidence, and it answers the same way on both providers.
+/// The same verification also recovers from a lost completion response. An
+/// unknown or already-consumed provider upload is accepted only when the
+/// object at the target key passes verification.
 async fn assemble_multipart_upload<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
@@ -1614,17 +1535,11 @@ async fn assemble_multipart_upload<S: ObjectStore + ?Sized>(
     }
 }
 
-/// Reports what a failed verification proves about the content.
+/// Classifies a content-verification failure.
 ///
-/// A verification that ran and disagreed is evidence about the bytes: the
-/// object is absent, the wrong length, or hashes to something else. Nothing
-/// the session can do changes that, so the reason is returned for the caller
-/// to end the session with.
-///
-/// A verification that could not run is evidence about nothing. The store
-/// refused the read or did not answer it, and the object it was asked about
-/// is untouched, so the store failure is propagated as itself: the session
-/// stays open, the object stays, and the completion can be retried.
+/// A confirmed absence, length mismatch, or checksum mismatch makes the
+/// upload unusable. A storage access failure is returned unchanged so the
+/// session remains open and completion can be retried.
 fn content_failure_reason(error: DurableContentValidationError) -> Result<String> {
     match error {
         DurableContentValidationError::Store { .. } => Err(CoreError::DurableContent(error)),

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -1,13 +1,9 @@
-//! Producer-only content preparation proofs and short-lived wire tokens.
+//! Content preparation proofs and short-lived tokens used by producers.
 //!
-//! A content token is an upload's receipt: it is minted only from a durable
-//! upload session already observed in its terminal completed state, and it
-//! says that the content it names is durable and verified so a later commit
-//! does not have to look. A serving session verifies token expiry once when
-//! turning a signed wire token into an opaque [`PreparedContent`]. Its
-//! internal admission then remains valid for the process lifetime: it records
-//! accepted authoritative evidence that the identified content is durable,
-//! rather than carrying another clock.
+//! A token can be created only from a durable, completed upload session. It
+//! proves that the named content was verified before publication. Token
+//! expiry is checked once when converting it to [`PreparedContent`]. The
+//! resulting in-process proof remains valid for that process lifetime.
 
 use crate::limits::CONTENT_RECEIPT_TTL_MS;
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
@@ -20,13 +16,11 @@ use thiserror::Error;
 
 const TOKEN_VERSION: &str = "vct0";
 
-/// Everything a receipt attests, read out of a durable upload session that
-/// was observed in its terminal completed state.
+/// Evidence read from a durable upload session in its completed state.
 ///
-/// The type has no public constructor on purpose. The only way to hold one
-/// is for the upload protocol to have loaded a completed session from the
-/// object store, so a receipt can never be minted from an in-memory
-/// expectation, a provider response, or a completion still in flight.
+/// The type has no public constructor. Only the upload protocol can create
+/// it after loading a completed session, so callers cannot create receipts
+/// from an in-memory expectation or an unverified provider response.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompletedUploadReceipt {
     namespace_id: NamespaceId,
@@ -132,12 +126,11 @@ pub enum ContentTokenError {
     TimeOverflow,
 }
 
-/// Mints one receipt for a completed upload.
+/// Creates a short-lived token for a completed upload.
 ///
-/// The receipt is short-lived because it does not have to be durable: the
-/// completed session is, so reading the session's status mints another one.
-/// That is what makes a lost publish response cost a request instead of a
-/// retransfer.
+/// The completed session remains durable, so a caller can obtain a new token
+/// by reading upload status. Losing a response therefore requires another
+/// status request, not another upload.
 pub fn mint_content_token(
     secret: &str,
     receipt: &CompletedUploadReceipt,

--- a/crates/loonfs-core/src/timing.rs
+++ b/crates/loonfs-core/src/timing.rs
@@ -1,13 +1,11 @@
-//! Local monotonic elapsed-time boundary for self-enforced publish budgets.
+//! Monotonic timing used to enforce local publication budgets.
 //!
-//! The trait and its process-clock implementation live in
-//! `loonfs-objectstore` (`loonfs_objectstore::timing`), where provider retry
-//! deadlines consume them; this module re-exports them so engine code has
-//! one import path for them. Crate-internal: nothing outside `loonfs-core`
-//! reads the clock through this seam.
-//! Budgets bound a writer's own segment-write-to-CAS window so the GC grace
-//! window is deterministically safe; they gate only the writer's next action
-//! (abandon-and-rebuild). No validator compares timestamps, nothing on the
-//! wire carries these readings, and commit validity never consults time.
+//! The timer implementation lives in `loonfs-objectstore` and is re-exported
+//! here for a consistent internal import path. It measures the writer's
+//! segment-write-to-CAS interval and determines when the writer must abandon
+//! and rebuild an over-budget publication.
+//!
+//! These readings are never stored, compared by validators, or used to
+//! determine commit validity.
 
 pub(crate) use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -28,18 +28,12 @@ fn hints_in_gap(
         .collect()
 }
 
-/// Fetches the hinted segments covering the replay gap concurrently.
+/// Concurrently fetches hinted WAL segments in the replay range.
 ///
-/// Failures and misses do not stop the load: the chain walk fetches anything
-/// the prefetch did not deliver, and a real read error surfaces there as
-/// [`WalChainLoadError::ReadWal`]. Hints therefore change where the bytes
-/// come from, never what the load returns.
-///
-/// A failed request is still a request, so the caller counts it against the
-/// fetch budget and the walk's own fetch of that segment counts again. A
-/// flaky store then drains the budget faster than the chain is long, which
-/// an operator reads as a budget problem. The failures are reported here,
-/// once per load, so the store shows up as the cause.
+/// A miss or failed prefetch does not fail the load; the normal chain walk
+/// fetches the segment again and reports any final read error. Every
+/// prefetch request still counts against the caller's fetch budget, including
+/// failures.
 async fn prefetch_recent_segments<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -112,13 +106,10 @@ impl WalkedChain {
     }
 }
 
-/// What a bounded chain load produced.
+/// Result of loading a WAL chain with a fetch limit.
 ///
-/// Both outcomes report `requests_issued`: how many `get` requests the load
-/// sent for segment bodies, prefetch included. A caller that meters its own
-/// reads charges for that number and nothing else, so its budget drains by
-/// what the store was actually asked for. It is never more than the limit
-/// the caller gave.
+/// `requests_issued` counts all segment-body requests, including prefetches,
+/// misses, and failed requests. It never exceeds the supplied limit.
 pub(crate) enum WalChainLoad {
     /// The whole chain was read inside the fetch limit.
     Complete {
@@ -213,19 +204,10 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
 
     let stop_after_seq = request.stop_after_seq.unwrap_or(request.chain_base_seq);
     let in_gap = hints_in_gap(request.recent_segments, stop_after_seq, request.head_seq);
-    // The invariant this function maintains: `fetches` counts every `get`
-    // request issued for a segment body, prefetch included, and it never
-    // exceeds `max_segment_fetches`.
-    //
-    // The prefetch issues its requests before the walk can decide it has
-    // read enough, so it takes its share of the budget up front and the
-    // walk spends what is left. Hints are newest first and the walk starts
-    // at the tip, so the prefix the budget covers is the part of the gap
-    // the walk reaches first. A hint list longer than the budget is cut
-    // down to the budget rather than refused: the walk reads what the
-    // budget covers and reports what it spent, so a caller that meters its
-    // reads is told where its budget went instead of being handed an empty
-    // answer that claims to have cost nothing.
+    // `fetches` counts every segment-body request, including prefetches, and
+    // never exceeds `max_segment_fetches`. Prefetch consumes its share first;
+    // the chain walk uses the remaining budget. Because hints are ordered from
+    // newest to oldest, a limited prefetch covers the segments nearest the tip.
     let prefetched_hints = in_gap.len().min(max_segment_fetches);
     let mut fetches = prefetched_hints;
     let mut prefetched = if prefetched_hints == 0 {
@@ -345,28 +327,16 @@ fn validate_pointer_matches_envelope(
     Ok(())
 }
 
-/// Counts the visible WAL tail segments above `chain_base_seq` from the
-/// head's chain pointers alone.
+/// Counts visible WAL-tail segments from the pointers stored in the head.
 ///
-/// Every head publish prepends its tip pointer to `recent_segments` under
-/// the same compare-and-swap that installs `visible_wal_tip`, so a hint run
-/// that is contiguous from the tip carries the same authority as the tip
-/// itself. The list holds every segment a legal unflushed tail can reach
-/// (see [`crate::limits::RECENT_SEGMENTS_LIMIT`]), so that run describes
-/// the whole tail and this takes no store parameter: the signature is the
-/// guarantee.
+/// Head publication updates `visible_wal_tip` and `recent_segments` in the
+/// same compare-and-swap, so a contiguous pointer list from the tip describes
+/// the complete legal tail. The function performs no object-store reads.
 ///
-/// A head that under-describes its own tail is corrupted, and is reported as
-/// [`WalChainLoadError::TailNotDescribedByHead`] rather than walked. This
-/// serves inspection surfaces (status, maintenance gating), and a serial
-/// chain walk of an unbounded tail is not something a foreground call
-/// should pay for silently. Replay consumers keep loading the validated
-/// chain, which does walk.
-///
-/// Unlike [`load_validated_wal_chain`], bodies are never fetched or
-/// checksum-verified, and the manifest boundary is accepted at
-/// `base <= chain_base_seq` rather than exact equality: callers here do not
-/// replay the tail.
+/// If the head does not describe its complete tail, the namespace is
+/// reported as corrupt rather than triggering an unbounded foreground chain
+/// walk. Segment bodies and checksums are not validated because this method
+/// only counts pointers; replay paths still load the full validated chain.
 #[tracing::instrument(
     level = "info",
     name = "loonfs.phase",

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -1,11 +1,9 @@
-//! Grep's two executors for the runtime's maintenance runner: building the
-//! index, and reclaiming what building it leaves behind.
+//! Grep index-building and garbage-collection jobs for the runtime
+//! maintenance runner.
 //!
-//! Both are upkeep like any other: one bounded unit of work against durable
-//! state, published through a compare-and-swap, reported as a conclusion.
-//! Registering them is all a host does — the runner they register with owns
-//! admission, the permit pool every maintenance family shares, backoff, and
-//! shutdown, so grep brings no scheduler of its own.
+//! Each job performs one bounded operation against durable state and reports
+//! a scheduling conclusion. The shared runner provides admission, permits,
+//! backoff, and shutdown; grep does not create another scheduler.
 
 use crate::root::{load_grep_root, GrepLifecycle};
 use crate::{
@@ -60,14 +58,12 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
         true
     }
 
-    /// Builds one bounded unit, and folds one only when there is nothing
-    /// left to build.
+    /// Runs one bounded build step, then one reorganization step only when the
+    /// index is caught up.
     ///
-    /// The order is the index's own priority: catching up with the namespace
-    /// keeps queries answerable, while reorganization only makes an already
-    /// complete answer cheaper. A step that built something says so and is
-    /// eligible again at once, so a backlog is drained by repeated steps
-    /// rather than by one long one.
+    /// Catch-up takes priority because it affects query completeness;
+    /// reorganization only improves read cost. Progress is scheduled again so a
+    /// backlog is drained through repeated bounded steps.
     async fn step(
         &self,
         namespace_id: &NamespaceId,
@@ -145,15 +141,11 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
     }
 }
 
-/// Reclaims one namespace's unreferenced grep objects, one bounded pass at
-/// a time.
+/// Runs one bounded grep garbage-collection pass.
 ///
-/// The enumeration cursor is the runner's, not this job's: it arrives as the
-/// step's `continuation` and leaves as the result's, exactly as the
-/// runtime's own collection carries its cursor. That costs nothing here,
-/// because the cursor was never authority — a resumed pass re-reads liveness
-/// and rebuilds the live key set just as a fresh one does, so a cursor lost
-/// with the process costs re-enumeration and can never authorize a deletion.
+/// The runner stores the enumeration cursor as the job continuation. Every
+/// resumed pass rebuilds liveness from durable state, so losing the cursor
+/// only restarts enumeration and cannot authorize deletion.
 #[derive(Debug, Clone)]
 pub struct GrepGcJob<S> {
     worker: GrepWorker<S>,
@@ -221,19 +213,12 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepGcJo
     }
 }
 
-/// One collection pass, read as one conclusion.
+/// Converts a grep GC report into a scheduling conclusion.
 ///
-/// Progress is where the enumeration got to, never what the counters say. A
-/// pass that hands back a cursor past the one it was given walked keyspace
-/// and has more to walk, so it runs again. A pass that hands back the very
-/// cursor it started from decided nothing at all, and repeating it
-/// immediately would repeat that exact result, so it parks like any other
-/// zero-progress step.
-///
-/// A pass that walked the whole prefix is finished: idle when it freed
-/// nothing, eligible again when it did. A namespace it could not read
-/// liveness or a root for suppressed deletions it might otherwise have made,
-/// so it parks distinctly rather than reading as idle.
+/// A changed cursor means enumeration advanced and should continue. An
+/// unchanged cursor means the pass made no progress and should park. A
+/// completed pass runs again only after deleting objects. Incomplete
+/// liveness information is reported as blocked rather than idle.
 fn grep_gc_step_result(
     report: GrepGcReport,
     submitted_cursor: Option<&str>,

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -54,14 +54,10 @@ pub(crate) const MAX_GREP_VERIFIED_FILES_PER_PAGE: usize = 256;
 /// cursor with them (see `reorganize_rejected_frontier`), so the next page
 /// continues past them instead of re-examining the same run.
 pub(crate) const MAX_GREP_EXAMINED_CANDIDATES_PER_PAGE: usize = 4096;
-/// Concurrent gram posting probes one grep query issues at a time: the
-/// (gram, segment) probes of an OR-set fan out in chunks of this size,
-/// each probe a handful of small ranged GETs (filter, index, and posting
-/// blocks). Deliberately below [`MAX_GREP_CONTENT_IO`]: probes multiply
-/// into many small requests per chunk, where a content read is one whole
-/// object. The read-side sibling of the maintenance path's
-/// `MAX_MAINTENANCE_TABLE_IO` (`checkpoint/runs.rs`), which stays at its
-/// own value.
+/// Maximum concurrent `(gram, segment)` posting probes.
+///
+/// Each probe may issue several small ranged reads, so this limit is lower
+/// than the whole-content read limit.
 pub(crate) const MAX_GREP_READ_IO: usize = 16;
 /// Commits one unindexed-tail page asks the change feed for. The tail is
 /// measured in files, not commits, so this is a transfer size rather than a
@@ -71,15 +67,11 @@ pub(crate) const TAIL_FEED_PAGE_COMMITS: usize = 256;
 /// Directory entries one plan-less scan page reads. The scan is bounded by
 /// [`MAX_GREP_SCAN_FILES`]; this only sizes the reads that reach it.
 pub(crate) const SCAN_DIRECTORY_PAGE_ENTRIES: usize = 1000;
-/// Concurrent candidate content reads one grep query issues at a time.
-/// Content verification is a whole-object GET of a small file (index
-/// eligibility caps candidates at `INDEX_GRAMS_MAX_FILE_BYTES`), so it
-/// tolerates a wider fan-out than the posting probes: 32 matches the
-/// content-object concurrency the ecosystem already runs against these
-/// stores (bulk content uploads fan out 32 wide). Each batch is
-/// additionally bounded by the remaining
-/// [`MAX_GREP_VERIFIED_FILES_PER_PAGE`] budget, so a page issues at most
-/// that many content reads however wide the batches are.
+/// Maximum concurrent content reads while verifying grep candidates.
+///
+/// Indexed files are size-limited, so content reads may use more concurrency
+/// than posting probes. The per-page verification budget still caps the total
+/// number of content reads.
 pub(crate) const MAX_GREP_CONTENT_IO: usize = 32;
 
 /// The immutable gram-index state one query reads.
@@ -271,26 +263,14 @@ impl GrepCandidates {
     }
 }
 
-/// Evaluates the plan against every gram index segment: for each AND set,
-/// the union of its grams' postings; the candidates are the intersection.
-/// The probes of one AND set — one per surviving (gram, segment) pair —
-/// are independent, so they run concurrently in chunks of
-/// [`MAX_GREP_READ_IO`]; the sets union order-independently, so the
-/// result is identical to a serial evaluation, and an AND set whose
-/// running intersection empties still short-circuits the sets after it.
+/// Evaluates the gram plan against all index segments.
 ///
-/// Probing also stops once the running intersection fits the page's
-/// verification budget ([`MAX_GREP_VERIFIED_FILES_PER_PAGE`]): further AND
-/// sets could only shrink a candidate set the page can already afford to
-/// verify whole. The invariant that makes this sound: dropping AND
-/// constraints only WIDENS the candidate set, and verification runs the
-/// real pattern over every candidate, so grep results are byte-identical
-/// — the only effect is fewer cold posting reads (a rare literal's 16
-/// single-gram sets typically stop after the first few). The stop rule is
-/// deliberately this simple; a refinement that also stops when an AND set
-/// fails to shrink the intersection materially (common terms whose grams
-/// match nearly everything) is left out until evidence demands a
-/// heuristic.
+/// For each required set, postings for alternative grams are unioned; the
+/// results of required sets are intersected. Independent probes run in
+/// bounded concurrent batches. Evaluation stops when the intersection is
+/// empty or small enough to verify within the page budget. Stopping early
+/// may widen the candidate set, but final byte-level pattern verification
+/// preserves exact results.
 async fn indexed_candidates<S: ObjectStore + ?Sized>(
     store: &S,
     block_cache: &GrepBlockCache,
@@ -316,12 +296,10 @@ async fn indexed_candidates<S: ObjectStore + ?Sized>(
                 probes.push((gram_lookup, descriptor));
             }
         }
-        // This union is the query's peak memory: worst case one
-        // (inode, revision) pair per indexed revision when a gram is
-        // common to every file — 16 bytes a pair, on the order of 16 MiB
-        // per million indexed revisions. A streamed merge-intersection
-        // would trade that ceiling for probe-ordering complexity; not
-        // taken until a profile shows these unions dominating.
+        // This union is the query's largest temporary allocation. In the worst
+        // case it holds one `(inode, revision)` pair per indexed revision. A
+        // streaming intersection would reduce memory but add probe-ordering
+        // complexity, so it is deferred until profiles show this allocation matters.
         let mut set_postings = BTreeSet::new();
         for chunk in probes.chunks(MAX_GREP_READ_IO) {
             let batches = try_join_all(chunk.iter().map(|(gram_lookup, descriptor)| {

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -1,14 +1,10 @@
-//! Explicit grep building, checkpointed backfill, reorganization, and
+//! Explicit grep-index backfill, incremental building, reorganization, and
 //! garbage collection.
 //!
-//! Reorganization is the same idea as the runtime's own metadata
-//! reorganization and uses the same word: a bounded step merges older runs
-//! into a newer one and publishes the result. The grep index carries one
-//! more level than the metadata store — delta, mid, base, against the
-//! metadata store's delta and base — because a gram posting list fans out
-//! far wider than a metadata row: every indexed file contributes to many
-//! gram keys, so merging deltas straight into the base would rewrite most
-//! of the base on every step. The mid level absorbs that churn.
+//! Reorganization publishes bounded merges like metadata reorganization.
+//! Grep uses delta, mid, and base levels because each file contributes to
+//! many gram posting lists. The mid level absorbs frequent delta merges
+//! without rewriting most of the base on every step.
 
 use crate::cache::{GrepBlockCache, MAX_CACHED_GREP_BLOCKS};
 use crate::codec::{
@@ -49,23 +45,18 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 
-/// User-checkpoint lifetime used by one backfill attempt.
+/// Lifetime of the checkpoint used by one grep backfill attempt.
 ///
-/// A backfill that outlives it needs no rescue and no extension: the pin
-/// keeps serving until a garbage-collection pass releases it, and the
-/// release is what the enumeration reports, at which point the worker
-/// rebootstraps onto a fresh checkpoint and a reset cursor. Nothing here
-/// refreshes a pin — an attempt this long has lost its race with the
-/// retention floor anyway, and starting over is the cheaper answer.
+/// If the checkpoint expires before backfill finishes, garbage collection
+/// eventually releases it and the worker restarts from a fresh checkpoint.
+/// The worker does not extend an old pin.
 pub const GREP_BACKFILL_CHECKPOINT_TTL_MS: u64 = 24 * 60 * 60 * 1000;
 
-/// Unreferenced grep objects receive one hour of unconditional protection
-/// before grep-owned garbage collection may delete them.
+/// Grace period before grep garbage collection may delete an unreferenced
+/// object.
 ///
-/// The window has to outlast the longest publication that could still be
-/// holding an object it has not yet made reachable. Grep's publications are
-/// bounded by the same [`METADATA_PUBLICATION_BUDGET_MS`] the runtime's own
-/// are, so the runtime's derived floor is the bound grep must clear too.
+/// The period must exceed the maximum publication window so an in-progress
+/// root update cannot lose an object it has written but not yet referenced.
 pub const GREP_GC_GRACE_WINDOW_MS: u64 = 60 * 60 * 1000;
 
 // The floor is derived from publication budgets and provider bounds rather
@@ -214,17 +205,12 @@ pub struct GrepGcReport {
     pub next_cursor: Option<String>,
 }
 
-/// Namespace-independent writer for the grep-owned durable keyspace.
+/// Bounded writer for grep-owned durable state.
 ///
-/// Calls are explicit and bounded. Whatever schedules them decides when to
-/// call them without changing the durable protocol.
-///
-/// The worker writes only grep's own keyspace, through `store`. Everything
-/// it needs from the filesystem it takes from the two runtime handles it
-/// borrows: reads through the reader, and the backfill checkpoint's
-/// creation and release through the admin handle — so the checkpoints grep
-/// pins are recorded under that handle's actor identity, like any other
-/// operator-created pin.
+/// The worker writes only grep keys. It reads namespace state through
+/// `FsReader` and creates or releases backfill checkpoints through `FsAdmin`,
+/// preserving the admin handle's actor identity. Scheduling is external to
+/// this type.
 #[derive(Clone)]
 pub struct GrepWorker<S> {
     store: S,

--- a/crates/loonfs-model/src/metadata.rs
+++ b/crates/loonfs-model/src/metadata.rs
@@ -1,13 +1,9 @@
-//! Independent implementation of the visibility semantics — on purpose.
+//! Independent reference implementation of metadata visibility.
 //!
-//! This module re-states the metadata visibility rules (binding identity,
-//! active bindings, tombstone coverage, visible-path resolution) from
-//! scratch, deliberately NOT sharing code with `loonfs-core`'s
-//! `metadata::visibility` module. The differential suite replays the same
-//! logical commits through both implementations and requires identical
-//! outcomes; that comparison only catches bugs while the two sides remain
-//! independent. Do not "deduplicate" this into core — collapsing them would
-//! turn the differential tests into a tautology.
+//! This module intentionally does not share code with
+//! `loonfs-core::metadata::visibility`. Differential tests replay the same
+//! commits through both implementations and compare their results. Merging
+//! the implementations would remove the independence those tests require.
 
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{ChangeSeq, ContentRef, InodeId, InodeKind, RevisionNo};
@@ -75,14 +71,13 @@ pub struct SubtreeTombstoneRecord {
     pub tombstone_seq: ChangeSeq,
     pub tombstone_delta_index: u32,
     pub deleted_at_ms: u64,
-    /// What this event did, mirroring the core row semantics: the newest
-    /// event per root wins, and a revoke as the newest means no active
-    /// tombstone.
+    /// Action recorded by this event. The newest event for each root determines
+    /// state; a newest `Revoke` means no tombstone is active.
     pub action: SubtreeTombstoneAction,
 }
 
-/// One inode's whole attribute map at one revision, spelled in this crate's
-/// own plain types: text keys, its own value enum, and flat fields.
+/// Complete attribute map for one inode revision, represented with this
+/// model's independent key, value, and field types.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttributeRevisionRecord {
     pub inode_id: InodeId,
@@ -109,17 +104,16 @@ pub enum AttributeContent {
     TextList(Vec<String>),
 }
 
-/// Where one deletion event committed. A revoke names its target this way,
-/// so the two events it takes to cancel a deletion stay tied together.
+/// Commit position of a deletion event. A revoke uses this value to identify
+/// the exact deletion it cancels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeletionGeneration {
     pub seq: ChangeSeq,
     pub delta_index: u32,
 }
 
-/// The binding a path delete removed, restated in this crate's own plain
-/// spelling. The three fields describe one binding, so they travel as one:
-/// an event either recorded a binding or it did not.
+/// Directory binding removed by a path deletion, represented with this
+/// model's independent types.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeletedBinding {
     pub parent_inode_id: InodeId,

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -14,44 +14,22 @@ use http::Uri;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-/// Endpoint families whose direct-transfer preconditions the live
-/// conformance suite has actually run against.
+/// Provider domain families validated by the live direct-transfer
+/// conformance suite.
 ///
-/// A presigned write hands a client a capability and then trusts the
-/// provider to have enforced the signed checksum and create-only
-/// precondition — completion never reads the bytes back. Only these
-/// endpoints have been run against that suite, so only they earn the trust.
-/// An endpoint override outside the provider's own domain family is some
-/// other implementation of the S3 API and is not covered by those runs.
+/// Direct completion depends on the provider enforcing the signed checksum and
+/// create-if-absent condition. Endpoint overrides outside these domain
+/// families are not covered by that validation.
 pub(crate) const AWS_S3_PROVEN_DOMAINS: &[&str] = &["amazonaws.com", "amazonaws.com.cn"];
 pub(crate) const CLOUDFLARE_R2_PROVEN_DOMAINS: &[&str] = &["r2.cloudflarestorage.com"];
 
-/// Whether GCS's direct transfers have been proven against a live bucket.
+/// Enables GCS direct transfers after live provider validation.
 ///
-/// The two S3-compatible providers earned their place in the lists above by
-/// a credentialed run of the conformance suite; this is the same bar,
-/// spelled as one flag because GCS has no endpoint override to key it on.
-/// It is `false` because that run has not happened yet: the signer, the
-/// readback, and the whole path are implemented and covered by unit tests,
-/// but no test has yet watched Google itself refuse a tampered checksum or a
-/// replayed create-only write, and the trust direct transfers rest on is
-/// exactly that refusal.
-///
-/// Flipping this to `true` belongs to the change that records a passing
-/// live run — nothing else in the build needs to move, and until then GCS
-/// deployments advertise no direct transfer and proxy every byte.
-///
-/// The run comes first and the flip second, which means doing it in that
-/// order locally: the ignored GCS suite in
-/// `crates/loonfs-server/tests/it/direct_put_real_provider.rs` asks a
-/// deployment for capabilities it does not yet advertise, so flip this,
-/// run the suite against a real bucket, and commit the flip with what the
-/// run showed.
-///
-/// Proven 2026-08-02 against a real bucket:
-/// `gcp_gcs_real_provider_conformance` passed (13.25s), and both live
-/// direct-transfer tests passed (8.92s) — the signed round trip, and the
-/// scoped, bounded, single-use capability assertions.
+/// Set this only when the credentialed conformance suite has confirmed that
+/// GCS enforces signed checksums and create-if-absent requests. The current
+/// value is supported by the live validation recorded on 2026-08-02. Until a
+/// provider is validated, deployments must proxy transfers through the
+/// server.
 const GCS_DIRECT_TRANSFERS_PROVEN: bool = true;
 
 /// Identifies the concrete provider backing a [`ConfiguredObjectStore`].
@@ -83,19 +61,11 @@ impl ConfiguredObjectStoreKind {
     }
 }
 
-/// One validated runtime provider, plus the direct transfers it can
-/// authorize.
+/// Validated provider client and the direct-transfer issuers it supports.
 ///
-/// Construction is the only thing this type adds: it holds the provider
-/// client as the same shared trait object every handle takes, so callers
-/// dispatch through the provider's own [`ObjectStore`](crate::ObjectStore)
-/// implementation rather than through a copy of it here.
-///
-/// Building the bundle *is* the trust decision. A provider that cannot sign
-/// the preconditions direct transfers rest on, or an endpoint outside the
-/// families the live conformance suite has run against, produces no bundle
-/// at all — so nothing above this crate re-derives that judgement from
-/// configuration.
+/// Construction decides whether direct transfers are allowed. Unsupported
+/// signing behavior or an unvalidated endpoint produces no direct-transfer
+/// issuers, so higher layers do not need to interpret provider configuration.
 #[derive(Debug)]
 pub struct ConfiguredObjectStore {
     inner: SharedObjectStore,
@@ -174,9 +144,9 @@ impl ConfiguredObjectStore {
         })
     }
 
-    /// Builds a native GCS store, and the reads and whole-object writes it
-    /// can authorize once [`GCS_DIRECT_TRANSFERS_PROVEN`] says a live run
-    /// has watched the provider enforce them.
+    /// Builds a native GCS store. Direct reads and whole-object writes are
+    /// enabled only after live validation sets `GCS_DIRECT_TRANSFERS_PROVEN`
+    /// to confirm that the provider enforces them.
     ///
     /// This adapter implements no multipart signing for GCS, so the bundle's
     /// multipart slot stays empty rather than holding a signer that would
@@ -249,19 +219,12 @@ fn s3_compatible_transfers(presigner: S3CompatiblePresigner) -> DirectTransferIs
         .with_multipart(presigner)
 }
 
-/// Whether an endpoint sits in one of the domain families whose signed
-/// preconditions the live conformance suite has exercised, *and* is reached
-/// over TLS.
+/// Returns whether an endpoint uses TLS and belongs to a provider domain
+/// family validated by the live conformance suite.
 ///
-/// An absent endpoint is the provider's own default, which qualifies on both
-/// counts. TLS is not incidental here: a presigned URL is a bearer
-/// capability to write or read one object, so issuing one over `http` would
-/// put it, and the signed headers with it, on the wire in cleartext for
-/// anyone on the path to replay. An `http` override of a provider's own
-/// domain is a misconfiguration rather than a different provider, and
-/// [`StoreConfig::validate`](crate::StoreConfig::validate) rejects it by
-/// name; this is the second gate, for a configuration built in Rust that
-/// never passed through that validation.
+/// A missing override uses the provider's validated default endpoint.
+/// Presigned URLs are bearer capabilities, so explicit `http` endpoints are
+/// rejected even when their host belongs to a validated provider.
 fn endpoint_is_proven(endpoint_url: Option<&str>, domain_families: &[&str]) -> bool {
     let Some(endpoint_url) = endpoint_url else {
         return true;

--- a/crates/loonfs-objectstore/src/immutable_write.rs
+++ b/crates/loonfs-objectstore/src/immutable_write.rs
@@ -10,7 +10,7 @@ use crate::{
 use bytes::Bytes;
 use thiserror::Error;
 
-/// Failure to establish that an immutable key contains the requested bytes.
+/// Failure to verify that an immutable key contains the requested bytes.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ImmutableWriteError {

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -45,31 +45,19 @@ pub const PROVIDER_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(30);
 /// One HTTP attempt's connect timeout.
 pub const PROVIDER_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Hard deadline for one logical object-store operation, consumed across
-/// every retry of that operation rather than restarting per attempt. Reads
-/// get it as the provider client's retry timeout; verified immutable writes
-/// and deletes share it through `TransportRetryPolicy`. The deadline gates
-/// starting another attempt, and one outer attempt may itself contain the
-/// inner client's full retry budget for status-code retries — so one
-/// operation's total wall time is bounded by the deadline plus the inner
-/// retry budget plus one attempt bound (worst case roughly six minutes),
-/// still a hard bound. The GC grace window is derived
-/// above this bound (format spec, "Garbage collection", rule 1); multipart
-/// uploads deliberately carry no whole-operation clock (their parts are
-/// individually bounded), which leaves the floor inequality untouched
-/// because everything it times — WAL segments inside the publish budget,
-/// the root compare-and-swap — is a small control object on the
-/// single-request path.
+/// Deadline shared by all retries of one logical object-store operation.
+///
+/// Reads apply it through the provider client. Verified immutable writes and
+/// deletes apply it through `TransportRetryPolicy`. A new outer attempt may
+/// start only while time remains. Multipart uploads are excluded because
+/// each part has its own timeout and retry limit. The garbage-collection
+/// grace period is longer than the maximum publication operation.
 pub const PROVIDER_OPERATION_DEADLINE: Duration = Duration::from_secs(120);
 
-/// Payload size at and above which overwrite puts use the provider's native
-/// multipart upload instead of one whole-object PUT, matching the multipart
-/// thresholds mainstream storage clients ship. The format spec allows this
-/// for large immutable file data and forbids relying on it for small
-/// mutable control objects: create-if-absent and compare-and-swap puts
-/// never take this path, because providers complete multipart uploads as
-/// unconditional overwrites and those modes exist to carry real provider
-/// preconditions.
+/// Minimum payload size for native multipart overwrite uploads.
+///
+/// Create-if-absent and compare-and-swap writes always use a single request
+/// because multipart completion cannot enforce those provider preconditions.
 pub const PROVIDER_MULTIPART_THRESHOLD_BYTES: u64 = 8 * 1024 * 1024;
 
 /// Fixed size of every multipart part except the last. Cloudflare R2
@@ -82,12 +70,10 @@ pub const PROVIDER_MULTIPART_PART_BYTES: u64 = 8 * 1024 * 1024;
 /// Concurrent in-flight parts per multipart upload.
 pub const PROVIDER_MULTIPART_PART_WINDOW: usize = 4;
 
-/// Buffered parts a streamed write holds at once.
+/// Number of multipart buffers retained by a streamed write.
 ///
-/// One. The in-memory path can afford a window because it already holds the
-/// whole payload; a streamed write exists precisely so that it does not, so
-/// it fills a buffer, uploads it, drops it, and only then fills the next.
-/// Peak memory is therefore one part whatever the object's size.
+/// Streamed writes upload and release each part before buffering the next, so
+/// peak payload memory remains one part regardless of object size.
 pub const PROVIDER_STREAMED_PART_WINDOW: usize = 1;
 
 /// Parts one provider multipart upload accepts. Every supported provider
@@ -95,12 +81,11 @@ pub const PROVIDER_STREAMED_PART_WINDOW: usize = 1;
 /// multipart write can produce.
 pub(crate) const MAX_PROVIDER_MULTIPART_PARTS: usize = 10_000;
 
-/// Bound for one payload-bearing HTTP attempt's request phase. A request
-/// body is opaque to progress observation while it uploads, so a flat
-/// generous bound stands in for stall detection: parts are at most
-/// [`PROVIDER_MULTIPART_PART_BYTES`], and an 8 MiB body that cannot finish
-/// inside this bound is moving slower than roughly 70 KiB/s — treated as
-/// stalled and retried on a fresh connection.
+/// Request-phase timeout for one HTTP attempt that carries a payload.
+///
+/// Upload progress is not observable while a request body is being sent, so
+/// this fixed timeout treats an excessively slow part as stalled. Multipart
+/// parts are bounded by [`PROVIDER_MULTIPART_PART_BYTES`].
 pub const PROVIDER_TRANSFER_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Request bodies at least this large are payload transfers and get
@@ -283,22 +268,15 @@ impl ProviderObjectStore {
         }
     }
 
-    /// Writes one large payload through the provider's native multipart
-    /// upload: fixed-size parts uploaded through a bounded window, each part
-    /// retried in place on transient failures (part indices are stable, so a
-    /// retry re-sends the same part), and a best-effort abort so a failed
-    /// upload does not strand parts. An ambiguous completion — a transport
-    /// failure whose attempt may have landed — is resolved by the immutable
-    /// operation's shared exact-byte read-back
-    /// ([`MultipartWrite::resolve_ambiguous_completion`]).
+    /// Uploads a large overwrite through the provider's multipart API.
     ///
-    /// There is deliberately no whole-operation clock: every part attempt is
-    /// individually bounded and every retry loop is count-bounded, so a
-    /// healthy transfer takes as long as the link needs while a stuck one
-    /// still fails within one part's retry budget. Completion itself is one
-    /// attempt: only [`ObjectStore::put_immutable_verified`] may replay an
-    /// object-publishing write. Conditional modes stay on the single-request
-    /// path where real provider preconditions exist.
+    /// Parts use stable indices, bounded concurrency, and bounded retries. A
+    /// failed upload is aborted on a best-effort basis. If completion returns an
+    /// ambiguous transport error, immutable writes verify the stored bytes before
+    /// deciding whether the write succeeded.
+    ///
+    /// Multipart uploads have per-part limits rather than one total deadline.
+    /// Conditional write modes do not use this path.
     async fn put_large_multipart(
         &self,
         multipart: &dyn MultipartStore,
@@ -328,14 +306,11 @@ impl ProviderObjectStore {
         }
     }
 
-    /// Applies the shared retry gate for one failed write attempt: `None`
-    /// means the budget is spent and the caller must surface the error;
-    /// `Some` carries the backoff to sleep before the next attempt. The
-    /// budget is the retry count, plus the operation deadline when the
-    /// operation carries one (multipart transfers deliberately do not — see
-    /// [`Self::put_large_multipart`]). Exhaustion logs name the payload
-    /// size so a too-slow-link failure is attributable instead of reading
-    /// as weather.
+    /// Returns the delay before the next write attempt, or `None` when the
+    /// retry count or operation deadline is exhausted.
+    ///
+    /// Multipart transfers use only the retry count. Exhaustion logs include the
+    /// payload size to help distinguish slow transfers from other failures.
     fn next_write_backoff(
         &self,
         key: &str,
@@ -448,15 +423,12 @@ impl PartReader {
     }
 }
 
-/// Abandons a provider multipart upload if the write that opened it is
-/// dropped before it finishes.
+/// Aborts a provider multipart upload when its streamed write is cancelled.
 ///
-/// Every path that returns from a streamed write aborts explicitly and
-/// disarms this. What is left is cancellation — a client that disconnects
-/// mid-upload takes the handler's future with it — where there is no
-/// `await` point to run cleanup from, so the abort is spawned. Without a
-/// runtime to spawn on, the upload falls back to the bucket's own
-/// incomplete-upload lifecycle rule, which is what collects it today.
+/// Normal return paths abort explicitly and disable this guard. Cancellation
+/// has no cleanup `await` point, so `Drop` starts the abort on the current
+/// Tokio runtime. Without a runtime, the bucket's incomplete-upload lifecycle
+/// policy must remove the parts.
 struct AbortUploadOnDrop {
     multipart: Option<Arc<dyn MultipartStore>>,
     path: Path,
@@ -532,23 +504,15 @@ impl MultipartWrite<'_> {
         }
     }
 
-    /// Uploads a stream as parts, one buffered part at a time, and
-    /// assembles them.
+    /// Uploads a stream as fixed-size parts while retaining at most one part.
     ///
-    /// `head` is the first part, already cut by the caller so it could
-    /// decide that the payload does not fit in one request. Every later part
-    /// is cut into a fresh buffer *after* its predecessor has been uploaded
-    /// and dropped, so peak memory is one part regardless of how large the
-    /// object is. The final part may be short.
+    /// `head` is the first part. Later parts are buffered only after the previous
+    /// part has been uploaded and released. The final part may be shorter.
     ///
-    /// Completion is not resolved by read-back the way the in-memory path's
-    /// is: there is no payload left in memory to prove a landed write
-    /// against. An ambiguous completion is a failure, and the caller abandons
-    /// the upload.
-    ///
-    /// `mode` is evaluated by [`Self::precondition_holds`] once the stream
-    /// has been consumed and immediately before the completion, because the
-    /// completion itself cannot carry it.
+    /// Because the original payload is no longer available, an ambiguous
+    /// completion cannot be verified by reading the object back. The caller
+    /// treats it as a failure. Conditional modes are checked after the stream is
+    /// consumed and immediately before completion.
     async fn upload_stream_and_complete(
         &self,
         upload_id: &provider_store::MultipartId,
@@ -585,24 +549,14 @@ impl MultipartWrite<'_> {
         }
     }
 
-    /// Evaluates the caller's write mode against the object at the key, in
-    /// the last moment before the completion assembles over it.
+    /// Checks a streamed multipart write's condition immediately before
+    /// completion.
     ///
-    /// A provider assembles a multipart upload unconditionally, so this
-    /// separate read is the only way a streamed create-only or
-    /// compare-and-swap write can be refused at all. Two things follow, and
-    /// both are contract:
-    ///
-    /// - It runs after the stream has been consumed, which is what
-    ///   [`ObjectStore::put_streamed`] promises a caller that folds a digest
-    ///   over the same stream: a refused write still leaves that caller a
-    ///   digest over the complete payload.
-    /// - It is not atomic with the completion. A key that was already
-    ///   occupied when this read ran is refused; a writer that lands between
-    ///   this read and the completion is not, and this write assembles over
-    ///   it. Callers that cannot tolerate that must keep concurrent writers
-    ///   off the key themselves, which is what the upload protocol's staging
-    ///   claim does.
+    /// Providers complete multipart uploads unconditionally, so this separate
+    /// read is required for create-if-absent and compare-and-swap modes. It runs
+    /// after the complete stream has been consumed. The check is not atomic with
+    /// completion; callers requiring stronger exclusion must prevent concurrent
+    /// writes to the key.
     async fn precondition_holds(&self, mode: &PutMode) -> Result<()> {
         let refused = || {
             Err(ObjectStoreError::PreconditionFailed {
@@ -721,18 +675,13 @@ impl MultipartWrite<'_> {
         }
     }
 
-    /// Decides an ambiguous completion by reading the object back: byte
-    /// equality with the payload is the only accepted proof that the write
-    /// landed. Size or etag agreement is never identity — this store serves
-    /// generic overwrite keys, so a stale object of the same length must
-    /// not pass as the new write. The payload is still in memory, so the
-    /// read-back costs one GET on this failure path and proves the put's
-    /// postcondition itself.
+    /// Resolves an ambiguous multipart completion by comparing the stored bytes
+    /// with the original in-memory payload.
     ///
-    /// A proven completion still aborts the upload id: when this upload's
-    /// completion landed the id is already gone and the abort is a no-op,
-    /// and when the proof came from an identical object some earlier writer
-    /// committed, the abort reclaims this upload's stranded parts.
+    /// Size and etag equality are insufficient because an older object may share
+    /// them. Exact byte equality proves the write's postcondition. After a
+    /// successful comparison, the upload id is aborted on a best-effort basis to
+    /// remove any remaining parts.
     async fn resolve_ambiguous_completion(
         &self,
         upload_id: &provider_store::MultipartId,
@@ -949,9 +898,8 @@ impl ObjectStore for ProviderObjectStore {
     /// itself draws, so a small streamed write behaves exactly like a small
     /// buffered one. Anything longer goes through the provider's multipart
     /// upload. A provider assembles one unconditionally, so a conditional
-    /// mode is evaluated by [`MultipartWrite::precondition_holds`] against a
-    /// separate read of the key, taken after the payload is consumed and
-    /// immediately before the completion.
+    /// mode is checked against a separate read of the key after the payload is
+    /// consumed and immediately before completion.
     async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
         let path = self.to_path(key)?;
         let mut reader = PartReader::new(body, self.multipart_geometry.part_bytes as usize);
@@ -1073,23 +1021,12 @@ fn map_put_mode(mode: PutMode) -> provider_store::PutMode {
     }
 }
 
-/// Reads a provider last-modified stamp as the age evidence it is, or as
-/// nothing.
+/// Converts a provider timestamp to object age information.
 ///
-/// A response without a `Last-Modified` header is not an object written at
-/// the unix epoch, but the AWS-compatible client path synthesizes one for it
-/// (`object_store`'s header parsing falls back to `timestamp_nanos(0)` where
-/// the header is not required, and the AWS path is the one that does not
-/// require it). S3-compatible endpoints — MinIO, Ceph RGW, gateways — are
-/// configured through exactly that path, so the synthesized stamp is
-/// reachable in production. Passing it on would make every object read as
-/// infinitely old, and garbage collection's grace window is measured against
-/// this number: an object stamped at the epoch is past every window there
-/// is, so the window would protect nothing.
-///
-/// Absent is the honest reading, and it is the reading the rest of the system
-/// already handles — an object whose age is unknown is treated as young and
-/// retained (format spec, "Garbage collection", rule 1).
+/// Some AWS-compatible clients represent a missing `Last-Modified` header as
+/// Unix epoch zero. Returning that value would make garbage collection treat
+/// the object as extremely old. Non-positive timestamps are therefore
+/// returned as `None`, which causes unknown-age objects to be retained.
 fn last_modified_ms(timestamp_millis: i64) -> Option<u64> {
     match timestamp_millis > 0 {
         true => u64::try_from(timestamp_millis).ok(),

--- a/crates/loonfs-objectstore/src/timing.rs
+++ b/crates/loonfs-objectstore/src/timing.rs
@@ -7,8 +7,8 @@
 //! they gate only the observer's next action (stop retrying,
 //! abandon-and-rebuild). No validator compares timestamps, nothing on the
 //! wire carries these readings, and commit validity never consults time.
-//! `loonfs-core` re-exports these types; the trait is an injection seam the
-//! external simulation harness also consumes.
+//! `loonfs-core` re-exports these types. The trait supports deterministic
+//! clock injection by the external simulation harness.
 
 use std::sync::OnceLock;
 use std::time::Instant;

--- a/crates/loonfs-objectstore/src/transfer_timeouts.rs
+++ b/crates/loonfs-objectstore/src/transfer_timeouts.rs
@@ -1,24 +1,14 @@
-//! Transfer-aware timeouts for provider HTTP requests.
+//! Progress-aware timeouts for provider HTTP requests.
 //!
-//! A blanket total-request timeout is the wrong shape for payload transfers:
-//! it turns "the payload is larger than the window allows at this link speed"
-//! into a deterministic failure that retries cannot fix. The connector here
-//! replaces the provider client's total-request timeout with two
-//! progress-shaped bounds, the same shape mainstream storage clients use:
+//! A total-request timeout makes large transfers fail solely because of their
+//! size. This connector instead applies:
 //!
-//! - The request phase (connect, request-body upload, response headers) gets
-//!   [`request_phase_bound`]: one flat bound for control-plane requests and
-//!   one flat, generous bound for payload-bearing requests. Payload bodies
-//!   are bounded by the multipart part size, so a flat number per request is
-//!   sufficient stall protection — no request ever carries a body a healthy
-//!   link cannot move inside it.
-//! - Response bodies get an idle bound: every body frame must arrive within
-//!   the base attempt timeout of the previous one. Bytes moving means the
-//!   transfer is alive; a body that stalls is cut without putting a total
-//!   clock on how long a large download may take.
+//! - a fixed request-phase timeout selected by body size; and
+//! - an idle timeout between response-body frames.
 //!
-//! Timeouts surface as [`HttpErrorKind::Timeout`], which the provider client
-//! retries exactly where it would retry its own request timeouts.
+//! Large downloads may continue indefinitely while frames keep arriving.
+//! Stalls are reported as [`HttpErrorKind::Timeout`] so the provider client
+//! can apply its normal retry policy.
 
 use crate::provider_object_store::{request_phase_bound, PROVIDER_ATTEMPT_TIMEOUT};
 use async_trait::async_trait;
@@ -36,10 +26,8 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::runtime::Handle;
 
-/// The stalled-transfer diagnostic carried by synthesized timeout errors: it
-/// names the phase, the bytes involved, and the enforced bound, so a timeout
-/// on a payload transfer is attributable to size and link speed instead of
-/// reading as an anonymous request failure.
+/// Diagnostic for a synthesized timeout, including the transfer phase,
+/// byte count, and enforced limit.
 #[derive(Debug, Error)]
 pub(crate) enum TransferTimeoutError {
     #[error(
@@ -117,10 +105,10 @@ async fn request_phase_timeout<T>(bound: Duration, request: impl Future<Output =
     tokio::time::timeout(bound, request).await.ok()
 }
 
-/// Response body enforcing an idle bound between frames: progress resets the
-/// clock, a stall past the bound fails the body with a retry-classifiable
-/// timeout. There is deliberately no total clock here — a large download is
-/// healthy for as long as bytes keep arriving.
+/// Response body with an idle timeout between frames.
+///
+/// Each received frame resets the timer. There is no total download timeout,
+/// so a large response remains valid while data continues to arrive.
 struct IdleDeadlineBody {
     inner: HttpResponseBody,
     idle_bound: Duration,

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -24,14 +24,12 @@ use tokio::sync::Semaphore;
 
 const OBJECT_STORE_METRICS_JSONL_ENV: &str = "LOONFS_OBJECT_STORE_METRICS_JSONL";
 
-/// Purpose-specific handles over one shared store client: read endpoints go
-/// through `reader`, mutations through `writer` (and the publication service
-/// it hands out), maintenance endpoints through `admin`. `writer` is also
-/// what a host settles at shutdown, and what [`app`] returns beside the
-/// router for that purpose.
+/// Request handles built over one shared store client.
 ///
-/// `reader` is a cheap clone derived from `writer` at construction, kept as
-/// its own field because most handlers only read.
+/// Read handlers use `reader`, mutations use `writer`, and maintenance uses
+/// `admin`. The host also shuts down `writer` after the listener drains.
+/// `reader` is stored separately because most handlers require only read
+/// access.
 #[derive(Clone)]
 pub(super) struct AppState {
     pub(super) config: Arc<ServerConfig>,
@@ -66,25 +64,21 @@ pub(super) struct AppState {
     /// worst-case download memory is
     /// `max_concurrent_downloads * max_download_bytes`.
     pub(super) download_permits: Arc<Semaphore>,
-    /// The recorder every handle in this process reports through, and the
-    /// request-level instruments only this server can report. `GET /metrics`
-    /// renders its snapshot. Always installed: a metrics surface a
-    /// deployment has to remember to switch on is a metrics surface nobody
-    /// has during the incident.
+    /// Shared recorder for runtime and request-level metrics. `GET /metrics`
+    /// renders its snapshot. It is always installed.
     pub(super) metrics: Arc<ServerMetrics>,
-    /// The node-local block cache this deployment keeps, when `[local_cache]`
-    /// asked for one. The handles reach it through the decoded block cache
-    /// they were built with; it is held here as its concrete type for the
-    /// two things the seam does not offer — reading foyer's own numbers at
-    /// scrape time, and closing the cache at shutdown.
+    /// Optional node-local block cache.
+    ///
+    /// Runtime handles use it through the shared cache interface. The server
+    /// retains the concrete type to read foyer statistics and close it during
+    /// shutdown.
     pub(super) local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
 }
 
-/// Everything a request path tells the writer's maintenance runner about
-/// the grep index, and the one question it asks before telling it anything.
+/// Request-side access to grep maintenance.
 ///
-/// The runner owns admission, the permit pool, backoff, and shutdown: this
-/// is a nudge and a probe, both cheap and neither blocking.
+/// Requests may probe whether indexing is due and submit a non-blocking nudge.
+/// The maintenance runner owns admission, concurrency, backoff, and shutdown.
 #[derive(Clone)]
 pub(super) struct GrepMaintenance {
     handle: MaintenanceHandle,
@@ -98,12 +92,10 @@ impl GrepMaintenance {
         self.handle.nudge(GREP_INDEX_JOB, namespace_id);
     }
 
-    /// Nudges only a namespace whose index is actually behind.
+    /// Nudges a namespace only when the probe reports that indexing is due.
     ///
-    /// A read has no business admitting work that does not exist, and the
-    /// job already knows how to answer that question in at most two small
-    /// reads. An unreadable answer nudges nothing: the step would only
-    /// rediscover the same failure.
+    /// Probe failures do not schedule work because the indexing step would fail
+    /// on the same unreadable state.
     pub(super) async fn nudge_if_behind(&self, namespace_id: &NamespaceId) {
         if matches!(
             self.job.probe(namespace_id).await,
@@ -114,23 +106,13 @@ impl GrepMaintenance {
     }
 }
 
-/// Builds the HTTP application: the router that serves requests, the writer
-/// whose background work its host must settle, and the local block cache
-/// that host must close.
+/// Builds the router and returns the resources the host must shut down.
 ///
-/// Everything this app spawns belongs to that writer — publications, and
-/// the maintenance runner that admits the runtime's steps alongside the
-/// grep index's. [`serve`] settles it itself. A host embedding the
-/// [`Router`] on its own HTTP server must call [`FsWriter::shutdown`] after
-/// its listener drains, or publisher tasks and writer maintenance outlive
-/// the listener unobserved, and must then call
-/// [`StoredMetadataBlockCache::close`] on the returned cache, or the blocks
-/// its memory tier still holds never reach disk. The writer also answers
-/// what a deployment's shape is, so a host that needs to know whether the
-/// grep index job is registered here asks
-/// [`FsWriter::maintenance_job`](loonfs::FsWriter::maintenance_job).
-///
-/// The cache is `None` unless the config carried a `[local_cache]` table.
+/// After an embedded listener drains, the host must call
+/// [`FsWriter::shutdown`] to settle publication and maintenance tasks, then
+/// close the returned cache so in-memory entries are flushed. [`serve`]
+/// performs both steps automatically. The cache is present only when
+/// `[local_cache]` is configured.
 pub async fn app(
     config: ServerConfig,
 ) -> Result<(Router, FsWriter, Option<Arc<FoyerStoredMetadataBlockCache>>), ServerConfigError> {
@@ -139,10 +121,8 @@ pub async fn app(
     // file-loaded ones fail at load.
     config.validate()?;
     let store = config.object_store()?;
-    // The store settled this at construction: a bundle exists only where the
-    // provider can sign the preconditions direct transfers rest on and the
-    // endpoint is one the live conformance suite has proven. Nothing here
-    // asks configuration about it a second time.
+    // Provider construction already validated direct-transfer signing and endpoint
+    // support. Reuse that decision without reinterpreting configuration here.
     let direct_transfers = store.direct_transfers();
     let store = store.into_shared();
     let (router, state) =
@@ -311,17 +291,11 @@ pub(super) async fn build_handles_with_metrics_jsonl_path(
     .await
 }
 
-/// Opens the process's handles on one store, with the metrics wiring every
-/// deployment gets.
+/// Builds the process handles over one store and one metrics recorder.
 ///
-/// Both handles report through the same recorder, so their instruments are
-/// one set of numbers rather than two. The optional JSONL path adds a second
-/// sink for the raw object-store samples; the handle fans one store wrapper
-/// out to both rather than stacking two.
-///
-/// The local block cache is installed on the writer, which is what puts it
-/// under the decoded block cache the reader and the admin share. One
-/// installation covers all three handles.
+/// An optional JSONL recorder receives the same object-store samples. The
+/// local block cache is installed once on the writer's shared runtime core,
+/// so the reader and admin use the same decoded cache hierarchy.
 async fn build_handles(
     config: &ServerConfig,
     store: SharedObjectStore,
@@ -534,19 +508,12 @@ where
         .with_graceful_shutdown(shutdown)
         .await
         .map_err(ServeError::Serve)?;
-    // Only once the listener has drained: the writer's shutdown refuses new
-    // mutations, so running it while requests are still arriving would fail
-    // work this server accepted. What order the shutdown itself runs in is
-    // the writer's business, not this function's. Panicked tasks surface
-    // here rather than disappearing with the process.
+    // Shut down the writer only after the listener drains, so accepted requests
+    // are not rejected by closing mutation admission. Task panics surface here.
     let settled = writer.shutdown().await.map_err(ServeError::Shutdown);
-    // The cache closes after the writer, and it closes whether or not the
-    // writer settled: a read may outlive the writer by design, and a lookup
-    // after the close is a miss by contract, so nothing is left waiting on
-    // bytes this takes away. Closing is what flushes the memory tier to
-    // disk, so a shutdown that skipped it would throw away the blocks this
-    // process spent the most on. A writer that failed to settle is the
-    // worse news of the two and is what a host is told about.
+    // Close the cache after writer shutdown, even when writer shutdown fails.
+    // Closing flushes retained memory entries to disk. If both steps fail, report
+    // the writer failure.
     let closed = match local_cache {
         Some(local_cache) => local_cache
             .close()

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2390,7 +2390,7 @@ fn assert_api_error<T: std::fmt::Debug>(
 /// what they wrote. These exercise that with a store double standing in for
 /// the provider: a loopback issuer that signs nothing, and a loopback
 /// object server reading the same store the deployment writes to — so the
-/// whole grant path (route, issuer seam, presigned fetch, client
+/// whole grant path (route, issuer adapter, presigned fetch, client
 /// verification) runs end to end without a real bucket.
 mod direct_download {
     use super::*;

--- a/crates/loonfs-server/src/local_cache.rs
+++ b/crates/loonfs-server/src/local_cache.rs
@@ -1,20 +1,13 @@
-//! The node-local cache of encoded metadata blocks, backed by foyer.
+//! Node-local cache of encoded metadata blocks, implemented with foyer.
 //!
-//! This module is the only place in the server that names a foyer type.
-//! Everything above it sees [`StoredMetadataBlockCache`], the runtime's seam:
-//! an async lookup that answers `None` on a miss, a fire-and-forget insert,
-//! an invalidation, and a close.
+//! Higher layers use the [`StoredMetadataBlockCache`] interface rather than
+//! foyer types. Cache reads and inserts are best effort: failures are recorded
+//! and treated as misses or dropped inserts. Closing is the only fallible
+//! operation exposed to the caller.
 //!
-//! The tier holds a copy of bytes object storage already holds, so nothing
-//! here is durable. A lookup that fails for any reason is a miss, an insert
-//! that cannot be kept is dropped, and both are counted rather than
-//! surfaced. The one failure a caller can observe is a close that did not
-//! finish cleanly, which a draining host reports on its way out.
-//!
-//! The directory the tier writes is this process's alone while it runs. An
-//! exclusive lock on a file under the configured root is what says so, and a
-//! second process pointed at the same root fails to start rather than
-//! interleaving writes into one device.
+//! An exclusive file lock gives one server process ownership of the cache
+//! directory. A second process configured with the same directory fails at
+//! startup.
 
 use crate::config::{LocalCacheConfig, ServerConfigError};
 use async_trait::async_trait;
@@ -62,16 +55,13 @@ const GEOMETRY_MARKER: &str = "geometry.json";
 /// counters carry.
 const CACHE_NAME: &str = "loonfs-metadata-blocks";
 
-// The four disk-engine numbers below are provisional until this tier is
-// qualified against real traffic. They are constants rather than
-// configuration for that reason: a deployment tuning them today would be
-// guessing from the same absence of measurement.
+// These disk-engine values remain fixed until production measurements support
+// exposing them as deployment settings.
 
-/// Size of one disk block. A block is the disk tier's allocation and
-/// eviction unit and holds many entries, so it is bounded from both sides:
-/// foyer claims the whole capacity as blocks at startup, one file per block
-/// and each one held open, and it refuses an entry larger than a block less
-/// its blob index. This is foyer's own default, which sits between the two.
+/// Size of one disk allocation and eviction block.
+///
+/// Foyer creates and holds one file per block at startup, and entries must fit
+/// within a block after index overhead. This uses foyer's default size.
 pub(crate) const DISK_BLOCK_BYTES: usize = 16 * 1024 * 1024;
 /// Flusher tasks writing the disk tier.
 const DISK_FLUSHERS: usize = 2;
@@ -83,14 +73,11 @@ const DISK_BUFFER_POOL_BYTES: usize = 64 * 1024 * 1024;
 /// ones. A drop is counted, never surfaced.
 const DISK_SUBMIT_QUEUE_THRESHOLD_BYTES: usize = 256 * 1024 * 1024;
 
-/// The smallest disk tier a deployment may configure, which the config
-/// check enforces so a too-small one is refused rather than run.
+/// Minimum supported disk capacity.
 ///
-/// The tier allocates whole blocks, so a capacity under one block allocates
-/// none: the cache opens, holds nothing on disk, and a restart is cold with
-/// nothing said about it. Six blocks is the floor because it is also the
-/// smallest count foyer itself calls stable, which wants the flusher count
-/// plus the clean-block threshold to be at most half the block count.
+/// Capacity is allocated in whole blocks. Six blocks is the smallest layout
+/// that satisfies foyer's stability requirement for flushers and clean-block
+/// reserves.
 pub(crate) const MIN_DISK_BYTES: u64 = 6 * DISK_BLOCK_BYTES as u64;
 
 /// Per-entry overhead the memory weigher charges on top of the value's
@@ -110,13 +97,10 @@ const BLOCK_KINDS: [StoredMetadataBlockKind; 3] = [
 /// One counter per block kind, indexed by [`kind_index`].
 type PerKind = [Arc<dyn CounterHandle>; BLOCK_KINDS.len()];
 
-/// A [`StoredMetadataBlockCache`] over a foyer hybrid cache: a byte-weighted
-/// memory tier in front of a block engine on local disk.
+/// Foyer-backed cache with a byte-limited memory tier and local disk tier.
 ///
-/// The cache has two states and one transition between them. It opens Open
-/// and [`close`](StoredMetadataBlockCache::close) makes it Closed, after
-/// which a lookup answers `None`, an insert and an invalidation do nothing,
-/// and closing again succeeds without doing anything further.
+/// After [`close`](StoredMetadataBlockCache::close), lookups return `None`,
+/// mutations do nothing, and repeated closes succeed.
 pub struct FoyerStoredMetadataBlockCache {
     cache: HybridCache<StoredMetadataBlockKey, Bytes>,
     /// The exclusive lock on the configured root, held for the life of this
@@ -146,17 +130,12 @@ impl Debug for FoyerStoredMetadataBlockCache {
 }
 
 impl FoyerStoredMetadataBlockCache {
-    /// Takes the configured directory and opens the cache in it.
+    /// Opens the cache in the configured directory.
     ///
-    /// The root is created if it is missing and locked exclusively, so a
-    /// second process pointed at the same root fails here rather than
-    /// writing into a device another process owns. The versioned directory
-    /// beneath it is foyer's, and foyer recovers what it can from it, but
-    /// only once [`prepare_directory`] has agreed the directory holds the
-    /// geometry this start is about to claim. A directory foyer then cannot
-    /// open at all fails startup rather than being deleted: an open failure
-    /// says something about the machine, and what to do about it is the
-    /// operator's decision and not this process's.
+    /// The root is created and locked exclusively. The versioned cache directory
+    /// is reused only when its recorded geometry matches the requested geometry.
+    /// If foyer cannot open a compatible directory, startup fails without deleting
+    /// it automatically.
     pub(crate) async fn open(
         config: &LocalCacheConfig,
         recorder: &dyn MetricsRecorder,
@@ -192,10 +171,7 @@ impl FoyerStoredMetadataBlockCache {
         })?;
         let cache = HybridCacheBuilder::<StoredMetadataBlockKey, Bytes>::new()
             .with_name(CACHE_NAME)
-            // Written to disk when an entry is inserted rather than when the
-            // memory tier evicts it: a block this process decoded once is
-            // worth keeping across a restart, and waiting for eviction means
-            // a restart loses whatever the memory tier still held.
+            // Persist entries on insertion so blocks still in memory survive a restart.
             .with_policy(HybridCachePolicy::WriteOnInsertion)
             .with_metrics_registry(Box::new(OverflowRegistry::new(overflow.clone())))
             .memory(memory_bytes)
@@ -214,12 +190,9 @@ impl FoyerStoredMetadataBlockCache {
                     .with_buffer_pool_size(DISK_BUFFER_POOL_BYTES)
                     .with_submit_queue_size_threshold(DISK_SUBMIT_QUEUE_THRESHOLD_BYTES),
             )
-            // The bytes are already the compressed form the segment object
-            // holds, so compressing them again would spend cpu for nothing.
+            // Stored segment sections are already compressed; do not recompress them.
             .with_compression(Compression::None)
-            // An entry recovery cannot make sense of is dropped rather than
-            // fatal. Every entry here is a copy of something object storage
-            // still has, so the worst a bad one costs is one miss.
+            // Drop unreadable recovered entries. Object storage remains authoritative.
             .with_recover_mode(RecoverMode::Quiet)
             .build()
             .await
@@ -310,17 +283,14 @@ impl StoredMetadataBlockCache for FoyerStoredMetadataBlockCache {
         if self.is_closed() {
             return;
         }
-        // The seam's one caller is a hit whose bytes did not decode, so this
-        // counts rejections rather than evictions. foyer evicts on its own
-        // and reports nothing here.
+        // Invalidation is called only for cached bytes that failed to decode, so
+        // record it as a rejection rather than an eviction.
         self.metrics.rejections[kind_index(key.kind)].increment(1);
         self.cache.remove(key);
     }
 
     async fn close(&self) -> Result<(), StoredMetadataBlockCacheCloseError> {
-        // The one transition. Whoever flips the flag owns the shutdown; a
-        // second caller has nothing left to do, and every call after the
-        // flip is already answering as a closed cache.
+        // The first caller performs shutdown. Later callers observe the closed state.
         if self.closed.swap(true, Ordering::AcqRel) {
             return Ok(());
         }
@@ -344,10 +314,8 @@ pub(crate) struct FoyerCacheStats {
     pub(crate) memory_bytes: usize,
     /// Bytes the memory tier may hold.
     pub(crate) memory_capacity_bytes: usize,
-    /// Bytes of the disk device the engine has claimed as blocks. foyer
-    /// exposes claimed space rather than live entry bytes, and the engine
-    /// claims the whole device at startup, so this is a level only in the
-    /// sense that it reports what the device gave up.
+    /// Disk capacity claimed as foyer blocks. This is allocated capacity, not
+    /// the size of live cache entries.
     pub(crate) disk_bytes: usize,
     /// Bytes of disk the device was opened with.
     pub(crate) disk_capacity_bytes: usize,
@@ -668,14 +636,11 @@ const FOYER_BUFFER_OVERFLOW_LABEL: &str = "buffer_overflow";
 /// threshold.
 const FOYER_CHANNEL_OVERFLOW_LABEL: &str = "channel_overflow";
 
-/// A metrics registry that keeps two of foyer's counters and discards the
-/// rest.
+/// Metrics registry that retains foyer's two overflow counters and discards
+/// all other instruments.
 ///
-/// foyer's registry is a push interface: it registers instrument vectors at
-/// construction and then only increments handles. Nothing reads back, so a
-/// host that wants a number has to have kept the handle. This registry keeps
-/// the two that matter and answers every other registration with a handle
-/// that drops what it is given.
+/// Foyer registers handles once and updates them later, so this registry keeps
+/// only the handles the server exposes.
 #[derive(Debug)]
 struct OverflowRegistry {
     counters: FoyerOverflowCounters,

--- a/crates/loonfs-sim/src/fault_store.rs
+++ b/crates/loonfs-sim/src/fault_store.rs
@@ -368,10 +368,10 @@ where
         self.put_with(key, kind, bytes, mode).await
     }
 
-    /// Streamed writes are traced but not fault-injected: every scheduled
-    /// write fault is expressed against a payload the harness holds, and a
-    /// stream has none to hold. The simulator drives content through `put`,
-    /// so nothing it schedules is being skipped here.
+    /// Traces streamed writes without injecting scheduled write faults.
+    ///
+    /// Scheduled write faults require an in-memory payload. Simulation scenarios
+    /// that inject those faults use `put` rather than `put_streamed`.
     async fn put_streamed(
         &self,
         key: &str,

--- a/crates/loonfs-sim/src/lib.rs
+++ b/crates/loonfs-sim/src/lib.rs
@@ -1,10 +1,8 @@
-//! Deterministic simulation primitives for LoonFS tests.
+//! Deterministic simulation tools for LoonFS tests.
 //!
-//! Seeded randomness ([`rng`]), a virtual clock ([`clock`]), and a
-//! fault-injecting object store ([`fault_store`]) that can lose put
-//! responses, serve stale reads, reject compare-and-swaps as stale, hide
-//! recent objects from listings, and corrupt bytes — plus trace and replay plumbing
-//! ([`trace`], [`replay`]) to reproduce any failing seed exactly.
+//! The crate provides seeded randomness, a virtual clock, object-store fault
+//! injection, and trace/replay support for reproducing failed simulation
+//! seeds.
 
 pub mod clock;
 pub mod failure;

--- a/crates/loonfs-test-support/src/lib.rs
+++ b/crates/loonfs-test-support/src/lib.rs
@@ -1,13 +1,10 @@
-//! Shared test helpers at the object-store boundary.
+//! Shared test helpers for the object-store boundary.
 //!
-//! This crate contains broadly reusable fault-injection stores, request
-//! instrumentation, runtime helpers, pagination constructors, and HTTP test
-//! setup. It depends only on `loonfs-api` and `loonfs-objectstore` among LoonFS
-//! crates so `loonfs-core` tests can use it without a development-dependency
-//! cycle. Helpers that require `loonfs-core`, `loonfs`, `loonfs-grep`, or
-//! `loonfs-server` types do not belong here; they stay canonicalized inside
-//! the crate that owns those types. Provider-specific conformance helpers also
-//! remain in `loonfs-objectstore`.
+//! This crate contains reusable fault-injection stores, instrumentation,
+//! runtime helpers, pagination constructors, and HTTP setup. It depends only
+//! on `loonfs-api` and `loonfs-objectstore`, which lets `loonfs-core` use it
+//! without a dependency cycle. Helpers that require higher-level crate types
+//! stay in the crate that owns those types.
 
 pub mod block_on;
 pub mod http;

--- a/crates/loonfs-test-support/src/stores/blocking_store.rs
+++ b/crates/loonfs-test-support/src/stores/blocking_store.rs
@@ -17,21 +17,12 @@ use tokio::sync::Notify;
 
 type Predicate = dyn for<'a> Fn(&OperationContext<'a>) -> bool + Send + Sync;
 
-/// Waits for a latch flag that the other side sets before notifying.
+/// Waits until the latch flag is set.
 ///
-/// The waits here are deliberately unbounded. Whoever is on the other side
-/// of a gate is either the test itself or work the test just started, so a
-/// wall-clock deadline inside this helper is a race with the machine rather
-/// than a check on the code under test: the whole `loonfs` integration
-/// suite shares one binary and one runtime, and a deadline that holds on an
-/// idle laptop starts firing once the rest of the suite is competing for
-/// CPU. A gate nobody opens is a hang, and the harness timeout is what
-/// reports it.
-///
-/// `Notified` only registers with the `Notify` on its first poll, so
-/// checking the flag and then awaiting would drop a notification landing in
-/// between. `enable` registers up front, which makes check-then-wait
-/// race-free without polling.
+/// The helper has no local timeout because tests control both sides of the
+/// gate; the test harness reports gates that are never released. The
+/// notification future is registered before checking the flag, preventing a
+/// notification from being lost between the check and the wait.
 async fn wait_for_latch(flag: &AtomicBool, notify: &Notify) {
     loop {
         let mut notified = pin!(notify.notified());

--- a/crates/loonfs-test-support/src/stores/buffer_watch_store.rs
+++ b/crates/loonfs-test-support/src/stores/buffer_watch_store.rs
@@ -1,19 +1,8 @@
-//! Watches how much of a payload a transfer path holds in memory at once.
+//! Measures payload buffers held by a transfer path.
 //!
-//! A streamed transfer's whole promise is that peak memory follows the chunk
-//! size rather than the object size, and that promise is easy to lose by
-//! accident: one `collect()` on the way through, one decorator that does not
-//! forward `put_streamed` and falls back to buffering, one read that asks for
-//! no range and gets the whole object — and a large transfer is materialized
-//! again with nothing failing.
-//!
-//! This wrapper makes the promise checkable without measuring the process.
-//! It sits above a store and watches every payload buffer that crosses the
-//! boundary in either direction — a whole-payload `put`, each chunk of a
-//! `put_streamed` stream, and each `get`, whole or ranged — recording the
-//! largest one and the most bytes alive at any instant. Liveness is exact:
-//! each buffer handed on carries a drop guard, so the counter falls when the
-//! consumer actually releases it, not when the wrapper guesses it has.
+//! The wrapper observes buffered puts, streamed chunks, and read results. It
+//! records the largest buffer and peak live bytes. Each observed buffer owns a
+//! drop guard, so live-byte counts fall when the consumer releases the buffer.
 
 use super::KeyPredicate;
 use async_trait::async_trait;
@@ -159,10 +148,10 @@ impl<S: ObjectStore> ObjectStore for BufferWatchStore<S> {
         self.inner.get_with_metadata(key).await
     }
 
-    /// A read's answer is a payload buffer like any other: one whole object
-    /// for an unranged read, one range for a chunked one. The caller's drop
-    /// is what releases it, so a reader that accumulates chunks shows up as
-    /// bytes alive rather than as chunks that were merely handed out.
+    /// Tracks the returned read buffer until the caller drops it.
+    ///
+    /// Unranged reads count the whole object; ranged reads count the returned
+    /// range. Retained chunks therefore remain included in peak live memory.
     async fn get(
         &self,
         key: &str,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -17,14 +17,12 @@ use loonfs_core::NamespaceEngine;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
-/// What a retry can still say about the payload it just staged.
+/// Evidence retained for comparing a newly staged payload with an earlier
+/// committed payload.
 ///
-/// A buffered put can answer any question about its bytes by hashing them
-/// again. A streamed put cannot: the payload went by once and is gone, and
-/// what it kept instead is the reference the write path built while hashing
-/// it. Both describe the same bytes; they differ only in which questions
-/// they can answer, and a question neither can answer is reported as such
-/// rather than guessed at.
+/// Buffered bytes can be hashed again with any supported algorithm. A
+/// streamed payload retains only its computed content reference, so checksum
+/// algorithms not recorded there cannot be compared.
 #[derive(Debug, Clone, Copy)]
 enum StagedPayload<'a> {
     /// The payload itself, which can produce any digest this build knows.
@@ -141,21 +139,17 @@ impl FsWriter {
             payload_class = tracing::field::Empty,
         )
     )]
-    /// Re-running this with a `commit_id` that already committed is safe
-    /// when the request is the same. A commit's identity names *which*
-    /// content object it wrote, and a re-run necessarily stages a fresh
-    /// one, so the publisher sees a different commit and reports
-    /// `commit_id_reuse_conflict`. This resolves that by reading back what
-    /// the commit id actually committed and rebuilding this request's
-    /// fingerprint around it: an identical value plus bytes that provably
-    /// agree means the operation had already succeeded. Anything else —
-    /// a different path, behavior, guard, message, or payload — surfaces
-    /// the conflict.
+    /// A retry with the same `commit_id` is reconciled against the durable
+    /// receipt.
     ///
-    /// The freshly staged duplicate object is then referenced by nothing.
-    /// That is by design, not a leak: it is a completed upload session's
-    /// content that no metadata names, and content garbage collection
-    /// reclaims exactly that once the reclamation grace passes.
+    /// Each retry stages a new content object, so its initial fingerprint differs
+    /// from the committed request. On a reuse conflict, the runtime reads the
+    /// committed change, rebuilds the fingerprint with the committed content
+    /// reference, and verifies that the staged bytes match. The retry succeeds
+    /// only when the complete request and payload are equivalent.
+    ///
+    /// The unused staged object remains unpublished and is reclaimed by content
+    /// garbage collection after the grace period.
     pub async fn put_file_bytes(
         &self,
         namespace_id: &NamespaceId,
@@ -260,23 +254,14 @@ impl FsWriter {
         }
     }
 
-    /// Decides whether a reused commit id already did this exact work.
+    /// Determines whether a commit-id conflict is an idempotent retry of the
+    /// same file write.
     ///
-    /// The proof is the commit's whole semantic identity, not a selection of
-    /// its parts. The conflict reports the fingerprint the receipt holds;
-    /// this reads the one change that commit id landed, rebuilds this
-    /// request's fingerprint with the committed content reference in place
-    /// of the freshly staged one, and requires the two to be equal. That
-    /// covers the path, the replacement behavior, the expected revision, the
-    /// annotation, and that the original commit was this one put — every
-    /// field a future request gains is covered the day it joins the
-    /// preimage. What the fingerprint cannot speak to is whether the two
-    /// content objects hold the same bytes, so digest evidence answers that
-    /// separately.
-    ///
-    /// Nothing weaker counts: every way of failing to prove the two requests
-    /// are the same — including the staged payload having no answer to give
-    /// — leaves the original conflict standing, never agreement.
+    /// The runtime compares the durable receipt's full request fingerprint with a
+    /// fingerprint rebuilt using the committed content reference. It separately
+    /// verifies that the newly staged payload matches the committed bytes. If
+    /// either comparison is unavailable or differs, the original conflict is
+    /// returned.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,
@@ -325,14 +310,12 @@ impl FsWriter {
         })
     }
 
-    /// Reads the one change a reuse conflict said the commit id landed at.
+    /// Reads the committed change identified by a reuse conflict.
     ///
-    /// There is no by-commit-id read, but the conflict already named the
-    /// sequence, so this is one feed page positioned on it rather than a
-    /// search. `None` means the evidence is not there to compare — the
-    /// sequence has fallen below the retention floor, or the row at it
-    /// belongs to some other commit — and the caller turns that into the
-    /// conflict rather than into a guess.
+    /// The conflict supplies the sequence, so one change-feed page can read the
+    /// expected row directly. Returns `None` when retention removed the row or
+    /// when the row belongs to another commit; the caller then preserves the
+    /// original conflict.
     async fn read_committed_change(
         &self,
         namespace_id: &NamespaceId,
@@ -357,21 +340,16 @@ impl FsWriter {
             .find(|change| change.seq == committed_seq && &change.commit_id == commit_id))
     }
 
-    /// Stages file bytes as durable content for later publication.
+    /// Stores file bytes and returns proof that they are ready to publish.
     ///
-    /// Preparation performs one content PUT and no content reads, plus the
-    /// two small control writes of the upload session that owns the object:
-    /// the session record lands before the bytes do, and the completion
-    /// after them. That is what a publish failing afterwards costs, and all
-    /// it costs — the object is a completed session's unpublished content,
-    /// which garbage collection reclaims once nothing references it and the
-    /// reclamation grace has passed.
+    /// Preparation writes the upload-session record, the content object, and the
+    /// completed session record, in that order. If publication later fails, the
+    /// unpublished object is reclaimed after the content-reclamation grace
+    /// period.
     ///
-    /// The same window bounds how long the returned value stays worth
-    /// holding. A prepared reference carries no clock and never expires by
-    /// itself, but the bytes behind it are protected only while its session
-    /// is inside that grace, so a prepared reference is for publishing now,
-    /// not for keeping.
+    /// `PreparedContent` has no local expiry, but callers should publish it
+    /// promptly because garbage collection protects the object only for that
+    /// grace period while it remains unpublished.
     #[tracing::instrument(
         level = "info",
         name = "loonfs.prepare",

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -14,22 +14,18 @@ use loonfs_core::cache::{MetadataTableCache, StoredMetadataBlockCache};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-/// Write-capable handle for normal application and server use.
+/// Write-capable runtime handle for applications and servers.
 ///
-/// `FsWriter` owns a writer identity and the full mutation surface:
-/// file and directory mutations, commit publication, uploads, and namespace
-/// lifecycle. With [`FsBackgroundWork::Enabled`] it also owns a maintenance
-/// runner, spawned on its owning runtime: metadata steps after writes that
-/// cross the WAL-tail threshold, and collection passes for the upload
-/// sessions it opened once their leases pass. Advancing the retention floor
-/// stays explicit [`FsAdmin`](crate::FsAdmin) work.
+/// `FsWriter` owns the writer identity, mutations, uploads, namespace
+/// lifecycle, and commit publication. With [`FsBackgroundWork::Enabled`], it
+/// also schedules metadata maintenance and upload garbage collection.
+/// Retention-floor advancement remains an explicit [`FsAdmin`](crate::FsAdmin)
+/// operation.
 ///
-/// The handle is runtime-bound: open it with `build().await` inside the
-/// long-lived Tokio runtime that will drive it, and do not share one writer
-/// across unrelated runtimes — open another from [`StoreConfig`] instead.
-/// `FsWriter` is cheap to clone; clones share the identity, caches, and
-/// background-work state — including its end, which is why
-/// [`Self::shutdown`] is one call rather than a sequence a host respells.
+/// Build the handle inside the Tokio runtime that will use it. Do not share a
+/// provider client across unrelated runtimes; build another handle from
+/// [`StoreConfig`]. Clones share identity, caches, background tasks, and
+/// shutdown state.
 #[derive(Clone)]
 pub struct FsWriter {
     pub(crate) core: ReadCore,
@@ -91,16 +87,11 @@ impl FsWriter {
         self.core.shared_store()
     }
 
-    /// This writer's publication service (see [`crate::publisher`]).
+    /// Returns this writer's shared publication service.
     ///
-    /// The direct mutation methods on this handle submit through the same
-    /// service; hosts that classify their own mutation candidates — the
-    /// reference server, for example — submit here directly. Clones share
-    /// the writer's per-namespace publishers.
-    ///
-    /// Lifecycle is not the caller's to drive here: [`Self::shutdown`] owns
-    /// closing this service, and [`Self::is_shutting_down`] answers the one
-    /// question a host asks about it from outside.
+    /// Direct mutation methods and integrations that submit classified
+    /// candidates use the same per-namespace publishers. [`Self::shutdown`]
+    /// closes the service; callers should not manage its lifecycle separately.
     pub fn publisher(&self) -> PublisherRegistry {
         self.publisher.clone()
     }
@@ -152,29 +143,22 @@ impl FsWriter {
         self.bits.maintenance.register(job)
     }
 
-    /// The executor registered under `job`, runtime-owned or extension-owned
-    /// alike, or `None` when nothing claims that id.
+    /// Returns the maintenance job registered under `job`.
     ///
-    /// For a host that drives bounded steps itself rather than through
-    /// admission: `loonfs admin run --drain` runs each key to a settled
-    /// conclusion under the operator's budget, and a caller with its own
-    /// budget needs the executor, not a nudge. What it gets is the same
-    /// bounded, compare-and-swap-published unit the runner admits — running
-    /// one here duplicates work at worst, because delivery is at-least-once
-    /// either way.
+    /// Hosts may call the job directly to run bounded steps under their own
+    /// budget. These are the same idempotent, compare-and-swap-based steps used
+    /// by the scheduler, so concurrent or repeated execution may duplicate work
+    /// but does not change correctness.
     pub fn maintenance_job(&self, job: MaintenanceJobId) -> Option<Arc<dyn MaintenanceJob>> {
         self.bits.maintenance.job(job)
     }
 
-    /// Waits until every writer-scheduled maintenance task has finished,
-    /// without closing anything. Panicked tasks surface as a runtime-task
-    /// error.
+    /// Waits for currently scheduled maintenance to finish without closing
+    /// admission.
     ///
-    /// Non-terminal: the writer keeps admitting work, so what this waits
-    /// for is quiet, not the end. A one-shot host calls it before exiting
-    /// so a step is never torn down mid-flight; a long-lived host calls it
-    /// to read durable state a step was about to leave. Callers await their
-    /// own publications, so a quiet runner is a quiet writer.
+    /// New work may still be scheduled while this method runs, so it waits for a
+    /// quiet point rather than performing terminal shutdown. Task panics are
+    /// returned as runtime errors.
     ///
     /// One task this waits for is not a bounded step. A family group that has
     /// outgrown one step is rebuilt by a streaming compaction paced by no
@@ -185,53 +169,25 @@ impl FsWriter {
         self.bits.maintenance.drain().await
     }
 
-    /// Terminal shutdown: closes maintenance admission, closes publication
-    /// admission, settles admitted publications, then settles in-flight
-    /// maintenance steps. Panicked tasks surface as a runtime-task error.
+    /// Gracefully shuts down writer-owned background work.
     ///
-    /// This is the only valid order, and it lives here so no host has to
-    /// respell it. Afterward, mutations fail with `shutting_down`, nudges
-    /// are dropped, and work that claimed a maintenance slot without
-    /// starting is refused rather than left running unobserved. Reads still
-    /// work: nothing here touches the read path.
+    /// Shutdown closes maintenance admission before its first await, then
+    /// closes publication admission, drains accepted publications, and waits
+    /// for maintenance tasks that were already running. Closing maintenance
+    /// first prevents completed publications from scheduling new work during
+    /// the drain. Maintenance jobs publish through [`FsAdmin`](crate::FsAdmin),
+    /// not the publication service, so the publication queue can only shrink.
     ///
-    /// Maintenance admission has to close first, and before this future's
-    /// first await — the publication drain below is that await. While it is
-    /// pending the runtime keeps polling the runner: its timer promotes
-    /// keys whose deadlines have arrived, each landing publication nudges
-    /// the jobs subscribed to publications, and a finishing step hands its
-    /// permit straight to the next queued key. Everything admitted in that
-    /// window is work this shutdown already decided to drop, and none of it
-    /// is free — a metadata step advances the metadata root, a collection
-    /// pass deletes provider objects, an index step writes segments, all
-    /// after the process was asked to stop, and all of it the drain then
-    /// has to sit through. Closing first leaves the window empty.
+    /// Closing maintenance admission also cancels streaming metadata
+    /// compactions. These jobs check for cancellation between block reads and
+    /// publish only after the complete merge finishes, so cancellation leaves
+    /// the current manifest unchanged. A later maintenance step can plan the
+    /// compaction again.
     ///
-    /// Closing maintenance admission also cancels every streaming metadata
-    /// compaction this writer is running. Such a job is background work with
-    /// no budget pacing it, so the drain below would otherwise wait for a
-    /// whole family group to be rebuilt. The job checks its token between
-    /// block fetches and stops, and it costs the work it had done and nothing
-    /// else: it publishes only at the end, so the metadata it was rebuilding
-    /// never moved and a later step plans the group again.
-    ///
-    /// Nor can the order wedge, for a reason worth stating because it is
-    /// not the obvious one: no maintenance step submits to the publication
-    /// service at all. Every job compare-and-swaps the namespace head
-    /// through [`FsAdmin`](crate::FsAdmin), so the publication drain waits
-    /// only on client work and its pending set can only shrink. A step
-    /// already running finishes normally, and its chain then ends rather
-    /// than passing its permit on, because a closed admission book releases
-    /// the permit instead of handing it to the next key.
-    ///
-    /// Takes `&self` because `FsWriter` is [`Clone`] and exclusivity is
-    /// therefore unenforceable: clones observe the shutdown rather than
-    /// being consumed by it, and [`Self::is_shutting_down`] is what they
-    /// see. Calling it again — from this handle or any clone — is safe: the
-    /// closes are idempotent and the drains are waits, so a later call
-    /// settles whatever a concurrent one has not and returns. Dropping
-    /// every clone without calling this is best-effort cleanup, not the
-    /// documented graceful shutdown path.
+    /// After shutdown, mutations return `shutting_down`, maintenance nudges
+    /// are ignored, and reads continue to work. The method is idempotent and
+    /// may be called from any clone because all clones share the same shutdown
+    /// state. Task panics are returned as runtime errors.
     pub async fn shutdown(&self) -> Result<()> {
         // Both closes belong above the first await, for the reason the doc
         // gives. Nothing may move below `drain`.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -23,16 +23,12 @@
 //! # Ok(()) }
 //! ```
 //!
-//! Background work belongs to the writer — publications, and the maintenance
-//! a publication schedules. One [`MaintenanceJob`] runner admits every
-//! background step: the writer nudges it, it decides when to run, and the
-//! executors re-read durable state each time. It covers the namespaces this
-//! process touches and the ones a host explicitly assigns to it, and it
-//! discovers none. LoonFS never creates a hidden maintenance runtime: that
-//! work is spawned on the writer's own owning runtime, and
-//! [`FsWriter::shutdown`] settles it in the one order that is correct.
-//! Readers and admins start no background work at all, so they have nothing
-//! to shut down.
+//! A writer owns publication and any automatically scheduled maintenance.
+//! One [`MaintenanceJob`] runner schedules work for namespaces touched or
+//! explicitly assigned to this process; it does not discover namespaces.
+//! Jobs run on the writer's Tokio runtime and re-read durable state before
+//! acting. [`FsWriter::shutdown`] drains this work. Readers and admins do not
+//! start background tasks.
 #![warn(missing_docs)]
 
 mod cache;
@@ -86,12 +82,12 @@ pub use loonfs_core::{
 };
 pub use publisher::PublishObserver;
 
-/// Integration seam: the vocabulary for handing classified commit work to
-/// the runtime's batch publication surface. The server's filesystem
-/// handlers build [`publish::CommitRequest`]s for the [`publisher`]
-/// front-end, which also accepts
-/// [`publish::CommitCandidate`]s directly. Most embedded users
-/// never need this module.
+/// Commit types used by integrations that submit classified mutations to
+/// the runtime publisher.
+///
+/// Server handlers build [`publish::CommitRequest`] values, and lower-level
+/// integrations may submit [`publish::CommitCandidate`] values directly.
+/// Most embedded applications do not need this module.
 pub mod publish {
     pub use loonfs_core::limits::{
         MAX_COMMIT_CONTENT_TOKENS, MAX_COMMIT_EXTERNAL_CONTENT_REFS, MAX_COMMIT_MESSAGE_BYTES,
@@ -104,22 +100,22 @@ pub mod publish {
     };
 }
 
-/// Server-integration seam for producer-only content preparation proofs.
+/// Content-preparation proof types used by server integrations.
 ///
-/// A serving session mints short-lived wire tokens after durable preparation;
-/// [`FsWriter::prepare_content_token`] verifies them against the namespace's
-/// catalog binding. The resulting admission records accepted durability
-/// evidence and does not expire. Most embedded users never need this module.
+/// A server mints a short-lived token after durable upload completion.
+/// [`FsWriter::prepare_content_token`] verifies the token against the
+/// namespace catalog and returns process-local proof that remains valid.
+/// Most embedded applications do not need this module.
 pub mod content_tokens {
     pub use loonfs_core::content::{
         mint_content_token, CompletedUpload, CompletedUploadReceipt, ContentTokenError,
     };
 }
 
-/// Server-integration seam: the resolved direct upload targets a serving
-/// session turns into presigned URLs for client-side object writes — one
-/// whole-object PUT, or one PUT per multipart part. Most embedded users
-/// never need this module.
+/// Direct-upload target types used by servers to create presigned URLs.
+///
+/// Targets describe either one whole-object PUT or individual multipart
+/// part uploads. Most embedded applications do not need this module.
 pub mod uploads {
     pub use loonfs_core::{
         BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse,
@@ -128,20 +124,17 @@ pub mod uploads {
     };
 }
 
-/// Server-integration seam: the resolved direct download target a serving
-/// read turns into a presigned URL for a client-side object read. The
-/// mirror of [`uploads`], and most embedded users never need it either.
+/// Direct-download target type used by servers to create a presigned
+/// object-read URL. Most embedded applications do not need this module.
 pub mod downloads {
     pub use loonfs_core::DirectDownloadTarget;
 }
 
-/// White-box seam over the durable control plane: typed loaders for a
-/// namespace's head, metadata root, and catalog entry.
+/// Typed loaders for inspecting durable namespace control objects.
 ///
-/// These read durable control objects directly rather than going through a
-/// handle, which is what makes them useful for asserting on layout in tests
-/// and for operational inspection. Normal reads and writes go through
-/// [`FsReader`] and [`FsWriter`]; nothing here is needed to use the runtime.
+/// These functions bypass runtime handles and are intended for layout tests
+/// and operational inspection. Normal application reads and writes should
+/// use [`FsReader`] and [`FsWriter`].
 pub mod control {
     pub use loonfs_core::control::{
         load_namespace_catalog_entry, load_namespace_head_control,
@@ -176,7 +169,7 @@ pub type Result<T> = std::result::Result<T, RuntimeError>;
 
 pub use self::RuntimeError as Error;
 
-/// The embedded runtime's error type, also exported as [`Error`].
+/// The embedded runtime's error type, also exported as [`enum@Error`].
 #[derive(Debug, Clone, Error)]
 #[non_exhaustive]
 pub enum RuntimeError {

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -1,41 +1,21 @@
-//! One runner admits every background maintenance step.
+//! Scheduler for bounded background maintenance.
 //!
-//! A [`MaintenanceJob`] knows how to do one bounded piece of upkeep for one
-//! namespace: it re-reads durable state, does at most one unit of work,
-//! publishes through a compare-and-swap, and reports a
-//! [`MaintenanceStepResult`]. It decides nothing about when to run.
+//! A [`MaintenanceJob`] performs one bounded unit of work for one namespace.
+//! Each step reloads durable state, performs at most one update, and reports a
+//! [`MaintenanceStepResult`]. Jobs do not decide when they run.
 //!
-//! The [`MaintenanceRunner`] decides that, and it is the only thing that
-//! does. It holds the pending `{job, namespace}` keys, the one permit pool
-//! every job shares, the per-key error backoff, the not-before times a
-//! wall-clock obligation plants, the opaque continuation a bounded job
-//! stopped at, and a bounded sweep over the keys it has admitted. Triggers
-//! — a publish crossing a threshold, an upload session opening — are hints:
-//! level-triggered, never authoritative, and safe to lose because the
-//! durable state a step re-reads is the truth.
+//! [`MaintenanceRunner`] owns scheduling. It tracks pending `(job, namespace)`
+//! keys, concurrency permits, retry backoff, earliest run times, per-job
+//! continuations, and reconciliation progress. Triggers are hints only; every
+//! step validates current durable state before acting.
 //!
-//! A job keeps no scheduling state of its own. Where its last bounded step
-//! stopped comes back to it as the `continuation` argument of the next one,
-//! so there is one place that knows what a key is waiting for. That state
-//! is in memory and performance-only: a step rebuilds every safety proof
-//! from durable state whatever position it starts from, so a continuation
-//! lost with the process costs a restarted pass and authorizes nothing.
+//! Continuations are in-memory performance hints. Losing one restarts the
+//! pass but does not change correctness.
 //!
-//! ## What automatic maintenance covers
-//!
-//! Automatic maintenance covers namespaces touched by the running process
-//! and namespaces explicitly assigned to a maintenance host. It never
-//! discovers namespaces: LoonFS has no operation that enumerates them, and
-//! this runner introduces none. A namespace enters the admitted set by
-//! being nudged — by a write, a query, a timed obligation, or an explicit
-//! assignment — and reconciliation revisits exactly that set. A namespace
-//! that no process has touched and no host has been assigned is outside
-//! this guarantee, and an operator brings it back in by assigning it.
-//!
-//! LoonFS never creates a hidden runtime for maintenance. Steps are spawned
-//! on the writer's own owning runtime and stay visible to shutdown through
-//! the registry here. Only a writer owns a runner: readers and admins
-//! schedule nothing.
+//! Automatic maintenance covers namespaces touched by this process or
+//! explicitly assigned to it. The runner never discovers namespaces.
+//! Maintenance tasks run on the writer's runtime and are included in writer
+//! shutdown. Readers and admin handles do not own a runner.
 
 mod admission;
 mod compaction;
@@ -59,15 +39,11 @@ pub(crate) use jobs::{
     completed_upload_reclaim_at_ms, register_core_jobs, upload_session_reclaim_at_ms,
 };
 
-/// How often the runner sweeps the keys it has admitted, looking for work no
-/// trigger reported.
+/// Interval between reconciliation sweeps of admitted maintenance keys.
 ///
-/// Triggers are hints, and a hint can be lost: a step that concluded
-/// `Blocked`, a namespace whose last writer went quiet mid-backlog, a key
-/// cleared by a shutdown earlier in this process. The sweep is the answer to
-/// all of them, so its period is how long such work may sit — short enough
-/// to be a hiccup, long enough that one cheap probe per admitted key is
-/// nothing next to the traffic the same process is serving.
+/// Sweeps recover work that was blocked, left behind by a quiet writer, or
+/// missed by a trigger. This interval is the maximum expected delay before
+/// such work is probed again.
 const RECONCILE_INTERVAL_MS: u64 = 60_000;
 
 /// Most admitted keys one reconciliation sweep probes. The sweep resumes
@@ -131,10 +107,10 @@ impl fmt::Display for MaintenanceJobId {
     }
 }
 
-/// What one bounded maintenance step accomplished.
+/// Result category for one bounded maintenance step.
 ///
-/// The conclusion is the executor's whole vocabulary for scheduling: it says
-/// what happened, and the runner decides what that means for the key.
+/// Jobs report what happened; the runner decides whether and when to schedule
+/// the key again.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MaintenanceStepConclusion {
     /// Durable state advanced. The key is eligible again at once — behind
@@ -169,11 +145,10 @@ impl MaintenanceStepConclusion {
     }
 }
 
-/// Everything one bounded step tells the runner.
+/// Scheduling information returned by one bounded maintenance step.
 ///
-/// A job returns this instead of a bare conclusion so that the scheduling
-/// state it produces — where it stopped, and when it should next be looked
-/// at — lives in the runner rather than in a map beside it.
+/// The runner stores the conclusion, optional continuation, and earliest next
+/// run time so jobs do not maintain separate scheduler state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MaintenanceStepResult {
     /// What the step accomplished.
@@ -187,13 +162,11 @@ pub struct MaintenanceStepResult {
     /// It never crosses a process boundary: a job that cannot restart its
     /// pass from the beginning safely must not use this.
     pub continuation: Option<String>,
-    /// The earliest wall-clock millisecond this step saw work becoming
-    /// eligible — a lease that will expire, a grace window that will pass.
+    /// Earliest Unix millisecond when the observed work may become eligible.
     ///
-    /// It joins the deadlines triggers plant, under the same rule: the
-    /// soonest of them is when the runner wakes, the latest is when the key
-    /// stops owing anything. `None` when the step observed no deadline,
-    /// which is not a claim that there is none.
+    /// The runner keeps the earliest deadline reported by either a trigger or a
+    /// step. `None` means this step did not observe a deadline; it does not prove
+    /// that no deadline exists.
     pub not_before_ms: Option<u64>,
 }
 
@@ -223,13 +196,11 @@ pub enum MaintenanceProbe {
     Idle,
 }
 
-/// One kind of bounded background upkeep, for one namespace at a time.
+/// A bounded maintenance operation that runs for one namespace at a time.
 ///
-/// An executor re-reads durable state on every call — it never trusts what
-/// the trigger that woke it claimed — does at most one bounded unit of work,
-/// and reports what happened. Delivery is at-least-once and conclusions are
-/// idempotent through the compare-and-swap each step publishes with, so a
-/// duplicated step costs a round trip and nothing else.
+/// Each call reloads durable state, performs at most one unit of work, and
+/// reports the result. Steps may run more than once, so implementations must
+/// be idempotent through their durable compare-and-swap.
 #[async_trait::async_trait]
 pub trait MaintenanceJob: Send + Sync + 'static {
     /// This job's stable identity.
@@ -252,32 +223,21 @@ pub trait MaintenanceJob: Send + Sync + 'static {
     /// job can. Called only by reconciliation, never on the hot path.
     async fn probe(&self, namespace_id: &NamespaceId) -> Result<MaintenanceProbe>;
 
-    /// Whether a landed publication is a reason to look at this job's work
-    /// for the namespace that published it.
+    /// Returns whether successful publications should nudge this job.
     ///
-    /// A job that derives something from the namespace's own history — an
-    /// index, a projection — says `true` and is nudged after every
-    /// publication the writer commits, so it needs no hook of its own on
-    /// the write path. The nudge is a hint like any other: it is dropped
-    /// when admission is closed, and the step it suggests re-reads what the
-    /// publication committed rather than trusting it.
-    ///
-    /// Jobs that answer to durable deadlines rather than to writes leave
-    /// this `false`, which is why it is the default.
+    /// Use `true` for work derived from namespace history, such as an index or
+    /// projection. The nudge is only a scheduling hint; the step must reload
+    /// durable state. Deadline-driven jobs keep the default `false`.
     fn nudged_by_publications(&self) -> bool {
         false
     }
 }
 
-/// Wall-clock milliseconds the runner schedules against.
+/// Clock used to schedule durable Unix-millisecond deadlines.
 ///
-/// Scheduling is all this clock decides. The deadlines it is compared with —
-/// an upload session's lease, a completed session's reclamation grace — are
-/// unix milliseconds stamped into durable records, so the runner has to read
-/// the same kind of clock to know when they arrive. Nothing here gates
-/// correctness: firing a step early costs one round trip that concludes
-/// there was nothing to do, because every executor re-derives its own
-/// safety from durable state under its own mutation context.
+/// This clock controls only when a step is attempted. Each job validates
+/// eligibility from durable state, so an early wake can waste a read but
+/// cannot make an unsafe update.
 pub(crate) trait MaintenanceClock: fmt::Debug + Send + Sync {
     /// Unix milliseconds.
     fn now_ms(&self) -> u64;
@@ -318,16 +278,10 @@ impl Default for SystemMaintenanceClock {
 
 impl MaintenanceClock for SystemMaintenanceClock {
     fn now_ms(&self) -> u64 {
-        // A clock before the unix epoch reads as the epoch here rather than
-        // failing. Every eligibility test is `at_ms <= now_ms`, so the
-        // epoch is the reading under which nothing timed comes due: work
-        // that answers to a durable deadline parks until something nudges
-        // it. That is the safe end to fall off. The opposite fallback would
-        // make every deadline due at once, and since the timer's sleep is
-        // floored at one millisecond it would drive reconciliation sweeps
-        // at that floor for as long as the clock stayed wrong. A pre-epoch
-        // clock is also a condition every durable path refuses outright, so
-        // there is no useful maintenance to run through it either way.
+        // Treat a pre-epoch system clock as Unix time zero. This leaves durable
+        // deadlines in the future instead of making every deadline immediately due
+        // and causing a tight scheduler loop. Durable mutation paths reject the same
+        // invalid clock independently.
         loonfs_core::time::current_time_ms().unwrap_or(0)
     }
 
@@ -353,12 +307,10 @@ fn split_mix_64(counter: u64) -> u64 {
     mixed ^ (mixed >> 31)
 }
 
-/// Cloneable, non-blocking way to tell the runner a key may have work.
+/// Cloneable handle for non-blocking maintenance hints.
 ///
-/// Nudges are hints. They never block the caller, never wait for a permit,
-/// and are simply dropped once the runner's admission has closed or the
-/// writer that owns it is gone — a write path holding one of these is not
-/// on the hook for the maintenance it suggests.
+/// Nudges coalesce and never wait for a permit. They are ignored after
+/// admission closes or after the owning writer is dropped.
 #[derive(Clone)]
 pub struct MaintenanceHandle {
     inner: Weak<RunnerInner>,
@@ -418,12 +370,10 @@ pub(crate) struct MaintenanceRunner {
     inner: Arc<RunnerInner>,
 }
 
-/// Running totals a trace reports beside the event that moved them.
+/// Process-wide counters included in maintenance trace events.
 ///
-/// Counters rather than a metrics framework, and process-wide rather than
-/// per key: what an operator asks of them is whether backoffs and timed
-/// wakes are happening at all and roughly how often, which a monotonic
-/// number on an existing event answers without any new cardinality.
+/// They show whether retry backoff and deadline wakes are occurring without
+/// adding per-key metric cardinality.
 #[derive(Debug, Default)]
 struct RunnerCounters {
     /// Steps that failed and were scheduled for a backoff retry.
@@ -632,15 +582,11 @@ impl MaintenanceRunner {
         Ok(())
     }
 
-    /// Tells every job that subscribes to publications that `namespace_id`
-    /// just committed one.
+    /// Nudges each registered job that subscribes to successful publications.
     ///
-    /// The write path calls this instead of knowing which jobs care, so a
-    /// job that wants publication nudges gets them by saying so on the
-    /// trait rather than by a host wiring an observer to it. Each nudge is
-    /// an ordinary one: non-blocking, coalescing, and dropped once
-    /// admission is closed or the policy is
-    /// [`FsBackgroundWork::ManualOnly`].
+    /// Subscription is declared by [`MaintenanceJob::nudged_by_publications`], so
+    /// the write path does not need job-specific wiring. Nudges are non-blocking,
+    /// coalesced, and ignored when automatic maintenance is disabled or closed.
     pub(crate) fn nudge_publication_subscribers(&self, namespace_id: &NamespaceId) {
         // The subscriber list is read out from under the job lock before
         // any nudge takes the scheduling lock: the two are never held
@@ -657,8 +603,8 @@ impl MaintenanceRunner {
         }
     }
 
-    /// Whether the key is admitted with work still owed to it. Test and
-    /// diagnostic seam; nothing on a hot path asks.
+    /// Returns whether this key is currently pending. Used only by tests and
+    /// diagnostics.
     #[cfg(test)]
     pub(crate) fn is_pending(&self, job: MaintenanceJobId, namespace_id: &NamespaceId) -> bool {
         self.inner
@@ -728,10 +674,10 @@ impl RunnerInner {
         }
     }
 
-    /// Spawns work on the owning runtime and registers it for shutdown, or
-    /// refuses after a shutdown. Dropping the future without running it must
-    /// release whatever it holds, so both refusals here clean up by
-    /// dropping.
+    /// Spawns maintenance on the owning runtime and tracks it for shutdown.
+    ///
+    /// If no runtime is available or admission has closed, the future is
+    /// dropped. It must release any claimed key or permit when dropped.
     pub(super) fn spawn(&self, future: impl Future<Output = ()> + Send + 'static) {
         let Some(runtime) = self.runtime() else {
             return;
@@ -793,10 +739,9 @@ fn dispatch_ready(inner: &Arc<RunnerInner>) {
         spawn_chain(inner, dispatch);
     }
     if dispatched > 0 {
-        // What is left behind is the useful half: a queue that keeps
-        // growing, or an oldest wait that keeps climbing, is the permit
-        // pool being too small for what this process admits. Queue-wide
-        // numbers, so no key names appear.
+        // Report the queue remaining after dispatch. Sustained queue growth or rising
+        // wait time indicates that the shared permit limit is too low. Metrics are
+        // aggregate and do not include namespace IDs.
         let now_ms = inner.clock.now_ms();
         let state = inner.lock_state();
         tracing::debug!(
@@ -834,12 +779,11 @@ fn spawn_chain(inner: &Arc<RunnerInner>, dispatch: MaintenanceDispatch) {
     });
 }
 
-/// Holds one permit across a chain of steps and gives it back exactly once.
+/// Owns one maintenance permit and releases it exactly once.
 ///
-/// The chain hands its permit straight to the next key on every ordinary
-/// finish. Dropping — on a panic, on a refused spawn, or on a task discarded
-/// with its runtime — releases the key and the permit instead, so neither is
-/// ever stranded.
+/// Normal completion may transfer the permit to the next ready key. Dropping
+/// the chain after a panic, refused spawn, or runtime shutdown abandons the
+/// current key and returns the permit.
 struct PermitChain {
     inner: Arc<RunnerInner>,
     dispatch: Option<MaintenanceDispatch>,
@@ -921,12 +865,11 @@ fn ensure_scheduler(inner: &Arc<RunnerInner>) {
     state.scheduler = Some(runtime.spawn(scheduler_loop(weak, wake)));
 }
 
-/// The one timer: it wakes for the soonest deadline any key is parked on,
-/// and at least once per reconciliation interval.
+/// Scheduler task for deadlines and periodic reconciliation.
 ///
-/// It holds the runner weakly and re-upgrades after every sleep, so a
-/// handle dropped without a shutdown lets this task exit on its own rather
-/// than keeping the runtime state alive behind it.
+/// It sleeps until the earliest key deadline or reconciliation interval. The
+/// task holds only a weak runner reference, so dropping the runner lets the
+/// task exit even without explicit shutdown.
 async fn scheduler_loop(inner: Weak<RunnerInner>, wake: Arc<Notify>) {
     loop {
         let delay = {
@@ -1004,15 +947,11 @@ fn take_reconcile_turn(inner: &Arc<RunnerInner>, now_ms: u64) -> bool {
     true
 }
 
-/// Asks a bounded slice of the admitted keys whether they have work.
+/// Probes a bounded batch of admitted maintenance keys.
 ///
-/// Scope is what this process admitted and nothing else: no namespace
-/// discovery, no listing. Automatic maintenance therefore covers the
-/// namespaces this process has touched and the ones a host has explicitly
-/// assigned to it — a set that starts empty at every start-up and grows
-/// only by being nudged. Nothing admitted is lost within one process
-/// lifetime; a namespace outside that set is outside the guarantee until
-/// something touches it or an operator assigns it.
+/// Reconciliation never discovers namespaces. It covers only namespaces
+/// touched by this process or explicitly assigned to it. The admitted set
+/// starts empty after each process restart and grows through nudges.
 async fn reconcile(inner: &Arc<RunnerInner>) {
     let batch = inner
         .lock_state()

--- a/crates/loonfs/src/maintenance_runner/admission.rs
+++ b/crates/loonfs/src/maintenance_runner/admission.rs
@@ -1,12 +1,8 @@
-//! Admission state: which `{job, namespace}` keys may run, which are
-//! running, where each one's job stopped, and when a parked key becomes
-//! eligible again.
+//! Synchronous scheduling state for maintenance jobs.
 //!
-//! Everything here is synchronous and guarded by the runner's one lock, so
-//! every scheduling decision — singleflight, coalescing, fairness, backoff,
-//! timed obligations, continuations, shutdown — can be reasoned about and
-//! tested without a runtime. The async half (permits held across a step,
-//! spawning, timers) lives in the parent module.
+//! The runner's lock protects admission, coalescing, fairness, backoff,
+//! deadlines, continuations, and shutdown. The parent module handles async
+//! execution, permits, and timers.
 
 use super::{MaintenanceClock, MaintenanceJobId, MaintenanceStepConclusion, MaintenanceStepResult};
 use crate::NamespaceId;
@@ -18,15 +14,11 @@ use std::sync::Arc;
 ///
 /// Small on purpose: one flaky call should come back quickly.
 const ERROR_BACKOFF_BASE_MS: u64 = 10;
-/// Ceiling the per-key error backoff window doubles up to.
+/// Maximum per-key error backoff window.
 ///
-/// A minute, because this backoff is fleet-wide: it governs every key this
-/// process has admitted. A cap sized for one namespace's indexer, where
-/// retrying every second costs nothing, turns a provider outage into every
-/// namespace retrying every second for as long as the outage lasts — a
-/// second outage stacked on the first. A minute is small enough that
-/// recovery is picked up within one reconciliation interval and large
-/// enough that a long outage costs a trickle.
+/// A one-minute cap prevents all admitted namespaces from retrying rapidly
+/// during a provider outage while still detecting recovery within one
+/// reconciliation interval.
 const ERROR_BACKOFF_CAP_MS: u64 = 60_000;
 
 /// One admitted unit of maintenance: a registered job, and the namespace it
@@ -49,11 +41,10 @@ impl MaintenanceKey {
     }
 }
 
-/// One claimed step, and everything running it needs.
+/// A claimed maintenance step and the scheduling data needed to run it.
 ///
-/// Taken under the lock that claimed it, so the runner never reads a
-/// dispatched step's state back out of the book — by the time it looked, the
-/// key could be queued again for its next run.
+/// This value is captured while holding the admission lock. The executor
+/// does not read the key's mutable scheduling state again.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MaintenanceDispatch {
     /// The key this permit is running.
@@ -107,8 +98,10 @@ impl ReadyRun {
         }
     }
 
-    /// Two requests for one key buy one run: the older ticket keeps its
-    /// place in line and its wait, and a gate on either still has to pass.
+    /// Coalesces two requests for the same key.
+    ///
+    /// The older ticket and queue time are preserved. The result also preserves
+    /// the later eligibility time, so a new request cannot bypass backoff.
     fn coalesced(self, other: Self) -> Self {
         Self {
             ticket: self.ticket.min(other.ticket),
@@ -138,15 +131,12 @@ enum KeyRunState {
     Running { rerun: Option<ReadyRun> },
 }
 
-/// The deadlines planted on one key.
+/// The earliest and latest outstanding deadlines for one key.
 ///
-/// Two times rather than one because the soonest is when to look and the
-/// latest is when the last thing asked for is definitely due, and a run
-/// consumes only the time it fired on. Every deadline in between is covered
-/// by the last: a pass that runs at the latest deadline reclaims everything
-/// whose own deadline has already passed, so re-arming on the latest loses
-/// nothing while keeping the state per key at two numbers instead of one per
-/// obligation.
+/// The earliest deadline determines the next wake. After it fires, the
+/// latest deadline is retained so later obligations are not lost. Intermediate
+/// deadlines need no separate storage because a run at the latest time covers
+/// all earlier obligations.
 #[derive(Debug, Clone, Copy)]
 struct TimedObligations {
     earliest_at_ms: u64,
@@ -168,8 +158,9 @@ impl TimedObligations {
         }
     }
 
-    /// What is still owed once the earliest deadline has fired at `now_ms`:
-    /// the latest, while it is still ahead, and nothing after that.
+    /// Re-arms the latest outstanding deadline after the earliest one fires.
+    ///
+    /// Returns `None` when all recorded deadlines have passed.
     fn re_armed(self, now_ms: u64) -> Option<Self> {
         (self.latest_at_ms > now_ms).then(|| Self::at(self.latest_at_ms))
     }
@@ -179,20 +170,17 @@ impl TimedObligations {
 #[derive(Debug, Default)]
 struct KeyState {
     run: KeyRunState,
-    /// Deadlines this key owes on its own, kept apart from `run` on purpose:
-    /// a key can be running right now because a publication nudged it and
-    /// still owe a lease deadline days out, so an unrelated run never
-    /// cancels an obligation.
+    /// Deadlines that remain active independently of the current run.
+    ///
+    /// A publication-triggered run must not cancel a later lease or grace-period
+    /// deadline.
     obligations: Option<TimedObligations>,
     /// Consecutive failed steps since the last conclusion, for the backoff.
     consecutive_failures: u32,
-    /// Where this key's job said its last step stopped, opaque here and
-    /// handed straight back to the next step.
+    /// Opaque continuation returned by the previous step.
     ///
-    /// It lives with the rest of the key's scheduling state so no job has
-    /// to keep a map of its own beside this one. Losing it costs a
-    /// restarted pass and nothing else: a step re-derives what it may do
-    /// from durable state whatever position it starts from.
+    /// Admission stores it and passes it to the next step. Losing it only
+    /// restarts the scan because each step revalidates durable state.
     continuation: Option<String>,
 }
 
@@ -393,12 +381,11 @@ impl Admission {
             .request_run(ticket, now_ms);
     }
 
-    /// Plants a timed obligation on the key: it becomes eligible on its own
-    /// once `at_ms` passes, even with nothing else asking for it.
+    /// Records a deadline that makes the key runnable at `at_ms`.
     ///
-    /// Merging keeps the soonest of the times asked for as the next wake,
-    /// and the latest as the point past which nothing is still owed. A time
-    /// already past is just a nudge.
+    /// Multiple deadlines retain the earliest next wake and the latest
+    /// outstanding obligation. A deadline that has already passed becomes an
+    /// immediate nudge.
     pub(crate) fn nudge_at(&mut self, key: MaintenanceKey, at_ms: u64, now_ms: u64) {
         if self.closed {
             return;
@@ -414,11 +401,10 @@ impl Admission {
         });
     }
 
-    /// Turns arrived obligations into ready keys, and re-arms a key whose
-    /// latest planted deadline is still ahead of the one that just fired.
+    /// Queues keys whose earliest deadline has arrived.
     ///
-    /// Reports how many keys arrived, which is what tells a timer wake a
-    /// deadline caused it from one an ordinary notify did.
+    /// If a key also has a later deadline, that deadline remains armed. Returns
+    /// the number of keys promoted.
     pub(crate) fn promote_due(&mut self, now_ms: u64) -> usize {
         if self.closed {
             return 0;
@@ -453,18 +439,13 @@ impl Admission {
         Some(dispatch)
     }
 
-    /// Ends one step and hands its permit to the next run, or releases the
-    /// permit when nothing is eligible.
+    /// Applies a step result and transfers its permit to the oldest eligible
+    /// queued run.
     ///
-    /// A request that arrived while the step ran is never lost and never
-    /// jumps the queue: it becomes an ordinary queued run with its own
-    /// ticket, and takes the permit only if it is the oldest eligible run
-    /// there is. Nothing else would bound it — a job that subscribes to
-    /// publications is renudged inside every step it runs, so a rerun that
-    /// kept the permit by finishing would let a couple of busy namespaces
-    /// hold every permit there is while a quiet key's collection never ran.
-    /// The outcome, the release, and the pick share one lock, so no request
-    /// is lost between freeing a permit and choosing its heir.
+    /// Requests received during the step keep their own tickets and do not jump
+    /// ahead. Applying the result and choosing the next run under one lock
+    /// prevents lost requests and keeps busy namespaces from monopolizing the
+    /// permit pool.
     pub(crate) fn finish(
         &mut self,
         key: &MaintenanceKey,
@@ -522,14 +503,10 @@ impl Admission {
         }
     }
 
-    /// The soonest wall-clock millisecond after `now_ms` at which a parked
-    /// key becomes eligible on its own, across obligations and backoffs.
+    /// Returns the next future deadline from obligations or backoff.
     ///
-    /// Deadlines already past are deliberately not reported: a key whose
-    /// backoff has expired is eligible now, and if it is not running it is
-    /// because the permit pool is full. Waking a timer for it would find
-    /// the pool still full and wake again immediately; the permit that
-    /// frees is what picks it up.
+    /// Expired deadlines are omitted because those keys are already eligible;
+    /// they will run when a permit becomes available.
     pub(crate) fn earliest_deadline_ms(&self, now_ms: u64) -> Option<u64> {
         self.keys
             .values()
@@ -683,13 +660,10 @@ impl Admission {
 
 /// How long a key waits after `consecutive_failures` failed steps.
 ///
-/// Full jitter over the exponential window: the delay is drawn uniformly
-/// from inside [`backoff_window_ms`] rather than being the window itself.
-/// Drawing is what keeps a provider outage from becoming a synchronized
-/// retry wave — keys that failed in the same millisecond come back spread
-/// across the window instead of together at the end of it — and it is the
-/// half of the policy that matters most at fleet scale, where the same
-/// error arrives for every admitted key at once.
+/// Draws a full-jitter delay from the exponential backoff window.
+///
+/// Randomizing each key's delay prevents a provider outage from producing a
+/// synchronized retry wave.
 fn backoff_delay_ms(consecutive_failures: u32, clock: &dyn MaintenanceClock) -> u64 {
     clock.jitter_below_ms(backoff_window_ms(consecutive_failures))
 }

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -1,14 +1,9 @@
-//! The two executors the runtime registers on every write-capable handle:
-//! metadata upkeep, and garbage collection.
+//! Runtime maintenance jobs for metadata upkeep and garbage collection.
 //!
-//! Both run the same operations an operator runs, through the same
-//! [`FsAdmin`] surface, rather than a private copy of them — and over the
-//! writer's own runtime, so their cache invalidations reach the writer's
-//! caches and publisher engines.
-//!
-//! Retention is deliberately not here. Advancing the floor surrenders
-//! replay history, which is a decision rather than upkeep, so it stays an
-//! explicit call with no scheduler behind it.
+//! Both jobs use the public [`FsAdmin`] operations on the writer's runtime,
+//! so they share the same behavior and cache invalidation paths as manual
+//! maintenance. Retention-floor advancement remains an explicit admin action
+//! because it discards replay history.
 
 use super::{
     BackgroundCompactions, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,
@@ -45,17 +40,11 @@ pub(crate) fn register_core_jobs(
     Ok(())
 }
 
-/// Earliest instant a garbage-collection pass could reclaim an upload
-/// session opened now.
+/// Returns the earliest safe time to run garbage collection for a newly
+/// durable upload session.
 ///
-/// Derived from what the collector actually waits for: a session opens with
-/// [`UPLOAD_SESSION_LEASE_MS`] of lease, an expired session is only aborted
-/// once the pass's grace window has passed on top of that, and
-/// [`GC_SAFETY_MARGIN_MS`] covers the skew between the clock reading here
-/// and the one the pass will read. Taken after the session is durable, so
-/// the schedule can only land after the collector's own predicate, never
-/// before it — a pass that arrives early finds the session retained and
-/// parks with nothing left to bring it back.
+/// The deadline includes the upload lease, the collector's grace window, and
+/// a clock-skew safety margin.
 pub(crate) fn upload_session_reclaim_at_ms(session_durable_at_ms: u64) -> u64 {
     session_durable_at_ms
         .saturating_add(UPLOAD_SESSION_LEASE_MS)
@@ -71,13 +60,11 @@ pub(crate) fn completed_upload_reclaim_at_ms(completion_observed_at_ms: u64) -> 
         .saturating_add(GC_SAFETY_MARGIN_MS)
 }
 
-/// What an executor needs from the writer that owns it.
+/// Writer-owned state needed by one maintenance step.
 ///
-/// The writer's state is held weakly and upgraded for the length of one
-/// step: a scheduled step is the writer's own work and publishes under its
-/// identity, so it holds that identity while it runs and schedules nothing
-/// once the writer is gone. Holding it strongly instead would make the
-/// runner and the writer keep each other alive forever.
+/// The writer is held weakly to avoid a reference cycle. Each step upgrades
+/// it for the duration of the operation and stops scheduling when the writer
+/// has been dropped.
 struct StepContext {
     core: ReadCore,
     bits: Weak<WriterBits>,
@@ -180,15 +167,11 @@ impl MaintenanceJob for MetadataJob {
     }
 }
 
-/// Runs one bounded mark-and-sweep pass, resuming the enumeration the last
-/// pass stopped at.
+/// Runs one bounded garbage-collection pass.
 ///
-/// The enumeration cursor is the runner's, not this job's: it arrives as
-/// the step's `continuation` and leaves as the result's. That keeps one
-/// place holding what a key is waiting for, and it costs nothing here
-/// because the cursor was never authority — a resumed pass rebuilds the
-/// live set exactly as a fresh one does, so a cursor lost with the process
-/// costs re-enumeration and can never authorize a deletion.
+/// The runner stores the enumeration cursor and passes it back as the next
+/// continuation. A resumed pass rebuilds its live set from durable state, so
+/// losing the cursor only restarts enumeration and cannot authorize deletion.
 struct GcJob {
     context: StepContext,
 }
@@ -228,13 +211,9 @@ impl MaintenanceJob for GcJob {
                 ));
             }
             Err(error) if continuation.is_some() && error.code() == ErrorCode::InvalidRequest => {
-                // This plan selects collection and nothing else, and fixes
-                // every field of it but the cursor, so the cursor it was
-                // resumed with is the one thing the step can be asked to
-                // reject. Concluding without one hands the runner an empty
-                // continuation and takes the key again, which restarts
-                // enumeration — always sound, because every pass rebuilds
-                // its own safety proof from durable state.
+                // The cursor is the only caller-supplied field in this GC plan. If it is
+                // rejected, clear the continuation and restart enumeration. Each pass
+                // rebuilds its safety checks from durable state.
                 tracing::info!(
                     namespace_id = %namespace_id,
                     error = %error,
@@ -277,12 +256,12 @@ fn metadata_has_nothing_to_maintain(error: &RuntimeError) -> bool {
     )
 }
 
-/// One upkeep pass's two outcomes, read as one conclusion.
+/// Combines WAL-flush and reorganization outcomes into one scheduling
+/// conclusion.
 ///
-/// Precedence runs progress, then races, then blocks: a step that flushed
-/// and then failed to fit a fold unit did move durable state and should run
-/// again; a step that only lost a race should take that race again; a step
-/// that only failed to fit has nothing to gain from an immediate retry.
+/// Progress takes precedence over a lost race, and a lost race takes
+/// precedence over a budget block. A step that changed durable state should
+/// run again even when its second operation was blocked.
 ///
 /// Starting a streaming compaction is progress of the useful kind: the step
 /// that started it did no folding, and the steps behind it now have the
@@ -341,39 +320,21 @@ fn gc_step_result(gc: GcResponse, submitted_cursor: Option<&str>) -> Maintenance
     MaintenanceStepResult {
         conclusion: gc_conclusion(&gc, submitted_cursor),
         continuation: gc.next_cursor,
-        // The pass itself is the source of truth for when it should be run
-        // again: it compared every retained candidate against its own
-        // clock, so it knows the soonest of those waits without being told.
-        // Handing it back here is what makes a pass self-scheduling —
-        // reclamation an upload path never planted a deadline for, and the
-        // deadlines a restart forgot, both come back through the next pass
-        // over the namespace rather than through a side channel.
+        // The pass reports the earliest future reclamation time it observed.
+        // Returning that deadline lets GC reschedule itself even when the original
+        // upload deadline was missed or lost during a restart.
         not_before_ms: gc.next_reclamation_at_ms,
     }
 }
 
-/// One collection pass, read as one conclusion.
+/// Converts one garbage-collection response into a scheduling conclusion.
 ///
-/// Progress is where the enumeration got to, never what the counters say. A
-/// pass that hands back a cursor past the one it was given walked keyspace
-/// and has more to walk, so it runs again. A pass that hands back the very
-/// cursor it started from decided nothing at all — its budget died in the
-/// marking or the content-reference scan, both of which every pass redoes
-/// before it may delete anything — and repeating it immediately would
-/// repeat that exact result forever, so it parks like any other
-/// zero-progress step and waits for something to change.
-///
-/// A pass that walked the whole keyspace is finished: idle when it freed
-/// nothing, eligible again when it did, because reclamation cascades — a
-/// deleted manifest can leave tables unreferenced. Ambiguous roots that
-/// suppressed deletion are the one clean-pass case with work provably left
-/// undone, so they park distinctly rather than reading as idle.
-///
-/// A pass with no cursor at all can still have run out: a namespace whose
-/// roots cost more than `max_objects` never gets as far as the keyspace,
-/// and says so outright. That parks too, and pointedly not as idle — idle
-/// clears the stored continuation, and this pass freed nothing and walked
-/// nowhere.
+/// A changed cursor means enumeration advanced and should continue. An
+/// unchanged cursor means the pass exhausted its budget before making
+/// progress and should park. A completed pass runs again only when it
+/// reclaimed something, because one deletion can expose more garbage.
+/// Budget exhaustion or degraded retention without progress is reported as
+/// blocked rather than idle.
 fn gc_conclusion(gc: &GcResponse, submitted_cursor: Option<&str>) -> MaintenanceStepConclusion {
     match gc.next_cursor.as_deref() {
         Some(next_cursor) if Some(next_cursor) == submitted_cursor => {
@@ -632,9 +593,8 @@ mod tests {
         );
     }
 
-    /// The cursor is the runner's now: it arrives as the step's
-    /// continuation and leaves as the result's, with no map on this job's
-    /// side of the seam.
+    /// The runner owns the cursor. The step receives it as its continuation
+    /// and returns it in the result without storing a job-local copy.
     #[test]
     fn a_collection_pass_hands_its_cursor_back_to_the_runner() {
         let mut walked = GcResponse::empty(namespace_id("demo"));

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1,63 +1,25 @@
-//! The runtime's publication service: every mutation publishes through
-//! here.
+//! Runtime publication service for namespace mutations.
 //!
-//! [`PublisherRegistry`] funnels every mutation for a namespace through one
-//! per-namespace publisher that:
+//! Each namespace has one publisher and one worker queue. The publisher:
 //!
-//! - coalesces concurrent requests into a single batched publication (one
-//!   WAL segment, one head compare-and-swap),
-//! - deduplicates resubmissions by commit id — a duplicate joins the
-//!   in-flight request, while reusing a commit id for semantically
-//!   different contents is rejected,
-//! - sequences namespace deletion as a barrier: work admitted before the
-//!   delete publishes first, work admitted after it fails once the delete
-//!   succeeds,
-//! - retries stale-head and unknown-outcome compare-and-swap results with
-//!   the same commit ids, so durable receipts replay instead of surfacing
-//!   ambiguity, and
-//! - paces successive head compare-and-swap attempts per namespace.
+//! - batches concurrent commits into one WAL segment and one head CAS,
+//! - joins duplicate in-flight commit IDs and rejects conflicting reuse,
+//! - orders namespace deletion after earlier work and before later work,
+//! - retries stale or unknown CAS outcomes with the same commit IDs, and
+//! - enforces the configured minimum interval between head CAS attempts.
 //!
-//! A publisher owns its namespace's commit engine and writer session for its
-//! whole life, so it is the single writer of head-advancing state: batches
-//! and the delete barrier run through one engine, under one session epoch,
-//! on one worker task draining one queue.
+//! A publisher keeps one commit engine and writer session for its lifetime.
+//! The writer session is small and cannot be reconstructed after fencing.
+//! The WAL-tail projection is rebuildable, so the registry evicts projections
+//! when the shared cache budget is exceeded.
 //!
-//! That life is the namespace's, not a cache entry's, so what a publisher
-//! may hold is bounded rather than dropped: the session's epoch and fencing
-//! are a few dozen bytes nothing can rebuild, while the engine's WAL-tail
-//! projection is large and rebuildable from the store. The registry
-//! therefore keeps every publisher and bounds the projections across them,
-//! against the same budget the read-side projection cache spends
-//! (`max_cached_namespaces` and the two WAL-tail knobs beside it).
+//! The first request for an idle namespace publishes immediately. Requests
+//! that arrive during a publish or its pacing interval join the next batch.
+//! Cancelling a caller does not cancel admitted work.
 //!
-//! Every writer owns one registry, and the direct
-//! [`FsWriter`](crate::FsWriter) mutation methods, the reference server,
-//! and any embedded host with many in-process writer agents all submit
-//! through it — one publication implementation, one batching policy, one
-//! delete barrier. [`FsWriter::publisher`](crate::FsWriter::publisher)
-//! exposes the writer's registry for hosts that want to submit
-//! already-classified candidates directly.
-//!
-//! Batching is adaptive, driven by one knob (the runtime's
-//! `min_publish_interval_ms`): a submission to a cold namespace publishes
-//! immediately, and while a publish is in flight or the namespace is
-//! within the pacing interval of its last publication start, later
-//! submissions coalesce into the next batch. A solo writer submitting
-//! sequentially therefore pays no added latency, while sustained
-//! concurrent load amortizes into batches at most one publication per
-//! interval — larger batches and fewer WAL segments instead of head
-//! compare-and-swap thrash. The trade sits on a cold burst: its first
-//! submission publishes alone and the rest coalesce into the next paced
-//! batch, so one extra segment buys the immediate first flush.
-//!
-//! Admitted work is owned by the publisher's worker task, never by the
-//! caller futures awaiting results: a cancelled caller abandons only its
-//! result delivery, and the publication still lands. At shutdown,
-//! [`PublisherRegistry::close_admission`] refuses new submissions with
-//! `shutting_down` and [`PublisherRegistry::drain`] settles everything
-//! already admitted. Hosts do not sequence those themselves:
-//! [`FsWriter::shutdown`](crate::FsWriter::shutdown) owns the order they
-//! run in relative to the maintenance runner's own close and drain.
+//! Shutdown first closes admission and then drains admitted work. Use
+//! [`FsWriter::shutdown`](crate::FsWriter::shutdown), which also coordinates
+//! shutdown with the maintenance runner.
 
 use crate::fs::{ReadCore, WriterBits};
 use crate::publish::{CommitCandidate, CommitRequest, PreparedContent};
@@ -97,18 +59,14 @@ pub type PublishObserver = Arc<dyn Fn(&NamespaceId, loonfs_api::ChangeSeq) + Sen
 /// `commit_queue_full`.
 const MAX_BATCH_CANDIDATES: usize = 1024;
 
-/// Shared front door to the per-namespace publishers of one writer.
+/// Registry of per-namespace publishers owned by one writer.
 ///
-/// Cloning is cheap; clones share the same per-namespace publishers, so
-/// every writer in the process should submit through clones of one
-/// registry — [`FsWriter::publisher`](crate::FsWriter::publisher) hands
-/// out exactly that.
+/// Clones share the same publishers and worker tasks. Submit through the
+/// registry returned by [`FsWriter::publisher`](crate::FsWriter::publisher).
 ///
-/// The registry owns the worker tasks its publishers spawn, and settling
-/// them is two steps: [`Self::close_admission`], then [`Self::drain`]. A
-/// host does not run them itself —
-/// [`FsWriter::shutdown`](crate::FsWriter::shutdown) does, in the order
-/// that is correct relative to the maintenance runner.
+/// Shutdown closes admission and then drains admitted work. Prefer
+/// [`FsWriter::shutdown`](crate::FsWriter::shutdown), which also coordinates
+/// the maintenance runner.
 #[derive(Clone)]
 pub struct PublisherRegistry {
     shared: Arc<RegistryShared>,
@@ -126,8 +84,8 @@ pub struct PublisherRegistry {
     trace_store_kind: &'static str,
 }
 
-/// Registry state every publisher reaches back into: admission gating, the
-/// publisher map, and the panic tally a shutdown reports.
+/// State shared by all publishers in this registry: admission status,
+/// publisher instances, retained projections, and contained panic count.
 struct RegistryShared {
     state: Mutex<RegistryState>,
     /// Publications and deletes whose panic a worker survived. Workers
@@ -143,10 +101,9 @@ struct RegistryState {
 }
 
 impl RegistryShared {
-    // Recover a poisoned lock instead of `expect`: every critical section
-    // over this state is a plain field update, and turning one panicked
-    // publication into a permanently unusable registry is exactly the
-    // failure the workers' panic containment exists to prevent.
+    // Recover the inner state after poisoning. These critical sections only
+    // update fields, and worker panic containment is intended to keep the
+    // registry usable after a publication panics.
     fn lock_state(&self) -> std::sync::MutexGuard<'_, RegistryState> {
         self.state
             .lock()
@@ -160,16 +117,13 @@ impl RegistryShared {
         state.projections.totals()
     }
 
-    /// Records what one namespace's publish left retained, then brings the
-    /// writer back under the shared projection budget.
+    /// Records the namespace's retained projection and evicts projections until
+    /// the writer is within its shared budget.
     ///
-    /// Victims are chosen least-recently-published first and lose their tail
-    /// projection only: never the publisher, never its engine identity,
-    /// never the writer session beside it. A victim whose engine is held —
-    /// a publication or delete is in flight — is skipped and stays
-    /// accounted, because that unit rebuilds and reports its own weight when
-    /// it finishes. Skipping therefore costs one sweep, not accounting
-    /// truth.
+    /// Eviction removes only rebuildable WAL-tail projections, starting with the
+    /// least recently published namespace. If a publication or delete currently
+    /// holds an engine, that namespace is skipped and remains counted. The active
+    /// operation reports its projection weight when it finishes.
     fn settle_projection(
         &self,
         namespace_id: &NamespaceId,
@@ -188,8 +142,9 @@ impl RegistryShared {
                 })
                 .collect::<Vec<_>>()
         };
-        // Swept outside the registry lock: locks nest publisher-then-
-        // registry on the eviction path, never the other way around.
+        // Invalidate projections without holding the registry lock.
+        // Publication may acquire the engine lock before the registry lock,
+        // so eviction must not acquire them in the opposite order.
         let dropped = victims
             .into_iter()
             .filter(|(_, publisher)| {
@@ -301,10 +256,11 @@ impl RetainedProjections {
             .saturating_sub(entry.weight.decoded_bytes);
     }
 
-    /// The namespaces to drop, least-recently-published first, until what
-    /// remains fits the budget — the same three knobs, read the same way, as
-    /// the read-side projection cache. Selection changes nothing: only an
-    /// eviction that actually took the engine does.
+    /// Selects least-recently-published projections until the remaining totals
+    /// fit the same three limits used by the read-side projection cache.
+    ///
+    /// Selection does not change accounting. Totals are updated only after a
+    /// selected projection is actually invalidated.
     fn over_budget_victims(&self, budget: &RuntimeCacheConfig) -> Vec<RetainedProjection> {
         let mut projections = self.entries.len();
         let mut rows = self.rows;
@@ -408,12 +364,12 @@ impl PublisherRegistry {
         publisher.submit(candidate).await
     }
 
-    /// Drops the rebuildable half of the namespace's publish state (its WAL
-    /// tail projection). The session's epoch and fencing are untouched:
-    /// they are facts about this process, not a cache.
+    /// Invalidates the namespace's rebuildable WAL-tail projection without
+    /// changing its writer epoch or fencing state.
     ///
-    /// A held engine means a publication or delete is in flight; that unit
-    /// revalidates against the live head itself, so skipping it is safe.
+    /// If an operation currently holds the engine, invalidation is skipped. That
+    /// operation validates the live head and reports its retained projection when
+    /// it completes.
     pub(crate) fn invalidate_projection(&self, namespace_id: &NamespaceId) {
         let publisher = self
             .shared
@@ -462,28 +418,29 @@ impl PublisherRegistry {
         self.shared.lock_state().closed
     }
 
-    /// Closes the front door: every later submission fails with
-    /// `shutting_down`, while already-admitted work keeps publishing.
-    /// Idempotent.
+    /// Stops accepting new submissions while allowing admitted work to finish.
+    ///
+    /// Later submissions fail with `shutting_down`. Calling this more than once
+    /// has no additional effect.
     pub fn close_admission(&self) {
         let publishers: Vec<NamespacePublisher> = {
             let mut state = self.shared.lock_state();
             state.closed = true;
             state.publishers.values().cloned().collect()
         };
-        // Swept outside the registry lock: locks nest publisher-then-
-        // registry on the eviction path, never the other way around.
+        // Close each publisher without holding the registry lock. Publisher
+        // operations may acquire their own state before the registry, so
+        // shutdown must not acquire those locks in the opposite order.
         for publisher in publishers {
             publisher.close_admission();
         }
     }
 
-    /// Waits for every publisher's worker to settle the work it owns,
-    /// surfacing publications whose panic the worker contained.
+    /// Waits for all current publisher workers to finish.
     ///
-    /// Call [`Self::close_admission`] first for a terminal drain; without
-    /// it this settles only the work admitted so far, and new submissions
-    /// keep scheduling more.
+    /// Returns an error if any publication or deletion panicked and the worker
+    /// contained the panic. Call [`Self::close_admission`] first to prevent new
+    /// work from being admitted during the drain.
     pub async fn drain(&self) -> Result<(), RuntimeError> {
         let publishers: Vec<NamespacePublisher> = self
             .shared
@@ -527,18 +484,12 @@ struct NamespacePublisher {
     trace_store_kind: &'static str,
 }
 
-/// The publisher's commit engine and writer session for its namespace.
+/// Commit engine and writer session retained by one namespace publisher.
 ///
-/// A writer session's acquired epoch and terminal fencing record are facts
-/// about this process, not cached views of durable state: nothing in the
-/// store can rebuild "this session was fenced". When they lived inside the
-/// LRU control cache, eviction erased them (and cache-disabled runs never
-/// kept them at all), so a fenced writer could silently bump the epoch back
-/// and fence the legitimate writer instead. They live here instead, with the
-/// publisher that owns every head-advancing write for the namespace: a few
-/// dozen bytes per namespace this process has published to, released only
-/// with the publisher itself, once the namespace is deleted and its id can
-/// never rebind.
+/// The session stores the acquired epoch and terminal fencing state. Those
+/// values describe this process and cannot be reconstructed from object
+/// storage. They therefore live for the publisher's lifetime rather than in
+/// an evictable cache. Only the engine's WAL-tail projection is invalidated.
 struct EngineSlot {
     /// Built on the first unit of work and kept for the publisher's life.
     /// Invalidation drops only its rebuildable tail projection.
@@ -547,12 +498,10 @@ struct EngineSlot {
     session: SharedWriterSessionState,
 }
 
-/// Whether the publisher still admits work, and if not, what it owes the
-/// caller.
+/// Admission state for a namespace publisher.
 ///
-/// One state rather than two flags, so the precedence holds by construction:
-/// a namespace whose delete landed is gone, not shutting down, and closing
-/// admission afterwards cannot demote it.
+/// A single enum preserves precedence: after deletion succeeds, the
+/// publisher remains `Deleted` even if registry shutdown closes admission.
 enum PublisherAdmissionState {
     Open,
     /// Set by the registry's admission close. Later admissions fail with
@@ -667,8 +616,7 @@ impl NamespacePublisher {
         }
     }
 
-    /// What an admission owes its caller right now, or `Ok(())` while the
-    /// publisher is open.
+    /// Returns the error for the current admission state, or succeeds when open.
     fn check_admission(&self, state: &NamespacePublisherState) -> Result<(), CoreError> {
         match state.admission {
             PublisherAdmissionState::Open => Ok(()),
@@ -690,16 +638,13 @@ impl NamespacePublisher {
         true
     }
 
-    /// Records what a publish left retained and sweeps the writer back under
-    /// the shared projection budget.
+    /// Records the projection retained by the completed publish and enforces the
+    /// writer's shared projection budget.
     ///
-    /// Called while the publish still holds its engine, so the weight
-    /// recorded is the projection the engine actually kept: no concurrent
-    /// sweep can drop it in between and leave the ledger claiming one that
-    /// is gone. Taking the registry lock under a held engine is the one
-    /// place the nesting runs that way and it still cannot cycle, because a
-    /// sweep releases the registry lock before it reaches for an engine and
-    /// never waits for one.
+    /// The caller still holds the engine lock, so the recorded weight matches the
+    /// projection in the engine. This path may acquire the registry lock while
+    /// holding the engine lock. Eviction avoids deadlock by releasing the
+    /// registry lock before attempting to lock any engine.
     fn settle_retained_projection(&self, weight: Option<PublishTailWeight>) {
         let Some(shared) = self.shared.upgrade() else {
             return;
@@ -715,10 +660,11 @@ impl NamespacePublisher {
             .publisher_retained_projections(totals.projections, totals.decoded_bytes);
     }
 
-    /// The path to `admit` is await-free: a submission future's first poll
-    /// either admits the candidate or fails, and only then parks on the
-    /// result channel. Cancellation tests rely on this — after one poll of
-    /// a submission, the publication is admitted and owned by the worker.
+    /// Admits the request before awaiting its result.
+    ///
+    /// The first poll either admits the candidate or returns an error. After
+    /// admission, cancelling the caller only drops result delivery; the worker
+    /// still owns and publishes the request.
     async fn submit(&self, candidate: CommitCandidate) -> CommitResult {
         let commit_id = candidate.commit_id().clone();
         let enqueued_at = Instant::now();
@@ -852,10 +798,9 @@ impl NamespacePublisher {
         loop {
             let collect_started = Instant::now();
             let queue_depth_start = queued_candidates(&self.lock_state());
-            // There is no fixed coalescing wait — batches form from what
-            // arrives while a publication is in flight or while the pacing
-            // interval since the last publication start runs out, so a cold
-            // namespace publishes its first submission immediately.
+            // Do not add a separate batching delay. The first request for an idle
+            // namespace publishes immediately; requests arriving during a publish or
+            // pacing interval form the next batch.
             self.await_cas_slot(false).await;
             let Some(item) = self.take_next_item() else {
                 return;
@@ -910,16 +855,13 @@ impl NamespacePublisher {
         item
     }
 
-    /// Publishes one taken batch, containing a panic in the publication.
+    /// Publishes one batch while containing panics from the publication.
     ///
-    /// Deliberate v0 scope, not defensive habit. This publisher is the only
-    /// path by which its namespace accepts writes, so a panic that killed
-    /// the worker would leave that namespace unwritable until the process
-    /// restarts, with every taken waiter hanging. The taken requests instead
-    /// settle as `commit_outcome_unknown` — the panic may have struck either
-    /// side of the head compare-and-swap, and that is an answer callers
-    /// already know how to resolve: retry with the same commit id and the
-    /// durable receipt replays. The worker keeps its queue and moves on.
+    /// This worker is the namespace's only publication path. If publication
+    /// panics, each request in the batch receives `commit_outcome_unknown`
+    /// because the panic may have occurred before or after the head CAS. Callers
+    /// can retry with the same commit ID and use the durable receipt to resolve
+    /// the outcome. The worker then continues with queued work.
     async fn publish_batch(&self, candidates: Vec<BatchCandidate>) {
         let taken_commit_ids = candidates
             .iter()
@@ -1030,9 +972,10 @@ impl NamespacePublisher {
             .collect()
     }
 
-    /// The publisher's engine, built on first use. The namespace's
-    /// immutable identity travels in the head every publish already loads,
-    /// so the engine needs nothing seeded but its caches and session.
+    /// Returns the publisher's lazily created commit engine.
+    ///
+    /// Each publish loads the namespace identity from the head, so construction
+    /// only needs the shared table cache and writer session.
     fn engine_for<'slot>(&self, slot: &'slot mut EngineSlot) -> &'slot mut NamespaceCommitEngine {
         slot.engine.get_or_insert_with(|| {
             NamespaceCommitEngine::new(self.namespace_id.clone())
@@ -1051,9 +994,8 @@ impl NamespacePublisher {
         {
             Ok(outcome) => outcome,
             Err(_) => {
-                // Contained like a panicked publication, but a delete has no
-                // receipt to replay: the caller is told, and the worker keeps
-                // serving the namespace the delete did not remove.
+                // Contain deletion panics so the worker can continue. Deletion has no commit
+                // receipt for reconciliation, so report an internal error to its callers.
                 self.record_panic();
                 Err(CoreError::Internal(
                     "delete task aborted mid-delete".to_owned(),
@@ -1144,13 +1086,11 @@ impl NamespacePublisher {
         }
     }
 
-    /// Sleeps until this namespace's next head compare-and-swap is allowed.
+    /// Waits until the namespace may start another head CAS.
     ///
-    /// `claim` decides what happens on arrival: a claiming waiter also
-    /// reserves the slot by pushing the next allowed instant out by one
-    /// pacing interval, so two waiters cannot both take the same slot. A
-    /// non-claiming waiter only observes that the slot is open — the caller
-    /// reserves it later, when it actually takes a work item.
+    /// When `claim` is true, this method also reserves the next slot by advancing
+    /// the deadline one pacing interval. When false, it only waits; the caller
+    /// reserves the slot when it removes work from the queue.
     async fn await_cas_slot(&self, claim: bool) {
         loop {
             let sleep_until = self.lock_state().next_allowed_cas_at;
@@ -1264,10 +1204,11 @@ fn take_queued_waiters(state: &mut NamespacePublisherState) -> QueuedWaiters {
     waiters
 }
 
-/// Retrying with the same commit ids is safe: candidates that actually
-/// committed replay their durable receipts. So an unknown head outcome is
-/// retried like a stale head, resolving it into a definite answer instead of
-/// handing `commit_outcome_unknown` to every waiter.
+/// Returns whether publication should retry the batch.
+///
+/// Retrying with the same commit IDs is safe because committed candidates
+/// replay their durable receipts. Both stale-head and unknown-outcome errors
+/// are retried to obtain a definite result.
 fn is_retryable_head_publish(result: &CommitResult) -> bool {
     matches!(
         result,

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -1540,7 +1540,7 @@ async fn registry_close_admission_refuses_new_work_while_admitted_work_drains() 
     };
     store.wait_until_blocked().await;
 
-    // ...then admission closes. New work is refused at the front door.
+    // Admission then closes, and new work is refused.
     registry.close_admission();
     let refused = registry
         .submit_commit(


### PR DESCRIPTION
Rewrites dense comments across the workspace so behavior and invariants are easier to understand without changing code. Validated with formatting, workspace checks, documentation generation, and the full test suite.