### PR TITLE
fix(core): scans skip the stored-block cache and the memo gets a byte cap

### DIFF
--- a/crates/loonfs-cli/src/main.rs
+++ b/crates/loonfs-cli/src/main.rs
@@ -1,6 +1,11 @@
 //! The `loonfs` CLI binary: parse arguments, run the command, render the
 //! result.
 
+// The embedded runtime's composed async call graph is deep enough that
+// rustc's future-layout computation exceeds its default query depth while
+// building this binary. Raising the limit is the fix rustc prescribes.
+#![recursion_limit = "256"]
+
 use std::process::ExitCode;
 
 #[tokio::main]

--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -1,11 +1,10 @@
 //! Fetching, decoding, and cache publication for SST index and filter blocks.
 //!
-//! A load consults three places in order: the per-view memo, the decoded
-//! block cache, and the node-local cache of the same blocks in their stored
-//! form. Only when all three come up empty does object storage answer, and
-//! what that one GET produced is offered back to the local tier section by
-//! section. The data-block loads in [`super::data_block_load`] reach the
-//! local tier through the same two helpers.
+//! Index, filter, and point data loads consult the per-view memo, the decoded
+//! block cache, and the node-local cache of stored bytes. Their fetched
+//! sections, including whole-small-segment loads, are offered to the local
+//! tier. Wide data spans skip that tier because its awaited point reads lose
+//! the coalescing provided by ranged store GETs.
 
 use super::block_load::SessionBlockMemo;
 use super::cache::{

--- a/crates/loonfs-core/src/checkpoint/block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/block_load.rs
@@ -9,8 +9,13 @@ use super::validate::validate_manifest_row_seq_range;
 use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow};
 use loonfs_api::wire::sst_blocks::{index_blocks_for_key_range, DecodedDataBlock};
 use loonfs_objectstore::ObjectStore;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
+
+/// Bounds decoded data retained by one view. 64 MiB comfortably holds one
+/// page's working set plus read-ahead, while a runaway scan cannot pin
+/// gigabytes through its memo.
+const SESSION_BLOCK_MEMO_DATA_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 
 /// The data blocks of one segment that can hold keys in
 /// `[lower_bound, upper_bound)`, shared straight from the decoded-block
@@ -58,14 +63,21 @@ impl SegmentKeyRangeBlocks {
     }
 }
 
