### PR TITLE
refactor: delete duplicated policy, progress, and placement state

### DIFF
--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -13,8 +13,8 @@ use futures::future::try_join_all;
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
 use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
-use loonfs_api::{sha256_digest, ChangeSeq, MetadataTableId, NamespaceId};
-use loonfs_objectstore::keys::metadata_table;
+use loonfs_api::{sha256_digest, ChangeSeq, MetadataCompactionId, MetadataTableId, NamespaceId};
+use loonfs_objectstore::keys::{metadata_compaction_table, metadata_table};
 use loonfs_objectstore::ObjectStore;
 use std::num::NonZeroUsize;
 
@@ -110,6 +110,7 @@ where
     S: ObjectStore + ?Sized,
     RowsForFamily: FnMut(MetadataTableFamily) -> Vec<MetadataRow>,
 {
+    let destination = MetadataTableDestination::Published { namespace_id };
     let mut tables = Vec::with_capacity(CHECKPOINT_TABLE_FAMILIES.len());
     for family in CHECKPOINT_TABLE_FAMILIES {
         let rows = rows_for_family(family);
@@ -126,12 +127,7 @@ where
         for (segment_index, segment_rows) in segments.into_iter().enumerate() {
             let segment_index = u32::try_from(segment_index)
                 .map_err(|_| CoreError::Internal("metadata SST index overflow".to_owned()))?;
-            let table_id = MetadataTableId::generate();
-            let object_key = metadata_table(namespace_id.as_str(), table_id.as_str());
-            requests.push(MetadataSstWriteRequest::new(
-                namespace_id,
-                table_id,
-                object_key,
+            requests.push(destination.write_request(
                 run_seq,
                 level,
                 family,
@@ -167,44 +163,71 @@ where
     Ok(tables)
 }
 
+/// The two physical locations a logically identical metadata table may use.
+/// Keeping namespace and staging-job identity here makes the object key a
+/// consequence of the destination instead of a caller-supplied coordinate.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum MetadataTableDestination<'a> {
+    Published {
+        namespace_id: &'a NamespaceId,
+    },
+    CompactionStaging {
+        namespace_id: &'a NamespaceId,
+        job_id: &'a MetadataCompactionId,
+    },
+}
+
+impl<'a> MetadataTableDestination<'a> {
+    fn namespace_id(self) -> &'a NamespaceId {
+        match self {
+            Self::Published { namespace_id } | Self::CompactionStaging { namespace_id, .. } => {
+                namespace_id
+            }
+        }
+    }
+
+    fn object_key(self, table_id: &MetadataTableId) -> String {
+        match self {
+            Self::Published { namespace_id } => {
+                metadata_table(namespace_id.as_str(), table_id.as_str())
+            }
+            Self::CompactionStaging {
+                namespace_id,
+                job_id,
+            } => {
+                metadata_compaction_table(namespace_id.as_str(), job_id.as_str(), table_id.as_str())
+            }
+        }
+    }
+
+    pub(super) fn write_request(
+        self,
+        run_seq: ChangeSeq,
+        level: u32,
+        family: MetadataTableFamily,
+        segment_index: u32,
+        rows: Vec<MetadataRow>,
+    ) -> MetadataSstWriteRequest<'a> {
+        MetadataSstWriteRequest {
+            destination: self,
+            table_id: MetadataTableId::generate(),
+            run_seq,
+            level,
+            family,
+            segment_index,
+            rows,
+        }
+    }
+}
+
 pub(super) struct MetadataSstWriteRequest<'a> {
-    namespace_id: &'a NamespaceId,
+    destination: MetadataTableDestination<'a>,
     table_id: MetadataTableId,
     run_seq: ChangeSeq,
     level: u32,
     family: MetadataTableFamily,
     segment_index: u32,
     rows: Vec<MetadataRow>,
-    object_key: String,
-}
-
-impl<'a> MetadataSstWriteRequest<'a> {
-    /// One segment to write. The caller supplies the object key rather than
-    /// having it derived, because a streaming compaction writes the same
-    /// segment shape to the staging directory instead of to
-    /// `metadata/tables/` (format spec, "Compaction").
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn new(
-        namespace_id: &'a NamespaceId,
-        table_id: MetadataTableId,
-        object_key: String,
-        run_seq: ChangeSeq,
-        level: u32,
-        family: MetadataTableFamily,
-        segment_index: u32,
-        rows: Vec<MetadataRow>,
-    ) -> Self {
-        Self {
-            namespace_id,
-            table_id,
-            run_seq,
-            level,
-            family,
-            segment_index,
-            rows,
-            object_key,
-        }
-    }
 }
 
 /// Largest filter block inlined into the segment's manifest descriptor, in
@@ -219,6 +242,7 @@ pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
     store: &S,
     request: MetadataSstWriteRequest<'_>,
 ) -> Result<MetadataFileRef> {
+    let object_key = request.destination.object_key(&request.table_id);
     let mut builder = SegmentBlocksBuilder::default();
     for row in &request.rows {
         let row_key = row.row_key_for_family(request.family);
@@ -226,27 +250,27 @@ pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
         builder.push(&row_key, &filter_key, row).map_err(|err| {
             CoreError::Internal(format!(
                 "failed to build metadata SST `{}`: {err}",
-                request.object_key
+                object_key
             ))
         })?;
     }
     let built = builder.finish().map_err(|err| {
         CoreError::Internal(format!(
             "failed to build metadata SST `{}`: {err}",
-            request.object_key
+            object_key
         ))
     })?;
     store
-        .put_immutable_verified(&request.object_key, Bytes::from(built.bytes.clone()))
+        .put_immutable_verified(&object_key, Bytes::from(built.bytes.clone()))
         .await?;
     let filter_inline = (built.filter.stored_len <= INLINE_SEGMENT_FILTER_MAX_BYTES).then(|| {
         let start = built.filter.offset as usize;
         hex_encode_bytes(&built.bytes[start..start + built.filter.stored_len as usize])
     });
     Ok(MetadataFileRef {
-        owner_namespace_id: request.namespace_id.clone(),
+        owner_namespace_id: request.destination.namespace_id().clone(),
         table_id: request.table_id,
-        object_key: request.object_key,
+        object_key,
         run_seq: request.run_seq,
         level: request.level,
         family: request.family,
@@ -282,4 +306,37 @@ pub(super) fn segment_rows_by_row_key_range(
             rows: rows.to_vec(),
         })
         .collect()
+}
+
+#[cfg(test)]
+mod destination_tests {
+    use super::*;
+
+    #[test]
+    fn destinations_preserve_published_and_staging_layouts() {
+        let namespace_id = NamespaceId::parse("ns-1").expect("namespace id");
+        let job_id =
+            MetadataCompactionId::parse("cmp_00000000000000000000000000000001").expect("job id");
+        let table_id =
+            MetadataTableId::parse("tbl_00000000000000000000000000000001").expect("table id");
+
+        assert_eq!(
+            MetadataTableDestination::Published {
+                namespace_id: &namespace_id,
+            }
+            .object_key(&table_id),
+            "namespaces/ns-1/metadata/tables/\
+             tbl_00000000000000000000000000000001.sst.zst",
+        );
+        assert_eq!(
+            MetadataTableDestination::CompactionStaging {
+                namespace_id: &namespace_id,
+                job_id: &job_id,
+            }
+            .object_key(&table_id),
+            "namespaces/ns-1/metadata/compactions/\
+             cmp_00000000000000000000000000000001/tables/\
+             tbl_00000000000000000000000000000001.sst.zst",
+        );
+    }
 }

--- a/crates/loonfs-core/src/checkpoint/compaction_output.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_output.rs
@@ -5,53 +5,26 @@
 //! segment's worth of rows, so output residency is the segment row budget and
 //! not the size of the group being merged.
 //!
-//! The paths differ in one thing, and [`MergeOutput`] is it: the key a segment
-//! lands under. A background job's segments are written long before the
-//! manifest that names them, so they go under the job's own prefix where a
+//! The paths differ in one thing: the destination that derives the key a
+//! segment lands under. A background job's segments are written long before
+//! the manifest that names them, so they go under the job's own prefix where a
 //! lease speaks for them (format spec, "Compaction"). A merge that runs inside
 //! a maintenance step publishes in that same step, so its segments go to
 //! `metadata/tables/` like any other freshly written run and are covered by
 //! the ordinary write-time grace.
 
-use super::build::{write_manifest_segment, MetadataSstWriteRequest};
+use super::build::{write_manifest_segment, MetadataTableDestination};
 use super::reorganize::MergePlacement;
 use super::runs::MetadataLsmPolicy;
 use crate::error::Result;
 use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
-use loonfs_api::{MetadataCompactionId, MetadataTableId, NamespaceId};
-use loonfs_objectstore::keys::{metadata_compaction_table, metadata_table};
 use loonfs_objectstore::ObjectStore;
-
-/// Where a merge's output segments are written.
-#[derive(Debug, Clone, Copy)]
-pub(super) enum MergeOutput<'a> {
-    /// Under the job's own prefix, for a merge whose publication comes much
-    /// later. The lease beside the segments is what tells garbage collection
-    /// that objects far older than any grace window still have an owner.
-    JobPrefix(&'a MetadataCompactionId),
-    /// At ordinary table keys, for a merge that publishes inside the step that
-    /// ran it. Its segments are seconds old when the manifest names them, so
-    /// the ordinary write-time grace already covers them and there is nothing
-    /// for a lease to say.
-    Tables,
-}
-
-impl MergeOutput<'_> {
-    fn object_key(&self, namespace_id: &NamespaceId, table_id: &MetadataTableId) -> String {
-        match self {
-            Self::JobPrefix(job_id) => {
-                metadata_compaction_table(namespace_id.as_str(), job_id.as_str(), table_id.as_str())
-            }
-            Self::Tables => metadata_table(namespace_id.as_str(), table_id.as_str()),
-        }
-    }
-}
 
 /// Accumulates one family's surviving rows and uploads a segment every time
 /// the segment row budget fills.
 pub(super) struct MergeSegmentWriter<'a> {
     family: MetadataTableFamily,
-    output: MergeOutput<'a>,
+    destination: MetadataTableDestination<'a>,
     placement: MergePlacement,
     rows: Vec<MetadataRow>,
     next_segment_index: u32,
@@ -61,12 +34,12 @@ pub(super) struct MergeSegmentWriter<'a> {
 impl<'a> MergeSegmentWriter<'a> {
     pub(super) fn new(
         family: MetadataTableFamily,
-        output: MergeOutput<'a>,
+        destination: MetadataTableDestination<'a>,
         placement: MergePlacement,
     ) -> Self {
         Self {
             family,
-            output,
+            destination,
             placement,
             rows: Vec::new(),
             next_segment_index: 0,
@@ -81,14 +54,13 @@ impl<'a> MergeSegmentWriter<'a> {
     pub(super) async fn roll_full_segments<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,
-        namespace_id: &NamespaceId,
         policy: MetadataLsmPolicy,
     ) -> Result<()> {
         let max_rows = policy.max_rows_per_segment.get();
         while self.rows.len() >= max_rows {
             let rest = self.rows.split_off(max_rows);
             let full = std::mem::replace(&mut self.rows, rest);
-            self.write_segment(store, namespace_id, full).await?;
+            self.write_segment(store, full).await?;
         }
         Ok(())
     }
@@ -96,11 +68,10 @@ impl<'a> MergeSegmentWriter<'a> {
     pub(super) async fn finish<S: ObjectStore + ?Sized>(
         mut self,
         store: &S,
-        namespace_id: &NamespaceId,
     ) -> Result<Vec<MetadataFileRef>> {
         let rest = std::mem::take(&mut self.rows);
         if !rest.is_empty() {
-            self.write_segment(store, namespace_id, rest).await?;
+            self.write_segment(store, rest).await?;
         }
         Ok(self.segments)
     }
@@ -108,17 +79,11 @@ impl<'a> MergeSegmentWriter<'a> {
     async fn write_segment<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,
-        namespace_id: &NamespaceId,
         rows: Vec<MetadataRow>,
     ) -> Result<()> {
-        let table_id = MetadataTableId::generate();
-        let object_key = self.output.object_key(namespace_id, &table_id);
         let descriptor = write_manifest_segment(
             store,
-            MetadataSstWriteRequest::new(
-                namespace_id,
-                table_id,
-                object_key,
+            self.destination.write_request(
                 self.placement.output_seq(),
                 self.placement.output_level(),
                 self.family,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -42,12 +42,13 @@
 
 use super::block_fetch::{load_segment_filter, segment_object_len};
 use super::block_load::SessionBlockMemo;
+use super::build::MetadataTableDestination;
 use super::cache::{MetadataTableCache, MetadataTableCacheConfig};
 use super::compaction_lease::{CompactionLease, LeaseHold};
 use super::compaction_merge::{
     locality_of, refill_iterators, select_next_iterator, LocalityGrouping, SegmentRowIterator,
 };
-use super::compaction_output::{MergeOutput, MergeSegmentWriter};
+use super::compaction_output::MergeSegmentWriter;
 use super::compaction_retention::{KeptRow, RetentionRule};
 use super::error::ManifestLoadError;
 use super::flush::ensure_metadata_publication_budget;
@@ -331,7 +332,7 @@ pub(super) async fn merge_group_in_step<S: ObjectStore + ?Sized>(
         group,
         placement,
         frozen_floor_seq,
-        MergeOutput::Tables,
+        MetadataTableDestination::Published { namespace_id },
         policy,
         &cancellation,
         runs.to_vec(),
@@ -374,7 +375,10 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
         spec.group,
         spec.placement,
         spec.frozen_floor_seq,
-        MergeOutput::JobPrefix(spec.job_id()),
+        MetadataTableDestination::CompactionStaging {
+            namespace_id,
+            job_id: spec.job_id(),
+        },
         policy,
         cancellation,
         resolve_snapshot_runs(tables, spec)?,
@@ -913,7 +917,7 @@ struct GroupMerge<'a, S: ObjectStore + ?Sized> {
     /// sequence every segment carries and whether rows may be dropped at all.
     placement: MergePlacement,
     frozen_floor_seq: ChangeSeq,
-    output: MergeOutput<'a>,
+    destination: MetadataTableDestination<'a>,
     policy: MetadataLsmPolicy,
     cancellation: &'a MetadataCompactionCancellation,
     snapshot: Vec<MetadataRunManifest>,
@@ -939,7 +943,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         group: MetadataFamilyGroup,
         placement: MergePlacement,
         frozen_floor_seq: ChangeSeq,
-        output: MergeOutput<'a>,
+        destination: MetadataTableDestination<'a>,
         policy: MetadataLsmPolicy,
         cancellation: &'a MetadataCompactionCancellation,
         snapshot: Vec<MetadataRunManifest>,
@@ -957,7 +961,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             group,
             placement,
             frozen_floor_seq,
-            output,
+            destination,
             policy,
             cancellation,
             snapshot,
@@ -1087,7 +1091,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             .map(|family| {
                 (
                     *family,
-                    MergeSegmentWriter::new(*family, self.output, self.placement),
+                    MergeSegmentWriter::new(*family, self.destination, self.placement),
                 )
             })
             .collect();
@@ -1157,7 +1161,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         }
 
         for writer in writers.into_values() {
-            let segments = writer.finish(self.store, self.namespace_id).await?;
+            let segments = writer.finish(self.store).await?;
             self.result.output_bytes = self
                 .result
                 .output_bytes
@@ -1222,9 +1226,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             .get_mut(&family)
             .expect("a cluster writes only the families it merges");
         writer.push(row);
-        writer
-            .roll_full_segments(self.store, self.namespace_id, self.policy)
-            .await
+        writer.roll_full_segments(self.store, self.policy).await
     }
 
     /// Remembers a below-floor unbind for the reverse pass, when the merge is

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -15,11 +15,17 @@ use loonfs_objectstore::{ObjectMetadata, ObjectStore};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PreparedCommitHeadPublish {
+pub struct PreparedControlWrite {
     pub object_key: String,
-    pub resulting_head: HeadState,
-    pub envelope: HeadStateEnvelope,
     pub encoded_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreparedCommitHeadPublish {
+    pub resulting_head: HeadState,
+    /// The physical write is kept together because its key and bytes are the
+    /// only encoded representation the store operation needs.
+    pub write: PreparedControlWrite,
 }
 
 pub fn prepare_commit_head_publish(
@@ -115,10 +121,11 @@ pub fn prepare_commit_head_publish(
         })?;
 
     Ok(PreparedCommitHeadPublish {
-        object_key,
         resulting_head,
-        envelope,
-        encoded_bytes,
+        write: PreparedControlWrite {
+            object_key,
+            encoded_bytes,
+        },
     })
 }
 
@@ -150,12 +157,12 @@ pub async fn publish_commit_head<S: ObjectStore + ?Sized>(
 
     store
         .compare_and_swap(
-            &prepared.object_key,
+            &prepared.write.object_key,
             expected_head_etag,
-            Bytes::copy_from_slice(&prepared.encoded_bytes),
+            Bytes::copy_from_slice(&prepared.write.encoded_bytes),
         )
         .await
-        .map_err(|error| map_object_store_error(&prepared.object_key, error))
+        .map_err(|error| map_object_store_error(&prepared.write.object_key, error))
 }
 
 fn map_object_store_error(object_key: &str, err: ObjectStoreError) -> CommitHeadPublishError {
@@ -301,6 +308,19 @@ mod tests {
         assert_eq!(
             prepared.resulting_head.visible_wal_tip,
             Some(wal.envelope.pointer(wal.object_key.clone()))
+        );
+        assert_eq!(
+            prepared.write.object_key,
+            wal_head(prepared.resulting_head.namespace_id.as_str()),
+        );
+        let expected_envelope = HeadStateEnvelope::from_state(
+            ControlObjectKind::WalHead,
+            prepared.resulting_head.clone(),
+        )
+        .expect("head envelope");
+        assert_eq!(
+            prepared.write.encoded_bytes,
+            encode_control_object(&expected_envelope).expect("encoded head"),
         );
     }
 

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -597,13 +597,19 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         unit: CollectedIndexUnit,
         policy: GramIndexBuildPolicy,
     ) -> Result<GrepBuildReport> {
-        let rows = gram_postings_rows(unit.postings)?;
+        let CollectedIndexUnit {
+            postings,
+            stats,
+            progress,
+        } = unit;
+        let run_seq = progress.run_seq();
+        let rows = gram_postings_rows(postings)?;
         let timer = StdMonotonicTimer::default();
         let publication_started_ms = timer.monotonic_now_ms();
         let new_segments = write_index_segments(
             &self.store,
             namespace_id,
-            unit.run_seq,
+            run_seq,
             current.manifest_state().index().next_run_ordinal,
             rows,
             policy.max_rows_per_segment,
@@ -618,36 +624,63 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         // A finished backfill turns steady at exactly the sequence its
         // checkpoint captured: the walk answered that state and no other, so
         // the watermark it hands the change feed is the target it reached.
-        let (lifecycle, completed_checkpoint_id) = match current.manifest_state().lifecycle() {
-            GrepLifecycle::Backfilling {
+        let (lifecycle, completed_checkpoint_id, built_through_seq) = match progress {
+            CollectedProgress::Backfill {
                 target_seq,
-                checkpoint_id,
-                ..
-            } => match unit.backfill_cursor {
-                Some(after_inode_id) => (
-                    GrepLifecycle::Backfilling {
-                        target_seq: *target_seq,
-                        cursor: Some(after_inode_id),
-                        checkpoint_id: checkpoint_id.clone(),
+                next_cursor,
+            } => {
+                let checkpoint_id = match current.manifest_state().lifecycle() {
+                    GrepLifecycle::Backfilling { checkpoint_id, .. } => checkpoint_id.clone(),
+                    _ => {
+                        return Err(CoreError::Internal(
+                            "a collected grep backfill unit no longer matches its root".to_owned(),
+                        )
+                        .into())
+                    }
+                };
+                match next_cursor {
+                    Some(after_inode_id) => (
+                        GrepLifecycle::Backfilling {
+                            target_seq,
+                            cursor: Some(after_inode_id),
+                            checkpoint_id,
+                        },
+                        None,
+                        target_seq,
+                    ),
+                    None => (
+                        GrepLifecycle::Steady {
+                            built_through_seq: target_seq,
+                            next_event_index: 0,
+                        },
+                        Some(checkpoint_id),
+                        target_seq,
+                    ),
+                }
+            }
+            CollectedProgress::Incremental {
+                run_seq: _,
+                built_through_seq,
+                next_event_index,
+            } => {
+                if !matches!(
+                    current.manifest_state().lifecycle(),
+                    GrepLifecycle::Steady { .. }
+                ) {
+                    return Err(CoreError::Internal(
+                        "a collected incremental grep unit no longer matches its root".to_owned(),
+                    )
+                    .into());
+                }
+                (
+                    GrepLifecycle::Steady {
+                        built_through_seq,
+                        next_event_index,
                     },
                     None,
-                ),
-                None => (
-                    GrepLifecycle::Steady {
-                        built_through_seq: unit.built_through_seq,
-                        next_event_index: unit.next_event_index,
-                    },
-                    Some(checkpoint_id.clone()),
-                ),
-            },
-            GrepLifecycle::Steady { .. } => (
-                GrepLifecycle::Steady {
-                    built_through_seq: unit.built_through_seq,
-                    next_event_index: unit.next_event_index,
-                },
-                None,
-            ),
-            GrepLifecycle::Disabled => unreachable!("disabled returned before collection"),
+                    built_through_seq,
+                )
+            }
         };
         let materialized = matches!(lifecycle, GrepLifecycle::Steady { .. });
         let next = GrepManifestState::new(
@@ -670,9 +703,9 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 Ok(build_report(
                     namespace_id,
                     GrepBuildOutcome::Published {
-                        built_through_seq: unit.built_through_seq,
-                        indexed_revisions: unit.indexed_revisions,
-                        skipped_revisions: unit.skipped_revisions,
+                        built_through_seq,
+                        indexed_revisions: stats.indexed_revisions,
+                        skipped_revisions: stats.skipped_revisions,
                         segments_written,
                         materialized,
                     },
@@ -737,12 +770,38 @@ fn root_names_checkpoint(root: &GrepManifestState, checkpoint_id: &CheckpointId)
 
 struct CollectedIndexUnit {
     postings: BTreeMap<Gram, Vec<GramPosting>>,
+    stats: IndexingStats,
+    progress: CollectedProgress,
+}
+
+#[derive(Default)]
+struct IndexingStats {
     indexed_revisions: u64,
     skipped_revisions: u64,
-    run_seq: ChangeSeq,
-    built_through_seq: ChangeSeq,
-    next_event_index: u32,
-    backfill_cursor: Option<InodeId>,
+}
+
+/// The resume state collected by one worker step. Naming the two modes here
+/// prevents a backfill cursor from ever being paired with change-feed
+/// progress, which used to be possible in the flat unit record.
+enum CollectedProgress {
+    Backfill {
+        target_seq: ChangeSeq,
+        next_cursor: Option<InodeId>,
+    },
+    Incremental {
+        run_seq: ChangeSeq,
+        built_through_seq: ChangeSeq,
+        next_event_index: u32,
+    },
+}
+
+impl CollectedProgress {
+    fn run_seq(&self) -> ChangeSeq {
+        match self {
+            Self::Backfill { target_seq, .. } => *target_seq,
+            Self::Incremental { run_seq, .. } => *run_seq,
+        }
+    }
 }
 
 /// Collects one backfill step from the files the checkpoint pins.
@@ -761,15 +820,9 @@ async fn collect_backfill_unit(
     cursor: Option<InodeId>,
     policy: GramIndexBuildPolicy,
 ) -> Result<Option<CollectedIndexUnit>> {
-    let mut unit = CollectedIndexUnit {
-        postings: BTreeMap::new(),
-        indexed_revisions: 0,
-        skipped_revisions: 0,
-        run_seq: target_seq,
-        built_through_seq: target_seq,
-        next_event_index: 0,
-        backfill_cursor: cursor,
-    };
+    let mut postings = BTreeMap::new();
+    let mut stats = IndexingStats::default();
+    let mut next_cursor = cursor;
     let mut pending = Vec::new();
     let mut planned_content_bytes = 0u64;
     let mut files_remaining = policy.max_files_per_step.get();
@@ -793,7 +846,7 @@ async fn collect_backfill_unit(
         for file in page.files {
             files_remaining = files_remaining.saturating_sub(1);
             if file.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES {
-                unit.skipped_revisions += 1;
+                stats.skipped_revisions += 1;
             } else {
                 planned_content_bytes += file.size_bytes;
                 pending.push(PendingRevisionContent {
@@ -802,7 +855,7 @@ async fn collect_backfill_unit(
                     content_ref: file.content_ref,
                 });
             }
-            unit.backfill_cursor = Some(file.inode_id);
+            next_cursor = Some(file.inode_id);
             if planned_content_bytes >= policy.max_content_bytes_per_step.get() {
                 budget_reached = true;
                 break;
@@ -814,7 +867,7 @@ async fn collect_backfill_unit(
         if page_exhausted_family {
             // Every file the checkpoint pins is indexed; the next published
             // root leaves backfill for the change feed.
-            unit.backfill_cursor = None;
+            next_cursor = None;
             break;
         }
         cursor = page.next_cursor;
@@ -822,8 +875,15 @@ async fn collect_backfill_unit(
             break;
         }
     }
-    load_and_fold_revision_contents(reads, &pending, &mut unit).await?;
-    Ok(Some(unit))
+    load_and_fold_revision_contents(reads, &pending, &mut postings, &mut stats).await?;
+    Ok(Some(CollectedIndexUnit {
+        postings,
+        stats,
+        progress: CollectedProgress::Backfill {
+            target_seq,
+            next_cursor,
+        },
+    }))
 }
 
 /// Collects one incremental step from the semantic change feed.
@@ -842,15 +902,11 @@ async fn collect_incremental_unit(
     if feed.changes.is_empty() {
         return Ok(None);
     }
-    let mut unit = CollectedIndexUnit {
-        postings: BTreeMap::new(),
-        indexed_revisions: 0,
-        skipped_revisions: 0,
-        run_seq: built_through_seq,
-        built_through_seq,
-        next_event_index,
-        backfill_cursor: None,
-    };
+    let mut postings = BTreeMap::new();
+    let mut stats = IndexingStats::default();
+    let mut run_seq = built_through_seq;
+    let mut collected_through_seq = built_through_seq;
+    let mut collected_next_event_index = next_event_index;
     let mut pending = Vec::new();
     let mut planned_content_bytes = 0u64;
     let mut examined_files = 0usize;
@@ -877,9 +933,9 @@ async fn collect_incremental_unit(
                     > policy.max_content_bytes_per_step.get();
             if examined_files >= policy.max_files_per_step.get() || would_exceed_content_budget {
                 if event_index > 0 {
-                    unit.built_through_seq = change.seq;
-                    unit.run_seq = change.seq;
-                    unit.next_event_index = u32::try_from(event_index).map_err(|_| {
+                    collected_through_seq = change.seq;
+                    run_seq = change.seq;
+                    collected_next_event_index = u32::try_from(event_index).map_err(|_| {
                         CoreError::Internal("grep event cursor overflow".to_owned())
                     })?;
                 }
@@ -887,7 +943,7 @@ async fn collect_incremental_unit(
             }
             examined_files += 1;
             if revision.content_ref.size_bytes > INDEX_GRAMS_MAX_FILE_BYTES {
-                unit.skipped_revisions += 1;
+                stats.skipped_revisions += 1;
             } else {
                 planned_content_bytes += revision.content_ref.size_bytes;
                 pending.push(PendingRevisionContent {
@@ -899,30 +955,39 @@ async fn collect_incremental_unit(
             if examined_files >= policy.max_files_per_step.get()
                 || planned_content_bytes >= policy.max_content_bytes_per_step.get()
             {
-                unit.built_through_seq = change.seq;
-                unit.run_seq = change.seq;
+                collected_through_seq = change.seq;
+                run_seq = change.seq;
                 let next_event_index = event_index
                     .checked_add(1)
                     .ok_or_else(|| CoreError::Internal("grep event cursor overflow".to_owned()))?;
                 if next_event_index < change.events.len() {
-                    unit.next_event_index = u32::try_from(next_event_index).map_err(|_| {
+                    collected_next_event_index = u32::try_from(next_event_index).map_err(|_| {
                         CoreError::Internal("grep event cursor overflow".to_owned())
                     })?;
                 } else {
-                    unit.next_event_index = 0;
+                    collected_next_event_index = 0;
                 }
                 break 'changes;
             }
         }
-        unit.built_through_seq = change.seq;
-        unit.run_seq = change.seq;
-        unit.next_event_index = 0;
+        collected_through_seq = change.seq;
+        run_seq = change.seq;
+        collected_next_event_index = 0;
     }
-    if unit.built_through_seq == built_through_seq && unit.next_event_index == next_event_index {
+    if collected_through_seq == built_through_seq && collected_next_event_index == next_event_index
+    {
         return Ok(None);
     }
-    load_and_fold_revision_contents(reads, &pending, &mut unit).await?;
-    Ok(Some(unit))
+    load_and_fold_revision_contents(reads, &pending, &mut postings, &mut stats).await?;
+    Ok(Some(CollectedIndexUnit {
+        postings,
+        stats,
+        progress: CollectedProgress::Incremental {
+            run_seq,
+            built_through_seq: collected_through_seq,
+            next_event_index: collected_next_event_index,
+        },
+    }))
 }
 
 struct PendingRevisionContent {
@@ -934,7 +999,8 @@ struct PendingRevisionContent {
 async fn load_and_fold_revision_contents(
     reads: &NamespaceReads<'_>,
     pending: &[PendingRevisionContent],
-    unit: &mut CollectedIndexUnit,
+    postings: &mut BTreeMap<Gram, Vec<GramPosting>>,
+    stats: &mut IndexingStats,
 ) -> Result<()> {
     for chunk in pending.chunks(MAX_GREP_WORKER_IO) {
         let contents = try_join_all(chunk.iter().map(|revision| {
@@ -945,7 +1011,7 @@ async fn load_and_fold_revision_contents(
         .await?;
         for (revision, content) in chunk.iter().zip(contents) {
             if !is_indexable_text_content(&content) {
-                unit.skipped_revisions += 1;
+                stats.skipped_revisions += 1;
                 continue;
             }
             let posting = GramPosting {
@@ -953,9 +1019,9 @@ async fn load_and_fold_revision_contents(
                 revision_no: revision.revision_no,
             };
             for gram in extract_grams(&content) {
-                unit.postings.entry(gram).or_default().push(posting);
+                postings.entry(gram).or_default().push(posting);
             }
-            unit.indexed_revisions += 1;
+            stats.indexed_revisions += 1;
         }
     }
     Ok(())

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -14,6 +14,13 @@ use thiserror::Error;
 
 pub use loonfs_objectstore::StoreConfig;
 
+/// The only request-authentication decisions exposed to HTTP helpers.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum AuthPolicy<'a> {
+    Unauthenticated,
+    BearerToken(&'a str),
+}
+
 /// Environment fallback for [`ServerConfig::auth_token`].
 const AUTH_TOKEN_ENV: &str = "LOONFS_AUTH_TOKEN";
 /// Environment fallback for [`ServerConfig::content_token_secret`].
@@ -305,44 +312,20 @@ impl GrepMode {
 }
 
 /// The server's `[grep]` table.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GrepConfig {
     pub mode: GrepMode,
-    pub max_files_per_step: usize,
-    pub max_content_bytes_per_step: u64,
-    pub max_rows_per_segment: usize,
-    pub max_l0_runs: usize,
-    pub max_mid_runs: usize,
-    pub max_decoded_input_rows_per_step: usize,
+    /// Flattening preserves the existing `[grep]` keys while leaving the
+    /// worker policy itself as their one in-memory owner.
+    #[serde(flatten)]
+    pub worker: GrepWorkerConfig,
 }
 
 impl GrepConfig {
     /// Returns the shared bounded-step configuration represented by this table.
     pub fn worker_config(self) -> GrepWorkerConfig {
-        GrepWorkerConfig {
-            max_files_per_step: self.max_files_per_step,
-            max_content_bytes_per_step: self.max_content_bytes_per_step,
-            max_rows_per_segment: self.max_rows_per_segment,
-            max_l0_runs: self.max_l0_runs,
-            max_mid_runs: self.max_mid_runs,
-            max_decoded_input_rows_per_step: self.max_decoded_input_rows_per_step,
-        }
-    }
-}
-
-impl Default for GrepConfig {
-    fn default() -> Self {
-        let worker = GrepWorkerConfig::default();
-        Self {
-            mode: GrepMode::default(),
-            max_files_per_step: worker.max_files_per_step,
-            max_content_bytes_per_step: worker.max_content_bytes_per_step,
-            max_rows_per_segment: worker.max_rows_per_segment,
-            max_l0_runs: worker.max_l0_runs,
-            max_mid_runs: worker.max_mid_runs,
-            max_decoded_input_rows_per_step: worker.max_decoded_input_rows_per_step,
-        }
+        self.worker
     }
 }
 
@@ -366,6 +349,13 @@ pub enum ServerConfigError {
 }
 
 impl ServerConfig {
+    pub(crate) fn auth_policy(&self) -> AuthPolicy<'_> {
+        match &self.auth_token {
+            Some(token) => AuthPolicy::BearerToken(token.expose()),
+            None => AuthPolicy::Unauthenticated,
+        }
+    }
+
     pub(crate) fn content_token_secret(&self) -> &str {
         self.content_token_secret.expose()
     }
@@ -1789,6 +1779,7 @@ root = "/tmp/loonfs-server"
         let config = load_server_config(&path).expect("load config");
         assert_eq!(config.grep, super::GrepConfig::default());
         assert_eq!(config.grep.mode, super::GrepMode::ServeAndMaintain);
+        assert_eq!(config.grep.worker, loonfs_grep::GrepWorkerConfig::default());
         assert_eq!(
             config
                 .grep

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -2,7 +2,7 @@
 
 use super::error::ApiResponseError;
 use super::serve::AppState;
-use crate::config::ServerConfig;
+use crate::config::AuthPolicy;
 use axum::extract::rejection::PathRejection;
 use axum::extract::{FromRequest, FromRequestParts, Path as AxumPath, Query};
 use axum::http::request::Parts;
@@ -29,17 +29,18 @@ pub(super) fn server_busy_error(what: &str) -> ApiResponseError {
 }
 
 pub(super) fn authorize(
-    config: &ServerConfig,
+    policy: AuthPolicy<'_>,
     headers: &HeaderMap,
 ) -> Result<(), ApiResponseError> {
-    let Some(expected) = &config.auth_token else {
-        return Ok(());
+    let expected = match policy {
+        AuthPolicy::Unauthenticated => return Ok(()),
+        AuthPolicy::BearerToken(expected) => expected,
     };
     let actual = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .unwrap_or_default();
-    let expected = format!("Bearer {}", expected.expose());
+    let expected = format!("Bearer {expected}");
     if constant_time_eq(actual.as_bytes(), expected.as_bytes()) {
         Ok(())
     } else {
@@ -209,7 +210,7 @@ where
         req: axum::extract::Request,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        authorize(&state.config, req.headers())?;
+        authorize(state.config.auth_policy(), req.headers())?;
         extract_json(req, state, json_body_too_large_error)
             .await
             .map(AppJson)
@@ -331,7 +332,7 @@ impl FromRequest<AppState> for UploadBodyStream {
         req: axum::extract::Request,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        authorize(&state.config, req.headers())?;
+        authorize(state.config.auth_policy(), req.headers())?;
         let permit = state
             .upload_permits
             .clone()
@@ -402,7 +403,7 @@ where
         req: axum::extract::Request,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        authorize(&state.config, req.headers())?;
+        authorize(state.config.auth_policy(), req.headers())?;
         let body = axum::body::to_bytes(req.into_body(), MAX_OPTIONAL_JSON_BODY_BYTES)
             .await
             .map_err(|error| {

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -4,7 +4,7 @@
 
 use super::error::ApiResponseError;
 use super::handlers_uploads::{
-    content_preparation_for_puts, current_unix_ms, PutContentPreparation,
+    content_preparation_for_puts, current_unix_ms, ContentTokenVerifier, PutContentPreparation,
 };
 use super::{authorize, AppJson, AppQuery, AppState, NamespaceIdPath};
 use axum::extract::State;
@@ -102,7 +102,7 @@ pub(super) async fn list_path_entries(
     headers: HeaderMap,
     query: AppQuery<ListPathPageQuery>,
 ) -> Result<Json<loonfs_api::ListPathEntriesResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
     let path = query.path;
@@ -156,7 +156,7 @@ pub(super) async fn stat_path(
     headers: HeaderMap,
     query: AppQuery<PathQuery>,
 ) -> Result<Json<loonfs_api::AuthoritativePathEntry>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
     let path = query.path;
@@ -202,7 +202,7 @@ pub(super) async fn get_file_bytes(
     headers: HeaderMap,
     query: AppQuery<ContentQuery>,
 ) -> Result<Response, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
     // Held for the read below: content reads buffer the whole file, so the
@@ -261,7 +261,7 @@ pub(super) async fn list_trash(
     headers: HeaderMap,
     query: AppQuery<PageQuery>,
 ) -> Result<Json<ListTrashResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
     let response = state
@@ -307,7 +307,7 @@ pub(super) async fn list_file_revisions(
     headers: HeaderMap,
     query: AppQuery<PathPageQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
     let path = query.path;
@@ -384,7 +384,7 @@ pub(super) async fn apply_commit(
             payload_class(usize::try_from(put_bytes).unwrap_or(usize::MAX)),
             content_preparation_for_puts(
                 &state.writer,
-                &state.config,
+                ContentTokenVerifier::new(state.config.content_token_secret()),
                 &namespace_id,
                 &put_content_refs,
                 &content_tokens,
@@ -467,7 +467,7 @@ pub(super) async fn list_changes(
     headers: HeaderMap,
     query: AppQuery<ChangesQuery>,
 ) -> Result<Json<ChangesResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
     let after_seq = loonfs_api::ChangeSeq(query.after_seq);

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -57,7 +57,7 @@ pub(super) async fn capabilities(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<loonfs_api::CapabilityDocument>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let mut capabilities = state.reader.capabilities();
     // Each direct transport is advertised from the issuer that performs it,
     // so a provider that signs whole-object writes but has no multipart API
@@ -212,7 +212,7 @@ pub(super) async fn namespace_status(
     namespace: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<loonfs_api::NamespaceStatusResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let status = state
         .admin
@@ -250,7 +250,7 @@ pub(super) async fn delete_namespace(
     query: AppQuery<DeleteNamespaceQuery>,
     headers: HeaderMap,
 ) -> Result<Json<loonfs_api::DeleteNamespaceResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
     let options = DeleteNamespaceOptions {
@@ -358,7 +358,7 @@ pub(super) async fn list_checkpoints(
     namespace: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<ListCheckpointsResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let response = state
         .admin
@@ -394,7 +394,7 @@ pub(super) async fn release_checkpoint(
     path: AppPath<CheckpointPathParams>,
     headers: HeaderMap,
 ) -> Result<Json<ReleaseCheckpointResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let CheckpointPathParams { checkpoint_id } = path.into_params()?;
     let checkpoint_id = parse_checkpoint_id(&checkpoint_id)?;

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -74,7 +74,7 @@ pub(super) async fn grep_queries_not_served(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     Err(ApiResponseError::not_supported(
         FEATURE_QUERY_GREP,
         "this deployment does not serve grep queries; set `[grep].mode` to `serve_only` \
@@ -88,7 +88,7 @@ pub(super) async fn grep_index_not_maintained(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     Err(ApiResponseError::not_supported(
         FEATURE_ADMIN_GREP_INDEX,
         "this deployment does not maintain the grep index; set `[grep].mode` to \
@@ -121,7 +121,7 @@ pub(super) async fn enable_grep_index(
     namespace: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<EnableGrepIndexResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let outcome = state
         .grep_worker
@@ -180,7 +180,7 @@ pub(super) async fn grep_index_status(
     namespace: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<GrepIndexStatusResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let root = state
         .grep_worker
@@ -232,7 +232,7 @@ pub(super) async fn disable_grep_index(
     namespace: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<DisableGrepIndexResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     // Disabling is one durable compare-and-swap and nothing else. A step
     // already running loses its own publication race to this one and
@@ -293,7 +293,7 @@ pub(super) async fn gc_grep_index(
     headers: HeaderMap,
     AppJson(request): AppJson<GrepGcRequest>,
 ) -> Result<Json<GrepGcResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let report = state
         .grep_worker

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -3,7 +3,6 @@
 
 use super::error::ApiResponseError;
 use super::{authorize, AppJson, AppPath, AppState, NamespaceIdPath, UploadBodyStream};
-use crate::config::ServerConfig;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
@@ -45,6 +44,45 @@ pub(super) enum PutContentPreparation {
     /// Every supplied token was rejected, each paired with the content ref
     /// it was supplied for. Never empty.
     Rejected(Vec<(ContentId, ContentTokenError)>),
+}
+
+/// The deployment material allowed to verify and mint content tokens.
+/// Keeping it separate means upload helpers cannot reach unrelated server
+/// configuration while handling a proof.
+#[derive(Clone, Copy)]
+pub(super) struct ContentTokenVerifier<'a> {
+    secret: &'a str,
+}
+
+impl<'a> ContentTokenVerifier<'a> {
+    pub(super) fn new(secret: &'a str) -> Self {
+        Self { secret }
+    }
+
+    async fn prepare(
+        self,
+        writer: &FsWriter,
+        namespace_id: &NamespaceId,
+        token: &ValidatedContentToken,
+        now_ms: u64,
+    ) -> Result<Result<PreparedContent, ContentTokenError>, ApiResponseError> {
+        writer
+            .prepare_content_token(namespace_id, self.secret, token, now_ms)
+            .await
+            .map_err(|error| ApiResponseError::runtime_for_namespace(namespace_id, error))
+    }
+
+    fn mint_receipt(
+        self,
+        receipt: Option<&CompletedUploadReceipt>,
+    ) -> Result<Option<String>, ApiResponseError> {
+        let Some(receipt) = receipt else {
+            return Ok(None);
+        };
+        let token = mint_content_token(self.secret, receipt, current_unix_ms()?)
+            .map_err(content_token_error)?;
+        Ok(Some(token))
+    }
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -337,7 +375,7 @@ pub(super) fn presign_time() -> SystemTime {
 /// loud even when the request it arrived in went on to publish.
 pub(super) async fn content_preparation_for_puts(
     writer: &FsWriter,
-    config: &ServerConfig,
+    verifier: ContentTokenVerifier<'_>,
     namespace_id: &NamespaceId,
     content_refs: &[&ContentRef],
     tokens: &[ValidatedContentToken],
@@ -351,10 +389,9 @@ pub(super) async fn content_preparation_for_puts(
         .cloned()
         .collect::<Vec<_>>();
     for token in &matching_tokens {
-        match writer
-            .prepare_content_token(namespace_id, config.content_token_secret(), token, now_ms)
-            .await
-            .map_err(|error| ApiResponseError::runtime_for_namespace(namespace_id, error))?
+        match verifier
+            .prepare(writer, namespace_id, token, now_ms)
+            .await?
         {
             Ok(prepared) => prepared_content.push(prepared),
             Err(error) => {
@@ -534,7 +571,9 @@ pub(super) async fn complete_upload(
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     let mut response = completed.response;
-    response.validated_content_token = mint_receipt(&state.config, completed.receipt.as_ref())?;
+    response.validated_content_token =
+        ContentTokenVerifier::new(state.config.content_token_secret())
+            .mint_receipt(completed.receipt.as_ref())?;
     Ok(Json(response))
 }
 
@@ -568,7 +607,7 @@ pub(super) async fn read_upload_status(
     // A completed session answers with a freshly minted content-validation
     // token, which is a capability to commit that content. Authorization
     // runs before the id is even parsed, as everywhere else.
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
@@ -582,7 +621,8 @@ pub(super) async fn read_upload_status(
         ..
     } = &mut response.status
     {
-        *validated_content_token = mint_receipt(&state.config, receipt.as_ref())?;
+        *validated_content_token = ContentTokenVerifier::new(state.config.content_token_secret())
+            .mint_receipt(receipt.as_ref())?;
     }
     Ok(Json(response))
 }
@@ -615,7 +655,7 @@ pub(super) async fn abort_upload(
     namespace: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
 ) -> Result<Json<AbortUploadResponse>, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
@@ -625,23 +665,6 @@ pub(super) async fn abort_upload(
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
-}
-
-/// Signs a receipt the core layer already proved is mintable.
-///
-/// Core decides *whether* a receipt exists — only a durable completed
-/// session inside its receipt window yields one — and the server owns the
-/// secret that signs it, so neither side can mint on its own.
-fn mint_receipt(
-    config: &ServerConfig,
-    receipt: Option<&CompletedUploadReceipt>,
-) -> Result<Option<String>, ApiResponseError> {
-    let Some(receipt) = receipt else {
-        return Ok(None);
-    };
-    let token = mint_content_token(config.content_token_secret(), receipt, current_unix_ms()?)
-        .map_err(content_token_error)?;
-    Ok(Some(token))
 }
 
 fn parse_upload_id(value: &str) -> Result<UploadId, ApiResponseError> {

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -434,7 +434,7 @@ async fn serve_metrics(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Response, ApiResponseError> {
-    authorize(&state.config, &headers)?;
+    authorize(state.config.auth_policy(), &headers)?;
     // Read at scrape time rather than accumulated: these are levels, and a
     // level is only true when it is asked for.
     let rendered = state.metrics.render(


### PR DESCRIPTION
GrepConfig contains GrepWorkerConfig instead of mirroring six fields (flat TOML preserved); grep backfill and incremental progress become one enum so invalid combinations are unrepresentable; the redundant retained head-publish envelope is gone; authorize and content-token preparation take AuthPolicy and ContentTokenVerifier instead of all of ServerConfig; SST writes name a destination and derive their object key instead of accepting an arbitrary path. Layouts and behavior byte-identical.