### PR TITLE
refactor(core): one authoritative inode allocator

### DIFF
--- a/crates/loonfs-core/src/commit/durable_adapter.rs
+++ b/crates/loonfs-core/src/commit/durable_adapter.rs
@@ -53,6 +53,7 @@ mod tests {
             commit_id: CommitId::parse("c_wal_payload").expect("valid commit id"),
             writer_epoch: WriterEpoch(1),
             ops: vec![PlannedOp::unchecked(CommitOp::CreateDirectory {
+                child_inode_id: InodeId(2),
                 parent_inode_id: InodeId(1),
                 display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
             })],

--- a/crates/loonfs-core/src/commit/inode_allocator.rs
+++ b/crates/loonfs-core/src/commit/inode_allocator.rs
@@ -1,0 +1,163 @@
+//! Transactional inode allocation for one publish batch.
+
+use crate::error::{CoreError, Result};
+use loonfs_api::InodeId;
+
+/// The one authoritative next-inode position for a tentative publish batch.
+#[derive(Debug)]
+pub(crate) struct InodeAllocator {
+    next: InodeId,
+}
+
+/// A candidate-local fork of the batch allocator.
+///
+/// Planning advances this fork while assigning IDs directly to create
+/// operations. Acceptance commits its final position; rejection discards it
+/// without changing the batch allocator.
+#[derive(Debug)]
+pub(crate) struct CandidateAllocation {
+    start: InodeId,
+    next: InodeId,
+}
+
+impl InodeAllocator {
+    pub(crate) fn new(next: InodeId) -> Self {
+        Self { next }
+    }
+
+    pub(crate) fn begin_candidate(&self) -> CandidateAllocation {
+        CandidateAllocation {
+            start: self.next,
+            next: self.next,
+        }
+    }
+
+    pub(crate) fn commit_candidate(&mut self, candidate: CandidateAllocation) -> Result<InodeId> {
+        if candidate.start != self.next {
+            // A candidate belongs to the allocator position it forked from;
+            // accepting it later would rewind or skip IDs from another one.
+            return Err(CoreError::Internal(
+                "inode allocation candidate was committed out of order".to_owned(),
+            ));
+        }
+        self.next = candidate.next;
+        Ok(self.next)
+    }
+
+    pub(crate) fn discard_candidate(&self, _candidate: CandidateAllocation) {
+        // Candidate allocation is forked state, so consuming it is the
+        // rollback: the authoritative batch position never moved.
+    }
+}
+
+impl CandidateAllocation {
+    pub(crate) fn allocate(&mut self) -> Result<InodeId> {
+        let allocated = self.next;
+        self.next = self
+            .next
+            .0
+            .checked_add(1)
+            .map(InodeId)
+            .ok_or_else(|| CoreError::Internal("next inode id counter overflow".to_owned()))?;
+        Ok(allocated)
+    }
+
+    pub(crate) fn resulting_next_inode_id(&self) -> InodeId {
+        self.next
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multiple_creates_in_one_candidate_receive_consecutive_ids() {
+        let mut allocator = InodeAllocator::new(InodeId(2));
+        let mut candidate = allocator.begin_candidate();
+
+        assert_eq!(candidate.allocate().expect("first create"), InodeId(2));
+        assert_eq!(candidate.allocate().expect("second create"), InodeId(3));
+        assert_eq!(candidate.allocate().expect("third create"), InodeId(4));
+        assert_eq!(
+            allocator.commit_candidate(candidate).expect("commit"),
+            InodeId(5)
+        );
+    }
+
+    #[test]
+    fn accepted_candidate_followed_by_rejected_candidate_keeps_only_accepted_ids() {
+        let mut allocator = InodeAllocator::new(InodeId(2));
+        let mut accepted = allocator.begin_candidate();
+        assert_eq!(accepted.allocate().expect("accepted create"), InodeId(2));
+        allocator
+            .commit_candidate(accepted)
+            .expect("commit accepted");
+
+        let mut rejected = allocator.begin_candidate();
+        assert_eq!(rejected.allocate().expect("rejected create"), InodeId(3));
+        allocator.discard_candidate(rejected);
+
+        let next = allocator.begin_candidate();
+        assert_eq!(next.resulting_next_inode_id(), InodeId(3));
+    }
+
+    #[test]
+    fn rejected_candidate_followed_by_accepted_candidate_reuses_the_discarded_id() {
+        let mut allocator = InodeAllocator::new(InodeId(2));
+        let mut rejected = allocator.begin_candidate();
+        assert_eq!(rejected.allocate().expect("rejected create"), InodeId(2));
+        allocator.discard_candidate(rejected);
+
+        let mut accepted = allocator.begin_candidate();
+        assert_eq!(accepted.allocate().expect("accepted create"), InodeId(2));
+        assert_eq!(
+            allocator
+                .commit_candidate(accepted)
+                .expect("commit accepted"),
+            InodeId(3)
+        );
+    }
+
+    #[test]
+    fn multiple_accepted_candidates_advance_one_batch_allocator() {
+        let mut allocator = InodeAllocator::new(InodeId(2));
+        for expected in [InodeId(2), InodeId(3), InodeId(4)] {
+            let mut candidate = allocator.begin_candidate();
+            assert_eq!(candidate.allocate().expect("create"), expected);
+            allocator.commit_candidate(candidate).expect("commit");
+        }
+
+        let next = allocator.begin_candidate();
+        assert_eq!(next.resulting_next_inode_id(), InodeId(5));
+    }
+
+    #[test]
+    fn retry_from_the_same_head_replays_the_same_allocations() {
+        let allocator = InodeAllocator::new(InodeId(7));
+        let mut first_attempt = allocator.begin_candidate();
+        let first_ids = [
+            first_attempt.allocate().expect("first id"),
+            first_attempt.allocate().expect("second id"),
+        ];
+        allocator.discard_candidate(first_attempt);
+
+        let mut retry = allocator.begin_candidate();
+        let retry_ids = [
+            retry.allocate().expect("retry first id"),
+            retry.allocate().expect("retry second id"),
+        ];
+
+        assert_eq!(retry_ids, first_ids);
+    }
+
+    #[test]
+    fn allocation_refuses_to_overflow_the_next_inode_boundary() {
+        let allocator = InodeAllocator::new(InodeId(u64::MAX));
+        let mut candidate = allocator.begin_candidate();
+
+        let error = candidate.allocate().expect_err("counter must not wrap");
+        assert!(matches!(error, CoreError::Internal(message) if message.contains("overflow")));
+        assert_eq!(candidate.resulting_next_inode_id(), InodeId(u64::MAX));
+    }
+}

--- a/crates/loonfs-core/src/commit/mod.rs
+++ b/crates/loonfs-core/src/commit/mod.rs
@@ -9,6 +9,7 @@
 mod durable_adapter;
 mod frame;
 mod identity;
+mod inode_allocator;
 mod ir;
 mod materialize;
 mod metadata_overlay;
@@ -22,6 +23,7 @@ mod validate_error;
 
 pub(crate) use self::durable_adapter::wal_payload_from_materialized_commit;
 pub use self::identity::CommitFingerprint;
+pub(crate) use self::inode_allocator::{CandidateAllocation, InodeAllocator};
 pub(crate) use self::ir::CommitIr;
 pub use self::materialize::MaterializedCommitDelta;
 pub(crate) use self::materialize::{materialize_commit, MaterializedCommit};
@@ -34,7 +36,7 @@ pub(crate) use self::publish::PreparedCommitHeadPublish;
 pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 pub use self::publish_error::CommitHeadPublishError;
 pub(crate) use self::validate::{
-    allocates_inode, build_commit_plan_for_publish, validate_ops, OpValidationCursor,
+    build_commit_plan_for_publish, validate_ops, OpValidationCursor,
     PublishCommitValidationContext, PublishValidationView,
 };
 pub use self::validate_error::CommitValidationError;

--- a/crates/loonfs-core/src/commit/ops.rs
+++ b/crates/loonfs-core/src/commit/ops.rs
@@ -42,6 +42,9 @@ impl PlannedOp {
 pub(crate) enum CommitOp {
     /// Create a directory under a parent inode.
     CreateDirectory {
+        /// Inode identity assigned once by the candidate allocator during
+        /// planning and carried unchanged through validation.
+        child_inode_id: InodeId,
         /// Visible directory that will own the new binding.
         parent_inode_id: InodeId,
         /// Requested child spelling, whose derived name key must be absent.
@@ -49,6 +52,9 @@ pub(crate) enum CommitOp {
     },
     /// Create a file under a parent inode.
     CreateFile {
+        /// Inode identity assigned once by the candidate allocator during
+        /// planning and carried unchanged through validation.
+        child_inode_id: InodeId,
         /// Visible directory that will own the new binding.
         parent_inode_id: InodeId,
         /// Requested child spelling, whose derived name key must be absent.

--- a/crates/loonfs-core/src/commit/prepared.rs
+++ b/crates/loonfs-core/src/commit/prepared.rs
@@ -66,6 +66,7 @@ mod tests {
             commit_id: CommitId::parse("commit-a").expect("valid commit id"),
             writer_epoch: WriterEpoch(1),
             ops: vec![PlannedOp::unchecked(CommitOp::CreateDirectory {
+                child_inode_id: InodeId(2),
                 parent_inode_id: InodeId(1),
                 display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
             })],

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -41,7 +41,6 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
     cursor: &mut OpValidationCursor,
     committed_seq: ChangeSeq,
     committed_at_ms: u64,
-    allocated_inode_ids: &mut impl Iterator<Item = InodeId>,
 ) -> Result<Vec<ValidatedOp>, CoreError> {
     let mut validated_ops = Vec::with_capacity(ops.len());
     let next_delta_index = &mut cursor.next_delta_index;
@@ -58,6 +57,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
         validate_explicit_preconditions(&planned.preconditions, metadata_state).await?;
         let validated_op = match &planned.op {
             CommitOp::CreateDirectory {
+                child_inode_id,
                 parent_inode_id,
                 display_name,
             } => {
@@ -70,15 +70,13 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     parent_inode_id: *parent_inode_id,
                     display_name: display_name.clone(),
                     name_key,
-                    child_inode_id: next_allocated_inode(
-                        allocated_inode_ids,
-                        CommitValidationError::NextInodeOverflow,
-                    )?,
+                    child_inode_id: *child_inode_id,
                     create_inode_delta_index: reserve_delta_index(next_delta_index)?,
                     bind_delta_index: reserve_delta_index(next_delta_index)?,
                 }
             }
             CommitOp::CreateFile {
+                child_inode_id,
                 parent_inode_id,
                 display_name,
                 content_ref,
@@ -92,10 +90,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     parent_inode_id: *parent_inode_id,
                     display_name: display_name.clone(),
                     name_key,
-                    child_inode_id: next_allocated_inode(
-                        allocated_inode_ids,
-                        CommitValidationError::NextInodeOverflow,
-                    )?,
+                    child_inode_id: *child_inode_id,
                     content_ref: content_ref.clone(),
                     create_inode_delta_index: reserve_delta_index(next_delta_index)?,
                     bind_delta_index: reserve_delta_index(next_delta_index)?,
@@ -435,13 +430,6 @@ async fn validate_explicit_preconditions<S: ObjectStore + ?Sized>(
     }
 
     Ok(())
-}
-
-fn next_allocated_inode(
-    allocated_inode_ids: &mut impl Iterator<Item = InodeId>,
-    error: CommitValidationError,
-) -> Result<InodeId, CommitValidationError> {
-    allocated_inode_ids.next().ok_or(error)
 }
 
 fn reserve_delta_index(next_delta_index: &mut u32) -> Result<u32, CommitValidationError> {

--- a/crates/loonfs-core/src/commit/validate/mod.rs
+++ b/crates/loonfs-core/src/commit/validate/mod.rs
@@ -11,7 +11,5 @@ mod tests;
 mod view;
 
 pub(crate) use checks::{validate_ops, OpValidationCursor};
-pub(crate) use plan_build::{
-    allocates_inode, build_commit_plan_for_publish, PublishCommitValidationContext,
-};
+pub(crate) use plan_build::{build_commit_plan_for_publish, PublishCommitValidationContext};
 pub(crate) use view::PublishValidationView;

--- a/crates/loonfs-core/src/commit/validate/plan_build.rs
+++ b/crates/loonfs-core/src/commit/validate/plan_build.rs
@@ -2,20 +2,14 @@
 //! chosen validation view, and delta-index assignment.
 
 use super::super::frame::validate_commit_request_frame;
-use super::super::{CommitIr, CommitOp, CommitPlan, CommitValidationError, PlannedOp};
+use super::super::{CandidateAllocation, CommitIr, CommitPlan, CommitValidationError};
 use super::checks::{validate_ops, OpValidationCursor};
 use super::view::PublishValidationView;
 use crate::error::CoreError;
 use crate::metadata::{MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
-use loonfs_api::{ChangeSeq, InodeId};
+use loonfs_api::ChangeSeq;
 use loonfs_objectstore::ObjectStore;
-
-struct CommitShape {
-    assigned_seq: ChangeSeq,
-    allocated_inode_ids: Vec<InodeId>,
-    resulting_next_inode_id: InodeId,
-}
 
 #[derive(Clone, Copy)]
 pub(crate) struct PublishCommitValidationContext<'a, S: ObjectStore + ?Sized> {
@@ -27,15 +21,22 @@ pub(crate) struct PublishCommitValidationContext<'a, S: ObjectStore + ?Sized> {
 pub(crate) async fn build_commit_plan_for_publish<S: ObjectStore + ?Sized>(
     request: &CommitIr,
     committed_at_ms: u64,
+    allocation: &CandidateAllocation,
     context: &PublishCommitValidationContext<'_, S>,
 ) -> Result<CommitPlan, CoreError> {
-    let shape = compute_commit_shape(request, context.head)?;
-    let committed_seq = shape.assigned_seq;
+    let committed_seq = context
+        .head
+        .seq
+        .0
+        .checked_add(1)
+        .map(ChangeSeq)
+        .ok_or(CommitValidationError::SeqOverflow)?;
     build_commit_plan(
         request,
         committed_at_ms,
         context.head,
-        shape,
+        committed_seq,
+        allocation,
         PublishValidationView::new(context.metadata_view, context.accepted_rows, committed_seq),
     )
     .await
@@ -45,7 +46,8 @@ async fn build_commit_plan<S: ObjectStore + ?Sized>(
     request: &CommitIr,
     committed_at_ms: u64,
     head: &HeadState,
-    shape: CommitShape,
+    committed_seq: ChangeSeq,
+    allocation: &CandidateAllocation,
     mut metadata_state: PublishValidationView<'_, S>,
 ) -> Result<CommitPlan, CoreError> {
     validate_commit_request_frame(request, head)?;
@@ -54,9 +56,8 @@ async fn build_commit_plan<S: ObjectStore + ?Sized>(
         &request.ops,
         &mut metadata_state,
         &mut OpValidationCursor::new(),
-        shape.assigned_seq,
+        committed_seq,
         committed_at_ms,
-        &mut shape.allocated_inode_ids.iter().copied(),
     )
     .await?;
 
@@ -64,60 +65,8 @@ async fn build_commit_plan<S: ObjectStore + ?Sized>(
         namespace_id: request.namespace_id.clone(),
         commit_id: request.commit_id.clone(),
         apply_after_seq: head.seq,
-        assigned_seq: shape.assigned_seq,
+        assigned_seq: committed_seq,
         validated_ops,
-        resulting_next_inode_id: shape.resulting_next_inode_id,
-    })
-}
-
-/// Counts the inode ids a commit allocates, in operation order. The planner
-/// predicts these same ids while resolving operations, so this is the one
-/// allocator both agree on.
-pub(crate) fn allocates_inode(op: &CommitOp) -> bool {
-    matches!(
-        op,
-        CommitOp::CreateDirectory { .. } | CommitOp::CreateFile { .. }
-    )
-}
-
-fn compute_commit_shape(
-    request: &CommitIr,
-    head: &HeadState,
-) -> Result<CommitShape, CommitValidationError> {
-    let assigned_seq = head
-        .seq
-        .0
-        .checked_add(1)
-        .map(ChangeSeq)
-        .ok_or(CommitValidationError::SeqOverflow)?;
-    let create_op_count = request
-        .ops
-        .iter()
-        .filter(|planned: &&PlannedOp| allocates_inode(&planned.op))
-        .count();
-    let allocated_inode_ids = (0..create_op_count)
-        .map(|offset| {
-            let offset =
-                u64::try_from(offset).map_err(|_| CommitValidationError::NextInodeOverflow)?;
-            head.next_inode_id
-                .0
-                .checked_add(offset)
-                .map(InodeId)
-                .ok_or(CommitValidationError::NextInodeOverflow)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let resulting_next_inode_id = head
-        .next_inode_id
-        .0
-        .checked_add(
-            u64::try_from(create_op_count).map_err(|_| CommitValidationError::NextInodeOverflow)?,
-        )
-        .map(InodeId)
-        .ok_or(CommitValidationError::NextInodeOverflow)?;
-
-    Ok(CommitShape {
-        assigned_seq,
-        allocated_inode_ids,
-        resulting_next_inode_id,
+        resulting_next_inode_id: allocation.resulting_next_inode_id(),
     })
 }

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -10,7 +10,8 @@
 use super::super::{CommitIr, CommitOp, PlannedOp};
 use super::{build_commit_plan_for_publish, PublishCommitValidationContext};
 use crate::commit::{
-    materialize_commit, CommitFingerprint, CommitPlan, CommitValidationError, PreparedCommit,
+    materialize_commit, CommitFingerprint, CommitPlan, CommitValidationError, InodeAllocator,
+    PreparedCommit,
 };
 use crate::error::{CoreError, ErrorCode};
 use crate::metadata::{InMemoryMetadataView, MetadataState};
@@ -206,9 +207,26 @@ async fn build_commit_plan(
     context: &TestValidationContext<'_>,
 ) -> Result<CommitPlan, CommitValidationError> {
     let accepted_rows = MetadataState::default();
+    let allocator = InodeAllocator::new(context.head.next_inode_id);
+    let mut allocation = allocator.begin_candidate();
+    for planned in &request.ops {
+        let assigned = match &planned.op {
+            CommitOp::CreateDirectory { child_inode_id, .. }
+            | CommitOp::CreateFile { child_inode_id, .. } => Some(*child_inode_id),
+            _ => None,
+        };
+        if let Some(assigned) = assigned {
+            assert_eq!(
+                allocation.allocate().expect("test inode allocation"),
+                assigned,
+                "test create operations must carry their planned inode ids"
+            );
+        }
+    }
     let result = build_commit_plan_for_publish(
         request,
         committed_at_ms,
+        &allocation,
         &PublishCommitValidationContext {
             head: &context.head,
             metadata_view: InMemoryMetadataView::in_memory(
@@ -396,10 +414,12 @@ async fn failed_multi_op_plan_uses_preview_without_mutating_base_metadata() {
         writer_epoch: WriterEpoch(1),
         ops: planned(vec![
             CommitOp::CreateDirectory {
+                child_inode_id: InodeId(2),
                 parent_inode_id: InodeId(1),
                 display_name: test_display_name("docs"),
             },
             CommitOp::CreateFile {
+                child_inode_id: InodeId(3),
                 parent_inode_id: InodeId(2),
                 display_name: test_display_name("readme.txt"),
                 content_ref: content_ref("content-1"),
@@ -458,6 +478,7 @@ async fn create_and_replace_under_ancestor_tombstone_report_corruption() {
             commit_id: CommitId::parse("create-under-tombstone").expect("valid commit id"),
             writer_epoch: WriterEpoch(1),
             ops: planned(vec![CommitOp::CreateFile {
+                child_inode_id: InodeId(4),
                 parent_inode_id: InodeId(2),
                 display_name: test_display_name("new.txt"),
                 content_ref: content_ref("content-2"),

--- a/crates/loonfs-core/src/path/write/plan_create.rs
+++ b/crates/loonfs-core/src/path/write/plan_create.rs
@@ -7,7 +7,8 @@ use super::planning_helpers::{
     PublishPathPlanningView,
 };
 use crate::commit::{
-    CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition, CommitValidationError,
+    CandidateAllocation, CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition,
+    CommitValidationError,
 };
 use crate::error::{CoreError, Result};
 use crate::path::helpers::{ensure_mutation_path, final_component};
@@ -20,6 +21,7 @@ pub(super) async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
     absolute_path: &AbsolutePath,
     parents: bool,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
+    allocation: &mut CandidateAllocation,
 ) -> Result<PlannedOperation> {
     ensure_mutation_path(absolute_path)?;
     publish_reject_tombstoned_path_ancestor(view, absolute_path).await?;
@@ -40,13 +42,14 @@ pub(super) async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
     let mut ops = Vec::new();
     let parent_inode_id = if parents {
         // The same ancestor auto-create the put-file plan performs.
-        let mut next_inode_id = view.next_inode_id;
-        publish_ensure_parent_directories(absolute_path, view, &mut ops, &mut next_inode_id).await?
+        publish_ensure_parent_directories(absolute_path, view, &mut ops, allocation).await?
     } else {
         publish_resolve_parent_directory(view, absolute_path).await?
     };
     let display_name = final_component(absolute_path)?;
+    let child_inode_id = allocation.allocate()?;
     ops.push(ApiCommitOp::CreateDirectory {
+        child_inode_id,
         parent_inode_id,
         display_name: display_name.clone(),
     });
@@ -152,6 +155,7 @@ pub(super) async fn plan_publish_put_file_content_ref<S: ObjectStore + ?Sized>(
     behavior: DestinationBehavior,
     expected_revision_no: Option<RevisionNo>,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
+    allocation: &mut CandidateAllocation,
 ) -> Result<PlannedOperation> {
     ensure_mutation_path(absolute_path)?;
     if expected_revision_no.is_some() && behavior == DestinationBehavior::NoReplace {
@@ -168,10 +172,8 @@ pub(super) async fn plan_publish_put_file_content_ref<S: ObjectStore + ?Sized>(
         .await;
 
     let mut ops = Vec::new();
-    let mut next_inode_id = view.next_inode_id;
     let final_parent_inode =
-        publish_ensure_parent_directories(absolute_path, view, &mut ops, &mut next_inode_id)
-            .await?;
+        publish_ensure_parent_directories(absolute_path, view, &mut ops, allocation).await?;
     let final_name = final_component(absolute_path)?;
     let mut preconditions = Vec::new();
 
@@ -219,7 +221,9 @@ pub(super) async fn plan_publish_put_file_content_ref<S: ObjectStore + ?Sized>(
             if expected_revision_no.is_some() {
                 return Err(CoreError::PathNotFound(absolute_path.as_str().to_owned()));
             }
+            let child_inode_id = allocation.allocate()?;
             ops.push(ApiCommitOp::CreateFile {
+                child_inode_id,
                 parent_inode_id: final_parent_inode,
                 display_name: final_name.clone(),
                 content_ref,

--- a/crates/loonfs-core/src/path/write/plan_transfer.rs
+++ b/crates/loonfs-core/src/path/write/plan_transfer.rs
@@ -6,7 +6,9 @@ use super::planning_helpers::{
     publish_reject_tombstoned_path_ancestor, publish_resolve_parent_directory,
     publish_resolve_replace_destination, PlannedOperation, PublishPathPlanningView,
 };
-use crate::commit::{CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition};
+use crate::commit::{
+    CandidateAllocation, CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition,
+};
 use crate::error::{CoreError, Result};
 use crate::path::helpers::{ensure_mutation_path, final_component};
 use loonfs_api::{AbsolutePath, AttributeRevisionNo, DestinationBehavior, InodeKind};
@@ -84,6 +86,7 @@ pub(super) async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
     to_path: &AbsolutePath,
     behavior: DestinationBehavior,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
+    allocation: &mut CandidateAllocation,
 ) -> Result<PlannedOperation> {
     ensure_mutation_path(from_path)?;
     ensure_mutation_path(to_path)?;
@@ -155,7 +158,9 @@ pub(super) async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
             });
         }
         ReplaceDestination::Vacant => {
+            let child_inode_id = allocation.allocate()?;
             ops.push(ApiCommitOp::CreateFile {
+                child_inode_id,
                 parent_inode_id: target_parent,
                 display_name: target_name.clone(),
                 content_ref: revision.content_ref,
@@ -176,11 +181,10 @@ pub(super) async fn plan_publish_copy_file_path<S: ObjectStore + ?Sized>(
                 .attributes_at_visible_seq(source.inode_id)
                 .await?;
             if !source_attributes.is_empty() {
-                // The create above is this operation's only inode
-                // allocation, so the commit plan hands it the request's next
-                // free id.
+                // Both operations carry the one identity assigned above, so
+                // validation cannot allocate a different inode for either.
                 ops.push(ApiCommitOp::UpdateAttributes {
-                    inode_id: view.next_inode_id,
+                    inode_id: child_inode_id,
                     base_attributes_revision_no: AttributeRevisionNo(0),
                     attributes: source_attributes,
                 });

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -11,23 +11,19 @@ use super::plan_restore::plan_publish_restore_revision;
 use super::plan_transfer::{plan_publish_copy_file_path, plan_publish_move_path};
 use super::planning_helpers::{PlannedOperation, PublishPathPlanningView};
 use crate::commit::{
-    allocates_inode, validate_ops, CommitFingerprint, CommitOp, OpValidationCursor, PlannedOp,
+    validate_ops, CandidateAllocation, CommitFingerprint, OpValidationCursor, PlannedOp,
     PublishValidationView,
 };
 use crate::error::{CoreError, Result};
 use crate::metadata::{MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
-use loonfs_api::{ChangeSeq, InodeId, NamespaceId};
+use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 
 /// One mutation request compiled into a commit's operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PlannedCommit {
     pub(crate) ops: Vec<PlannedOp>,
-    /// The next free inode id the planner predicted while resolving. The
-    /// commit plan recomputes it from the operation list; a disagreement
-    /// means prediction and allocation drifted.
-    pub(crate) resulting_next_inode_id: InodeId,
 }
 
 /// Computes the semantic fingerprint of a mutation request.
@@ -64,6 +60,7 @@ pub(crate) async fn plan_commit_against_publish_view<S: ObjectStore + ?Sized>(
     base_view: MetadataView<'_, '_, S>,
     accepted_rows: &MetadataState,
     committed_at_ms: u64,
+    allocation: &mut CandidateAllocation,
 ) -> Result<PlannedCommit> {
     if request.operations.is_empty() {
         return Err(CoreError::InvalidCommitRequest(
@@ -79,23 +76,19 @@ pub(crate) async fn plan_commit_against_publish_view<S: ObjectStore + ?Sized>(
 
     let mut resolved = PublishValidationView::new(base_view, accepted_rows, committed_seq);
     let mut cursor = OpValidationCursor::new();
-    let mut next_inode_id = head.next_inode_id;
     let mut ops: Vec<PlannedOp> = Vec::new();
     let operation_count = request.operations.len();
     for (index, operation) in request.operations.iter().enumerate() {
         let unit = {
             let resolution_view = resolved.view();
             let view = PublishPathPlanningView {
-                next_inode_id,
                 metadata_state: &resolution_view,
             };
-            plan_operation(operation, &view)
+            plan_operation(operation, &view, allocation)
                 .await
                 .map_err(|error| attribute(error, index, operation_count))?
         };
         let unit_ops = unit.into_planned_ops();
-        let allocated = allocate_inode_ids(&unit_ops, &mut next_inode_id)?;
-        debug_assert_parents_are_allocated(&unit_ops, next_inode_id);
         if operation_count > 1 {
             validate_ops(
                 &unit_ops,
@@ -103,7 +96,6 @@ pub(crate) async fn plan_commit_against_publish_view<S: ObjectStore + ?Sized>(
                 &mut cursor,
                 committed_seq,
                 committed_at_ms,
-                &mut allocated.iter().copied(),
             )
             .await
             .map_err(|error| attribute(error, index, operation_count))?;
@@ -111,19 +103,17 @@ pub(crate) async fn plan_commit_against_publish_view<S: ObjectStore + ?Sized>(
         ops.extend(unit_ops);
     }
 
-    Ok(PlannedCommit {
-        ops,
-        resulting_next_inode_id: next_inode_id,
-    })
+    Ok(PlannedCommit { ops })
 }
 
 async fn plan_operation<S: ObjectStore + ?Sized>(
     operation: &FilesystemOperation,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
+    allocation: &mut CandidateAllocation,
 ) -> Result<PlannedOperation> {
     match operation {
         FilesystemOperation::CreateDirectory { path, parents } => {
-            plan_publish_create_directory(path, *parents, view).await
+            plan_publish_create_directory(path, *parents, view, allocation).await
         }
         FilesystemOperation::PutFile {
             path,
@@ -137,6 +127,7 @@ async fn plan_operation<S: ObjectStore + ?Sized>(
                 *behavior,
                 *expected_revision_no,
                 view,
+                allocation,
             )
             .await
         }
@@ -154,7 +145,7 @@ async fn plan_operation<S: ObjectStore + ?Sized>(
             from_path,
             to_path,
             behavior,
-        } => plan_publish_copy_file_path(from_path, to_path, *behavior, view).await,
+        } => plan_publish_copy_file_path(from_path, to_path, *behavior, view, allocation).await,
         FilesystemOperation::RestoreRevision {
             path,
             source_revision_no,
@@ -195,63 +186,12 @@ fn attribute(error: CoreError, index: usize, operation_count: usize) -> CoreErro
     error.at_operation(index)
 }
 
-/// Allocates inode IDs for `ops` in operation order and advances the shared
-/// counter.
-///
-/// The planner and final commit plan use the same ordering so they assign
-/// identical IDs to every created inode.
-fn allocate_inode_ids(ops: &[PlannedOp], next_inode_id: &mut InodeId) -> Result<Vec<InodeId>> {
-    let mut allocated = Vec::new();
-    for planned in ops {
-        if !allocates_inode(&planned.op) {
-            continue;
-        }
-        allocated.push(*next_inode_id);
-        *next_inode_id = next_inode_id
-            .0
-            .checked_add(1)
-            .map(InodeId)
-            .ok_or_else(|| CoreError::Internal("next inode id counter overflow".to_owned()))?;
-    }
-    Ok(allocated)
-}
-
-/// Verifies that every planned parent inode already exists or was allocated
-/// earlier in this request.
-///
-/// A parent ID at or after `next_inode_id` means the planner referenced an
-/// inode that the commit plan will not create.
-fn debug_assert_parents_are_allocated(ops: &[PlannedOp], next_inode_id: InodeId) {
-    debug_assert!(
-        ops.iter().all(|planned| {
-            let parent = match &planned.op {
-                CommitOp::CreateDirectory {
-                    parent_inode_id, ..
-                }
-                | CommitOp::CreateFile {
-                    parent_inode_id, ..
-                }
-                | CommitOp::Undelete {
-                    parent_inode_id, ..
-                } => *parent_inode_id,
-                CommitOp::Rename {
-                    new_parent_inode_id,
-                    ..
-                } => *new_parent_inode_id,
-                _ => return true,
-            };
-            parent < next_inode_id
-        }),
-        "planner predicted an inode id the commit plan has not allocated"
-    );
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::commit::{
-        build_commit_plan_for_publish, CommitIr, CommitPlan, CommitValidationError,
-        PublishCommitValidationContext,
+        build_commit_plan_for_publish, CandidateAllocation, CommitIr, CommitOp, CommitPlan,
+        CommitValidationError, InodeAllocator, PublishCommitValidationContext,
     };
     use crate::commit_engine::{publish_namespace_commits_batch, CommitCandidate};
     use crate::context::MutationContext;
@@ -259,9 +199,26 @@ mod tests {
     use crate::path::write::ops::{delete_path, put_file_bytes};
     use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
-    use loonfs_api::{AbsolutePath, CommitId, DeleteDirectoryBehavior, DestinationBehavior};
+    use loonfs_api::{
+        AbsolutePath, CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeId,
+    };
     use loonfs_objectstore::local_fs_store::LocalFsStore;
+    use std::ops::Deref;
     use tempfile::tempdir;
+
+    #[derive(Debug)]
+    struct TestPlannedCommit {
+        commit: PlannedCommit,
+        allocation: CandidateAllocation,
+    }
+
+    impl Deref for TestPlannedCommit {
+        type Target = PlannedCommit;
+
+        fn deref(&self) -> &Self::Target {
+            &self.commit
+        }
+    }
 
     fn test_context() -> MutationContext {
         MutationContext {
@@ -352,7 +309,7 @@ mod tests {
         store: &LocalFsStore,
         namespace_id: &NamespaceId,
         request: &CommitRequest,
-    ) -> Result<PlannedCommit> {
+    ) -> Result<TestPlannedCommit> {
         let (view, _projection) = load_publish_metadata_view(
             store,
             None,
@@ -364,21 +321,25 @@ mod tests {
         .await
         .expect("publish view");
         let empty_overlay = MetadataState::default();
-        plan_commit_against_publish_view(
+        let allocator = InodeAllocator::new(view.head().next_inode_id);
+        let mut allocation = allocator.begin_candidate();
+        let commit = plan_commit_against_publish_view(
             request,
             view.head(),
             view.metadata_view(),
             &empty_overlay,
             1,
+            &mut allocation,
         )
-        .await
+        .await?;
+        Ok(TestPlannedCommit { commit, allocation })
     }
 
     async fn plan_against_current_state(
         store: &LocalFsStore,
         namespace_id: &NamespaceId,
         request: &CommitRequest,
-    ) -> PlannedCommit {
+    ) -> TestPlannedCommit {
         try_plan_against_current_state(store, namespace_id, request)
             .await
             .expect("plan")
@@ -388,7 +349,7 @@ mod tests {
         store: &LocalFsStore,
         namespace_id: &NamespaceId,
         commit_id: &str,
-        planned: PlannedCommit,
+        planned: TestPlannedCommit,
     ) -> Result<CommitPlan> {
         let (view, _projection) = load_publish_metadata_view(
             store,
@@ -405,10 +366,11 @@ mod tests {
                 namespace_id: namespace_id.clone(),
                 commit_id: CommitId::parse(commit_id).expect("valid commit id"),
                 writer_epoch: view.head().writer_epoch,
-                ops: planned.ops,
+                ops: planned.commit.ops,
                 message: None,
             },
             1,
+            &planned.allocation,
             &PublishCommitValidationContext {
                 head: view.head(),
                 metadata_view: view.metadata_view(),
@@ -773,17 +735,27 @@ mod tests {
         .await;
 
         assert_eq!(planned.ops.len(), 2);
+        assert!(matches!(
+            &planned.ops[0].op,
+            CommitOp::CreateDirectory {
+                child_inode_id: InodeId(2),
+                parent_inode_id: InodeId(1),
+                ..
+            }
+        ));
         // The put binds under the directory the create allocated rather than
-        // re-creating it.
+        // re-creating it, and validation receives the exact ID planning
+        // assigned to the file.
         assert!(matches!(
             &planned.ops[1].op,
             CommitOp::CreateFile {
+                child_inode_id: InodeId(3),
                 parent_inode_id,
                 display_name,
                 ..
             } if *parent_inode_id == InodeId(2) && display_name.as_str() == "a.txt"
         ));
-        assert_eq!(planned.resulting_next_inode_id, InodeId(4));
+        assert_eq!(planned.allocation.resulting_next_inode_id(), InodeId(4));
     }
 
     /// A batch that deletes a path and recreates it resolves the create

--- a/crates/loonfs-core/src/path/write/planning_helpers.rs
+++ b/crates/loonfs-core/src/path/write/planning_helpers.rs
@@ -1,6 +1,6 @@
 //! Shared publish-planning preconditions and visible-ancestor walks.
 
-use crate::commit::PlannedOp;
+use crate::commit::{CandidateAllocation, PlannedOp};
 use crate::commit::{CommitOp as ApiCommitOp, CommitPrecondition as ApiCommitPrecondition};
 use crate::error::{CoreError, Result};
 use crate::metadata::{MetadataView, ResolvedVisiblePath, VisiblePathError};
@@ -44,10 +44,6 @@ impl PlannedOperation {
 }
 
 pub(super) struct PublishPathPlanningView<'a, 'b, 'store, S: ObjectStore + ?Sized> {
-    /// The next inode id this request has not yet handed out. Operations
-    /// predict the ids of the directories they create from it, in the same
-    /// order the commit plan allocates them.
-    pub(super) next_inode_id: InodeId,
     pub(super) metadata_state: &'a MetadataView<'b, 'store, S>,
 }
 
@@ -184,7 +180,7 @@ pub(super) async fn publish_ensure_parent_directories<S: ObjectStore + ?Sized>(
     absolute_path: &AbsolutePath,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
     ops: &mut Vec<ApiCommitOp>,
-    next_inode_id: &mut InodeId,
+    allocation: &mut CandidateAllocation,
 ) -> Result<InodeId> {
     let components = absolute_path.components();
     if components.len() <= 1 {
@@ -218,13 +214,13 @@ pub(super) async fn publish_ensure_parent_directories<S: ObjectStore + ?Sized>(
             creating_missing_ancestors = true;
         }
 
+        let child_inode_id = allocation.allocate()?;
         ops.push(ApiCommitOp::CreateDirectory {
+            child_inode_id,
             parent_inode_id: current_inode,
             display_name,
         });
-        let allocated = *next_inode_id;
-        *next_inode_id = InodeId(next_inode_id.0.saturating_add(1));
-        current_inode = allocated;
+        current_inode = child_inode_id;
     }
     Ok(current_inode)
 }

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -3,7 +3,7 @@
 
 use super::intent::CommitRequest;
 use super::planner::{plan_commit_against_publish_view, PlannedCommit};
-use crate::commit::CommitPlan;
+use crate::commit::{CandidateAllocation, CommitPlan, InodeAllocator};
 use crate::error::Result;
 use crate::metadata::{DurableVisibilityCache, MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
@@ -23,6 +23,7 @@ use loonfs_objectstore::ObjectStore;
 /// namespace.
 pub(crate) struct PublishPlanningSession {
     head: HeadState,
+    inode_allocator: InodeAllocator,
     accepted_rows: MetadataState,
     /// Durable-layer lookups memoized across the whole batch attempt; the
     /// accepted-rows overlay is the only layer that changes between
@@ -34,6 +35,7 @@ impl PublishPlanningSession {
     pub(crate) fn new(head: &HeadState) -> Self {
         Self {
             head: head.clone(),
+            inode_allocator: InodeAllocator::new(head.next_inode_id),
             accepted_rows: MetadataState::default(),
             durable_cache: DurableVisibilityCache::default(),
         }
@@ -51,11 +53,20 @@ impl PublishPlanningSession {
         &self.durable_cache
     }
 
+    pub(crate) fn begin_candidate(&self) -> CandidateAllocation {
+        self.inode_allocator.begin_candidate()
+    }
+
+    pub(crate) fn discard_candidate(&self, allocation: CandidateAllocation) {
+        self.inode_allocator.discard_candidate(allocation);
+    }
+
     pub(crate) async fn plan_commit<S: ObjectStore + ?Sized>(
         &self,
         request: &CommitRequest,
         base_view: MetadataView<'_, '_, S>,
         committed_at_ms: u64,
+        allocation: &mut CandidateAllocation,
     ) -> Result<PlannedCommit> {
         let cached_view = base_view.with_durable_cache(&self.durable_cache);
         plan_commit_against_publish_view(
@@ -64,16 +75,24 @@ impl PublishPlanningSession {
             cached_view,
             &self.accepted_rows,
             committed_at_ms,
+            allocation,
         )
         .await
     }
 
     /// Folds an accepted commit into the session so later candidates in the
     /// same batch plan and validate against it.
-    pub(crate) fn apply_accepted_commit(&mut self, preview: &WalCommitPayload, plan: &CommitPlan) {
+    pub(crate) fn apply_accepted_commit(
+        &mut self,
+        preview: &WalCommitPayload,
+        plan: &CommitPlan,
+        allocation: CandidateAllocation,
+    ) -> Result<()> {
+        let resulting_next_inode_id = self.inode_allocator.commit_candidate(allocation)?;
         self.accepted_rows.apply_committed_wal_record_mut(preview);
         self.head.seq = plan.assigned_seq;
-        self.head.next_inode_id = plan.resulting_next_inode_id;
+        self.head.next_inode_id = resulting_next_inode_id;
+        Ok(())
     }
 }
 
@@ -85,10 +104,11 @@ mod tests {
     use crate::context::MutationContext;
     use crate::error::{CoreError, ErrorCode};
     use crate::namespace::bootstrap::bootstrap_namespace;
+    use crate::namespace::control::load_namespace_head_control;
     use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
     use crate::storage::content_admission::{ContentAdmission, PreparedContent};
-    use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior};
+    use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeId};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use tempfile::tempdir;
 
@@ -140,6 +160,53 @@ mod tests {
         )
     }
 
+    fn create_directory_candidate(commit_id: &str, absolute_path: &str) -> CommitCandidate {
+        CommitCandidate::new(CommitRequest::single(
+            CommitId::parse(commit_id).expect("valid commit id"),
+            None,
+            FilesystemOperation::CreateDirectory {
+                path: AbsolutePath::parse(absolute_path).expect("path"),
+                parents: false,
+            },
+        ))
+    }
+
+    fn candidate_that_allocates_then_fails(commit_id: &str) -> CommitCandidate {
+        CommitCandidate::new(CommitRequest {
+            commit_id: CommitId::parse(commit_id).expect("valid commit id"),
+            message: None,
+            operations: vec![
+                FilesystemOperation::CreateDirectory {
+                    path: AbsolutePath::parse("/discarded").expect("path"),
+                    parents: false,
+                },
+                FilesystemOperation::DeletePath {
+                    path: AbsolutePath::parse("/missing").expect("path"),
+                    behavior: DeleteDirectoryBehavior::NonRecursive,
+                    expected_inode_id: None,
+                },
+            ],
+        })
+    }
+
+    async fn visible_inode_id(
+        store: &LocalFsStore,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+    ) -> InodeId {
+        crate::path::read::load_metadata_view(
+            store,
+            namespace_id,
+            crate::path::read::ReadLoadContext::latest(),
+        )
+        .await
+        .expect("load view")
+        .resolve_path(absolute_path, crate::path::read::AttributeProjection::Omit)
+        .await
+        .expect("visible path")
+        .inode_id
+    }
+
     /// Two plans through one session share the durable-layer memo: the
     /// second plan's path walk answers from cache instead of re-scanning
     /// the manifest for the components both paths share.
@@ -187,10 +254,17 @@ mod tests {
                 expected_revision_no: None,
             },
         );
+        let mut first_allocation = session.begin_candidate();
         session
-            .plan_commit(&first_request, view.metadata_view(), 1)
+            .plan_commit(
+                &first_request,
+                view.metadata_view(),
+                1,
+                &mut first_allocation,
+            )
             .await
             .expect("first plan");
+        session.discard_candidate(first_allocation);
         let after_first = session.durable_cache().stats();
 
         let second_request = CommitRequest::single(
@@ -203,10 +277,17 @@ mod tests {
                 expected_revision_no: None,
             },
         );
+        let mut second_allocation = session.begin_candidate();
         session
-            .plan_commit(&second_request, view.metadata_view(), 1)
+            .plan_commit(
+                &second_request,
+                view.metadata_view(),
+                1,
+                &mut second_allocation,
+            )
             .await
             .expect("second plan");
+        session.discard_candidate(second_allocation);
         let after_second = session.durable_cache().stats();
 
         assert!(
@@ -254,18 +335,76 @@ mod tests {
         let second = results[1].as_ref().expect("second create succeeds");
         assert!(second.committed_seq > first.committed_seq);
 
-        for path in ["/wide/a.txt", "/wide/b.txt"] {
-            crate::path::read::load_metadata_view(
-                &store,
-                &namespace_id,
-                crate::path::read::ReadLoadContext::latest(),
-            )
+        assert_eq!(
+            visible_inode_id(&store, &namespace_id, "/wide").await,
+            InodeId(2)
+        );
+        assert_eq!(
+            visible_inode_id(&store, &namespace_id, "/wide/a.txt").await,
+            InodeId(3)
+        );
+        assert_eq!(
+            visible_inode_id(&store, &namespace_id, "/wide/b.txt").await,
+            InodeId(4)
+        );
+        let head = load_namespace_head_control(&store, &namespace_id)
             .await
-            .expect("load view")
-            .resolve_path(path, crate::path::read::AttributeProjection::Omit)
+            .expect("load head");
+        assert_eq!(head.state.next_inode_id, InodeId(5));
+    }
+
+    #[tokio::test]
+    async fn accepted_candidate_followed_by_rejected_candidate_does_not_consume_rejected_ids() {
+        let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+
+        let results = publish_namespace_commits_batch(
+            &store,
+            &namespace_id,
+            vec![
+                create_directory_candidate("accept-first", "/kept"),
+                candidate_that_allocates_then_fails("reject-second"),
+            ],
+            &context,
+        )
+        .await;
+
+        results[0].as_ref().expect("first candidate accepted");
+        results[1].as_ref().expect_err("second candidate rejected");
+        assert_eq!(
+            visible_inode_id(&store, &namespace_id, "/kept").await,
+            InodeId(2)
+        );
+        let head = load_namespace_head_control(&store, &namespace_id)
             .await
-            .expect("published file is visible");
-        }
+            .expect("load head");
+        assert_eq!(head.state.next_inode_id, InodeId(3));
+    }
+
+    #[tokio::test]
+    async fn rejected_candidate_followed_by_accepted_candidate_reuses_the_rejected_id() {
+        let (_temp_dir, store, namespace_id, context) = setup_namespace().await;
+
+        let results = publish_namespace_commits_batch(
+            &store,
+            &namespace_id,
+            vec![
+                candidate_that_allocates_then_fails("reject-first"),
+                create_directory_candidate("accept-second", "/kept"),
+            ],
+            &context,
+        )
+        .await;
+
+        results[0].as_ref().expect_err("first candidate rejected");
+        results[1].as_ref().expect("second candidate accepted");
+        assert_eq!(
+            visible_inode_id(&store, &namespace_id, "/kept").await,
+            InodeId(2)
+        );
+        let head = load_namespace_head_control(&store, &namespace_id)
+            .await
+            .expect("load head");
+        assert_eq!(head.state.next_inode_id, InodeId(3));
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -137,43 +137,41 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 accepted_rows: session.accepted_rows(),
             };
             let request = candidate_request.request;
+            let semantic_identity = candidate_request.semantic_identity;
+            let allocation = candidate_request.allocation;
             if let Err(error) =
                 validate_commit_content_references(candidate, view.content_store_id())
             {
+                session.discard_candidate(allocation);
                 outcomes[index] = Some(Err(error));
                 continue;
             }
             let plan = {
                 let span = tracing::debug_span!("loonfs.phase", phase = "build_commit_plan");
-                match build_commit_plan_for_publish(&request, context.now_ms, &validation)
-                    .instrument(span)
-                    .await
+                match build_commit_plan_for_publish(
+                    &request,
+                    context.now_ms,
+                    &allocation,
+                    &validation,
+                )
+                .instrument(span)
+                .await
                 {
                     Ok(plan) => plan,
                     Err(error) => {
+                        session.discard_candidate(allocation);
                         outcomes[index] = Some(Err(error));
                         continue;
                     }
                 }
             };
-            // One allocator: the planner predicted these ids while resolving
-            // the request's operations, and the plan re-derives them from the
-            // operation list. A disagreement would mean an operation was
-            // parented under an inode nothing creates.
-            debug_assert_eq!(
-                plan.resulting_next_inode_id, candidate_request.predicted_next_inode_id,
-                "planner prediction and commit-plan allocation disagree"
-            );
             let prepared = {
                 let _span = tracing::debug_span!("loonfs.phase", phase = "PreparedCommit::prepare")
                     .entered();
-                match PreparedCommit::new(
-                    request,
-                    plan.clone(),
-                    candidate_request.semantic_identity,
-                ) {
+                match PreparedCommit::new(request, plan.clone(), semantic_identity) {
                     Ok(value) => value,
                     Err(error) => {
+                        session.discard_candidate(allocation);
                         outcomes[index] = Some(Err(CoreError::Internal(format!(
                             "commit preparation failed: {error}"
                         ))));
@@ -195,6 +193,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 match wal_payload_from_materialized_commit(&materialized) {
                     Ok(payload) => payload,
                     Err(error) => {
+                        session.discard_candidate(allocation);
                         outcomes[index] = Some(Err(error.into()));
                         continue;
                     }
@@ -204,7 +203,10 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 let _span =
                     tracing::debug_span!("loonfs.phase", phase = "apply_committed_wal_record")
                         .entered();
-                session.apply_accepted_commit(&preview, &plan);
+                if let Err(error) = session.apply_accepted_commit(&preview, &plan, allocation) {
+                    outcomes[index] = Some(Err(error));
+                    continue;
+                }
             }
             accepted.push((index, materialized));
         }

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -3,24 +3,21 @@
 //! and same-batch primaries.
 
 use super::publish_view::PublishMetadataView;
-use crate::commit::{CommitFingerprint, CommitIr as CoreCommitRequest};
+use crate::commit::{CandidateAllocation, CommitFingerprint, CommitIr as CoreCommitRequest};
 use crate::commit_engine::{CommitCandidate, ContentPreparation, ContentPreparationError};
 use crate::error::{CoreError, Result};
 use crate::metadata::CommitReceiptRecord;
 use crate::path::write::{FilesystemOperation, PublishPlanningSession};
 use crate::storage::content_admission::ContentAdmission;
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
-use loonfs_api::{CommitId, ContentRef, ContentStoreId, InodeId, NamespaceId};
+use loonfs_api::{CommitId, ContentRef, ContentStoreId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashMap;
 
 pub(super) struct CandidateCoreRequest {
     pub(super) request: CoreCommitRequest,
     pub(super) semantic_identity: CommitFingerprint,
-    /// The next free inode id the planner predicted for this request. The
-    /// commit plan derives the same value from the operation list; the
-    /// publish path checks that the two agree.
-    pub(super) predicted_next_inode_id: InodeId,
+    pub(super) allocation: CandidateAllocation,
 }
 
 /// How one batch candidate resolved during admission.
@@ -155,9 +152,22 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         return Ok(admission);
     }
     validate_new_primary(candidate)?;
-    let planned = session
-        .plan_commit(mutation, view.metadata_view(), committed_at_ms)
-        .await?;
+    let mut allocation = session.begin_candidate();
+    let planned = match session
+        .plan_commit(
+            mutation,
+            view.metadata_view(),
+            committed_at_ms,
+            &mut allocation,
+        )
+        .await
+    {
+        Ok(planned) => planned,
+        Err(error) => {
+            session.discard_candidate(allocation);
+            return Err(error);
+        }
+    };
     Ok(CandidateAdmission::Prepared(CandidateCoreRequest {
         request: CoreCommitRequest {
             namespace_id: namespace_id.clone(),
@@ -167,7 +177,7 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
             message: mutation.message.clone(),
         },
         semantic_identity,
-        predicted_next_inode_id: planned.resulting_next_inode_id,
+        allocation,
     }))
 }
 

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -34,6 +34,7 @@ async fn build_wal_record_payload_matches_segment_record_payload() {
         commit_id: CommitId::parse("c_wal_payload").expect("valid commit id"),
         writer_epoch: WriterEpoch(1),
         ops: vec![PlannedOp::unchecked(CommitOp::CreateDirectory {
+            child_inode_id: InodeId(2),
             parent_inode_id: InodeId(1),
             display_name: loonfs_api::DisplayName::parse("docs").expect("valid display name"),
         })],
@@ -437,6 +438,7 @@ fn materialized_create_directory(
         commit_id: CommitId::parse(commit_id).expect("valid commit id"),
         writer_epoch: WriterEpoch(1),
         ops: vec![PlannedOp::unchecked(CommitOp::CreateDirectory {
+            child_inode_id: InodeId(2),
             parent_inode_id: InodeId(1),
             display_name: loonfs_api::DisplayName::parse(display_name).expect("valid display name"),
         })],

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -660,6 +660,33 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
         visible_segment.payload.records[0].commit_id,
         CommitId::parse("retry-after-orphan").expect("valid commit id")
     );
+    let orphan_wal = store
+        .get(orphan_keys[0], None)
+        .await
+        .expect("read orphan wal")
+        .expect("orphan wal exists");
+    let orphan_segment =
+        decode_wal_segment_envelope_zstd(&orphan_wal).expect("decode orphan segment");
+    let visible_created_ids = visible_segment.payload.records[0]
+        .deltas
+        .iter()
+        .filter_map(|delta| match &delta.delta {
+            WalDelta::CreateInode { inode_id, .. } => Some(*inode_id),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let orphan_created_ids = orphan_segment.payload.records[0]
+        .deltas
+        .iter()
+        .filter_map(|delta| match &delta.delta {
+            WalDelta::CreateInode { inode_id, .. } => Some(*inode_id),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        visible_created_ids, orphan_created_ids,
+        "retrying from the unchanged head must assign the same inode ids"
+    );
 
     let changes = list_changes_after(&store, &namespace_id, ChangeSeq(0))
         .await


### PR DESCRIPTION
Path planning and commit validation each ran their own inode allocator, synchronized by a cross-layer debug assert. One transactional allocator with candidate begin/commit/discard now assigns every ID once; predicted_next_inode_id, the planner's local counter, validation's re-allocation, and the assert are deleted. Risk tests cover same-request references, accept/reject orderings, retries, and the overflow boundary.