### PR TITLE
feat(cli): select namespaces per process and serialize config writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "bytes",
  "clap",
  "dialoguer",
+ "fs4",
  "futures",
  "hostname",
  "http",

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 bytes.workspace = true
 clap.workspace = true
 futures.workspace = true
+fs4.workspace = true
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 hostname = "0.4"
 http.workspace = true

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -48,6 +48,8 @@ Selectors
   Commands that address one namespace also accept:
     --namespace <name>
       Namespace to run against, defaulting to the profile's default
+    LOONFS_NAMESPACE=<name>
+      Environment default; --namespace wins, and the profile default follows
 
   Commands that commit (put, mkdir, rm, mv, cp, restore, undelete) accept:
     -m, --message <message>
@@ -80,6 +82,8 @@ Config file location
     3. $XDG_CONFIG_HOME/loonfs/config.toml, when XDG_CONFIG_HOME names an
        absolute directory
     4. ~/.loonfs/config.toml
+  Namespace selection uses --namespace, then LOONFS_NAMESPACE=<name>, then
+  the profile default.
 
   A path given to --config or LOONFS_CONFIG is the file this invocation
   uses whether or not it is there yet, and `loonfs init` creates the

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -39,6 +39,8 @@ pub(crate) enum Command {
         command: NamespaceCommand,
     },
     /// Set the default namespace for a profile.
+    /// This sets the interactive default; concurrent automation should pass
+    /// `--namespace` or set `LOONFS_NAMESPACE`.
     Use(NamespaceUseArgs),
     /// Show the active profile and its default namespace.
     Current(CurrentArgs),
@@ -306,6 +308,8 @@ pub(crate) struct ProfileSelectorArgs {
 pub(crate) struct TargetSelectorArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
+    /// Namespace to run against. Precedence is `--namespace`,
+    /// `LOONFS_NAMESPACE`, then the profile default.
     #[arg(long)]
     pub namespace: Option<String>,
 }

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -6,7 +6,7 @@ use crate::args::{
     CommandKind, CurrentArgs, NamespaceCommand, NamespaceCreateArgs, NamespaceDeleteArgs,
     NamespaceForkArgs, NamespaceUseArgs, RuntimeBehavior,
 };
-use crate::config::save_config;
+use crate::config::mutate_config;
 use crate::error::CliError;
 use crate::profiles::{default_namespace, set_default_namespace};
 use crate::prompt::prompt_line;
