### PR TITLE
feat(maintenance): durable compaction accounting

### DIFF
--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -686,15 +686,16 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
 ///
 /// Bounded steps may continue merging newer delta runs. When no bounded merge
 /// can make the required progress, maintenance plans a streaming compaction
-/// of the complete group. The warning is emitted once per step until that job
-/// starts.
+/// of the complete group. This is normal adaptive behavior, so it reports at
+/// debug; the case that never resolves — no compaction runner — has its own
+/// warning where the job would have started.
 fn report_group_bottom_over_budget(
     namespace_id: &NamespaceId,
     group: MetadataFamilyGroup,
     bottom: &OverBudgetRun,
     policy: MetadataLsmPolicy,
 ) {
-    tracing::warn!(
+    tracing::debug!(
         namespace_id = namespace_id.as_str(),
         families = ?group.families(),
         run_seq = bottom.run_seq.0,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -282,6 +282,8 @@ pub(super) struct MetadataMergeResult {
     pub(super) output_segments: Vec<MetadataFileRef>,
     pub(super) rows_read: u64,
     pub(super) rows_written: u64,
+    pub(super) input_bytes: u64,
+    pub(super) output_bytes: u64,
     pub(super) rows_written_by_family: BTreeMap<MetadataTableFamily, u64>,
     /// Point reads into the snapshot's unbind family, one per reverse bind
     /// row at or below the frozen floor. Zero for a merge that resolves the
@@ -401,6 +403,8 @@ pub enum MetadataCompactionJobOutcome {
         manifest_id: ManifestId,
         rows_read: u64,
         rows_written: u64,
+        input_bytes: u64,
+        output_bytes: u64,
         output_segments: usize,
     },
     /// The cancellation token was set. The manifest never moved and the
@@ -529,6 +533,8 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
 
     let rows_read = result.rows_read;
     let rows_written = result.rows_written;
+    let input_bytes = result.input_bytes;
+    let output_bytes = result.output_bytes;
     let output_segments = result.output_segments.len();
     match finalize_metadata_compaction(
         store,
@@ -555,6 +561,8 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
                 families = ?spec.families(),
                 rows_read,
                 rows_written,
+                input_bytes,
+                output_bytes,
                 output_segments,
                 manifest_id = manifest_id.0,
                 "streaming metadata compaction published"
@@ -563,6 +571,8 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
                 manifest_id,
                 rows_read,
                 rows_written,
+                input_bytes,
+                output_bytes,
                 output_segments,
             })
         }
@@ -936,6 +946,11 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         reverse_binds: ReverseBindResolution,
         input_rows: Option<u64>,
     ) -> Self {
+        let input_bytes = snapshot
+            .iter()
+            .flat_map(|run| group_run_descriptors(run, group))
+            .map(metadata_segment_bytes)
+            .sum();
         Self {
             store,
             namespace_id,
@@ -950,7 +965,10 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             probe_cache: MetadataTableCache::new(MetadataTableCacheConfig {
                 max_decoded_bytes: PROBE_CACHE_DECODED_BYTES,
             }),
-            result: MetadataMergeResult::default(),
+            result: MetadataMergeResult {
+                input_bytes,
+                ..MetadataMergeResult::default()
+            },
             canonical_digest: RowDigest::default(),
             index_digest: RowDigest::default(),
             last_input_key_by_family: BTreeMap::new(),
@@ -1140,6 +1158,10 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
 
         for writer in writers.into_values() {
             let segments = writer.finish(self.store, self.namespace_id).await?;
+            self.result.output_bytes = self
+                .result
+                .output_bytes
+                .saturating_add(segments.iter().map(metadata_segment_bytes).sum());
             self.result.output_segments.extend(segments);
         }
         Ok(ClusterEnd::Merged)
@@ -1384,6 +1406,14 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             self.index_digest.spell(),
         )))
     }
