### PR TITLE
feat(server): add request and shutdown deadlines

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -40,6 +40,9 @@ pub enum ErrorKind {
     /// precondition (base revision, expected head) no longer holds. Re-read
     /// fresh state, re-plan, and retry if desired.
     Conflict,
+    /// The server cancelled work that exceeded its configured request
+    /// deadline. Reconcile any mutation before deciding whether to retry.
+    DeadlineExceeded,
     /// The system is temporarily unavailable. Back off and retry.
     Unavailable,
     /// The operation may have committed: its acknowledgment was lost. Retry
@@ -147,6 +150,7 @@ error_codes! {
     CommitQueueFull => "commit_queue_full",
     ServerBusy => "server_busy",
     ShuttingDown => "shutting_down",
+    DeadlineExceeded => "deadline_exceeded",
     CheckpointUnavailable => "checkpoint_unavailable",
     MaintenanceRequired => "maintenance_required",
     UploadNotFound => "upload_not_found",
@@ -186,6 +190,7 @@ impl ErrorCode {
             ErrorCode::MethodNotAllowed => ErrorKind::MethodNotAllowed,
             ErrorCode::NamespaceDeleted => ErrorKind::Gone,
             ErrorCode::NamespaceExists => ErrorKind::AlreadyExists,
+            ErrorCode::DeadlineExceeded => ErrorKind::DeadlineExceeded,
             // `index_lagging` clears once maintenance catches the index up,
             // so it is served as retryable unavailability.
             ErrorCode::CommitQueueFull

--- a/crates/loonfs-server/deploy/helm/loonfs-server/README.md
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/README.md
@@ -137,7 +137,7 @@ deletes it every time it stops.
 | `config.key` | `config.toml` | The entry in that Secret holding the TOML config. |
 | `service.port` | `9400` | The port the Service publishes and the probes call. |
 | `service.annotations` | `{}` | Annotations for the Service. |
-| `terminationGracePeriodSeconds` | `600` | How long the kubelet waits after SIGTERM before SIGKILL. |
+| `terminationGracePeriodSeconds` | `660` | How long the kubelet waits after SIGTERM before SIGKILL. |
 | `localCache.enabled` | `false` | Mount an `emptyDir` at `/var/cache/loonfs`. |
 | `localCache.sizeLimit` | `""` | That `emptyDir`'s `sizeLimit`, such as `100Gi`. Empty means no limit. |
 | `extraEnv` | `[]` | Environment variables for the container, as Kubernetes `EnvVar` entries. |
@@ -179,12 +179,12 @@ loonfs-server --config /etc/loonfs/config.toml --check-config
 
 ## Shutdown
 
-`terminationGracePeriodSeconds` defaults to 600.
+`terminationGracePeriodSeconds` defaults to 660.
 
 The server's shutdown stops accepting, drains the requests in flight, and
-settles its background work. It holds no timeout of its own, and one degraded
-object-store operation is bounded at roughly six minutes. 600 seconds clears
-that case.
+settles its background work. The drain abandons requests still running after
+`shutdown_deadline_ms`, which defaults to 600 seconds. The extra minute lets
+writer and cache settlement finish before the kubelet sends SIGKILL.
 
 The kubelet sends SIGKILL when the grace period runs out. Writer-epoch
 fencing contains what that leaves behind, so a killed process corrupts

--- a/crates/loonfs-server/deploy/helm/loonfs-server/templates/deployment.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/templates/deployment.yaml
@@ -35,8 +35,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      # The shutdown drains and settles with no timeout of its own, and one
-      # degraded object-store operation runs for about six minutes.
+      # The kubelet grace outlasts the server's drain deadline and settle time.
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: loonfs-server

--- a/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
@@ -40,10 +40,8 @@ service:
   # Annotations for the Service.
   annotations: {}
 
-# How long the kubelet waits after SIGTERM before it sends SIGKILL. The
-# server's shutdown has no timeout of its own and one degraded object-store
-# operation runs for about six minutes, so the default clears that case.
-terminationGracePeriodSeconds: 600
+# The kubelet's grace must outlast shutdown_deadline_ms (default 600s) plus settle time.
+terminationGracePeriodSeconds: 660
 
 localCache:
   # Mount an emptyDir at /var/cache/loonfs for the server's disk cache. The

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -179,10 +179,10 @@ docker run --rm \
 The server is PID 1 and shuts down on SIGTERM, which is what `docker stop`
 and a Kubernetes pod deletion send. It stops accepting, drains the requests
 in flight, settles its background work, and exits zero. Allow enough time for
-that: pass `--timeout 120` to `docker stop`. A process killed before it
+that: pass `--timeout 660` to `docker stop`. A process killed before it
 settles may lose work it had already accepted. The chart below gives the pod
-600 seconds for the same reason, and its README says where that number comes
-from.
+660 seconds: requests drain for `shutdown_deadline_ms` (600 seconds by default),
+then the writer and cache settle.
 
 [`scripts/test-image.sh`](../scripts/test-image.sh) builds the image and runs
 this whole path against it, down to the restart. CI runs the same script on

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -65,6 +65,14 @@ pub struct ServerConfig {
     /// the embedded default's latency bias.
     #[serde(default = "default_min_publish_interval_ms")]
     pub min_publish_interval_ms: u64,
+    /// Maximum time a metadata or query request may run, in milliseconds.
+    /// Streamed content and long-running operator work are exempt.
+    #[serde(default = "default_request_deadline_ms")]
+    pub request_deadline_ms: u64,
+    /// Maximum time graceful shutdown waits for accepted requests to drain,
+    /// in milliseconds. Writer and cache settlement continue afterward.
+    #[serde(default = "default_shutdown_deadline_ms")]
+    pub shutdown_deadline_ms: u64,
     /// Largest request body accepted for service-proxied upload content
     /// requests (`PUT .../uploads/{upload_id}/content`). Enforced
     /// incrementally while the body streams to the store, so it bounds the
@@ -135,6 +143,14 @@ pub struct TlsServerConfig {
 
 fn default_min_publish_interval_ms() -> u64 {
     1_000
+}
+
+fn default_request_deadline_ms() -> u64 {
+    60_000
+}
+
+fn default_shutdown_deadline_ms() -> u64 {
+    600_000
 }
 
 fn default_max_upload_bytes() -> u64 {
@@ -463,6 +479,18 @@ impl ServerConfig {
         if self.max_upload_bytes == 0 {
             return Err(ServerConfigError::InvalidField {
                 field: "max_upload_bytes",
+                reason: "must be greater than zero".to_owned(),
+            });
+        }
+        if self.request_deadline_ms == 0 {
+            return Err(ServerConfigError::InvalidField {
+                field: "request_deadline_ms",
+                reason: "must be greater than zero".to_owned(),
+            });
+        }
+        if self.shutdown_deadline_ms == 0 {
+            return Err(ServerConfigError::InvalidField {
+                field: "shutdown_deadline_ms",
                 reason: "must be greater than zero".to_owned(),
             });
         }
@@ -1132,6 +1160,41 @@ root = "/tmp/loonfs-server"
         );
         let error = load_server_config(&path).expect_err("zero upload limit");
         assert_invalid_field(error, "max_upload_bytes");
+    }
+
+    #[test]
+    fn request_and_shutdown_deadlines_default_and_reject_zero() {
+        let path = write_config(
+            r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#,
+        );
+        let config = load_server_config(&path).expect("valid config");
+        assert_eq!(config.request_deadline_ms, 60_000);
+        assert_eq!(config.shutdown_deadline_ms, 600_000);
+
+        for field in ["request_deadline_ms", "shutdown_deadline_ms"] {
+            let path = write_config(&format!(
+                r#"
+bind = "127.0.0.1:9400"
+auth_token = "dev-token"
+writer_id = "loonfs-server"
+{field} = 0
+
+[store]
+kind = "local-fs"
+root = "/tmp/loonfs-server"
+"#
+            ));
+            let error = load_server_config(&path).expect_err("zero deadline must be rejected");
+            assert_invalid_field(error, field);
+        }
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -138,6 +138,7 @@ fn status_for_error_kind(kind: ErrorKind) -> StatusCode {
         ErrorKind::MethodNotAllowed => StatusCode::METHOD_NOT_ALLOWED,
         ErrorKind::Gone => StatusCode::GONE,
         ErrorKind::AlreadyExists | ErrorKind::Conflict => StatusCode::CONFLICT,
+        ErrorKind::DeadlineExceeded => StatusCode::REQUEST_TIMEOUT,
         ErrorKind::NotSupported => StatusCode::NOT_IMPLEMENTED,
         ErrorKind::Unavailable | ErrorKind::OutcomeUnknown => StatusCode::SERVICE_UNAVAILABLE,
         ErrorKind::DataCorruption | ErrorKind::Internal => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -90,6 +90,27 @@ async fn with_request_id(request: Request, next: Next) -> Response {
     response
 }
 
+/// Cancels bounded request work once the deployment's deadline passes.
+async fn with_request_deadline(request_deadline_ms: u64, request: Request, next: Next) -> Response {
+    match tokio::time::timeout(
+        std::time::Duration::from_millis(request_deadline_ms),
+        next.run(request),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(_) => ApiResponseError::new(
+            StatusCode::REQUEST_TIMEOUT,
+            ErrorCode::DeadlineExceeded,
+            &format!(
+                "the server cancelled the request at the configured deadline; \
+                 request_deadline_ms is {request_deadline_ms} milliseconds"
+            ),
+        )
+        .into_response(),
+    }
+}
+
 /// Counts and times every request against the route axum matched it to.
 ///
 /// The label is the route template, never the request's own path: a path
@@ -160,7 +181,8 @@ fn router(state: AppState) -> Router {
     } else {
         get(grep_index_not_maintained)
     };
-    Router::new()
+    let request_deadline_ms = state.config.request_deadline_ms;
+    let bounded_routes = Router::new()
         .route("/health", get(health))
         .route("/readiness", get(readiness))
         .route("/metrics", get(serve_metrics))
@@ -176,10 +198,6 @@ fn router(state: AppState) -> Router {
             get(list_path_entries),
         )
         .route("/v0/namespaces/{namespace}/filesystem/stat", get(stat_path))
-        .route(
-            "/v0/namespaces/{namespace}/filesystem/content",
-            get(get_file_bytes),
-        )
         // The read this deployment authorizes rather than performs. It sits
         // beside the proxied read because it answers the same question
         // about the same path; the route exists everywhere and refuses with
@@ -195,18 +213,6 @@ fn router(state: AppState) -> Router {
             grep_status_route,
         )
         .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/enable",
-            enable_grep_route,
-        )
-        .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/disable",
-            disable_grep_route,
-        )
-        .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/gc",
-            grep_gc_route,
-        )
-        .route(
             "/v0/namespaces/{namespace}/filesystem/revisions",
             get(list_file_revisions),
         )
@@ -214,16 +220,11 @@ fn router(state: AppState) -> Router {
             "/v0/namespaces/{namespace}/filesystem/trash",
             get(list_trash),
         )
+        // A commit that reaches the deadline may still land. The publisher
+        // owns an accepted candidate, as after a client disconnect, and the
+        // commit receipt makes retry safe.
         .route("/v0/namespaces/{namespace}/commits", post(apply_commit))
         .route("/v0/namespaces/{namespace}/uploads", post(begin_upload))
-        .route(
-            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
-            // No body-limit layer: the upload route never buffers its
-            // body, so a framework limit measured against a buffered read
-            // would never fire. `UploadBodyStream` counts the bytes as it
-            // forwards them and enforces `upload.max_content_bytes` itself.
-            put(upload_content),
-        )
         .route(
             "/v0/namespaces/{namespace}/uploads/{upload_id}/parts",
             post(sign_upload_parts),
@@ -249,6 +250,23 @@ fn router(state: AppState) -> Router {
             "/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release",
             post(release_checkpoint),
         )
+        .route_layer(middleware::from_fn(move |request: Request, next: Next| {
+            with_request_deadline(request_deadline_ms, request, next)
+        }));
+
+    let exempt_routes = Router::new()
+        .route(
+            "/v0/namespaces/{namespace}/filesystem/content",
+            get(get_file_bytes),
+        )
+        .route(
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+            // No body-limit layer: the upload route never buffers its
+            // body, so a framework limit measured against a buffered read
+            // would never fire. `UploadBodyStream` counts the bytes as it
+            // forwards them and enforces `upload.max_content_bytes` itself.
+            put(upload_content),
+        )
         .route(
             "/v0/admin/namespaces/{namespace}/maintenance/step",
             post(maintenance_step),
@@ -256,6 +274,21 @@ fn router(state: AppState) -> Router {
         // The one admin route whose subject is the store rather than a
         // namespace, so it sits beside them rather than under one.
         .route("/v0/admin/store/probe", post(probe_store))
+        .route(
+            "/v0/admin/namespaces/{namespace}/grep/index/enable",
+            enable_grep_route,
+        )
+        .route(
+            "/v0/admin/namespaces/{namespace}/grep/index/disable",
+            disable_grep_route,
+        )
+        .route(
+            "/v0/admin/namespaces/{namespace}/grep/index/gc",
+            grep_gc_route,
+        );
+
+    bounded_routes
+        .merge(exempt_routes)
         // Unmatched paths and wrong methods answer inside the error
         // contract instead of axum's empty default bodies.
         .fallback(route_not_found)

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -17,8 +17,10 @@ use loonfs_api::NamespaceId;
 use loonfs_grep::{GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker, GREP_INDEX_JOB};
 use loonfs_objectstore::presign::DirectTransferIssuers;
 use std::ffi::OsString;
+use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::Semaphore;
 
@@ -476,7 +478,7 @@ pub async fn serve_with_shutdown(
 /// The one serving body, over whichever listener the deployment configured.
 /// Plaintext and TLS differ in what `accept` returns and in nothing else:
 /// the same router, the same graceful shutdown, and the same writer settles
-/// after the listener has drained.
+/// after the listener drains or reaches its deadline.
 pub(super) async fn serve_on<L>(
     listener: L,
     config: ServerConfig,
@@ -485,8 +487,17 @@ pub(super) async fn serve_on<L>(
 where
     L: axum::serve::Listener<Addr = SocketAddr>,
 {
+    let shutdown_deadline_ms = config.shutdown_deadline_ms;
     let (router, writer, local_cache) = app(config).await?;
-    serve_and_settle(listener, router, writer, local_cache, shutdown).await
+    serve_and_settle(
+        listener,
+        router,
+        writer,
+        local_cache,
+        shutdown_deadline_ms,
+        shutdown,
+    )
+    .await
 }
 
 /// Serves until the shutdown trigger fires, then settles what this process
@@ -499,17 +510,52 @@ pub(super) async fn serve_and_settle<L>(
     router: Router,
     writer: FsWriter,
     local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
+    shutdown_deadline_ms: u64,
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), ServeError>
 where
     L: axum::serve::Listener<Addr = SocketAddr>,
 {
-    axum::serve(listener, router)
-        .with_graceful_shutdown(shutdown)
-        .await
-        .map_err(ServeError::Serve)?;
-    // Shut down the writer only after the listener drains, so accepted requests
-    // are not rejected by closing mutation admission. Task panics surface here.
+    let (drain_started_tx, mut drain_started_rx) = tokio::sync::oneshot::channel();
+    let shutdown = async move {
+        shutdown.await;
+        let _ = drain_started_tx.send(());
+    };
+    let mut server = Box::pin(
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown)
+            .into_future(),
+    );
+    // The budget starts when shutdown fires. It does not limit server uptime.
+    let served = tokio::select! {
+        result = server.as_mut() => result,
+        drain_started = &mut drain_started_rx => {
+            if drain_started.is_err() {
+                server.as_mut().await
+            } else {
+                match tokio::time::timeout(
+                    Duration::from_millis(shutdown_deadline_ms),
+                    server.as_mut(),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => {
+                        tracing::warn!(
+                            shutdown_deadline_ms,
+                            "graceful drain deadline passed; remaining requests are abandoned"
+                        );
+                        Ok(())
+                    }
+                }
+            }
+        }
+    };
+    drop(server);
+    served.map_err(ServeError::Serve)?;
+    // Shut down the writer after the drain finishes or its deadline passes.
+    // Accepted requests keep mutation admission through the drain window.
+    // Task panics surface here.
     let settled = writer.shutdown().await.map_err(ServeError::Shutdown);
     // Close the cache after writer shutdown, even when writer shutdown fails.
     // Closing flushes retained memory entries to disk. If both steps fail, report

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -297,6 +297,72 @@ async fn app_validates_directly_built_configs() {
     }
 }
 
+#[tokio::test]
+#[allow(clippy::disallowed_methods)]
+// The sleeping handler is the controlled work the deadline cancels.
+async fn request_deadline_answers_408_and_leaves_fast_handlers_untouched() {
+    use tower::ServiceExt;
+
+    let request_deadline_ms = 10;
+    let router = axum::Router::new()
+        .route(
+            "/slow",
+            axum::routing::get(|| async {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                "slow"
+            }),
+        )
+        .route("/fast", axum::routing::get(|| async { "fast" }))
+        .route_layer(axum::middleware::from_fn(
+            move |request: axum::extract::Request, next: axum::middleware::Next| {
+                super::with_request_deadline(request_deadline_ms, request, next)
+            },
+        ))
+        .layer(axum::middleware::from_fn(super::with_request_id));
+
+    let slow = router
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/slow")
+                .body(axum::body::Body::empty())
+                .expect("slow request"),
+        )
+        .await
+        .expect("slow response");
+    assert_eq!(slow.status(), axum::http::StatusCode::REQUEST_TIMEOUT);
+    let request_id = slow
+        .headers()
+        .get(super::REQUEST_ID_HEADER)
+        .expect("request id header")
+        .to_str()
+        .expect("request id header text")
+        .to_owned();
+    let body = axum::body::to_bytes(slow.into_body(), usize::MAX)
+        .await
+        .expect("deadline body");
+    let error: loonfs_api::ApiError = serde_json::from_slice(&body).expect("deadline envelope");
+    assert_eq!(error.code, ErrorCode::DeadlineExceeded.as_str());
+    assert_eq!(error.request_id.as_deref(), Some(request_id.as_str()));
+    assert!(error.message.contains("request_deadline_ms"));
+    assert!(error.message.contains("10"));
+
+    let fast = router
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/fast")
+                .body(axum::body::Body::empty())
+                .expect("fast request"),
+        )
+        .await
+        .expect("fast response");
+    assert_eq!(fast.status(), axum::http::StatusCode::OK);
+    let body = axum::body::to_bytes(fast.into_body(), usize::MAX)
+        .await
+        .expect("fast body");
+    assert_eq!(&body[..], b"fast");
+}
+
 /// The `[local_cache]` table is the whole switch: without it nothing is
 /// built, and a scrape says nothing about a tier this deployment does not
 /// have.
@@ -353,6 +419,7 @@ async fn graceful_shutdown_closes_the_local_cache() {
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
     let mut config = test_config(temp_dir.path(), "shutdown-local-cache-writer");
     config.local_cache = Some(test_local_cache_config(cache_dir.path()));
+    let shutdown_deadline_ms = config.shutdown_deadline_ms;
 
     let (router, state) = app_with_store_and_state(config, store)
         .await
@@ -369,6 +436,7 @@ async fn graceful_shutdown_closes_the_local_cache() {
         router,
         state.writer.clone(),
         state.local_cache.clone(),
+        shutdown_deadline_ms,
         async move {
             let _ = shutdown_rx.await;
         },
@@ -384,6 +452,80 @@ async fn graceful_shutdown_closes_the_local_cache() {
         local_cache.is_closed(),
         "the graceful path closes the cache before it returns"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(clippy::disallowed_methods)]
+// The sleeping handler keeps one connection in flight past the drain budget.
+async fn graceful_shutdown_abandons_requests_at_the_deadline_and_settles_the_writer() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let writer = test_runtime(store, "shutdown-deadline-writer").await;
+    let handler_started = Arc::new(tokio::sync::Notify::new());
+    let handler_signal = handler_started.clone();
+    let router = axum::Router::new().route(
+        "/slow",
+        axum::routing::get(move || {
+            let handler_signal = handler_signal.clone();
+            async move {
+                handler_signal.notify_one();
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                "late"
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let shutdown_deadline_ms = 25;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(super::serve::serve_and_settle(
+        listener,
+        router,
+        writer.clone(),
+        None,
+        shutdown_deadline_ms,
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    ));
+
+    let client = tokio::spawn(async move {
+        let mut stream = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("connect client");
+        stream
+            .write_all(b"GET /slow HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .expect("send slow request");
+        let mut response = Vec::new();
+        stream
+            .read_to_end(&mut response)
+            .await
+            .expect("read slow response");
+    });
+    tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        handler_started.notified(),
+    )
+    .await
+    .expect("slow handler starts");
+
+    shutdown_tx.send(()).expect("trigger shutdown");
+    tokio::time::timeout(
+        std::time::Duration::from_millis(shutdown_deadline_ms + 1_000),
+        server,
+    )
+    .await
+    .expect("serve_and_settle returns within the drain deadline plus slack")
+    .expect("join server task")
+    .expect("shutdown settles the writer");
+    assert!(writer.is_shutting_down(), "writer shutdown completed");
+
+    client.abort();
 }
 
 fn test_local_cache_config(root: &Path) -> crate::config::LocalCacheConfig {
@@ -2290,6 +2432,8 @@ fn test_config(root: &Path, writer_id: &str) -> ServerConfig {
         grep: crate::config::GrepConfig::default(),
         maintenance: crate::config::MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,
+        request_deadline_ms: 60_000,
+        shutdown_deadline_ms: 600_000,
         max_upload_bytes: 256 * 1024 * 1024,
         max_download_bytes: 256 * 1024 * 1024,
         max_concurrent_uploads: 8,

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -274,6 +274,8 @@ pub(crate) fn test_config(
         grep: GrepConfig::default(),
         maintenance: MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,
+        request_deadline_ms: 60_000,
+        shutdown_deadline_ms: 600_000,
         max_upload_bytes: 256 * 1024 * 1024,
         max_download_bytes: 256 * 1024 * 1024,
         max_concurrent_uploads: 8,

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -581,6 +581,8 @@ fn test_config(store_root: &Path, mode: GrepMode) -> ServerConfig {
         },
         maintenance: MaintenanceMode::Automatic,
         min_publish_interval_ms: 0,
+        request_deadline_ms: 60_000,
+        shutdown_deadline_ms: 600_000,
         max_upload_bytes: 1024 * 1024,
         max_download_bytes: 1024 * 1024,
         max_concurrent_uploads: 2,

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -273,6 +273,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `commit_queue_full` | 503 | The namespace write queue is full; back off and retry. |
 | `server_busy` | 503 | The server is at its configured concurrency limit for this kind of work (proxied upload bodies or proxied content reads); back off and retry. |
 | `shutting_down` | 503 | The serving process closed admission for shutdown; work admitted earlier still settles. Retry against a live instance. |
+| `deadline_exceeded` | 408 | The server cancelled a bounded request at its configured `request_deadline_ms`. A commit may still land after this response; reconcile it by commit id before retrying. |
 | `checkpoint_unavailable` | 503 | Required checkpoint state is unavailable: not yet published, released during the operation, or referenced material is missing. Retry after maintenance. |
 | `maintenance_required` | 503 | Namespace metadata requires maintenance before the request can be served; run maintenance and retry. |
 | `index_lagging` | 503 | The grep index trails the head past the exhaustive-scan budget; let the grep worker catch up (or set `allow_stale`) and retry. |


### PR DESCRIPTION
A read with a client that died kept running, and graceful shutdown waited on it forever; the audit's container needed a force kill and exited 137. HTTP/1 gives no mid-request disconnect signal, so the bound has to be the server's own.

Two deadlines. `request_deadline_ms` (default 60s) is a route layer on every route except the two content byte streams, the maintenance step, the store probe, and the mutating grep admin routes. On expiry the request answers 408 with a new `deadline_exceeded` code, which is not retryable. There is no cancellation-token plumbing: read work runs inside the handler future with no detached tasks, so dropping the future at its next await already cancels it.

`shutdown_deadline_ms` (default 600s) starts when the shutdown signal fires, not at serve time. A drain that outlives it logs one warning, abandons the remaining requests, and settles the writer and local cache exactly as a clean drain does. The Helm grace period rises to 660s so the kubelet outlasts the server's own budget.

A commit that hits the deadline may still land: the publisher owns an accepted candidate, as with a client disconnect, and commit receipts make the retry safe.

Tests: deadline middleware (408, envelope, request id, fast handlers untouched), a drain that abandons a stuck request within budget and still settles the writer, config validation for both fields, the spec-sync suites, and the full workspace suite (33 binaries, 1738 passed, 0 failed).