### PR TITLE
fix(core): preserve basis verification errors

### DIFF
--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -89,9 +89,18 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
             Err(error) => {
                 // Cleanup is best effort on an error and must not replace its
                 // original classification.
-                let _ =
+                if let Err(cleanup_error) =
                     release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms)
-                        .await;
+                        .await
+                {
+                    tracing::warn!(
+                        namespace_id = %namespace_id,
+                        checkpoint_id = %checkpoint_id,
+                        original_error = %error,
+                        cleanup_error = %cleanup_error,
+                        "failed to release a checkpoint record after basis verification failed"
+                    );
+                }
                 return Err(error);
             }
         };

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -2,7 +2,10 @@
 //! then pin the resulting manifest under one durable checkpoint record.
 
 use super::flush::{try_flush_wal, TryFlushWal};
-use super::record::{release_checkpoint_record, verify_checkpoint_basis, write_checkpoint_record};
+use super::record::{
+    release_checkpoint_record, verify_checkpoint_basis, write_checkpoint_record,
+    CheckpointBasisVerification,
+};
 #[cfg(test)]
 use super::row::manifest_rows_for_family;
 #[cfg(test)]
@@ -81,10 +84,20 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
         let verify_started_ms = timer.monotonic_now_ms();
         write_checkpoint_record(store, &record).await?;
 
-        let verified = verify_checkpoint_basis(store, &record).await?;
+        let verification = match verify_checkpoint_basis(store, &record).await {
+            Ok(verification) => verification,
+            Err(error) => {
+                // Cleanup is best effort on an error and must not replace its
+                // original classification.
+                let _ =
+                    release_checkpoint_record(store, namespace_id, &checkpoint_id, context.now_ms)
+                        .await;
+                return Err(error);
+            }
+        };
         let within_budget = timer.monotonic_now_ms().saturating_sub(verify_started_ms)
             <= CHECKPOINT_VERIFY_BUDGET_MS;
