### PR TITLE
refactor(core): one authoritative identity for cached publish projections

### DIFF
--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -18,7 +18,7 @@ use super::scan::{ordered_manifest_tables, VerifiedMetadataTables};
 use super::validate::{validate_manifest_materialization_ranges, validate_namespace_manifest};
 use crate::error::{CoreError, MetadataProjectionLoadError};
 use crate::metadata::MetadataState;
-use crate::namespace::basis::{genesis_next_inode_id, MetadataBasis};
+use crate::namespace::basis::{genesis_next_inode_id, MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::bootstrap::bootstrap_metadata_state;
 use loonfs_api::wire::control::{genesis_commit_id, HeadState, MetadataRootState};
 use loonfs_api::wire::manifest::{
@@ -92,9 +92,10 @@ pub(super) fn genesis_basis_manifest(namespace_id: &NamespaceId) -> NamespaceMan
     }
 }
 
-/// The materialized tables a basis resolves to, plus the in-memory rows the
-/// WAL tail replays over.
-pub(crate) struct BasisMetadataTables<'a, S: ObjectStore + ?Sized> {
+/// One verified basis load: its semantic identity, materialized tables, and
+/// the in-memory rows the WAL tail replays over.
+pub(crate) struct LoadedMetadataBasis<'a, S: ObjectStore + ?Sized> {
+    pub(crate) identity: MetadataBasisIdentity,
     pub(crate) tables: VerifiedMetadataTables<'a, S>,
     /// Rows the basis contributes outside any SST: the genesis root inode,
     /// and nothing at all once a manifest exists.
@@ -113,13 +114,16 @@ pub(crate) async fn load_basis_metadata_tables<'a, S: ObjectStore + ?Sized>(
     table_cache: Option<&'a MetadataTableCache>,
     namespace_id: &NamespaceId,
     basis: &MetadataBasis,
-) -> crate::error::Result<BasisMetadataTables<'a, S>> {
+) -> crate::error::Result<LoadedMetadataBasis<'a, S>> {
     let Some(manifest) = basis.manifest() else {
-        return Ok(BasisMetadataTables {
-            tables: VerifiedMetadataTables::synthesized(
-                store,
-                genesis_basis_manifest(namespace_id),
+        let tables =
+            VerifiedMetadataTables::synthesized(store, genesis_basis_manifest(namespace_id));
+        return Ok(LoadedMetadataBasis {
+            identity: MetadataBasisIdentity::from_verified_basis(
+                basis.clone(),
+                tables.manifest().payload.head_seq,
             ),
+            tables,
             base_state: bootstrap_metadata_state(),
         });
     };
@@ -143,7 +147,9 @@ pub(crate) async fn load_basis_metadata_tables<'a, S: ObjectStore + ?Sized>(
             tables.manifest().payload_checksum,
         )));
     }
