### PR TITLE
refactor(gc): give collection passes explicit lifecycle ownership

### DIFF
--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -1,7 +1,5 @@
 //! What `max_objects` meters, and what a pass does when it runs out.
 
-use super::config::GcConfig;
-
 /// The work one garbage-collection pass is allowed to do, from its first
 /// read to its last. Marking is inside the bound, not before it.
 ///
@@ -47,10 +45,6 @@ impl PassBudget {
             max_objects,
             spent: 0,
         }
-    }
-
-    pub(super) fn of(config: &GcConfig) -> Self {
-        Self::new(config.max_objects)
     }
 
     /// True once nothing further may be charged: the caller stops where it

--- a/crates/loonfs-core/src/gc/config.rs
+++ b/crates/loonfs-core/src/gc/config.rs
@@ -1,7 +1,9 @@
 //! GC configuration.
 
+use super::cursor::GcCursor;
 use crate::error::{CoreError, Result};
 use crate::limits::GC_MIN_GRACE_WINDOW_MS;
+use loonfs_api::NamespaceId;
 use serde::{Deserialize, Serialize};
 
 /// The grace window for the sweep (format spec, "Garbage collection"). It is
@@ -70,5 +72,35 @@ impl GcConfig {
             ));
         }
         Ok(())
+    }
+}
+
+/// Validated, namespace-bound policy for one collection pass.
+///
+/// The decoded cursor belongs here because it controls this pass's walk. The
+/// original token is retained separately only because a pass that makes no
+/// progress must return it byte for byte; decoding and re-encoding is not the
+/// external contract.
+#[derive(Debug)]
+pub(super) struct GcPolicy {
+    pub(super) grace_window_ms: u64,
+    pub(super) max_objects: Option<u64>,
+    pub(super) resume: GcCursor,
+    pub(super) unchanged_cursor: Option<String>,
+}
+
+impl GcPolicy {
+    pub(super) fn settle(config: &GcConfig, namespace_id: &NamespaceId) -> Result<Self> {
+        config.validate()?;
+        let resume = match config.cursor.as_deref() {
+            Some(token) => GcCursor::decode(token, namespace_id)?,
+            None => GcCursor::initial(namespace_id),
+        };
+        Ok(Self {
+            grace_window_ms: config.grace_window_ms,
+            max_objects: config.max_objects,
+            resume,
+            unchanged_cursor: config.cursor.clone(),
+        })
     }
 }

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -3,7 +3,7 @@
 
 use super::budget::PassBudget;
 use super::compaction_staging::{CompactionLeases, StagedObject};
