### PR TITLE
refactor(grep): share one byte-weighted single-flight block cache

### DIFF
--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -30,9 +30,9 @@ use loonfs_api::{
 };
 use loonfs_client::NamespacePath;
 use loonfs_grep::{
-    GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepGcJob,
-    GrepIndexSnapshot, GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads, GREP_GC_JOB,
-    GREP_INDEX_JOB,
+    GramIndexBuildPolicy, GrepBlockCache, GrepDisableOutcome, GrepEnableOutcome, GrepError,
+    GrepGcJob, GrepIndexSnapshot, GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
+    GREP_GC_JOB, GREP_INDEX_JOB,
 };
 use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, StoreProbeReport};
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
@@ -55,9 +55,11 @@ pub(crate) struct EmbeddedBackend {
     pub(crate) reader: FsReader,
     pub(crate) admin: FsAdmin,
     /// Grep is composed here rather than by the runtime: this service owns
-    /// the query-side block cache for the length of the command, and the
-    /// worker below is built from the same handles the other commands use.
+    /// the query side for the length of the command.
     pub(crate) grep: GrepService,
+    /// The process-wide grep cache is retained separately so workers created
+    /// lazily by commands share the service's decoded immutable blocks.
+    pub(crate) grep_block_cache: Arc<GrepBlockCache>,
 }
 
 /// How many times a gated publish resubmits after settling the maintenance