-    Ok(BasisMetadataTables {
+    let manifest_head_seq = tables.manifest().payload.head_seq;
+    Ok(LoadedMetadataBasis {
+        identity: MetadataBasisIdentity::from_verified_basis(basis.clone(), manifest_head_seq),
         tables,
         base_state: MetadataState::default(),
     })

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -78,6 +78,7 @@ pub(crate) use self::list::list_checkpoints;
 pub(crate) use self::load::{
     head_from_manifest, load_basis_metadata_tables, load_namespace_manifest_envelope,
     load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,
+    LoadedMetadataBasis,
 };
 pub(crate) use self::record::read_checkpoint_record;
 pub(crate) use self::release::release_checkpoint;

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -19,9 +19,7 @@ use crate::storage::content_admission::{ContentAdmission, ContentTokenError, Pre
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_api::v0::CommitResponse as ApiCommitResponse;
 use loonfs_api::wire::control::{AcquiredWriter, HeadState};
-use loonfs_api::{
-    ChangeSeq, CommitId, ContentId, DeleteNamespaceResponse, ManifestId, NamespaceId,
-};
+use loonfs_api::{ChangeSeq, CommitId, ContentId, DeleteNamespaceResponse, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -220,7 +218,6 @@ pub struct ResultingReadState {
     /// Metadata basis used for replay. The published head still references this
     /// basis, so a seeded read cache matches the next store-backed read.
     pub basis: MetadataBasis,
-    pub manifest_id: ManifestId,
     pub manifest_head_seq: ChangeSeq,
     pub tail_rows: Arc<MetadataState>,
 }
@@ -462,13 +459,12 @@ impl NamespaceCommitEngine {
         // Seedable only when the CAS landed unambiguously and the updated
         // projection survived (it carries the post-publish tail and etag).
         let resulting_read_state = match (resulting_head, self.publish_tail_projection.as_ref()) {
-            (Some(head), Some(projection)) if projection.head_seq == head.seq => {
+            (Some(head), Some(projection)) if projection.head_seq() == head.seq => {
                 Some(ResultingReadState {
                     head,
-                    head_etag: projection.head_etag.clone(),
-                    basis: projection.basis.clone(),
-                    manifest_id: projection.manifest_id,
-                    manifest_head_seq: projection.manifest_head_seq,
+                    head_etag: projection.head_etag().to_owned(),
+                    basis: projection.basis().clone(),
+                    manifest_head_seq: projection.manifest_head_seq(),
                     tail_rows: Arc::new(projection.tail_state.clone()),
                 })
             }
@@ -524,8 +520,7 @@ impl NamespaceCommitEngine {
                 for record in &records {
                     projection.tail_state.apply_committed_wal_record_mut(record);
                 }
-                projection.head_seq = head.seq;
-                projection.head_etag = head_etag;
+                projection.reanchor(head.seq, head_etag);
                 if projection.within_limits(tail_options) {
                     self.publish_tail_projection = Some(projection);
                 } else {

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -48,6 +48,37 @@ pub struct BasisManifest {
     pub manifest_payload_checksum: String,
 }
 
+/// The semantic identity of a metadata basis after its manifest has been
+/// loaded and verified.
+///
+/// The resolved [`MetadataBasis`] owns the manifest object identity, owner,
+/// logical position, and the checksum that authorized the load. The verified
+/// manifest contributes its head sequence. Keeping these coordinates together
+/// gives projection caches one value to compare without duplicating manifest
+/// fields beside it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MetadataBasisIdentity {
+    basis: MetadataBasis,
+    manifest_head_seq: ChangeSeq,
+}
+
+impl MetadataBasisIdentity {
+    pub(crate) fn from_verified_basis(basis: MetadataBasis, manifest_head_seq: ChangeSeq) -> Self {
+        Self {
+            basis,
+            manifest_head_seq,
+        }
+    }
+
+    pub(crate) fn basis(&self) -> &MetadataBasis {
+        &self.basis
+    }
+
+    pub(crate) fn manifest_head_seq(&self) -> ChangeSeq {
+        self.manifest_head_seq
+    }
+}
+
 impl MetadataBasis {
     pub fn manifest(&self) -> Option<&BasisManifest> {
         match self {

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -3,17 +3,19 @@
 //! publishers.
 
 use crate::checkpoint::VerifiedMetadataTables;
-use crate::checkpoint::{head_from_manifest, load_basis_metadata_tables, MetadataTableCache};
+use crate::checkpoint::{
+    head_from_manifest, load_basis_metadata_tables, LoadedMetadataBasis, MetadataTableCache,
+};
 use crate::control_object::ControlObjectLoadError;
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result, StoreFailureClass};
 use crate::metadata::{CommitReceiptRecord, MetadataState, MetadataView};
-use crate::namespace::basis::{read_head_and_metadata_basis, MetadataBasis};
+use crate::namespace::basis::{read_head_and_metadata_basis, MetadataBasis, MetadataBasisIdentity};
 use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::control::read_head_object;
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState};
-use loonfs_api::{ChangeSeq, CommitId, ContentStoreId, ManifestId, NamespaceId};
+use loonfs_api::{ChangeSeq, CommitId, ContentStoreId, NamespaceId};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::ObjectStore;
 
@@ -71,36 +73,28 @@ pub struct PublishTailWeight {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct HeadAnchor {
+    seq: ChangeSeq,
+    etag: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PublishProjectionKey {
+    namespace_id: NamespaceId,
+    head: HeadAnchor,
+    basis: MetadataBasisIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PublishTailProjection {
-    pub(crate) namespace_id: NamespaceId,
-    pub(crate) head_etag: String,
-    pub(crate) head_seq: ChangeSeq,
-    /// The basis this projection replayed over, so a caller seeding a read
-    /// anchor from a landed publish pins the same one.
-    pub(crate) basis: MetadataBasis,
-    pub(crate) manifest_id: ManifestId,
-    pub(crate) manifest_head_seq: ChangeSeq,
-    pub(crate) manifest_payload_checksum: String,
+    key: PublishProjectionKey,
     pub(crate) wal_tail_segments: u64,
     pub(crate) tail_state: MetadataState,
 }
 
 impl PublishTailProjection {
-    fn matches(
-        &self,
-        namespace_id: &NamespaceId,
-        head: &HeadState,
-        head_etag: &str,
-        manifest_id: ManifestId,
-        manifest_head_seq: ChangeSeq,
-        manifest_payload_checksum: &str,
-    ) -> bool {
-        self.namespace_id == *namespace_id
-            && self.head_etag == head_etag
-            && self.head_seq == head.seq
-            && self.manifest_id == manifest_id
-            && self.manifest_head_seq == manifest_head_seq
-            && self.manifest_payload_checksum == manifest_payload_checksum
+    fn is_reusable_for(&self, key: &PublishProjectionKey, options: &PublishTailOptions) -> bool {
+        self.key == *key && self.within_limits(options)
     }
 
     pub(crate) fn weight(&self) -> PublishTailWeight {
@@ -114,6 +108,26 @@ impl PublishTailProjection {
         let weight = self.weight();
         weight.rows <= options.max_tail_rows
             && weight.decoded_bytes <= options.max_tail_decoded_bytes
+    }
+
+    pub(crate) fn head_seq(&self) -> ChangeSeq {
+        self.key.head.seq
+    }
+
+    pub(crate) fn head_etag(&self) -> &str {
+        &self.key.head.etag
+    }
+
+    pub(crate) fn basis(&self) -> &MetadataBasis {
+        self.key.basis.basis()
+    }
+
+    pub(crate) fn manifest_head_seq(&self) -> ChangeSeq {
+        self.key.basis.manifest_head_seq()
+    }
+
+    pub(crate) fn reanchor(&mut self, seq: ChangeSeq, etag: String) {
+        self.key.head = HeadAnchor { seq, etag };
     }
 }
 
@@ -141,36 +155,25 @@ pub(crate) async fn load_publish_metadata_view<'a, S: ObjectStore + ?Sized>(
     }
     ensure_publish_head_matches_acquired_writer(&head, &acquired_writer)?;
     let catalog_entry = VerifiedNamespaceCatalogEntry::from_head(&head);
-    let basis = load_basis_metadata_tables(store, table_cache, namespace_id, &loaded.basis).await?;
-    let manifest_tables = basis.tables;
-    let manifest_id = loaded.basis.manifest_id();
-    let manifest_head = head_from_manifest(&head, manifest_tables.manifest());
-    let manifest_payload_checksum = manifest_tables.manifest().payload_checksum.clone();
-    let projection = if let Some(cached) = cached_projection.filter(|cached| {
-        cached.matches(
-            namespace_id,
-            &head,
-            &head_etag,
-            manifest_id,
-            manifest_head.seq,
-            &manifest_payload_checksum,
-        ) && cached.within_limits(options)
-    }) {
+    let loaded_basis =
+        load_basis_metadata_tables(store, table_cache, namespace_id, &loaded.basis).await?;
+    let key = PublishProjectionKey {
+        namespace_id: namespace_id.clone(),
+        head: HeadAnchor {
+            seq: head.seq,
+            etag: head_etag.clone(),
+        },
+        basis: loaded_basis.identity.clone(),
+    };
+    let projection = if let Some(cached) =
+        cached_projection.filter(|cached| cached.is_reusable_for(&key, options))
+    {
         cached.clone()
     } else {
-        load_publish_tail_projection(
-            store,
-            namespace_id,
-            &head,
-            &head_etag,
-            loaded.basis.clone(),
-            &manifest_head,
-            &basis.base_state,
-            manifest_payload_checksum,
-        )
-        .await?
+        load_publish_tail_projection(store, &head, key, &loaded_basis).await?
     };
 
+    let manifest_tables = loaded_basis.tables;
     let tail_state = projection.tail_state.clone();
     ensure_publish_head_etag_still_current(store, namespace_id, &head_etag, &acquired_writer)
         .await?;
@@ -203,21 +206,17 @@ fn ensure_publish_head_matches_acquired_writer(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     store: &S,
-    namespace_id: &NamespaceId,
     head: &HeadState,
-    head_etag: &str,
-    basis: MetadataBasis,
-    manifest_head: &HeadState,
-    base_state: &MetadataState,
-    manifest_payload_checksum: String,
+    key: PublishProjectionKey,
+    loaded_basis: &LoadedMetadataBasis<'_, S>,
 ) -> Result<PublishTailProjection> {
+    let manifest_head = head_from_manifest(head, loaded_basis.tables.manifest());
     let wal_chain = load_validated_wal_chain(
         store,
         WalChainLoadRequest {
-            namespace_id,
+            namespace_id: &key.namespace_id,
             chain_base_seq: manifest_head.seq,
             head_seq: head.seq,
             visible_tip: head.visible_wal_tip.clone(),
@@ -230,8 +229,8 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
         CoreError::MetadataProjection(MetadataProjectionLoadError::WalChainLoad(error))
     })?;
     let replayed = project_validated_wal_tail(
-        manifest_head,
-        base_state,
+        &manifest_head,
+        &loaded_basis.base_state,
         Some(head.writer_epoch),
         &wal_chain,
     )
@@ -241,13 +240,7 @@ async fn load_publish_tail_projection<S: ObjectStore + ?Sized>(
     ensure_publish_reconstructed_head_matches(head, &replayed.resulting_head)?;
     let wal_tail_segments = u64::try_from(wal_chain.segments().len()).unwrap_or(u64::MAX);
     let projection = PublishTailProjection {
-        namespace_id: namespace_id.clone(),
-        head_etag: head_etag.to_owned(),
-        head_seq: head.seq,
-        manifest_id: basis.manifest_id(),
-        basis,
-        manifest_head_seq: manifest_head.seq,
-        manifest_payload_checksum,
+        key,
         wal_tail_segments,
         tail_state: replayed.resulting_metadata_state,
     };
@@ -330,4 +323,221 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::namespace::basis::BasisManifest;
+    use crate::namespace::bootstrap::bootstrap_metadata_state;
+    use loonfs_api::ManifestObjectId;
+
+    fn namespace_id(value: &str) -> NamespaceId {
+        NamespaceId::parse(value).expect("valid namespace id")
+    }
+
+    fn manifest_basis(
+        owner: &str,
+        manifest_id: u64,
+        object_nonce: &str,
+        checksum: &str,
+    ) -> MetadataBasis {
+        MetadataBasis::Manifest(BasisManifest {
+            owner_namespace_id: namespace_id(owner),
+            manifest_id: loonfs_api::ManifestId(manifest_id),
+            manifest_object_id: ManifestObjectId::parse(format!(
+                "{manifest_id:020}-{object_nonce}"
+            ))
+            .expect("valid manifest object id"),
+            manifest_payload_checksum: checksum.to_owned(),
+        })
+    }
+
+    fn projection_key(
+        namespace: &str,
+        head_seq: u64,
+        head_etag: &str,
+        basis: MetadataBasis,
+        manifest_head_seq: u64,
+    ) -> PublishProjectionKey {
+        PublishProjectionKey {
+            namespace_id: namespace_id(namespace),
+            head: HeadAnchor {
+                seq: ChangeSeq(head_seq),
+                etag: head_etag.to_owned(),
+            },
+            basis: MetadataBasisIdentity::from_verified_basis(basis, ChangeSeq(manifest_head_seq)),
+        }
+    }
+
+    fn projection(key: PublishProjectionKey) -> PublishTailProjection {
+        PublishTailProjection {
+            key,
+            wal_tail_segments: 3,
+            tail_state: bootstrap_metadata_state(),
+        }
+    }
+
+    fn roomy_options() -> PublishTailOptions {
+        PublishTailOptions {
+            max_tail_rows: usize::MAX,
+            max_tail_decoded_bytes: usize::MAX,
+        }
+    }
+
+    #[test]
+    fn cached_projection_misses_on_every_authoritative_key_component() {
+        let key = projection_key(
+            "fork-target",
+            9,
+            "head-etag-a",
+            manifest_basis("fork-source", 4, "0123456789abcdef", "sha256:basis-a"),
+            7,
+        );
+        let projection = projection(key.clone());
+        let options = roomy_options();
+        assert!(projection.is_reusable_for(&key, &options));
+
+        let changed_keys = [
+            (
+                "namespace id",
+                projection_key(
+                    "other-target",
+                    9,
+                    "head-etag-a",
+                    manifest_basis("fork-source", 4, "0123456789abcdef", "sha256:basis-a"),
+                    7,
+                ),
+            ),
+            (
+                "head sequence",
+                projection_key(
+                    "fork-target",
+                    10,
+                    "head-etag-a",
+                    manifest_basis("fork-source", 4, "0123456789abcdef", "sha256:basis-a"),
+                    7,
+                ),
+            ),
+            (
+                "head etag",
+                projection_key(
+                    "fork-target",
+                    9,
+                    "head-etag-b",
+                    manifest_basis("fork-source", 4, "0123456789abcdef", "sha256:basis-a"),
+                    7,
+                ),
+            ),
+            (
+                "basis kind",
+                projection_key("fork-target", 9, "head-etag-a", MetadataBasis::Genesis, 0),
+            ),
+            (
+                "basis owner namespace",
+                projection_key(
+                    "fork-target",
+                    9,
+                    "head-etag-a",
+                    manifest_basis("other-source", 4, "0123456789abcdef", "sha256:basis-a"),
+                    7,
+                ),
+            ),
+            (
+                "manifest logical identity",
+                projection_key(
+                    "fork-target",
+                    9,
+                    "head-etag-a",
+                    manifest_basis("fork-source", 5, "0123456789abcdef", "sha256:basis-a"),
+                    7,
+                ),
+            ),
+            (
+                "manifest object identity",
+                projection_key(
+                    "fork-target",
+                    9,
+                    "head-etag-a",
+                    manifest_basis("fork-source", 4, "fedcba9876543210", "sha256:basis-a"),
+                    7,
+                ),
+            ),
+            (
+                "manifest checksum",
+                projection_key(
+                    "fork-target",
+                    9,
+                    "head-etag-a",
+                    manifest_basis("fork-source", 4, "0123456789abcdef", "sha256:basis-b"),
+                    7,
+                ),
+            ),
+            (
+                "verified manifest head sequence",
+                projection_key(
+                    "fork-target",
+                    9,
+                    "head-etag-a",
+                    manifest_basis("fork-source", 4, "0123456789abcdef", "sha256:basis-a"),
+                    8,
+                ),
+            ),
+        ];
+
+        for (component, changed_key) in changed_keys {
+            assert!(
+                !projection.is_reusable_for(&changed_key, &options),
+                "changing {component} must miss the cached projection"
+            );
+        }
+    }
+
+    #[test]
+    fn cached_projection_hits_when_only_derived_payload_values_are_observed() {
+        let key = projection_key(
+            "fork-target",
+            9,
+            "head-etag-a",
+            manifest_basis("fork-source", 4, "0123456789abcdef", "sha256:basis-a"),
+            7,
+        );
+        let mut projection = projection(key.clone());
+
+        // Manifest position is derived from the cohesive basis identity, and
+        // the measured tail count remains cached payload rather than becoming
+        // a second lookup coordinate.
+        assert_eq!(projection.basis().manifest_id(), loonfs_api::ManifestId(4));
+        assert_eq!(projection.manifest_head_seq(), ChangeSeq(7));
+        projection.wal_tail_segments += 1;
+        assert!(projection.is_reusable_for(&key, &roomy_options()));
+    }
+
+    #[test]
+    fn cached_projection_reuse_keeps_limit_checks_explicit() {
+        let key = projection_key(
+            "genesis-namespace",
+            0,
+            "genesis-etag",
+            MetadataBasis::Genesis,
+            0,
+        );
+        let projection = projection(key.clone());
+
+        assert!(projection.is_reusable_for(&key, &roomy_options()));
+        assert!(!projection.is_reusable_for(
+            &key,
+            &PublishTailOptions {
+                max_tail_rows: 0,
+                max_tail_decoded_bytes: usize::MAX,
+            },
+        ));
+        assert!(!projection.is_reusable_for(
+            &key,
+            &PublishTailOptions {
+                max_tail_rows: usize::MAX,
+                max_tail_decoded_bytes: 0,
+            },
+        ));
+    }
 }

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -362,6 +362,7 @@ impl ReadCore {
         }
         let max_cached_namespaces = self.inner.config.runtime_cache.max_cached_namespaces;
         let head_seq = state.head.seq;
+        let manifest_id = state.basis.manifest_id();
         self.inner.control_cache().insert_namespace_head(
             namespace_id,
             CachedNamespaceAnchor {
@@ -378,7 +379,7 @@ impl ReadCore {
         self.inner.wal_tail_projection_cache.insert(
             loonfs_core::cache::WalTailProjectionCacheKey {
                 namespace_id: namespace_id.clone(),
-                manifest_id: state.manifest_id,
+                manifest_id,
                 manifest_head_seq: state.manifest_head_seq,
                 head_seq,
                 head_etag: state.head_etag,


### PR DESCRIPTION
`PublishTailProjection` retained seven independent coordinates of one identity — namespace, head ETag, head sequence, basis, manifest id, manifest head sequence, manifest payload checksum — and `matches()` compared them field by field. Reuse is now decided by one projection key built from the head anchor plus the verified basis identity; the derivable duplicates are deleted (`ResultingReadState.manifest_id` included, now derived from its basis), the projection loader loses its long flat signature and its `too_many_arguments` suppression, and invalidation is at least as strict as before. 