### PR TITLE
refactor(core): make publish writer ownership mandatory

### DIFF
--- a/crates/loonfs-core/src/commit/mod.rs
+++ b/crates/loonfs-core/src/commit/mod.rs
@@ -33,7 +33,6 @@ pub(crate) use self::publish::PreparedCommitHeadPublish;
 pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
 pub use self::publish_error::CommitHeadPublishError;
 pub(crate) use self::validate::{
-    validate_commit_for_publish, validate_ops, OpValidationCursor, PublishCommitValidationContext,
-    PublishValidationView,
+    validate_commit_for_publish, validate_ops, OpValidationCursor, PublishValidationView,
 };
 pub use self::validate_error::CommitValidationError;

--- a/crates/loonfs-core/src/commit/validate/mod.rs
+++ b/crates/loonfs-core/src/commit/validate/mod.rs
@@ -11,5 +11,5 @@ mod tests;
 mod view;
 
 pub(crate) use checks::{validate_ops, OpValidationCursor};
-pub(crate) use plan_build::{validate_commit_for_publish, PublishCommitValidationContext};
+pub(crate) use plan_build::validate_commit_for_publish;
 pub(crate) use view::PublishValidationView;

--- a/crates/loonfs-core/src/commit/validate/plan_build.rs
+++ b/crates/loonfs-core/src/commit/validate/plan_build.rs
@@ -11,20 +11,14 @@ use loonfs_api::wire::control::HeadState;
 use loonfs_api::ChangeSeq;
 use loonfs_objectstore::ObjectStore;
 