-use super::config::GcConfig;
+use super::config::{GcConfig, GcPolicy};
 use super::cursor::{CandidateFamily, GcCursor};
 use super::fork_checkpoints::{
     maybe_release_fork_checkpoint, release_missing_basis_checkpoint, ForkCheckpointSweep,
@@ -46,17 +46,13 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     reverify_chunk: usize,
 ) -> Result<GcResponse> {
-    config.validate()?;
-    let resume = match config.cursor.as_deref() {
-        Some(token) => GcCursor::decode(token, namespace_id)?,
-        None => GcCursor::initial(namespace_id),
-    };
+    let policy = GcPolicy::settle(config, namespace_id)?;
     let mut report = GcResponse::empty(namespace_id.clone());
     // The budget opens before the first read, so marking spends out of it
     // too. A pass that cannot afford its own roots reports that. It does
     // not read the whole retained chain for free and then meter only what
     // comes after.
-    let mut budget = PassBudget::of(config);
+    let mut budget = PassBudget::new(policy.max_objects);
 
     // The head is the namespace: without one there is nothing to collect,
     // and nothing could have been written under the prefix either, because
@@ -73,11 +69,11 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
 
     // Every invocation rebuilds all roots before interpreting the cursor.
     // The cursor can skip enumeration only; it never carries safety state.
-    let mark = match collect_live_set(
+    let initial_live = match collect_live_set(
         store,
         namespace_id,
         &loaded,
-        config.grace_window_ms,
+        policy.grace_window_ms,
         None,
         &mut budget,
         context,
@@ -93,471 +89,420 @@ pub(super) async fn gc_namespace_with_reverify_chunk<S: ObjectStore + ?Sized>(
         LiveSetCollection::BudgetExhausted => {
             report.budget_exhausted = true;
             report.content_reclamation_deferred = true;
-            report.next_cursor.clone_from(&config.cursor);
+            report.next_cursor.clone_from(&policy.unchanged_cursor);
             return Ok(report);
         }
     };
-    let mut sweep = SweepVerifier::seeded(Arc::clone(&mark), reverify_chunk);
-    // Content references are collected from this same root set, lazily and
-    // at most once per invocation. The derived reclamation grace is what
-    // lets one collection stand for every candidate that follows it: past
-    // it, no receipt survives that could add a reference. The scan is
-    // charged against the budget like everything else, and an invocation
-    // that cannot afford it skips content reclamation instead of
-    // overrunning — the sessions waiting on it are retained and the sweep
-    // continues.
-    let mut references = ContentReferences::over(&mark);
-    // What this pass has learned about the compaction job whose objects it is
-    // walking. One lease read per job rather than one per object.
-    let mut leases = CompactionLeases::default();
-    // The position this pass walked to, or `None` while it has decided
-    // nothing and has no progress of its own to report.
-    let mut position: Option<GcCursor> = None;
 
-    // Data precedes mutable records. A crash or bounded return can therefore
-    // leave data protected for an extra pass, never a readable record whose
-    // basis was removed underneath it.
-    for &family in &CandidateFamily::ALL[resume.family.index()..] {
-        let prefix = family.prefix(namespace_id);
-        let mut stream = store.list_prefix_stream(&prefix);
-        while let Some(item) = stream.next().await {
-            let key = item.map_err(|error| CoreError::store(&prefix, &error))?;
-            if family == resume.family
-                && resume
-                    .last_key
-                    .as_ref()
-                    .is_some_and(|last_key| key <= *last_key)
-            {
-                continue;
-            }
-            // This one-key lookahead proves work remains. It performs no
-            // candidate reads or mutations, and the key is reconsidered
-            // from the exclusive last-examined position on resume.
-            if budget.exhausted() {
-                leases.finish(store).await?;
-                return stopped_on_budget(report, config, position.as_ref(), &sweep);
-            }
-
-            let step = process_candidate(
-                store,
-                namespace_id,
-                &content_store_id,
-                config,
-                context,
-                family,
-                &key,
-                &mark,
-                &mut sweep,
-                &mut references,
-                &mut leases,
-                &mut budget,
-                &mut report,
-            )
-            .await?;
-            if step == SweepStep::BudgetExhausted {
-                // The re-verification this candidate's decision needs could
-                // not be paid for, so the candidate stays undecided and is
-                // reconsidered from the same exclusive position on resume.
-                leases.finish(store).await?;
-                return stopped_on_budget(report, config, position.as_ref(), &sweep);
-            }
-            // Every candidate that gets past the check above comes back
-            // decided one way or the other, so the cursor always advances
-            // past it. The one thing a pass can run out of budget to
-            // answer is whether a completed session's content is still
-            // referenced. The sweep answers that by retaining the session
-            // rather than by leaving the key undecided. A budget below that
-            // scan's cost would otherwise pin the walk to one key forever.
-            budget.charge();
-            position = Some(GcCursor::after(namespace_id, family, key));
-        }
-    }
-
-    // The last job the walk claimed has no following key to close it out, so
-    // the pass closes it here: its lease goes after the objects it covered.
-    leases.finish(store).await?;
-    report.degraded_retention = sweep.degraded;
-    Ok(report)
-}
-
-/// Closes a pass that stopped on its budget partway through the sweep. The
-/// pass reports the work it did.
-///
-/// A pass that decided at least one candidate returns the position it
-/// walked to. A pass that decided none returns the token it was given, byte
-/// for byte, because it made no progress to report. The runner compares
-/// that token against the one it submitted to tell a pass that walked from
-/// a pass that did not, so re-encoding the position here would have to rely
-/// on decode-then-encode producing the same bytes.
-fn stopped_on_budget(
-    mut report: GcResponse,
-    config: &GcConfig,
-    position: Option<&GcCursor>,
-    sweep: &SweepVerifier,
-) -> Result<GcResponse> {
-    report.budget_exhausted = true;
-    match position {
-        Some(position) => report.next_cursor = Some(position.encode()?),
-        None => report.next_cursor.clone_from(&config.cursor),
-    }
-    report.degraded_retention = sweep.degraded;
-    Ok(report)
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn process_candidate<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    content_store_id: &ContentStoreId,
-    config: &GcConfig,
-    context: &MutationContext,
-    family: CandidateFamily,
-    key: &str,
-    mark: &LiveSet,
-    sweep: &mut SweepVerifier,
-    references: &mut ContentReferences<'_>,
-    leases: &mut CompactionLeases,
-    budget: &mut PassBudget,
-    report: &mut GcResponse,
-) -> Result<SweepStep> {
-    if family == CandidateFamily::UploadSessions {
-        process_upload_session(
-            store,
-            namespace_id,
-            content_store_id,
-            config,
-            context,
-            key,
-            references,
-            budget,
-            report,
-        )
-        .await?;
-        return Ok(SweepStep::Continue);
-    }
-
-    if family == CandidateFamily::Checkpoints && mark.missing_basis_records.contains(key) {
-        if release_missing_basis_checkpoint(
-            store,
-            namespace_id,
-            key,
-            config.grace_window_ms,
-            context,
-        )
-        .await?
-        {
-            report.released_missing_basis_checkpoints += 1;
-        } else {
-            report.retain(RetainedReason::CheckpointNotReleasable);
-        }
-        return Ok(SweepStep::Continue);
-    }
-
-    // Objects reachable from the invocation's root snapshot — either
-    // anchor's — are skipped, while every selected candidate is re-verified
-    // immediately before its decision.
-    let selected = match family {
-        CandidateFamily::WalSegments => !mark.protects_wal_segment(key),
-        // A staged segment a publication landed is named by the manifest like
-        // any other table, so the same root set answers for both families.
-        CandidateFamily::MetadataTables | CandidateFamily::CompactionStaging => {
-            !mark.tables.contains(key)
-        }
-        CandidateFamily::Manifests => match manifest_object_id_of(key) {
-            Some(Ok(id)) => !mark.manifests.contains(&id),
-            // A key that names no readable manifest is reachable from no
-            // root, so it is selected like any other unreferenced
-            // candidate; the decision below is where it is kept and said.
-            None | Some(Err(_)) => true,
-        },
-        CandidateFamily::Checkpoints => !mark.checkpoint_keys.contains(key),
-        CandidateFamily::UploadSessions => false,
-    };
-    if !selected {
-        return Ok(SweepStep::Continue);
-    }
-
-    if sweep
-        .refresh_if_due(store, namespace_id, config.grace_window_ms, budget, context)
-        .await?
-        == SweepStep::BudgetExhausted
-    {
-        return Ok(SweepStep::BudgetExhausted);
-    }
-    // Each arm names the one reason it kept a candidate. The decisions are
-    // exactly the ones they always were — the `||` conditions below are
-    // split only so a retention can say which half of the condition held.
-    match family {
-        CandidateFamily::WalSegments => {
-            if sweep.live.protects_wal_segment(key) {
-                report.retain(RetainedReason::Referenced);
-            } else if sweep_aged(store, key, config.grace_window_ms, context, sweep, report).await?
-            {
-                report.deleted_wal_segments += 1;
-            }
-        }
-        CandidateFamily::MetadataTables => {
-            // Rule 5 is sticky across every re-collection in this pass.
-            if sweep.degraded {
-                report.retain(RetainedReason::DegradedRoots);
-            } else if sweep.live.tables.contains(key) {
-                report.retain(RetainedReason::Referenced);
-            } else if sweep_aged(store, key, config.grace_window_ms, context, sweep, report).await?
-            {
-                report.deleted_metadata_tables += 1;
-            }
-        }
-        // A compaction job's prefix holds the segments it has written and the
-        // lease that says who owns them. A published segment is named by the
-        // manifest and is live like any other table; everything else is
-        // decided by the lease, because a job outlives the ordinary grace
-        // window and its output would otherwise read as an aged orphan while
-        // it was still being written. Only the segments are counted as
-        // metadata tables — a lease is a control object, and a pass that
-        // reclaims one reclaims that job's segments in the same walk.
-        CandidateFamily::CompactionStaging => {
-            if sweep.degraded {
-                report.retain(RetainedReason::DegradedRoots);
-            } else if sweep.live.tables.contains(key) {
-                report.retain(RetainedReason::Referenced);
-            } else {
-                match leases
-                    .owner_of(store, namespace_id, key, context.now_ms)
-                    .await?
-                {
-                    // The same reason an object inside its window is kept:
-                    // something that has not run out yet still protects it.
-                    StagedObject::OwnedByALiveJob => report.retain(RetainedReason::GraceWindow),
-                    StagedObject::UnrecognizedKey => {
-                        report.retain(RetainedReason::UnrecognizedKey);
-                    }
-                    // Decided, and deleted when the walk leaves this prefix:
-                    // the claim goes after the objects it fenced, so a pass
-                    // that stops in between leaves a lease that says the reap
-                    // is unfinished rather than nothing at all.
-                    StagedObject::ClaimedLease => {}
-                    StagedObject::Orphaned => {
-                        if sweep_aged(
-                            store,
-                            key,
-                            METADATA_COMPACTION_STAGING_GRACE_MS,
-                            context,
-                            sweep,
-                            report,
-                        )
-                        .await?
-                            && key.ends_with(".sst.zst")
-                        {
-                            report.deleted_metadata_tables += 1;
-                        }
-                    }
-                }
-            }
-        }
-        CandidateFamily::Manifests => {
-            if sweep.degraded {
-                report.retain(RetainedReason::DegradedRoots);
-            } else {
-                match manifest_object_id_of(key) {
-                    Some(Ok(id)) if sweep.live.manifests.contains(&id) => {
-                        report.retain(RetainedReason::Referenced);
-                    }
-                    Some(Ok(_)) => {
-                        if sweep_aged(store, key, config.grace_window_ms, context, sweep, report)
-                            .await?
-                        {
-                            report.deleted_manifests += 1;
-                        }
-                    }
-                    // A key under the manifest prefix that does not name a
-                    // manifest is never deleted: this pass cannot tell what
-                    // wrote it, so it is retained and reported.
-                    None | Some(Err(_)) => report.retain(RetainedReason::UnrecognizedKey),
-                }
-            }
-        }
-        CandidateFamily::Checkpoints => {
-            process_checkpoint(store, namespace_id, config, context, key, sweep, report).await?;
-        }
-        CandidateFamily::UploadSessions => {}
-    }
-    Ok(SweepStep::Continue)
-}
-
-/// Ages one unreferenced key out, recording the reason when it stays.
-/// Answers whether the key was deleted, so each family still counts its own
-/// deletions.
-///
-/// Two things have to hold before the key goes. The object's own write time
-/// has to be `grace_window_ms` old, which is what protects a publication
-/// still in flight and every object the reference anchor predates. And the
-/// reference anchor has to say the object was already unreferenced when the
-/// window opened, which is what protects a reader still holding an anchor it
-/// pinned inside the window. A pass with no anchor cannot answer the second
-/// question, so it keeps every aged candidate and says so.
-///
-/// The window is a parameter because one family does not use the configured
-/// one: an object under a compaction job's prefix whose lease is stale or
-/// gone ages under [`METADATA_COMPACTION_STAGING_GRACE_MS`], which covers the
-/// lease's own expiry plus the publication that could still be naming the
-/// object.
-async fn sweep_aged<S: ObjectStore + ?Sized>(
-    store: &S,
-    key: &str,
-    grace_window_ms: u64,
-    context: &MutationContext,
-    sweep: &SweepVerifier,
-    report: &mut GcResponse,
-) -> Result<bool> {
-    match grace_age(store, key, grace_window_ms, context.now_ms)
-        .await
-        .map_err(|error| CoreError::store(key, &error))?
-    {
-        // Nothing was decided about a key that is already gone, so nothing
-        // is counted for it either.
-        GraceAge::Gone => return Ok(false),
-        GraceAge::Young => {
-            report.retain(RetainedReason::GraceWindow);
-            return Ok(false);
-        }
-        GraceAge::Unknown => {
-            report.retain(RetainedReason::NoProviderTimestamp);
-            return Ok(false);
-        }
-        GraceAge::Aged if !sweep.live.anchor.proves_unreferencing() => {
-            report.retain(RetainedReason::NoReferenceManifest);
-            return Ok(false);
-        }
-        GraceAge::Aged => {}
-    }
-    store
-        .delete(key)
-        .await
-        .map_err(|error| CoreError::store(key, &error))?;
-    Ok(true)
-}
-
-async fn process_checkpoint<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    config: &GcConfig,
-    context: &MutationContext,
-    key: &str,
-    sweep: &SweepVerifier,
-    report: &mut GcResponse,
-) -> Result<()> {
-    if sweep.live.checkpoint_keys.contains(key) {
-        report.retain(RetainedReason::Referenced);
-        return Ok(());
-    }
-    match maybe_release_fork_checkpoint(store, key, context).await? {
-        ForkCheckpointSweep::Released => {
-            report.released_fork_checkpoints += 1;
-            return Ok(());
-        }
-        ForkCheckpointSweep::Retained => {
-            report.retain(RetainedReason::CheckpointNotReleasable);
-            return Ok(());
-        }
-        ForkCheckpointSweep::NotAnActiveFork => {}
-    }
-    match sweep_checkpoint_record(
-        store,
-        namespace_id,
-        key,
-        config.grace_window_ms,
-        sweep.live.namespace_deleted,
-        context,
-    )
-    .await?
-    {
-        CheckpointSweep::Delete => {
-            store
-                .delete(key)
-                .await
-                .map_err(|error| CoreError::store(key, &error))?;
-            report.deleted_checkpoint_records += 1;
-        }
-        CheckpointSweep::Released => report.released_expired_checkpoints += 1,
-        CheckpointSweep::Retain => report.retain(RetainedReason::CheckpointNotReleasable),
-    }
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn process_upload_session<S: ObjectStore + ?Sized>(
-    store: &S,
-    namespace_id: &NamespaceId,
-    content_store_id: &ContentStoreId,
-    config: &GcConfig,
-    context: &MutationContext,
-    key: &str,
-    references: &mut ContentReferences<'_>,
-    budget: &mut PassBudget,
-    report: &mut GcResponse,
-) -> Result<()> {
-    let Some(upload_id) = upload_id_of(key) else {
-        report.retain(RetainedReason::UnrecognizedKey);
-        return Ok(());
-    };
-    match sweep_upload_session(
+    // A pass exists only after root collection succeeds. From here on it is
+    // the one owner of every mutable sweep concern, including cleanup owed by
+    // an early budget stop or error.
+    GcPass {
         store,
         namespace_id,
         content_store_id,
-        &upload_id,
-        config.grace_window_ms,
-        references,
+        policy,
+        mutation: context,
+        initial_live: Arc::clone(&initial_live),
+        sweep: SweepVerifier::seeded(Arc::clone(&initial_live), reverify_chunk),
+        references: ContentReferences::over(initial_live),
+        leases: CompactionLeases::default(),
         budget,
-        context,
-    )
-    .await?
-    {
-        UploadSessionSweep::Delete { reclaimed_content } => {
-            store
-                .delete(key)
-                .await
-                .map_err(|error| CoreError::store(key, &error))?;
-            report.deleted_upload_sessions += 1;
-            if reclaimed_content {
-                report.deleted_content_objects += 1;
-            }
-        }
-        UploadSessionSweep::Retain { reclaimable_at_ms } => {
-            // A deadline is the difference between "come back then" and
-            // "ask again next pass", and the sweep already draws that line.
-            report.retain(match reclaimable_at_ms {
-                Some(_) => RetainedReason::UploadSessionWindow,
-                None => RetainedReason::UploadSessionUndecided,
-            });
-            note_reclamation_deadline(report, reclaimable_at_ms, context.now_ms);
-        }
-        UploadSessionSweep::ContentReclamationDeferred => {
-            // Retained for the same reason any undecidable session is,
-            // plus a flag, so a caller can tell a pass that swept
-            // everything from one that skipped a question it could not
-            // afford to ask.
-            report.retain(RetainedReason::ContentScanDeferred);
-            report.content_reclamation_deferred = true;
-        }
+        report,
+        position: None,
     }
-    Ok(())
+    .run()
+    .await
 }
 
-/// Folds one retained candidate's deadline into the soonest the pass will
-/// report.
+/// One initialized garbage-collection pass.
 ///
-/// Only deadlines still ahead of this pass's own clock are kept. One
-/// already past is not an obligation this pass is leaving behind — it is
-/// something the pass just decided against for another reason — and
-/// reporting it would only ask a scheduler to come straight back.
-fn note_reclamation_deadline(report: &mut GcResponse, at_ms: Option<u64>, now_ms: u64) {
-    let Some(at_ms) = at_ms.filter(|at_ms| *at_ms > now_ms) else {
-        return;
-    };
-    report.next_reclamation_at_ms = Some(match report.next_reclamation_at_ms {
-        Some(soonest_ms) => soonest_ms.min(at_ms),
-        None => at_ms,
-    });
+/// These fields share a lifecycle rather than merely sharing a call site:
+/// candidate decisions mutate the verifier, reference memo, lease claim,
+/// budget, cursor, and report together, and [`Self::run`] settles all of them
+/// exactly once.
+struct GcPass<'a, S: ?Sized> {
+    store: &'a S,
+    namespace_id: &'a NamespaceId,
+    content_store_id: ContentStoreId,
+    policy: GcPolicy,
+    mutation: &'a MutationContext,
+    /// The root snapshot used to select candidates and collect content
+    /// references. Re-verification has its own newer snapshot in `sweep`.
+    initial_live: Arc<LiveSet>,
+    sweep: SweepVerifier,
+    references: ContentReferences,
+    leases: CompactionLeases,
+    budget: PassBudget,
+    report: GcResponse,
+    /// The last candidate this pass decided, if it has made progress.
+    position: Option<GcCursor>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PassEnd {
+    Complete,
+    BudgetExhausted,
+}
+
+impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
+    /// Runs and settles the pass. Lease cleanup deliberately happens before
+    /// the walk result is propagated, so no error or budget return can bypass
+    /// a claimed compaction lease.
+    async fn run(mut self) -> Result<GcResponse> {
+        let walked = self.walk_candidates().await;
+        let leases_finished = self.leases.finish(self.store).await;
+        leases_finished?;
+        self.finish_report(walked?)
+    }
+
+    async fn walk_candidates(&mut self) -> Result<PassEnd> {
+        let resume_family = self.policy.resume.family;
+        let resume_last_key = self.policy.resume.last_key.clone();
+
+        // Data precedes mutable records. A crash or bounded return can
+        // therefore leave data protected for an extra pass, never a readable
+        // record whose basis was removed underneath it.
+        for &family in &CandidateFamily::ALL[resume_family.index()..] {
+            let prefix = family.prefix(self.namespace_id);
+            let mut stream = self.store.list_prefix_stream(&prefix);
+            while let Some(item) = stream.next().await {
+                let key = item.map_err(|error| CoreError::store(&prefix, &error))?;
+                if family == resume_family
+                    && resume_last_key
+                        .as_ref()
+                        .is_some_and(|last_key| key.as_str() <= last_key.as_str())
+                {
+                    continue;
+                }
+                // This one-key lookahead proves work remains. It performs no
+                // candidate reads or mutations, and the key is reconsidered
+                // from the exclusive last-examined position on resume.
+                if self.budget.exhausted() {
+                    return Ok(PassEnd::BudgetExhausted);
+                }
+
+                if self.process_candidate(family, &key).await? == SweepStep::BudgetExhausted {
+                    // The re-verification this candidate's decision needs
+                    // could not be paid for, so the candidate stays undecided
+                    // and is reconsidered from the same exclusive position on
+                    // resume.
+                    return Ok(PassEnd::BudgetExhausted);
+                }
+                // Every candidate that gets past the check above comes back
+                // decided one way or the other, so the cursor always advances
+                // past it. A content-reference scan that exhausts the budget
+                // retains its session instead of pinning the cursor forever.
+                self.budget.charge();
+                self.position = Some(GcCursor::after(self.namespace_id, family, key));
+            }
+        }
+        Ok(PassEnd::Complete)
+    }
+
+    /// Decides one candidate using the pass-owned verifier and family state.
+    async fn process_candidate(&mut self, family: CandidateFamily, key: &str) -> Result<SweepStep> {
+        if family == CandidateFamily::UploadSessions {
+            self.process_upload_session(key).await?;
+            return Ok(SweepStep::Continue);
+        }
+
+        if family == CandidateFamily::Checkpoints
+            && self.initial_live.missing_basis_records.contains(key)
+        {
+            self.process_missing_basis_checkpoint(key).await?;
+            return Ok(SweepStep::Continue);
+        }
+
+        // Objects reachable from the invocation's root snapshot — either
+        // anchor's — are skipped, while every selected candidate is
+        // re-verified immediately before its decision.
+        if !self.is_selected(family, key) {
+            return Ok(SweepStep::Continue);
+        }
+        if self
+            .sweep
+            .refresh_if_due(
+                self.store,
+                self.namespace_id,
+                self.policy.grace_window_ms,
+                &mut self.budget,
+                self.mutation,
+            )
+            .await?
+            == SweepStep::BudgetExhausted
+        {
+            return Ok(SweepStep::BudgetExhausted);
+        }
+
+        match family {
+            CandidateFamily::WalSegments => self.process_wal_segment(key).await?,
+            CandidateFamily::MetadataTables => self.process_metadata_table(key).await?,
+            CandidateFamily::CompactionStaging => self.process_compaction_staging(key).await?,
+            CandidateFamily::Manifests => self.process_manifest(key).await?,
+            CandidateFamily::Checkpoints => self.process_checkpoint(key).await?,
+            CandidateFamily::UploadSessions => unreachable!("uploads return before selection"),
+        }
+        Ok(SweepStep::Continue)
+    }
+
+    fn is_selected(&self, family: CandidateFamily, key: &str) -> bool {
+        match family {
+            CandidateFamily::WalSegments => !self.initial_live.protects_wal_segment(key),
+            // A staged segment a publication landed is named by the manifest
+            // like any other table, so the same root set answers for both
+            // families.
+            CandidateFamily::MetadataTables | CandidateFamily::CompactionStaging => {
+                !self.initial_live.tables.contains(key)
+            }
+            CandidateFamily::Manifests => match manifest_object_id_of(key) {
+                Some(Ok(id)) => !self.initial_live.manifests.contains(&id),
+                // A key that names no readable manifest is reachable from no
+                // root. The family decision retains unrecognized names.
+                None | Some(Err(_)) => true,
+            },
+            CandidateFamily::Checkpoints => !self.initial_live.checkpoint_keys.contains(key),
+            CandidateFamily::UploadSessions => false,
+        }
+    }
+
+    async fn process_wal_segment(&mut self, key: &str) -> Result<()> {
+        if self.sweep.live.protects_wal_segment(key) {
+            self.report.retain(RetainedReason::Referenced);
+        } else if self.sweep_aged(key, self.policy.grace_window_ms).await? {
+            self.report.deleted_wal_segments += 1;
+        }
+        Ok(())
+    }
+
+    async fn process_metadata_table(&mut self, key: &str) -> Result<()> {
+        // Rule 5 is sticky across every re-collection in this pass.
+        if self.sweep.degraded {
+            self.report.retain(RetainedReason::DegradedRoots);
+        } else if self.sweep.live.tables.contains(key) {
+            self.report.retain(RetainedReason::Referenced);
+        } else if self.sweep_aged(key, self.policy.grace_window_ms).await? {
+            self.report.deleted_metadata_tables += 1;
+        }
+        Ok(())
+    }
+
+    async fn process_compaction_staging(&mut self, key: &str) -> Result<()> {
+        if self.sweep.degraded {
+            self.report.retain(RetainedReason::DegradedRoots);
+            return Ok(());
+        }
+        if self.sweep.live.tables.contains(key) {
+            self.report.retain(RetainedReason::Referenced);
+            return Ok(());
+        }
+
+        // A compaction job's prefix holds the segments it has written and
+        // the lease that says who owns them. A claimed lease goes only after
+        // the objects it fenced, which [`Self::run`] enforces at every exit.
+        match self
+            .leases
+            .owner_of(self.store, self.namespace_id, key, self.mutation.now_ms)
+            .await?
+        {
+            StagedObject::OwnedByALiveJob => self.report.retain(RetainedReason::GraceWindow),
+            StagedObject::UnrecognizedKey => {
+                self.report.retain(RetainedReason::UnrecognizedKey);
+            }
+            StagedObject::ClaimedLease => {}
+            StagedObject::Orphaned => {
+                if self
+                    .sweep_aged(key, METADATA_COMPACTION_STAGING_GRACE_MS)
+                    .await?
+                    && key.ends_with(".sst.zst")
+                {
+                    self.report.deleted_metadata_tables += 1;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn process_manifest(&mut self, key: &str) -> Result<()> {
+        if self.sweep.degraded {
+            self.report.retain(RetainedReason::DegradedRoots);
+            return Ok(());
+        }
+        match manifest_object_id_of(key) {
+            Some(Ok(id)) if self.sweep.live.manifests.contains(&id) => {
+                self.report.retain(RetainedReason::Referenced);
+            }
+            Some(Ok(_)) => {
+                if self.sweep_aged(key, self.policy.grace_window_ms).await? {
+                    self.report.deleted_manifests += 1;
+                }
+            }
+            // A key under the manifest prefix that does not name a manifest
+            // is never deleted because this pass cannot tell what wrote it.
+            None | Some(Err(_)) => self.report.retain(RetainedReason::UnrecognizedKey),
+        }
+        Ok(())
+    }
+
+    async fn process_missing_basis_checkpoint(&mut self, key: &str) -> Result<()> {
+        if release_missing_basis_checkpoint(
+            self.store,
+            self.namespace_id,
+            key,
+            self.policy.grace_window_ms,
+            self.mutation,
+        )
+        .await?
+        {
+            self.report.released_missing_basis_checkpoints += 1;
+        } else {
+            self.report.retain(RetainedReason::CheckpointNotReleasable);
+        }
+        Ok(())
+    }
+
+    async fn process_checkpoint(&mut self, key: &str) -> Result<()> {
+        if self.sweep.live.checkpoint_keys.contains(key) {
+            self.report.retain(RetainedReason::Referenced);
+            return Ok(());
+        }
+        match maybe_release_fork_checkpoint(self.store, key, self.mutation).await? {
+            ForkCheckpointSweep::Released => {
+                self.report.released_fork_checkpoints += 1;
+                return Ok(());
+            }
+            ForkCheckpointSweep::Retained => {
+                self.report.retain(RetainedReason::CheckpointNotReleasable);
+                return Ok(());
+            }
+            ForkCheckpointSweep::NotAnActiveFork => {}
+        }
+        match sweep_checkpoint_record(
+            self.store,
+            self.namespace_id,
+            key,
+            self.policy.grace_window_ms,
+            self.sweep.live.namespace_deleted,
+            self.mutation,
+        )
+        .await?
+        {
+            CheckpointSweep::Delete => {
+                self.store
+                    .delete(key)
+                    .await
+                    .map_err(|error| CoreError::store(key, &error))?;
+                self.report.deleted_checkpoint_records += 1;
+            }
+            CheckpointSweep::Released => self.report.released_expired_checkpoints += 1,
+            CheckpointSweep::Retain => self.report.retain(RetainedReason::CheckpointNotReleasable),
+        }
+        Ok(())
+    }
+
+    async fn process_upload_session(&mut self, key: &str) -> Result<()> {
+        let Some(upload_id) = upload_id_of(key) else {
+            self.report.retain(RetainedReason::UnrecognizedKey);
+            return Ok(());
+        };
+        match sweep_upload_session(
+            self.store,
+            self.namespace_id,
+            &self.content_store_id,
+            &upload_id,
+            self.policy.grace_window_ms,
+            &mut self.references,
+            &mut self.budget,
+            self.mutation,
+        )
+        .await?
+        {
+            UploadSessionSweep::Delete { reclaimed_content } => {
+                self.store
+                    .delete(key)
+                    .await
+                    .map_err(|error| CoreError::store(key, &error))?;
+                self.report.deleted_upload_sessions += 1;
+                if reclaimed_content {
+                    self.report.deleted_content_objects += 1;
+                }
+            }
+            UploadSessionSweep::Retain { reclaimable_at_ms } => {
+                // A deadline is the difference between "come back then" and
+                // "ask again next pass", and the sweep already draws that
+                // line.
+                self.report.retain(match reclaimable_at_ms {
+                    Some(_) => RetainedReason::UploadSessionWindow,
+                    None => RetainedReason::UploadSessionUndecided,
+                });
+                self.note_reclamation_deadline(reclaimable_at_ms);
+            }
+            UploadSessionSweep::ContentReclamationDeferred => {
+                self.report.retain(RetainedReason::ContentScanDeferred);
+                self.report.content_reclamation_deferred = true;
+            }
+        }
+        Ok(())
+    }
+
+    /// Ages one unreferenced key out, recording the reason when it stays.
+    async fn sweep_aged(&mut self, key: &str, grace_window_ms: u64) -> Result<bool> {
+        match grace_age(self.store, key, grace_window_ms, self.mutation.now_ms)
+            .await
+            .map_err(|error| CoreError::store(key, &error))?
+        {
+            // Nothing was decided about a key that is already gone, so
+            // nothing is counted for it either.
+            GraceAge::Gone => return Ok(false),
+            GraceAge::Young => {
+                self.report.retain(RetainedReason::GraceWindow);
+                return Ok(false);
+            }
+            GraceAge::Unknown => {
+                self.report.retain(RetainedReason::NoProviderTimestamp);
+                return Ok(false);
+            }
+            GraceAge::Aged if !self.sweep.live.anchor.proves_unreferencing() => {
+                self.report.retain(RetainedReason::NoReferenceManifest);
+                return Ok(false);
+            }
+            GraceAge::Aged => {}
+        }
+        self.store
+            .delete(key)
+            .await
+            .map_err(|error| CoreError::store(key, &error))?;
+        Ok(true)
+    }
+
+    /// Folds one retained candidate's future deadline into the report.
+    fn note_reclamation_deadline(&mut self, at_ms: Option<u64>) {
+        let Some(at_ms) = at_ms.filter(|at_ms| *at_ms > self.mutation.now_ms) else {
+            return;
+        };
+        self.report.next_reclamation_at_ms = Some(match self.report.next_reclamation_at_ms {
+            Some(soonest_ms) => soonest_ms.min(at_ms),
+            None => at_ms,
+        });
+    }
+
+    /// Produces the response after lease settlement. Budget-stop cursor and
+    /// degraded-root reporting live here so every completed walk uses the
+    /// same finalization path.
+    fn finish_report(mut self, end: PassEnd) -> Result<GcResponse> {
+        if end == PassEnd::BudgetExhausted {
+            self.report.budget_exhausted = true;
+            match self.position.as_ref() {
+                Some(position) => self.report.next_cursor = Some(position.encode()?),
+                None => self
+                    .report
+                    .next_cursor
+                    .clone_from(&self.policy.unchanged_cursor),
+            }
+        }
+        self.report.degraded_retention = self.sweep.degraded;
+        Ok(self.report)
+    }
 }
 
 fn upload_id_of(key: &str) -> Option<UploadId> {

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -2,6 +2,7 @@
 
 use super::budget::PassBudget;
 use super::config::GcConfig;
+use super::cursor::{CandidateFamily, GcCursor};
 use super::live_set::{recollect_live_set, LiveSet};
 use super::run::{gc_namespace, gc_namespace_with_reverify_chunk};
 use crate::checkpoint::advance_retention_floor;
@@ -2207,6 +2208,118 @@ async fn a_lease_that_does_not_decode_fails_the_pass() {
             .expect("head a staged object")
             .is_some());
     }
+}
+
+/// Once a pass claims a stale compaction lease, every exit owes that lease a
+/// deletion. A later candidate failure must not strand the claim in `Reaping`
+/// just because the normal end of the prefix was never reached.
+#[tokio::test]
+async fn a_candidate_error_still_finishes_the_claimed_compaction_lease() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let (inner, staged_key, lease_key) =
+        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+
+    let died_at_ms = now_after_newest_object(inner.inner(), &namespace_id, 0).await;
+    write_compaction_lease(&inner, &namespace_id, TEST_JOB_ID, died_at_ms).await;
+    let reclaimable_ms = now_after_newest_object(
+        inner.inner(),
+        &namespace_id,
+        METADATA_COMPACTION_STAGING_GRACE_MS + 1,
+    )
+    .await;
+
+    // The lease sorts before the staged table. GC claims it first, then this
+    // injected metadata failure makes the table decision return early.
+    let store = FailStore::new(
+        inner,
+        KeyPredicate::exact(staged_key.clone()),
+        OperationClass::Head,
+        InjectedError::Transport("staged table metadata timed out".to_owned()),
+    );
+    store.fail_all();
+    let error = gc_namespace(&store, &namespace_id, &config(), &context(reclaimable_ms))
+        .await
+        .expect_err("the candidate read still fails the pass");
+
+    assert_eq!(error.code(), crate::error::ErrorCode::ServerError);
+    assert!(
+        store
+            .inner()
+            .head(&lease_key)
+            .await
+            .expect("head the claimed lease")
+            .is_none(),
+        "pass settlement deletes the claimed lease on the error path"
+    );
+    assert!(
+        store
+            .inner()
+            .head(&staged_key)
+            .await
+            .expect("head the undecided table")
+            .is_some(),
+        "the failing candidate itself stays for a later pass"
+    );
+}
+
+/// A budget stop uses the same settlement boundary as an error. Once the
+/// lease candidate has been decided, the lookahead that notices an empty
+/// budget must close the claim before returning its cursor.
+#[tokio::test]
+async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let (store, staged_key, lease_key) =
+        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+
+    let died_at_ms = now_after_newest_object(store.inner(), &namespace_id, 0).await;
+    write_compaction_lease(&store, &namespace_id, TEST_JOB_ID, died_at_ms).await;
+    let reclaimable = context(
+        now_after_newest_object(
+            store.inner(),
+            &namespace_id,
+            METADATA_COMPACTION_STAGING_GRACE_MS + 1,
+        )
+        .await,
+    );
+    let marking = marking_units(&store, &namespace_id, &reclaimable).await;
+
+    // Resume immediately before compaction staging and buy exactly its lease
+    // candidate. The staged table is the lookahead that stops the pass.
+    let mut bounded = config();
+    bounded.max_objects = Some(marking + 1);
+    bounded.cursor = Some(
+        GcCursor::after(
+            &namespace_id,
+            CandidateFamily::MetadataTables,
+            format!("{}~", metadata_table_prefix(namespace_id.as_str())),
+        )
+        .encode()
+        .expect("encode cursor"),
+    );
+    let report = gc_namespace(&store, &namespace_id, &bounded, &reclaimable)
+        .await
+        .expect("bounded pass");
+
+    assert!(report.budget_exhausted);
+    assert!(report.next_cursor.is_some());
+    assert!(
+        store
+            .head(&lease_key)
+            .await
+            .expect("head the claimed lease")
+            .is_none(),
+        "pass settlement deletes the claimed lease at the budget boundary"
+    );
+    assert!(
+        store
+            .head(&staged_key)
+            .await
+            .expect("head the unvisited table")
+            .is_some(),
+        "the cursor leaves the unvisited table for the resumed pass"
+    );
 }
 
 /// A published job's output is an ordinary referenced table. The manifest

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -26,6 +26,7 @@ use loonfs_api::wire::sst_blocks::string_prefix_upper_bound;
 use loonfs_api::{ContentId, ContentStoreId, NamespaceId, UploadId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 /// Rows read from one metadata table per request while collecting content
 /// references. Each wave is one page of rows and costs one budget unit, so
@@ -67,7 +68,7 @@ pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
     content_store_id: &ContentStoreId,
     upload_id: &UploadId,
     grace_window_ms: u64,
-    references: &mut ContentReferences<'_>,
+    references: &mut ContentReferences,
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> Result<UploadSessionSweep> {
@@ -249,13 +250,13 @@ enum CollectedReferences {
 /// only when an aged completed session needs it. It is not stored in the
 /// pagination cursor because the cursor records position, not permission to
 /// delete. A resumed invocation performs a new budgeted scan.
-pub(super) struct ContentReferences<'a> {
-    live: &'a LiveSet,
+pub(super) struct ContentReferences {
+    live: Arc<LiveSet>,
     collected: CollectedReferences,
 }
 
-impl<'a> ContentReferences<'a> {
-    pub(super) fn over(live: &'a LiveSet) -> Self {
+impl ContentReferences {
+    pub(super) fn over(live: Arc<LiveSet>) -> Self {
         Self {
             live,
             collected: CollectedReferences::NotYet,
@@ -273,7 +274,7 @@ impl<'a> ContentReferences<'a> {
             self.collected = if self.live.degraded {
                 CollectedReferences::Unavailable
             } else {
-                collect_referenced_content(store, namespace_id, self.live, budget).await?
+                collect_referenced_content(store, namespace_id, &self.live, budget).await?
             };
         }
         Ok(match &self.collected {


### PR DESCRIPTION
The GC pass already had a lifecycle; its state was threaded through a thirteen-argument function. GcPass now owns the pass-wide state, candidate processing is a method, and lease finalization and budget-stop are centralized so early returns cannot skip cleanup. Structural only: every deletion-safety rule, cursor semantic, and retained-reason counter is unchanged. 