@@ -129,10 +131,11 @@ impl EmbeddedBackend {
     /// the writer's store client, its filesystem reads the reader, and its
     /// backfill checkpoints the admin handle.
     fn grep_worker(&self) -> GrepWorker<SharedObjectStore> {
-        GrepWorker::new(
+        GrepWorker::with_block_cache(
             self.writer.object_store(),
             self.reader.clone(),
             self.admin.clone(),
+            Arc::clone(&self.grep_block_cache),
         )
     }
 

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -9,7 +9,8 @@ use crate::profiles::{default_namespace, resolve_profile};
 use loonfs::{FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreKind};
 use loonfs_api::{ErrorCode, NamespaceId};
 use loonfs_client::{Client, ClientConfig};
-use loonfs_grep::GrepService;
+use loonfs_grep::{GrepBlockCache, GrepService, DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES};
+use std::sync::Arc;
 
 pub(crate) struct LoadedConfig {
     pub path: std::path::PathBuf,
@@ -188,13 +189,16 @@ impl EmbeddedTarget {
             .build()
             .await
             .map_err(map_runtime_error)?;
+        let grep_block_cache =
+            Arc::new(GrepBlockCache::new(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES));
         let backend = EmbeddedBackend {
             writer,
             reader,
             admin,
             // Embedded mode composes grep itself: the runtime handles above
             // know nothing about it.
-            grep: GrepService::new(),
+            grep: GrepService::with_block_cache(Arc::clone(&grep_block_cache)),
+            grep_block_cache,
         };
         Ok(Self { backend })
     }

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -3,12 +3,34 @@
 use crate::codec::IndexRow;
 use crate::root::GrepManifestState;
 use loonfs::Recency;
-use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
+use loonfs_api::wire::sst_blocks::{
+    DecodedDataBlock, SegmentFilter, SegmentIndexEntry, DEFAULT_TARGET_BLOCK_BYTES,
+};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use tokio::sync::OnceCell;
 
-/// Maximum decoded manifests and segment sections retained by one grep service or worker.
-pub(crate) const MAX_CACHED_GREP_BLOCKS: usize = 4_096;
+/// Default decoded-byte budget for cached grep manifests and segment blocks.
+///
+/// This preserves the former 4,096-entry cache's intended capacity at the
+/// usual 64 KiB decoded data-block target while preventing unusually large
+/// decoded blocks from making the cache effectively unbounded. Zero disables
+/// the cache.
+pub const DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES: usize = 4_096 * DEFAULT_TARGET_BLOCK_BYTES;
+
+/// Cumulative activity counters for one grep block cache.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GrepBlockCacheStats {
+    /// Successful cache lookups.
+    pub hits: usize,
+    /// Cache lookups that required a load.
+    pub misses: usize,
+    /// Blocks inserted after successful loads.
+    pub inserts: usize,
+    /// Blocks removed to enforce the decoded-byte budget.
+    pub evictions: usize,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum GrepBlockKind {
@@ -27,22 +49,59 @@ pub(crate) struct GrepBlockCacheKey {
 
 #[derive(Debug, Clone)]
 pub(crate) enum DecodedGrepBlock {
-    Manifest(Arc<GrepManifestState>),
-    Filter(Arc<SegmentFilter>),
-    Index(Arc<Vec<SegmentIndexEntry>>),
-    Data(Arc<DecodedDataBlock<IndexRow>>),
+    Manifest {
+        state: Arc<GrepManifestState>,
+        decoded_byte_len: usize,
+    },
+    Filter {
+        filter: Arc<SegmentFilter>,
+        decoded_byte_len: usize,
+    },
+    Index {
+        entries: Arc<Vec<SegmentIndexEntry>>,
+        decoded_byte_len: usize,
+    },
+    Data {
+        block: Arc<DecodedDataBlock<IndexRow>>,
+        decoded_byte_len: usize,
+    },
 }
 
+impl DecodedGrepBlock {
+    fn decoded_byte_len(&self) -> usize {
+        match self {
+            Self::Manifest {
+                decoded_byte_len, ..
+            }
+            | Self::Filter {
+                decoded_byte_len, ..
+            }
+            | Self::Index {
+                decoded_byte_len, ..
+            }
+            | Self::Data {
+                decoded_byte_len, ..
+            } => *decoded_byte_len,
+        }
+    }
+}
+
+/// A process-shareable cache of immutable decoded grep blocks.
 #[derive(Debug)]
-pub(crate) struct GrepBlockCache {
-    max_blocks: usize,
+pub struct GrepBlockCache {
+    max_decoded_bytes: usize,
     inner: Mutex<GrepBlockCacheInner>,
+    stats: GrepBlockCacheStatsInner,
+    /// One cell per in-flight block fetch, keyed by immutable block identity,
+    /// so concurrent readers share a single object-store read per block.
+    in_flight: Mutex<HashMap<GrepBlockCacheKey, Arc<OnceCell<DecodedGrepBlock>>>>,
 }
 
 #[derive(Debug, Default)]
 struct GrepBlockCacheInner {
     entries: HashMap<GrepBlockCacheKey, CacheSlot>,
     order: Recency<GrepBlockCacheKey>,
+    decoded_byte_len: usize,
 }
 
 #[derive(Debug)]
@@ -53,50 +112,134 @@ struct CacheSlot {
     last_touch: u64,
 }
 
+#[derive(Debug, Default)]
+struct GrepBlockCacheStatsInner {
+    hits: AtomicUsize,
+    misses: AtomicUsize,
+    inserts: AtomicUsize,
+    evictions: AtomicUsize,
+}
+
 impl GrepBlockCache {
-    pub(crate) fn new(max_blocks: usize) -> Self {
+    /// Creates a cache with the supplied decoded-byte budget.
+    pub fn new(max_decoded_bytes: usize) -> Self {
         Self {
-            max_blocks,
+            max_decoded_bytes,
             inner: Mutex::new(GrepBlockCacheInner::default()),
+            stats: GrepBlockCacheStatsInner::default(),
+            in_flight: Mutex::new(HashMap::new()),
         }
     }
 
-    pub(crate) fn get(&self, key: &GrepBlockCacheKey) -> Option<DecodedGrepBlock> {
-        if self.max_blocks == 0 {
+    /// Resolves one block access through a per-key single-flight cell.
+    pub(crate) async fn get_or_load<E, F, Fut>(
+        &self,
+        cache_key: &GrepBlockCacheKey,
+        fetch: F,
+    ) -> Result<DecodedGrepBlock, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<DecodedGrepBlock, E>>,
+    {
+        let cell = {
+            let mut in_flight = self
+                .in_flight
+                .lock()
+                .expect("grep block cache in-flight lock should not be poisoned");
+            Arc::clone(
+                in_flight
+                    .entry(cache_key.clone())
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        let result = cell
+            .get_or_try_init(|| async {
+                if let Some(block) = self.get(cache_key) {
+                    return Ok(block);
+                }
+                let block = fetch().await?;
+                self.insert(cache_key.clone(), block.clone());
+                Ok(block)
+            })
+            .await
+            .cloned();
+        let mut in_flight = self
+            .in_flight
+            .lock()
+            .expect("grep block cache in-flight lock should not be poisoned");
+        if in_flight
+            .get(cache_key)
+            .is_some_and(|current| Arc::ptr_eq(current, &cell))
+        {
+            in_flight.remove(cache_key);
+        }
+        result
+    }
+
+    /// Returns cumulative hit, miss, insert, and eviction counters.
+    pub fn stats(&self) -> GrepBlockCacheStats {
+        GrepBlockCacheStats {
+            hits: self.stats.hits.load(Ordering::SeqCst),
+            misses: self.stats.misses.load(Ordering::SeqCst),
+            inserts: self.stats.inserts.load(Ordering::SeqCst),
+            evictions: self.stats.evictions.load(Ordering::SeqCst),
+        }
+    }
+
+    fn get(&self, key: &GrepBlockCacheKey) -> Option<DecodedGrepBlock> {
+        if self.max_decoded_bytes == 0 {
             return None;
         }
         let mut inner = self
             .inner
             .lock()
             .expect("grep block cache lock should not be poisoned");
-        let block = inner.entries.get(key)?.block.clone();
+        let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
+            self.stats.misses.fetch_add(1, Ordering::SeqCst);
+            return None;
+        };
         inner.touch(key);
+        self.stats.hits.fetch_add(1, Ordering::SeqCst);
         Some(block)
     }
 
-    pub(crate) fn insert(&self, key: GrepBlockCacheKey, block: DecodedGrepBlock) {
-        if self.max_blocks == 0 {
+    fn insert(&self, key: GrepBlockCacheKey, block: DecodedGrepBlock) {
+        if self.max_decoded_bytes == 0 {
             return;
         }
         let mut inner = self
             .inner
             .lock()
             .expect("grep block cache lock should not be poisoned");
-        inner.entries.insert(
+        let decoded_byte_len = block.decoded_byte_len();
+        if let Some(previous) = inner.entries.insert(
             key.clone(),
             CacheSlot {
                 block,
                 last_touch: 0,
             },
-        );
+        ) {
+            inner.decoded_byte_len = inner
+                .decoded_byte_len
+                .saturating_sub(previous.block.decoded_byte_len());
+        }
+        inner.decoded_byte_len = inner.decoded_byte_len.saturating_add(decoded_byte_len);
         inner.touch(&key);
-        let GrepBlockCacheInner { entries, order } = &mut *inner;
-        while entries.len() > self.max_blocks {
-            let Some(evicted) = order.pop_oldest(|key, stamp| slot_is_live(entries, key, stamp))
+        self.stats.inserts.fetch_add(1, Ordering::SeqCst);
+        let GrepBlockCacheInner {
+            entries,
+            order,
+            decoded_byte_len,
+        } = &mut *inner;
+        while *decoded_byte_len > self.max_decoded_bytes {
+            let Some(candidate) = order.pop_oldest(|key, stamp| slot_is_live(entries, key, stamp))
             else {
                 break;
             };
-            entries.remove(&evicted);
+            if let Some(slot) = entries.remove(&candidate) {
+                *decoded_byte_len = decoded_byte_len.saturating_sub(slot.block.decoded_byte_len());
+                self.stats.evictions.fetch_add(1, Ordering::SeqCst);
+            }
         }
     }
 }
@@ -124,4 +267,64 @@ fn slot_is_live(
     entries
         .get(key)
         .is_some_and(|slot| slot.last_touch == stamp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind};
+    use loonfs_api::wire::sst_blocks::DecodedDataBlock;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    fn block(decoded_byte_len: usize) -> DecodedGrepBlock {
+        DecodedGrepBlock::Data {
+            block: Arc::new(DecodedDataBlock {
+                row_keys: Vec::new(),
+                rows: Vec::new(),
+            }),
+            decoded_byte_len,
+        }
+    }
+
+    fn key(checksum: &str) -> GrepBlockCacheKey {
+        GrepBlockCacheKey {
+            payload_checksum: checksum.to_owned(),
+            block_kind: GrepBlockKind::Data,
+            block_offset: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_loads_of_one_key_run_one_underlying_load() {
+        let cache = GrepBlockCache::new(1_000);
+        let loads = AtomicUsize::new(0);
+        let cache_key = key("a");
+        let first = cache.get_or_load(&cache_key, || async {
+            loads.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            Ok::<_, String>(block(100))
+        });
+        let second = cache.get_or_load(&cache_key, || async {
+            loads.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, String>(block(100))
+        });
+
+        let (first, second) = tokio::join!(first, second);
+        assert!(first.is_ok());
+        assert!(second.is_ok());
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        assert_eq!(cache.stats().misses, 1);
+        assert_eq!(cache.stats().inserts, 1);
+    }
+
+    #[test]
+    fn decoded_byte_budget_evicts_the_oldest_block() {
+        let cache = GrepBlockCache::new(1_000);
+        cache.insert(key("a"), block(600));
+        cache.insert(key("b"), block(600));
+
+        assert!(cache.get(&key("a")).is_none());
+        assert!(cache.get(&key("b")).is_some());
+        assert_eq!(cache.stats().evictions, 1);
+    }
 }

--- a/crates/loonfs-grep/src/index_read.rs
+++ b/crates/loonfs-grep/src/index_read.rs
@@ -74,16 +74,23 @@ pub(crate) async fn load_filter_block<S: ObjectStore + ?Sized>(
     handle: &BlockHandle,
 ) -> Result<Arc<SegmentFilter>> {
     let key = cache_key(payload_checksum, GrepBlockKind::Filter, handle);
-    if let Some(DecodedGrepBlock::Filter(filter)) = cache.get(&key) {
-        return Ok(filter);
+    let decoded = cache
+        .get_or_load(&key, || async {
+            let bytes = load_index_section_bytes(store, object_key, handle).await?;
+            let filter = Arc::new(
+                decode_filter_block(&bytes, handle)
+                    .map_err(|error| index_segment_corrupt(object_key, "filter block", &error))?,
+            );
+            Ok::<_, GrepError>(DecodedGrepBlock::Filter {
+                filter,
+                decoded_byte_len: handle.decoded_len as usize,
+            })
+        })
+        .await?;
+    match decoded {
+        DecodedGrepBlock::Filter { filter, .. } => Ok(filter),
+        _ => Err(cache_kind_corrupt(object_key, "filter")),
     }
-    let bytes = load_index_section_bytes(store, object_key, handle).await?;
-    let filter = Arc::new(
-        decode_filter_block(&bytes, handle)
-            .map_err(|error| index_segment_corrupt(object_key, "filter block", &error))?,
-    );
-    cache.insert(key, DecodedGrepBlock::Filter(Arc::clone(&filter)));
-    Ok(filter)
 }
 
 pub(crate) async fn load_index_block<S: ObjectStore + ?Sized>(
@@ -94,16 +101,23 @@ pub(crate) async fn load_index_block<S: ObjectStore + ?Sized>(
     handle: &BlockHandle,
 ) -> Result<Arc<Vec<SegmentIndexEntry>>> {
     let key = cache_key(payload_checksum, GrepBlockKind::Index, handle);
-    if let Some(DecodedGrepBlock::Index(entries)) = cache.get(&key) {
-        return Ok(entries);
+    let decoded = cache
+        .get_or_load(&key, || async {
+            let bytes = load_index_section_bytes(store, object_key, handle).await?;
+            let entries = Arc::new(
+                decode_index_block(&bytes, handle)
+                    .map_err(|error| index_segment_corrupt(object_key, "index block", &error))?,
+            );
+            Ok::<_, GrepError>(DecodedGrepBlock::Index {
+                entries,
+                decoded_byte_len: handle.decoded_len as usize,
+            })
+        })
+        .await?;
+    match decoded {
+        DecodedGrepBlock::Index { entries, .. } => Ok(entries),
+        _ => Err(cache_kind_corrupt(object_key, "index")),
     }
-    let bytes = load_index_section_bytes(store, object_key, handle).await?;
-    let entries = Arc::new(
-        decode_index_block(&bytes, handle)
-            .map_err(|error| index_segment_corrupt(object_key, "index block", &error))?,
-    );
-    cache.insert(key, DecodedGrepBlock::Index(Arc::clone(&entries)));
-    Ok(entries)
 }
 
 pub(crate) async fn load_data_block<S: ObjectStore + ?Sized>(
@@ -114,14 +128,29 @@ pub(crate) async fn load_data_block<S: ObjectStore + ?Sized>(
     handle: &BlockHandle,
 ) -> Result<Arc<DecodedDataBlock<IndexRow>>> {
     let key = cache_key(payload_checksum, GrepBlockKind::Data, handle);
-    if let Some(DecodedGrepBlock::Data(block)) = cache.get(&key) {
-        return Ok(block);
+    let decoded = cache
+        .get_or_load(&key, || async {
+            let bytes = load_index_section_bytes(store, object_key, handle).await?;
+            let block = Arc::new(
+                decode_data_block_rows::<IndexRow>(&bytes, handle)
+                    .map_err(|error| index_segment_corrupt(object_key, "data block", &error))?,
+            );
+            Ok::<_, GrepError>(DecodedGrepBlock::Data {
+                block,
+                decoded_byte_len: handle.decoded_len as usize,
+            })
+        })
+        .await?;
+    match decoded {
+        DecodedGrepBlock::Data { block, .. } => Ok(block),
+        _ => Err(cache_kind_corrupt(object_key, "data")),
     }
-    let bytes = load_index_section_bytes(store, object_key, handle).await?;
-    let block = Arc::new(
-        decode_data_block_rows::<IndexRow>(&bytes, handle)
-            .map_err(|error| index_segment_corrupt(object_key, "data block", &error))?,
-    );
-    cache.insert(key, DecodedGrepBlock::Data(Arc::clone(&block)));
-    Ok(block)
+}
+
+fn cache_kind_corrupt(object_key: &str, expected: &str) -> GrepError {
+    GrepError::CorruptIndex {
+        message: format!(
+            "index segment `{object_key}` resolved its {expected} block to a different cache kind"
+        ),
+    }
 }

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -76,6 +76,7 @@ pub mod root;
 mod service;
 mod worker;
 
+pub use cache::{GrepBlockCache, GrepBlockCacheStats, DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES};
 pub use config::{GrepWorkerConfig, GrepWorkerConfigError};
 pub use error::GrepError as Error;
 pub use error::{GrepError, Result};

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -2,7 +2,8 @@
 //! of a namespace.
 
 use crate::cache::{
-    DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind, MAX_CACHED_GREP_BLOCKS,
+    DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind,
+    DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
 };
 use crate::codec::{lookup, Gram, IndexRow, INDEX_GRAMS_MAX_FILE_BYTES};
 use crate::index_read::{
@@ -125,12 +126,44 @@ impl GrepIndexSnapshot {
             block_kind: GrepBlockKind::Manifest,
             block_offset: 0,
         };
-        let state = match service.block_cache.get(&cache_key) {
-            Some(DecodedGrepBlock::Manifest(state)) => state,
-            Some(
-                DecodedGrepBlock::Filter(_)
-                | DecodedGrepBlock::Index(_)
-                | DecodedGrepBlock::Data(_),
+        let state = match service
+            .block_cache
+            .get_or_load(&cache_key, || async {
+                let manifest = load_grep_manifest(store, namespace_id, pointer.pointer())
+                    .await
+                    .map_err(GrepError::from)?
+                    .ok_or_else(|| GrepError::CorruptIndex {
+                        message: format!(
+                            "grep root `{}` names missing manifest `{}`",
+                            pointer.object_key(),
+                            manifest_key(namespace_id, manifest_id)
+                        ),
+                    })?;
+                let state = Arc::new(manifest.manifest_state().clone());
+                // As with the metadata manifest cache, JSON-backed decoded
+                // state is weighted at twice its canonical payload bytes to
+                // cover both owned strings and decoded structure overhead.
+                let decoded_byte_len = serde_json::to_vec(manifest.manifest_state())
+                    .map_err(|error| {
+                        CoreError::Internal(format!(
+                            "failed to size decoded grep manifest `{}`: {error}",
+                            manifest_key(namespace_id, manifest_id)
+                        ))
+                    })?
+                    .len()
+                    .saturating_mul(2);
+                Ok(DecodedGrepBlock::Manifest {
+                    state,
+                    decoded_byte_len,
+                })
+            })
+            .await
+        {
+            Ok(DecodedGrepBlock::Manifest { state, .. }) => state,
+            Ok(
+                DecodedGrepBlock::Filter { .. }
+                | DecodedGrepBlock::Index { .. }
+                | DecodedGrepBlock::Data { .. },
             ) => {
                 return Self::from_error(GrepError::CorruptIndex {
                     message: format!(
@@ -139,27 +172,7 @@ impl GrepIndexSnapshot {
                     ),
                 });
             }
-            None => {
-                let manifest =
-                    match load_grep_manifest(store, namespace_id, pointer.pointer()).await {
-                        Ok(Some(manifest)) => manifest,
-                        Ok(None) => {
-                            return Self::from_error(GrepError::CorruptIndex {
-                                message: format!(
-                                    "grep root `{}` names missing manifest `{}`",
-                                    pointer.object_key(),
-                                    manifest_key(namespace_id, manifest_id)
-                                ),
-                            });
-                        }
-                        Err(error) => return Self::from_error(error.into()),
-                    };
-                let state = Arc::new(manifest.manifest_state().clone());
-                service
-                    .block_cache
-                    .insert(cache_key, DecodedGrepBlock::Manifest(state.clone()));
-                state
-            }
+            Err(error) => return Self::from_error(error),
         };
         if state.namespace_id() != namespace_id {
             return Self::from_error(GrepError::CorruptIndex {
@@ -212,18 +225,23 @@ impl GrepIndexSnapshot {
     }
 }
 
-/// Namespace-independent grep execution with its own decoded-block cache.
+/// Namespace-independent grep execution over a decoded-block cache.
 #[derive(Debug)]
 pub struct GrepService {
-    block_cache: GrepBlockCache,
+    block_cache: Arc<GrepBlockCache>,
 }
 
 impl GrepService {
-    /// Creates a service with the fixed grep-private block-cache bound.
+    /// Creates a service with a fresh default-sized block cache.
     pub fn new() -> Self {
-        Self {
-            block_cache: GrepBlockCache::new(MAX_CACHED_GREP_BLOCKS),
-        }
+        Self::with_block_cache(Arc::new(GrepBlockCache::new(
+            DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
+        )))
+    }
+
+    /// Creates a service over a host-composed process-wide grep block cache.
+    pub fn with_block_cache(block_cache: Arc<GrepBlockCache>) -> Self {
+        Self { block_cache }
     }
 }
 

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -6,7 +6,7 @@
 //! many gram posting lists. The mid level absorbs frequent delta merges
 //! without rewriting most of the base on every step.
 
-use crate::cache::{GrepBlockCache, MAX_CACHED_GREP_BLOCKS};
+use crate::cache::{GrepBlockCache, DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES};
 use crate::codec::{
     extract_grams, lookup::GRAM_ROW_PREFIX, Gram, GramPosting, IndexRow, INDEX_GRAMS_MAX_FILE_BYTES,
 };
@@ -232,13 +232,29 @@ impl<S: std::fmt::Debug> std::fmt::Debug for GrepWorker<S> {
 
 impl<S: ObjectStore + Clone> GrepWorker<S> {
     /// Creates a worker over one grep-keyspace store handle and the runtime
-    /// handles it reads and checkpoints through.
+    /// handles it reads and checkpoints through, with a fresh default-sized
+    /// block cache.
     pub fn new(store: S, reader: FsReader, admin: FsAdmin) -> Self {
+        Self::with_block_cache(
+            store,
+            reader,
+            admin,
+            Arc::new(GrepBlockCache::new(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES)),
+        )
+    }
+
+    /// Creates a worker over a host-composed process-wide grep block cache.
+    pub fn with_block_cache(
+        store: S,
+        reader: FsReader,
+        admin: FsAdmin,
+        block_cache: Arc<GrepBlockCache>,
+    ) -> Self {
         Self {
             store,
             reader,
             admin,
-            block_cache: Arc::new(GrepBlockCache::new(MAX_CACHED_GREP_BLOCKS)),
+            block_cache,
         }
     }
 

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -12,9 +12,11 @@ use loonfs_api::v0::{DisableGrepIndexResponse, EnableGrepIndexResponse, GrepInde
 use loonfs_api::{ChangeSeq, GrepRequest, GrepResponse, NamespaceId};
 use loonfs_grep::root::GrepLifecycle;
 use loonfs_grep::{
-    GramIndexBuildPolicy, GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepIndexSnapshot,
-    GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
+    GramIndexBuildPolicy, GrepBlockCache, GrepDisableOutcome, GrepEnableOutcome, GrepError,
+    GrepIndexSnapshot, GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
+    DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
 };
+use std::sync::Arc;
 
 pub(crate) struct GrepHost {
     pub(crate) store: SharedObjectStore,
@@ -22,6 +24,7 @@ pub(crate) struct GrepHost {
     pub(crate) admin: FsAdmin,
     pub(crate) service: GrepService,
     pub(crate) worker: GrepWorker<SharedObjectStore>,
+    pub(crate) block_cache: Arc<GrepBlockCache>,
 }
 
 impl GrepHost {
@@ -35,12 +38,19 @@ impl GrepHost {
             .build()
             .await
             .expect("build admin");
+        let block_cache = Arc::new(GrepBlockCache::new(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES));
         Self {
             store: store.clone(),
             reader: reader.clone(),
             admin: admin.clone(),
-            service: GrepService::new(),
-            worker: GrepWorker::new(store.clone(), reader, admin),
+            service: GrepService::with_block_cache(Arc::clone(&block_cache)),
+            worker: GrepWorker::with_block_cache(
+                store.clone(),
+                reader,
+                admin,
+                Arc::clone(&block_cache),
+            ),
+            block_cache,
         }
     }
 

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -1274,11 +1274,17 @@ async fn worker_and_service_share_decoded_index_blocks() {
         "the worker must publish decoded blocks to the shared cache"
     );
 
+    let gets_before_query = raw_store.index_segment_get_count();
     let result = host
         .grep(&namespace_id, &request("needle"))
         .await
         .expect("grep after worker load");
     assert_eq!(result.matches.len(), 8);
+    assert_eq!(
+        raw_store.index_segment_get_count() - gets_before_query,
+        0,
+        "the service must not refetch index-segment sections the worker warmed"
+    );
     assert!(
         host.block_cache.stats().hits > stats_after_fold.hits,
         "the service must hit blocks inserted by the worker"

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -15,7 +15,9 @@ use loonfs::{
 };
 use loonfs_api::{decode_cursor, AbsolutePath, GrepPageCursor, GrepRequest};
 use loonfs_grep::codec::INDEX_GRAMS_MAX_FILE_BYTES;
-use loonfs_grep::{GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepWorker};
+use loonfs_grep::{
+    GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepReorganizeOutcome, GrepWorker,
+};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -1201,116 +1203,85 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// Fold steps and grep queries deliberately use separate decoded-block
-/// caches: warming grep must not warm the worker's folding cache.
-///
-/// Two identically shaped delta folds run through one runtime — eight
-/// one-file rounds each, explicit worker steps folding on the eighth. The
-/// first fold runs cold and is the in-test control; before the second, a
-/// grep warms seven of its eight inputs in the grep-private cache. The two
-/// identically shaped folds must therefore issue the same section reads.
+/// A worker's partial fold leaves its input segments query-visible. The
+/// service composed over the same cache must hit those worker-loaded blocks
+/// instead of retaining and reading a second decoded copy.
 #[tokio::test]
-async fn a_fold_does_not_reuse_grep_private_index_blocks() {
+async fn worker_and_service_share_decoded_index_blocks() {
     let temp_dir = tempdir().expect("tempdir");
     let raw_store = Arc::new(IndexSegmentGetCountingStore::new(temp_dir.path()));
     let store: loonfs::SharedObjectStore = raw_store.clone();
-    let namespace_id = NamespaceId::parse("grams-fold-cache").expect("namespace id");
+    let namespace_id = NamespaceId::parse("grams-shared-cache").expect("namespace id");
 
     let writer = FsWriter::builder_with_store(store.clone())
-        .writer_id("grams-fold-writer")
+        .writer_id("grams-shared-cache-writer")
         .min_publish_interval_ms(0)
         .build()
         .await
         .expect("build writer");
-    // The host's query service and the worker keep separate block caches:
-    // one warms on posting probes, the other on folding.
-    let host = GrepHost::new(&store, "grams-fold-admin").await;
+    let host = GrepHost::new(&store, "grams-shared-cache-admin").await;
 
     writer
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
     host.enable_grep_index(&namespace_id).await.expect("enable");
-    drive_worker_step(&host.worker, &namespace_id, GramIndexBuildPolicy::default()).await;
 
-    // One delta segment per round; the explicit fold step tiers the deltas
-    // into a mid run on the eighth round.
-    let put_round = |round: u32| {
-        let writer = writer.clone();
-        let namespace_id = namespace_id.clone();
-        let grep_worker = &host.worker;
-        async move {
-            writer
-                .put_file_bytes(
-                    &namespace_id,
-                    &format!("/notes/needle-{round:02}.txt"),
-                    format!("a needle numbered {round}\n").as_bytes(),
-                    PutFileOptions::default(),
-                )
-                .await
-                .expect("write file");
-            drive_worker_step(grep_worker, &namespace_id, GramIndexBuildPolicy::default()).await;
-        }
-    };
-
-    for round in 1..8u32 {
-        put_round(round).await;
+    // Build eight separate delta runs without invoking reorganization.
+    for round in 1..=8u32 {
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                &format!("/notes/needle-{round:02}.txt"),
+                format!("a needle numbered {round}\n").as_bytes(),
+                PutFileOptions::default(),
+            )
+            .await
+            .expect("write file");
+        host.worker
+            .build_step(&namespace_id, GramIndexBuildPolicy::default())
+            .await
+            .expect("build delta segment");
     }
-    let before_cold_fold = raw_store.index_segment_get_count();
-    put_round(8).await;
-    let cold_fold_gets = raw_store.index_segment_get_count() - before_cold_fold;
+
+    // One decoded row cannot exhaust the fold, so its loaded snapshot
+    // segments remain visible to the following service read.
+    let fold_policy = GramIndexBuildPolicy {
+        max_decoded_input_rows_per_step: nonzero_usize(1),
+        ..GramIndexBuildPolicy::default()
+    };
+    let gets_before_fold = raw_store.index_segment_get_count();
+    let stats_before_fold = host.block_cache.stats();
+    let fold = host
+        .worker
+        .reorganize_step(&namespace_id, fold_policy)
+        .await
+        .expect("partial fold");
+    assert!(matches!(
+        fold.outcome,
+        GrepReorganizeOutcome::StepPublished {
+            completed: false,
+            ..
+        }
+    ));
     assert!(
-        cold_fold_gets > 0,
-        "the eighth round's fold must read its snapshot segments from the store"
+        raw_store.index_segment_get_count() > gets_before_fold,
+        "the worker must load its snapshot's segment blocks"
+    );
+    let stats_after_fold = host.block_cache.stats();
+    assert!(
+        stats_after_fold.inserts > stats_before_fold.inserts,
+        "the worker must publish decoded blocks to the shared cache"
     );
 
-    for round in 9..16u32 {
-        put_round(round).await;
-    }
-    // The warm-up: one grep that matches every file decodes the pending
-    // delta segments' index and posting blocks into the shared cache.
-    let warm = host
+    let result = host
         .grep(&namespace_id, &request("needle"))
         .await
-        .expect("warming grep");
-    assert_eq!(warm.matches.len(), 15);
-
-    let before_warm_fold = raw_store.index_segment_get_count();
-    put_round(16).await;
-    let warm_fold_gets = raw_store.index_segment_get_count() - before_warm_fold;
+        .expect("grep after worker load");
+    assert_eq!(result.matches.len(), 8);
     assert!(
-        warm_fold_gets > 0,
-        "the sixteenth round's fold must still read the delta its own step wrote"
-    );
-    assert_eq!(
-        warm_fold_gets, cold_fold_gets,
-        "grep-private cache entries must not alter worker fold reads: cold \
-         fold read {cold_fold_gets} sections, query-warmed fold read \
-         {warm_fold_gets}"
-    );
-
-    // The premise of the comparison: both rounds really did fold, leaving
-    // two mid runs and no deltas.
-    let root = loonfs_grep::root::load_grep_root(&*store, &namespace_id)
-        .await
-        .expect("load grep root")
-        .expect("grep root exists");
-    let grams: Vec<(u32, u64)> = root
-        .manifest_state()
-        .segments()
-        .iter()
-        .map(|segment| (segment.level, segment.run_ordinal))
-        .collect();
-    assert!(
-        grams.iter().all(|(level, _)| *level == 1),
-        "sixteen one-delta rounds must leave only mid-level segments, got {grams:?}"
-    );
-    let mid_runs: std::collections::BTreeSet<u64> =
-        grams.iter().map(|(_, run_seq)| *run_seq).collect();
-    assert_eq!(
-        mid_runs.len(),
-        2,
-        "each eight-round batch must have folded into its own mid run, got {grams:?}"
+        host.block_cache.stats().hits > stats_after_fold.hits,
+        "the service must hit blocks inserted by the worker"
     );
 
     writer.shutdown().await.expect("writer shutdown");

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -14,7 +14,10 @@ use loonfs::{
     TraceStoreKind,
 };
 use loonfs_api::NamespaceId;
-use loonfs_grep::{GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker, GREP_INDEX_JOB};
+use loonfs_grep::{
+    GrepBlockCache, GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker,
+    DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES, GREP_INDEX_JOB,
+};
 use loonfs_objectstore::presign::DirectTransferIssuers;
 use std::ffi::OsString;
 use std::future::IntoFuture;
@@ -181,17 +184,25 @@ pub(super) async fn app_with_store_and_direct_transfers(
     )
     .await?;
     let probe_store = writer.object_store();
+    let grep_block_cache = Arc::new(GrepBlockCache::new(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES));
     // A deployment that maintains the index needs a worker whether or not it
     // answers queries with one. It runs on the writer's own instrumented
     // client, so the grep-owned traffic is measured like every other
     // request instead of escaping on a second, raw client.
-    let grep_worker = (config.grep.mode.serves_grep() || config.grep.mode.maintains_index())
-        .then(|| GrepWorker::new(writer.object_store(), reader.clone(), admin.clone()));
+    let grep_worker =
+        (config.grep.mode.serves_grep() || config.grep.mode.maintains_index()).then(|| {
+            GrepWorker::with_block_cache(
+                writer.object_store(),
+                reader.clone(),
+                admin.clone(),
+                Arc::clone(&grep_block_cache),
+            )
+        });
     let grep_service = config
         .grep
         .mode
         .serves_grep()
-        .then(|| Arc::new(GrepService::new()));
+        .then(|| Arc::new(GrepService::with_block_cache(Arc::clone(&grep_block_cache))));
     let grep_maintenance = if maintains_grep_index {
         let policy = config
             .grep


### PR DESCRIPTION
`GrepWorker` and `GrepService` each constructed a private count-limited block cache, so one server retained the same immutable grep segment twice and could issue duplicate concurrent reads of it. One `Arc<GrepBlockCache>` is now built at each composition root — the server, and the CLI's embedded backend (which keeps the Arc because it builds workers lazily) — and shared by both holders. `new()` still builds a fresh cache for tests and simple callers.

The cache migrates in place to the metadata block cache idiom: keyed by immutable identity, byte-weighted under `DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES` (256 MiB, derived from the old entry count times a typical decoded block), single-flight concurrent loads, and hit/miss/insert/eviction stats. Call sites move from get-then-load-then-insert onto `get_or_load`, so the single-flight actually deduplicates reads.
