### PR TITLE
fix(server): the HTTP boundary owns request-outcome logging

### DIFF
--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -92,9 +92,9 @@ pub(super) struct MetadataSstRows {
 }
 
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "write_manifest_tables", key_class = "manifest_table")
 )]

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -121,7 +121,7 @@ pub(super) async fn try_flush_wal<S: ObjectStore + ?Sized>(
 ) -> Result<TryFlushWal> {
     let publication_started_ms = timer.monotonic_now_ms();
     let projection = load_root_projection(store, namespace_id)
-        .instrument(tracing::info_span!(
+        .instrument(tracing::debug_span!(
             "loonfs.phase",
             phase = "scan_namespace_state"
         ))
@@ -273,7 +273,8 @@ pub(super) async fn load_root_projection<'a, S: ObjectStore + ?Sized>(
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
     let replayed = {
-        let _span = tracing::info_span!("loonfs.phase", phase = "project_metadata_state").entered();
+        let _span =
+            tracing::debug_span!("loonfs.phase", phase = "project_metadata_state").entered();
         project_validated_wal_tail(
             &manifest_head,
             &basis.base_state,

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -192,7 +192,7 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
     let fetch = || async {
         let Some(manifest_bytes) = store
             .get(&manifest_key, None)
-            .instrument(tracing::info_span!(
+            .instrument(tracing::debug_span!(
                 "loonfs.phase",
                 phase = "load_namespace_manifest",
                 key_class = "manifest_table"
@@ -297,7 +297,7 @@ pub(crate) async fn load_namespace_manifest_envelope_if_present<S: ObjectStore +
 ) -> Result<Option<NamespaceManifestEnvelope>, ManifestLoadError> {
     let Some(manifest_bytes) = store
         .get(manifest_key, None)
-        .instrument(tracing::info_span!(
+        .instrument(tracing::debug_span!(
             "loonfs.phase",
             phase = "load_namespace_manifest",
             key_class = "manifest_table"

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -26,9 +26,9 @@ pub(super) enum ManifestPublicationOutcome {
 }
 
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "write_namespace_manifest", key_class = "manifest_table")
 )]
@@ -110,9 +110,9 @@ pub(super) fn manifest_write_failure(error: MetadataProjectionLoadError) -> Core
 }
 
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "publish_metadata_root", key_class = "metadata_root")
 )]

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -193,9 +193,9 @@ pub struct MetadataReorganizeReport {
 /// compactions: which group a job is rebuilding right now, and how long each
 /// group has been merging deltas over a frozen base.
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "reorganize_metadata", key_class = "manifest")
 )]

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -113,9 +113,9 @@ pub(super) async fn load_manifest_materialization_for_inspection_if_present<
 }
 
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "load_manifest_tables", key_class = "manifest_table")
 )]

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -258,7 +258,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         })?;
         let replayed = {
             let _span =
-                tracing::info_span!("loonfs.phase", phase = "project_metadata_state").entered();
+                tracing::debug_span!("loonfs.phase", phase = "project_metadata_state").entered();
             project_validated_wal_tail(
                 &manifest_head,
                 &loaded_basis.base_state,
@@ -284,9 +284,9 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
     }
 
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.phase",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             phase = "walk_path",
@@ -636,9 +636,9 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
     }
 
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.phase",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             phase = "walk_path",
@@ -693,7 +693,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .cursor
             .as_ref()
             .map(|cursor| cursor.last_name_key.as_str());