+}
+
+/// Returns the immutable segment object's stored byte length.
+fn metadata_segment_bytes(descriptor: &MetadataFileRef) -> u64 {
+    descriptor
+        .index_block
+        .offset
+        .saturating_add(u64::from(descriptor.index_block.stored_len))
 }
 
 /// An order-independent digest of the rows one family was written.

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -6,6 +6,7 @@
 //! checkpoint calls, and its hosts drive it.
 
 use crate::maintenance_runner::CompactionStart;
+use crate::metrics::{CompactionOutcome, CompactionTotals};
 use crate::FsAdmin;
 use crate::NamespaceStatusResponse;
 use crate::{
@@ -16,6 +17,8 @@ use crate::{
 };
 use crate::{ChangeSeq, Result, RuntimeError};
 use loonfs_core::cache::{load_namespace_fold_basis, load_namespace_head_summary};
+use std::time::Duration;
+use tokio::time::Instant;
 
 #[cfg(test)]
 mod tests;
@@ -452,27 +455,70 @@ impl FsAdmin {
             // No runner behind this handle, so there is no slot to claim and
             // no permit to wait for.
             let cancellation = loonfs_core::MetadataCompactionCancellation::default();
-            return Ok(MetadataCompactionOutcome::Ran(
-                self.run_streaming_compaction(namespace_id, &spec, &cancellation)
-                    .await?,
-            ));
+            let started = Instant::now();
+            let outcome = self
+                .run_streaming_compaction(namespace_id, &spec, &cancellation)
+                .await;
+            self.record_streaming_compaction(&outcome, started.elapsed());
+            return Ok(MetadataCompactionOutcome::Ran(outcome?));
         };
         let Some(mut claim) = compactions.claim(namespace_id, &spec) else {
             return Ok(MetadataCompactionOutcome::AlreadyRunning);
         };
         if !claim.admitted().await {
-            return Ok(MetadataCompactionOutcome::Ran(
-                loonfs_core::MetadataCompactionJobOutcome::Cancelled,
-            ));
+            let outcome = loonfs_core::MetadataCompactionJobOutcome::Cancelled;
+            self.record_streaming_compaction(&Ok(outcome.clone()), Duration::ZERO);
+            return Ok(MetadataCompactionOutcome::Ran(outcome));
         }
+        let started = Instant::now();
         let outcome = self
             .run_streaming_compaction(namespace_id, &spec, claim.cancellation())
             .await;
+        self.record_streaming_compaction(&outcome, started.elapsed());
         claim.finished(matches!(
             outcome,
             Ok(loonfs_core::MetadataCompactionJobOutcome::Published { .. })
         ));
         Ok(MetadataCompactionOutcome::Ran(outcome?))
+    }
+
+    /// Files one compaction ending in this handle's cumulative instruments.
+    pub(crate) fn record_streaming_compaction(
+        &self,
+        outcome: &Result<loonfs_core::MetadataCompactionJobOutcome>,
+        elapsed: Duration,
+    ) {
+        let (outcome, totals) = match outcome {
+            Ok(loonfs_core::MetadataCompactionJobOutcome::Published {
+                rows_read,
+                rows_written,
+                input_bytes,
+                output_bytes,
+                ..
+            }) => (
+                CompactionOutcome::Completed,
+                Some(CompactionTotals {
+                    input_rows: *rows_read,
+                    output_rows: *rows_written,
+                    input_bytes: *input_bytes,
+                    output_bytes: *output_bytes,
+                }),
+            ),
+            Ok(
+                loonfs_core::MetadataCompactionJobOutcome::Abandoned
+                | loonfs_core::MetadataCompactionJobOutcome::Superseded,
+            ) => (CompactionOutcome::Superseded, None),
+            Ok(loonfs_core::MetadataCompactionJobOutcome::Cancelled) => {
+                (CompactionOutcome::Cancelled, None)
+            }
+            Ok(loonfs_core::MetadataCompactionJobOutcome::Fenced) => {
+                (CompactionOutcome::Fenced, None)
+            }
+            Err(_) => (CompactionOutcome::Failed, None),
+        };
+        self.core
+            .instruments()
+            .compaction_finished(outcome, elapsed, totals);
     }
 
     /// Runs one streaming compaction to its end and says what that end was.
