### PR TITLE
fix(cli,spec): current honors LOONFS_NAMESPACE, no-progress silences everything, api.md names a real code

### DIFF
--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -147,8 +147,8 @@ async fn run_admin_gc(
 ///
 /// The first pass's line is written only once a second pass proves the run
 /// is a multi-pass one, so a single-pass run stays as quiet as it always
-/// was. Nothing is written at all under `--json`, where standard output is
-/// the whole answer.
+/// was. Nothing is written when progress is off or uses structured events;
+/// these pass summaries are human-readable prose.
 struct PassProgress {
     enabled: bool,
     held_first_line: Option<String>,
@@ -158,7 +158,7 @@ struct PassProgress {
 impl PassProgress {
     fn new(runtime: RuntimeBehavior) -> Self {
         Self {
-            enabled: !runtime.json,
+            enabled: runtime.progress.human_lines_enabled(),
             held_first_line: None,
             passes: 0,
         }
@@ -746,7 +746,11 @@ mod tests {
             json,
             no_input: true,
             interactive: false,
-            progress: ProgressMode::Off,
+            progress: if json {
+                ProgressMode::Events
+            } else {
+                ProgressMode::Human
+            },
         }
     }
 

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -624,14 +624,14 @@ fn local_open_error(
     derived_name: bool,
 ) -> CliError {
     if error.kind() == std::io::ErrorKind::NotFound {
-        return CliError::new(
-            "io_error",
+        let parent_error = std::io::Error::new(
+            error.kind(),
             format!(
-                "i/o error for `{}`: parent directory `{}` does not exist",
-                destination.display(),
+                "parent directory `{}` does not exist",
                 partial::parent_of(destination).display()
             ),
         );
+        return CliError::io_for_path(destination, parent_error);
     }
     local_destination_error(destination, error, force, derived_name)
 }

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -8,10 +8,11 @@ use crate::args::{
 };
 use crate::config::mutate_config;
 use crate::error::CliError;
-use crate::profiles::{default_namespace, set_default_namespace};
+use crate::profiles::set_default_namespace;
 use crate::prompt::prompt_line;
 use crate::resolve::{
-    load_cli_config, parse_namespace_id, resolve_target_profile, resolve_target_profile_from_config,
+    load_cli_config, parse_namespace_id, resolve_namespace, resolve_target_profile,
+    resolve_target_profile_from_config,
 };
 use std::path::Path;
 
@@ -202,6 +203,14 @@ pub(crate) async fn run_namespace_current(
         crate::profiles::resolve_profile(&loaded.config, explicit_profile)
             .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = profile.mode_str().to_owned();
+    // `current` is a status command, so an unassigned namespace remains a
+    // successful `null`; configured values still use normal flag/env/profile
+    // precedence and validation.
+    let namespace = match resolve_namespace(&loaded.config, explicit_profile, None) {
+        Ok(resolved) => Some(resolved.namespace.to_string()),
+        Err(error) if error.is_no_default_namespace() => None,
+        Err(error) => return Err(fail_for(kind, profile_name, &mode, error)),
+    };
 
     Ok(CommandOutput {
         kind,
@@ -209,7 +218,7 @@ pub(crate) async fn run_namespace_current(
         mode: Some(mode),
         data: CommandData::Current {
             profile: profile_name.to_owned(),
-            namespace: default_namespace(profile).map(ToOwned::to_owned),
+            namespace,
         },
     })
 }

--- a/crates/loonfs-cli/src/commands/partial.rs
+++ b/crates/loonfs-cli/src/commands/partial.rs
@@ -228,13 +228,6 @@ pub(super) fn parent_of(destination: &Path) -> &Path {
         .unwrap_or_else(|| Path::new("."))
 }
 
-/// Shapes a note this build wrote and cannot now read. Nothing surfaces it:
-/// it is the reason a resume did not happen, not a failure of the download.
-#[allow(dead_code)]
-fn unreadable_note(error: serde_json::Error) -> CliError {
-    CliError::invalid_input(format!("unreadable partial-download note: {error}"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -162,7 +162,7 @@ pub(crate) async fn run_put_tree(
         {
             Ok(_) => {
                 tally.directories += 1;
-                if !runtime.json {
+                if runtime.progress.human_lines_enabled() {
                     write_stderr_progress(format_args!("created {}", spec_target(&spec)));
                 }
             }
@@ -233,7 +233,7 @@ pub(crate) async fn run_put_tree(
         match result {
             Ok(target) => {
                 tally.files += 1;
-                if !runtime.json {
+                if runtime.progress.human_lines_enabled() {
                     write_stderr_progress(format_args!("stored {target}"));
                 }
             }
@@ -346,7 +346,7 @@ pub(crate) async fn run_get_tree(
         match result {
             Ok(local) => {
                 tally.files += 1;
-                if !runtime.json {
+                if runtime.progress.human_lines_enabled() {
                     write_stderr_progress(format_args!("wrote {local}"));
                 }
             }
@@ -405,7 +405,7 @@ pub(crate) async fn run_copy_tree(
         {
             Ok(_) => {
                 tally.directories += 1;
-                if !runtime.json {
+                if runtime.progress.human_lines_enabled() {
                     write_stderr_progress(format_args!("created {}", spec_target(&spec)));
                 }
             }
@@ -461,7 +461,7 @@ pub(crate) async fn run_copy_tree(
         match result {
             Ok(target) => {
                 tally.files += 1;
-                if !runtime.json {
+                if runtime.progress.human_lines_enabled() {
                     write_stderr_progress(format_args!("copied {target}"));
                 }
             }

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -99,6 +99,11 @@ impl CliError {
         )
     }
 
+    /// Whether namespace resolution found no configured default.
+    pub(crate) fn is_no_default_namespace(&self) -> bool {
+        self.code == "no_default_namespace"
+    }
+
     pub(crate) fn profile_already_exists(name: &str) -> Self {
         Self::new(
             "profile_already_exists",

--- a/crates/loonfs-cli/src/progress.rs
+++ b/crates/loonfs-cli/src/progress.rs
@@ -47,6 +47,12 @@ impl ProgressMode {
             Self::Off
         }
     }
+
+    /// Whether human-readable progress lines belong on standard error.
+    /// Event mode writes structured JSON through [`ProgressReporter`].
+    pub(crate) fn human_lines_enabled(self) -> bool {
+        self == Self::Human
+    }
 }
 
 /// Which transfer an event is about. The value an agent sees in `op`.

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1179,6 +1179,29 @@ fn progress_is_silent_unless_someone_is_watching() {
     assert_eq!(json_error(&clash)["code"], "path_conflict");
 }
 
+#[test]
+fn no_progress_silences_recursive_item_lines() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let tree = harness.temp_dir.path().join("quiet-tree");
+    fs::create_dir_all(tree.join("empty")).expect("create tree dirs");
+    fs::write(tree.join("doc.txt"), b"body").expect("write tree file");
+
+    let put = harness.run(&[
+        "--no-progress",
+        "put",
+        "-r",
+        tree.to_str().expect("utf-8 path"),
+        "/quiet-tree",
+    ]);
+
+    assert_success(&put);
+    assert_eq!(stderr_string(&put), "");
+}
+
 /// A large file and a pipe both round-trip through an embedded profile,
 /// and the retry contract holds for them exactly as it does for a payload
 /// small enough to hold.
@@ -3278,6 +3301,36 @@ fn current_reports_profile_specific_namespace() {
     assert_success(&current_alpha);
     assert_eq!(json_data(&current_alpha)["profile"], "alpha");
     assert_eq!(json_data(&current_alpha)["namespace"], "alpha-ns");
+}
+
+#[test]
+fn current_uses_namespace_from_environment() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "profile-default"]));
+    assert_success(&harness.run(&["use", "profile-default"]));
+
+    let current = harness.run_with_env(
+        &[("LOONFS_NAMESPACE", "from-environment")],
+        &["--json", "current"],
+    );
+
+    assert_success(&current);
+    assert_eq!(json_data(&current)["namespace"], "from-environment");
+}
+
+#[test]
+fn current_uses_profile_default_without_namespace_environment() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "profile-default"]));
+    assert_success(&harness.run(&["use", "profile-default"]));
+
+    // `Harness::run` spawns the command with `LOONFS_NAMESPACE` removed.
+    let current = harness.run(&["--json", "current"]);
+
+    assert_success(&current);
+    assert_eq!(json_data(&current)["namespace"], "profile-default");
 }
 
 #[test]

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -61,7 +61,7 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
         Err(ImmutableWriteError::Transport { source, .. }) => Err(
             MetadataProjectionLoadError::ManifestLoad(ManifestLoadError::ReadManifest {
                 object_key: manifest_key,
-                message: source.to_string(),
+                message: source.message(),
             }),
         ),
         Err(error) => Err(MetadataProjectionLoadError::ManifestLoad(

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -92,10 +92,7 @@ pub async fn load_grep_root_pointer<S: ObjectStore + ?Sized>(
     else {
         return Ok(None);
     };
-    let envelope = decode_grep_root(&body.bytes).map_err(|error| GrepRootError::Corrupt {
-        object_key: object_key.clone(),
-        message: error.to_string(),
-    })?;
+    let envelope = decode_grep_root(&body.bytes).map_err(|error| corrupt(&object_key, error))?;
     if envelope.pointer().namespace_id() != namespace_id {
         return Err(GrepRootError::IdentityMismatch {
             object_key,
@@ -129,10 +126,7 @@ pub async fn load_grep_manifest<S: ObjectStore + ?Sized>(
     else {
         return Ok(None);
     };
-    let envelope = decode_grep_manifest(&bytes).map_err(|error| GrepRootError::Corrupt {
-        object_key: object_key.clone(),
-        message: error.to_string(),
-    })?;
+    let envelope = decode_grep_manifest(&bytes).map_err(|error| corrupt(&object_key, error))?;
     if envelope.payload_checksum() != pointer.manifest_payload_checksum() {
         return Err(GrepRootError::Corrupt {
             object_key,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -34,6 +34,117 @@ use loonfs_objectstore::{
 };
 use std::path::Path;
 
+const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
+    "aborted_at_ms",
+    "active_acquired_at_ms",
+    "active_deletion_seq",
+    "active_writer",
+    "active_writer_epoch",
+    "actual_attributes_revision_no",
+    "actual_head_seq",
+    "actual_revision",
+    "advance_retention",
+    "after_seq",
+    "allow_scan",
+    "allow_stale",
+    "attributes_changed",
+    "attributes_revision_no",
+    "bearer_auth",
+    "begin_put",
+    "budget_exhausted",
+    "built_through_seq",
+    "checkpoint_id",
+    "checkpoint_not_releasable",
+    "checkpoint_seq",
+    "commit_id",
+    "committed_at_ms",
+    "committed_fingerprint",
+    "committed_seq",
+    "compaction_at_capacity",
+    "compaction_required",
+    "compaction_running",
+    "compaction_started",
+    "complete_upload_prepared",
+    "completed_at_ms",
+    "content_changed",
+    "content_reclamation_deferred",
+    "content_ref",
+    "content_scan_deferred",
+    "content_store_id",
+    "content_tokens",
+    "created_at_ms",
+    "cursor_inode_id",
+    "degraded_retention",
+    "degraded_roots",
+    "deleted_at_seq",
+    "destination_exists",
+    "direct_multipart",
+    "direct_put",
+    "display_name",
+    "expected_attributes_revision_no",
+    "expected_head_seq",
+    "expected_inode_id",
+    "expected_revision",
+    "expected_revision_no",
+    "expires_at_ms",
+    "fenced_epoch",
+    "from_name",
+    "from_parent_inode_id",
+    "grace_window",
+    "grace_window_ms",
+    "head_seq",
+    "include_attributes",
+    "inode_id",
+    "inode_kind",
+    "manifest_id",
+    "max_objects",
+    "max_wal_tail_segments",
+    "name_key",
+    "namespace_id",
+    "new_namespace_id",
+    "next_after_seq",
+    "next_cursor",
+    "next_event_index",
+    "next_reclamation_at_ms",
+    "no_provider_timestamp",
+    "no_reference_manifest",
+    "no_replace",
+    "operation_id",
+    "operation_index",
+    "operation_kind",
+    "operation_part",
+    "parent_inode_id",
+    "part_size_bytes",
+    "path_prefix",
+    "prepare_content_ref",
+    "prepare_file_bytes",
+    "protocol_version",
+    "put_file",
+    "put_file_prepared",
+    "request_deadline_ms",
+    "request_id",
+    "requested_deletion_seq",
+    "retained_candidates",
+    "retention_floor_seq",
+    "revision_no",
+    "run_id",
+    "service_proxied",
+    "size_bytes",
+    "storage_checksum",
+    "target_namespace_id",
+    "target_seq",
+    "to_name",
+    "to_parent_inode_id",
+    "ttl_ms",
+    "unrecognized_key",
+    "update_attributes",
+    "upload_session_undecided",
+    "upload_session_window",
+    "validated_content_token",
+    "wal_flush",
+    "whole_file_sha256",
+];
+
 fn replace_file_options() -> PutFileOptions {
     PutFileOptions {
         behavior: DestinationBehavior::Replace,
@@ -98,6 +209,34 @@ fn error_status_mapping_matches_the_api_spec_table() {
         documented.is_empty(),
         "api.md documents codes this build does not register: {documented:?}"
     );
+    assert_api_spec_error_codes_are_registered(&spec);
+}
+
+fn assert_api_spec_error_codes_are_registered(spec: &str) {
+    for token in spec
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .filter(|token| is_snake_case_token(token))
+    {
+        if API_SPEC_NON_ERROR_CODE_TOKENS.contains(&token) {
+            continue;
+        }
+        assert!(
+            ErrorCode::parse(token).is_some(),
+            "api.md uses unregistered error-code-shaped token `{token}`"
+        );
+    }
+}
+
+fn is_snake_case_token(token: &str) -> bool {
+    token.contains('_')
+        && token.starts_with(|character: char| character.is_ascii_lowercase())
+        && !token.ends_with('_')
+        && !token.contains("__")
+        && token
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
 use loonfs_test_support::http::raw_agent;
 use loonfs_test_support::ids::namespace_id;

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2172,7 +2172,7 @@ them. A search is a bounded sampling read over content, not an
 enumeration contract; a client that needs one consistent cut across pages
 re-issues the search when `head_seq` changes between pages. A cursor from
 a head newer than the serving view's is still rejected
-(`snapshot_unavailable`) — drift tolerance runs forward, never backward.
+(`rebootstrap_required`) — drift tolerance runs forward, never backward.
 
 A pattern with no required
 literal bytes is rejected with `query_unindexable` unless `allow_scan`


### PR DESCRIPTION
Aligns CLI namespace reporting and progress suppression with the behavior used by the rest of the command set. loonfs current now resolves the active namespace through the normal profile, configuration, and LOONFS_NAMESPACE precedence. --no-progress now suppresses per-item recursive transfer output and admin GC pass messages as well as progress bars.

Corrects the documented error for a cursor that is ahead of retained history from snapshot_unavailable to rebootstrap_required. The specification test now checks code-like tokens throughout the document so unregistered error names are caught outside the registry block.

Also removes a dead helper and replaces several one-off error constructions with existing typed helpers. Tests cover namespace precedence, quiet progress modes, and the documented error-code registry.