### PR TITLE
refactor(server,core): simplify the audit stack's observability paths

### DIFF
--- a/crates/loonfs-core/src/checkpoint/block_fetch.rs
+++ b/crates/loonfs-core/src/checkpoint/block_fetch.rs
@@ -187,7 +187,7 @@ const WHOLE_SEGMENT_LOAD_MAX_BYTES: u64 = 128 * 1024;
 
 /// A segment object's total stored length: the index block is the last
 /// section, so it ends the object.
-fn segment_object_len(descriptor: &MetadataFileRef) -> u64 {
+pub(super) fn segment_object_len(descriptor: &MetadataFileRef) -> u64 {
     descriptor.index_block.offset + u64::from(descriptor.index_block.stored_len)
 }
 
@@ -341,7 +341,7 @@ async fn load_and_publish_segment_sections<S: ObjectStore + ?Sized>(
     })
 }
 
-pub(super) fn publish_segment_block(
+fn publish_segment_block(
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
     cache_key: MetadataTableCacheKey,

--- a/crates/loonfs-core/src/checkpoint/block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/block_load.rs
@@ -14,8 +14,9 @@ use std::sync::{Arc, Mutex};
 
 /// Bounds decoded data retained by one view. 64 MiB comfortably holds one
 /// page's working set plus read-ahead, while a runaway scan cannot pin
-/// gigabytes through its memo.
-const SESSION_BLOCK_MEMO_DATA_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+/// gigabytes through its memo. Its `_DECODED_BYTES` suffix follows the
+/// decoded-byte budget family in [`super::cache`].
+const SESSION_BLOCK_MEMO_DATA_DECODED_BYTES: usize = 64 * 1024 * 1024;
 
 /// The data blocks of one segment that can hold keys in
 /// `[lower_bound, upper_bound)`, shared straight from the decoded-block
@@ -75,8 +76,8 @@ pub(super) struct SessionBlockMemo {
 
 #[derive(Debug, Default)]
 struct SessionBlockMemoInner {
-    blocks: HashMap<MetadataTableCacheKey, DecodedMetadataTableBlock>,
-    data_insertion_order: VecDeque<MetadataTableCacheKey>,
+    blocks: HashMap<Arc<MetadataTableCacheKey>, DecodedMetadataTableBlock>,
+    data_insertion_order: VecDeque<Arc<MetadataTableCacheKey>>,
     data_decoded_bytes: usize,
 }
 
@@ -98,39 +99,43 @@ impl SessionBlockMemo {
         cache_key: &MetadataTableCacheKey,
         block: &DecodedMetadataTableBlock,
     ) {
+        let cache_key = Arc::new(cache_key.clone());
+        let DecodedMetadataTableBlock::Data {
+            decoded_byte_len, ..
+        } = block
+        else {
+            self.inner
+                .lock()
+                .expect("session block memo lock should not be poisoned")
+                .blocks
+                .insert(cache_key, block.clone());
+            return;
+        };
         let mut inner = self
             .inner
             .lock()
             .expect("session block memo lock should not be poisoned");
-        let previous = inner.blocks.insert(cache_key.clone(), block.clone());
-        if let Some(DecodedMetadataTableBlock::Data {
-            decoded_byte_len, ..
-        }) = previous
-        {
-            inner.data_decoded_bytes = inner.data_decoded_bytes.saturating_sub(decoded_byte_len);
-        } else if matches!(block, DecodedMetadataTableBlock::Data { .. }) {
-            inner.data_insertion_order.push_back(cache_key.clone());
+        let previous = inner.blocks.insert(Arc::clone(&cache_key), block.clone());
+        if let Some(previous) = previous {
+            inner.data_decoded_bytes = inner
+                .data_decoded_bytes
+                .saturating_sub(previous.decoded_byte_len());
+        } else {
+            inner.data_insertion_order.push_back(cache_key);
         }
-        if let DecodedMetadataTableBlock::Data {
-            decoded_byte_len, ..
-        } = block
-        {
-            inner.data_decoded_bytes = inner.data_decoded_bytes.saturating_add(*decoded_byte_len);
-        }
-        while inner.data_decoded_bytes > SESSION_BLOCK_MEMO_DATA_BUDGET_BYTES {
+        inner.data_decoded_bytes = inner.data_decoded_bytes.saturating_add(*decoded_byte_len);
+        while inner.data_decoded_bytes > SESSION_BLOCK_MEMO_DATA_DECODED_BYTES {
             let oldest = inner
                 .data_insertion_order
                 .pop_front()
                 .expect("accounted data blocks should have an insertion-order entry");
-            let Some(DecodedMetadataTableBlock::Data {
-                decoded_byte_len, ..
-            }) = inner.blocks.get(&oldest)
-            else {
-                continue;
-            };
-            let decoded_byte_len = *decoded_byte_len;
-            inner.blocks.remove(&oldest);
-            inner.data_decoded_bytes = inner.data_decoded_bytes.saturating_sub(decoded_byte_len);
+            let evicted = inner
+                .blocks
+                .remove(&oldest)
+                .expect("session block memo queue and map should stay one-to-one");
+            inner.data_decoded_bytes = inner
+                .data_decoded_bytes
+                .saturating_sub(evicted.decoded_byte_len());
         }
     }
 }
@@ -192,15 +197,10 @@ pub(super) async fn load_manifest_segment_rows_in_key_range_with_cache<S: Object
 #[cfg(test)]
 mod tests {
     use super::super::cache::MetadataTableBlockKind;
+    use super::super::load::genesis_basis_manifest;
     use super::*;
-    use loonfs_api::wire::manifest::{
-        NamespaceManifestEnvelope, NamespaceManifestKind, NamespaceManifestPayload,
-        NAMESPACE_MANIFEST_FORMAT_VERSION,
-    };
     use loonfs_api::wire::sst_blocks::{decode_filter_block, SegmentBlocksBuilder};
-    use loonfs_api::{
-        ChangeSeq, CommitId, InodeId, ManifestId, ManifestObjectId, NamespaceId, WriterEpoch,
-    };
+    use loonfs_api::NamespaceId;
 
     fn key(kind: MetadataTableBlockKind, offset: u64) -> MetadataTableCacheKey {
         MetadataTableCacheKey {
@@ -237,29 +237,9 @@ mod tests {
     }
 
     fn manifest_block() -> DecodedMetadataTableBlock {
-        let manifest = NamespaceManifestEnvelope {
-            kind: NamespaceManifestKind::NamespaceManifest,
-            format_version: NAMESPACE_MANIFEST_FORMAT_VERSION,
-            payload_checksum: String::new(),
-            payload: NamespaceManifestPayload {
-                namespace_id: NamespaceId::parse("memo").expect("namespace id"),
-                manifest_id: ManifestId(0),
-                manifest_object_id: ManifestObjectId::parse(
-                    "00000000000000000000-0000000000000000",
-                )
-                .expect("manifest object id"),
-                head_seq: ChangeSeq(0),
-                head_commit_id: CommitId::parse("c_00000000000000000000000000000000")
-                    .expect("commit id"),
-                base_seq: ChangeSeq(0),
-                writer_epoch: WriterEpoch(0),
-                next_inode_id: InodeId(1),
-                retention_floor_seq: ChangeSeq(0),
-                metadata_files: Vec::new(),
-            },
-        };
+        let namespace_id = NamespaceId::parse("memo").expect("namespace id");
         DecodedMetadataTableBlock::Manifest {
-            manifest: Arc::new(manifest),
+            manifest: Arc::new(genesis_basis_manifest(&namespace_id)),
             scan_runs: Arc::new(Vec::new()),
             decoded_byte_len: 1,
         }
@@ -286,11 +266,11 @@ mod tests {
         let newest_data_key = key(MetadataTableBlockKind::Data, 6);
         memo.record(
             &oldest_data_key,
-            &data_block(SESSION_BLOCK_MEMO_DATA_BUDGET_BYTES / 2),
+            &data_block(SESSION_BLOCK_MEMO_DATA_DECODED_BYTES / 2),
         );
         memo.record(
             &newer_data_key,
-            &data_block(SESSION_BLOCK_MEMO_DATA_BUDGET_BYTES / 2),
+            &data_block(SESSION_BLOCK_MEMO_DATA_DECODED_BYTES / 2),
         );
         memo.record(&newest_data_key, &data_block(1));
 

--- a/crates/loonfs-core/src/checkpoint/data_block_load.rs
+++ b/crates/loonfs-core/src/checkpoint/data_block_load.rs
@@ -153,36 +153,60 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
         spans.push((start, cursor));
     }
 
-    futures::future::try_join_all(spans.iter().map(|(start, end)| {
-        let span = &entries[*start..*end];
-        async move {
-            // Single-flight on the span's first block: the winning fetch
-            // decodes and publishes the whole span, so a concurrent scan
-            // waiting here finds the remaining blocks in the shared cache
-            // instead of re-fetching the span.
-            let first_key = segment_block_cache_key(
-                descriptor,
-                MetadataTableBlockKind::Data,
-                span[0].block.offset,
-            );
-            let fetch = || async {
-                load_and_publish_span(store, table_cache, memo, descriptor, span).await
-            };
-            match table_cache {
-                Some(cache) => {
-                    cache.get_or_load(&first_key, fetch).await?;
+    let mut span_decodes = vec![None; spans.len()];
+    futures::future::try_join_all(spans.iter().zip(&mut span_decodes).map(
+        |((start, end), winner_decodes)| {
+            let span = &entries[*start..*end];
+            async move {
+                // Single-flight on the span's first block: the winning fetch
+                // keeps what it decoded and publishes the whole span. A
+                // concurrent loser resolves the remaining blocks from caches.
+                let first_key = segment_block_cache_key(
+                    descriptor,
+                    MetadataTableBlockKind::Data,
+                    span[0].block.offset,
+                );
+                let fetch = || async move {
+                    load_and_publish_span(
+                        store,
+                        table_cache,
+                        memo,
+                        descriptor,
+                        span,
+                        winner_decodes,
+                    )
+                    .await
+                };
+                match table_cache {
+                    Some(cache) => {
+                        cache.get_or_load(&first_key, fetch).await?;
+                    }
+                    None => {
+                        fetch().await?;
+                    }
                 }
-                None => {
-                    fetch().await?;
-                }
+                Ok::<_, ManifestLoadError>(())
             }
-            Ok::<_, ManifestLoadError>(())
-        }
-    }))
+        },
+    ))
     .await?;
 
-    // Everything the winner published (or this call fetched) is resolvable
-    // now; blocks that lost a cache race are fetched alone.
+    for ((start, end), winner_decodes) in spans.iter().zip(span_decodes) {
+        let Some(winner_decodes) = winner_decodes else {
+            continue;
+        };
+        assert_eq!(
+            winner_decodes.len(),
+            end - start,
+            "a span winner should retain every block it decoded"
+        );
+        for (slot, block) in blocks[*start..*end].iter_mut().zip(winner_decodes) {
+            *slot = Some(block);
+        }
+    }
+
+    // Only single-flight losers still need to resolve what the winner
+    // published, with the existing point-load fallback on cache eviction.
     for (position, entry) in entries.iter().enumerate() {
         if blocks[position].is_some() {
             continue;
@@ -198,21 +222,23 @@ pub(super) async fn load_segment_data_block_span<S: ObjectStore + ?Sized>(
 }
 
 /// Fetches one contiguous span with a single ranged GET, decodes every
-/// block, and publishes them to the per-view memo and (when populating) the
-/// shared cache. Returns the first block's cache entry for the single-flight
-/// cell.
+/// block, keeps the winner's decodes, and publishes them to the per-view memo
+/// and (when populating) the shared cache. Returns the first block's cache
+/// entry for the single-flight cell.
 async fn load_and_publish_span<S: ObjectStore + ?Sized>(
     store: &S,
     table_cache: Option<&MetadataTableCache>,
     memo: &SessionBlockMemo,
     descriptor: &MetadataFileRef,
     span: &[SegmentIndexEntry],
+    winner_decodes: &mut Option<Vec<Arc<DecodedDataBlock>>>,
 ) -> Result<DecodedMetadataTableBlock, ManifestLoadError> {
     let first = &span[0].block;
     let last = &span[span.len() - 1].block;
     let span_len = last.offset + u64::from(last.stored_len) - first.offset;
     let bytes = load_section_bytes(store, &descriptor.object_key, first.offset, span_len).await?;
     let mut first_block = None;
+    let mut retained = Vec::with_capacity(span.len());
     for entry in span {
         let handle = entry.block;
         let begin = (handle.offset - first.offset) as usize;
@@ -225,7 +251,7 @@ async fn load_and_publish_span<S: ObjectStore + ?Sized>(
             segment_block_cache_key(descriptor, MetadataTableBlockKind::Data, handle.offset);
         let cache_block = DecodedMetadataTableBlock::Data {
             decoded_byte_len: decoded_manifest_block_weight(descriptor.family, &decoded.rows),
-            block: decoded,
+            block: Arc::clone(&decoded),
         };
         memo.record(&cache_key, &cache_block);
         if let Some(cache) = table_cache {
@@ -236,7 +262,9 @@ async fn load_and_publish_span<S: ObjectStore + ?Sized>(
         if first_block.is_none() {
             first_block = Some(cache_block);
         }
+        retained.push(decoded);
     }
+    *winner_decodes = Some(retained);
     Ok(first_block.expect("a span should always hold at least one block"))
 }
 

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -71,7 +71,7 @@ pub(super) fn ensure_root_matches_manifest(
 /// exists because the manifest payload shape requires one.
 const GENESIS_MANIFEST_OBJECT_ID: &str = "00000000000000000000-0000000000000000";
 
-fn genesis_basis_manifest(namespace_id: &NamespaceId) -> NamespaceManifestEnvelope {
+pub(super) fn genesis_basis_manifest(namespace_id: &NamespaceId) -> NamespaceManifestEnvelope {
     NamespaceManifestEnvelope {
         kind: NamespaceManifestKind::NamespaceManifest,
         format_version: NAMESPACE_MANIFEST_FORMAT_VERSION,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -40,7 +40,7 @@
 //! The step that plans it starts it and returns; the runner cancels it on
 //! shutdown and joins it with the rest of its background work.
 
-use super::block_fetch::load_segment_filter;
+use super::block_fetch::{load_segment_filter, segment_object_len};
 use super::block_load::SessionBlockMemo;
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
 use super::compaction_lease::{CompactionLease, LeaseHold};
@@ -949,7 +949,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         let input_bytes = snapshot
             .iter()
             .flat_map(|run| group_run_descriptors(run, group))
-            .map(metadata_segment_bytes)
+            .map(segment_object_len)
             .sum();
         Self {
             store,
@@ -1161,7 +1161,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             self.result.output_bytes = self
                 .result
                 .output_bytes
-                .saturating_add(segments.iter().map(metadata_segment_bytes).sum());
+                .saturating_add(segments.iter().map(segment_object_len).sum());
             self.result.output_segments.extend(segments);
         }
         Ok(ClusterEnd::Merged)
@@ -1406,14 +1406,6 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             self.index_digest.spell(),
         )))
     }
-}
-
-/// Returns the immutable segment object's stored byte length.
-fn metadata_segment_bytes(descriptor: &MetadataFileRef) -> u64 {
-    descriptor
-        .index_block
-        .offset
-        .saturating_add(u64::from(descriptor.index_block.stored_len))
 }
 
 /// An order-independent digest of the rows one family was written.

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -76,6 +76,19 @@ pub struct StoreProbeCheck {
     pub outcome: StoreProbeOutcome,
 }
 
+impl StoreProbeCheck {
+    /// Renders this check as one operator-facing report line.
+    pub fn check_line(&self) -> String {
+        match &self.outcome {
+            StoreProbeOutcome::Passed => format!("{}: passed", self.name),
+            StoreProbeOutcome::Unsupported => format!("{}: unsupported", self.name),
+            StoreProbeOutcome::Failed { message } => {
+                format!("{}: failed: {message}", self.name)
+            }
+        }
+    }
+}
+
 /// What one check concluded about the store.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StoreProbeOutcome {

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -311,13 +311,7 @@ fn probe_report_lines(report: &StoreProbeReport) -> String {
     report
         .checks
         .iter()
-        .map(|check| match &check.outcome {
-            StoreProbeOutcome::Passed => format!("  {}: passed", check.name),
-            StoreProbeOutcome::Unsupported => format!("  {}: unsupported", check.name),
-            StoreProbeOutcome::Failed { message } => {
-                format!("  {}: failed: {message}", check.name)
-            }
-        })
+        .map(|check| format!("  {}", check.check_line()))
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -150,6 +150,8 @@ fn default_request_deadline_ms() -> u64 {
 }
 
 fn default_shutdown_deadline_ms() -> u64 {
+    // Clears loonfs_objectstore::PROVIDER_OPERATION_DEADLINE so an accepted
+    // request can finish the provider operation it already started.
     600_000
 }
 

--- a/crates/loonfs-server/src/http/metrics.rs
+++ b/crates/loonfs-server/src/http/metrics.rs
@@ -83,7 +83,7 @@ impl ServerMetrics {
         method: &Method,
         status: StatusCode,
         elapsed_seconds: f64,
-    ) {
+    ) -> &'static str {
         let route = self.route_label(matched_route);
         let (seconds, served) = {
             let mut requests = lock(&self.requests);
@@ -99,6 +99,7 @@ impl ServerMetrics {
         };
         served.increment(1);
         seconds.record(elapsed_seconds);
+        route
     }
 
     /// Reports one proxied upload refused for want of a transfer slot.
@@ -322,27 +323,28 @@ fn render_scrape_gauges(
 ) {
     for (field, value) in cache_gauges(cache) {
         let name = format!("loonfs_cache_{field}");
-        let _ = writeln!(rendered, "# HELP {name} Runtime cache counter `{field}`");
-        let _ = writeln!(rendered, "# TYPE {name} gauge");
-        let _ = writeln!(rendered, "{name} {value}");
+        write_gauge(
+            rendered,
+            &name,
+            &format!("Runtime cache counter `{field}`"),
+            value,
+        );
     }
     // Absent when this deployment keeps no local cache, so a scrape reports
     // nothing about a tier that does not exist rather than reporting zeros
     // that read like an idle one.
     if let Some(local_cache) = local_cache {
         for (name, description, value) in local_cache_gauges(&local_cache) {
-            let _ = writeln!(rendered, "# HELP {name} {description}");
-            let _ = writeln!(rendered, "# TYPE {name} gauge");
-            let _ = writeln!(rendered, "{name} {value}");
+            write_gauge(rendered, name, description, value);
         }
     }
-    #[cfg(target_os = "linux")]
     if let Some(resident_bytes) = process_resident_bytes() {
-        let name = "loonfs_process_resident_bytes";
-        let description = "Resident set size of the server process, sampled at scrape";
-        let _ = writeln!(rendered, "# HELP {name} {description}");
-        let _ = writeln!(rendered, "# TYPE {name} gauge");
-        let _ = writeln!(rendered, "{name} {resident_bytes}");
+        write_gauge(
+            rendered,
+            "loonfs_process_resident_bytes",
+            "Resident set size of the server process, sampled at scrape",
+            resident_bytes,
+        );
     }
     for (name, description, value) in [
         (
@@ -356,10 +358,19 @@ fn render_scrape_gauges(
             download_permits,
         ),
     ] {
-        let _ = writeln!(rendered, "# HELP {name} {description}");
-        let _ = writeln!(rendered, "# TYPE {name} gauge");
-        let _ = writeln!(rendered, "{name} {value}");
+        write_gauge(rendered, name, description, value);
     }
+}
+
+fn write_gauge(
+    rendered: &mut String,
+    name: &str,
+    description: &str,
+    value: impl std::fmt::Display,
+) {
+    let _ = writeln!(rendered, "# HELP {name} {description}");
+    let _ = writeln!(rendered, "# TYPE {name} gauge");
+    let _ = writeln!(rendered, "{name} {value}");
 }
 
 /// Reads the Linux-only resident-page count for this process.
@@ -370,6 +381,11 @@ fn process_resident_bytes() -> Option<u64> {
     // Neither rustix nor libc is a direct dependency. Every deployment
     // target shipped by this project uses 4 KiB pages.
     Some(resident_pages.saturating_mul(4096))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_resident_bytes() -> Option<u64> {
+    None
 }
 
 /// What foyer says about the local block cache, as gauges.

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -22,7 +22,9 @@ mod tls;
 
 #[cfg(feature = "openapi")]
 pub use self::openapi::{openapi_document, openapi_json_pretty};
-pub use self::serve::{app, check_config, serve, serve_with_shutdown, ServeError};
+pub use self::serve::{
+    app, app_with_store, check_config, probe_store, serve, serve_with_shutdown, ServeError,
+};
 pub use self::tls::TlsConfigError;
 
 use self::error::ApiResponseError;
@@ -43,7 +45,7 @@ use self::handlers_query::{
     disable_grep_index, enable_grep_index, gc_grep_index, grep, grep_index_not_maintained,
     grep_index_status, grep_queries_not_served,
 };
-use self::handlers_store::probe_store;
+use self::handlers_store::probe_store as probe_store_handler;
 use self::handlers_uploads::{
     abort_upload, begin_upload, complete_upload, read_upload_status, sign_upload_parts,
     upload_content,
@@ -51,7 +53,7 @@ use self::handlers_uploads::{
 use self::serve::AppState;
 #[cfg(test)]
 use self::serve::{
-    app_with_store, app_with_store_and_direct_transfers, app_with_store_and_state,
+    app_with_store_and_direct_transfers, app_with_store_and_state,
     build_handles_with_metrics_jsonl_path, serve_on,
 };
 use axum::extract::{MatchedPath, Request, State};
@@ -75,6 +77,29 @@ tokio::task_local! {
     pub(super) static REQUEST_ID: String;
 }
 
+macro_rules! request_completion_event {
+    ($level:ident, $method:expr, $route:expr, $status:expr, $started:expr, $request_id:expr) => {
+        tracing::$level!(
+            target: "loonfs_server::http::request",
+            method = %$method,
+            route = $route,
+            status = $status.as_u16(),
+            elapsed_ms = u64::try_from($started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            request_id = $request_id.as_str(),
+            "request completed"
+        )
+    };
+}
+
+// Membership is limited to streamed content and operator work that is long by design.
+const DEADLINE_EXEMPT_ROUTES: &[&str] = &[
+    "/v0/namespaces/{namespace}/filesystem/content",
+    "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+    "/v0/admin/namespaces/{namespace}/maintenance/step",
+    "/v0/admin/store/probe",
+    "/v0/admin/namespaces/{namespace}/grep/index/gc",
+];
+
 /// Assigns each request a correlation id: every response carries it as the
 /// `x-request-id` header, and error bodies repeat it as
 /// `ApiError.request_id` so a caller's log line and the server's trace can
@@ -92,6 +117,13 @@ async fn with_request_id(request: Request, next: Next) -> Response {
 
 /// Cancels bounded request work once the deployment's deadline passes.
 async fn with_request_deadline(request_deadline_ms: u64, request: Request, next: Next) -> Response {
+    if request
+        .extensions()
+        .get::<MatchedPath>()
+        .is_some_and(|matched| DEADLINE_EXEMPT_ROUTES.contains(&matched.as_str()))
+    {
+        return next.run(request).await;
+    }
     match tokio::time::timeout(
         std::time::Duration::from_millis(request_deadline_ms),
         next.run(request),
@@ -111,91 +143,33 @@ async fn with_request_deadline(request_deadline_ms: u64, request: Request, next:
     }
 }
 
-enum RequestRoute {
-    Matched(MatchedPath),
-    Unmatched(String),
-}
-
-impl RequestRoute {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Matched(path) => path.as_str(),
-            Self::Unmatched(path) => path,
-        }
-    }
-}
-
-/// Logs the response once the request has reached its HTTP outcome.
-async fn with_request_completion(request: Request, next: Next) -> Response {
-    let method = request.method().clone();
-    let route = request.extensions().get::<MatchedPath>().map_or_else(
-        || RequestRoute::Unmatched(request.uri().path().to_owned()),
-        |path| RequestRoute::Matched(path.clone()),
-    );
-    let started = request_clock();
-    let response = next.run(request).await;
-    let status = response.status();
-    let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
-
-    REQUEST_ID.with(|request_id| match status {
-        status if status.is_server_error() => tracing::error!(
-            target: "loonfs_server::http::request",
-            method = %method,
-            route = route.as_str(),
-            status = status.as_u16(),
-            elapsed_ms,
-            request_id = request_id.as_str(),
-            "request completed"
-        ),
-        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::TOO_MANY_REQUESTS => {
-            tracing::warn!(
-                target: "loonfs_server::http::request",
-                method = %method,
-                route = route.as_str(),
-                status = status.as_u16(),
-                elapsed_ms,
-                request_id = request_id.as_str(),
-                "request completed"
-            );
-        }
-        _ => tracing::debug!(
-            target: "loonfs_server::http::request",
-            method = %method,
-            route = route.as_str(),
-            status = status.as_u16(),
-            elapsed_ms,
-            request_id = request_id.as_str(),
-            "request completed"
-        ),
-    });
-    response
-}
-
-/// Counts and times every request against the route axum matched it to.
-///
-/// The label is the route template, never the request's own path: a path
-/// carries namespace, upload, and checkpoint ids, and one unbounded label
-/// set is how a metrics backend dies. A request that matched no route — a
-/// 404 — reports as `unmatched`, which is one label rather than one per
-/// probe an internet-facing listener receives.
-async fn with_request_metrics(
+/// Counts, times, and logs every request once it reaches its HTTP outcome.
+async fn with_request_observability(
     State(state): State<AppState>,
     request: Request,
     next: Next,
 ) -> Response {
-    let route = request
-        .extensions()
-        .get::<MatchedPath>()
-        .map(|matched| matched.as_str().to_owned());
     let method = request.method().clone();
+    let matched_route = request.extensions().get::<MatchedPath>().cloned();
     let started = request_clock();
     let response = next.run(request).await;
-    state.metrics.request_served(
-        route.as_deref(),
+    let status = response.status();
+    let route = state.metrics.request_served(
+        matched_route.as_ref().map(MatchedPath::as_str),
         &method,
-        response.status(),
+        status,
         started.elapsed().as_secs_f64(),
     );
+
+    REQUEST_ID.with(|request_id| match status {
+        status if status.is_server_error() => {
+            request_completion_event!(error, method, route, status, started, request_id)
+        }
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+            request_completion_event!(warn, method, route, status, started, request_id)
+        }
+        _ => request_completion_event!(debug, method, route, status, started, request_id),
+    });
     response
 }
 
@@ -242,7 +216,7 @@ fn router(state: AppState) -> Router {
         get(grep_index_not_maintained)
     };
     let request_deadline_ms = state.config.request_deadline_ms;
-    let bounded_routes = Router::new()
+    Router::new()
         .route("/health", get(health))
         .route("/readiness", get(readiness))
         .route("/metrics", get(serve_metrics))
@@ -258,6 +232,10 @@ fn router(state: AppState) -> Router {
             get(list_path_entries),
         )
         .route("/v0/namespaces/{namespace}/filesystem/stat", get(stat_path))
+        .route(
+            "/v0/namespaces/{namespace}/filesystem/content",
+            get(get_file_bytes),
+        )
         // The read this deployment authorizes rather than performs. It sits
         // beside the proxied read because it answers the same question
         // about the same path; the route exists everywhere and refuses with
@@ -273,6 +251,18 @@ fn router(state: AppState) -> Router {
             grep_status_route,
         )
         .route(
+            "/v0/admin/namespaces/{namespace}/grep/index/enable",
+            enable_grep_route,
+        )
+        .route(
+            "/v0/admin/namespaces/{namespace}/grep/index/disable",
+            disable_grep_route,
+        )
+        .route(
+            "/v0/admin/namespaces/{namespace}/grep/index/gc",
+            grep_gc_route,
+        )
+        .route(
             "/v0/namespaces/{namespace}/filesystem/revisions",
             get(list_file_revisions),
         )
@@ -285,6 +275,14 @@ fn router(state: AppState) -> Router {
         // commit receipt makes retry safe.
         .route("/v0/namespaces/{namespace}/commits", post(apply_commit))
         .route("/v0/namespaces/{namespace}/uploads", post(begin_upload))
+        .route(
+            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+            // No body-limit layer: the upload route never buffers its
+            // body, so a framework limit measured against a buffered read
+            // would never fire. `UploadBodyStream` counts the bytes as it
+            // forwards them and enforces `upload.max_content_bytes` itself.
+            put(upload_content),
+        )
         .route(
             "/v0/namespaces/{namespace}/uploads/{upload_id}/parts",
             post(sign_upload_parts),
@@ -310,57 +308,26 @@ fn router(state: AppState) -> Router {
             "/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release",
             post(release_checkpoint),
         )
-        .route_layer(middleware::from_fn(move |request: Request, next: Next| {
-            with_request_deadline(request_deadline_ms, request, next)
-        }));
-
-    let exempt_routes = Router::new()
-        .route(
-            "/v0/namespaces/{namespace}/filesystem/content",
-            get(get_file_bytes),
-        )
-        .route(
-            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
-            // No body-limit layer: the upload route never buffers its
-            // body, so a framework limit measured against a buffered read
-            // would never fire. `UploadBodyStream` counts the bytes as it
-            // forwards them and enforces `upload.max_content_bytes` itself.
-            put(upload_content),
-        )
         .route(
             "/v0/admin/namespaces/{namespace}/maintenance/step",
             post(maintenance_step),
         )
         // The one admin route whose subject is the store rather than a
         // namespace, so it sits beside them rather than under one.
-        .route("/v0/admin/store/probe", post(probe_store))
-        .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/enable",
-            enable_grep_route,
-        )
-        .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/disable",
-            disable_grep_route,
-        )
-        .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/gc",
-            grep_gc_route,
-        );
-
-    bounded_routes
-        .merge(exempt_routes)
+        .route("/v0/admin/store/probe", post(probe_store_handler))
+        .route_layer(middleware::from_fn(move |request: Request, next: Next| {
+            with_request_deadline(request_deadline_ms, request, next)
+        }))
         // Unmatched paths and wrong methods answer inside the error
         // contract instead of axum's empty default bodies.
         .fallback(route_not_found)
         .method_not_allowed_fallback(method_not_allowed)
-        // Request timing runs inside the correlation id, so a slow request's
-        // trace and its measurement name the same id.
+        // Request observation runs inside the correlation id, so its trace
+        // and measurements name the same request.
         .layer(middleware::from_fn_with_state(
             state.clone(),
-            with_request_metrics,
+            with_request_observability,
         ))
-        // Completion logging runs inside the request-id scope.
-        .layer(middleware::from_fn(with_request_completion))
         .layer(middleware::from_fn(with_request_id))
         .with_state(state)
 }

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -16,6 +16,7 @@ use loonfs::{
 use loonfs_api::NamespaceId;
 use loonfs_grep::{GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker, GREP_INDEX_JOB};
 use loonfs_objectstore::presign::DirectTransferIssuers;
+use loonfs_objectstore::{run_store_contract_probe, StoreProbeReport};
 use std::ffi::OsString;
 use std::future::IntoFuture;
 use std::net::SocketAddr;
@@ -132,8 +133,8 @@ pub async fn app(
     Ok((router, state.writer, state.local_cache))
 }
 
-#[cfg(test)]
-pub(super) async fn app_with_store(
+#[doc(hidden)]
+pub async fn app_with_store(
     config: ServerConfig,
     store: SharedObjectStore,
 ) -> Result<Router, ServerConfigError> {
@@ -440,6 +441,13 @@ pub async fn check_config(config: &ServerConfig) -> Result<(), ServeError> {
     Ok(())
 }
 
+/// Runs the object-store contract probe against the store this config builds.
+pub async fn probe_store(config: &ServerConfig) -> Result<StoreProbeReport, ServeError> {
+    let store = config.object_store()?.into_shared();
+    let run_id = loonfs_api::generated_id("probe");
+    Ok(run_store_contract_probe(store.as_ref(), &run_id).await)
+}
+
 /// Serves until ctrl-c or SIGTERM, then shuts down gracefully: the listener
 /// stops accepting, in-flight requests drain, publisher work finishes, and
 /// writer maintenance — the runtime's steps and grep's alike — settles
@@ -530,28 +538,25 @@ where
     // The budget starts when shutdown fires. It does not limit server uptime.
     let served = tokio::select! {
         result = server.as_mut() => result,
-        drain_started = &mut drain_started_rx => {
-            if drain_started.is_err() {
-                server.as_mut().await
-            } else {
-                match tokio::time::timeout(
-                    Duration::from_millis(shutdown_deadline_ms),
-                    server.as_mut(),
-                )
-                .await
-                {
-                    Ok(result) => result,
-                    Err(_) => {
-                        tracing::warn!(
-                            shutdown_deadline_ms,
-                            "graceful drain deadline passed; remaining requests are abandoned"
-                        );
-                        Ok(())
-                    }
+        Ok(()) = &mut drain_started_rx => {
+            match tokio::time::timeout(
+                Duration::from_millis(shutdown_deadline_ms),
+                server.as_mut(),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => {
+                    tracing::warn!(
+                        shutdown_deadline_ms,
+                        "graceful drain deadline passed; remaining requests are abandoned"
+                    );
+                    Ok(())
                 }
             }
         }
     };
+    // Dropping the server cancels requests left behind by an expired drain.
     drop(server);
     served.map_err(ServeError::Serve)?;
     // Shut down the writer after the drain finishes or its deadline passes.

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -363,6 +363,41 @@ async fn request_deadline_answers_408_and_leaves_fast_handlers_untouched() {
     assert_eq!(&body[..], b"fast");
 }
 
+#[tokio::test]
+async fn every_deadline_exemption_names_a_served_route() {
+    use tower::ServiceExt;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let router = app_with_store(
+        test_config(temp_dir.path(), "deadline-exempt-route-writer"),
+        store,
+    )
+    .await
+    .expect("build app");
+
+    for route in super::DEADLINE_EXEMPT_ROUTES {
+        let uri = route
+            .replace("{namespace}", "deadline-exempt")
+            .replace("{upload_id}", "upl_deadline_exempt");
+        let response = router
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(&uri)
+                    .body(axum::body::Body::empty())
+                    .expect("route request"),
+            )
+            .await
+            .expect("route response");
+        assert_ne!(
+            response.status(),
+            axum::http::StatusCode::NOT_FOUND,
+            "deadline exemption `{route}` does not match a served route"
+        );
+    }
+}
+
 /// The `[local_cache]` table is the whole switch: without it nothing is
 /// built, and a scrape says nothing about a tier this deployment does not
 /// have.

--- a/crates/loonfs-server/src/lib.rs
+++ b/crates/loonfs-server/src/lib.rs
@@ -14,7 +14,10 @@ pub use config::{
     load_server_config, GrepConfig, GrepMode, LocalCacheConfig, MaintenanceMode,
     RuntimeCacheConfigOverrides, ServerConfig, ServerConfigError, StoreConfig, TlsServerConfig,
 };
-pub use http::{app, check_config, serve, serve_with_shutdown, ServeError, TlsConfigError};
+pub use http::{
+    app, app_with_store, check_config, probe_store, serve, serve_with_shutdown, ServeError,
+    TlsConfigError,
+};
 #[cfg(feature = "openapi")]
 pub use http::{openapi_document, openapi_json_pretty};
 pub use local_cache::FoyerStoredMetadataBlockCache;

--- a/crates/loonfs-server/src/main.rs
+++ b/crates/loonfs-server/src/main.rs
@@ -2,7 +2,6 @@
 //! until shutdown.
 
 use clap::Parser;
-use loonfs_objectstore::{run_store_contract_probe, StoreProbeOutcome};
 use std::io::Write as _;
 use std::process::ExitCode;
 
@@ -28,37 +27,27 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
     let args = Args::parse();
     loonfs_server::init_tracing_from_env()?;
     let config = loonfs_server::load_server_config(&args.config)?;
+    let mut exit_code = ExitCode::SUCCESS;
     if args.check_config || args.probe_store {
-        // Run this once when the flags are combined: the probe adds to the
-        // startup checks instead of opening the cache a second time.
+        // Either flag includes the startup checks, and combined flags run
+        // them once before printing both requested reports.
         loonfs_server::check_config(&config).await?;
         let mut stdout = std::io::stdout().lock();
-        if args.probe_store {
-            let store = config.object_store()?.into_shared();
-            let run_id = loonfs_api::generated_id("probe");
-            let report = run_store_contract_probe(store.as_ref(), &run_id).await;
-            for check in &report.checks {
-                match &check.outcome {
-                    StoreProbeOutcome::Passed => writeln!(stdout, "{}: passed", check.name)?,
-                    StoreProbeOutcome::Unsupported => {
-                        writeln!(stdout, "{}: unsupported", check.name)?
-                    }
-                    StoreProbeOutcome::Failed { message } => {
-                        writeln!(stdout, "{}: failed: {message}", check.name)?
-                    }
-                }
-            }
-            stdout.flush()?;
-            return Ok(if report.all_passed() {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::FAILURE
-            });
+        if args.check_config {
+            writeln!(stdout, "{}", config.check_summary())?;
         }
-        writeln!(stdout, "{}", config.check_summary())?;
+        if args.probe_store {
+            let report = loonfs_server::probe_store(&config).await?;
+            for check in &report.checks {
+                writeln!(stdout, "{}", check.check_line())?;
+            }
+            if !report.all_passed() {
+                exit_code = ExitCode::FAILURE;
+            }
+        }
         stdout.flush()?;
-        return Ok(ExitCode::SUCCESS);
+    } else {
+        loonfs_server::serve(config).await?;
     }
-    loonfs_server::serve(config).await?;
-    Ok(ExitCode::SUCCESS)
+    Ok(exit_code)
 }

--- a/crates/loonfs-server/tests/it/check_config.rs
+++ b/crates/loonfs-server/tests/it/check_config.rs
@@ -63,51 +63,23 @@ fn write_tls_identity(dir: &Path) -> (PathBuf, PathBuf) {
     (cert_path, key_path)
 }
 
-fn check_config(config_path: &Path) -> std::process::Output {
-    Command::new(env!("CARGO_BIN_EXE_loonfs-server"))
-        .arg("--config")
-        .arg(config_path)
-        .arg("--check-config")
-        .output()
-        .expect("run loonfs-server --check-config")
-}
-
-fn probe_store(config_path: &Path, check_config_too: bool) -> std::process::Output {
+fn run_server(config_path: &Path, flags: &[&str]) -> std::process::Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_loonfs-server"));
-    command
-        .arg("--config")
-        .arg(config_path)
-        .arg("--probe-store");
-    if check_config_too {
-        command.arg("--check-config");
-    }
-    command.output().expect("run loonfs-server --probe-store")
+    command.arg("--config").arg(config_path).args(flags);
+    command.output().expect("run loonfs-server")
 }
 
-const STORE_PROBE_CHECKS: &[&str] = &[
-    "create_if_absent_enforced",
-    "compare_and_swap_rejects_stale",
-    "compare_and_swap_missing_object_rejected",
-    "overwrite_updates_head_and_body",
-    "get_with_metadata_round_trip",
-    "head_reports_last_modified",
-    "visibility_after_write",
-    "visibility_after_delete",
-    "delete_missing_idempotent",
-    "sorted_listing",
-    "range_reads",
-    "multipart_round_trip",
-    "stored_checksum_readback",
-    "cleanup_leaves_prefix_empty",
-];
-
-#[test]
-fn probe_store_reports_every_check_for_a_working_local_store() {
+#[tokio::test]
+async fn probe_store_reports_every_check_for_a_working_local_store() {
     let dir = tempfile::tempdir().expect("tempdir");
     let store_root = dir.path().join("store");
     let config_path = write_config(dir.path(), "127.0.0.1:9400", &store_root);
 
-    let output = probe_store(&config_path, false);
+    let config = loonfs_server::load_server_config(&config_path).expect("load config");
+    let report = loonfs_server::probe_store(&config)
+        .await
+        .expect("probe store through library boundary");
+    let output = run_server(&config_path, &["--probe-store"]);
 
     let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
     let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
@@ -117,11 +89,16 @@ fn probe_store_reports_every_check_for_a_working_local_store() {
         output.status
     );
     let lines: Vec<&str> = stdout.lines().collect();
-    assert_eq!(lines.len(), STORE_PROBE_CHECKS.len(), "{stdout}");
-    for name in STORE_PROBE_CHECKS {
-        let expected = format!("{name}: passed");
-        assert!(lines.contains(&expected.as_str()), "{stdout}");
-    }
+    let expected: Vec<String> = report
+        .checks
+        .iter()
+        .map(|check| check.check_line())
+        .collect();
+    assert_eq!(
+        lines,
+        expected.iter().map(String::as_str).collect::<Vec<_>>(),
+        "{stdout}"
+    );
     assert!(!stdout.contains("check-config-token"), "{stdout}");
     assert!(!stdout.contains("check-config-secret"), "{stdout}");
     assert!(!stderr.contains("check-config-token"), "{stderr}");
@@ -135,7 +112,7 @@ fn probe_store_fails_when_the_local_store_root_cannot_be_created() {
     std::fs::write(&occupied, b"a file, not a directory").expect("occupy the store path");
     let config_path = write_config(dir.path(), "127.0.0.1:9400", &occupied);
 
-    let output = probe_store(&config_path, false);
+    let output = run_server(&config_path, &["--probe-store"]);
 
     assert!(!output.status.success(), "expected a non-zero exit");
     let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
@@ -147,25 +124,26 @@ fn probe_store_fails_when_the_local_store_root_cannot_be_created() {
     assert!(!stderr.contains("check-config-secret"), "{stderr}");
 }
 
-#[test]
-fn probe_store_and_check_config_may_be_combined() {
+#[tokio::test]
+async fn probe_store_and_check_config_may_be_combined() {
     let dir = tempfile::tempdir().expect("tempdir");
     let config_path = write_config(dir.path(), "127.0.0.1:9400", &dir.path().join("store"));
 
-    let output = probe_store(&config_path, true);
+    let config = loonfs_server::load_server_config(&config_path).expect("load config");
+    let report = loonfs_server::probe_store(&config)
+        .await
+        .expect("probe store through library boundary");
+    let output = run_server(&config_path, &["--probe-store", "--check-config"]);
 
     assert!(
         output.status.success(),
         "combined checks failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(
-        String::from_utf8(output.stdout)
-            .expect("utf-8 stdout")
-            .lines()
-            .count(),
-        STORE_PROBE_CHECKS.len()
-    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines[0], config.check_summary());
+    assert_eq!(lines.len(), report.checks.len() + 1);
 }
 
 #[test]
@@ -174,7 +152,7 @@ fn check_config_accepts_a_valid_config_and_names_what_it_validated() {
     let store_root = dir.path().join("store");
     let config_path = write_config(dir.path(), "127.0.0.1:9400", &store_root);
 
-    let output = check_config(&config_path);
+    let output = run_server(&config_path, &["--check-config"]);
 
     let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
     assert!(
@@ -209,7 +187,7 @@ root = "/tmp/loonfs-check-config-unused"
     )
     .expect("write server config");
 
-    let output = check_config(&config_path);
+    let output = run_server(&config_path, &["--check-config"]);
 
     assert!(!output.status.success(), "expected a non-zero exit");
     let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
@@ -238,7 +216,7 @@ fn check_config_reports_a_tls_identity_it_cannot_load() {
         &tls_table(&missing_cert, &key_path),
     );
 
-    let output = check_config(&config_path);
+    let output = run_server(&config_path, &["--check-config"]);
 
     assert!(
         !output.status.success(),
@@ -261,7 +239,7 @@ fn check_config_reports_a_tls_identity_it_cannot_load() {
         &tls_table(&cert_path, &not_pem),
     );
 
-    let output = check_config(&config_path);
+    let output = run_server(&config_path, &["--check-config"]);
 
     assert!(
         !output.status.success(),
@@ -289,7 +267,7 @@ fn check_config_reports_a_local_cache_it_cannot_open() {
         &local_cache_table(&occupied),
     );
 
-    let output = check_config(&config_path);
+    let output = run_server(&config_path, &["--check-config"]);
 
     assert!(
         !output.status.success(),
@@ -329,7 +307,7 @@ fn check_config_opens_the_local_cache_and_leaves_it_openable() {
         ),
     );
 
-    let output = check_config(&config_path);
+    let output = run_server(&config_path, &["--check-config"]);
 
     let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
     assert!(
@@ -347,7 +325,7 @@ fn check_config_opens_the_local_cache_and_leaves_it_openable() {
         "the check opens the cache, and opening it builds the directory"
     );
 
-    let second = check_config(&config_path);
+    let second = run_server(&config_path, &["--check-config"]);
 
     assert!(
         second.status.success(),
@@ -365,7 +343,7 @@ fn check_config_does_not_bind_the_port() {
     let bind = listener.local_addr().expect("local addr").to_string();
     let config_path = write_config(dir.path(), &bind, &dir.path().join("store"));
 
-    let output = check_config(&config_path);
+    let output = run_server(&config_path, &["--check-config"]);
 
     let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
     let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");

--- a/crates/loonfs-server/tests/logging.rs
+++ b/crates/loonfs-server/tests/logging.rs
@@ -1,4 +1,7 @@
 //! Request-outcome logging at the HTTP boundary.
+//!
+//! This is a separate binary because its global subscriber would leak across
+//! the shared `it` harness and capture unrelated tests.
 
 #[path = "it/common/mod.rs"]
 mod common;
@@ -7,9 +10,11 @@ use axum::body::{to_bytes, Body};
 use axum::http::Request;
 use axum::Router;
 use common::http_split_support::test_config;
-use loonfs::CreateNamespaceOptions;
-use loonfs_server::{app, MaintenanceMode};
+use loonfs::{CreateNamespaceOptions, FsWriter, SharedObjectStore, TraceMode, TraceStoreKind};
+use loonfs_objectstore::local_fs_store::LocalFsStore;
+use loonfs_server::{app, app_with_store, MaintenanceMode};
 use loonfs_test_support::ids::namespace_id;
+use loonfs_test_support::stores::{FailStore, InjectedError, KeyPredicate, OperationClass};
 use std::fmt;
 use std::sync::{Arc, Mutex, OnceLock};
 use tower::ServiceExt as _;
@@ -199,29 +204,33 @@ async fn store_fault_has_one_error_from_the_boundary() {
     let mut config = test_config(store_root.clone(), "logging-store-fault", key_prefix);
     config.maintenance = MaintenanceMode::Manual;
 
-    let (first_router, first_writer, _local_cache) =
-        app(config.clone()).await.expect("build first app");
-    first_writer
+    let failing = Arc::new(FailStore::new(
+        LocalFsStore::with_key_prefix(&store_root, Some(key_prefix)).expect("build local store"),
+        KeyPredicate::wal_head("faulty"),
+        OperationClass::Read,
+        InjectedError::Transport("injected WAL-head read failure".to_owned()),
+    ));
+    let store: SharedObjectStore = failing.clone();
+    let bootstrap = FsWriter::builder_with_store(store.clone())
+        .writer_id("logging-store-fault-bootstrap")
+        .trace_mode(TraceMode::Remote)
+        .trace_store_kind(TraceStoreKind::LocalFs)
+        .build()
+        .await
+        .expect("build bootstrap writer");
+    bootstrap
         .create_namespace(&namespace_id("faulty"), CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    first_writer
+    bootstrap
         .shutdown()
         .await
-        .expect("shutdown first writer");
-    drop(first_router);
-    drop(first_writer);
+        .expect("shutdown bootstrap writer");
 
-    // A directory at an object key is a deterministic local-store fault.
-    let head_path = store_root
-        .join(key_prefix)
-        .join("namespaces/faulty/wal/head.json");
-    std::fs::remove_file(&head_path).expect("remove WAL head object");
-    std::fs::create_dir(&head_path).expect("replace WAL head with a directory");
-
-    let (second_router, second_writer, _local_cache) = app(config).await.expect("build second app");
+    failing.fail_all();
+    let router = app_with_store(config, store).await.expect("build app");
     capture.clear();
-    let (status, _body, request_id) = request_error(&second_router, "/v0/namespaces/faulty").await;
+    let (status, _body, request_id) = request_error(&router, "/v0/namespaces/faulty").await;
     assert_eq!(status, 500);
 
     let events = capture.snapshot();
@@ -235,8 +244,5 @@ async fn store_fault_has_one_error_from_the_boundary() {
     assert_eq!(errors[0].request_id.as_deref(), Some(request_id.as_str()));
     assert_eq!(completion_events(&events, &request_id).len(), 1);
 
-    second_writer
-        .shutdown()
-        .await
-        .expect("shutdown second writer");
+    drop(router);
 }

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -6,7 +6,6 @@
 //! checkpoint calls, and its hosts drive it.
 
 use crate::maintenance_runner::CompactionStart;
-use crate::metrics::{CompactionOutcome, CompactionTotals};
 use crate::FsAdmin;
 use crate::NamespaceStatusResponse;
 use crate::{
@@ -17,7 +16,6 @@ use crate::{
 };
 use crate::{ChangeSeq, Result, RuntimeError};
 use loonfs_core::cache::{load_namespace_fold_basis, load_namespace_head_summary};
-use std::time::Duration;
 use tokio::time::Instant;
 
 #[cfg(test)]
@@ -455,11 +453,9 @@ impl FsAdmin {
             // No runner behind this handle, so there is no slot to claim and
             // no permit to wait for.
             let cancellation = loonfs_core::MetadataCompactionCancellation::default();
-            let started = Instant::now();
             let outcome = self
                 .run_streaming_compaction(namespace_id, &spec, &cancellation)
                 .await;
-            self.record_streaming_compaction(&outcome, started.elapsed());
             return Ok(MetadataCompactionOutcome::Ran(outcome?));
         };
         let Some(mut claim) = compactions.claim(namespace_id, &spec) else {
@@ -467,58 +463,17 @@ impl FsAdmin {
         };
         if !claim.admitted().await {
             let outcome = loonfs_core::MetadataCompactionJobOutcome::Cancelled;
-            self.record_streaming_compaction(&Ok(outcome.clone()), Duration::ZERO);
+            self.core.instruments().compaction_not_admitted();
             return Ok(MetadataCompactionOutcome::Ran(outcome));
         }
-        let started = Instant::now();
         let outcome = self
             .run_streaming_compaction(namespace_id, &spec, claim.cancellation())
             .await;
-        self.record_streaming_compaction(&outcome, started.elapsed());
         claim.finished(matches!(
             outcome,
             Ok(loonfs_core::MetadataCompactionJobOutcome::Published { .. })
         ));
         Ok(MetadataCompactionOutcome::Ran(outcome?))
-    }
-
-    /// Files one compaction ending in this handle's cumulative instruments.
-    pub(crate) fn record_streaming_compaction(
-        &self,
-        outcome: &Result<loonfs_core::MetadataCompactionJobOutcome>,
-        elapsed: Duration,
-    ) {
-        let (outcome, totals) = match outcome {
-            Ok(loonfs_core::MetadataCompactionJobOutcome::Published {
-                rows_read,
-                rows_written,
-                input_bytes,
-                output_bytes,
-                ..
-            }) => (
-                CompactionOutcome::Completed,
-                Some(CompactionTotals {
-                    input_rows: *rows_read,
-                    output_rows: *rows_written,
-                    input_bytes: *input_bytes,
-                    output_bytes: *output_bytes,
-                }),
-            ),
-            Ok(
-                loonfs_core::MetadataCompactionJobOutcome::Abandoned
-                | loonfs_core::MetadataCompactionJobOutcome::Superseded,
-            ) => (CompactionOutcome::Superseded, None),
-            Ok(loonfs_core::MetadataCompactionJobOutcome::Cancelled) => {
-                (CompactionOutcome::Cancelled, None)
-            }
-            Ok(loonfs_core::MetadataCompactionJobOutcome::Fenced) => {
-                (CompactionOutcome::Fenced, None)
-            }
-            Err(_) => (CompactionOutcome::Failed, None),
-        };
-        self.core
-            .instruments()
-            .compaction_finished(outcome, elapsed, totals);
     }
 
     /// Runs one streaming compaction to its end and says what that end was.
@@ -536,11 +491,16 @@ impl FsAdmin {
         spec: &loonfs_core::MetadataCompactionSpec,
         cancellation: &loonfs_core::MetadataCompactionCancellation,
     ) -> Result<loonfs_core::MetadataCompactionJobOutcome> {
+        let started = Instant::now();
         let outcome = self
             .engine(namespace_id)
             .run_metadata_compaction(spec, cancellation)
             .await
             .map_err(RuntimeError::Core);
+        let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.core
+            .instruments()
+            .compaction_finished(&outcome, elapsed_ms);
         match &outcome {
             Ok(loonfs_core::MetadataCompactionJobOutcome::Published {
                 manifest_id,

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -42,9 +42,7 @@ use loonfs_core::{
 };
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, Weak};
-use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-use tokio::time::Instant;
 
 /// Streaming compactions this process runs at once, across every namespace it
 /// serves.
@@ -256,19 +254,14 @@ impl BackgroundCompactions {
         let namespace_id = namespace_id.clone();
         runner.spawn(async move {
             if !claim.admitted().await {
-                admin.record_streaming_compaction(
-                    &Ok(MetadataCompactionJobOutcome::Cancelled),
-                    Duration::ZERO,
-                );
+                admin.core.instruments().compaction_not_admitted();
                 return;
             }
-            let started = Instant::now();
             // Every ending is logged inside, including the error one, so what
             // a task nobody awaits needs from it is only what to do next.
             let outcome = admin
                 .run_streaming_compaction(&namespace_id, &spec, claim.cancellation())
                 .await;
-            admin.record_streaming_compaction(&outcome, started.elapsed());
             let published = matches!(outcome, Ok(MetadataCompactionJobOutcome::Published { .. }));
             claim.finished(published);
         });

--- a/crates/loonfs/src/metrics.rs
+++ b/crates/loonfs/src/metrics.rs
@@ -56,9 +56,7 @@ pub use loonfs_objectstore::metrics::{
     RangeClass, VecObjectStoreMetricsRecorder,
 };
 
-pub(crate) use instruments::{
-    fan_out_object_store_recorder, CompactionOutcome, CompactionTotals, RuntimeInstruments,
-};
+pub(crate) use instruments::{fan_out_object_store_recorder, RuntimeInstruments};
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -19,10 +19,11 @@ use super::{
     ObjectStoreMetricsRecorder, SMALL_COUNT_BOUNDARIES,
 };
 use crate::metrics::LATENCY_SECONDS_BOUNDARIES;
-use crate::{GcResponse, MaintenanceJobId, MaintenanceStepConclusion};
+use crate::{
+    GcResponse, MaintenanceJobId, MaintenanceStepConclusion, MetadataCompactionJobOutcome,
+};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::Duration;
 
 /// The closed outcome vocabulary for a finished streaming compaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,14 +36,6 @@ pub(crate) enum CompactionOutcome {
 }
 
 impl CompactionOutcome {
-    const ALL: [Self; 5] = [
-        Self::Completed,
-        Self::Failed,
-        Self::Superseded,
-        Self::Cancelled,
-        Self::Fenced,
-    ];
-
     const fn as_str(self) -> &'static str {
         match self {
             Self::Completed => "completed",
@@ -52,25 +45,6 @@ impl CompactionOutcome {
             Self::Fenced => "fenced",
         }
     }
-
-    const fn index(self) -> usize {
-        match self {
-            Self::Completed => 0,
-            Self::Failed => 1,
-            Self::Superseded => 2,
-            Self::Cancelled => 3,
-            Self::Fenced => 4,
-        }
-    }
-}
-
-/// Logical input and output totals from one finished merge.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CompactionTotals {
-    pub(crate) input_rows: u64,
-    pub(crate) output_rows: u64,
-    pub(crate) input_bytes: u64,
-    pub(crate) output_bytes: u64,
 }
 
 /// One reclaimable family: its label, and the count a pass reports for it.
@@ -204,35 +178,56 @@ impl RuntimeInstruments {
     /// Reports one finished streaming compaction and any merge it completed.
     pub(crate) fn compaction_finished(
         &self,
+        outcome: &crate::Result<MetadataCompactionJobOutcome>,
+        elapsed_ms: u64,
+    ) {
+        let (outcome, totals) = match outcome {
+            Ok(MetadataCompactionJobOutcome::Published {
+                rows_read,
+                rows_written,
+                input_bytes,
+                output_bytes,
+                ..
+            }) => (
+                CompactionOutcome::Completed,
+                Some((*rows_read, *rows_written, *input_bytes, *output_bytes)),
+            ),
+            Ok(
+                MetadataCompactionJobOutcome::Abandoned | MetadataCompactionJobOutcome::Superseded,
+            ) => (CompactionOutcome::Superseded, None),
+            Ok(MetadataCompactionJobOutcome::Cancelled) => (CompactionOutcome::Cancelled, None),
+            Ok(MetadataCompactionJobOutcome::Fenced) => (CompactionOutcome::Fenced, None),
+            Err(_) => (CompactionOutcome::Failed, None),
+        };
+        self.record_compaction(outcome, elapsed_ms, totals);
+    }
+
+    /// Reports a queued compaction cancelled before it began doing work.
+    pub(crate) fn compaction_not_admitted(&self) {
+        self.record_compaction(CompactionOutcome::Cancelled, 0, None);
+    }
+
+    fn record_compaction(
+        &self,
         outcome: CompactionOutcome,
-        elapsed: Duration,
-        totals: Option<CompactionTotals>,
+        elapsed_ms: u64,
+        totals: Option<(u64, u64, u64, u64)>,
     ) {
         let Some(installed) = &self.installed else {
             return;
         };
-        let outcome_instruments = &installed.compactions.outcomes[outcome.index()];
+        let outcome_instruments = installed.compactions.outcome(outcome);
         outcome_instruments.count.increment(1);
-        outcome_instruments.seconds.record(elapsed.as_secs_f64());
-        let Some(totals) = totals else {
+        outcome_instruments
+            .seconds
+            .record(seconds_from_ms(elapsed_ms));
+        let Some((input_rows, output_rows, input_bytes, output_bytes)) = totals else {
             return;
         };
-        installed
-            .compactions
-            .input_rows
-            .increment(totals.input_rows);
-        installed
-            .compactions
-            .output_rows
-            .increment(totals.output_rows);
-        installed
-            .compactions
-            .input_bytes
-            .increment(totals.input_bytes);
-        installed
-            .compactions
-            .output_bytes
-            .increment(totals.output_bytes);
+        installed.compactions.input_rows.increment(input_rows);
+        installed.compactions.output_rows.increment(output_rows);
+        installed.compactions.input_bytes.increment(input_bytes);
+        installed.compactions.output_bytes.increment(output_bytes);
     }
 
     /// Reports the candidates a namespace has admitted but not yet taken.
@@ -533,7 +528,11 @@ impl MaintenanceJobInstruments {
 struct CompactionInstruments {
     running: Arc<dyn GaugeHandle>,
     queued: Arc<dyn GaugeHandle>,
-    outcomes: [CompactionOutcomeInstruments; 5],
+    completed: CompactionOutcomeInstruments,
+    failed: CompactionOutcomeInstruments,
+    superseded: CompactionOutcomeInstruments,
+    cancelled: CompactionOutcomeInstruments,
+    fenced: CompactionOutcomeInstruments,
     input_rows: Arc<dyn CounterHandle>,
     output_rows: Arc<dyn CounterHandle>,
     input_bytes: Arc<dyn CounterHandle>,
@@ -547,10 +546,10 @@ struct CompactionOutcomeInstruments {
 
 impl CompactionInstruments {
     fn register(recorder: &dyn MetricsRecorder) -> Self {
-        let outcomes = CompactionOutcome::ALL.map(|outcome| CompactionOutcomeInstruments {
+        let outcome = |outcome: CompactionOutcome| CompactionOutcomeInstruments {
             count: recorder.register_counter(
                 "loonfs.maintenance.compactions",
-                "Streaming metadata compactions by outcome.",
+                "Streaming metadata compactions by outcome",
                 &[("outcome", outcome.as_str())],
             ),
             seconds: recorder.register_histogram(
@@ -559,7 +558,7 @@ impl CompactionInstruments {
                 &[("outcome", outcome.as_str())],
                 LATENCY_SECONDS_BOUNDARIES,
             ),
-        });
+        };
         let rows = |direction: &'static str| {
             recorder.register_counter(
                 "loonfs.maintenance.compaction_rows",
@@ -586,11 +585,25 @@ impl CompactionInstruments {
                  process permit",
                 &[],
             ),
-            outcomes,
+            completed: outcome(CompactionOutcome::Completed),
+            failed: outcome(CompactionOutcome::Failed),
+            superseded: outcome(CompactionOutcome::Superseded),
+            cancelled: outcome(CompactionOutcome::Cancelled),
+            fenced: outcome(CompactionOutcome::Fenced),
             input_rows: rows("input"),
             output_rows: rows("output"),
             input_bytes: bytes("input"),
             output_bytes: bytes("output"),
+        }
+    }
+
+    fn outcome(&self, outcome: CompactionOutcome) -> &CompactionOutcomeInstruments {
+        match outcome {
+            CompactionOutcome::Completed => &self.completed,
+            CompactionOutcome::Failed => &self.failed,
+            CompactionOutcome::Superseded => &self.superseded,
+            CompactionOutcome::Cancelled => &self.cancelled,
+            CompactionOutcome::Fenced => &self.fenced,
         }
     }
 }
@@ -1001,14 +1014,15 @@ mod tests {
         let instruments = RuntimeInstruments::new(Some(recorder.clone()));
 
         instruments.compaction_finished(
-            CompactionOutcome::Completed,
-            Duration::from_millis(25),
-            Some(CompactionTotals {
-                input_rows: 20,
-                output_rows: 10,
+            &Ok(MetadataCompactionJobOutcome::Published {
+                manifest_id: loonfs_api::ManifestId(1),
+                rows_read: 20,
+                rows_written: 10,
                 input_bytes: 2_000,
                 output_bytes: 1_000,
+                output_segments: 1,
             }),
+            25,
         );
 
         let snapshot = recorder.snapshot();


### PR DESCRIPTION
Cleanup pass:
- One request-observability middleware replaces the stacked metrics and completion layers: method, route, and start time read once per request; the unmatched arm uses the metrics' `UNMATCHED_ROUTE` label instead of logging raw caller-controlled paths; the 429 arm the server can never produce is gone; the three level arms share one macro.
- The deadline exemption is now a named `DEADLINE_EXEMPT_ROUTES` list checked against `MatchedPath` inside the middleware, over one router restored to API-area order. A test asserts every exempt entry matches a route the real router serves, so a renamed route fails loudly and a new route is bounded by default. Deliberate membership change: grep `enable`/`disable` are CAS metadata flips and move under the deadline; content streams, the maintenance step, the store probe, and grep `gc` stay exempt.
- Span loads keep what they decode: the single-flight winner fills its output slots directly instead of re-resolving every block through the memo — which the 64 MiB cap could evict first, forcing a fresh single-block GET now that spans skip the stored tier. The memo record path loses its impossible branches, double key clones, and pre-lock work, and its constant joins the `*_DECODED_BYTES` family.
- Duplicates collapse onto their originals: `metadata_segment_bytes` → `segment_object_len`, the copied genesis-manifest fixture → `genesis_basis_manifest`, the probe check line → one `check_line` on `StoreProbeCheck` shared by the binary and the conformance test, four hand-spelled gauge emits → one `write_gauge`, two test `counter()` helpers → one.
- Compaction metrics classify outcomes beside their labels (`compaction_finished` takes the job outcome, the way `gc_pass` takes `GcResponse`), deleting `CompactionTotals`, the `ALL`/`index()` parallel orderings, and both re-exports; both paths time and record inside `run_streaming_compaction`.
- `probe_store` orchestration moves to a library function beside `check_config`; `main.rs` goes back to flags → call → print → one exit code, and `--check-config --probe-store` now prints both reports instead of silently dropping the summary. The drain select loses its unreachable arm; the shutdown default's 600s carries the why (`PROVIDER_OPERATION_DEADLINE`); the logging test binary states why it is separate and injects its fault through `FailStore` instead of corrupting the store layout by hand.