@@ -501,6 +547,7 @@ impl FsAdmin {
                 rows_read,
                 rows_written,
                 output_segments,
+                ..
             }) => {
                 // The manifest moved, so every cached view of this namespace
                 // is one manifest behind.

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -7,6 +7,7 @@
 //! through [`FsAdmin::starve_reorganization_row_budget`]. Everything else —
 //! planning, admission, the executor, the finalizer — is the shipped path.
 
+use crate::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};
 use crate::{
     CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter,
     MaintenancePlan, MetadataCompactionOutcome, MetadataMaintenanceOptions, MoveOptions,
@@ -40,9 +41,12 @@ const BINDINGS: MetadataFamilyGroup = MetadataFamilyGroup::Bindings;
 /// admin is the contrast — the same store, but attached to the writer's
 /// runner, so its steps plan under the amortizing policy a writer's own
 /// upkeep runs under.
-async fn manual_deployment(root: &std::path::Path) -> (FsWriter, FsAdmin, FsAdmin) {
+async fn manual_deployment(
+    root: &std::path::Path,
+) -> (FsWriter, FsAdmin, FsAdmin, Arc<DefaultMetricsRecorder>) {
     let store: SharedObjectStore =
         Arc::new(LocalFsStore::new(root).expect("create local-fs store"));
+    let recorder = Arc::new(DefaultMetricsRecorder::new());
     let writer = FsWriter::builder_with_store(Arc::clone(&store))
         .writer_id("manual-writer")
         .background_work(FsBackgroundWork::ManualOnly)
@@ -51,6 +55,7 @@ async fn manual_deployment(root: &std::path::Path) -> (FsWriter, FsAdmin, FsAdmi
         .expect("build the writer");
     let standalone = FsAdmin::builder_with_store(Arc::clone(&store))
         .actor_id("standalone-admin")
+        .metrics_recorder(recorder.clone())
         .build()
         .await
         .expect("build the standalone admin");
@@ -60,7 +65,23 @@ async fn manual_deployment(root: &std::path::Path) -> (FsWriter, FsAdmin, FsAdmi
         .build()
         .await
         .expect("build the writer-backed admin");
-    (writer, standalone, scheduled)
+    (writer, standalone, scheduled, recorder)
+}
+
+fn counter(snapshot: &MetricsSnapshot, name: &str, labels: &[(&str, &str)]) -> u64 {
+    let entry = snapshot
+        .by_name(name)
+        .find(|entry| entry.labels == labels)
+        .expect("the counter must be registered with these labels");
+    assert!(
+        matches!(entry.value, MetricValue::Counter(_)),
+        "expected a counter, found {:?}",
+        entry.value
+    );
+    let MetricValue::Counter(value) = entry.value else {
+        return 0;
+    };
+    value
 }
 
 fn metadata_plan() -> MaintenancePlan {
@@ -267,7 +288,7 @@ async fn bindings_runs<S: ObjectStore + ?Sized>(
 #[tokio::test]
 async fn explicit_compaction_runs_the_job_while_a_delta_merge_is_still_available() {
     let temp_dir = tempdir().expect("tempdir");
-    let (writer, standalone, scheduled) = manual_deployment(temp_dir.path()).await;
+    let (writer, standalone, scheduled, recorder) = manual_deployment(temp_dir.path()).await;
     let explicit = namespace_id("explicit");
     let automatic = namespace_id("automatic");
     for namespace in [&explicit, &automatic] {
@@ -332,6 +353,27 @@ async fn explicit_compaction_runs_the_job_while_a_delta_merge_is_still_available
         "the rebuild drops the churn below the retention floor: {rows_before} rows became \
          {rows_after}"
     );
+
+    let snapshot = recorder.snapshot();
+    assert_eq!(
+        counter(
+            &snapshot,
+            "loonfs.maintenance.compactions",
+            &[("outcome", "completed")],
+        ),
+        1,
+    );
+    for (name, direction) in [
+        ("loonfs.maintenance.compaction_rows", "input"),
+        ("loonfs.maintenance.compaction_rows", "output"),
+        ("loonfs.maintenance.compaction_bytes", "input"),
+        ("loonfs.maintenance.compaction_bytes", "output"),
+    ] {
+        assert!(
+            counter(&snapshot, name, &[("direction", direction)]) > 0,
+            "`{name}` must report nonzero `{direction}` work"
+        );
+    }
 }
 
 /// A standalone bounded step reports the compaction it cannot run, and the
@@ -343,7 +385,7 @@ async fn explicit_compaction_runs_the_job_while_a_delta_merge_is_still_available
 #[tokio::test]
 async fn a_standalone_step_reports_the_compaction_the_explicit_call_runs() {
     let temp_dir = tempdir().expect("tempdir");
-    let (writer, standalone, _scheduled) = manual_deployment(temp_dir.path()).await;
+    let (writer, standalone, _scheduled, _recorder) = manual_deployment(temp_dir.path()).await;
     let namespace = namespace_id("manual");
     namespace_with_a_frozen_base(&writer, &standalone, &namespace).await;
     let store = LocalFsStore::new(temp_dir.path()).expect("create local-fs store");

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -42,7 +42,9 @@ use loonfs_core::{
 };
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::time::Instant;
 
 /// Streaming compactions this process runs at once, across every namespace it
 /// serves.
@@ -254,16 +256,20 @@ impl BackgroundCompactions {
         let namespace_id = namespace_id.clone();
         runner.spawn(async move {
             if !claim.admitted().await {
+                admin.record_streaming_compaction(
+                    &Ok(MetadataCompactionJobOutcome::Cancelled),
+                    Duration::ZERO,
+                );
                 return;
             }
+            let started = Instant::now();
             // Every ending is logged inside, including the error one, so what
             // a task nobody awaits needs from it is only what to do next.
-            let published = matches!(
-                admin
-                    .run_streaming_compaction(&namespace_id, &spec, claim.cancellation())
-                    .await,
-                Ok(MetadataCompactionJobOutcome::Published { .. })
-            );
+            let outcome = admin
+                .run_streaming_compaction(&namespace_id, &spec, claim.cancellation())
+                .await;
+            admin.record_streaming_compaction(&outcome, started.elapsed());
+            let published = matches!(outcome, Ok(MetadataCompactionJobOutcome::Published { .. }));
             claim.finished(published);
         });
         if queued {

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -954,8 +954,6 @@ fn compaction_plan() -> loonfs_core::MetadataCompactionSpec {
     loonfs_core::MetadataCompactionSpec::planned_over_no_runs()
 }
 
-/// Claims the compaction slots of `count` namespaces named `job-0`, `job-1`,
-/// and so on, in order.
 fn claim_all(
     compactions: &BackgroundCompactions,
     count: usize,

--- a/crates/loonfs/src/metrics.rs
+++ b/crates/loonfs/src/metrics.rs
@@ -56,7 +56,9 @@ pub use loonfs_objectstore::metrics::{
     RangeClass, VecObjectStoreMetricsRecorder,
 };
 
-pub(crate) use instruments::{fan_out_object_store_recorder, RuntimeInstruments};
+pub(crate) use instruments::{
+    fan_out_object_store_recorder, CompactionOutcome, CompactionTotals, RuntimeInstruments,
+};
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -22,6 +22,56 @@ use crate::metrics::LATENCY_SECONDS_BOUNDARIES;
 use crate::{GcResponse, MaintenanceJobId, MaintenanceStepConclusion};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+/// The closed outcome vocabulary for a finished streaming compaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompactionOutcome {
+    Completed,
+    Failed,
+    Superseded,
+    Cancelled,
+    Fenced,
+}
+
+impl CompactionOutcome {
+    const ALL: [Self; 5] = [
+        Self::Completed,
+        Self::Failed,
+        Self::Superseded,
+        Self::Cancelled,
+        Self::Fenced,
+    ];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Superseded => "superseded",
+            Self::Cancelled => "cancelled",
+            Self::Fenced => "fenced",
+        }
+    }
+
+    const fn index(self) -> usize {
+        match self {
+            Self::Completed => 0,
+            Self::Failed => 1,
+            Self::Superseded => 2,
+            Self::Cancelled => 3,
+            Self::Fenced => 4,
+        }
+    }
+}
+
+/// Logical input and output totals from one finished merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompactionTotals {
+    pub(crate) input_rows: u64,
+    pub(crate) output_rows: u64,
+    pub(crate) input_bytes: u64,
+    pub(crate) output_bytes: u64,
+}
 
 /// One reclaimable family: its label, and the count a pass reports for it.
 type GcCategory = (&'static str, fn(&GcResponse) -> u64);
@@ -149,6 +199,40 @@ impl RuntimeInstruments {
             .compactions
             .queued
             .set(i64::try_from(queued).unwrap_or(i64::MAX));
+    }
+
+    /// Reports one finished streaming compaction and any merge it completed.
+    pub(crate) fn compaction_finished(
+        &self,
+        outcome: CompactionOutcome,
+        elapsed: Duration,
+        totals: Option<CompactionTotals>,
+    ) {
+        let Some(installed) = &self.installed else {
+            return;
+        };
+        let outcome_instruments = &installed.compactions.outcomes[outcome.index()];
+        outcome_instruments.count.increment(1);
+        outcome_instruments.seconds.record(elapsed.as_secs_f64());
+        let Some(totals) = totals else {
+            return;
+        };
+        installed
+            .compactions
+            .input_rows
+            .increment(totals.input_rows);
+        installed
+            .compactions
+            .output_rows
+            .increment(totals.output_rows);
+        installed
+            .compactions
+            .input_bytes
+            .increment(totals.input_bytes);
+        installed
+            .compactions
+            .output_bytes
+            .increment(totals.output_bytes);
     }
 
     /// Reports the candidates a namespace has admitted but not yet taken.
@@ -445,15 +529,51 @@ impl MaintenanceJobInstruments {
     }
 }
 
-/// The two numbers that describe this process's streaming metadata
-/// compactions: how many are running, and how many are waiting to.
+/// The gauges and durable totals for this process's streaming compactions.
 struct CompactionInstruments {
     running: Arc<dyn GaugeHandle>,
     queued: Arc<dyn GaugeHandle>,
+    outcomes: [CompactionOutcomeInstruments; 5],
+    input_rows: Arc<dyn CounterHandle>,
+    output_rows: Arc<dyn CounterHandle>,
+    input_bytes: Arc<dyn CounterHandle>,
+    output_bytes: Arc<dyn CounterHandle>,
+}
+
+struct CompactionOutcomeInstruments {
+    count: Arc<dyn CounterHandle>,
+    seconds: Arc<dyn HistogramHandle>,
 }
 
 impl CompactionInstruments {
     fn register(recorder: &dyn MetricsRecorder) -> Self {
+        let outcomes = CompactionOutcome::ALL.map(|outcome| CompactionOutcomeInstruments {
+            count: recorder.register_counter(
+                "loonfs.maintenance.compactions",
+                "Streaming metadata compactions by outcome.",
+                &[("outcome", outcome.as_str())],
+            ),
+            seconds: recorder.register_histogram(
+                "loonfs.maintenance.compaction_seconds",
+                "Duration of a finished streaming metadata compaction in seconds",
+                &[("outcome", outcome.as_str())],
+                LATENCY_SECONDS_BOUNDARIES,
+            ),
+        });
+        let rows = |direction: &'static str| {
+            recorder.register_counter(
+                "loonfs.maintenance.compaction_rows",
+                "Rows processed by streaming metadata compactions",
+                &[("direction", direction)],
+            )
+        };
+        let bytes = |direction: &'static str| {
+            recorder.register_counter(
+                "loonfs.maintenance.compaction_bytes",
+                "Bytes processed by streaming metadata compactions",
+                &[("direction", direction)],
+            )
+        };
         Self {
             running: recorder.register_gauge(
                 "loonfs.maintenance.compactions_running",
@@ -466,6 +586,11 @@ impl CompactionInstruments {
                  process permit",
                 &[],
             ),
+            outcomes,
+            input_rows: rows("input"),
+            output_rows: rows("output"),
+            input_bytes: bytes("input"),
+            output_bytes: bytes("output"),
         }
     }
 }
@@ -867,6 +992,71 @@ mod tests {
                 &[("job", "metadata")],
             ),
             0
+        );
+    }
+
+    #[test]
+    fn compaction_instruments_register_the_closed_vocabularies() {
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let instruments = RuntimeInstruments::new(Some(recorder.clone()));
+
+        instruments.compaction_finished(
+            CompactionOutcome::Completed,
+            Duration::from_millis(25),
+            Some(CompactionTotals {
+                input_rows: 20,
+                output_rows: 10,
+                input_bytes: 2_000,
+                output_bytes: 1_000,
+            }),
+        );
+
+        let snapshot = recorder.snapshot();
+        assert_eq!(
+            snapshot.by_name("loonfs.maintenance.compactions").count(),
+            5
+        );
+        assert_eq!(
+            snapshot
+                .by_name("loonfs.maintenance.compaction_seconds")
+                .count(),
+            5
+        );
+        assert_eq!(
+            snapshot
+                .by_name("loonfs.maintenance.compaction_rows")
+                .count(),
+            2
+        );
+        assert_eq!(
+            snapshot
+                .by_name("loonfs.maintenance.compaction_bytes")
+                .count(),
+            2
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.maintenance.compactions",
+                &[("outcome", "completed")],
+            ),
+            1
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.maintenance.compaction_rows",
+                &[("direction", "input")],
+            ),
+            20
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.maintenance.compaction_bytes",
+                &[("direction", "output")],
+            ),
+            1_000
         );
     }
 


### PR DESCRIPTION
The audit found completed compactions leave no durable record: the `compactions_running`/`compactions_queued` gauges return to zero, and nothing else says a job ran, how long it took, or how much it moved.

Four cumulative instruments now record every compaction: `loonfs.maintenance.compactions` by outcome (completed, failed, superseded, cancelled, fenced), a duration histogram by the same outcomes, and rows/bytes counters by direction. They increment at the two places completion is already known: where the background job releases the running gauge, and where the explicit path returns its outcome. The merge result carried row totals but not bytes; byte totals now accumulate from the in-memory segment descriptors — no new provider reads, no wire or durable change.

The per-step outgrown-run report drops from warn to debug. It describes normal adaptive behavior — steps keep merging deltas and a streaming compaction rebuilds the group — and the case that never resolves, a deployment with no compaction runner, keeps its own warning at the point the job would have started.

Two pieces from the first cut of this PR were dropped as overdefensive for a regular runtime: in-process admission for explicit maintenance steps (a new `maintenance_running` error code and a guard set — correctness never needed it, CAS fences and the #555 lease already hold, and a stampede now shows up in the counters as `superseded` completions instead of being policed), and a two-map warning dedup whose job the one-line debug demotion does.