### PR TITLE
fix(storage,server): stream provider uploads, abort on drop, hold the download permit

### DIFF
--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -410,7 +410,7 @@ impl ResolvedTarget {
         start_offset: u64,
     ) -> Result<FileDownload, BackendError> {
         if let (Self::Remote(target), Some(size_bytes)) = (self, size_bytes) {
-            if target.client.offers_direct_download(size_bytes).await {
+            if target.client.offers_direct_download(size_bytes).await? {
                 let grant = target.client.begin_download(spec, revision_no).await?;
                 return Ok(FileDownload::Direct {
                     stream: Box::new(

--- a/crates/loonfs-client/src/download_tests.rs
+++ b/crates/loonfs-client/src/download_tests.rs
@@ -54,10 +54,19 @@ async fn a_file_past_the_default_proxy_cap_takes_the_grant() {
     let client = client();
     let _guard = test_transport::script([capabilities(true, Some(DEFAULT_PROXY_CAP_BYTES))]);
 
-    assert!(client.offers_direct_download(AUDIT_FILE_BYTES).await);
+    assert!(client
+        .offers_direct_download(AUDIT_FILE_BYTES)
+        .await
+        .expect("capabilities"));
     // Cached document, so no second scripted response is needed.
-    assert!(!client.offers_direct_download(DEFAULT_PROXY_CAP_BYTES).await);
-    assert!(!client.offers_direct_download(1).await);
+    assert!(!client
+        .offers_direct_download(DEFAULT_PROXY_CAP_BYTES)
+        .await
+        .expect("cached capabilities"));
+    assert!(!client
+        .offers_direct_download(1)
+        .await
+        .expect("cached capabilities"));
 }
 
 /// A deployment that cannot presign reads proxies everything, whatever the
@@ -69,7 +78,10 @@ async fn a_deployment_without_the_capability_never_takes_the_grant() {
     let client = client();
     let _guard = test_transport::script([capabilities(false, Some(DEFAULT_PROXY_CAP_BYTES))]);
 
-    assert!(!client.offers_direct_download(AUDIT_FILE_BYTES).await);
+    assert!(!client
+        .offers_direct_download(AUDIT_FILE_BYTES)
+        .await
+        .expect("capabilities"));
 }
 
 /// A deployment that states no cap is left on the proxied path: nothing
@@ -80,7 +92,21 @@ async fn a_deployment_that_advertises_no_cap_stays_proxied() {
     let client = client();
     let _guard = test_transport::script([capabilities(true, None)]);
 
-    assert!(!client.offers_direct_download(AUDIT_FILE_BYTES).await);
+    assert!(!client
+        .offers_direct_download(AUDIT_FILE_BYTES)
+        .await
+        .expect("capabilities"));
+}
+
+#[tokio::test]
+async fn a_capability_failure_is_not_reported_as_no_direct_download() {
+    let client = client();
+    let transport = test_transport::script([Outcome::Success(b"not json".to_vec())]);
+
+    let result = client.offers_direct_download(AUDIT_FILE_BYTES).await;
+
+    assert!(matches!(result, Err(ClientError::Json(_))), "{result:?}");
+    assert_eq!(transport.attempts(), 1);
 }
 
 fn grant(content_ref: ContentRef, url: &str) -> BeginDownloadResponse {

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -769,15 +769,13 @@ impl Client {
     ///
     /// A deployment that advertises no cap is left on the proxied path:
     /// nothing here knows it would refuse.
-    pub async fn offers_direct_download(&self, size_bytes: u64) -> bool {
-        let Ok(capabilities) = self.capabilities().await else {
-            return false;
-        };
-        capabilities.supports(FEATURE_DOWNLOADS_DIRECT_GET)
+    pub async fn offers_direct_download(&self, size_bytes: u64) -> Result<bool> {
+        let capabilities = self.capabilities().await?;
+        Ok(capabilities.supports(FEATURE_DOWNLOADS_DIRECT_GET)
             && capabilities
                 .limits
                 .get(LIMIT_DOWNLOAD_MAX_CONTENT_BYTES)
-                .is_some_and(|proxy_cap| size_bytes > *proxy_cap)
+                .is_some_and(|proxy_cap| size_bytes > *proxy_cap))
     }
 
     /// Asks for one short-lived capability to read a file's content object
@@ -1448,7 +1446,7 @@ impl Client {
         // never refuses. Both streaming transports measure the payload as
         // they send it, and the one that cannot — a whole-object write —
         // measures it in the pass it has to make anyway.
-        match self.provisional_transport(source.size_bytes()).await {
+        match self.provisional_transport(source.size_bytes()).await? {
             UploadTransport::Multipart => {
                 let (stream, _) = source.into_stream();
                 self.stage_via_multipart(
@@ -1536,13 +1534,14 @@ impl Client {
     /// payload without sending a byte, and any refusal comes after. Where
     /// one is not, the payload streams to the service, which measures it as
     /// it receives it and answers `content_too_large` if it must.
-    async fn provisional_transport(&self, size_hint: Option<u64>) -> UploadTransport {
-        match self.transport_for(size_hint).await {
+    async fn provisional_transport(&self, size_hint: Option<u64>) -> Result<UploadTransport> {
+        let capabilities = self.capabilities().await?;
+        Ok(match Self::transport_for(&capabilities, size_hint) {
             Ok(transport) => transport,
             Err(no_fit) => no_fit
                 .direct_put_algorithm
                 .map_or(UploadTransport::Proxied, UploadTransport::DirectPut),
-        }
+        })
     }
 
     /// Routes a payload whose length this client measured, refusing when no
@@ -1552,12 +1551,13 @@ impl Client {
     /// moves rather than after the capped proxy has read and rejected the
     /// whole payload.
     async fn transport_for_measured(&self, size: MeasuredBytes) -> Result<UploadTransport> {
-        self.transport_for(Some(size.0))
-            .await
-            .map_err(|no_fit| ClientError::UploadTooLarge {
+        let capabilities = self.capabilities().await?;
+        Self::transport_for(&capabilities, Some(size.0)).map_err(|no_fit| {
+            ClientError::UploadTooLarge {
                 size_bytes: size.0,
                 reason: no_fit.reason,
-            })
+            }
+        })
     }
 
     /// The best transport for a payload of this length, against what the
@@ -1575,15 +1575,10 @@ impl Client {
     /// assumed about how the deployment is configured, which is why the
     /// document is fetched even for a small payload: the fetch happens once
     /// per client and is cached, so the round trip is paid at most once.
-    async fn transport_for(
-        &self,
+    fn transport_for(
+        capabilities: &CapabilityDocument,
         size_bytes: Option<u64>,
     ) -> std::result::Result<UploadTransport, NoTransportFits> {
-        let Ok(capabilities) = self.capabilities().await else {
-            // A deployment that will not describe itself gets the transport
-            // that needs no description.
-            return Ok(UploadTransport::Proxied);
-        };
         // Below one part there is nothing to cut, and a length nobody knows
         // cannot rule parts out.
         let worth_cutting = size_bytes.is_none_or(|size| size >= STREAMING_PUT_MIN_BYTES);

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -848,6 +848,19 @@ async fn a_refusal_reports_the_measured_length_not_the_declared_one() {
     }
 }
 
+#[tokio::test]
+async fn a_capability_failure_does_not_downgrade_a_measured_upload_to_the_proxy() {
+    let transport = test_transport::script([Outcome::Success(b"not json".to_vec())]);
+
+    let error = client()
+        .put_file_bytes(&spec(), b"payload", &PutFileOptions::default())
+        .await
+        .expect_err("capability discovery failure must remain visible");
+
+    assert!(matches!(error, ClientError::Json(_)), "{error:?}");
+    assert_eq!(transport.attempts(), 1);
+}
+
 /// A file-backed source is the dominant case, and it pays nothing extra:
 /// the second pass re-opens the file the caller named, so the payload is
 /// never copied anywhere — not into memory and not into a spool.

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -1,6 +1,6 @@
 //! Azure Blob Storage provider.
 
-use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use super::{ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::object_store::Result;
 use crate::secret::SecretString;
 use crate::store_io_runtime::StoreIoRuntime;
@@ -127,6 +127,10 @@ impl ObjectStore for AzureAbsStore {
 
     async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> Result<ObjectMetadata> {
         self.inner.put(key, bytes, mode).await
+    }
+
+    async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
+        self.inner.put_streamed(key, body, mode).await
     }
 
     async fn delete(&self, key: &str) -> Result<()> {

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -1,6 +1,6 @@
 //! Google Cloud Storage provider.
 
-use super::{ByteRange, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
+use super::{ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::object_store::Result;
 use crate::presign::{stored_crc32c, GcsPresignerConfig, GcsV4Presigner, PresignedUrl};
 use crate::store_io_runtime::StoreIoRuntime;
@@ -212,10 +212,9 @@ impl ObjectStore for GcpGcsStore {
 
         let headers = response.headers();
         let storage_checksum = stored_crc32c_from_headers(headers).ok_or_else(|| {
-            ObjectStoreError::transport(
-                key,
-                "provider reported no crc32c for this object".to_owned(),
-            )
+            ObjectStoreError::StoredChecksumMissing {
+                object_key: key.to_owned(),
+            }
         })?;
         let size_bytes = headers
             .get(http::header::CONTENT_LENGTH)
@@ -256,6 +255,21 @@ impl ObjectStore for GcpGcsStore {
         ))
     }
 
+    async fn put_streamed(&self, key: &str, body: ByteStream, mode: PutMode) -> Result<u64> {
+        self.inner.validate_key(key)?;
+        if matches!(mode, PutMode::CompareAndSwap { .. }) {
+            // The public GCS compare token is an object generation, while
+            // `ProviderObjectStore` can only compare the raw e-tag returned
+            // by its provider HEAD before multipart completion. Forwarding
+            // streamed CAS would therefore enforce a different condition
+            // from `head`; reject it instead of claiming false CAS safety.
+            return Err(ObjectStoreError::Unsupported(
+                "streamed compare-and-swap with GCS generation tokens",
+            ));
+        }
+        self.inner.put_streamed(key, body, mode).await
+    }
+
     async fn delete(&self, key: &str) -> Result<()> {
         self.inner.delete(key).await
     }
@@ -284,8 +298,9 @@ fn stored_crc32c_from_headers(headers: &http::HeaderMap) -> Option<StorageChecks
 mod tests {
     use super::{stored_crc32c_from_headers, GcpGcsStore, GcpGcsStoreConfig};
     use crate::test_support::gcs_fixture_service_account_key_file;
-    use crate::{ObjectStore, ObjectStoreError};
+    use crate::{ObjectStore, ObjectStoreError, PutMode};
     use bytes::Bytes;
+    use futures::StreamExt;
 
     #[tokio::test]
     async fn invalid_keys_are_rejected_before_generation_tokens() {
@@ -303,6 +318,31 @@ mod tests {
                 .await,
             Err(ObjectStoreError::InvalidKey { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn streamed_compare_and_swap_rejects_the_mismatched_token_semantics() {
+        let service_account_key_path = gcs_fixture_service_account_key_file("gcs-streamed-cas");
+        let store = GcpGcsStore::new(GcpGcsStoreConfig {
+            bucket: "bucket".to_owned(),
+            service_account_key_path: service_account_key_path.display().to_string(),
+            key_prefix: None,
+        })
+        .expect("construct gcs store");
+        let body = futures::stream::iter([Ok(Bytes::from_static(b"payload"))]).boxed();
+
+        let error = store
+            .put_streamed(
+                "namespaces/demo/wal/head.json",
+                body,
+                PutMode::CompareAndSwap {
+                    expected_etag: "123".to_owned(),
+                },
+            )
+            .await
+            .expect_err("streamed GCS CAS must not compare an e-tag to a generation");
+
+        assert!(matches!(error, ObjectStoreError::Unsupported(_)));
     }
 
     #[test]

--- a/crates/loonfs-objectstore/src/immutable_write.rs
+++ b/crates/loonfs-objectstore/src/immutable_write.rs
@@ -1,7 +1,7 @@
 //! Verified writes for objects whose keys name immutable bytes.
 
 use crate::retry::{
-    transport_retry_backoff, transport_retry_pause, OperationDeadline, TransportRetryPolicy,
+    next_retry_backoff, transport_retry_pause, OperationDeadline, TransportRetryPolicy,
 };
 use crate::timing::StdMonotonicTimer;
 use crate::{
@@ -67,23 +67,17 @@ pub(crate) async fn put<S: ObjectStore + ?Sized>(
                     .await;
             }
             Err(error @ ObjectStoreError::Transport { .. }) => {
-                let Some(remaining) = deadline.remaining() else {
+                let Some(backoff) = next_retry_backoff(
+                    &retry_policy,
+                    key,
+                    "put_immutable_verified",
+                    bytes.len() as u64,
+                    &mut retries,
+                    Some(&deadline),
+                    &error,
+                ) else {
                     return resolve_readback(store, key, &bytes, error).await;
                 };
-                if retries >= retry_policy.max_retries {
-                    return resolve_readback(store, key, &bytes, error).await;
-                }
-                retries += 1;
-                let backoff = transport_retry_backoff(&retry_policy, retries).min(remaining);
-                tracing::info!(
-                    object_key = key,
-                    operation = "put_immutable_verified",
-                    retry = retries,
-                    max_retries = retry_policy.max_retries,
-                    backoff_ms = u64::try_from(backoff.as_millis()).unwrap_or(u64::MAX),
-                    error = %error,
-                    "transient immutable write failure, backing off before retry",
-                );
                 ambiguous_transport = Some(error);
                 transport_retry_pause(backoff).await;
             }

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -756,6 +756,7 @@ fn classify_error(error: &ObjectStoreError) -> ObjectStoreResultClass {
         ObjectStoreError::InvalidRange { .. } => ObjectStoreResultClass::InvalidRange,
         ObjectStoreError::PreconditionFailed { .. } => ObjectStoreResultClass::PreconditionFailed,
         ObjectStoreError::PermissionDenied { .. } => ObjectStoreResultClass::PermissionDenied,
+        ObjectStoreError::StoredChecksumMissing { .. } => ObjectStoreResultClass::Unsupported,
         ObjectStoreError::Unsupported(_) => ObjectStoreResultClass::Unsupported,
         // Configuration failures happen at store construction, before any
         // metered operation; classify defensively as transport.

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -163,6 +163,16 @@ pub enum ObjectStoreError {
         /// Sanitized provider explanation with credential material removed.
         message: String,
     },
+    /// Reports an object that exists but has no stored full-object checksum.
+    ///
+    /// This is distinct from [`Self::Unsupported`]: the store can perform
+    /// checksum readback, but this particular object carries no checksum it
+    /// can honestly return.
+    #[error("stored full-object checksum missing for `{object_key}`")]
+    StoredChecksumMissing {
+        /// Object whose provider metadata carried no stored checksum.
+        object_key: String,
+    },
     /// Not object-scoped: the store lacks a required capability.
     #[error("unsupported capability: {0}")]
     Unsupported(&'static str),
@@ -198,6 +208,7 @@ impl ObjectStoreError {
             | Self::InvalidRange { object_key }
             | Self::PreconditionFailed { object_key }
             | Self::PermissionDenied { object_key, .. }
+            | Self::StoredChecksumMissing { object_key }
             | Self::Transport { object_key, .. } => Some(object_key),
             Self::InvalidContentRef(_) | Self::Unsupported(_) | Self::Configuration(_) => None,
         }
@@ -215,6 +226,7 @@ impl ObjectStoreError {
             Self::PermissionDenied { message, .. } => {
                 format!("permission denied: {message}")
             }
+            Self::StoredChecksumMissing { .. } => "stored full-object checksum missing".to_owned(),
             Self::Unsupported(capability) => format!("unsupported capability: {capability}"),
             Self::Configuration(message) => {
                 format!("invalid object store configuration: {message}")
@@ -260,11 +272,13 @@ pub trait ObjectStore: Send + Sync + Debug {
     /// code that reaches for it passes its tests against S3 and fails in
     /// production.
     ///
-    /// Stores that cannot report a stored checksum return
-    /// [`ObjectStoreError::Unsupported`]. That is the same capability line
-    /// as presigned direct uploads: a deployment whose provider cannot show
-    /// the checksum back also cannot offer `direct_put`, because completion
-    /// would have nothing to verify against.
+    /// Stores that cannot perform checksum readback return
+    /// [`ObjectStoreError::Unsupported`]. A store that can ask but finds an
+    /// existing object with no stored checksum returns
+    /// [`ObjectStoreError::StoredChecksumMissing`]. That is the same
+    /// capability line as presigned direct uploads: a deployment whose
+    /// provider cannot show the checksum back also cannot offer `direct_put`,
+    /// because completion would have nothing to verify against.
     async fn head_stored_checksum(&self, key: &str) -> Result<Option<StoredObjectChecksum>> {
         let _ = key;
         Err(ObjectStoreError::Unsupported(

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -732,14 +732,8 @@ async fn stored_checksum_readback(store: &dyn ObjectStore, run: &ProbeRun) -> Ch
         Ok(stored) => present("a present object's checksum", stored)?,
         // A provider that stores no checksum for this object must say so
         // rather than invent an answer.
-        Err(error) => {
-            let message = error.message();
-            return if message.contains("no full-object checksum") {
-                Ok(())
-            } else {
-                Err(failed("stored-checksum read", &error))
-            };
-        }
+        Err(ObjectStoreError::StoredChecksumMissing { .. }) => return Ok(()),
+        Err(error) => return Err(failed("stored-checksum read", &error)),
     };
 
     if stored.size_bytes != payload.len() as u64 {
@@ -1007,6 +1001,53 @@ mod tests {
         }
     }
 
+    /// A checksum-capable provider may encounter an object written without
+    /// a stored checksum. That per-object answer is distinct from the store
+    /// lacking the readback capability altogether.
+    #[derive(Debug)]
+    struct MissingStoredChecksumStore {
+        inner: LocalFsStore,
+    }
+
+    #[async_trait]
+    impl ObjectStore for MissingStoredChecksumStore {
+        async fn head(&self, key: &str) -> StoreResult<Option<ObjectMetadata>> {
+            self.inner.head(key).await
+        }
+
+        async fn head_stored_checksum(
+            &self,
+            key: &str,
+        ) -> StoreResult<Option<crate::StoredObjectChecksum>> {
+            match self.inner.head(key).await? {
+                Some(_) => Err(ObjectStoreError::StoredChecksumMissing {
+                    object_key: key.to_owned(),
+                }),
+                None => Ok(None),
+            }
+        }
+
+        async fn get_with_metadata(&self, key: &str) -> StoreResult<Option<ObjectBody>> {
+            self.inner.get_with_metadata(key).await
+        }
+
+        async fn get(&self, key: &str, range: Option<ByteRange>) -> StoreResult<Option<Bytes>> {
+            self.inner.get(key, range).await
+        }
+
+        async fn put(&self, key: &str, bytes: Bytes, mode: PutMode) -> StoreResult<ObjectMetadata> {
+            self.inner.put(key, bytes, mode).await
+        }
+
+        async fn delete(&self, key: &str) -> StoreResult<()> {
+            self.inner.delete(key).await
+        }
+
+        fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
+            self.inner.list_prefix_stream(prefix)
+        }
+    }
+
     /// A store that stamps every object at the unix epoch — what an
     /// S3-compatible endpoint that omits `Last-Modified` becomes once the
     /// AWS client path synthesizes a time for it.
@@ -1073,6 +1114,22 @@ mod tests {
         assert_eq!(
             outcome(&report, "stored_checksum_readback"),
             &StoreProbeOutcome::Unsupported
+        );
+        assert!(report.all_passed());
+    }
+
+    #[tokio::test]
+    async fn a_present_object_without_a_stored_checksum_is_matched_structurally() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let store = MissingStoredChecksumStore {
+            inner: LocalFsStore::new(temp_dir.path()).expect("create local object store"),
+        };
+
+        let report = run_store_contract_probe(&store, "probe_test_missing_checksum").await;
+
+        assert_eq!(
+            outcome(&report, "stored_checksum_readback"),
+            &StoreProbeOutcome::Passed
         );
         assert!(report.all_passed());
     }

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -2,14 +2,13 @@
 //! delete and multipart stages, and multipart upload for large immutable
 //! payloads.
 
-use crate::attempts::count_retry_attempt;
 use crate::immutable_write::{readback, ImmutableReadback};
 use crate::keyspace::{
     normalize_key_prefix, scope_list_prefix, scope_object_key, unscope_listed_key,
 };
 use crate::object_store::Result;
 use crate::retry::{
-    transport_retry_backoff, transport_retry_pause, OperationDeadline, TransportRetryPolicy,
+    next_retry_backoff, transport_retry_pause, OperationDeadline, TransportRetryPolicy,
 };
 use crate::timing::{MonotonicTimer, StdMonotonicTimer};
 use crate::{
@@ -279,7 +278,7 @@ impl ProviderObjectStore {
     /// Conditional write modes do not use this path.
     async fn put_large_multipart(
         &self,
-        multipart: &dyn MultipartStore,
+        multipart: Arc<dyn MultipartStore>,
         key: &str,
         path: &Path,
         bytes: Bytes,
@@ -292,76 +291,24 @@ impl ProviderObjectStore {
             path,
         };
 
-        let upload_id = upload.create(size_bytes).await?;
-        let result = upload.upload_parts_and_complete(&upload_id, &bytes).await;
+        let mut abort_on_drop = upload.create(size_bytes).await?;
+        let result = upload
+            .upload_parts_and_complete(abort_on_drop.upload_id(), &bytes)
+            .await;
         match result {
-            Ok(metadata) => Ok(metadata),
+            Ok(metadata) => {
+                abort_on_drop.disarm();
+                Ok(metadata)
+            }
             Err(err) => {
                 // Best effort, and harmless when the failure raced a landed
                 // completion: the upload id no longer exists then, and the
                 // abort cannot touch the completed object.
-                upload.abort(&upload_id).await;
+                upload.abort(abort_on_drop.upload_id()).await;
+                abort_on_drop.disarm();
                 Err(err)
             }
         }
-    }
-
-    /// Returns the delay before the next write attempt, or `None` when the
-    /// retry count or operation deadline is exhausted.
-    ///
-    /// Multipart transfers use only the retry count. Exhaustion logs include the
-    /// payload size to help distinguish slow transfers from other failures.
-    fn next_write_backoff(
-        &self,
-        key: &str,
-        operation: &'static str,
-        payload_bytes: u64,
-        retries: &mut u32,
-        deadline: Option<&OperationDeadline<'_>>,
-        err: &provider_store::Error,
-    ) -> Option<Duration> {
-        if *retries >= self.transport_retry.max_retries {
-            tracing::warn!(
-                object_key = key,
-                operation,
-                retry = *retries,
-                payload_bytes,
-                error = %err,
-                "object store write retry budget exhausted; not retrying",
-            );
-            return None;
-        }
-        let mut remaining = Duration::MAX;
-        if let Some(deadline) = deadline {
-            let Some(deadline_remaining) = deadline.remaining() else {
-                tracing::warn!(
-                    object_key = key,
-                    operation,
-                    retry = *retries,
-                    payload_bytes,
-                    error = %err,
-                    "object store operation deadline exhausted; not retrying",
-                );
-                return None;
-            };
-            remaining = deadline_remaining;
-        }
-        *retries += 1;
-        // Every write retry this store grants passes through here, so this
-        // is the one place a measuring wrapper above needs counted for its
-        // sample's attempt count.
-        count_retry_attempt();
-        let backoff = transport_retry_backoff(&self.transport_retry, *retries).min(remaining);
-        tracing::info!(
-            object_key = key,
-            operation,
-            retry = *retries,
-            max_retries = self.transport_retry.max_retries,
-            backoff_ms = u64::try_from(backoff.as_millis()).unwrap_or(u64::MAX),
-            error = %err,
-            "transient object store write failure, backing off before retry",
-        );
-        Some(backoff)
     }
 }
 
@@ -423,7 +370,7 @@ impl PartReader {
     }
 }
 
-/// Aborts a provider multipart upload when its streamed write is cancelled.
+/// Aborts a provider multipart upload when its write is cancelled.
 ///
 /// Normal return paths abort explicitly and disable this guard. Cancellation
 /// has no cleanup `await` point, so `Drop` starts the abort on the current
@@ -436,6 +383,22 @@ struct AbortUploadOnDrop {
 }
 
 impl AbortUploadOnDrop {
+    fn new(
+        multipart: Arc<dyn MultipartStore>,
+        path: Path,
+        upload_id: provider_store::MultipartId,
+    ) -> Self {
+        Self {
+            multipart: Some(multipart),
+            path,
+            upload_id,
+        }
+    }
+
+    fn upload_id(&self) -> &provider_store::MultipartId {
+        &self.upload_id
+    }
+
     fn disarm(&mut self) {
         self.multipart = None;
     }
@@ -450,7 +413,7 @@ impl Drop for AbortUploadOnDrop {
             tracing::warn!(
                 object_key = %self.path,
                 operation = "abort_multipart",
-                "abandoned streamed write has no runtime to abort its multipart upload on; \
+                "abandoned write has no runtime to abort its multipart upload on; \
                  parts remain until the bucket lifecycle rule collects them",
             );
             return;
@@ -463,7 +426,7 @@ impl Drop for AbortUploadOnDrop {
                     object_key = %path,
                     operation = "abort_multipart",
                     error = %err,
-                    "failed to abort the multipart upload of an abandoned streamed write",
+                    "failed to abort the multipart upload of an abandoned write",
                 );
             }
         });
@@ -474,23 +437,30 @@ impl Drop for AbortUploadOnDrop {
 /// surface, and the object being written.
 struct MultipartWrite<'op> {
     store: &'op ProviderObjectStore,
-    multipart: &'op dyn MultipartStore,
+    multipart: Arc<dyn MultipartStore>,
     key: &'op str,
     path: &'op Path,
 }
 
 impl MultipartWrite<'_> {
-    async fn create(&self, payload_bytes: u64) -> Result<provider_store::MultipartId> {
+    async fn create(&self, payload_bytes: u64) -> Result<AbortUploadOnDrop> {
         let mut retries: u32 = 0;
         loop {
             let err = match self.multipart.create_multipart(self.path).await {
-                Ok(upload_id) => return Ok(upload_id),
+                Ok(upload_id) => {
+                    return Ok(AbortUploadOnDrop::new(
+                        Arc::clone(&self.multipart),
+                        self.path.clone(),
+                        upload_id,
+                    ));
+                }
                 Err(err) => err,
             };
             if !provider_transport_retryable(&err) {
                 return Err(map_provider_error(self.key, err));
             }
-            let Some(backoff) = self.store.next_write_backoff(
+            let Some(backoff) = next_retry_backoff(
+                &self.store.transport_retry,
                 self.key,
                 "create_multipart",
                 payload_bytes,
@@ -640,7 +610,8 @@ impl MultipartWrite<'_> {
             if !provider_transport_retryable(&err) {
                 return Err(map_provider_error(self.key, err));
             }
-            let Some(backoff) = self.store.next_write_backoff(
+            let Some(backoff) = next_retry_backoff(
+                &self.store.transport_retry,
                 self.key,
                 "put_part",
                 payload_bytes,
@@ -859,9 +830,7 @@ impl ObjectStore for ProviderObjectStore {
             && size_bytes >= self.multipart_geometry.threshold_bytes
         {
             if let Some(multipart) = self.multipart.clone() {
-                return self
-                    .put_large_multipart(multipart.as_ref(), key, &path, bytes)
-                    .await;
+                return self.put_large_multipart(multipart, key, &path, bytes).await;
             }
         }
         // Raw flat writes are deliberately one attempt. In particular, a
@@ -924,26 +893,24 @@ impl ObjectStore for ProviderObjectStore {
 
         let upload = MultipartWrite {
             store: self,
-            multipart: multipart.as_ref(),
+            multipart,
             key,
             path: &path,
         };
-        let upload_id = upload.create(0).await?;
-        let mut abort_on_drop = AbortUploadOnDrop {
-            multipart: Some(Arc::clone(&multipart)),
-            path: path.clone(),
-            upload_id: upload_id.clone(),
-        };
+        let mut abort_on_drop = upload.create(0).await?;
         let result = upload
-            .upload_stream_and_complete(&upload_id, head, reader, &mode)
+            .upload_stream_and_complete(abort_on_drop.upload_id(), head, reader, &mode)
             .await;
-        abort_on_drop.disarm();
         match result {
-            Ok(size_bytes) => Ok(size_bytes),
+            Ok(size_bytes) => {
+                abort_on_drop.disarm();
+                Ok(size_bytes)
+            }
             Err(err) => {
                 // Best effort, and harmless when the failure raced a landed
                 // completion: the upload id no longer exists then.
-                upload.abort(&upload_id).await;
+                upload.abort(abort_on_drop.upload_id()).await;
+                abort_on_drop.disarm();
                 Err(err)
             }
         }
@@ -966,9 +933,15 @@ impl ObjectStore for ProviderObjectStore {
             if !provider_transport_retryable(&err) {
                 return Err(map_provider_error(key, err));
             }
-            let Some(backoff) =
-                self.next_write_backoff(key, "delete", 0, &mut retries, Some(&deadline), &err)
-            else {
+            let Some(backoff) = next_retry_backoff(
+                &self.transport_retry,
+                key,
+                "delete",
+                0,
+                &mut retries,
+                Some(&deadline),
+                &err,
+            ) else {
                 return Err(map_provider_error(key, err));
             };
             transport_retry_pause(backoff).await;
@@ -1188,6 +1161,7 @@ mod tests {
     use crate::metrics::{
         InstrumentedObjectStore, ObjectStoreOperation, VecObjectStoreMetricsRecorder,
     };
+    use crate::retry::transport_retry_backoff;
     use crate::test_support::SteppingTimer;
     use futures::StreamExt;
     use object_store::memory::InMemory;
@@ -1462,8 +1436,9 @@ mod tests {
 
     use provider_store::{GetResult, ListResult, MultipartUpload, PutMultipartOptions};
     use std::collections::{BTreeMap, HashMap, VecDeque};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Mutex;
+    use tokio::sync::Notify;
 
     #[derive(Debug)]
     enum WriteScript {
@@ -1503,6 +1478,9 @@ mod tests {
         part_attempts: Mutex<HashMap<usize, usize>>,
         multipart_completes: AtomicUsize,
         multipart_aborts: AtomicUsize,
+        block_part_uploads: AtomicBool,
+        part_started: Notify,
+        multipart_aborted: Notify,
         next_upload_id: AtomicUsize,
         multipart_uploads: Mutex<HashMap<String, BTreeMap<usize, Bytes>>>,
     }
@@ -1700,6 +1678,10 @@ mod tests {
             part_idx: usize,
             data: PutPayload,
         ) -> provider_store::Result<PartId> {
+            if self.block_part_uploads.load(Ordering::SeqCst) {
+                self.part_started.notify_one();
+                return std::future::pending().await;
+            }
             *self
                 .part_attempts
                 .lock()
@@ -1771,6 +1753,7 @@ mod tests {
                 .lock()
                 .expect("uploads")
                 .remove(id.as_str());
+            self.multipart_aborted.notify_one();
             Ok(())
         }
     }
@@ -2273,6 +2256,39 @@ mod tests {
         assert_eq!(
             store.get(MULTIPART_KEY, None).await.expect("get"),
             Some(Bytes::from(payload))
+        );
+    }
+
+    /// Cancellation has no error arm to run. The upload id must therefore
+    /// be guarded from the instant creation returns, including for the
+    /// buffered multipart path.
+    #[tokio::test]
+    async fn dropping_a_buffered_multipart_write_aborts_its_provider_upload() {
+        let flaky = Arc::new(FlakyStore::default());
+        flaky.block_part_uploads.store(true, Ordering::SeqCst);
+        let store = multipart_test_store(Arc::clone(&flaky));
+        let part_started = flaky.part_started.notified();
+        let multipart_aborted = flaky.multipart_aborted.notified();
+
+        {
+            let write = store.put_overwrite(MULTIPART_KEY, Bytes::from(multipart_payload(1300)));
+            tokio::pin!(write);
+            let completed = tokio::select! {
+                () = part_started => None,
+                result = &mut write => Some(result),
+            };
+            assert!(
+                completed.is_none(),
+                "blocked multipart write completed unexpectedly: {completed:?}"
+            );
+        }
+
+        multipart_aborted.await;
+        assert_eq!(flaky.multipart_creates.load(Ordering::SeqCst), 1);
+        assert_eq!(flaky.multipart_aborts.load(Ordering::SeqCst), 1);
+        assert!(
+            flaky.multipart_uploads.lock().expect("uploads").is_empty(),
+            "cancelling the write must leave no provider upload behind"
         );
     }
 

--- a/crates/loonfs-objectstore/src/retry.rs
+++ b/crates/loonfs-objectstore/src/retry.rs
@@ -1,7 +1,9 @@
 //! Shared bounded-backoff machinery for replay-safe store operations.
 
+use crate::attempts::count_retry_attempt;
 use crate::timing::MonotonicTimer;
 use crate::PROVIDER_OPERATION_DEADLINE;
+use std::fmt::Display;
 use std::time::Duration;
 
 /// Bounded retry configuration matching the provider client's read budget.
@@ -28,6 +30,60 @@ pub(crate) fn transport_retry_backoff(policy: &TransportRetryPolicy, retry: u32)
         .initial_backoff
         .saturating_mul(1u32 << doublings)
         .min(policy.max_backoff)
+}
+
+/// Grants one retry under the shared count and deadline budgets.
+///
+/// Every replay-safe write retry passes through here, so attempt metrics and
+/// granted/exhausted warnings cannot drift between callers.
+pub(crate) fn next_retry_backoff(
+    policy: &TransportRetryPolicy,
+    key: &str,
+    operation: &'static str,
+    payload_bytes: u64,
+    retries: &mut u32,
+    deadline: Option<&OperationDeadline<'_>>,
+    error: &dyn Display,
+) -> Option<Duration> {
+    if *retries >= policy.max_retries {
+        tracing::warn!(
+            object_key = key,
+            operation,
+            retry = *retries,
+            payload_bytes,
+            error = %error,
+            "object store write retry budget exhausted; not retrying",
+        );
+        return None;
+    }
+    let mut remaining = Duration::MAX;
+    if let Some(deadline) = deadline {
+        let Some(deadline_remaining) = deadline.remaining() else {
+            tracing::warn!(
+                object_key = key,
+                operation,
+                retry = *retries,
+                payload_bytes,
+                error = %error,
+                "object store operation deadline exhausted; not retrying",
+            );
+            return None;
+        };
+        remaining = deadline_remaining;
+    }
+    *retries += 1;
+    count_retry_attempt();
+    let backoff = transport_retry_backoff(policy, *retries).min(remaining);
+    tracing::warn!(
+        object_key = key,
+        operation,
+        retry = *retries,
+        max_retries = policy.max_retries,
+        backoff_ms = u64::try_from(backoff.as_millis()).unwrap_or(u64::MAX),
+        error = %error,
+        "transient object store write failure, backing off before retry",
+    );
+    Some(backoff)
 }
 
 /// Elapsed-time state for one logical operation's retry loop.
@@ -64,4 +120,39 @@ pub(crate) async fn transport_retry_pause(backoff: Duration) {
     // Replay-safe operations wait at this isolated timer boundary so backoff
     // pacing never feeds protocol state and replay stays deterministic.
     tokio::time::sleep(backoff).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attempts::counting_attempts;
+
+    #[tokio::test]
+    async fn every_granted_retry_counts_as_an_attempt() {
+        let policy = TransportRetryPolicy {
+            max_retries: 1,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(1),
+            operation_deadline: Duration::from_secs(1),
+        };
+        let error = "injected transport failure".to_owned();
+        let (_, attempts) = counting_attempts(async {
+            let mut retries = 0;
+            assert_eq!(
+                next_retry_backoff(
+                    &policy,
+                    "namespaces/demo/wal/segments/seg_test.wal.zst",
+                    "put_immutable_verified",
+                    7,
+                    &mut retries,
+                    None,
+                    &error,
+                ),
+                Some(Duration::from_millis(1))
+            );
+        })
+        .await;
+
+        assert_eq!(attempts, 2);
+    }
 }

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -381,10 +381,9 @@ impl ObjectStore for S3CompatibleStore {
 
         let headers = &response.headers;
         let Some(storage_checksum) = s3_stored_checksum(headers) else {
-            return Err(ObjectStoreError::transport(
-                key,
-                "provider reported no full-object checksum for this object".to_owned(),
-            ));
+            return Err(ObjectStoreError::StoredChecksumMissing {
+                object_key: key.to_owned(),
+            });
         };
         let size_bytes = headers
             .get(http::header::CONTENT_LENGTH)

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -255,6 +255,20 @@ async fn gcp_gcs_real_provider_conformance() {
 }
 
 #[tokio::test]
+#[ignore = "requires real GCP GCS credentials"]
+async fn gcp_gcs_streamed_write_round_trips() {
+    let config = GcpGcsConformanceConfig::from_env()
+        .expect("load GCP GCS real-provider conformance environment");
+    let store = GcpGcsStore::new(GcpGcsStoreConfig {
+        bucket: config.bucket,
+        service_account_key_path: config.service_account_key_path,
+        key_prefix: Some(config.prefix),
+    })
+    .expect("create GCP GCS object store");
+    assert_streamed_write_round_trips(&store).await;
+}
+
+#[tokio::test]
 #[ignore = "requires real Azure Blob Storage credentials"]
 async fn azure_abs_real_provider_conformance() {
     let config = AzureAbsConformanceConfig::from_env()
@@ -268,6 +282,22 @@ async fn azure_abs_real_provider_conformance() {
     })
     .expect("create Azure Blob Storage object store");
     assert_provider_conformance(&store).await;
+}
+
+#[tokio::test]
+#[ignore = "requires real Azure Blob Storage credentials"]
+async fn azure_abs_streamed_write_round_trips() {
+    let config = AzureAbsConformanceConfig::from_env()
+        .expect("load Azure Blob Storage real-provider conformance environment");
+    let store = AzureAbsStore::new(AzureAbsStoreConfig {
+        account_name: config.account_name,
+        container_name: config.container_name,
+        access_key: config.access_key.into(),
+        endpoint_url: config.endpoint,
+        key_prefix: Some(config.prefix),
+    })
+    .expect("create Azure Blob Storage object store");
+    assert_streamed_write_round_trips(&store).await;
 }
 
 /// The live provider sweep: the store contract probe, plus the key

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -7,10 +7,12 @@ use super::handlers_uploads::{
     content_preparation_for_puts, current_unix_ms, ContentTokenVerifier, PutContentPreparation,
 };
 use super::{authorize, AppJson, AppQuery, AppState, NamespaceIdPath};
+use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use futures::Stream;
 use loonfs::publish::{CommitCandidate, CommitRequest, ContentPreparationError};
 use loonfs::{
     payload_class, ErrorCode, ListChangesOptions, ListPathEntriesOptions, StatPathOptions,
@@ -28,6 +30,10 @@ use loonfs_api::{
     FilesystemOperation, LimitError, ListFileRevisionsResponse, ListTrashResponse, PageCursorError,
     PageRequest, PaginationPolicy, RevisionNo,
 };
+use std::convert::Infallible;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::OwnedSemaphorePermit;
 use tracing::Instrument;
 
 #[derive(Debug, serde::Deserialize)]
@@ -64,6 +70,24 @@ pub(super) struct PageQuery {
 pub(super) struct ContentQuery {
     path: String,
     revision_no: Option<String>,
+}
+
+/// One materialized download plus the permit accounting for its memory.
+///
+/// The stream owns the permit even after yielding its only chunk, so the
+/// response body releases admission only when it is fully consumed or
+/// abandoned and dropped.
+struct DownloadBodyStream {
+    bytes: Option<bytes::Bytes>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl Stream for DownloadBodyStream {
+    type Item = Result<bytes::Bytes, Infallible>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.bytes.take().map(Ok))
+    }
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -205,9 +229,9 @@ pub(super) async fn get_file_bytes(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
-    // Held for the read below: content reads buffer the whole file, so the
-    // permit is what bounds how many such buffers exist at once.
-    let _permit = state
+    // Content reads buffer the whole file, so the permit must follow those
+    // bytes through the response body rather than ending with this handler.
+    let permit = state
         .download_permits
         .clone()
         .try_acquire_owned()
@@ -231,7 +255,16 @@ pub(super) async fn get_file_bytes(
         None => state.reader.get_file_bytes(&namespace_id, &path).await,
     }
     .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    Ok((StatusCode::OK, file.bytes).into_response())
+    let body = Body::from_stream(DownloadBodyStream {
+        bytes: Some(file.bytes.into()),
+        _permit: permit,
+    });
+    Ok((
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
+        body,
+    )
+        .into_response())
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2294,6 +2294,64 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     server.abort();
 }
 
+#[tokio::test]
+async fn download_admission_is_held_until_the_response_body_is_consumed() {
+    use tower::ServiceExt;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let seed_writer = bootstrap_namespace(&store, "runtime-writer", &namespace_id("demo")).await;
+    write_file_bytes(
+        &seed_writer,
+        &namespace_id("demo"),
+        "/note.txt",
+        b"bounded",
+        "download-body-permit-seed-01",
+    )
+    .await;
+    let mut config = test_config(temp_dir.path(), "server-writer");
+    config.max_concurrent_downloads = 1;
+    let (router, state) = app_with_store_and_state(config, store)
+        .await
+        .expect("build app");
+
+    let response = router
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/v0/namespaces/demo/filesystem/content?path=%2Fnote.txt")
+                .header(axum::http::header::AUTHORIZATION, "Bearer test-token")
+                .body(axum::body::Body::empty())
+                .expect("download request"),
+        )
+        .await
+        .expect("download response");
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    assert_eq!(
+        response.headers().get(axum::http::header::CONTENT_TYPE),
+        Some(&axum::http::HeaderValue::from_static(
+            "application/octet-stream"
+        ))
+    );
+    assert_eq!(state.download_permits.available_permits(), 0);
+
+    let next_permit = state.download_permits.clone().acquire_owned();
+    tokio::pin!(next_permit);
+    assert!(matches!(
+        futures::poll!(next_permit.as_mut()),
+        std::task::Poll::Pending
+    ));
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("download body");
+    assert_eq!(&body[..], b"bounded");
+    let acquired = next_permit
+        .await
+        .expect("the next download is admitted after full consumption");
+    drop(acquired);
+    assert_eq!(state.download_permits.available_permits(), 1);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_content_read_over_the_download_limit_answers_content_too_large() {
     let temp_dir = tempdir().expect("tempdir");

--- a/docs/specs/object-storage-providers.md
+++ b/docs/specs/object-storage-providers.md
@@ -165,15 +165,14 @@ here rather than advertised as a capability.
 | AWS S3 | Yes, provider multipart | One part (8 MiB by default), whatever the object's size |
 | Cloudflare R2 | Yes, provider multipart | One part, whatever the object's size |
 | Other S3-compatible endpoints | Yes, provider multipart | One part, whatever the object's size |
-| Google Cloud Storage | No | The whole payload, bounded by `upload.max_content_bytes` |
-| Azure Blob Storage | No | The whole payload, bounded by `upload.max_content_bytes` |
+| Google Cloud Storage | Yes, provider multipart | One part, whatever the object's size |
+| Azure Blob Storage | Yes, provider multipart | One part, whatever the object's size |
 | Local filesystem | Yes, staging file | One chunk as it arrives |
 
-The two providers without an incremental write are not broken by this and
-are not silently degraded either: they buffer and write in one request,
-which is exactly what every provider did before, and the byte cap that
-bounded that buffering still bounds it. Adding an incremental write for them
-is a provider-adapter change, not a contract change.
+Every built-in provider has a real incremental write path. Cloud providers
+regroup the incoming stream into provider multipart parts, while the local
+filesystem stages chunks into a file. The server therefore retains only one
+part or chunk for a proxied upload, independent of the object's total size.
 
 ## 5. Local Filesystem Provider
 


### PR DESCRIPTION
Prevents streamed uploads from being buffered unnecessarily on GCS and Azure by forwarding put_streamed to the provider implementations. The conformance suite now exercises streamed round trips, and GCS reports streamed compare-and-swap as unsupported because its generation tokens are not compatible with the inner ETag check.

Buffered multipart uploads now keep an abort-on-drop guard from the moment the provider upload is created, so cancellation cannot strand an unfinished upload. Missing stored checksums are represented by a typed storage error instead of provider-specific message matching.

The server now keeps a download concurrency permit until the response body is dropped, preserving the configured memory bound for buffered downloads. The client also propagates persistent capability-discovery failures instead of silently falling back to a different upload transport.