### PR TITLE
feat(cli): bound ls by default and add streaming modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "bytes",
  "clap",
  "dialoguer",
+ "fs4",
  "futures",
  "hostname",
  "http",

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 bytes.workspace = true
 clap.workspace = true
 futures.workspace = true
+fs4.workspace = true
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 hostname = "0.4"
 http.workspace = true

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -138,11 +138,11 @@ Namespace management
     Show the active profile and its default namespace
 
 Reading
-  loonfs ls [path] [--limit <n>] [--cursor <cursor>]
+  loonfs ls [path] [--limit <n> | --all] [--cursor <cursor>] [--jsonl]
     List the entries of a directory, `/` when the path is omitted. Without
-    --limit the whole directory is printed, however large; --limit stops
+    --limit or --all, one server page is printed. --limit stops
     after that many entries in total and reports a next_cursor, which
-    --cursor resumes from
+    --cursor resumes; --all streams pages except in JSON; --jsonl streams entries
 
   loonfs stat <path>
     Describe one path: kind, size, revision, content digest, and the

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -48,6 +48,8 @@ Selectors
   Commands that address one namespace also accept:
     --namespace <name>
       Namespace to run against, defaulting to the profile's default
+    LOONFS_NAMESPACE=<name>
+      Environment default; --namespace wins, and the profile default follows
 
   Commands that commit (put, mkdir, rm, mv, cp, restore, undelete) accept:
     -m, --message <message>
@@ -80,6 +82,8 @@ Config file location
     3. $XDG_CONFIG_HOME/loonfs/config.toml, when XDG_CONFIG_HOME names an
        absolute directory
     4. ~/.loonfs/config.toml
+  Namespace selection uses --namespace, then LOONFS_NAMESPACE=<name>, then
+  the profile default.
 
   A path given to --config or LOONFS_CONFIG is the file this invocation
   uses whether or not it is there yet, and `loonfs init` creates the

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -39,6 +39,8 @@ pub(crate) enum Command {
         command: NamespaceCommand,
     },
     /// Set the default namespace for a profile.
+    /// This sets the interactive default; concurrent automation should pass
+    /// `--namespace` or set `LOONFS_NAMESPACE`.
     Use(NamespaceUseArgs),
     /// Show the active profile and its default namespace.
     Current(CurrentArgs),
@@ -306,6 +308,8 @@ pub(crate) struct ProfileSelectorArgs {
 pub(crate) struct TargetSelectorArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
+    /// Namespace to run against. Precedence is `--namespace`,
+    /// `LOONFS_NAMESPACE`, then the profile default.
     #[arg(long)]
     pub namespace: Option<String>,
 }

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -370,13 +370,18 @@ pub(crate) struct FilesystemLsArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     pub path: Option<String>,
-    /// Stop after this many entries in total. Without it the command
-    /// follows cursors and prints the whole directory, however large.
-    #[arg(long)]
+    /// Stop after this many entries in total.
+    #[arg(long, conflicts_with = "all")]
     pub limit: Option<u32>,
     /// Resume cursor from a previous bounded listing.
     #[arg(long)]
     pub cursor: Option<String>,