-/// Per-view memo of decoded blocks, so one operation never re-fetches or
-/// re-decodes a block it already saw — the reuse that keeps cache-disabled
-/// paths (cold boot, diagnostics) linear in the blocks they touch. Entries
-/// share the decoded allocations with the shared cache and concurrent
-/// readers; the memo retains pointers, not copies, for the view's lifetime.
+/// Per-view memo of decoded blocks. Index, filter, and manifest entries stay
+/// for the view's lifetime, while data entries have a decoded-byte budget and
+/// leave in insertion order. This is a dedupe map, not an owner:
+/// [`SegmentKeyRangeBlocks`] holds its own block [`Arc`]s, so eviction cannot
+/// invalidate borrowed rows. Its worst case is one extra shared-cache lookup.
 #[derive(Debug, Default)]
 pub(super) struct SessionBlockMemo {
-    blocks: Mutex<HashMap<MetadataTableCacheKey, DecodedMetadataTableBlock>>,
+    inner: Mutex<SessionBlockMemoInner>,
+}
+
+#[derive(Debug, Default)]
+struct SessionBlockMemoInner {
+    blocks: HashMap<MetadataTableCacheKey, DecodedMetadataTableBlock>,
+    data_insertion_order: VecDeque<MetadataTableCacheKey>,
+    data_decoded_bytes: usize,
 }
 
 impl SessionBlockMemo {
@@ -73,9 +85,10 @@ impl SessionBlockMemo {
         &self,
         cache_key: &MetadataTableCacheKey,
     ) -> Option<DecodedMetadataTableBlock> {
-        self.blocks
+        self.inner
             .lock()
             .expect("session block memo lock should not be poisoned")
+            .blocks
             .get(cache_key)
             .cloned()
     }
@@ -85,10 +98,40 @@ impl SessionBlockMemo {
         cache_key: &MetadataTableCacheKey,
         block: &DecodedMetadataTableBlock,
     ) {
-        self.blocks
+        let mut inner = self
+            .inner
             .lock()
-            .expect("session block memo lock should not be poisoned")
-            .insert(cache_key.clone(), block.clone());
+            .expect("session block memo lock should not be poisoned");
+        let previous = inner.blocks.insert(cache_key.clone(), block.clone());
+        if let Some(DecodedMetadataTableBlock::Data {
+            decoded_byte_len, ..
+        }) = previous
+        {
+            inner.data_decoded_bytes = inner.data_decoded_bytes.saturating_sub(decoded_byte_len);
+        } else if matches!(block, DecodedMetadataTableBlock::Data { .. }) {
+            inner.data_insertion_order.push_back(cache_key.clone());
+        }
+        if let DecodedMetadataTableBlock::Data {
+            decoded_byte_len, ..
+        } = block
+        {
+            inner.data_decoded_bytes = inner.data_decoded_bytes.saturating_add(*decoded_byte_len);
+        }
+        while inner.data_decoded_bytes > SESSION_BLOCK_MEMO_DATA_BUDGET_BYTES {
+            let oldest = inner
+                .data_insertion_order
+                .pop_front()
+                .expect("accounted data blocks should have an insertion-order entry");
+            let Some(DecodedMetadataTableBlock::Data {
+                decoded_byte_len, ..
+            }) = inner.blocks.get(&oldest)
+            else {
+                continue;
+            };
+            let decoded_byte_len = *decoded_byte_len;
+            inner.blocks.remove(&oldest);
+            inner.data_decoded_bytes = inner.data_decoded_bytes.saturating_sub(decoded_byte_len);
+        }
     }
 }
 
@@ -144,4 +187,118 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
         descriptor.run_seq,
     )?;
     Ok(SegmentKeyRangeBlocks { blocks })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::cache::MetadataTableBlockKind;