@@ -158,7 +158,7 @@ pub(crate) async fn run_namespace_use(
     args: NamespaceUseArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let mut loaded = load_cli_config(config_path)
+    let loaded = load_cli_config(config_path)
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let resolved =
         resolve_target_profile_from_config(&loaded.config, explicit_profile, args.profile.no_retry)
@@ -174,10 +174,10 @@ pub(crate) async fn run_namespace_use(
         .await
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
-    set_default_namespace(&mut loaded.config, &resolved.profile_name, &args.namespace)
-        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
-    save_config(&loaded.path, &loaded.config)
-        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+    mutate_config(&loaded.path, |config| {
+        set_default_namespace(config, &resolved.profile_name, &args.namespace)
+    })
+    .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     Ok(CommandOutput {
         kind,

--- a/crates/loonfs-cli/src/commands/profile.rs
+++ b/crates/loonfs-cli/src/commands/profile.rs
@@ -10,8 +10,8 @@ use crate::args::{
     CommandKind, ProfileCommand, ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavior,
 };
 use crate::config::{
-    load_config, load_config_for_repair, load_config_if_exists, load_or_default_config,
-    save_config, save_config_table, ConfigLoad, ProfileConfig,
+    load_config, load_config_for_repair, load_config_if_exists, mutate_config, save_config,
+    save_config_table, ConfigLoad, ProfileConfig,
 };
 use crate::error::CliError;
 use crate::profiles::{
@@ -75,10 +75,7 @@ fn run_profile_create(
             &AmbientCredentials::from_env(),
             runtime,
         )?;
-        let mut config = load_or_default_config(config_path)?;
-        let (profile_name, redacted) = add_profile(&mut config, &name, profile)?;
-        save_config(config_path, &config)?;
-        Ok((profile_name, redacted))
+        mutate_config(config_path, |config| add_profile(config, &name, profile))
     })()
     .map_err(|error| fail(kind, Some(name.clone()), None, error))?;
 
@@ -98,8 +95,12 @@ fn run_profile_update(
 ) -> Result<CommandOutput, CommandFailure> {
     let name = args.name.clone();
     let result = (|| -> Result<(String, ProfileConfig), CliError> {
-        let mut config = load_config(config_path)?;
-        let existing = config
+        // The update is gathered before the lock: the interactive editor can
+        // sit at a prompt for minutes, and holding the config lock across it
+        // would block every other writer. `update_profile` re-checks the
+        // profile against the fresh config under the lock, so a profile
+        // deleted meanwhile still fails cleanly.
+        let existing = load_config(config_path)?
             .profiles
             .get(&name)
             .ok_or_else(|| CliError::profile_not_found(&name))?
@@ -115,9 +116,7 @@ fn run_profile_update(
             ));
         };
 
-        let (profile_name, redacted) = update_profile(&mut config, &name, updated)?;
-        save_config(config_path, &config)?;
-        Ok((profile_name, redacted))
+        mutate_config(config_path, |config| update_profile(config, &name, updated))
     })()
     .map_err(|error| fail(kind, Some(name.clone()), None, error))?;
 

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -6,7 +6,7 @@ use loonfs_client::ClientConfig;
 use loonfs_objectstore::{SecretString, StoreConfigError};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -453,6 +453,7 @@ pub(crate) fn load_or_default_config(path: &Path) -> Result<CliConfig, CliError>
 }
 
 pub(crate) fn save_config(path: &Path, config: &CliConfig) -> Result<(), CliError> {
+    let _lock = lock_config(path)?;
     config.validate()?;
     let contents = toml::to_string_pretty(config)
         .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
@@ -463,12 +464,34 @@ pub(crate) fn save_config(path: &Path, config: &CliConfig) -> Result<(), CliErro
 /// commands when the file no longer strict-decodes: round-tripping through
 /// [`CliConfig`] would drop the content the user still needs to fix.
 pub(crate) fn save_config_table(path: &Path, table: &toml::Table) -> Result<(), CliError> {
+    let _lock = lock_config(path)?;
     let contents = toml::to_string_pretty(table)
         .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
     persist_config_contents(path, &contents)
 }
 
-fn persist_config_contents(path: &Path, contents: &str) -> Result<(), CliError> {
+/// Applies one edit to the latest config under the exclusive lock, so
+/// concurrent writers cannot lose each other's updates. The closure's value
+/// comes back to the caller once the file is durably replaced.
+pub(crate) fn mutate_config<T>(
+    path: &Path,
+    mutate: impl FnOnce(&mut CliConfig) -> Result<T, CliError>,
+) -> Result<T, CliError> {
+    let _lock = lock_config(path)?;
+    let mut config = load_or_default_config(path)?;
+    let value = mutate(&mut config)?;
+    config.validate()?;
+    let contents = toml::to_string_pretty(&config)
+        .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
+    persist_config_contents(path, &contents)?;
+    Ok(value)
+}
+
+struct ConfigLock {
+    _file: File,
+}
+
+fn lock_config(path: &Path) -> Result<ConfigLock, CliError> {
     let parent = path.parent().ok_or_else(|| {
         CliError::invalid_config(format!(
             "config path has no parent directory: {}",
@@ -478,14 +501,62 @@ fn persist_config_contents(path: &Path, contents: &str) -> Result<(), CliError> 
     fs::create_dir_all(parent).map_err(|err| {
         CliError::invalid_config(format!("failed to create config directory: {err}"))
     })?;
-    let tmp_path = path.with_extension("tmp");
-    write_owner_only(&tmp_path, contents.as_bytes())?;
-    fs::rename(&tmp_path, path).map_err(|err| {
+    let lock_path = path.with_extension("lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|err| {
+            CliError::invalid_config(format!(
+                "failed to open the lock file `{}`: {err}",
+                lock_path.display()
+            ))
+        })?;
+    fs4::fs_std::FileExt::lock_exclusive(&file).map_err(|err| {
+        CliError::invalid_config(format!("failed to lock `{}`: {err}", lock_path.display()))
+    })?;
+    Ok(ConfigLock { _file: file })
+}
+
+fn persist_config_contents(path: &Path, contents: &str) -> Result<(), CliError> {
+    let parent = path.parent().ok_or_else(|| {
         CliError::invalid_config(format!(
-            "failed to persist config {}: {err}",
+            "config path has no parent directory: {}",
             path.display()
         ))
     })?;
+    let mut temp_file = tempfile::Builder::new()
+        .prefix(".loonfs-config-")
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .map_err(|err| {
+            CliError::invalid_config(format!(
+                "failed to create temporary config file in {}: {err}",
+                parent.display()
+            ))
+        })?;
+    temp_file
+        .write_all(contents.as_bytes())
+        .map_err(|err| CliError::invalid_config(format!("failed to write config: {err}")))?;
+    temp_file
+        .flush()
+        .map_err(|err| CliError::invalid_config(format!("failed to flush config: {err}")))?;
+    temp_file
+        .as_file()
+        .sync_all()
+        .map_err(|err| CliError::invalid_config(format!("failed to sync config: {err}")))?;
+    temp_file.persist(path).map_err(|err| {
+        CliError::invalid_config(format!(
+            "failed to persist config {}: {}",
+            path.display(),
+            err.error
+        ))
+    })?;
+    if let Ok(directory) = File::open(parent) {
+        let _ = directory.sync_all();
+    }
     Ok(())
 }
 
@@ -525,43 +596,6 @@ fn redacted_config_value(key: Option<&str>, value: &toml::Value) -> toml::Value 
     }
 }
 
-fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<(), CliError> {
-    #[cfg(unix)]
-    let mut file = {
-        use std::os::unix::fs::OpenOptionsExt;
-        OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .mode(0o600)
-            .open(path)
-            .map_err(|err| {
-                CliError::invalid_config(format!(
-                    "failed to create config file {}: {err}",
-                    path.display()
-                ))
-            })?
-    };
-    #[cfg(not(unix))]
-    let mut file = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(path)
-        .map_err(|err| {
-            CliError::invalid_config(format!(
-                "failed to create config file {}: {err}",
-                path.display()
-            ))
-        })?;
-
-    file.write_all(bytes)
-        .map_err(|err| CliError::invalid_config(format!("failed to write config: {err}")))?;
-    file.sync_all()
-        .map_err(|err| CliError::invalid_config(format!("failed to flush config: {err}")))?;
-    Ok(())
-}
-
 fn require_non_empty(field: &str, value: &str) -> Result<(), CliError> {
     if value.trim().is_empty() {
         return Err(CliError::invalid_config(format!("missing `{field}`")));
@@ -593,7 +627,7 @@ mod tests {
     #![allow(clippy::panic)]
     // Config tests use panic in unexpected match arms for precise diagnostics.
 
-    use super::CliConfig;
+    use super::{CliConfig, ProfileConfig};
 
     fn parse(contents: &str) -> Result<CliConfig, toml::de::Error> {
         toml::from_str(contents)
@@ -835,6 +869,99 @@ secret_access_key = "secret"
                 "{}",
                 error.message
             );
+        }
+    }
+
+    #[test]
+    fn concurrent_mutations_preserve_every_profile_and_remove_temp_files() {
+        const THREADS: usize = 16;
+        const MUTATIONS_PER_THREAD: usize = 8;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        let barrier = std::sync::Barrier::new(THREADS);
+
+        std::thread::scope(|scope| {
+            let mut handles = Vec::with_capacity(THREADS);
+            for thread_index in 0..THREADS {
+                let barrier = &barrier;
+                let path = &path;
+                handles.push(scope.spawn(move || {
+                    let profile_name = format!("agent-{thread_index}");
+                    barrier.wait();
+                    for mutation_index in 0..MUTATIONS_PER_THREAD {
+                        let namespace = format!("namespace-{thread_index}-{mutation_index}");
+                        super::mutate_config(path, |config| {
+                            config.profiles.insert(
+                                profile_name.clone(),
+                                ProfileConfig::Remote {
+                                    server_url: format!(
+                                        "https://agent-{thread_index}-{mutation_index}.example.com"
+                                    ),
+                                    default_namespace: Some(namespace),
+                                    auth_token: None,
+                                    ca_cert_path: None,
+                                },
+                            );
+                            Ok(())
+                        })
+                        .expect("mutate config");
+                    }
+                }));
+            }
+            for handle in handles {
+                handle.join().expect("mutation thread");
+            }
+        });
+
+        let contents = std::fs::read_to_string(&path).expect("read final config");
+        let config: CliConfig = toml::from_str(&contents).expect("parse final config");
+        config.validate().expect("validate final config");
+        for thread_index in 0..THREADS {
+            let profile_name = format!("agent-{thread_index}");
+            let expected_namespace =
+                format!("namespace-{thread_index}-{}", MUTATIONS_PER_THREAD - 1);
+            let Some(ProfileConfig::Remote {
+                default_namespace, ..
+            }) = config.profiles.get(&profile_name)
+            else {
+                panic!("missing remote profile {profile_name}");
+            };
+            assert_eq!(
+                default_namespace.as_deref(),
+                Some(expected_namespace.as_str())
+            );
+        }
+
+        let temp_files: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read config directory")
+            .map(|entry| entry.expect("read directory entry").path())
+            .filter(|path| path.extension().is_some_and(|extension| extension == "tmp"))
+            .collect();
+        assert!(
+            temp_files.is_empty(),
+            "temporary files remain: {temp_files:?}"
+        );
+    }
+
+    #[test]
+    fn mutate_config_creates_an_owner_only_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("config.toml");
+
+        super::mutate_config(&path, |_| Ok(())).expect("create config");
+
+        assert!(path.is_file());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mode = std::fs::metadata(&path)
+                .expect("config metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600);
         }
     }
 

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -93,7 +93,7 @@ impl CliError {
         Self::new(
             "no_default_namespace",
             format!(
-                "no default namespace is set for profile `{profile}`; use `loonfs use <namespace>` or `--namespace`"
+                "no default namespace is set for profile `{profile}`; use `--namespace`, `LOONFS_NAMESPACE`, or `loonfs use <namespace>`"
             ),
         )
     }

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -65,6 +65,13 @@ pub(crate) fn resolve_namespace(
             namespace: parse_namespace_id(namespace)?,
         });
     }
+    if let Ok(namespace) = std::env::var("LOONFS_NAMESPACE") {
+        if !namespace.trim().is_empty() {
+            return Ok(ResolvedNamespace {
+                namespace: parse_namespace_id(&namespace)?,
+            });
+        }
+    }
     let (profile_name, profile) = resolve_profile(config, explicit_profile)?;
     let namespace =
         default_namespace(profile).ok_or_else(|| CliError::no_default_namespace(profile_name))?;

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -3157,6 +3157,69 @@ fn filesystem_requires_default_namespace_when_omitted() {
 }
 
 #[test]
+fn namespace_resolution_uses_environment_before_profile_default() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "profile-default"]));
+    assert_success(&harness.run(&["namespace", "create", "from-environment"]));
+    assert_success(&harness.run(&["use", "profile-default"]));
+
+    let output = harness.run_with_env(
+        &[("LOONFS_NAMESPACE", "from-environment")],
+        &["--json", "changes"],
+    );
+
+    assert_success(&output);
+    assert_eq!(json_data(&output)["namespace_id"], "from-environment");
+}
+
+#[test]
+fn namespace_resolution_uses_flag_before_environment() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "from-environment"]));
+    assert_success(&harness.run(&["namespace", "create", "from-flag"]));
+
+    let output = harness.run_with_env(
+        &[("LOONFS_NAMESPACE", "from-environment")],
+        &["--json", "changes", "--namespace", "from-flag"],
+    );
+
+    assert_success(&output);
+    assert_eq!(json_data(&output)["namespace_id"], "from-flag");
+}
+
+#[test]
+fn namespace_resolution_gives_invalid_environment_the_flag_error_code() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+
+    let from_environment =
+        harness.run_with_env(&[("LOONFS_NAMESPACE", "bad/name")], &["--json", "changes"]);
+    let from_flag = harness.run(&["--json", "changes", "--namespace", "bad/name"]);
+
+    assert_failure(&from_environment);
+    assert_failure(&from_flag);
+    assert_eq!(
+        json_error(&from_environment)["code"],
+        json_error(&from_flag)["code"]
+    );
+}
+
+#[test]
+fn namespace_resolution_ignores_empty_environment() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "profile-default"]));
+    assert_success(&harness.run(&["use", "profile-default"]));
+
+    let output = harness.run_with_env(&[("LOONFS_NAMESPACE", "")], &["--json", "changes"]);
+
+    assert_success(&output);
+    assert_eq!(json_data(&output)["namespace_id"], "profile-default");
+}
+
+#[test]
 fn embedded_profile_missing_namespace_reports_user_facing_message() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