+    /// Follow every page and print entries as pages arrive.
+    #[arg(long)]
+    pub all: bool,
+    /// Print one JSON entry per line as pages arrive.
+    #[arg(long, conflicts_with = "json")]
+    pub jsonl: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -50,6 +50,7 @@ pub(crate) async fn run_filesystem_ls(
     kind: CommandKind,
     config_path: &Path,
     args: FilesystemLsArgs,
+    runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let allow_root = true;
@@ -59,18 +60,37 @@ pub(crate) async fn run_filesystem_ls(
         allow_root,
     )
     .map_err(|error| context.fail(kind, error))?;
-    let (entries, next_cursor) = match (args.limit, args.cursor.as_deref()) {
-        // Unbounded is still the default: a listing nobody bounded prints
-        // the whole directory, as it always has.
-        (None, None) => {
-            let entries = context
-                .target
-                .list_path_entries_all(&spec)
-                .await
-                .map_err(|error| context.fail(kind, error))?;
-            (entries, None)
-        }
-        (limit, cursor) => list_bounded_path_entries(&context, kind, &spec, limit, cursor).await?,
+    let streams_pages = args.jsonl || (args.all && !runtime.json);
+    if streams_pages {
+        stream_path_entries(
+            &context,
+            kind,
+            &spec,
+            args.limit,
+            args.cursor.as_deref(),
+            args.all,
+            args.jsonl,
+        )
+        .await?;
+        return Ok(CommandOutput {
+            kind,
+            profile: Some(context.profile_name),
+            mode: Some(context.mode),
+            data: CommandData::StreamedToStdout,
+        });
+    }
+
+    let (entries, next_cursor) = if args.all {
+        list_all_path_entries(&context, kind, &spec, args.cursor.as_deref()).await?
+    } else if let Some(limit) = args.limit {
+        list_bounded_path_entries(&context, kind, &spec, limit, args.cursor.as_deref()).await?
+    } else {
+        let page = context
+            .target
+            .list_path_entries_page(&spec, None, args.cursor.as_deref())
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        (page.entries, page.next_cursor)
     };
     Ok(CommandOutput {
         kind,
@@ -83,38 +103,100 @@ pub(crate) async fn run_filesystem_ls(
     })
 }
 
-/// Reads pages until `limit` entries are in hand, and reports the cursor
-/// that resumes where it stopped.
-///
-/// `limit` bounds the total, not one page, so the loop asks for what it
-/// still needs — clamped to a page size every deployment accepts, because a
-/// caller-supplied page limit above `pagination.max_limit` is rejected
-/// rather than clamped by the server. An absent `limit` follows the cursor
-/// to the end, which is what `--cursor` alone asks for.
+/// Reads pages until `limit` entries are in hand.
 async fn list_bounded_path_entries(
     context: &CommandContext,
     kind: CommandKind,
     spec: &NamespacePath,
-    limit: Option<u32>,
+    limit: u32,
     cursor: Option<&str>,
 ) -> Result<(Vec<loonfs_api::AuthoritativePathEntry>, Option<String>), CommandFailure> {
     let mut entries = Vec::new();
     let mut cursor = cursor.map(ToOwned::to_owned);
     loop {
+        // Servers reject oversized page limits, so ask only for the part of
+        // the total bound that one default deployment page can accept.
+        let remaining = limit.saturating_sub(entries.len() as u32);
+        let page_limit = remaining.min(loonfs_api::DEFAULT_PAGE_LIMIT);
+        let page = context
+            .target
+            .list_path_entries_page(spec, Some(page_limit), cursor.as_deref())
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        entries.extend(page.entries);
+        cursor = page.next_cursor;
+        let filled = entries.len() as u32 >= limit;
+        if filled || cursor.is_none() {
+            return Ok((entries, cursor));
+        }
+    }
+}
+
+/// Reads every page into one result for `--json --all`.
+async fn list_all_path_entries(
+    context: &CommandContext,
+    kind: CommandKind,
+    spec: &NamespacePath,
+    cursor: Option<&str>,
+) -> Result<(Vec<loonfs_api::AuthoritativePathEntry>, Option<String>), CommandFailure> {
+    let mut entries = Vec::new();
+    let mut cursor = cursor.map(ToOwned::to_owned);
+    loop {
+        let page = context
+            .target
+            .list_path_entries_page(spec, None, cursor.as_deref())
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        entries.extend(page.entries);
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            return Ok((entries, None));
+        }
+    }
+}
+
+/// Writes each page before fetching the next one.
+async fn stream_path_entries(
+    context: &CommandContext,
+    kind: CommandKind,
+    spec: &NamespacePath,
+    limit: Option<u32>,
+    cursor: Option<&str>,
+    all: bool,
+    jsonl: bool,
+) -> Result<(), CommandFailure> {
+    let mut written = 0_u32;
+    let mut cursor = cursor.map(ToOwned::to_owned);
+    loop {
         let page_limit = limit.map(|limit| {
-            let remaining = limit.saturating_sub(entries.len() as u32);
-            remaining.min(loonfs_api::DEFAULT_PAGE_LIMIT)
+            limit
+                .saturating_sub(written)
+                .min(loonfs_api::DEFAULT_PAGE_LIMIT)
         });
         let page = context
             .target
             .list_path_entries_page(spec, page_limit, cursor.as_deref())
             .await
             .map_err(|error| context.fail(kind, error))?;
-        entries.extend(page.entries);
+        written = written.saturating_add(page.entries.len() as u32);
+        crate::render::write_path_entries_page(&page.entries, jsonl)
+            .map_err(|error| context.fail(kind, CliError::io(error)))?;
         cursor = page.next_cursor;
-        let filled = limit.is_some_and(|limit| entries.len() as u32 >= limit);
-        if filled || cursor.is_none() {
-            return Ok((entries, cursor));
+
+        let filled = limit.is_some_and(|limit| written >= limit);
+        let follows_cursor = all || limit.is_some();
+        if filled || !follows_cursor || cursor.is_none() {
+            // Standard output stays machine-pure in `--jsonl`, so the
+            // continuation signal goes to standard error, where this CLI
+            // already reports progress. Without it a one-page stream would
+            // truncate silently.
+            if let Some(cursor) = cursor {
+                crate::render::write_stderr_progress(format!(
+                    "more entries exist; continue with --cursor {cursor} or stream everything \
+                     with --all"
+                ));
+            }
+            return Ok(());
         }
     }
 }

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -55,7 +55,7 @@ pub(crate) async fn run(
         }
         Command::Use(args) => namespace::run_namespace_use(kind, config_path, args).await,
         Command::Current(args) => namespace::run_namespace_current(kind, config_path, args).await,
-        Command::Ls(args) => fs::run_filesystem_ls(kind, config_path, args).await,
+        Command::Ls(args) => fs::run_filesystem_ls(kind, config_path, args, runtime).await,
         Command::Stat(args) => fs::run_filesystem_stat(kind, config_path, args).await,
         Command::Annotate(args) => fs::run_filesystem_annotate(kind, config_path, args).await,
         Command::Cat(args) => fs::run_filesystem_cat(kind, config_path, args).await,

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -6,7 +6,7 @@ use crate::args::{
     CommandKind, CurrentArgs, NamespaceCommand, NamespaceCreateArgs, NamespaceDeleteArgs,
     NamespaceForkArgs, NamespaceUseArgs, RuntimeBehavior,
 };
-use crate::config::save_config;
+use crate::config::mutate_config;
 use crate::error::CliError;
 use crate::profiles::{default_namespace, set_default_namespace};
 use crate::prompt::prompt_line;
@@ -158,7 +158,7 @@ pub(crate) async fn run_namespace_use(
     args: NamespaceUseArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let explicit_profile = args.profile.profile.as_deref();
-    let mut loaded = load_cli_config(config_path)
+    let loaded = load_cli_config(config_path)
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let resolved =
         resolve_target_profile_from_config(&loaded.config, explicit_profile, args.profile.no_retry)
@@ -174,10 +174,10 @@ pub(crate) async fn run_namespace_use(
         .await
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
-    set_default_namespace(&mut loaded.config, &resolved.profile_name, &args.namespace)
-        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
-    save_config(&loaded.path, &loaded.config)
-        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+    mutate_config(&loaded.path, |config| {
+        set_default_namespace(config, &resolved.profile_name, &args.namespace)
+    })
+    .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     Ok(CommandOutput {
         kind,

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -141,9 +141,7 @@ pub(crate) enum CommandData {
     Trash(TrashListing),
     PathEntries {
         entries: Vec<AuthoritativePathEntry>,
-        /// Where a bounded listing stopped, and how to resume it. Present
-        /// only when `--limit` cut the listing short; its presence is what
-        /// says the directory holds more than was printed.
+        /// Where a bounded listing stopped, and how to resume it.
         #[serde(skip_serializing_if = "Option::is_none")]
         next_cursor: Option<String>,
     },

--- a/crates/loonfs-cli/src/commands/profile.rs
+++ b/crates/loonfs-cli/src/commands/profile.rs
@@ -10,8 +10,8 @@ use crate::args::{
     CommandKind, ProfileCommand, ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavior,
 };
 use crate::config::{
-    load_config, load_config_for_repair, load_config_if_exists, load_or_default_config,
-    save_config, save_config_table, ConfigLoad, ProfileConfig,
+    load_config, load_config_for_repair, load_config_if_exists, mutate_config, save_config,
+    save_config_table, ConfigLoad, ProfileConfig,
 };
 use crate::error::CliError;
 use crate::profiles::{
@@ -75,10 +75,7 @@ fn run_profile_create(
             &AmbientCredentials::from_env(),
             runtime,
         )?;
-        let mut config = load_or_default_config(config_path)?;
-        let (profile_name, redacted) = add_profile(&mut config, &name, profile)?;
-        save_config(config_path, &config)?;
-        Ok((profile_name, redacted))
+        mutate_config(config_path, |config| add_profile(config, &name, profile))
     })()
     .map_err(|error| fail(kind, Some(name.clone()), None, error))?;
 
@@ -98,8 +95,12 @@ fn run_profile_update(
 ) -> Result<CommandOutput, CommandFailure> {
     let name = args.name.clone();
     let result = (|| -> Result<(String, ProfileConfig), CliError> {
-        let mut config = load_config(config_path)?;
-        let existing = config
+        // The update is gathered before the lock: the interactive editor can
+        // sit at a prompt for minutes, and holding the config lock across it
+        // would block every other writer. `update_profile` re-checks the
+        // profile against the fresh config under the lock, so a profile
+        // deleted meanwhile still fails cleanly.
+        let existing = load_config(config_path)?
             .profiles
             .get(&name)
             .ok_or_else(|| CliError::profile_not_found(&name))?
@@ -115,9 +116,7 @@ fn run_profile_update(
             ));
         };
 
-        let (profile_name, redacted) = update_profile(&mut config, &name, updated)?;
-        save_config(config_path, &config)?;
-        Ok((profile_name, redacted))
+        mutate_config(config_path, |config| update_profile(config, &name, updated))
     })()
     .map_err(|error| fail(kind, Some(name.clone()), None, error))?;
 

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -6,7 +6,7 @@ use loonfs_client::ClientConfig;
 use loonfs_objectstore::{SecretString, StoreConfigError};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -453,6 +453,7 @@ pub(crate) fn load_or_default_config(path: &Path) -> Result<CliConfig, CliError>
 }
 
 pub(crate) fn save_config(path: &Path, config: &CliConfig) -> Result<(), CliError> {
+    let _lock = lock_config(path)?;
     config.validate()?;
     let contents = toml::to_string_pretty(config)
         .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
@@ -463,12 +464,34 @@ pub(crate) fn save_config(path: &Path, config: &CliConfig) -> Result<(), CliErro
 /// commands when the file no longer strict-decodes: round-tripping through
 /// [`CliConfig`] would drop the content the user still needs to fix.
 pub(crate) fn save_config_table(path: &Path, table: &toml::Table) -> Result<(), CliError> {
+    let _lock = lock_config(path)?;
     let contents = toml::to_string_pretty(table)
         .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
     persist_config_contents(path, &contents)
 }
 
-fn persist_config_contents(path: &Path, contents: &str) -> Result<(), CliError> {
+/// Applies one edit to the latest config under the exclusive lock, so
+/// concurrent writers cannot lose each other's updates. The closure's value
+/// comes back to the caller once the file is durably replaced.
+pub(crate) fn mutate_config<T>(
+    path: &Path,
+    mutate: impl FnOnce(&mut CliConfig) -> Result<T, CliError>,
+) -> Result<T, CliError> {
+    let _lock = lock_config(path)?;
+    let mut config = load_or_default_config(path)?;
+    let value = mutate(&mut config)?;
+    config.validate()?;
+    let contents = toml::to_string_pretty(&config)
+        .map_err(|err| CliError::invalid_config(format!("failed to encode config: {err}")))?;
+    persist_config_contents(path, &contents)?;
+    Ok(value)
+}
+
+struct ConfigLock {
+    _file: File,
+}
+
+fn lock_config(path: &Path) -> Result<ConfigLock, CliError> {
     let parent = path.parent().ok_or_else(|| {
         CliError::invalid_config(format!(
             "config path has no parent directory: {}",
@@ -478,14 +501,62 @@ fn persist_config_contents(path: &Path, contents: &str) -> Result<(), CliError> 
     fs::create_dir_all(parent).map_err(|err| {
         CliError::invalid_config(format!("failed to create config directory: {err}"))
     })?;
-    let tmp_path = path.with_extension("tmp");
-    write_owner_only(&tmp_path, contents.as_bytes())?;
-    fs::rename(&tmp_path, path).map_err(|err| {
+    let lock_path = path.with_extension("lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|err| {
+            CliError::invalid_config(format!(
+                "failed to open the lock file `{}`: {err}",
+                lock_path.display()
+            ))
+        })?;
+    fs4::fs_std::FileExt::lock_exclusive(&file).map_err(|err| {
+        CliError::invalid_config(format!("failed to lock `{}`: {err}", lock_path.display()))
+    })?;
+    Ok(ConfigLock { _file: file })
+}
+
+fn persist_config_contents(path: &Path, contents: &str) -> Result<(), CliError> {
+    let parent = path.parent().ok_or_else(|| {
         CliError::invalid_config(format!(
-            "failed to persist config {}: {err}",
+            "config path has no parent directory: {}",
             path.display()
         ))
     })?;
+    let mut temp_file = tempfile::Builder::new()
+        .prefix(".loonfs-config-")
+        .suffix(".tmp")
+        .tempfile_in(parent)
+        .map_err(|err| {
+            CliError::invalid_config(format!(
+                "failed to create temporary config file in {}: {err}",
+                parent.display()
+            ))
+        })?;
+    temp_file
+        .write_all(contents.as_bytes())
+        .map_err(|err| CliError::invalid_config(format!("failed to write config: {err}")))?;
+    temp_file
+        .flush()
+        .map_err(|err| CliError::invalid_config(format!("failed to flush config: {err}")))?;
+    temp_file
+        .as_file()
+        .sync_all()
+        .map_err(|err| CliError::invalid_config(format!("failed to sync config: {err}")))?;
+    temp_file.persist(path).map_err(|err| {
+        CliError::invalid_config(format!(
+            "failed to persist config {}: {}",
+            path.display(),
+            err.error
+        ))
+    })?;
+    if let Ok(directory) = File::open(parent) {
+        let _ = directory.sync_all();
+    }
     Ok(())
 }
 
@@ -525,43 +596,6 @@ fn redacted_config_value(key: Option<&str>, value: &toml::Value) -> toml::Value 
     }
 }
 
-fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<(), CliError> {
-    #[cfg(unix)]
-    let mut file = {
-        use std::os::unix::fs::OpenOptionsExt;
-        OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .mode(0o600)
-            .open(path)
-            .map_err(|err| {
-                CliError::invalid_config(format!(
-                    "failed to create config file {}: {err}",
-                    path.display()
-                ))
-            })?
-    };
-    #[cfg(not(unix))]
-    let mut file = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(path)
-        .map_err(|err| {
-            CliError::invalid_config(format!(
-                "failed to create config file {}: {err}",
-                path.display()
-            ))
-        })?;
-
-    file.write_all(bytes)
-        .map_err(|err| CliError::invalid_config(format!("failed to write config: {err}")))?;
-    file.sync_all()
-        .map_err(|err| CliError::invalid_config(format!("failed to flush config: {err}")))?;
-    Ok(())
-}
-
 fn require_non_empty(field: &str, value: &str) -> Result<(), CliError> {
     if value.trim().is_empty() {
         return Err(CliError::invalid_config(format!("missing `{field}`")));
@@ -593,7 +627,7 @@ mod tests {
     #![allow(clippy::panic)]
     // Config tests use panic in unexpected match arms for precise diagnostics.
 
-    use super::CliConfig;
+    use super::{CliConfig, ProfileConfig};
 
     fn parse(contents: &str) -> Result<CliConfig, toml::de::Error> {
         toml::from_str(contents)
@@ -835,6 +869,99 @@ secret_access_key = "secret"
                 "{}",
                 error.message
             );
+        }
+    }
+
+    #[test]
+    fn concurrent_mutations_preserve_every_profile_and_remove_temp_files() {
+        const THREADS: usize = 16;
+        const MUTATIONS_PER_THREAD: usize = 8;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        let barrier = std::sync::Barrier::new(THREADS);
+
+        std::thread::scope(|scope| {
+            let mut handles = Vec::with_capacity(THREADS);
+            for thread_index in 0..THREADS {
+                let barrier = &barrier;
+                let path = &path;
+                handles.push(scope.spawn(move || {
+                    let profile_name = format!("agent-{thread_index}");
+                    barrier.wait();
+                    for mutation_index in 0..MUTATIONS_PER_THREAD {
+                        let namespace = format!("namespace-{thread_index}-{mutation_index}");
+                        super::mutate_config(path, |config| {
+                            config.profiles.insert(
+                                profile_name.clone(),
+                                ProfileConfig::Remote {
+                                    server_url: format!(
+                                        "https://agent-{thread_index}-{mutation_index}.example.com"
+                                    ),
+                                    default_namespace: Some(namespace),
+                                    auth_token: None,
+                                    ca_cert_path: None,
+                                },
+                            );
+                            Ok(())
+                        })
+                        .expect("mutate config");
+                    }
+                }));
+            }
+            for handle in handles {
+                handle.join().expect("mutation thread");
+            }
+        });
+
+        let contents = std::fs::read_to_string(&path).expect("read final config");
+        let config: CliConfig = toml::from_str(&contents).expect("parse final config");
+        config.validate().expect("validate final config");
+        for thread_index in 0..THREADS {
+            let profile_name = format!("agent-{thread_index}");
+            let expected_namespace =
+                format!("namespace-{thread_index}-{}", MUTATIONS_PER_THREAD - 1);
+            let Some(ProfileConfig::Remote {
+                default_namespace, ..
+            }) = config.profiles.get(&profile_name)
+            else {
+                panic!("missing remote profile {profile_name}");
+            };
+            assert_eq!(
+                default_namespace.as_deref(),
+                Some(expected_namespace.as_str())
+            );
+        }
+
+        let temp_files: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read config directory")
+            .map(|entry| entry.expect("read directory entry").path())
+            .filter(|path| path.extension().is_some_and(|extension| extension == "tmp"))
+            .collect();
+        assert!(
+            temp_files.is_empty(),
+            "temporary files remain: {temp_files:?}"
+        );
+    }
+
+    #[test]
+    fn mutate_config_creates_an_owner_only_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("config.toml");
+
+        super::mutate_config(&path, |_| Ok(())).expect("create config");
+
+        assert!(path.is_file());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mode = std::fs::metadata(&path)
+                .expect("config metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600);
         }
     }
 

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -93,7 +93,7 @@ impl CliError {
         Self::new(
             "no_default_namespace",
             format!(
-                "no default namespace is set for profile `{profile}`; use `loonfs use <namespace>` or `--namespace`"
+                "no default namespace is set for profile `{profile}`; use `--namespace`, `LOONFS_NAMESPACE`, or `loonfs use <namespace>`"
             ),
         )
     }

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -18,7 +18,7 @@ mod render;
 mod resolve;
 mod uploads;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use std::process::ExitCode;
 
 /// Exit status for a command line the parser rejected, which is clap's own.
@@ -33,6 +33,15 @@ pub async fn main() -> ExitCode {
         Ok(cli) => cli,
         Err(error) => return render_parse_failure(&error),
     };
+    // Clap does not check a child argument's conflict against a global
+    // argument written before the subcommand, so close that ordering gap.
+    if cli.json && matches!(&cli.command, args::Command::Ls(args) if args.jsonl) {
+        let error = args::Cli::command().error(
+            clap::error::ErrorKind::ArgumentConflict,
+            "the argument '--jsonl' cannot be used with '--json'",
+        );
+        return render_parse_failure(&error);
+    }
     let runtime = args::RuntimeBehavior::detect(&cli);
 
     match commands::run(cli, runtime).await {

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -299,6 +299,23 @@ pub(crate) fn write_stderr_progress(message: impl std::fmt::Display) {
     let _ = writeln!(io::stderr().lock(), "{message}");
 }
 
+/// Writes one listing page and makes it visible before the next fetch.
+pub(crate) fn write_path_entries_page(
+    entries: &[loonfs_api::AuthoritativePathEntry],
+    jsonl: bool,
+) -> io::Result<()> {
+    let mut stdout = io::stdout().lock();
+    for entry in entries {
+        if jsonl {
+            serde_json::to_writer(&mut stdout, entry).map_err(io::Error::other)?;
+            stdout.write_all(b"\n")?;
+        } else {
+            writeln!(stdout, "{}", human_path_entry(entry))?;
+        }
+    }
+    stdout.flush()
+}
+
 pub(crate) fn json_success(output: &CommandOutput) -> io::Result<String> {
     match &output.data {
         CommandData::StreamBytes(_) | CommandData::StreamedToStdout => Err(io::Error::new(
@@ -572,19 +589,10 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             entries,
             next_cursor,
         } => {
-            let mut lines: Vec<String> = entries
-                .iter()
-                .map(|entry| {
-                    let size = entry
-                        .size_bytes
-                        .map(|value: u64| value.to_string())
-                        .unwrap_or_else(|| "-".to_owned());
-                    format!("{}\t{}\t{}", entry.inode_kind, size, entry.absolute_path)
-                })
-                .collect();
+            let mut lines: Vec<String> = entries.iter().map(human_path_entry).collect();
             if let Some(cursor) = next_cursor {
                 lines.push(format!(
-                    "next_cursor: {cursor} (more entries; resume with --cursor)"
+                    "more entries exist; continue with --cursor {cursor} or list everything with --all"
                 ));
             }
             lines.join("\n")
@@ -903,6 +911,14 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         CommandData::Version { version } => version.clone(),
         CommandData::StreamBytes(_) | CommandData::StreamedToStdout => String::new(),
     }
+}
+
+fn human_path_entry(entry: &loonfs_api::AuthoritativePathEntry) -> String {
+    let size = entry
+        .size_bytes
+        .map(|value: u64| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    format!("{}\t{}\t{}", entry.inode_kind, size, entry.absolute_path)
 }
 
 /// One attribute value on one line. A list joins on `, `, which is a display

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -65,6 +65,13 @@ pub(crate) fn resolve_namespace(
             namespace: parse_namespace_id(namespace)?,
         });
     }
+    if let Ok(namespace) = std::env::var("LOONFS_NAMESPACE") {
+        if !namespace.trim().is_empty() {
+            return Ok(ResolvedNamespace {
+                namespace: parse_namespace_id(&namespace)?,
+            });
+        }
+    }
     let (profile_name, profile) = resolve_profile(config, explicit_profile)?;
     let namespace =
         default_namespace(profile).ok_or_else(|| CliError::no_default_namespace(profile_name))?;

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -3157,6 +3157,69 @@ fn filesystem_requires_default_namespace_when_omitted() {
 }
 
 #[test]
+fn namespace_resolution_uses_environment_before_profile_default() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "profile-default"]));
+    assert_success(&harness.run(&["namespace", "create", "from-environment"]));
+    assert_success(&harness.run(&["use", "profile-default"]));
+
+    let output = harness.run_with_env(
+        &[("LOONFS_NAMESPACE", "from-environment")],
+        &["--json", "changes"],
+    );
+
+    assert_success(&output);
+    assert_eq!(json_data(&output)["namespace_id"], "from-environment");
+}
+
+#[test]
+fn namespace_resolution_uses_flag_before_environment() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "from-environment"]));
+    assert_success(&harness.run(&["namespace", "create", "from-flag"]));
+
+    let output = harness.run_with_env(
+        &[("LOONFS_NAMESPACE", "from-environment")],
+        &["--json", "changes", "--namespace", "from-flag"],
+    );
+
+    assert_success(&output);
+    assert_eq!(json_data(&output)["namespace_id"], "from-flag");
+}
+
+#[test]
+fn namespace_resolution_gives_invalid_environment_the_flag_error_code() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+
+    let from_environment =
+        harness.run_with_env(&[("LOONFS_NAMESPACE", "bad/name")], &["--json", "changes"]);
+    let from_flag = harness.run(&["--json", "changes", "--namespace", "bad/name"]);
+
+    assert_failure(&from_environment);
+    assert_failure(&from_flag);
+    assert_eq!(
+        json_error(&from_environment)["code"],
+        json_error(&from_flag)["code"]
+    );
+}
+
+#[test]
+fn namespace_resolution_ignores_empty_environment() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "profile-default"]));
+    assert_success(&harness.run(&["use", "profile-default"]));
+
+    let output = harness.run_with_env(&[("LOONFS_NAMESPACE", "")], &["--json", "changes"]);
+
+    assert_success(&output);
+    assert_eq!(json_data(&output)["namespace_id"], "profile-default");
+}
+
+#[test]
 fn embedded_profile_missing_namespace_reports_user_facing_message() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