+    use super::*;
+    use loonfs_api::wire::manifest::{
+        NamespaceManifestEnvelope, NamespaceManifestKind, NamespaceManifestPayload,
+        NAMESPACE_MANIFEST_FORMAT_VERSION,
+    };
+    use loonfs_api::wire::sst_blocks::{decode_filter_block, SegmentBlocksBuilder};
+    use loonfs_api::{
+        ChangeSeq, CommitId, InodeId, ManifestId, ManifestObjectId, NamespaceId, WriterEpoch,
+    };
+
+    fn key(kind: MetadataTableBlockKind, offset: u64) -> MetadataTableCacheKey {
+        MetadataTableCacheKey {
+            identity: format!("memo-{offset}"),
+            block_kind: kind,
+            block_offset: offset,
+        }
+    }
+
+    fn data_block(decoded_byte_len: usize) -> DecodedMetadataTableBlock {
+        DecodedMetadataTableBlock::Data {
+            block: Arc::new(DecodedDataBlock {
+                row_keys: Vec::new(),
+                rows: Vec::new(),
+            }),
+            decoded_byte_len,
+        }
+    }
+
+    fn filter_block() -> DecodedMetadataTableBlock {
+        let mut builder = SegmentBlocksBuilder::default();
+        builder
+            .push("key", "key", &0_u8)
+            .expect("filter fixture row should encode");
+        let built = builder.finish().expect("filter fixture should finish");
+        let start = built.filter.offset as usize;
+        let end = start + built.filter.stored_len as usize;
+        let filter = decode_filter_block(&built.bytes[start..end], &built.filter)
+            .expect("filter fixture should decode");
+        DecodedMetadataTableBlock::Filter {
+            filter: Arc::new(filter),
+            decoded_byte_len: 1,
+        }
+    }
+
+    fn manifest_block() -> DecodedMetadataTableBlock {
+        let manifest = NamespaceManifestEnvelope {
+            kind: NamespaceManifestKind::NamespaceManifest,
+            format_version: NAMESPACE_MANIFEST_FORMAT_VERSION,
+            payload_checksum: String::new(),
+            payload: NamespaceManifestPayload {
+                namespace_id: NamespaceId::parse("memo").expect("namespace id"),
+                manifest_id: ManifestId(0),
+                manifest_object_id: ManifestObjectId::parse(
+                    "00000000000000000000-0000000000000000",
+                )
+                .expect("manifest object id"),
+                head_seq: ChangeSeq(0),
+                head_commit_id: CommitId::parse("c_00000000000000000000000000000000")
+                    .expect("commit id"),
+                base_seq: ChangeSeq(0),
+                writer_epoch: WriterEpoch(0),
+                next_inode_id: InodeId(1),
+                retention_floor_seq: ChangeSeq(0),
+                metadata_files: Vec::new(),
+            },
+        };
+        DecodedMetadataTableBlock::Manifest {
+            manifest: Arc::new(manifest),
+            scan_runs: Arc::new(Vec::new()),
+            decoded_byte_len: 1,
+        }
+    }
+
+    #[test]
+    fn data_budget_evicts_oldest_data_and_preserves_metadata_entries() {
+        let memo = SessionBlockMemo::default();
+        let index_key = key(MetadataTableBlockKind::Index, 1);
+        let filter_key = key(MetadataTableBlockKind::Filter, 2);
+        let manifest_key = key(MetadataTableBlockKind::Manifest, 3);
+        memo.record(
+            &index_key,
+            &DecodedMetadataTableBlock::Index {
+                entries: Arc::new(Vec::new()),
+                decoded_byte_len: 1,
+            },
+        );
+        memo.record(&filter_key, &filter_block());
+        memo.record(&manifest_key, &manifest_block());
+
+        let oldest_data_key = key(MetadataTableBlockKind::Data, 4);
+        let newer_data_key = key(MetadataTableBlockKind::Data, 5);
+        let newest_data_key = key(MetadataTableBlockKind::Data, 6);
+        memo.record(
+            &oldest_data_key,
+            &data_block(SESSION_BLOCK_MEMO_DATA_BUDGET_BYTES / 2),
+        );
+        memo.record(
+            &newer_data_key,
+            &data_block(SESSION_BLOCK_MEMO_DATA_BUDGET_BYTES / 2),
+        );
+        memo.record(&newest_data_key, &data_block(1));
+
+        assert!(memo.get(&oldest_data_key).is_none());
+        assert!(memo.get(&newer_data_key).is_some());
+        assert!(memo.get(&newest_data_key).is_some());
+        assert!(memo.get(&index_key).is_some());
+        assert!(memo.get(&filter_key).is_some());
+        assert!(memo.get(&manifest_key).is_some());
+    }
 }

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -1,13 +1,14 @@
 //! Fetching, decoding, coalescing, and cache publication for SST data blocks.
 //!
-//! Both loads below consult the same three places [`super::block_fetch`]
-//! describes — the per-view memo, the decoded block cache, and the
-//! node-local cache of stored bytes — before object storage answers, and
-//! offer every block a fetch produced back to the local tier.
+//! Point loads consult the per-view memo, the decoded block cache, and the
+//! node-local cache of stored bytes. Span loads skip the stored-byte tier
+//! because it answers one block per awaited read, turning a wide scan into
+//! tens of thousands of serial point reads. Spans use the decoded caches and
+//! coalesced store GETs, and they do not populate the stored-byte tier.
 
 use super::block_fetch::{
-    load_section_bytes, offer_stored_block, publish_segment_block, segment_block_cache_key,
-    segment_codec_error, stored_block_section,
+    load_section_bytes, offer_stored_block, segment_block_cache_key, segment_codec_error,
+    stored_block_section,
 };
 use super::block_load::SessionBlockMemo;
 use super::cache::{DecodedMetadataTableBlock, MetadataTableBlockKind, MetadataTableCache};