-#[derive(Clone, Copy)]
-pub(crate) struct PublishCommitValidationContext<'a, S: ObjectStore + ?Sized> {
-    pub(crate) head: &'a HeadState,
-    pub(crate) metadata_view: MetadataView<'a, 'a, S>,
-    pub(crate) accepted_rows: &'a MetadataState,
-}
-
 pub(crate) async fn validate_commit_for_publish<S: ObjectStore + ?Sized>(
     request: &CommitIr,
     committed_at_ms: u64,
-    context: &PublishCommitValidationContext<'_, S>,
+    head: &HeadState,
+    metadata_view: MetadataView<'_, '_, S>,
+    accepted_rows: &MetadataState,
 ) -> Result<ValidatedCommitPlan, CoreError> {
-    let committed_seq = context
-        .head
+    let committed_seq = head
         .seq
         .0
         .checked_add(1)
@@ -33,9 +27,9 @@ pub(crate) async fn validate_commit_for_publish<S: ObjectStore + ?Sized>(
     build_commit_plan(
         request,
         committed_at_ms,
-        context.head,
+        head,
         committed_seq,
-        PublishValidationView::new(context.metadata_view, context.accepted_rows, committed_seq),
+        PublishValidationView::new(metadata_view, accepted_rows, committed_seq),
     )
     .await
 }

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -8,7 +8,7 @@
 #![allow(clippy::panic)]
 
 use super::super::{CommitIr, CommitOp, PlannedOp};
-use super::{validate_commit_for_publish, PublishCommitValidationContext};
+use super::validate_commit_for_publish;
 use crate::commit::{
     materialize_commit, CommitFingerprint, CommitPlan, CommitValidationError, InodeAllocator,
 };
@@ -225,15 +225,9 @@ async fn build_commit_plan(
     let result = validate_commit_for_publish(
         request,
         committed_at_ms,
-        &PublishCommitValidationContext {
-            head: &context.head,
-            metadata_view: InMemoryMetadataView::in_memory(
-                context.metadata_state,
-                None,
-                context.head.seq,
-            ),
-            accepted_rows: &accepted_rows,
-        },
+        &context.head,
+        InMemoryMetadataView::in_memory(context.metadata_state, None, context.head.seq),
+        &accepted_rows,
     )
     .await;
 

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -405,7 +405,7 @@ impl NamespaceCommitEngine {
             store,
             self.table_cache.as_deref(),
             &self.namespace_id,
-            Some(acquired_writer),
+            acquired_writer,
             self.publish_tail_projection.as_ref(),
             tail_options,
         )

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -186,6 +186,16 @@ pub(crate) struct LoadedMetadataView<'a, S: ObjectStore + ?Sized> {
 }
 
 impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
+    #[cfg(test)]
+    pub(crate) fn head(&self) -> &HeadState {
+        &self.head
+    }
+
+    #[cfg(test)]
+    pub(crate) fn projected_metadata_view(&self) -> MetadataView<'_, '_, S> {
+        self.metadata_view()
+    }
+
     async fn load_at_head(
         store: &'a S,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -191,13 +191,13 @@ mod tests {
     use super::*;
     use crate::commit::{
         validate_commit_for_publish, CandidateAllocation, CommitIr, CommitOp,
-        CommitValidationError, InodeAllocator, PublishCommitValidationContext, ValidatedCommitPlan,
+        CommitValidationError, InodeAllocator, ValidatedCommitPlan,
     };
     use crate::commit_engine::{publish_namespace_commits_batch, CommitCandidate};
     use crate::context::MutationContext;
     use crate::namespace::bootstrap::bootstrap_namespace;
+    use crate::path::read::{load_metadata_view, ReadLoadContext};
     use crate::path::write::ops::{delete_path, put_file_bytes};
-    use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
     use crate::storage::content::store_bytes_as_content;
     use loonfs_api::{
         AbsolutePath, CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeId,
@@ -310,23 +310,16 @@ mod tests {
         namespace_id: &NamespaceId,
         request: &CommitRequest,
     ) -> Result<TestPlannedCommit> {
-        let (view, _projection) = load_publish_metadata_view(
-            store,
-            None,
-            namespace_id,
-            None,
-            None,
-            &PublishTailOptions::default(),
-        )
-        .await
-        .expect("publish view");
+        let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+            .await
+            .expect("metadata view");
         let empty_overlay = MetadataState::default();
         let allocator = InodeAllocator::new(view.head().next_inode_id);
         let mut allocation = allocator.begin_candidate();
         let commit = plan_commit_against_publish_view(
             request,
             view.head(),
-            view.metadata_view(),
+            view.projected_metadata_view(),
             &empty_overlay,
             1,
             &mut allocation,
@@ -351,15 +344,7 @@ mod tests {
         commit_id: &str,
         planned: TestPlannedCommit,
     ) -> Result<ValidatedCommitPlan> {
-        let (view, _projection) = load_publish_metadata_view(
-            store,
-            None,
-            namespace_id,
-            None,
-            None,
-            &PublishTailOptions::default(),
-        )
-        .await?;
+        let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest()).await?;
         let empty_overlay = MetadataState::default();
         validate_commit_for_publish(
             &CommitIr {
@@ -370,11 +355,9 @@ mod tests {
                 message: None,
             },
             1,
-            &PublishCommitValidationContext {
-                head: view.head(),
-                metadata_view: view.metadata_view(),
-                accepted_rows: &empty_overlay,
-            },
+            view.head(),
+            view.projected_metadata_view(),
+            &empty_overlay,
         )
         .await
     }
@@ -437,18 +420,11 @@ mod tests {
         .await
         .expect("put file");
 
-        let (view, _projection) = load_publish_metadata_view(
-            &store,
-            None,
-            &namespace_id,
-            None,
-            None,
-            &PublishTailOptions::default(),
-        )
-        .await
-        .expect("publish view");
+        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+            .await
+            .expect("metadata view");
         let resolved = view
-            .metadata_view()
+            .projected_metadata_view()
             .resolve_visible_path(&AbsolutePath::parse("/docs/nested/a.txt").expect("path"))
             .await
             .expect("resolve created file");

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -3,7 +3,10 @@
 
 use super::intent::CommitRequest;
 use super::planner::{plan_commit_against_publish_view, PlannedCommit};
-use crate::commit::{CandidateAllocation, CommitPlan, InodeAllocator};
+use crate::commit::{
+    validate_commit_for_publish, CandidateAllocation, CommitIr, CommitPlan, InodeAllocator,
+    ValidatedCommitPlan,
+};
 use crate::error::Result;
 use crate::metadata::{DurableVisibilityCache, MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
@@ -41,14 +44,7 @@ impl PublishPlanningSession {
         }
     }
 
-    pub(crate) fn head(&self) -> &HeadState {
-        &self.head
-    }
-
-    pub(crate) fn accepted_rows(&self) -> &MetadataState {
-        &self.accepted_rows
-    }
-
+    #[cfg(test)]
     pub(crate) fn durable_cache(&self) -> &DurableVisibilityCache {
         &self.durable_cache
     }
@@ -80,6 +76,22 @@ impl PublishPlanningSession {
         .await
     }
 
+    pub(crate) async fn validate_commit<S: ObjectStore + ?Sized>(
+        &self,
+        request: &CommitIr,
+        base_view: MetadataView<'_, '_, S>,
+        committed_at_ms: u64,
+    ) -> Result<ValidatedCommitPlan> {
+        validate_commit_for_publish(
+            request,
+            committed_at_ms,
+            &self.head,
+            base_view.with_durable_cache(&self.durable_cache),
+            &self.accepted_rows,
+        )
+        .await
+    }
+
     /// Commits the candidate-local allocator fork and returns the new
     /// authoritative batch position.
     pub(crate) fn commit_candidate(
@@ -107,7 +119,7 @@ mod tests {
     use crate::error::{CoreError, ErrorCode};
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::namespace::control::load_namespace_head_control;
-    use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
+    use crate::path::read::{load_metadata_view, ReadLoadContext};
     use crate::storage::content::store_bytes_as_content;
     use crate::storage::content_admission::{ContentAdmission, PreparedContent};
     use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeId};
@@ -234,16 +246,9 @@ mod tests {
         .remove(0)
         .expect("seed publish");
 
-        let (view, _projection) = load_publish_metadata_view(
-            &store,
-            None,
-            &namespace_id,
-            None,
-            None,
-            &PublishTailOptions::default(),
-        )
-        .await
-        .expect("load publish view");
+        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+            .await
+            .expect("load metadata view");
         let session = PublishPlanningSession::new(view.head());
 
         let first_request = CommitRequest::single(
@@ -260,7 +265,7 @@ mod tests {
         session
             .plan_commit(
                 &first_request,
-                view.metadata_view(),
+                view.projected_metadata_view(),
                 1,
                 &mut first_allocation,
             )
@@ -283,7 +288,7 @@ mod tests {
         session
             .plan_commit(
                 &second_request,
-                view.metadata_view(),
+                view.projected_metadata_view(),
                 1,
                 &mut second_allocation,
             )

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -8,8 +8,8 @@ use super::candidates::{
 use super::publish_view::PublishMetadataView;
 use crate::commit::{
     materialize_commit, prepare_commit_head_publish, publish_commit_head,
-    validate_commit_for_publish, wal_payload_from_materialized_commit, CommitHeadPublishError,
-    MaterializedCommit, PreparedCommitHeadPublish, PublishCommitValidationContext,
+    wal_payload_from_materialized_commit, CommitHeadPublishError, MaterializedCommit,
+    PreparedCommitHeadPublish,
 };
 use crate::commit_engine::CommitCandidate;
 use crate::context::MutationContext;
@@ -129,13 +129,6 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                     continue;
                 }
             };
-            let validation = PublishCommitValidationContext {
-                head: session.head(),
-                metadata_view: view
-                    .metadata_view()
-                    .with_durable_cache(session.durable_cache()),
-                accepted_rows: session.accepted_rows(),
-            };
             let request = candidate_request.request;
             let semantic_identity = candidate_request.semantic_identity;
             let allocation = candidate_request.allocation;
@@ -148,7 +141,8 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             }
             let validated = {
                 let span = tracing::debug_span!("loonfs.phase", phase = "validate_commit");
-                match validate_commit_for_publish(&request, context.now_ms, &validation)
+                match session
+                    .validate_commit(&request, view.metadata_view(), context.now_ms)
                     .instrument(span)
                     .await
                 {
@@ -314,10 +308,7 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
     let result = async {
         let wal = prepare_wal_segment(
             namespace_id.clone(),
-            view.acquired_writer
-                .as_ref()
-                .expect("publish view should carry acquired writer")
-                .writer_epoch,
+            view.acquired_writer.writer_epoch,
             view.head.visible_wal_tip.clone(),
             records,
         )

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -133,10 +133,6 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
     committed_at_ms: u64,
     dedup: &mut BatchDedup,
 ) -> Result<CandidateAdmission> {
-    let acquired_writer = view
-        .acquired_writer
-        .as_ref()
-        .expect("publish view should carry acquired writer");
     let mutation = candidate.request();
     let semantic_identity = candidate.semantic_identity(namespace_id)?;
     if let Some(admission) = resolve_commit_id_reuse(
@@ -172,7 +168,7 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
         request: CoreCommitRequest {
             namespace_id: namespace_id.clone(),
             commit_id: mutation.commit_id.clone(),
-            writer_epoch: acquired_writer.writer_epoch,
+            writer_epoch: view.acquired_writer.writer_epoch,
             ops: planned.ops,
             message: mutation.message.clone(),
         },

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -21,17 +21,12 @@ pub(crate) struct PublishMetadataView<'a, S: ObjectStore + ?Sized> {
     content_store_id: ContentStoreId,
     pub(super) head: HeadState,
     pub(super) head_etag: String,
-    pub(super) acquired_writer: Option<AcquiredWriter>,
+    pub(super) acquired_writer: AcquiredWriter,
     manifest_tables: VerifiedMetadataTables<'a, S>,
     tail_state: MetadataState,
 }
 
 impl<S: ObjectStore + ?Sized> PublishMetadataView<'_, S> {
-    #[cfg(test)]
-    pub(crate) fn head(&self) -> &HeadState {
-        &self.head
-    }
-
     pub(crate) fn metadata_view(&self) -> MetadataView<'_, '_, S> {
         MetadataView::from_loaded_head(&self.head, &self.manifest_tables, &self.tail_state)
     }
@@ -126,7 +121,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     table_cache: Option<&'a MetadataTableCache>,
     namespace_id: &NamespaceId,
-    acquired_writer: Option<AcquiredWriter>,
+    acquired_writer: AcquiredWriter,
     cached_projection: Option<&PublishTailProjection>,
     options: &PublishTailOptions,
 ) -> Result<(PublishMetadataView<'a, S>, PublishTailProjection)> {
@@ -144,9 +139,7 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
             },
         ));
     }
-    if let Some(acquired_writer) = &acquired_writer {
-        ensure_publish_head_matches_acquired_writer(&head, acquired_writer)?;
-    }
+    ensure_publish_head_matches_acquired_writer(&head, &acquired_writer)?;
     let catalog_entry = VerifiedNamespaceCatalogEntry::from_head(&head);
     let basis = load_basis_metadata_tables(store, table_cache, namespace_id, &loaded.basis).await?;
     let manifest_tables = basis.tables;
@@ -179,13 +172,8 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     };
 
     let tail_state = projection.tail_state.clone();
-    ensure_publish_head_etag_still_current(
-        store,
-        namespace_id,
-        &head_etag,
-        acquired_writer.as_ref(),
-    )
-    .await?;
+    ensure_publish_head_etag_still_current(store, namespace_id, &head_etag, &acquired_writer)
+        .await?;
 
     Ok((
         PublishMetadataView {
@@ -298,7 +286,7 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     loaded_head_etag: &str,
-    acquired_writer: Option<&AcquiredWriter>,
+    acquired_writer: &AcquiredWriter,
 ) -> Result<()> {
     let object_key = wal_head(namespace_id.as_str());
     let metadata = store
@@ -326,15 +314,13 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
         })
     })?;
     if current_head_etag != loaded_head_etag {
-        if let Some(acquired_writer) = acquired_writer {
-            let moved_head = read_head_object(store, namespace_id)
-                .await
-                .map_err(|error| {
-                    CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
-                })?
-                .state;
-            ensure_publish_head_matches_acquired_writer(&moved_head, acquired_writer)?;
-        }
+        let moved_head = read_head_object(store, namespace_id)
+            .await
+            .map_err(|error| {
+                CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
+            })?
+            .state;
+        ensure_publish_head_matches_acquired_writer(&moved_head, acquired_writer)?;
         return Err(CoreError::MetadataProjection(
             MetadataProjectionLoadError::HeadChangedDuringLoad {
                 object_key,


### PR DESCRIPTION
Publication now requires an acquired writer when it loads and carries publish metadata. The type records that requirement directly, so WAL construction and stale-head checks can use the writer without an optional field or a runtime assertion. Read-only metadata loading remains available without writer ownership.

The publish planning session now validates each candidate using the head, metadata cache, and accepted rows it already owns. This removes the temporary validation context that copied those references for every candidate. Publication behavior is unchanged, including writer fencing, stale-head detection, same-batch visibility, retries, and WAL output.