@@ -5089,15 +5152,15 @@ impl Harness {
         command.args(args).output().expect("run loonfs")
     }
 
-    /// Every invocation starts from the temp home with the config
-    /// environment cleared, so a developer's own `XDG_CONFIG_HOME` or
-    /// `LOONFS_CONFIG` can never decide which file a test reads.
+    /// Every invocation starts from the temp home with CLI selection
+    /// environment cleared, so a developer's shell cannot affect a test.
     fn command(&self) -> Command {
         let mut command = Command::new(loon_binary_path());
         command
             .env("HOME", &self.home_dir)
             .env_remove("XDG_CONFIG_HOME")
-            .env_remove("LOONFS_CONFIG");
+            .env_remove("LOONFS_CONFIG")
+            .env_remove("LOONFS_NAMESPACE");
         command
     }
 
@@ -5116,6 +5179,7 @@ impl Harness {
             .env("HOME", &self.home_dir)
             .env_remove("XDG_CONFIG_HOME")
             .env_remove("LOONFS_CONFIG")
+            .env_remove("LOONFS_NAMESPACE")
             .output()
             .expect("replay the printed command")
     }

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -4688,10 +4688,123 @@ fn cp_and_mv_land_inside_an_existing_directory_in_both_modes() {
     }
 }
 
