### PR TITLE
refactor(core): route immutable manifests and WAL segments through verified writes

### DIFF
--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -247,6 +247,7 @@ impl<'a> CompactionLease<'a> {
     /// resolve.
     pub(super) async fn create<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
         let encoded = encode_lease(&self.state)?;
+        // A lease is mutable control state, so its first lifecycle state is a conditional create.
         let metadata = match store.put_if_absent(&self.object_key, encoded).await {
             Ok(metadata) => metadata,
             Err(ObjectStoreError::PreconditionFailed { .. }) => {

--- a/crates/loonfs-core/src/checkpoint/error.rs
+++ b/crates/loonfs-core/src/checkpoint/error.rs
@@ -48,6 +48,13 @@ pub enum ManifestLoadError {
         actual: ManifestObjectId,
     },
     #[error(
+        "namespace manifest object conflict for `{object_key}` manifest `{manifest_id}`: the immutable key contains different bytes"
+    )]
+    ManifestObjectConflict {
+        object_key: String,
+        manifest_id: ManifestId,
+    },
+    #[error(
         "namespace manifest conflict for `{object_key}` manifest `{manifest_id}`: expected payload checksum `{expected_payload_checksum}`, actual `{actual_payload_checksum}`"
     )]
     ManifestConflict {
@@ -104,9 +111,7 @@ pub enum ManifestLoadError {
 impl ManifestLoadError {
     pub fn failure_class(&self) -> ManifestLoadFailureClass {
         match self {
-            Self::ReadManifest { .. }
-            | Self::ReadSegment { .. }
-            | Self::ManifestConflict { .. } => ManifestLoadFailureClass::Store,
+            Self::ReadManifest { .. } | Self::ReadSegment { .. } => ManifestLoadFailureClass::Store,
             _ => ManifestLoadFailureClass::Corrupt,
         }
     }

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -15,8 +15,6 @@ use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
 
-const DIFFERENT_MANIFEST_BYTES: &str = "unavailable because the encoded bytes differ";
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ManifestPublicationOutcome {
     Published(MetadataRootState),
@@ -55,11 +53,9 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
     {
         Ok(()) => Ok(()),
         Err(ImmutableWriteError::DifferentObject { .. }) => Err(
-            MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestConflict {
+            MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestObjectConflict {
                 object_key: manifest_key,
                 manifest_id: manifest.payload.manifest_id,
-                expected_payload_checksum: manifest.payload_checksum.clone(),
-                actual_payload_checksum: DIFFERENT_MANIFEST_BYTES.to_owned(),
             }),
         ),
         Err(ImmutableWriteError::Transport { source, .. }) => Err(
@@ -87,10 +83,10 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
 /// contention, and it is reported as such.
 pub(super) fn manifest_write_failure(error: MetadataProjectionLoadError) -> CoreError {
     match error {
-        MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestConflict {
-            object_key,
-            ..
-        }) => CoreError::NamespaceCorrupt(format!(
+        MetadataProjectionLoadError::ManifestLoad(
+            ManifestLoadError::ManifestObjectConflict { object_key, .. }
+            | ManifestLoadError::ManifestConflict { object_key, .. },
+        ) => CoreError::NamespaceCorrupt(format!(
             "namespace manifest `{object_key}` already exists with a different payload"
         )),
         error => CoreError::MetadataProjection(error),

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -2,7 +2,6 @@
 //! advance `metadata/root.json` by monotonic compare-and-swap.
 
 use super::error::ManifestLoadError;
-use super::load::load_namespace_manifest_envelope_if_present;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::limits::CONTENTION_RETRY_LIMIT;
@@ -14,7 +13,9 @@ use loonfs_api::wire::control::{
 use loonfs_api::wire::manifest::{encode_namespace_manifest_json, NamespaceManifestEnvelope};
 use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::metadata_manifest_object;
-use loonfs_objectstore::{ObjectStore, ObjectStoreError};
+use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
+
+const DIFFERENT_MANIFEST_BYTES: &str = "unavailable because the encoded bytes differ";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ManifestPublicationOutcome {
@@ -40,46 +41,33 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
         manifest.payload.namespace_id.as_str(),
         &manifest.payload.manifest_object_id,
     );
-    let manifest_bytes = encode_namespace_manifest_json(manifest).map_err(|err| {
+    let manifest_bytes = Bytes::from(encode_namespace_manifest_json(manifest).map_err(|err| {
         MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestCodec {
             object_key: manifest_key.clone(),
             message: err.to_string(),
         })
-    })?;
+    })?);
+    // Immutable format objects use verified writes so identical bytes are an idempotent success
+    // and different bytes are corruption.
     match store
-        .put_if_absent(&manifest_key, Bytes::from(manifest_bytes))
+        .put_immutable_verified(&manifest_key, manifest_bytes)
         .await
     {
-        Ok(_) => Ok(()),
-        Err(ObjectStoreError::PreconditionFailed { .. }) => {
-            let Some(existing) = load_namespace_manifest_envelope_if_present(
-                store,
-                &manifest.payload.namespace_id,
-                &manifest.payload.manifest_object_id,
-                &manifest_key,
-            )
-            .await
-            .map_err(MetadataProjectionLoadError::ManifestLoad)?
-            else {
-                return Err(MetadataProjectionLoadError::ManifestLoad(
-                    ManifestLoadError::MissingManifest {
-                        object_key: manifest_key,
-                    },
-                ));
-            };
-            if existing.payload_checksum == manifest.payload_checksum {
-                Ok(())
-            } else {
-                Err(MetadataProjectionLoadError::ManifestLoad(
-                    ManifestLoadError::ManifestConflict {
-                        object_key: manifest_key,
-                        manifest_id: manifest.payload.manifest_id,
-                        expected_payload_checksum: manifest.payload_checksum.clone(),
-                        actual_payload_checksum: existing.payload_checksum,
-                    },
-                ))
-            }
-        }
+        Ok(()) => Ok(()),
+        Err(ImmutableWriteError::DifferentObject { .. }) => Err(
+            MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestConflict {
+                object_key: manifest_key,
+                manifest_id: manifest.payload.manifest_id,
+                expected_payload_checksum: manifest.payload_checksum.clone(),
+                actual_payload_checksum: DIFFERENT_MANIFEST_BYTES.to_owned(),
+            }),
+        ),
+        Err(ImmutableWriteError::Transport { source, .. }) => Err(
+            MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ReadManifest {
+                object_key: manifest_key,
+                message: source.to_string(),
+            }),
+        ),
         Err(error) => Err(MetadataProjectionLoadError::ManifestLoad(
             ManifestLoadError::ReadManifest {
                 object_key: manifest_key,
@@ -247,6 +235,7 @@ async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
     let encoded = encode_control_object(&envelope).map_err(|err| {
         CoreError::Internal(format!("failed to encode metadata root object: {err}"))
     })?;
+    // The metadata root is mutable control state, so its first publication is a conditional create.
     match store.put_if_absent(&object_key, Bytes::from(encoded)).await {
         Ok(_) => Ok(Some(next)),
         Err(ObjectStoreError::PreconditionFailed { .. }) => Ok(None),

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -53,6 +53,7 @@ pub(crate) async fn write_checkpoint_record<S: ObjectStore + ?Sized>(
 ) -> Result<()> {
     let encoded = encode_checkpoint_record(record)?;
     let object_key = checkpoint_record(record.namespace_id.as_str(), record.checkpoint_id.as_str());
+    // A checkpoint record is mutable control state, so its first lifecycle state is a conditional create.
     match store.put_if_absent(&object_key, encoded).await {
         Ok(_) => Ok(()),
         Err(ObjectStoreError::PreconditionFailed { .. }) => Err(CoreError::Internal(format!(

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -115,6 +115,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
                     .compare_and_swap(&object_key, expected_etag, Bytes::from(encoded))
                     .await
             }
+            // The retention floor is mutable control state, so its first publication is a conditional create.
             None => store.put_if_absent(&object_key, Bytes::from(encoded)).await,
         };
         match published {

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -932,22 +932,16 @@ async fn write_namespace_manifest_conflict_different_payload_is_error() {
         .await
         .expect_err("different same-id manifest must conflict");
 
+    assert_eq!(
+        CoreError::MetadataProjection(error.clone()).code(),
+        ErrorCode::NamespaceCorrupt
+    );
     match error {
-        MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestConflict {
+        MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ManifestObjectConflict {
             manifest_id,
-            expected_payload_checksum,
-            actual_payload_checksum,
             ..
         }) => {
             assert_eq!(manifest_id, ManifestId(1));
-            assert_eq!(
-                expected_payload_checksum,
-                conflicting_manifest.payload_checksum
-            );
-            assert_eq!(
-                actual_payload_checksum,
-                "unavailable because the encoded bytes differ"
-            );
         }
         other => panic!("unexpected error: {other:?}"),
     }

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -209,10 +209,9 @@ async fn create_checkpoint_surfaces_conflicting_invalid_manifest() {
     .expect("write hello");
 
     match create_checkpoint(&store, &namespace_id, &context).await {
-        Err(CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(
-            ManifestLoadError::ManifestCodec { .. },
-        ))) => {}
-        other => panic!("expected manifest codec manifest load error, got {other:?}"),
+        Err(CoreError::NamespaceCorrupt(message))
+            if message.contains("already exists with a different payload") => {}
+        other => panic!("expected conflicting manifest corruption error, got {other:?}"),
     }
 
     let materialization = load_current_projection(&store, &namespace_id)
@@ -945,7 +944,10 @@ async fn write_namespace_manifest_conflict_different_payload_is_error() {
                 expected_payload_checksum,
                 conflicting_manifest.payload_checksum
             );
-            assert_eq!(actual_payload_checksum, manifest.payload_checksum);
+            assert_eq!(
+                actual_payload_checksum,
+                "unavailable because the encoded bytes differ"
+            );
         }
         other => panic!("unexpected error: {other:?}"),
     }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -294,11 +294,9 @@ impl From<ImmutableWriteError> for CoreError {
     fn from(value: ImmutableWriteError) -> Self {
         let fallback_object_key = value.object_key().to_owned();
         match value {
-            ImmutableWriteError::DifferentObject { object_key } => Self::Store {
-                object_key,
-                message: "immutable object already exists with different bytes".to_owned(),
-                class: StoreFailureClass::Other,
-            },
+            ImmutableWriteError::DifferentObject { object_key } => Self::NamespaceCorrupt(format!(
+                "immutable object `{object_key}` already exists with different bytes"
+            )),
             ImmutableWriteError::Transport { object_key, source } => Self::Store {
                 object_key,
                 message: source.message(),

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -146,6 +146,7 @@ pub(super) async fn install_namespace_head<S: ObjectStore + ?Sized>(
         .map_err(|err| CoreError::Internal(format!("failed to build head envelope: {err}")))?;
     let bytes = encode_control_object(&envelope)
         .map_err(|err| CoreError::Internal(format!("failed to encode head object: {err}")))?;
+    // The namespace head is mutable control state, so installation must be a conditional create.
     match store.put_if_absent(&object_key, Bytes::from(bytes)).await {
         Ok(_) => Ok(NamespaceHeadInstall::Landed),
         Err(ObjectStoreError::PreconditionFailed { .. }) => {

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -23,7 +23,7 @@ use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::WalCommitPayload;
 use loonfs_api::NamespaceId;
-use loonfs_objectstore::{ObjectMetadata, ObjectStore};
+use loonfs_objectstore::{ImmutableWriteError, ObjectMetadata, ObjectStore};
 use tracing::Instrument;
 
 #[derive(Debug, Clone)]
@@ -339,19 +339,41 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
         )
         .map_err(|error| CoreError::Internal(format!("wal build failed: {error}")))?;
         store
-            .put_if_absent(&wal.object_key, Bytes::copy_from_slice(&wal.encoded_bytes))
+            .put_immutable_verified(&wal.object_key, Bytes::copy_from_slice(&wal.encoded_bytes))
             .await
-            .map_err(|error| CoreError::WalWrite {
-                object_key: wal.object_key.clone(),
-                message: error.message(),
-                class: StoreFailureClass::of(&error),
-            })?;
+            .map_err(wal_immutable_write_error)?;
         Ok(wal)
     }
     .instrument(span.clone())
     .await;
     span.record("result", if result.is_ok() { "ok" } else { "error" });
     result
+}
+
+fn wal_immutable_write_error(error: ImmutableWriteError) -> CoreError {
+    let fallback_object_key = error.object_key().to_owned();
+    let (object_key, message, class) = match error {
+        ImmutableWriteError::DifferentObject { object_key } => (
+            object_key,
+            "immutable WAL segment already exists with different bytes".to_owned(),
+            StoreFailureClass::Other,
+        ),
+        ImmutableWriteError::Transport { object_key, source } => {
+            let message = source.message();
+            let class = StoreFailureClass::of(&source);
+            (object_key, message, class)
+        }
+        error => (
+            fallback_object_key,
+            error.to_string(),
+            StoreFailureClass::Other,
+        ),
+    };
+    CoreError::WalWrite {
+        object_key,
+        message,
+        class,
+    }
 }
 
 /// Advances the namespace head past the new WAL segment by compare-and-swap.

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -352,27 +352,24 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
 
 fn wal_immutable_write_error(error: ImmutableWriteError) -> CoreError {
     let fallback_object_key = error.object_key().to_owned();
-    let (object_key, message, class) = match error {
-        ImmutableWriteError::DifferentObject { object_key } => (
-            object_key,
-            "immutable WAL segment already exists with different bytes".to_owned(),
-            StoreFailureClass::Other,
+    match error {
+        ImmutableWriteError::DifferentObject { object_key } => CoreError::NamespaceCorrupt(
+            format!("immutable WAL segment `{object_key}` already exists with different bytes"),
         ),
         ImmutableWriteError::Transport { object_key, source } => {
             let message = source.message();
             let class = StoreFailureClass::of(&source);
-            (object_key, message, class)
+            CoreError::WalWrite {
+                object_key,
+                message,
+                class,
+            }
         }
-        error => (
-            fallback_object_key,
-            error.to_string(),
-            StoreFailureClass::Other,
-        ),
-    };
-    CoreError::WalWrite {
-        object_key,
-        message,
-        class,
+        error => CoreError::WalWrite {
+            object_key: fallback_object_key,
+            message: error.to_string(),
+            class: StoreFailureClass::Other,
+        },
     }
 }
 

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -423,6 +423,7 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
         CoreError::Internal(format!("failed to encode upload session envelope: {err}"))
     })?;
     let object_key = upload_session(namespace_id.as_str(), upload_id.as_str());
+    // An upload session is mutable control state, so its first lifecycle state is a conditional create.
     store
         .put_if_absent(&object_key, Bytes::from(encoded))
         .await

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -686,8 +686,9 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
     let store = InjectCreateFailureStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
         KeyMatcher::Prefix("namespaces/demo/wal/segments/".to_owned()),
-        InjectedCreateFailure::Transport {
-            message: "injected wal write failure",
+        InjectedCreateFailure::PreconditionFailed {
+            write_attempted_object: false,
+            additional_writes: Vec::new(),
         },
     );
     bootstrap_namespace(&store, &namespace_id, &context, false)

--- a/crates/loonfs-objectstore/src/immutable_write.rs
+++ b/crates/loonfs-objectstore/src/immutable_write.rs
@@ -15,6 +15,9 @@ use thiserror::Error;
 #[non_exhaustive]
 pub enum ImmutableWriteError {
     /// The key names bytes other than the immutable payload supplied here.
+    ///
+    /// This is a corruption tripwire, not a provider failure: callers must
+    /// preserve that classification at their public error boundary.
     #[error("immutable object `{object_key}` already exists with different bytes")]
     DifferentObject {
         /// Durable key whose existing bytes violated immutability.


### PR DESCRIPTION
First slice of the idiom-consistency review (its finding 3). The verified immutable-write helper already owns create-if-absent, transport ambiguity, readback, and exact-byte comparison; metadata and grep segments use it. The namespace manifest hand-rolled the same protocol at checksum granularity, and the batch WAL segment write was a raw `put_if_absent`. Both now go through the helper: identical existing bytes are idempotent success, different bytes at an immutable key are `ManifestConflict`/corruption. The manifest's local reload-and-compare branch and its now-unused loader are deleted.

The sweep classified every other `put_if_absent` in core: metadata root, compaction lease, retention floor, checkpoint record, head, and upload session are conditional writes of mutable control objects — genuinely different — and each now carries a one-line exemption comment where it writes.

Tests pin same-key-identical-bytes success and different-bytes conflict. Full workspace suite green.