### PR TITLE
fix(core): upload terminality, revision timestamps, GC error honesty, head-write classes

### DIFF
--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -89,7 +89,6 @@ impl PaginationPolicy {
     pub fn resolve_limit(self, requested: Option<u32>) -> Result<EffectiveLimit, LimitError> {
         match requested {
             None => Ok(EffectiveLimit(self.default_limit)),
-            Some(0) => Err(LimitError::Zero),
             Some(value) if value > self.max_limit.get() => Err(LimitError::ExceedsMax {
                 requested: value,
                 max_limit: self.max_limit.get(),

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -374,7 +374,7 @@ pub fn decode_data_block_rows<R: serde::de::DeserializeOwned>(
     while cursor < entries.len() {
         let shared_len = read_varint(entries, &mut cursor)? as usize;
         let suffix_len = read_varint(entries, &mut cursor)? as usize;
-        if shared_len > previous_key.len() {
+        if shared_len > previous_key.len() || !previous_key.is_char_boundary(shared_len) {
             return Err(SstBlockCodecError::Malformed(
                 "shared prefix exceeds previous key".to_owned(),
             ));
@@ -962,6 +962,34 @@ mod tests {
             matches!(&error, SstBlockCodecError::Malformed(message) if message.contains("row-key order")),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn decoding_rejects_a_shared_prefix_inside_a_utf8_code_point() {
+        let (_, _, row) = inode_row(1);
+        let mut row_bytes = Vec::new();
+        ciborium::ser::into_writer(&row, &mut row_bytes).expect("encode row");
+        let mut payload = Vec::new();
+        write_varint(&mut payload, 0);
+        write_varint(&mut payload, "é".len() as u64);
+        payload.extend_from_slice("é".as_bytes());
+        write_varint(&mut payload, row_bytes.len() as u64);
+        payload.extend_from_slice(&row_bytes);
+        write_varint(&mut payload, 1);
+        write_varint(&mut payload, 0);
+        write_varint(&mut payload, row_bytes.len() as u64);
+        payload.extend_from_slice(&row_bytes);
+        payload.extend_from_slice(&0u32.to_le_bytes());
+
+        let mut bytes = Vec::new();
+        let handle = append_section(&mut bytes, &payload, true).expect("append section");
+        let error = decode_data_block(&bytes, &handle)
+            .expect_err("a partial utf-8 prefix should be rejected");
+        assert!(matches!(
+            &error,
+            SstBlockCodecError::Malformed(message)
+                if message == "shared prefix exceeds previous key"
+        ));
     }
 
     #[test]

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -5,7 +5,7 @@ use crate::control_object::{
     core_control_load_error, expect_identity_field, expect_namespace, load_control_object,
     ControlObjectLoadError, LoadedControl,
 };
-use crate::error::CoreError;
+use crate::error::{CoreError, StoreFailureClass};
 use crate::namespace::control::{read_head_object, LoadedHeadObject};
 use bytes::Bytes;
 use loonfs_api::wire::control::{
@@ -48,7 +48,11 @@ pub(crate) enum ControlUpdateError {
     #[error("control object codec error for `{object_key}`: {message}")]
     Codec { object_key: String, message: String },
     #[error("control object store error for `{object_key}`: {message}")]
-    Store { object_key: String, message: String },
+    Store {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("control object update retries exhausted after {attempts} attempts")]
     RetryExhausted { attempts: usize },
 }
@@ -85,7 +89,8 @@ where
             Err(error) => {
                 return Err(E::from(ControlUpdateError::Store {
                     object_key: loaded.object_key,
-                    message: error.to_string(),
+                    message: error.message(),
+                    class: StoreFailureClass::of(&error),
                 }))
             }
         }

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -684,11 +684,17 @@ impl From<crate::control_update::ControlUpdateError> for CoreError {
             ControlUpdateError::LoadHead(error) => {
                 CoreError::MetadataProjection(MetadataProjectionLoadError::LoadHead(error))
             }
-            // The remaining variants (codec, control store error, retries
-            // exhausted) are control-plane plumbing failures with no
-            // single object key in scope at this blanket conversion. They share
-            // the ServerError wire code with `Store`; keep the detail as a
-            // prefixed message.
+            ControlUpdateError::Store {
+                object_key,
+                message,
+                class,
+            } => CoreError::Store {
+                object_key,
+                message,
+                class,
+            },
+            // Codec and retry exhaustion are non-store control-plane
+            // failures. Preserve their prefixed detail as an internal error.
             other => CoreError::Internal(other.to_string()),
         }
     }
@@ -699,10 +705,9 @@ fn classify_writer_epoch_acquire_error(error: &WriterEpochAcquireError) -> Error
         WriterEpochAcquireError::LoadHead(error) => classify_control_object_load_error(error),
         WriterEpochAcquireError::NamespaceDeleted { .. } => ErrorCode::NamespaceDeleted,
         WriterEpochAcquireError::EmptyWriterId
-        | WriterEpochAcquireError::MissingHeadEtag { .. }
         | WriterEpochAcquireError::WriterEpochOverflow { .. }
-        | WriterEpochAcquireError::HeadWrite(_)
         | WriterEpochAcquireError::RetryExhausted { .. } => ErrorCode::ServerError,
+        WriterEpochAcquireError::HeadWrite { class, .. } => classify_store_failure(*class),
     }
 }
 

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -138,7 +138,20 @@ pub(super) async fn fork_target_proven_gone<S: ObjectStore + ?Sized>(
         Err(ControlObjectLoadError::MissingObject { .. }) => {
             Ok(lease_expired(record, context.now_ms))
         }
-        // An unreadable target head is not verifiably deleted; retain.
-        Err(_) => Ok(false),
+        Err(error) => match &error {
+            // An unreadable target head is not verifiably deleted; retain.
+            ControlObjectLoadError::Store { object_key, .. } => {
+                tracing::warn!(
+                    namespace_id = %target_namespace_id,
+                    object_key,
+                    error = %error,
+                    "the fork target head did not read; retaining its source checkpoint"
+                );
+                Ok(false)
+            }
+            _ => Err(CoreError::NamespaceCorrupt(format!(
+                "the fork target head does not load: {error}"
+            ))),
+        },
     }
 }

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -556,7 +556,7 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
 ///
 /// `None` reports that the budget ran out. A pass that cannot pay for this
 /// has no root set at all, the same as any other partial collection.
-async fn select_reference_anchor<S: ObjectStore + ?Sized>(
+pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     grace_window_ms: u64,
@@ -606,18 +606,32 @@ async fn select_reference_anchor<S: ObjectStore + ?Sized>(
     if !budget.try_charge() {
         return Ok(None);
     }
-    // A manifest that will not load is no evidence. Retaining is what the
-    // pass does with every root it cannot resolve.
-    let Ok(Some(manifest)) =
-        load_namespace_manifest_envelope_if_present(store, namespace_id, &manifest_object_id, &key)
-            .await
-    else {
-        tracing::debug!(
-            namespace_id = %namespace_id,
-            object_key = key,
-            "the reference manifest did not load; retaining every aged candidate"
-        );
-        return Ok(Some(ReferenceAnchor::Missing));
+    let manifest = match load_namespace_manifest_envelope_if_present(
+        store,
+        namespace_id,
+        &manifest_object_id,
+        &key,
+    )
+    .await
+    {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => return Ok(Some(ReferenceAnchor::Missing)),
+        Err(error) => match error.failure_class() {
+            ManifestLoadFailureClass::Store => {
+                tracing::warn!(
+                    namespace_id = %namespace_id,
+                    object_key = key,
+                    error = %error,
+                    "the reference manifest did not read; retaining every aged candidate"
+                );
+                return Ok(Some(ReferenceAnchor::Missing));
+            }
+            ManifestLoadFailureClass::Corrupt => {
+                return Err(CoreError::NamespaceCorrupt(format!(
+                    "the reference manifest does not load: {error}"
+                )));
+            }
+        },
     };
     Ok(Some(ReferenceAnchor::Manifest(Box::new(
         AnchoredManifest {

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -24,6 +24,15 @@ use loonfs_api::{ContentStoreId, NamespaceId, RetainedReason, UploadId};
 use loonfs_objectstore::ObjectStore;
 use std::sync::Arc;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SweepCandidateFamily {
+    WalSegments,
+    MetadataTables,
+    CompactionStaging,
+    Manifests,
+    Checkpoints,
+}
+
 pub async fn gc_namespace<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -202,17 +211,23 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
 
     /// Decides one candidate using the pass-owned verifier and family state.
     async fn process_candidate(&mut self, family: CandidateFamily, key: &str) -> Result<SweepStep> {
-        if family == CandidateFamily::UploadSessions {
-            self.process_upload_session(key).await?;
-            return Ok(SweepStep::Continue);
-        }
-
-        if family == CandidateFamily::Checkpoints
-            && self.initial_live.missing_basis_records.contains(key)
-        {
-            self.process_missing_basis_checkpoint(key).await?;
-            return Ok(SweepStep::Continue);
-        }
+        let family = match family {
+            CandidateFamily::UploadSessions => {
+                self.process_upload_session(key).await?;
+                return Ok(SweepStep::Continue);
+            }
+            CandidateFamily::Checkpoints
+                if self.initial_live.missing_basis_records.contains(key) =>
+            {
+                self.process_missing_basis_checkpoint(key).await?;
+                return Ok(SweepStep::Continue);
+            }
+            CandidateFamily::WalSegments => SweepCandidateFamily::WalSegments,
+            CandidateFamily::MetadataTables => SweepCandidateFamily::MetadataTables,
+            CandidateFamily::CompactionStaging => SweepCandidateFamily::CompactionStaging,
+            CandidateFamily::Manifests => SweepCandidateFamily::Manifests,
+            CandidateFamily::Checkpoints => SweepCandidateFamily::Checkpoints,
+        };
 
         // Objects reachable from the invocation's root snapshot — either
         // anchor's — are skipped, while every selected candidate is
@@ -236,33 +251,31 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
         }
 
         match family {
-            CandidateFamily::WalSegments => self.process_wal_segment(key).await?,
-            CandidateFamily::MetadataTables => self.process_metadata_table(key).await?,
-            CandidateFamily::CompactionStaging => self.process_compaction_staging(key).await?,
-            CandidateFamily::Manifests => self.process_manifest(key).await?,
-            CandidateFamily::Checkpoints => self.process_checkpoint(key).await?,
-            CandidateFamily::UploadSessions => unreachable!("uploads return before selection"),
+            SweepCandidateFamily::WalSegments => self.process_wal_segment(key).await?,
+            SweepCandidateFamily::MetadataTables => self.process_metadata_table(key).await?,
+            SweepCandidateFamily::CompactionStaging => self.process_compaction_staging(key).await?,
+            SweepCandidateFamily::Manifests => self.process_manifest(key).await?,
+            SweepCandidateFamily::Checkpoints => self.process_checkpoint(key).await?,
         }
         Ok(SweepStep::Continue)
     }
 
-    fn is_selected(&self, family: CandidateFamily, key: &str) -> bool {
+    fn is_selected(&self, family: SweepCandidateFamily, key: &str) -> bool {
         match family {
-            CandidateFamily::WalSegments => !self.initial_live.protects_wal_segment(key),
+            SweepCandidateFamily::WalSegments => !self.initial_live.protects_wal_segment(key),
             // A staged segment a publication landed is named by the manifest
             // like any other table, so the same root set answers for both
             // families.
-            CandidateFamily::MetadataTables | CandidateFamily::CompactionStaging => {
+            SweepCandidateFamily::MetadataTables | SweepCandidateFamily::CompactionStaging => {
                 !self.initial_live.tables.contains(key)
             }
-            CandidateFamily::Manifests => match manifest_object_id_of(key) {
+            SweepCandidateFamily::Manifests => match manifest_object_id_of(key) {
                 Some(Ok(id)) => !self.initial_live.manifests.contains(&id),
                 // A key that names no readable manifest is reachable from no
                 // root. The family decision retains unrecognized names.
                 None | Some(Err(_)) => true,
             },
-            CandidateFamily::Checkpoints => !self.initial_live.checkpoint_keys.contains(key),
-            CandidateFamily::UploadSessions => false,
+            SweepCandidateFamily::Checkpoints => !self.initial_live.checkpoint_keys.contains(key),
         }
     }
 

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -3,8 +3,9 @@
 use super::budget::PassBudget;
 use super::config::GcConfig;
 use super::cursor::{CandidateFamily, GcCursor};
-use super::live_set::{recollect_live_set, LiveSet};
+use super::live_set::{recollect_live_set, select_reference_anchor, LiveSet, ReferenceAnchor};
 use super::run::{gc_namespace, gc_namespace_with_reverify_chunk};
+use super::uploads::{collect_referenced_content, CollectedReferences};
 use crate::checkpoint::advance_retention_floor;
 use crate::checkpoint::record::release_checkpoint_record;
 use crate::checkpoint::tests::{
@@ -1182,6 +1183,137 @@ async fn namespace_with_a_scan_worth_bounding(
         )
         .await;
     }
+}
+
+#[tokio::test]
+async fn content_reference_scan_surfaces_a_manifest_corrupted_after_marking() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&store, &namespace_id, &setup).await;
+    let live = live_set(&store, &namespace_id, &setup).await;
+    let manifest_object_id = live.manifests.iter().next().expect("live manifest").clone();
+    let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
+    store
+        .put_overwrite(&manifest_key, Bytes::from_static(b"not json"))
+        .await
+        .expect("corrupt marked manifest");
+    let mut budget = PassBudget::new(None);
+
+    let error = collect_referenced_content(&store, &namespace_id, &live, &mut budget)
+        .await
+        .expect_err("corruption after marking must still surface");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(error.message().contains(&manifest_key));
+}
+
+#[tokio::test]
+async fn content_reference_scan_is_unavailable_when_a_marked_manifest_does_not_read() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
+    let live = live_set(&inner, &namespace_id, &setup).await;
+    let store = FailStore::new(
+        inner,
+        KeyPredicate::prefix(metadata_manifest_prefix(namespace_id.as_str())),
+        OperationClass::Read,
+        InjectedError::Transport("marked manifest timed out".to_owned()),
+    );
+    store.fail_all();
+    let mut budget = PassBudget::new(None);
+
+    let references = collect_referenced_content(&store, &namespace_id, &live, &mut budget)
+        .await
+        .expect("a manifest store failure remains conservative");
+    assert!(matches!(references, CollectedReferences::Unavailable));
+}
+
+#[tokio::test]
+async fn content_reference_scan_surfaces_corrupt_metadata_rows() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&store, &namespace_id, &setup).await;
+    let (upload_id, content_ref, content_store_id, _) =
+        complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
+    let table_keys = store
+        .list_prefix(&metadata_table_prefix(namespace_id.as_str()))
+        .await
+        .expect("list metadata tables");
+    assert!(
+        !table_keys.is_empty(),
+        "the fixture must publish metadata tables"
+    );
+    for key in &table_keys {
+        let mut bytes = store
+            .get(key, None)
+            .await
+            .expect("read metadata table")
+            .expect("metadata table exists")
+            .to_vec();
+        bytes[0] ^= 0xff;
+        store
+            .put_overwrite(key, Bytes::from(bytes))
+            .await
+            .expect("corrupt metadata table");
+    }
+    let content_key =
+        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+
+    let error = gc_namespace(&store, &namespace_id, &config(), &past)
+        .await
+        .expect_err("corrupt content-reference rows must fail the pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(table_keys.iter().any(|key| error.message().contains(key)));
+    assert!(store
+        .head(&content_key)
+        .await
+        .expect("head content")
+        .is_some());
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_some());
+}
+
+#[tokio::test]
+async fn content_reference_scan_retains_content_when_metadata_rows_do_not_read() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
+    let (upload_id, content_ref, content_store_id, _) =
+        complete_upload_for_gc(&inner, &namespace_id, b"unpublished\n", &setup).await;
+    let content_key =
+        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+    let store = FailStore::new(
+        inner,
+        KeyPredicate::prefix(metadata_table_prefix(namespace_id.as_str())),
+        OperationClass::Read,
+        InjectedError::Transport("metadata rows timed out".to_owned()),
+    );
+    store.fail_all();
+    let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
+
+    let report = gc_namespace(&store, &namespace_id, &config(), &past)
+        .await
+        .expect("a metadata-row store failure retains conservatively");
+    assert_eq!(report.deleted_content_objects, 0);
+    assert_eq!(report.deleted_upload_sessions, 0);
+    assert!(store
+        .inner()
+        .head(&content_key)
+        .await
+        .expect("head content")
+        .is_some());
+    assert!(read_upload_session(&store, &namespace_id, &upload_id)
+        .await
+        .is_some());
 }
 
 /// A budget with room for the roots and one candidate a pass has nothing
@@ -3611,6 +3743,67 @@ async fn gc_releases_fork_checkpoints_of_terminally_deleted_targets_across_passe
     stat_root(&store, &source).await;
 }
 
+#[tokio::test]
+async fn gc_surfaces_a_corrupt_fork_target_head() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let source = NamespaceId::parse("source").expect("namespace id");
+    let clone = NamespaceId::parse("clone").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &source, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&store, &source, "/docs/one.txt", "gc-one", &setup).await;
+    fork_namespace(&store, &source, &clone, &setup)
+        .await
+        .expect("fork");
+    store
+        .put_overwrite(&wal_head(clone.as_str()), Bytes::from_static(b"not json"))
+        .await
+        .expect("corrupt target head");
+    let before = namespace_keys(&store, &source).await;
+
+    let error = gc_namespace(&store, &source, &config(), &setup)
+        .await
+        .expect_err("a corrupt target head must fail the source pass");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(error.message().contains(&wal_head(clone.as_str())));
+    assert_eq!(namespace_keys(&store, &source).await, before);
+}
+
+#[tokio::test]
+async fn gc_retains_a_fork_checkpoint_when_the_target_head_does_not_read() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let source = NamespaceId::parse("source").expect("namespace id");
+    let clone = NamespaceId::parse("clone").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&inner, &source, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&inner, &source, "/docs/one.txt", "gc-one", &setup).await;
+    fork_namespace(&inner, &source, &clone, &setup)
+        .await
+        .expect("fork");
+    let fork_record = read_fork_record(&inner, &source).await;
+    let store = FailStore::new(
+        inner,
+        KeyPredicate::exact(wal_head(clone.as_str())),
+        OperationClass::Read,
+        InjectedError::Transport("target head timed out".to_owned()),
+    );
+    store.fail_all();
+
+    let report = gc_namespace(&store, &source, &config(), &setup)
+        .await
+        .expect("an unreadable target is retained conservatively");
+    assert_eq!(report.released_fork_checkpoints, 0);
+    assert_eq!(
+        checkpoint_lifecycle(store.inner(), &source, &fork_record.checkpoint_id).await,
+        CheckpointRecordLifecycle::Active {}
+    );
+}
+
 /// A finished fork owns its source pin for as long as the target lives.
 /// The lease bounds the attempt, not the result: once the target head is
 /// there, no number of passes at any clock past the lease can release the
@@ -3911,6 +4104,69 @@ async fn gc_fails_the_pass_when_a_checkpoint_record_does_not_read() {
         before,
         "a failed pass deletes nothing"
     );
+}
+
+#[tokio::test]
+async fn corrupt_reference_anchor_manifest_fails_instead_of_becoming_missing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&store, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    create_checkpoint(&store, &namespace_id, &setup)
+        .await
+        .expect("checkpoint");
+    let manifest_key = store
+        .list_prefix(&metadata_manifest_prefix(namespace_id.as_str()))
+        .await
+        .expect("list manifests")
+        .into_iter()
+        .next()
+        .expect("published manifest");
+    store
+        .put_overwrite(&manifest_key, Bytes::from_static(b"not json"))
+        .await
+        .expect("corrupt reference manifest");
+    let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
+    let mut budget = PassBudget::new(None);
+
+    let error = select_reference_anchor(&store, &namespace_id, GRACE_MS, &mut budget, &aged)
+        .await
+        .expect_err("a corrupt reference anchor must surface");
+    assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
+    assert!(error.message().contains(&manifest_key));
+}
+
+#[tokio::test]
+async fn unreadable_reference_anchor_manifest_remains_conservative() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let setup = context(1_000);
+    bootstrap_namespace(&inner, &namespace_id, &setup, false)
+        .await
+        .expect("bootstrap");
+    write_test_file(&inner, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
+    create_checkpoint(&inner, &namespace_id, &setup)
+        .await
+        .expect("checkpoint");
+    let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
+    let store = FailStore::new(
+        inner,
+        KeyPredicate::prefix(metadata_manifest_prefix(namespace_id.as_str())),
+        OperationClass::Read,
+        InjectedError::Transport("reference manifest timed out".to_owned()),
+    );
+    store.fail_all();
+    let mut budget = PassBudget::new(None);
+
+    let anchor = select_reference_anchor(&store, &namespace_id, GRACE_MS, &mut budget, &aged)
+        .await
+        .expect("a store failure keeps a missing anchor");
+    assert!(matches!(anchor, Some(ReferenceAnchor::Missing)));
 }
 
 /// The manifest arm of the same split: a rooted manifest that reads but

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -11,7 +11,7 @@
 
 use super::budget::PassBudget;
 use super::live_set::LiveSet;
-use crate::checkpoint::load_verified_manifest_tables;
+use crate::checkpoint::{load_verified_manifest_tables, ManifestLoadFailureClass};
 use crate::context::MutationContext;
 use crate::control_update::{
     read_upload_session_state, try_update_upload_session, UploadSessionCas, UploadSessionUpdate,
@@ -230,7 +230,8 @@ enum ContentReference {
 }
 
 /// What the reference scan has produced for this invocation.
-enum CollectedReferences {
+#[derive(Debug)]
+pub(super) enum CollectedReferences {
     /// The scan has not run yet. Only the memo starts here.
     NotYet,
     /// A root could not be read, so this pass has no reference set at all
@@ -315,7 +316,7 @@ impl ContentReferences {
 ///
 /// Every return is a verdict the memo can hold: an attempt that has run
 /// never comes back as [`CollectedReferences::NotYet`].
-async fn collect_referenced_content<S: ObjectStore + ?Sized>(
+pub(super) async fn collect_referenced_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     live: &LiveSet,
@@ -326,18 +327,33 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
         if !budget.try_charge() {
             return Ok(CollectedReferences::Deferred);
         }
-        let Ok(tables) =
-            load_verified_manifest_tables(store, namespace_id, manifest_object_id).await
-        else {
-            return Ok(CollectedReferences::Unavailable);
-        };
+        let tables =
+            match load_verified_manifest_tables(store, namespace_id, manifest_object_id).await {
+                Ok(tables) => tables,
+                Err(error) => match error.failure_class() {
+                    ManifestLoadFailureClass::Store => {
+                        tracing::warn!(
+                            namespace_id = %namespace_id,
+                            manifest_object_id = %manifest_object_id,
+                            error = %error,
+                            "a content-reference manifest did not read; retaining completed content"
+                        );
+                        return Ok(CollectedReferences::Unavailable);
+                    }
+                    ManifestLoadFailureClass::Corrupt => {
+                        return Err(CoreError::NamespaceCorrupt(format!(
+                            "a content-reference manifest does not load: {error}"
+                        )));
+                    }
+                },
+            };
         let mut lower_bound = lookup_keys::REVISION_ROW_PREFIX.to_owned();
         let upper_bound = string_prefix_upper_bound(lookup_keys::REVISION_ROW_PREFIX);
         loop {
             if !budget.try_charge() {
                 return Ok(CollectedReferences::Deferred);
             }
-            let Ok(rows) = tables
+            let rows = match tables
                 .scan_range_page_with_keys(
                     MetadataTableFamily::Revisions,
                     &lower_bound,
@@ -345,8 +361,24 @@ async fn collect_referenced_content<S: ObjectStore + ?Sized>(
                     REVISION_SCAN_WAVE_ROWS,
                 )
                 .await
-            else {
-                return Ok(CollectedReferences::Unavailable);
+            {
+                Ok(rows) => rows,
+                Err(error) => match error.failure_class() {
+                    ManifestLoadFailureClass::Store => {
+                        tracing::warn!(
+                            namespace_id = %namespace_id,
+                            manifest_object_id = %manifest_object_id,
+                            error = %error,
+                            "content-reference rows did not read; retaining completed content"
+                        );
+                        return Ok(CollectedReferences::Unavailable);
+                    }
+                    ManifestLoadFailureClass::Corrupt => {
+                        return Err(CoreError::NamespaceCorrupt(format!(
+                            "content-reference rows do not load: {error}"
+                        )));
+                    }
+                },
             };
             let exhausted = rows.len() < REVISION_SCAN_WAVE_ROWS;
             match rows.last() {

--- a/crates/loonfs-core/src/metadata/view_session.rs
+++ b/crates/loonfs-core/src/metadata/view_session.rs
@@ -446,116 +446,113 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
             let lookup_name_key = component_name_keys.get(wave);
             let is_leaf_wave = wave == component_name_keys.len();
 
-            let want_inode = !self.inode_at_seq_cache.contains_key(&current_inode_id);
-            let want_tombstone = !self.active_tombstone_cache.contains_key(&current_inode_id);
-            let want_parent_binding = !self
-                .latest_parent_binding_cache
-                .contains_key(&current_inode_id);
             let arrived_by_binding = pending_binding.take();
-            let unbind_lookup = arrived_by_binding
-                .as_ref()
-                .filter(|binding| {
-                    !self
-                        .unbind_cache
-                        .contains_key(&BindingCacheKey::from(*binding))
-                })
-                .cloned();
-            let bound_child_lookup = lookup_name_key
-                .filter(|name_key| {
-                    !self.bound_child_cache.contains_key(&ParentNameCacheKey {
-                        parent_inode_id: current_inode_id,
-                        name_key: (*name_key).clone(),
-                    })
-                })
-                .cloned();
-            let want_revision = is_leaf_wave
-                && prefetch_leaf_revision == LeafRevisionPrefetch::Prefetch
-                && !self
-                    .latest_revision_head_cache
-                    .contains_key(&current_inode_id);
+            let prefetch_revision =
+                is_leaf_wave && prefetch_leaf_revision == LeafRevisionPrefetch::Prefetch;
 
             let base = &self.base;
-            let (inode, tombstones, child_bindings, unbinds, bound_rows, revision) = futures::try_join!(
+            let (inode, tombstone, parent_binding, unbind, bound_child, revision) = futures::try_join!(
                 async {
-                    match want_inode {
-                        true => base.inode_at_seq(current_inode_id).await.map(Some),
-                        false => Ok(None),
+                    match self.inode_at_seq_cache.get(&current_inode_id).cloned() {
+                        Some(inode) => Ok(inode),
+                        None => base.inode_at_seq(current_inode_id).await,
                     }
                 },
                 async {
-                    match want_tombstone {
-                        true => base.tombstones_for_root(current_inode_id).await.map(Some),
-                        false => Ok(None),
+                    match self.active_tombstone_cache.get(&current_inode_id).cloned() {
+                        Some(tombstone) => Ok(tombstone),
+                        None => base
+                            .tombstones_for_root(current_inode_id)
+                            .await
+                            .map(|rows| {
+                                super::rows::active_tombstone_from_records(
+                                    rows.iter().cloned(),
+                                    visible_seq,
+                                )
+                            }),
                     }
                 },
                 async {
-                    match want_parent_binding {
-                        true => base
+                    match self
+                        .latest_parent_binding_cache
+                        .get(&current_inode_id)
+                        .cloned()
+                    {
+                        Some(binding) => Ok(binding),
+                        None => base
                             .direntry_binds_for_child(current_inode_id)
                             .await
-                            .map(Some),
-                        false => Ok(None),
+                            .map(|rows| {
+                                rows.iter()
+                                    .filter(|direntry| direntry.bind_seq <= visible_seq)
+                                    .max_by_key(|direntry| {
+                                        (direntry.bind_seq, direntry.bind_delta_index)
+                                    })
+                                    .cloned()
+                            }),
                     }
                 },
                 async {
-                    match &unbind_lookup {
-                        Some(binding) => base.direntry_unbinds_for_binding(binding).await.map(Some),
-                        None => Ok(None),
-                    }
+                    let Some(binding) = &arrived_by_binding else {
+                        return Ok(None);
+                    };
+                    let cache_key = BindingCacheKey::from(binding);
+                    let unbound = match self.unbind_cache.get(&cache_key).copied() {
+                        Some(unbound) => unbound,
+                        None => base
+                            .direntry_unbinds_for_binding(binding)
+                            .await?
+                            .iter()
+                            .any(|unbind| unbind.unbind_seq <= visible_seq),
+                    };
+                    Ok(Some((cache_key, unbound)))
                 },
                 async {
-                    match &bound_child_lookup {
-                        Some(name_key) => base
+                    let Some(name_key) = lookup_name_key else {
+                        return Ok(None);
+                    };
+                    let cache_key = ParentNameCacheKey {
+                        parent_inode_id: current_inode_id,
+                        name_key: name_key.clone(),
+                    };
+                    let binding = match self.bound_child_cache.get(&cache_key).cloned() {
+                        Some(binding) => binding,
+                        None => base
                             .direntry_binds_for_parent_name(current_inode_id, name_key)
-                            .await
-                            .map(Some),
-                        None => Ok(None),
-                    }
+                            .await?
+                            .iter()
+                            .filter(|direntry| direntry.bind_seq <= visible_seq)
+                            .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
+                            .cloned(),
+                    };
+                    Ok(Some((cache_key, binding)))
                 },
                 async {
-                    match want_revision {
-                        true => base
-                            .latest_revision_record(current_inode_id)
-                            .await
-                            .map(Some),
-                        false => Ok(None),
+                    if !prefetch_revision {
+                        return Ok(None);
+                    }
+                    match self
+                        .latest_revision_head_cache
+                        .get(&current_inode_id)
+                        .cloned()
+                    {
+                        Some(revision) => Ok(revision),
+                        None => base.latest_revision_record(current_inode_id).await,
                     }
                 },
             )?;
 
-            if let Some(inode) = inode {
-                self.inode_at_seq_cache.insert(current_inode_id, inode);
-            }
-            if let Some(tombstones) = tombstones {
-                let active = super::rows::active_tombstone_from_records(
-                    tombstones.iter().cloned(),
-                    visible_seq,
-                );
-                self.active_tombstone_cache.insert(current_inode_id, active);
-            }
-            if let Some(bindings) = child_bindings {
-                let latest = bindings
-                    .iter()
-                    .filter(|direntry| direntry.bind_seq <= visible_seq)
-                    .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-                    .cloned();
-                self.latest_parent_binding_cache
-                    .insert(current_inode_id, latest);
-            }
-            if let Some(revision) = revision {
+            self.inode_at_seq_cache.insert(current_inode_id, inode);
+            self.active_tombstone_cache
+                .insert(current_inode_id, tombstone);
+            self.latest_parent_binding_cache
+                .insert(current_inode_id, parent_binding);
+            if prefetch_revision {
                 self.latest_revision_head_cache
                     .insert(current_inode_id, revision);
             }
-            if let Some(binding) = &arrived_by_binding {
-                let cache_key = BindingCacheKey::from(binding);
-                let unbound = match unbinds {
-                    Some(rows) => {
-                        let unbound = rows.iter().any(|unbind| unbind.unbind_seq <= visible_seq);
-                        self.unbind_cache.insert(cache_key, unbound);
-                        unbound
-                    }
-                    None => self.unbind_cache.get(&cache_key).copied().unwrap_or(false),
-                };
+            if let Some((cache_key, unbound)) = unbind {
+                self.unbind_cache.insert(cache_key, unbound);
                 if unbound {
                     // The walk dead-ends at the previous component; probing
                     // deeper would warm caches for nothing.
@@ -563,34 +560,10 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
                 }
             }
 
-            let Some(name_key) = lookup_name_key else {
+            let Some((cache_key, bound)) = bound_child else {
                 break;
             };
-            let bound = match bound_rows {
-                Some(rows) => {
-                    let latest = rows
-                        .iter()
-                        .filter(|direntry| direntry.bind_seq <= visible_seq)
-                        .max_by_key(|direntry| (direntry.bind_seq, direntry.bind_delta_index))
-                        .cloned();
-                    self.bound_child_cache.insert(
-                        ParentNameCacheKey {
-                            parent_inode_id: current_inode_id,
-                            name_key: name_key.clone(),
-                        },
-                        latest.clone(),
-                    );
-                    latest
-                }
-                None => self
-                    .bound_child_cache
-                    .get(&ParentNameCacheKey {
-                        parent_inode_id: current_inode_id,
-                        name_key: name_key.clone(),
-                    })
-                    .cloned()
-                    .flatten(),
-            };
+            self.bound_child_cache.insert(cache_key, bound.clone());
             let Some(binding) = bound else {
                 break;
             };

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -4,6 +4,7 @@
 use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::control_update::{update_head, ControlUpdateError, HeadReplacement};
+use crate::error::StoreFailureClass;
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState, WriterBlock};
 use loonfs_api::{NamespaceId, WriterEpoch};
 use loonfs_objectstore::ObjectStore;
@@ -21,12 +22,14 @@ pub enum WriterEpochAcquireError {
     NamespaceDeleted { namespace_id: NamespaceId },
     #[error("empty writer id")]
     EmptyWriterId,
-    #[error("missing head etag for `{object_key}`")]
-    MissingHeadEtag { object_key: String },
     #[error("writer epoch overflow from `{active}`")]
     WriterEpochOverflow { active: WriterEpoch },
-    #[error("failed to write head object during writer epoch acquire: {0}")]
-    HeadWrite(String),
+    #[error("failed to write head object `{object_key}` during writer epoch acquire: {message}")]
+    HeadWrite {
+        object_key: String,
+        message: String,
+        class: StoreFailureClass,
+    },
     #[error("writer epoch acquire retries exhausted after {attempts} attempts")]
     RetryExhausted { attempts: usize },
 }
@@ -123,11 +126,20 @@ impl From<ControlUpdateError> for WriterEpochAcquireError {
             ControlUpdateError::Codec {
                 object_key,
                 message,
-            }
-            | ControlUpdateError::Store {
+            } => Self::HeadWrite {
                 object_key,
                 message,
-            } => Self::HeadWrite(format!("`{object_key}`: {message}")),
+                class: StoreFailureClass::Other,
+            },
+            ControlUpdateError::Store {
+                object_key,
+                message,
+                class,
+            } => Self::HeadWrite {
+                object_key,
+                message,
+                class,
+            },
             ControlUpdateError::RetryExhausted { attempts } => Self::RetryExhausted { attempts },
         }
     }
@@ -138,7 +150,7 @@ mod tests {
     use super::*;
     use crate::commit_engine::delete_namespace;
     use crate::commit_engine::{CommitCandidate, NamespaceCommitEngine};
-    use crate::error::ErrorCode;
+    use crate::error::{CoreError, ErrorCode};
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::namespace::control::read_head_object;
     use crate::options::DeleteNamespaceOptions;
@@ -175,6 +187,7 @@ mod tests {
     use loonfs_objectstore::{
         ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
     };
+    use loonfs_test_support::stores::{FailStore, InjectedError, KeyPredicate, OperationClass};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::tempdir;
 
@@ -252,6 +265,38 @@ mod tests {
         let writer = head.writer.expect("writer block");
         assert_eq!(writer.writer_id, "writer");
         assert_eq!(writer.acquired_at_ms, 2_000);
+    }
+
+    #[tokio::test]
+    async fn a_permission_denied_head_write_is_classified_as_permission_denied() {
+        let temp_dir = tempdir().expect("tempdir");
+        let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        write_head(
+            &inner,
+            &namespace_id,
+            head_owned_by(&namespace_id, "writer-a", WriterEpoch(7)),
+        )
+        .await;
+        let store = FailStore::new(
+            inner,
+            KeyPredicate::exact(wal_head(namespace_id.as_str())),
+            OperationClass::CompareAndSwap,
+            InjectedError::PermissionDenied("head write forbidden".to_owned()),
+        );
+        store.fail_all();
+
+        let error = acquire_writer_epoch(&store, &namespace_id, &context("writer-b", 2_000))
+            .await
+            .expect_err("permission-denied head write must fail");
+        assert!(matches!(
+            &error,
+            WriterEpochAcquireError::HeadWrite {
+                class: StoreFailureClass::PermissionDenied,
+                ..
+            }
+        ));
+        assert_eq!(CoreError::from(error).code(), ErrorCode::PermissionDenied);
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -622,6 +622,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         entry.revision_no = Some(revision.revision_no);
         entry.size_bytes = Some(revision.content_ref.size_bytes);
         entry.content_ref = Some(revision.content_ref.clone());
+        entry.committed_at_ms = Some(revision.committed_at_ms);
         ensure_within_read_limit(revision.content_ref.size_bytes, max_content_bytes)?;
         let read = read_durable_content_bytes(store, &self.content_store_id, &revision.content_ref)
             .await?;
@@ -674,29 +675,26 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             validate_directory_cursor(cursor, &resolved)?;
         }
 
-        if resolved.inode_kind == InodeKind::File {
-            if request.cursor.is_some() {
-                return Err(invalid_cursor(
-                    "directory cursor cannot resume a file listing",
-                ));
+        match resolved.inode_kind {
+            InodeKind::File => {
+                if request.cursor.is_some() {
+                    return Err(invalid_cursor(
+                        "directory cursor cannot resume a file listing",
+                    ));
+                }
+                return Ok(Page {
+                    items: vec![
+                        self.build_authoritative_path_entry_with_session(
+                            &mut session,
+                            &resolved,
+                            attributes,
+                        )
+                        .await?,
+                    ],
+                    next_cursor: None,
+                });
             }
-            return Ok(Page {
-                items: vec![
-                    self.build_authoritative_path_entry_with_session(
-                        &mut session,
-                        &resolved,
-                        attributes,
-                    )
-                    .await?,
-                ],
-                next_cursor: None,
-            });
-        }
-        if resolved.inode_kind != InodeKind::Directory {
-            return Err(CoreError::ExpectedDirectory {
-                path: resolved.absolute_path,
-                kind: resolved.inode_kind,
-            });
+            InodeKind::Directory => {}
         }
 
         let start_after = request

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -1454,18 +1454,7 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
             }
             match verify_durable_content_checksum(store, content_store_id, promised).await {
                 Ok(()) => Ok(CompletionOutcome::Verified(promised.clone())),
-                Err(err) => {
-                    let reason = content_failure_reason(err)?;
-                    // The id is random and still open, so the object nothing
-                    // can name is safe to remove and would otherwise leak.
-                    delete_unpublished_content_object(
-                        store,
-                        content_store_id,
-                        &requested.content_id,
-                    )
-                    .await;
-                    Err(CoreError::InvalidUploadContent(reason))
-                }
+                Err(err) => Ok(CompletionOutcome::Unusable(content_failure_reason(err)?)),
             }
         }
         CompletionPlan::DirectMultipart {
@@ -1554,6 +1543,7 @@ mod tests {
     use crate::namespace::bootstrap::bootstrap_namespace;
     use loonfs_api::v0::BeginUploadRequest;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
+    use loonfs_objectstore::PutMode;
     use tempfile::tempdir;
 
     const BYTES: &[u8] = b"terminal states\n";
@@ -1662,6 +1652,77 @@ mod tests {
             }
         ));
         assert!(store.head(&content_key).await.expect("head").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_failed_direct_put_completion_aborts_and_retries_as_terminal() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let setup = context(1_000);
+        bootstrap_namespace(&store, &namespace_id, &setup, false)
+            .await
+            .expect("bootstrap");
+        let begin = begin_direct_put_upload_target(
+            &store,
+            &namespace_id,
+            DirectPutContentClaim {
+                size_bytes: BYTES.len() as u64,
+                storage_checksum: StorageChecksum::sha256(BYTES),
+            },
+            &setup,
+        )
+        .await
+        .expect("begin direct put");
+        store
+            .put(
+                &begin.target.object_key,
+                Bytes::from(vec![b'x'; BYTES.len()]),
+                PutMode::CreateIfAbsent,
+            )
+            .await
+            .expect("write mismatched direct-put bytes");
+        let content_store_id = load_namespace_content_store_id(&store, &namespace_id)
+            .await
+            .expect("content store id");
+
+        let error = complete_upload(
+            &store,
+            &namespace_id,
+            &content_store_id,
+            &begin.upload_id,
+            &CompleteUploadRequest::for_content_ref(begin.target.content_ref.clone()),
+            &context(2_000),
+        )
+        .await
+        .expect_err("mismatched bytes cannot complete");
+        assert!(matches!(error, CoreError::InvalidUploadContent(_)));
+        let state = read_upload_session_state(&store, &namespace_id, &begin.upload_id)
+            .await
+            .expect("session remains readable");
+        assert!(matches!(
+            state.state,
+            UploadSessionLifecycle::Aborted {
+                aborted_at_ms: 2_000
+            }
+        ));
+        assert!(store
+            .head(&begin.target.object_key)
+            .await
+            .expect("head mismatched content")
+            .is_none());
+
+        let retry = complete_upload(
+            &store,
+            &namespace_id,
+            &content_store_id,
+            &begin.upload_id,
+            &CompleteUploadRequest::for_content_ref(begin.target.content_ref),
+            &context(3_000),
+        )
+        .await
+        .expect_err("an aborted direct put stays terminal");
+        assert!(matches!(retry, CoreError::UploadNotFound { .. }));
     }
 
     /// Completion is terminal in the other direction. An abort cannot

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -882,12 +882,16 @@ async fn revision_queries_read_historical_bytes_and_path_restore_appends_revisio
     )
     .await
     .expect("create file");
+    let replacement_context = MutationContext {
+        writer_id: context.writer_id.clone(),
+        now_ms: 2_000,
+    };
     write_file_bytes(
         &store,
         &namespace_id,
         "/docs/rev.txt",
         b"two",
-        &context,
+        &replacement_context,
         Some("rev-replace"),
     )
     .await
@@ -915,6 +919,8 @@ async fn revision_queries_read_historical_bytes_and_path_restore_appends_revisio
             .await
             .expect("read first revision");
     assert_eq!(historical.bytes, b"one");
+    assert_eq!(historical.entry.committed_at_ms, Some(context.now_ms));
+    assert_eq!(entry.committed_at_ms, Some(replacement_context.now_ms));
     let inode_historical =
         read_file_revision_bytes_for_inode(&store, &namespace_id, inode_id, RevisionNo(2))
             .await

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -111,15 +111,11 @@ fn direct_put_upload_flow_validates_durable_object_on_complete() {
         .object_key
         .ends_with(content_ref.content_id.as_str()));
 
-    let complete_request = CompleteUploadRequest::for_content_ref(content_ref.clone());
-    assert!(fs
-        .complete_upload_blocking(&namespace_id, &begin.upload_id, &complete_request)
-        .is_err());
-
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
     block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
         .expect("write direct object");
 
+    let complete_request = CompleteUploadRequest::for_content_ref(content_ref.clone());
     let completed = fs
         .complete_upload_blocking(&namespace_id, &begin.upload_id, &complete_request)
         .expect("complete direct put");


### PR DESCRIPTION
Fixes several cases where core operations could leave state open or report misleading data. A failed direct-upload completion now marks the session unusable, matching multipart completion, and historical revision reads return the timestamp stored on the selected revision. Unbind lookups now return a required effective value instead of defaulting a missing result to false.

GC now handles control-object failures consistently: storage failures degrade the current pass with a warning, while corrupt data remains an error. Sweep dispatch uses an explicit state match instead of guards followed by an unreachable panic. Head writes preserve the underlying storage error class, so permission failures are reported the same way on reads and writes.

The remaining changes remove unreachable branches and obsolete error variants, and fold block-boundary validation into the existing corruption path. Tests cover each behavior change.