@@ -5089,15 +5152,15 @@ impl Harness {
         command.args(args).output().expect("run loonfs")
     }
 
-    /// Every invocation starts from the temp home with the config
-    /// environment cleared, so a developer's own `XDG_CONFIG_HOME` or
-    /// `LOONFS_CONFIG` can never decide which file a test reads.
+    /// Every invocation starts from the temp home with CLI selection
+    /// environment cleared, so a developer's shell cannot affect a test.
     fn command(&self) -> Command {
         let mut command = Command::new(loon_binary_path());
         command
             .env("HOME", &self.home_dir)
             .env_remove("XDG_CONFIG_HOME")
-            .env_remove("LOONFS_CONFIG");
+            .env_remove("LOONFS_CONFIG")
+            .env_remove("LOONFS_NAMESPACE");
         command
     }
 
@@ -5116,6 +5179,7 @@ impl Harness {
             .env("HOME", &self.home_dir)
             .env_remove("XDG_CONFIG_HOME")
             .env_remove("LOONFS_CONFIG")
+            .env_remove("LOONFS_NAMESPACE")
             .output()
             .expect("replay the printed command")
     }


### PR DESCRIPTION
A black-box audit ran eight parallel agents against one CLI config and hit two problems. Concurrent `loonfs use` calls raced the config write through one fixed `.tmp` sibling path, so twenty-four of forty writes failed with "No such file or directory". And one shared `default_namespace` cannot represent several concurrent agent contexts at all.

Config writes now take an exclusive lock on a `.lock` sibling and write through a uniquely named temp file before the atomic rename. Read-modify-write flows go through a new `mutate_config`, which reloads the latest config under the lock, so concurrent writers cannot lose each other's updates. The interactive profile editor gathers its input before taking the lock, so a human at a prompt does not block the fleet.

Namespace selection gains `LOONFS_NAMESPACE`. Precedence is `--namespace`, then the environment, then the profile default. `loonfs use` stays the interactive default; automation passes the flag or the variable.

Tests: a 16-thread mutation race over one config file, env precedence and validation through the spawned binary, and the full workspace suite (25 binaries, 1166 passed, 0 failed).