-/// `ls` bounds its own output on request, and the cursor it reports
-/// resumes exactly where it stopped.
+/// The default listing stops after one real server page, while the explicit
+/// streaming modes cross that boundary and a cursor resumes at the next row.
 #[test]
-fn ls_limit_bounds_the_whole_listing_and_resumes_from_its_cursor() {
+fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    // The pagination policy is fixed at 1,000 entries, so one extra file is
+    // the smallest integration fixture that produces a continuation cursor.
+    let local = harness.temp_dir.path().join("listing");
+    fs::create_dir(&local).expect("create listing fixture");
+    for index in 0..=loonfs_api::DEFAULT_PAGE_LIMIT {
+        fs::write(local.join(format!("f{index:04}.txt")), b"x").expect("write listing entry");
+    }
+    let uploaded = harness.run(&[
+        "--json",
+        "--no-progress",
+        "put",
+        "-r",
+        local.to_str().expect("utf-8 path"),
+        "/listing",
+    ]);
+    assert_success(&uploaded);
+
+    let default_human = harness.run(&["ls", "/listing"]);
+    assert_success(&default_human);
+    let default_human = stdout_string(&default_human);
+    let human_lines = default_human.lines().collect::<Vec<_>>();
+    assert_eq!(
+        human_lines.len(),
+        loonfs_api::DEFAULT_PAGE_LIMIT as usize + 1
+    );
+    assert!(human_lines
+        .last()
+        .expect("continuation line")
+        .starts_with("more entries exist; continue with --cursor "));
+    assert!(human_lines
+        .last()
+        .expect("continuation line")
+        .ends_with(" or list everything with --all"));
+
+    let first = harness.run(&["--json", "ls", "/listing"]);
+    assert_success(&first);
+    let first_data = json_data(&first);
+    let first_entries = first_data["entries"].as_array().expect("first page");
+    assert_eq!(first_entries.len(), loonfs_api::DEFAULT_PAGE_LIMIT as usize);
+    let cursor = first_data["next_cursor"]
+        .as_str()
+        .expect("default JSON page carries a cursor");
+
+    let one_page_jsonl = harness.run(&["ls", "/listing", "--jsonl"]);
+    assert_success(&one_page_jsonl);
+    assert_eq!(
+        stdout_string(&one_page_jsonl).lines().count(),
+        loonfs_api::DEFAULT_PAGE_LIMIT as usize
+    );
+
+    let all = harness.run(&["ls", "/listing", "--all"]);
+    assert_success(&all);
+    assert_eq!(
+        stdout_string(&all).lines().count(),
+        loonfs_api::DEFAULT_PAGE_LIMIT as usize + 1
+    );
+    assert!(!stdout_string(&all).contains("more entries exist"));
+
+    let all_json = harness.run(&["--json", "ls", "/listing", "--all"]);
+    assert_success(&all_json);
+    let all_json_data = json_data(&all_json);
+    assert_eq!(
+        all_json_data["entries"]
+            .as_array()
+            .expect("all entries")
+            .len(),
+        loonfs_api::DEFAULT_PAGE_LIMIT as usize + 1
+    );
+    assert!(all_json_data.get("next_cursor").is_none());
+
+    let jsonl = harness.run(&["ls", "/listing", "--all", "--jsonl"]);
+    assert_success(&jsonl);
+    let jsonl_entries = stdout_string(&jsonl)
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("one JSON entry per line"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        jsonl_entries.len(),
+        loonfs_api::DEFAULT_PAGE_LIMIT as usize + 1
+    );
+    assert!(jsonl_entries
+        .iter()
+        .all(|entry| entry.get("data").is_none()));
+    let actual_paths = jsonl_entries
+        .iter()
+        .map(|entry| entry["absolute_path"].as_str().expect("entry path"))
+        .collect::<Vec<_>>();
+    let expected_paths = (0..=loonfs_api::DEFAULT_PAGE_LIMIT)
+        .map(|index| format!("/listing/f{index:04}.txt"))
+        .collect::<Vec<_>>();
+    assert_eq!(actual_paths, expected_paths);
+
+    let second = harness.run(&["--json", "ls", "/listing", "--cursor", cursor]);
+    assert_success(&second);
+    let second_data = json_data(&second);
+    let second_entries = second_data["entries"].as_array().expect("second page");
+    assert_eq!(second_entries.len(), 1);
+    assert_eq!(
+        first_entries.last().expect("last first-page entry")["absolute_path"],
+        "/listing/f0999.txt"
+    );
+    assert_eq!(second_entries[0]["absolute_path"], "/listing/f1000.txt");
+}
+
+/// `ls --limit` bounds the total, and incompatible output bounds fail in
+/// clap before the command runs.
+#[test]
+fn ls_limit_bounds_the_whole_listing_and_rejects_all() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
     assert_success(&harness.run(&["namespace", "create", "demo"]));