@@ -98,12 +99,11 @@ pub(super) fn decoded_data_cache_block(
     }
 }
 
-/// Bulk path for wide selections: resolve each block against the caches in
-/// turn, group the blocks none of them answered into consecutive spans, and
-/// fetch each span with coalesced ranged GETs instead of one request per
-/// block. Duplicate concurrent span fetches are possible and benign — two
-/// fetches of one block offer the same bytes under the same key; the narrow
-/// path keeps single-flight for the hot point lookups.
+/// Bulk path for wide selections: resolve each block against the memo and
+/// shared decoded cache, group the blocks neither answered into consecutive
+/// spans, and fetch each span with coalesced ranged GETs instead of one
+/// request per block. Duplicate concurrent span fetches are possible and
+/// benign; the narrow path keeps single-flight for the hot point lookups.
 pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -127,31 +127,6 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
                 blocks[position] = Some(block);
                 continue;
             }
-        }
-        // The local stored-block cache, one tier below the two above. A hit
-        // is decoded and published exactly as a fetched block is; a miss —
-        // including an entry that did not decode, which drops itself — is a
-        // true miss the span grouping below covers.
-        if let Some(decoded) = stored_block_section(
-            table_cache,
-            descriptor,
-            StoredMetadataBlockKind::Data,
-            &handle,
-            decode_data_block,
-        )
-        .await
-        {
-            let block = Arc::new(decoded);
-            publish_segment_block(
-                table_cache,
-                memo,
-                probe_key.clone(),
-                &DecodedMetadataTableBlock::Data {
-                    decoded_byte_len: decoded_manifest_block_weight(descriptor.family, &block.rows),
-                    block: Arc::clone(&block),
-                },
-            );
-            blocks[position] = Some(block);
         }
     }
 
@@ -224,9 +199,8 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
 
 /// Fetches one contiguous span with a single ranged GET, decodes every
 /// block, and publishes them to the per-view memo and (when populating) the
-/// shared cache. Every block the GET covered is also offered to the local
-/// stored-block cache under its own key. Returns the first block's cache
-/// entry for the single-flight cell.
+/// shared cache. Returns the first block's cache entry for the single-flight
+/// cell.
 async fn load_and_publish_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
@@ -243,15 +217,6 @@ async fn load_and_publish_span<S: ObjectStore + ?Sized>(
         let handle = entry.block;
         let begin = (handle.offset - first.offset) as usize;
         let stored = &bytes[begin..begin + handle.stored_len as usize];
-        // Every block the span GET produced is offered under its own key, so
-        // a later read of any one of them needs no fetch.
-        offer_stored_block(
-            table_cache,
-            descriptor,
-            StoredMetadataBlockKind::Data,
-            &handle,
-            stored,
-        );
         let decoded = Arc::new(
             decode_data_block(stored, &handle)
                 .map_err(|err| segment_codec_error(&descriptor.object_key, err))?,

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -1224,30 +1224,6 @@ fn seed_local_blocks(
     }
 }
 
-/// The block offsets one recorded slice inserted, in ascending order. Spans
-/// are fetched concurrently, so the order they are offered in is not fixed.
-fn offered_offsets(calls: &[RecordedStoredMetadataBlockCall]) -> Vec<u64> {
-    let mut offsets: Vec<u64> = calls
-        .iter()
-        .filter_map(|call| match call {
-            RecordedStoredMetadataBlockCall::Insert { key, .. } => Some(key.offset),
-            RecordedStoredMetadataBlockCall::Get { .. }
-            | RecordedStoredMetadataBlockCall::Invalidate { .. } => None,
-        })
-        .collect();
-    offsets.sort_unstable();
-    offsets
-}
-
-fn block_offsets(index: &[SegmentIndexEntry], positions: &[usize]) -> Vec<u64> {
-    let mut offsets: Vec<u64> = positions
-        .iter()
-        .map(|position| index[*position].block.offset)
-        .collect();
-    offsets.sort_unstable();
-    offsets
-}
-
 /// One wide read over a whole segment through `cache`, with the per-view
 /// memo a fresh request would carry, and the segment fetches it paid.
 async fn wide_read(
@@ -1339,114 +1315,30 @@ async fn a_narrow_data_block_load_fills_the_local_cache_and_then_reads_from_it()
     );
 }
 