-        if verified && within_budget {
+        if verification == CheckpointBasisVerification::Verified && within_budget {
             return Ok(CreateCheckpointResponse {
                 namespace_id: namespace_id.clone(),
                 checkpoint_id,

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -11,11 +11,12 @@
 //! manifests.
 
 use super::load::load_namespace_manifest_envelope;
+use super::ManifestLoadError;
 use crate::control_object::{
     core_control_load_error, expect_identity_field, expect_namespace, load_control_object,
     ControlObjectLoadError, LoadedControl,
 };
-use crate::error::{CoreError, Result};
+use crate::error::{CoreError, MetadataProjectionLoadError, Result};
 use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::read_head_object;
 use bytes::Bytes;
@@ -202,6 +203,12 @@ pub(crate) async fn release_checkpoint_record<S: ObjectStore + ?Sized>(
     )))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckpointBasisVerification {
+    Verified,
+    Invalid,
+}
+
 /// Checks that a record's basis is still intact: the retention floor has
 /// not passed it, and the basis manifest still loads with the expected
 /// checksum.
@@ -212,7 +219,7 @@ pub(crate) async fn release_checkpoint_record<S: ObjectStore + ?Sized>(
 pub(crate) async fn verify_checkpoint_basis<S: ObjectStore + ?Sized>(
     store: &S,
     record: &CheckpointRecordState,
-) -> Result<bool> {
+) -> Result<CheckpointBasisVerification> {
     let head = read_head_object(store, &record.namespace_id)
         .await
         .map_err(CoreError::load_head)?
@@ -221,8 +228,9 @@ pub(crate) async fn verify_checkpoint_basis<S: ObjectStore + ?Sized>(
         .await
         .map_err(CoreError::load_head)?;
     if floor_seq > record.manifest_head_seq {
-        return Ok(false);
+        return Ok(CheckpointBasisVerification::Invalid);
     }
+    // House rule: Err is not converted into absence or false unless the name says so.
     let manifest = match load_namespace_manifest_envelope(
         store,
         &record.namespace_id,
@@ -231,9 +239,22 @@ pub(crate) async fn verify_checkpoint_basis<S: ObjectStore + ?Sized>(
     .await
     {
         Ok(manifest) => manifest,
-        Err(_) => return Ok(false),
+        Err(ManifestLoadError::MissingManifest { .. }) => {
+            return Ok(CheckpointBasisVerification::Invalid)
+        }
+        Err(error) => {
+            return Err(CoreError::MetadataProjection(
+                MetadataProjectionLoadError::ManifestLoad(error),
+            ))
+        }
     };
-    Ok(manifest.payload_checksum == record.manifest_payload_checksum)
+    Ok(
+        if manifest.payload_checksum == record.manifest_payload_checksum {
+            CheckpointBasisVerification::Verified
+        } else {
+            CheckpointBasisVerification::Invalid
+        },
+    )
 }
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -248,13 +248,19 @@ pub(crate) async fn verify_checkpoint_basis<S: ObjectStore + ?Sized>(
             ))
         }
     };
-    Ok(
-        if manifest.payload_checksum == record.manifest_payload_checksum {
-            CheckpointBasisVerification::Verified
-        } else {
-            CheckpointBasisVerification::Invalid
-        },
-    )
+    if manifest.payload_checksum != record.manifest_payload_checksum {
+        // Both durable objects loaded successfully, so their disagreement is
+        // corruption rather than a retention race that a new checkpoint can fix.
+        return Err(CoreError::NamespaceCorrupt(format!(
+            "checkpoint `{}` for namespace `{}` records manifest `{}` payload checksum `{}`, but the manifest carries `{}`",
+            record.checkpoint_id,
+            record.namespace_id,
+            record.manifest_object_id,
+            record.manifest_payload_checksum,
+            manifest.payload_checksum,
+        )));
+    }
+    Ok(CheckpointBasisVerification::Verified)
 }
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -2,6 +2,103 @@
 
 use super::*;
 use loonfs_objectstore::keys::{checkpoint_prefix, wal_segment_prefix};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+#[derive(Debug)]
+struct ManifestChecksumMismatchOnceStore {
+    inner: LocalFsStore,
+    checkpoint_prefix: String,
+    manifest_key: String,
+    mismatched_manifest: Bytes,
+    mismatch_armed: AtomicBool,
+    mismatch_injected: AtomicBool,
+    checkpoint_writes: AtomicUsize,
+}
+
+impl ManifestChecksumMismatchOnceStore {
+    fn new(
+        inner: LocalFsStore,
+        namespace_id: &NamespaceId,
+        manifest_key: String,
+        mismatched_manifest: Bytes,
+    ) -> Self {
+        Self {
+            inner,
+            checkpoint_prefix: checkpoint_prefix(namespace_id.as_str()),
+            manifest_key,
+            mismatched_manifest,
+            mismatch_armed: AtomicBool::new(false),
+            mismatch_injected: AtomicBool::new(false),
+            checkpoint_writes: AtomicUsize::new(0),
+        }
+    }
+
+    fn inner(&self) -> &LocalFsStore {
+        &self.inner
+    }
+
+    fn checkpoint_writes(&self) -> usize {
+        self.checkpoint_writes.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ManifestChecksumMismatchOnceStore {
+    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> Result<Option<Bytes>, ObjectStoreError> {
+        let full_object = range.is_none();
+        let stored = self.inner.get(key, range).await?;
+        if key == self.manifest_key
+            && full_object
+            && self.mismatch_armed.swap(false, Ordering::SeqCst)
+        {
+            return Ok(Some(self.mismatched_manifest.clone()));
+        }
+        Ok(stored)
+    }
+
+    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> Result<ObjectMetadata, ObjectStoreError> {
+        let creates_checkpoint =
+            key.starts_with(&self.checkpoint_prefix) && matches!(&mode, PutMode::CreateIfAbsent);
+        let result = self.inner.put(key, bytes, mode).await;
+        if result.is_ok() && creates_checkpoint {
+            self.checkpoint_writes.fetch_add(1, Ordering::SeqCst);
+            // Only the first verification observes the contradiction. If the
+            // operation retries, the next basis is sound and would hide it.
+            if !self.mismatch_injected.swap(true, Ordering::SeqCst) {
+                self.mismatch_armed.store(true, Ordering::SeqCst);
+            }
+        }
+        result
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_stream(
+        &self,
+        prefix: &str,
+    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_stream(prefix)
+    }
+}
 
 async fn current_manifest_id<S: ObjectStore + ?Sized>(
     store: &S,
@@ -713,6 +810,81 @@ async fn checkpoint_basis_verification_store_failure_surfaces_and_releases_recor
         manifest_reads.load(std::sync::atomic::Ordering::SeqCst),
         2,
         "the injected failure follows the projection's manifest read"
+    );
+
+    let record_keys = store
+        .inner()
+        .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+        .await
+        .expect("list checkpoint records");
+    assert_eq!(record_keys.len(), 1, "the failed create wrote one record");
+    let checkpoint_id = record_keys[0]
+        .rsplit('/')
+        .next()
+        .and_then(|name| name.strip_suffix(".json"))
+        .and_then(|id| CheckpointId::parse(id).ok())
+        .expect("checkpoint record key");
+    let record = read_checkpoint_record(store.inner(), &namespace_id, &checkpoint_id)
+        .await
+        .expect("read checkpoint record")
+        .expect("record remains for cleanup inspection")
+        .state;
+    assert_eq!(
+        record.state,
+        loonfs_api::wire::control::CheckpointRecordLifecycle::Released {
+            released_at_ms: context.now_ms
+        }
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_checksum_disagreement_is_terminal_corruption_and_releases_record() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let setup_store = LocalFsStore::new(temp_dir.path()).expect("setup store");
+    bootstrap_namespace(&setup_store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+
+    let manifest_key = current_manifest_key(&setup_store, &namespace_id).await;
+    let manifest_bytes = setup_store
+        .get(&manifest_key, None)
+        .await
+        .expect("read manifest")
+        .expect("current manifest exists");
+    let manifest = decode_namespace_manifest_json(&manifest_bytes).expect("decode manifest");
+    let record_checksum = manifest.payload_checksum.clone();
+    let mut mismatched_payload = manifest.payload;
+    mismatched_payload.next_inode_id = InodeId(mismatched_payload.next_inode_id.0 + 1);
+    let mismatched_manifest = NamespaceManifestEnvelope::from_payload(mismatched_payload)
+        .expect("build mismatched manifest");
+    let manifest_checksum = mismatched_manifest.payload_checksum.clone();
+    assert_ne!(record_checksum, manifest_checksum);
+    let mismatched_bytes = Bytes::from(
+        encode_namespace_manifest_json(&mismatched_manifest).expect("encode mismatched manifest"),
+    );
+    let store = ManifestChecksumMismatchOnceStore::new(
+        setup_store,
+        &namespace_id,
+        manifest_key,
+        mismatched_bytes,
+    );
+
+    let error = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect_err("a durable checksum contradiction must fail checkpoint creation");
+
+    assert_eq!(error.code(), ErrorCode::NamespaceCorrupt);
+    let CoreError::NamespaceCorrupt(message) = error else {
+        panic!("expected namespace corruption, got {error:?}");
+    };
+    assert!(message.contains(&record_checksum));
+    assert!(message.contains(&manifest_checksum));
+    assert_eq!(
+        store.checkpoint_writes(),
+        1,
+        "the checksum contradiction must not be retried under a new checkpoint id"
     );
 
     let record_keys = store

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -1,7 +1,7 @@
 //! Checkpoint retention, reorganization, compaction, and publication budgets.
 
 use super::*;
-use loonfs_objectstore::keys::wal_segment_prefix;
+use loonfs_objectstore::keys::{checkpoint_prefix, wal_segment_prefix};
 
 async fn current_manifest_id<S: ObjectStore + ?Sized>(
     store: &S,
@@ -657,7 +657,87 @@ async fn checkpoint_verification_rejects_a_basis_below_the_floor() {
     let verified = super::record::verify_checkpoint_basis(&store, &stale)
         .await
         .expect("verification runs");
-    assert!(!verified, "sub-floor basis must not verify");
+    assert_eq!(
+        verified,
+        super::record::CheckpointBasisVerification::Invalid,
+        "sub-floor basis must not verify"
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_basis_verification_store_failure_surfaces_and_releases_record() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+    let context = test_context();
+    let setup_store = LocalFsStore::new(temp_dir.path()).expect("setup store");
+    bootstrap_namespace(&setup_store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap");
+    let manifest_key = current_manifest_key(&setup_store, &namespace_id).await;
+    let manifest_reads = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let selected_reads = Arc::clone(&manifest_reads);
+    let selected_manifest_key = manifest_key.clone();
+    let store = FailStore::matching(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        move |operation| {
+            operation.key() == selected_manifest_key
+                && matches!(
+                    operation.kind(),
+                    loonfs_test_support::stores::OperationKind::Get { .. }
+                )
+                && selected_reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 1
+        },
+        InjectedError::Transport("injected basis verification failure".to_owned()),
+    );
+    store.fail_next(1);
+
+    let error = create_checkpoint(&store, &namespace_id, &context)
+        .await
+        .expect_err("basis verification store failure must surface");
+
+    assert_eq!(error.code(), ErrorCode::ServerError);
+    match error {
+        CoreError::MetadataProjection(MetadataProjectionLoadError::ManifestLoad(
+            ManifestLoadError::ReadManifest {
+                object_key,
+                message,
+            },
+        )) => {
+            assert_eq!(object_key, manifest_key);
+            assert!(message.contains("injected basis verification failure"));
+        }
+        other => panic!("expected a classified manifest store error, got {other:?}"),
+    }
+    assert_eq!(store.attempts(), 1, "only the verification read fails");
+    assert_eq!(
+        manifest_reads.load(std::sync::atomic::Ordering::SeqCst),
+        2,
+        "the injected failure follows the projection's manifest read"
+    );
+
+    let record_keys = store
+        .inner()
+        .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+        .await
+        .expect("list checkpoint records");
+    assert_eq!(record_keys.len(), 1, "the failed create wrote one record");
+    let checkpoint_id = record_keys[0]
+        .rsplit('/')
+        .next()
+        .and_then(|name| name.strip_suffix(".json"))
+        .and_then(|id| CheckpointId::parse(id).ok())
+        .expect("checkpoint record key");
+    let record = read_checkpoint_record(store.inner(), &namespace_id, &checkpoint_id)
+        .await
+        .expect("read checkpoint record")
+        .expect("record remains for cleanup inspection")
+        .state;
+    assert_eq!(
+        record.state,
+        loonfs_api::wire::control::CheckpointRecordLifecycle::Released {
+            released_at_ms: context.now_ms
+        }
+    );
 }
 
 async fn wal_segment_count(store: &LocalFsStore, namespace_id: &NamespaceId) -> usize {


### PR DESCRIPTION
`verify_checkpoint_basis` caught every manifest-load failure and returned `false`, so checkpoint creation released the new record and retried as though the basis merely became invalid — an outage or corruption during verification surfaced as generic checkpoint-unavailable. The helper now returns a two-state verified/invalid result for the genuinely fail-closed cases (retention passed the basis, manifest legitimately gone), and real load or decode errors keep their classification: the newly written record is still released as cleanup on every unsuccessful path, and cleanup failure cannot mask the original error.