@@ -4707,8 +4820,8 @@ fn ls_limit_bounds_the_whole_listing_and_resumes_from_its_cursor() {
         ]));
     }
 
-    // Unbounded still prints everything and reports no cursor.
-    let all = harness.run(&["--json", "ls"]);
+    // Explicitly unbounded JSON still prints everything in one document.
+    let all = harness.run(&["--json", "ls", "--all"]);
     assert_success(&all);
     let all_data = json_data(&all);
     assert_eq!(all_data["entries"].as_array().expect("json array").len(), 5);
@@ -4752,10 +4865,19 @@ fn ls_limit_bounds_the_whole_listing_and_resumes_from_its_cursor() {
     );
     assert!(rest_data.get("next_cursor").is_none());
 
-    // The human rendering says the listing stopped early.
+    // The human rendering says how to continue after the bound.
     let human = harness.run(&["ls", "--limit", "2"]);
     assert_success(&human);
-    assert!(stdout_string(&human).contains("next_cursor:"));
+    assert!(stdout_string(&human).contains("continue with --cursor"));
+
+    let conflicting_bound = harness.run(&["ls", "--all", "--limit", "2"]);
+    assert_failure(&conflicting_bound);
+    assert_eq!(conflicting_bound.status.code(), Some(2));
+
+    let conflicting_json = harness.run(&["--json", "ls", "--jsonl"]);
+    assert_failure(&conflicting_json);
+    assert_eq!(conflicting_json.status.code(), Some(2));
+    assert!(conflicting_json.stdout.is_empty());
 }
 
 /// The admin plane and the change feed work end to end, and both profile