-/// A wide read over a mixed segment: two blocks already decoded, two held
-/// locally in their stored form, the rest nowhere. Only the blocks nothing
-/// answered are fetched, in one ranged GET per run of consecutive ones, and
-/// exactly those blocks are offered back.
+/// Decoded blocks split a wide selection into coalesced spans around them.
 #[tokio::test]
-async fn a_wide_read_fetches_and_offers_only_the_blocks_no_cache_answered() {
+async fn a_wide_read_coalesces_the_blocks_the_decoded_cache_did_not_answer() {
     let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
     let (expected, _) = wide_read(&store, None, &descriptor, &index).await;
 
-    // Positions 0 and 1 are decoded, 3 and 7 are held locally; the rest are
-    // nowhere. That leaves three runs of consecutive misses — {2}, {4, 5, 6},
-    // and {8..} — so three ranged GETs.
-    let decoded = [0usize, 1];
-    let local = [3usize, 7];
-    let missing: Vec<usize> = (0..index.len())
-        .filter(|position| !decoded.contains(position) && !local.contains(position))
-        .collect();
-    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
-    let cache = table_cache_over(&blocks);
+    let decoded = [0usize, 4];
+    let cache = MetadataTableCache::new(MetadataTableCacheConfig::default());
     let object = segment_object_bytes(&store, &descriptor).await;
     seed_decoded_blocks(&cache, &object, &descriptor, &index, &decoded);
-    seed_local_blocks(&blocks, &object, &descriptor, &index, &local);
 
-    let calls_before = blocks.call_count();
     let (read, gets) = wide_read(&store, Some(&cache), &descriptor, &index).await;
-    let calls = blocks.calls();
-    let during = &calls[calls_before..];
 
     assert_eq!(read, expected);
     assert_eq!(
-        gets, 3,
+        gets, 2,
         "one ranged GET per run of consecutive blocks nothing answered"
     );
-    assert_eq!(
-        offered_offsets(during),
-        block_offsets(&index, &missing),
-        "exactly the fetched blocks are offered to the local cache"
-    );
-    let probed: Vec<u64> = during
-        .iter()
-        .filter_map(|call| match call {
-            RecordedStoredMetadataBlockCall::Get { key, .. } => Some(key.offset),
-            RecordedStoredMetadataBlockCall::Insert { .. }
-            | RecordedStoredMetadataBlockCall::Invalidate { .. } => None,
-        })
-        .collect();
-    assert_eq!(
-        probed,
-        (0..index.len())
-            .filter(|position| !decoded.contains(position))
-            .map(|position| index[position].block.offset)
-            .collect::<Vec<_>>(),
-        "a decoded block short-circuits the probe; every other block is probed once, in order"
-    );
 }
 
-/// A cold local cache changes nothing about how a wide read groups its
-/// fetches: it is one more tier consulted per block, and the blocks nothing
-/// answered coalesce exactly as they do without it.
+/// A span load ignores the local stored-block tier in both directions, even
+/// when that tier already holds every selected block.
 #[tokio::test]
-async fn a_cold_local_block_cache_does_not_change_how_a_wide_read_groups_its_fetches() {
-    let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
-    let plain = MetadataTableCache::new(MetadataTableCacheConfig::default());
-    let (plain_read, plain_gets) = wide_read(&store, Some(&plain), &descriptor, &index).await;
-
-    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
-    let cold = table_cache_over(&blocks);
-    let (cold_read, cold_gets) = wide_read(&store, Some(&cold), &descriptor, &index).await;
-
-    assert_eq!(cold_read, plain_read);
-    assert_eq!(plain_gets, 1, "a selection nothing answered is one span");
-    assert_eq!(cold_gets, plain_gets);
-    assert_eq!(
-        blocks
-            .calls()
-            .iter()
-            .filter(|call| matches!(
-                call,
-                RecordedStoredMetadataBlockCall::Get { hit: false, .. }
-            ))
-            .count(),
-        index.len(),
-        "the cold tier was consulted for every block"
-    );
-
-    // The same comparison where the grouping is not trivial: two decoded
-    // blocks split the selection into two spans on both sides.
-    let object = segment_object_bytes(&store, &descriptor).await;
-    let split_plain = MetadataTableCache::new(MetadataTableCacheConfig::default());
-    seed_decoded_blocks(&split_plain, &object, &descriptor, &index, &[0, 4]);
-    let (_, split_plain_gets) = wide_read(&store, Some(&split_plain), &descriptor, &index).await;
-    let split_blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
-    let split_cold = table_cache_over(&split_blocks);
-    seed_decoded_blocks(&split_cold, &object, &descriptor, &index, &[0, 4]);
-    let (_, split_cold_gets) = wide_read(&store, Some(&split_cold), &descriptor, &index).await;
-
-    assert_eq!(
-        split_plain_gets, 2,
-        "a decoded block in the middle splits the selection into two spans"
-    );
-    assert_eq!(split_cold_gets, split_plain_gets);
-}
-
-/// One local entry inside a span that no longer decodes is dropped, refetched
-/// with the span it falls in, and the read succeeds. What it held was a copy;
-/// object storage still holds the authority.
-#[tokio::test]
-async fn a_corrupt_local_entry_inside_a_span_is_dropped_and_refetched() {
+async fn a_span_load_never_reads_or_writes_the_local_block_cache() {
     let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
     let (expected, _) = wide_read(&store, None, &descriptor, &index).await;
 
@@ -1454,40 +1346,76 @@ async fn a_corrupt_local_entry_inside_a_span_is_dropped_and_refetched() {
     let object = segment_object_bytes(&store, &descriptor).await;
     let every_block: Vec<usize> = (0..index.len()).collect();
     seed_local_blocks(&blocks, &object, &descriptor, &index, &every_block);
+    let calls_before = blocks.call_count();
+    let cache = table_cache_over(&blocks);
+
+    let (read, gets) = wide_read(&store, Some(&cache), &descriptor, &index).await;
+
+    assert_eq!(read, expected);
+    assert_eq!(gets, 1, "the unresolved selection should stay one span");
+    assert_eq!(
+        blocks.call_count(),
+        calls_before,
+        "a span load must perform no local-cache gets or inserts"
+    );
+}
+
+/// A corrupt local entry on the narrow path is dropped and refetched once.
+/// What it held was a copy; object storage still holds the authority.
+#[tokio::test]
+async fn a_corrupt_local_entry_on_a_narrow_load_is_dropped_and_refetched() {
+    let (_temp_dir, store, descriptor, index) = multi_block_direntry_segment().await;
+    let blocks = Arc::new(RecordingStoredMetadataBlockCache::new());
+    let object = segment_object_bytes(&store, &descriptor).await;
     let corrupt = 5usize;
+    let entry = &index[corrupt];
+    let expected = decode_data_block(&stored_block_bytes(&object, &entry.block), &entry.block)
+        .expect("authoritative block should decode");
+    seed_local_blocks(&blocks, &object, &descriptor, &index, &[corrupt]);
     let corrupt_key = stored_key(
         &descriptor,
         StoredMetadataBlockKind::Data,
-        index[corrupt].block.offset,
+        entry.block.offset,
     );
     blocks.corrupt(&corrupt_key);
 
     let cache = table_cache_over(&blocks);
     let calls_before = blocks.call_count();
-    let (read, gets) = wide_read(&store, Some(&cache), &descriptor, &index).await;
+    store.reset();
+    let read = data_block_load::load_segment_data_block(
+        &store,
+        Some(&cache),
+        &load::SessionBlockMemo::default(),
+        &descriptor,
+        entry,
+    )
+    .await
+    .expect("narrow load should recover from a corrupt local copy");
     let calls = blocks.calls();
     let during = &calls[calls_before..];
 
-    assert_eq!(read, expected);
+    assert_eq!(read.as_ref(), &expected);
     assert_eq!(
-        gets, 1,
-        "the bad entry costs one span fetch and no retry loop"
-    );
-    assert_eq!(
-        during
-            .iter()
-            .filter(|call| **call
-                == RecordedStoredMetadataBlockCall::Invalidate {
-                    key: corrupt_key.clone()
-                })
-            .count(),
+        store.count(OperationClass::Read),
         1,
-        "the entry that did not decode should have been dropped once"
+        "the bad entry costs one point fetch and no retry loop"
     );
     assert_eq!(
-        offered_offsets(during),
-        block_offsets(&index, &[corrupt]),
-        "only the refetched block is offered back"
+        during,
+        [
+            RecordedStoredMetadataBlockCall::Get {
+                key: corrupt_key.clone(),
+                hit: true,
+            },
+            RecordedStoredMetadataBlockCall::Invalidate {
+                key: corrupt_key.clone(),
+            },
+            RecordedStoredMetadataBlockCall::Insert {
+                key: corrupt_key,
+                bytes: entry.block.stored_len as usize,
+            },
+        ],
+        "the narrow load should drop the bad copy and offer the fetched bytes"
     );
 }
 

--- a/crates/loonfs-server/src/http/metrics.rs
+++ b/crates/loonfs-server/src/http/metrics.rs
@@ -311,8 +311,8 @@ fn write_entry(rendered: &mut String, name: &str, entry: &MetricEntry) {
 
 /// Appends the values that are read when a scrape asks rather than
 /// accumulated as work happens: the runtime's cache counters, what foyer
-/// says about the local block cache, and the transfer slots this server has
-/// free.
+/// says about the local block cache, Linux process RSS, and the transfer
+/// slots this server has free.
 fn render_scrape_gauges(
     rendered: &mut String,
     cache: &RuntimeCacheStats,
@@ -336,6 +336,14 @@ fn render_scrape_gauges(
             let _ = writeln!(rendered, "{name} {value}");
         }
     }
+    #[cfg(target_os = "linux")]
+    if let Some(resident_bytes) = process_resident_bytes() {
+        let name = "loonfs_process_resident_bytes";
+        let description = "Resident set size of the server process, sampled at scrape";
+        let _ = writeln!(rendered, "# HELP {name} {description}");
+        let _ = writeln!(rendered, "# TYPE {name} gauge");
+        let _ = writeln!(rendered, "{name} {resident_bytes}");
+    }
     for (name, description, value) in [
         (
             "loonfs_server_upload_permits_available",
@@ -352,6 +360,16 @@ fn render_scrape_gauges(
         let _ = writeln!(rendered, "# TYPE {name} gauge");
         let _ = writeln!(rendered, "{name} {value}");
     }
+}
+
+/// Reads the Linux-only resident-page count for this process.
+#[cfg(target_os = "linux")]
+fn process_resident_bytes() -> Option<u64> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let resident_pages = statm.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+    // Neither rustix nor libc is a direct dependency. Every deployment
+    // target shipped by this project uses 4 KiB pages.
+    Some(resident_pages.saturating_mul(4096))
 }
 
 /// What foyer says about the local block cache, as gauges.

--- a/crates/loonfs-server/src/http/metrics/tests.rs
+++ b/crates/loonfs-server/src/http/metrics/tests.rs
@@ -150,9 +150,25 @@ fn scrape_time_gauges_carry_every_runtime_cache_counter() {
             .lines()
             .filter(|line| line.starts_with("# TYPE"))
             .count(),
-        20,
-        "eighteen cache counters and the two permit pools"
+        if cfg!(target_os = "linux") { 21 } else { 20 },
+        "eighteen cache counters, the two permit pools, and Linux RSS where available"
     );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_scrape_reports_positive_process_resident_bytes() {
+    let mut rendered = String::new();
+    render_scrape_gauges(&mut rendered, &RuntimeCacheStats::default(), None, 0, 0);
+
+    let resident_bytes = rendered
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("loonfs_process_resident_bytes ")
+                .and_then(|value| value.parse::<u64>().ok())
+        })
+        .expect("a Linux scrape should render process RSS");
+    assert!(resident_bytes > 0);
 }
 
 /// The whole reason the label is the matched template: a route seen twice is

--- a/crates/loonfs-server/tests/it/local_cache.rs
+++ b/crates/loonfs-server/tests/it/local_cache.rs
@@ -44,17 +44,15 @@ fn test_config_with_local_cache(
     }
 }
 
-/// A restarted server reads every metadata segment section — index, filter,
-/// and data — out of the local cache instead of the store.
+/// A restarted server uses the local cache for point-shaped section loads,
+/// while a directory scan skips it for data blocks.
 ///
 /// The second server starts with empty in-memory caches, so the only thing
-/// carried over is the cache directory the first one closed. Every section it
-/// wants is one the first server fetched and filled, and a section it had to
-/// fetch would show up here twice over: as a miss on the way in and as an
-/// insert on the way back. Zero of both is what makes this a full read with
-/// no segment bytes read at all.
+/// carried over is the cache directory the first one closed. Its index read
+/// hits that tier. Its data span performs no local-cache operation because
+/// the store path can coalesce the selected blocks.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_restarted_server_reads_every_segment_section_from_its_local_cache() {
+async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
     let store_dir = tempdir().expect("store tempdir");
     let cache_dir = tempdir().expect("cache tempdir");
     let namespace = namespace_id("warm");
@@ -133,12 +131,15 @@ async fn a_restarted_server_reads_every_segment_section_from_its_local_cache() {
     assert_eq!(served.entries, warmed.entries);
 
     let restarted = scrape(&second.server_url, Some("test-token")).expect("scrape the second");
-    for kind in ["index", "data"] {
-        assert!(
-            series(&restarted, &gets(kind, "hit")) >= 1.0,
-            "the restarted server should read {kind} sections from the cache"
-        );
-    }
+    assert!(
+        series(&restarted, &gets("index", "hit")) >= 1.0,
+        "the restarted server should read index sections from the cache"
+    );
+    assert_eq!(
+        series(&restarted, &gets("data", "hit")),
+        0.0,
+        "a scan should not read data blocks from the local cache"
+    );
     for kind in BLOCK_KINDS {
         assert_eq!(
             series(&restarted, &gets(kind, "miss")),


### PR DESCRIPTION
A compacted 80,000-entry listing against a fully warm SSD cache ran 35s at 565-668 MiB RSS where plain object storage ran 19.5s at 122 MiB... `load_segment_data_block_span` probed the foyer tier serially — one awaited get per selected block, about 70,000 point reads — where the store path coalesces the same blocks into ~218 ranged GETs of up to 4 MiB.

Three changes, but none edit the durable format or the shared decoded cache's policy:

- The span path stops touching the stored-block tier in both directions: no per-block probe, and span fetches no longer flood the tier with a one-pass working set that evicts the point-read blocks it exists for. Point lookups and the whole-small-segment shortcut keep their probe and offer — their restart benefit is measured and tested. There is no access-pattern enum: the narrow/span function split already is the classification.
- The per-view memo pinned every decoded block for the view's lifetime. Data blocks now leave oldest-first past a 64 MiB budget. The memo is a dedupe map, not an owner — scan borrows hold their own Arcs — so eviction can never invalidate a borrow and costs one shared-cache lookup at most. Index, filter, and manifest entries stay for the view.
- The metrics scrape reports `loonfs_process_resident_bytes` on Linux, because the foyer memory gauge covers only its own tier and the audit mistook it for process memory.

The restart integration test now pins the new contract directly: a restarted server reads index sections from the local tier and performs zero data-block cache operations during a scan. New tests cover the zero-touch span invariant, span coalescing against the decoded cache, narrow-path probe/offer and corrupt-entry recovery, and memo eviction with metadata survival.