### PR TITLE
feat(server): pre-start store probe, a Helm cache guardrail, and admin run docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,14 @@ jobs:
             --set image.digest=sha256:1111111111111111111111111111111111111111111111111111111111111111 >/dev/null
           helm template rel "$CHART" $SECRET \
             --set 'extraEnvFrom[0].secretRef.name=loonfs-server-secrets' >/dev/null
+      - name: reject an unbounded local cache
+        run: |
+          if output="$(helm template rel "$CHART" $SECRET \
+            --set localCache.enabled=true 2>&1)"; then
+            echo "FAIL: enabled cache without localCache.sizeLimit rendered" >&2
+            exit 1
+          fi
+          grep -q 'localCache.sizeLimit.*cache emptyDir.*disk_bytes' <<<"$output"
       - name: assert the single-writer settings
         run: |
           rendered="$(helm template rel "$CHART" $SECRET)"

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -232,6 +232,8 @@ History and recovery
 
 Maintenance
   loonfs admin run --namespace <ns>... [--job <job>...] [--drain] [--max-steps <n>] [--deadline-ms <ms>]
+    This command is embedded-only; remote servers host background
+    maintenance themselves
     Host maintenance for the namespaces named here, continuously until a
     signal; nothing discovers namespaces, so at least one --namespace is
     required. --job selects `metadata`, `core-gc`, `grep-index`, or

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -695,8 +695,8 @@ pub(crate) enum AdminCommand {
     /// Advance the retention floor, surrendering replay history below the
     /// flushed manifest head. File revision history is never affected.
     RetentionAdvance(AdminNamespaceArgs),
-    /// Host maintenance for explicitly assigned namespaces: continuously
-    /// until a signal, or as one bounded catch-up with --drain.
+    /// Host maintenance in-process for assigned namespaces; this command is
+    /// embedded-only.
     Run(AdminRunArgs),
     /// Run one core maintenance step (WAL flush and metadata folds).
     Step(AdminStepArgs),

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -213,8 +213,8 @@ fn upload_sessions_need_a_remote_profile() -> BackendError {
 fn maintenance_host_needs_an_embedded_profile() -> BackendError {
     BackendError::new(
         loonfs_api::ErrorCode::NotSupported.as_str(),
-        "`admin run` hosts maintenance in this process and needs an embedded profile; \
-         a remote profile's server runs its own maintenance",
+        "`admin run` is embedded-only; the remote server hosts background maintenance itself; \
+         use `loonfs admin step` for an on-demand pass and `loonfs admin index-status` to inspect index maintenance",
     )
 }
 

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -4297,7 +4297,7 @@ fn admin_store_probe_renders_the_profile_stores_report() {
     );
 }
 
-/// A remote profile's server hosts its own runner. Stepping one from here
+/// A remote profile's server hosts its own runner. Hosting another one here
 /// would be a second scheduler over the same namespaces, so the command
 /// refuses instead of pretending it can.
 #[test]
@@ -4320,12 +4320,10 @@ fn admin_run_refuses_a_remote_profile() {
     assert_failure(&refused);
     let error = json_error(&refused);
     assert_eq!(error["code"], "not_supported");
-    assert!(
-        error["message"]
-            .as_str()
-            .expect("message")
-            .contains("embedded profile"),
-        "{error}"
+    assert_eq!(
+        error["message"],
+        "`admin run` is embedded-only; the remote server hosts background maintenance itself; \
+         use `loonfs admin step` for an on-demand pass and `loonfs admin index-status` to inspect index maintenance"
     );
 }
 

--- a/crates/loonfs-server/deploy/helm/loonfs-server/README.md
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/README.md
@@ -66,6 +66,18 @@ That config names them at `/etc/loonfs/gcs-service-account.json`,
 `config.key` names the entry holding the TOML, and the container reads
 `/etc/loonfs/<key>`. The default is `config.toml`.
 
+Patch this optional init container into the Deployment pod spec to gate startup:
+
+```yaml
+# Use the same image as the server container.
+# initContainers:
+#   - name: probe-store
+#     image: ghcr.io/loonfs/loonfs-server:vX.Y.Z
+#     args: ["--probe-store", "--config", "/etc/loonfs/config.toml"]
+#     volumeMounts:
+#       - {name: config, mountPath: /etc/loonfs, readOnly: true}
+```
+
 Changing the Secret does not restart the pod. Roll it yourself:
 
 ```bash
@@ -110,10 +122,9 @@ Three numbers have to line up, and the server enforces the first of them.
 fails the process at startup rather than starting a cache that holds nothing.
 
 The disk tier claims the whole of `disk_bytes` up front, as 16 MiB files, and
-it holds every one of them open. `localCache.sizeLimit` has to be at least
-`disk_bytes` for that reason. The kubelet evicts a pod whose `emptyDir` grows
-past its limit, and a cache sized above the limit reaches it as it fills. The
-100 GiB config above needs `sizeLimit: 100Gi` or more.
+it holds every one of them open. The chart requires `localCache.sizeLimit`
+when the cache is enabled, and it must comfortably exceed `disk_bytes`. The
+kubelet evicts a pod whose `emptyDir` grows past its limit.
 
 The container's open-file limit has to be above `disk_bytes` divided by
 16 MiB, because every claimed file stays open. The 100 GiB config above asks
@@ -139,7 +150,7 @@ deletes it every time it stops.
 | `service.annotations` | `{}` | Annotations for the Service. |
 | `terminationGracePeriodSeconds` | `660` | How long the kubelet waits after SIGTERM before SIGKILL. |
 | `localCache.enabled` | `false` | Mount an `emptyDir` at `/var/cache/loonfs`. |
-| `localCache.sizeLimit` | `""` | That `emptyDir`'s `sizeLimit`, such as `100Gi`. Empty means no limit. |
+| `localCache.sizeLimit` | `""` | Required when the cache is enabled; it bounds that `emptyDir` and must comfortably exceed `disk_bytes`. |
 | `extraEnv` | `[]` | Environment variables for the container, as Kubernetes `EnvVar` entries. |
 | `extraEnvFrom` | `[]` | Environment sources for the container, as Kubernetes `EnvFromSource` entries. |
 | `podAnnotations` | `{}` | Annotations for the pod. |

--- a/crates/loonfs-server/deploy/helm/loonfs-server/templates/deployment.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.localCache.enabled (empty .Values.localCache.sizeLimit) }}
+{{- fail "localCache.sizeLimit is required when the cache is enabled; it bounds the cache emptyDir and must comfortably exceed the configured disk_bytes" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,12 +98,8 @@ spec:
         # it goes with the pod. The config's [local_cache] path has to name
         # this mount point.
         - name: local-cache
-          {{- if .Values.localCache.sizeLimit }}
           emptyDir:
             sizeLimit: {{ .Values.localCache.sizeLimit | quote }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
@@ -48,9 +48,9 @@ localCache:
   # chart writes nothing into the config: the config's [local_cache] table
   # has to name /var/cache/loonfs as its `path`.
   enabled: false
-  # The emptyDir's sizeLimit, as a quantity such as "100Gi". Set it to at
-  # least the config's `disk_bytes`, because the kubelet evicts a pod whose
-  # emptyDir grows past the limit. Empty means the chart sets no limit.
+  # The emptyDir's sizeLimit, as a quantity such as "100Gi". The chart
+  # requires it when the cache is enabled, and it must comfortably exceed
+  # the config's `disk_bytes`.
   sizeLimit: ""
 
 # Environment variables for the container, passed through as written. Each

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -421,8 +421,9 @@ fn tls_server_config(
 /// Two startup failures stay outside it. It does not bind the configured
 /// address, because a check that held the port could not run beside the
 /// server it is checking, and it performs no object-store operation, because
-/// a reachability check belongs to `loonfs admin store-probe`. Constructing
-/// the store still creates a `local-fs` root, as a start does.
+/// a reachability check belongs to `loonfs-server --probe-store` or
+/// `loonfs admin store-probe`. Constructing the store still creates a
+/// `local-fs` root, as a start does.
 pub async fn check_config(config: &ServerConfig) -> Result<(), ServeError> {
     config.validate()?;
     config.object_store()?;

--- a/crates/loonfs-server/src/main.rs
+++ b/crates/loonfs-server/src/main.rs
@@ -2,7 +2,9 @@
 //! until shutdown.
 
 use clap::Parser;
+use loonfs_objectstore::{run_store_contract_probe, StoreProbeOutcome};
 use std::io::Write as _;
+use std::process::ExitCode;
 
 #[derive(Debug, Parser)]
 #[command(name = "loonfs-server", version)]
@@ -10,31 +12,53 @@ struct Args {
     /// Config file to load.
     #[arg(long)]
     config: String,
-    /// Run the startup checks, report the result, and exit without serving.
-    /// The check reads the config, loads the TLS identity, and opens the
-    /// local block cache. It does not bind the configured address and it
-    /// performs no object-store operation, though constructing a `local-fs`
-    /// store creates its root directory as a start does.
+    /// Validate the startup config and exit without serving.
     #[arg(long)]
     check_config: bool,
+    /// Validate startup, write and delete scratch objects while probing the
+    /// configured store, and exit without serving.
+    #[arg(long)]
+    probe_store: bool,
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
     // Parse the arguments first. `--version` and `--help` then answer even
     // when `LOONFS_TRACE` holds a value this build rejects.
     let args = Args::parse();
     loonfs_server::init_tracing_from_env()?;
     let config = loonfs_server::load_server_config(&args.config)?;
-    if args.check_config {
-        // The summary is printed only once the checks a start runs have
-        // passed, so the printed line means the same thing the flag claims.
+    if args.check_config || args.probe_store {
+        // Run this once when the flags are combined: the probe adds to the
+        // startup checks instead of opening the cache a second time.
         loonfs_server::check_config(&config).await?;
         let mut stdout = std::io::stdout().lock();
+        if args.probe_store {
+            let store = config.object_store()?.into_shared();
+            let run_id = loonfs_api::generated_id("probe");
+            let report = run_store_contract_probe(store.as_ref(), &run_id).await;
+            for check in &report.checks {
+                match &check.outcome {
+                    StoreProbeOutcome::Passed => writeln!(stdout, "{}: passed", check.name)?,
+                    StoreProbeOutcome::Unsupported => {
+                        writeln!(stdout, "{}: unsupported", check.name)?
+                    }
+                    StoreProbeOutcome::Failed { message } => {
+                        writeln!(stdout, "{}: failed: {message}", check.name)?
+                    }
+                }
+            }
+            stdout.flush()?;
+            return Ok(if report.all_passed() {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            });
+        }
         writeln!(stdout, "{}", config.check_summary())?;
         stdout.flush()?;
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     }
     loonfs_server::serve(config).await?;
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }

--- a/crates/loonfs-server/tests/it/check_config.rs
+++ b/crates/loonfs-server/tests/it/check_config.rs
@@ -1,6 +1,6 @@
-//! `loonfs-server --check-config` tests, driven through the real binary.
+//! `loonfs-server` startup-check tests, driven through the real binary.
 //!
-//! The flag exists so an operator can validate a config before a deployment
+//! The flags exist so an operator can validate a config before a deployment
 //! starts, so these tests run the binary the operator runs.
 
 use std::net::TcpListener;
@@ -70,6 +70,102 @@ fn check_config(config_path: &Path) -> std::process::Output {
         .arg("--check-config")
         .output()
         .expect("run loonfs-server --check-config")
+}
+
+fn probe_store(config_path: &Path, check_config_too: bool) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_loonfs-server"));
+    command
+        .arg("--config")
+        .arg(config_path)
+        .arg("--probe-store");
+    if check_config_too {
+        command.arg("--check-config");
+    }
+    command.output().expect("run loonfs-server --probe-store")
+}
+
+const STORE_PROBE_CHECKS: &[&str] = &[
+    "create_if_absent_enforced",
+    "compare_and_swap_rejects_stale",
+    "compare_and_swap_missing_object_rejected",
+    "overwrite_updates_head_and_body",
+    "get_with_metadata_round_trip",
+    "head_reports_last_modified",
+    "visibility_after_write",
+    "visibility_after_delete",
+    "delete_missing_idempotent",
+    "sorted_listing",
+    "range_reads",
+    "multipart_round_trip",
+    "stored_checksum_readback",
+    "cleanup_leaves_prefix_empty",
+];
+
+#[test]
+fn probe_store_reports_every_check_for_a_working_local_store() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store_root = dir.path().join("store");
+    let config_path = write_config(dir.path(), "127.0.0.1:9400", &store_root);
+
+    let output = probe_store(&config_path, false);
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        output.status.success(),
+        "expected success, got {:?}: {stdout}{stderr}",
+        output.status
+    );
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), STORE_PROBE_CHECKS.len(), "{stdout}");
+    for name in STORE_PROBE_CHECKS {
+        let expected = format!("{name}: passed");
+        assert!(lines.contains(&expected.as_str()), "{stdout}");
+    }
+    assert!(!stdout.contains("check-config-token"), "{stdout}");
+    assert!(!stdout.contains("check-config-secret"), "{stdout}");
+    assert!(!stderr.contains("check-config-token"), "{stderr}");
+    assert!(!stderr.contains("check-config-secret"), "{stderr}");
+}
+
+#[test]
+fn probe_store_fails_when_the_local_store_root_cannot_be_created() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let occupied = dir.path().join("store");
+    std::fs::write(&occupied, b"a file, not a directory").expect("occupy the store path");
+    let config_path = write_config(dir.path(), "127.0.0.1:9400", &occupied);
+
+    let output = probe_store(&config_path, false);
+
+    assert!(!output.status.success(), "expected a non-zero exit");
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(stderr.contains("store"), "{stderr}");
+    assert!(!stdout.contains("check-config-token"), "{stdout}");
+    assert!(!stdout.contains("check-config-secret"), "{stdout}");
+    assert!(!stderr.contains("check-config-token"), "{stderr}");
+    assert!(!stderr.contains("check-config-secret"), "{stderr}");
+}
+
+#[test]
+fn probe_store_and_check_config_may_be_combined() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config_path = write_config(dir.path(), "127.0.0.1:9400", &dir.path().join("store"));
+
+    let output = probe_store(&config_path, true);
+
+    assert!(
+        output.status.success(),
+        "combined checks failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout)
+            .expect("utf-8 stdout")
+            .lines()
+            .count(),
+        STORE_PROBE_CHECKS.len()
+    );
 }
 
 #[test]


### PR DESCRIPTION
A server with invalid store credentials starts and answers 200 from `/health` and `/readiness`, because readiness is deliberately process-only — and stays that way. The missing piece was a pre-start check from the same image with the same config. `loonfs-server --probe-store` runs everything `--check-config` runs, then writes and deletes scratch objects through the existing store contract probe, prints one line per check (passed, unsupported, or failed with detail), and exits nonzero on any failure. The flags compose; startup checks run once. Tests verify the configured secrets never reach the output. The chart README carries a nine-line init-container example.

Helm now refuses to render `localCache.enabled=true` without `localCache.sizeLimit`: one template `fail` naming the field, what it bounds, and that it must comfortably exceed `disk_bytes`. The CI helm job gained the failure-render case.

`admin run` already refused remote profiles; the error now says the command is embedded-only, that a remote server hosts its own maintenance, and names `loonfs admin step` and `loonfs admin index-status` as the remote path.