### PR DESCRIPTION
`loonfs ls` with no flags used to follow every cursor and hold the whole directory in CLI memory before rendering anything; the audit's 80,000-entry listing built a 26 MiB JSON document and held ~90 MiB. LoonFS is prerelease, so this makes the clean breaking change now.

The default is one server page. When more entries exist, human output ends with one line naming both continuations (`--cursor <c>` or `--all`), and `--json` keeps carrying `next_cursor`.

`--all` follows every page and writes each page as it arrives — the CLI no longer accumulates. `--jsonl` writes one JSON object per line for automation and composes with `--all`; when a bounded `--jsonl` stream stops with entries remaining, the continuation cursor goes to standard error, so stdout stays machine-pure and the stream cannot truncate silently. `--json --all` still accumulates a single document, because a JSON array cannot stream. `--limit` keeps its total-bound meaning; `--all --limit` and `--json --jsonl` are rejected. Nothing depends on whether stdout is a TTY.

`trash`, `revisions`, and `changes` already page one bounded call at a time; the recursive transfer machinery keeps its internal full listing, which is not an output command.

Tests: a 1,001-file fixture crossing the fixed 1,000-entry page proves the default page boundary, `--all`, `--jsonl` line-validity, cursor resumption, and the `--limit` bound; clippy clean; 63 unit + 97 integration tests pass.