-        let select_span = tracing::info_span!(
+        let select_span = tracing::debug_span!(
             "loonfs.phase",
             phase = "list_page_select_children",
             list_page_requested_limit = request.limit.as_usize() as u64,
@@ -726,7 +726,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             None
         };
 
-        let build_span = tracing::info_span!(
+        let build_span = tracing::debug_span!(
             "loonfs.phase",
             phase = "list_page_build_entries",
             list_page_children_returned = children.len() as u64,

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -95,7 +95,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     let mut accepted: Vec<(usize, MaterializedCommit)> = Vec::new();
     let mut dedup = BatchDedup::default();
 
-    let prepare_span = tracing::info_span!(
+    let prepare_span = tracing::debug_span!(
         "publisher.batch_prepare",
         phase = "batch_prepare",
         batch_size,
@@ -112,7 +112,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 context.now_ms,
                 &mut dedup,
             )
-            .instrument(tracing::info_span!(
+            .instrument(tracing::debug_span!(
                 "loonfs.phase",
                 phase = "prepare_commit"
             ))
@@ -144,7 +144,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 continue;
             }
             let plan = {
-                let span = tracing::info_span!("loonfs.phase", phase = "build_commit_plan");
+                let span = tracing::debug_span!("loonfs.phase", phase = "build_commit_plan");
                 match build_commit_plan_for_publish(&request, context.now_ms, &validation)
                     .instrument(span)
                     .await
@@ -165,7 +165,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 "planner prediction and commit-plan allocation disagree"
             );
             let prepared = {
-                let _span = tracing::info_span!("loonfs.phase", phase = "PreparedCommit::prepare")
+                let _span = tracing::debug_span!("loonfs.phase", phase = "PreparedCommit::prepare")
                     .entered();
                 match PreparedCommit::new(
                     request,
@@ -183,11 +183,11 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             };
             let materialized = {
                 let _span =
-                    tracing::info_span!("loonfs.phase", phase = "materialize_commit").entered();
+                    tracing::debug_span!("loonfs.phase", phase = "materialize_commit").entered();
                 materialize_commit(prepared, context.now_ms)
             };
             let preview = {
-                let _span = tracing::info_span!(
+                let _span = tracing::debug_span!(
                     "loonfs.phase",
                     phase = "wal_payload_from_materialized_commit"
                 )
@@ -202,7 +202,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             };
             {
                 let _span =
-                    tracing::info_span!("loonfs.phase", phase = "apply_committed_wal_record")
+                    tracing::debug_span!("loonfs.phase", phase = "apply_committed_wal_record")
                         .entered();
                 session.apply_accepted_commit(&preview, &plan);
             }
@@ -318,7 +318,7 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
     batch_size: u64,
     accepted_count: u64,
 ) -> Result<PreparedWalSegment> {
-    let span = tracing::info_span!(
+    let span = tracing::debug_span!(
         "publisher.batch_write_wal",
         phase = "batch_write_wal",
         batch_size,
@@ -362,7 +362,7 @@ async fn cas_batch_head<S: ObjectStore + ?Sized>(
     batch_size: u64,
     accepted_count: u64,
 ) -> Result<ObjectMetadata> {
-    let span = tracing::info_span!(
+    let span = tracing::debug_span!(
         "publisher.batch_cas_head",
         phase = "batch_cas_head",
         batch_size,

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -589,9 +589,9 @@ async fn validate_content_size<S: ObjectStore + ?Sized>(
 /// content store first. See [`store_bytes_as_content_with_store_id`] for
 /// what this is for and what it is not.
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "write_content_blob", key_class = "content_blob")
 )]

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -129,9 +129,9 @@ pub(crate) enum WalChainLoad {
 /// read past what the caller may pay for. The loader itself keeps no
 /// budget, because foreground reads and the changefeed share it.
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "load_wal_chain_within", key_class = "wal_segment")
 )]
@@ -153,9 +153,9 @@ pub(crate) async fn load_wal_chain_within<S: ObjectStore + ?Sized>(
 }
 
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "load_validated_wal_chain", key_class = "wal_segment")
 )]
@@ -338,9 +338,9 @@ fn validate_pointer_matches_envelope(
 /// walk. Segment bodies and checksums are not validated because this method
 /// only counts pointers; replay paths still load the full validated chain.
 #[tracing::instrument(
-    level = "info",
+    level = "debug",
     name = "loonfs.phase",
-    err,
+    err(level = "warn"),
     skip_all,
     fields(phase = "count_wal_tail_segments", key_class = "wal_segment")
 )]

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -653,9 +653,9 @@ impl GrepService {
     /// page is evaluated against the snapshot it runs on and reports that
     /// head in `head_seq`.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.phase",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(phase = "grep")
     )]

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -399,7 +399,7 @@ pub(super) async fn apply_commit(
         operations,
     };
     let response_result = if let Some((payload_class, preparation)) = put_content_preparation {
-        let span = tracing::info_span!(
+        let span = tracing::debug_span!(
             "loonfs.put",
             operation = "put",
             mode = "remote",

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -111,6 +111,66 @@ async fn with_request_deadline(request_deadline_ms: u64, request: Request, next:
     }
 }
 
+enum RequestRoute {
+    Matched(MatchedPath),
+    Unmatched(String),
+}
+
+impl RequestRoute {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Matched(path) => path.as_str(),
+            Self::Unmatched(path) => path,
+        }
+    }
+}
+
+/// Logs the response once the request has reached its HTTP outcome.
+async fn with_request_completion(request: Request, next: Next) -> Response {
+    let method = request.method().clone();
+    let route = request.extensions().get::<MatchedPath>().map_or_else(
+        || RequestRoute::Unmatched(request.uri().path().to_owned()),
+        |path| RequestRoute::Matched(path.clone()),
+    );
+    let started = request_clock();
+    let response = next.run(request).await;
+    let status = response.status();
+    let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+    REQUEST_ID.with(|request_id| match status {
+        status if status.is_server_error() => tracing::error!(
+            target: "loonfs_server::http::request",
+            method = %method,
+            route = route.as_str(),
+            status = status.as_u16(),
+            elapsed_ms,
+            request_id = request_id.as_str(),
+            "request completed"
+        ),
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::TOO_MANY_REQUESTS => {
+            tracing::warn!(
+                target: "loonfs_server::http::request",
+                method = %method,
+                route = route.as_str(),
+                status = status.as_u16(),
+                elapsed_ms,
+                request_id = request_id.as_str(),
+                "request completed"
+            );
+        }
+        _ => tracing::debug!(
+            target: "loonfs_server::http::request",
+            method = %method,
+            route = route.as_str(),
+            status = status.as_u16(),
+            elapsed_ms,
+            request_id = request_id.as_str(),
+            "request completed"
+        ),
+    });
+    response
+}
+
 /// Counts and times every request against the route axum matched it to.
 ///
 /// The label is the route template, never the request's own path: a path
@@ -299,6 +359,8 @@ fn router(state: AppState) -> Router {
             state.clone(),
             with_request_metrics,
         ))
+        // Completion logging runs inside the request-id scope.
+        .layer(middleware::from_fn(with_request_completion))
         .layer(middleware::from_fn(with_request_id))
         .with_state(state)
 }

--- a/crates/loonfs-server/tests/logging.rs
+++ b/crates/loonfs-server/tests/logging.rs
@@ -1,0 +1,242 @@
+//! Request-outcome logging at the HTTP boundary.
+
+#[path = "it/common/mod.rs"]
+mod common;
+
+use axum::body::{to_bytes, Body};
+use axum::http::Request;
+use axum::Router;
+use common::http_split_support::test_config;
+use loonfs::CreateNamespaceOptions;
+use loonfs_server::{app, MaintenanceMode};
+use loonfs_test_support::ids::namespace_id;
+use std::fmt;
+use std::sync::{Arc, Mutex, OnceLock};
+use tower::ServiceExt as _;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt as _};
+
+const COMPLETION_TARGET: &str = "loonfs_server::http::request";
+const COMPLETION_MESSAGE: &str = "request completed";
+
+#[derive(Clone, Debug)]
+struct CapturedEvent {
+    level: Level,
+    target: String,
+    message: Option<String>,
+    request_id: Option<String>,
+}
+
+#[derive(Clone)]
+struct Capture {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+    test_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl Capture {
+    fn clear(&self) {
+        self.events.lock().expect("capture lock").clear();
+    }
+
+    fn snapshot(&self) -> Vec<CapturedEvent> {
+        self.events.lock().expect("capture lock").clone()
+    }
+}
+
+struct CaptureLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut fields = CapturedFields::default();
+        event.record(&mut fields);
+        self.events
+            .lock()
+            .expect("capture lock")
+            .push(CapturedEvent {
+                level: *event.metadata().level(),
+                target: event.metadata().target().to_owned(),
+                message: fields.message,
+                request_id: fields.request_id,
+            });
+    }
+}
+
+#[derive(Default)]
+struct CapturedFields {
+    message: Option<String>,
+    request_id: Option<String>,
+}
+
+impl CapturedFields {
+    fn record(&mut self, field: &Field, value: String) {
+        match field.name() {
+            "message" => self.message = Some(value),
+            "request_id" => self.request_id = Some(value),
+            _ => {}
+        }
+    }
+}
+
+impl Visit for CapturedFields {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record(field, value.to_owned());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.record(field, format!("{value:?}").trim_matches('"').to_owned());
+    }
+}
+
+fn capture() -> &'static Capture {
+    static CAPTURE: OnceLock<Capture> = OnceLock::new();
+    CAPTURE.get_or_init(|| {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer {
+            events: events.clone(),
+        });
+        tracing::subscriber::set_global_default(subscriber).expect("install capture subscriber");
+        Capture {
+            events,
+            test_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    })
+}
+
+async fn request_error(router: &Router, uri: &str) -> (u16, loonfs_api::ApiError, String) {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header("authorization", "Bearer test-token")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("route request");
+    let status = response.status().as_u16();
+    let request_id = response
+        .headers()
+        .get("x-request-id")
+        .expect("request-id response header")
+        .to_str()
+        .expect("request-id response header value")
+        .to_owned();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read API error body");
+    let body = serde_json::from_slice::<loonfs_api::ApiError>(&bytes).expect("API error body");
+    assert_eq!(body.request_id.as_deref(), Some(request_id.as_str()));
+    (status, body, request_id)
+}
+
+fn completion_events<'a>(events: &'a [CapturedEvent], request_id: &str) -> Vec<&'a CapturedEvent> {
+    events
+        .iter()
+        .filter(|event| {
+            event.target == COMPLETION_TARGET
+                && event.message.as_deref() == Some(COMPLETION_MESSAGE)
+                && event.request_id.as_deref() == Some(request_id)
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_path_has_one_debug_completion_and_no_errors() {
+    let capture = capture();
+    let _test_guard = capture.test_lock.lock().await;
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let mut config = test_config(
+        temp_dir.path().join("store"),
+        "logging-missing-path",
+        "logging-missing-path",
+    );
+    config.maintenance = MaintenanceMode::Manual;
+    let (router, writer, _local_cache) = app(config).await.expect("build app");
+    writer
+        .create_namespace(&namespace_id("demo"), CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    capture.clear();
+
+    let (status, body, request_id) = request_error(
+        &router,
+        "/v0/namespaces/demo/filesystem/stat?path=%2Fmissing.txt",
+    )
+    .await;
+    assert_eq!(status, 404);
+    assert_eq!(body.code, "path_not_found");
+
+    let events = capture.snapshot();
+    assert!(
+        events.iter().all(|event| event.level != Level::ERROR),
+        "missing path emitted ERROR events: {events:#?}"
+    );
+    let completions = completion_events(&events, &request_id);
+    assert_eq!(
+        completions.len(),
+        1,
+        "expected one completion event: {events:#?}"
+    );
+    assert_eq!(completions[0].level, Level::DEBUG);
+
+    writer.shutdown().await.expect("shutdown writer");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn store_fault_has_one_error_from_the_boundary() {
+    let capture = capture();
+    let _test_guard = capture.test_lock.lock().await;
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let store_root = temp_dir.path().join("store");
+    let key_prefix = "logging-store-fault";
+    let mut config = test_config(store_root.clone(), "logging-store-fault", key_prefix);
+    config.maintenance = MaintenanceMode::Manual;
+
+    let (first_router, first_writer, _local_cache) =
+        app(config.clone()).await.expect("build first app");
+    first_writer
+        .create_namespace(&namespace_id("faulty"), CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    first_writer
+        .shutdown()
+        .await
+        .expect("shutdown first writer");
+    drop(first_router);
+    drop(first_writer);
+
+    // A directory at an object key is a deterministic local-store fault.
+    let head_path = store_root
+        .join(key_prefix)
+        .join("namespaces/faulty/wal/head.json");
+    std::fs::remove_file(&head_path).expect("remove WAL head object");
+    std::fs::create_dir(&head_path).expect("replace WAL head with a directory");
+
+    let (second_router, second_writer, _local_cache) = app(config).await.expect("build second app");
+    capture.clear();
+    let (status, _body, request_id) = request_error(&second_router, "/v0/namespaces/faulty").await;
+    assert_eq!(status, 500);
+
+    let events = capture.snapshot();
+    let errors: Vec<_> = events
+        .iter()
+        .filter(|event| event.level == Level::ERROR)
+        .collect();
+    assert_eq!(errors.len(), 1, "expected one ERROR event: {events:#?}");
+    assert_eq!(errors[0].target, COMPLETION_TARGET);
+    assert_eq!(errors[0].message.as_deref(), Some(COMPLETION_MESSAGE));
+    assert_eq!(errors[0].request_id.as_deref(), Some(request_id.as_str()));
+    assert_eq!(completion_events(&events, &request_id).len(), 1);
+
+    second_writer
+        .shutdown()
+        .await
+        .expect("shutdown second writer");
+}

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -392,7 +392,7 @@ impl ReadCore {
     /// exactly the same reasons, so a caller that owns a publication service
     /// drops that too; see `FsWriter::invalidate_namespace`.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.phase",
         skip_all,
         fields(phase = "update_cache")

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -109,9 +109,9 @@ impl FsAdmin {
     /// did not select that action. Losing the head race or being superseded
     /// by another publisher is an outcome, not an error.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.maintenance.step",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "maintenance.step",
@@ -572,9 +572,9 @@ impl FsAdmin {
     /// one is published first for the current durable namespace state; this
     /// is not a request to compact metadata.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.maintenance.checkpoint_create",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "maintenance.checkpoint_create",
@@ -687,9 +687,9 @@ impl FsAdmin {
     /// fold the tail, advance the root, invalidate what the fold
     /// invalidated.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.maintenance.wal_flush",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "maintenance.wal_flush",

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -33,9 +33,9 @@ impl FsReader {
     /// Resolves an absolute path to its authoritative entry at the current
     /// head, projecting what `options` asks for.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.stat",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "stat",

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -87,9 +87,9 @@ impl FsWriter {
     /// published only afterward. `options.behavior` selects create-only or
     /// replace semantics.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.put",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "put",
@@ -149,9 +149,9 @@ impl FsWriter {
     /// because the payload is gone: what this pass measured and hashed on
     /// the way past is what the reconciliation compares.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.put",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "put",
@@ -310,9 +310,9 @@ impl FsWriter {
     /// promptly because garbage collection protects the object only for that
     /// grace period while it remains unpublished.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.prepare",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "prepare",
@@ -347,9 +347,9 @@ impl FsWriter {
     /// SHA-256, same publication path, same guarantees — so callers that
     /// already hold their bytes have no reason to come here.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.prepare",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "prepare",
@@ -378,9 +378,9 @@ impl FsWriter {
     /// Submission and publication perform no content I/O. `options.behavior`
     /// selects create-only or replace semantics.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.put",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "put",
@@ -428,9 +428,9 @@ impl FsWriter {
     /// before publication. Callers that already hold proof should prefer
     /// [`Self::put_file_prepared`].
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.put",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "put",
@@ -465,9 +465,9 @@ impl FsWriter {
     /// GET and digest check. Later prepared publication performs no content
     /// I/O.
     #[tracing::instrument(
-        level = "info",
+        level = "debug",
         name = "loonfs.prepare",
-        err,
+        err(level = "debug"),
         skip_all,
         fields(
             operation = "prepare",
@@ -796,7 +796,7 @@ pub(crate) async fn publish_batch_with_engine(
         engine.invalidate_projection();
     }
     {
-        let _span = tracing::info_span!(
+        let _span = tracing::debug_span!(
             "loonfs.phase",
             phase = "batch_update_cache",
             mode = core.trace_mode(),

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -903,7 +903,7 @@ impl NamespacePublisher {
             );
         }
 
-        let publish_span = tracing::info_span!(
+        let publish_span = tracing::debug_span!(
             "loonfs.phase",
             phase = "batch_publish",
             mode = self.trace_mode,


### PR DESCRIPTION
An ordinary missing-path read logged at ERROR twice. The cause is `#[tracing::instrument(err, ...)]`, which logs a returned error at ERROR by default, sitting on nested read functions. Separately, the info-level phase spans emit a close line each under `FmtSpan::CLOSE`.

Interior layers no longer log request outcomes at ERROR. The `err` directives drop to `debug` where client-expected errors flow (path walks, puts, grep queries) and to `warn` where only faults do (WAL chain loads, manifest publication, content writes) — those keep their phase context as a correlating warning. Phase and operation spans drop to debug, so the default info filter stays quiet during normal traffic; `RUST_LOG=debug` brings the spans back. The explicit error owners with no request above them (checkpoint flush, fork recovery) and the maintenance lifecycle info lines are unchanged.

One new middleware at the boundary emits a single completion event per request — method, matched route, status, elapsed, request id — at error for 5xx, warn for 401/403/429, debug otherwise. Faults now log exactly one ERROR, from the boundary, correlated by request id.