### PR TITLE
fix(client): secrets stay redacted across the seam, errors say what they are

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "tracing",
  "urlencoding",
 ]
 

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -41,6 +41,7 @@ mod name_policy;
 pub mod options;
 mod pagination;
 mod path;
+mod secret;
 mod sst_blocks;
 pub mod v0;
 mod wal;
@@ -139,6 +140,7 @@ pub use path::{
     AbsolutePath, DisplayName, PathComponent, PathError, MAX_DISPLAY_NAME_BYTES, MAX_PATH_BYTES,
     MAX_PATH_DEPTH,
 };
+pub use secret::SecretString;
 
 // Curated root re-exports of the common v0 HTTP surface. v0 HTTP shapes live
 // in `v0`; add here only what most consumers touch.

--- a/crates/loonfs-api/src/secret.rs
+++ b/crates/loonfs-api/src/secret.rs
@@ -28,6 +28,11 @@ impl SecretString {
         Self(value.into())
     }
 
+    /// Returns whether the secret contains only whitespace.
+    pub fn is_blank(&self) -> bool {
+        self.0.trim().is_empty()
+    }
+
     /// Returns the raw secret. Keep the exposure site as small as possible.
     pub fn expose(&self) -> &str {
         &self.0
@@ -78,6 +83,12 @@ mod tests {
         assert_eq!(format!("{secret:?}"), "<redacted>");
         assert_eq!(format!("{secret}"), "<redacted>");
         assert_eq!(secret.expose(), "super-secret-value");
+    }
+
+    #[test]
+    fn blank_detection_ignores_surrounding_whitespace() {
+        assert!(SecretString::new(" \t\n").is_blank());
+        assert!(!SecretString::new(" secret ").is_blank());
     }
 
     #[test]

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -5,9 +5,9 @@ use crate::args::{InitArgs, ProfileCreateArgs, ProfileUpdateArgs, RuntimeBehavio
 use crate::config::{non_empty_env, ProfileConfig, StoreConfig};
 use crate::error::CliError;
 use crate::prompt;
+use loonfs_api::SecretString;
 use loonfs_objectstore::{
-    ConfiguredObjectStoreKind, SecretString, ACCESS_KEY_ID_ENV, SECRET_ACCESS_KEY_ENV,
-    SESSION_TOKEN_ENV,
+    ConfiguredObjectStoreKind, ACCESS_KEY_ID_ENV, SECRET_ACCESS_KEY_ENV, SESSION_TOKEN_ENV,
 };
 
 const AWS_REGIONS: &[&str] = &[
@@ -852,7 +852,7 @@ mod tests {
     };
     use crate::args::{ProfileUpdateArgs, RuntimeBehavior};
     use crate::config::{ProfileConfig, StoreConfig};
-    use loonfs_objectstore::SecretString;
+    use loonfs_api::SecretString;
 
     #[test]
     fn create_profile_supports_azure_abs() {

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -1,9 +1,9 @@
 //! The CLI config file: profiles, defaults, and strict TOML loading.
 
 use crate::error::CliError;
-use loonfs_api::NamespaceId;
+use loonfs_api::{NamespaceId, SecretString};
 use loonfs_client::ClientConfig;
-use loonfs_objectstore::{SecretString, StoreConfigError};
+use loonfs_objectstore::StoreConfigError;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -9,7 +9,7 @@ use crate::config::{
 use crate::error::CliError;
 use crate::profiles::{default_namespace, resolve_profile};
 use loonfs::{FsAdmin, FsBackgroundWork, FsWriter, SharedObjectStore, TraceStoreKind};
-use loonfs_api::{ErrorCode, NamespaceId};
+use loonfs_api::{ErrorCode, NamespaceId, SecretString};
 use loonfs_client::{Client, ClientConfig};
 use loonfs_grep::{GrepBlockCache, GrepService, DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES};
 use std::sync::Arc;
@@ -126,7 +126,7 @@ impl ResolvedTarget {
                 ..
             } => Ok(Self::Remote(RemoteTarget::new(
                 server_url,
-                auth_token.as_ref().map(|token| token.expose()),
+                auth_token.clone(),
                 ca_cert_path.as_deref(),
                 no_retry,
             )?)),
@@ -207,13 +207,13 @@ impl EmbeddedTarget {
 impl RemoteTarget {
     fn new(
         server_url: &str,
-        auth_token: Option<&str>,
+        auth_token: Option<SecretString>,
         ca_cert_path: Option<&str>,
         no_retry: bool,
     ) -> Result<Self, CliError> {
         let client = Client::new(ClientConfig {
             server_url: server_url.to_owned(),
-            auth_token: auth_token.map(ToOwned::to_owned),
+            auth_token,
             request_timeout_ms: None,
             disable_transient_retry: no_retry,
             ca_cert_path: ca_cert_path.map(ToOwned::to_owned),

--- a/crates/loonfs-client/Cargo.toml
+++ b/crates/loonfs-client/Cargo.toml
@@ -21,6 +21,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
+tracing.workspace = true
 urlencoding.workspace = true
 
 [dev-dependencies]

--- a/crates/loonfs-client/src/config.rs
+++ b/crates/loonfs-client/src/config.rs
@@ -3,6 +3,7 @@
 
 use crate::{ClientError, Result};
 use http::Uri;
+use loonfs_api::SecretString;
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;
@@ -18,7 +19,7 @@ pub struct ClientConfig {
     /// Base URL for the LoonFS server.
     pub server_url: String,
     /// Optional bearer token.
-    pub auth_token: Option<String>,
+    pub auth_token: Option<SecretString>,
     /// Optional overall per-request deadline in milliseconds. Unset means no
     /// whole-request deadline: requests are bounded only by the built-in
     /// 60-second socket inactivity timeouts, so slow-but-progressing large
@@ -64,7 +65,7 @@ impl ClientConfig {
     pub fn validate(&self) -> Result<()> {
         validate_absolute_http_url("server_url", &self.server_url)?;
         if let Some(token) = &self.auth_token {
-            if token.trim().is_empty() {
+            if token.is_blank() {
                 return Err(ClientError::ConfigValidation {
                     field: "auth_token",
                     reason: "must not be empty".to_owned(),

--- a/crates/loonfs-client/src/download_tests.rs
+++ b/crates/loonfs-client/src/download_tests.rs
@@ -144,7 +144,7 @@ async fn a_streamed_read_is_refused_when_the_bytes_are_not_what_the_grant_named(
         .await
         .expect_err("bytes that are not the granted object");
     assert!(
-        matches!(&error, ClientError::Http(message) if message.contains("grant named")),
+        matches!(&error, ClientError::Protocol(message) if message.contains("grant named")),
         "unexpected error: {error}"
     );
 }
@@ -196,7 +196,7 @@ async fn a_crc32c_only_grant_verifies_the_bytes_it_receives() {
         .await
         .expect_err("bytes that are not the granted object");
     assert!(
-        matches!(&error, ClientError::Http(message) if message.contains("grant named")),
+        matches!(&error, ClientError::Protocol(message) if message.contains("grant named")),
         "unexpected error: {error}"
     );
 }
@@ -243,7 +243,7 @@ async fn a_resumed_crc32c_download_folds_the_prefix_into_the_same_verdict() {
         }
     };
     assert!(
-        matches!(&error, ClientError::Http(message) if message.contains("grant named")),
+        matches!(&error, ClientError::Protocol(message) if message.contains("grant named")),
         "unexpected error: {error}"
     );
 }
@@ -362,7 +362,7 @@ async fn a_grant_that_does_not_authorize_a_read_is_refused_before_any_request() 
         .await
         .expect_err("a write capability cannot serve a read");
     assert!(
-        matches!(&error, ClientError::Http(message) if message.contains("presigned download method")),
+        matches!(&error, ClientError::Protocol(message) if message.contains("presigned download method")),
         "unexpected error: {error}"
     );
     assert!(sink.is_empty());

--- a/crates/loonfs-client/src/error.rs
+++ b/crates/loonfs-client/src/error.rs
@@ -1,12 +1,12 @@
-//! [`ClientError`]: every failure the blocking client surfaces.
+//! [`ClientError`]: every failure the async client surfaces.
 
 use loonfs_api::{ErrorCode, ErrorDetails, ErrorKind};
 use thiserror::Error;
 
-/// Error returned by the blocking HTTP client.
+/// Error returned by the async HTTP client.
 ///
-/// Foreign causes (io, json, ureq) are captured as message strings rather
-/// than `#[source]` chains.
+/// Foreign causes (I/O, JSON, and HTTP transport) are captured as message
+/// strings rather than `#[source]` chains.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ClientError {

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -38,7 +38,7 @@ use loonfs_api::{
     GrepResponse, InodeId, ListCheckpointsResponse, ListFileRevisionsResponse,
     ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest, MaintenanceStepResponse,
     NamespaceId, NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RevisionNo,
-    StorageChecksum, StreamingChecksum, UploadId, FEATURE_DOWNLOADS_DIRECT_GET,
+    SecretString, StorageChecksum, StreamingChecksum, UploadId, FEATURE_DOWNLOADS_DIRECT_GET,
     FEATURE_UPLOADS_DIRECT_MULTIPART, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES,
     LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
@@ -127,7 +127,7 @@ pub type Result<T> = std::result::Result<T, ClientError>;
 #[derive(Debug, Clone)]
 pub struct Client {
     base_url: String,
-    auth_token: Option<String>,
+    auth_token: Option<SecretString>,
     http: reqwest::Client,
     /// Whether transient server errors are retried (see
     /// [`ClientConfig::disable_transient_retry`]).
@@ -196,7 +196,7 @@ impl DirectDownloadStream {
                 self.size_bytes = self.size_bytes.saturating_add(chunk.len() as u64);
                 if self.size_bytes > self.expected.size_bytes {
                     self.finished = true;
-                    return Err(ClientError::Http(format!(
+                    return Err(ClientError::Protocol(format!(
                         "direct download of `{}` sent more than the {} bytes the grant named",
                         self.path, self.expected.size_bytes
                     )));
@@ -214,7 +214,7 @@ impl DirectDownloadStream {
             None => {
                 self.finished = true;
                 if self.size_bytes != self.expected.size_bytes {
-                    return Err(ClientError::Http(format!(
+                    return Err(ClientError::Protocol(format!(
                         "direct download of `{}` ended after {} bytes, not the {} the grant named",
                         self.path, self.size_bytes, self.expected.size_bytes
                     )));
@@ -228,7 +228,7 @@ impl DirectDownloadStream {
                 )
                 .finish();
                 if observed != expected {
-                    return Err(ClientError::Http(format!(
+                    return Err(ClientError::Protocol(format!(
                         "direct download of `{}` produced {}:{}, not the {}:{} the grant named",
                         self.path,
                         observed.algorithm,
@@ -355,7 +355,7 @@ fn presigned_put_request(access: &ObjectTransferAccess) -> Result<WireRequest> {
         ..
     } = access;
     if method != "PUT" {
-        return Err(ClientError::Http(format!(
+        return Err(ClientError::Protocol(format!(
             "unsupported presigned upload method `{method}`"
         )));
     }
@@ -424,7 +424,7 @@ impl MultipartParts<'_> {
             Self::Streamed(reader) => reader
                 .next_part()
                 .await
-                .map_err(|error| ClientError::Http(format!("reading the payload failed: {error}"))),
+                .map_err(|error| ClientError::Io(format!("reading the payload failed: {error}"))),
         }
     }
 }
@@ -451,7 +451,7 @@ fn signed_access(signed: &[SignedUploadPart], part_number: u32) -> Result<Object
         .find(|part| part.part_number == part_number)
         .map(|part| part.access.clone())
         .ok_or_else(|| {
-            ClientError::Http(format!(
+            ClientError::Protocol(format!(
                 "server authorized no upload for part {part_number}"
             ))
         })
@@ -463,7 +463,9 @@ fn signed_access(signed: &[SignedUploadPart], part_number: u32) -> Result<Object
 /// out, from what the deployment advertises, so a different mode coming
 /// back is a broken server rather than something to fall back from.
 fn negotiated_a_different_upload_mode() -> ClientError {
-    ClientError::Http("the server answered with a different upload mode than negotiated".to_owned())
+    ClientError::Protocol(
+        "the server answered with a different upload mode than negotiated".to_owned(),
+    )
 }
 
 /// A path qualified by namespace.
@@ -501,7 +503,10 @@ impl Client {
             auth_token: config.auth_token,
             http: builder
                 .build()
-                .map_err(|err| ClientError::Http(err.to_string()))?,
+                .map_err(|err| ClientError::ConfigValidation {
+                    field: "http_client",
+                    reason: format!("failed to build: {err}"),
+                })?,
             transient_retry: !config.disable_transient_retry,
             capabilities: Arc::new(OnceLock::new()),
         })
@@ -627,30 +632,28 @@ impl Client {
         spec: &NamespacePath,
         options: &ListPathEntriesOptions,
     ) -> Result<ListPathEntriesResponse> {
-        let mut entries = Vec::new();
-        let mut envelope = None;
-        let mut cursor = None;
-        loop {
+        let first_page = self
+            .list_path_entries_page_with_options(spec, None, None, options)
+            .await?;
+        let mut envelope = ListPathEntriesResponse {
+            namespace_id: first_page.namespace_id,
+            absolute_path: first_page.absolute_path,
+            head_seq: first_page.head_seq,
+            entries: first_page.entries,
+            next_cursor: None,
+        };
+        let mut next_cursor = first_page.next_cursor;
+        while let Some(cursor) = next_cursor {
             let page = self
-                .list_path_entries_page_with_options(spec, None, cursor.as_deref(), options)
+                .list_path_entries_page_with_options(spec, None, Some(&cursor), options)
                 .await?;
-            let envelope_ref = envelope.get_or_insert_with(|| ListPathEntriesResponse {
-                namespace_id: page.namespace_id.clone(),
-                absolute_path: page.absolute_path.clone(),
-                head_seq: page.head_seq,
-                entries: Vec::new(),
-                next_cursor: None,
-            });
-            envelope_ref.head_seq = envelope_ref.head_seq.max(page.head_seq);
-            entries.extend(page.entries);
-            cursor = page.next_cursor;
-            if cursor.is_none() {
-                // Pages arrive in canonical name-key order; concatenation
-                // preserves it, so aggregation must not re-sort.
-                envelope_ref.entries = entries;
-                return Ok(envelope.expect("first page initializes response envelope"));
-            }
+            envelope.head_seq = envelope.head_seq.max(page.head_seq);
+            envelope.entries.extend(page.entries);
+            next_cursor = page.next_cursor;
         }
+        // Pages arrive in canonical name-key order; concatenation preserves
+        // it, so aggregation must not re-sort.
+        Ok(envelope)
     }
 
     /// Lists one page of a directory. Entries carry no attributes;
@@ -832,7 +835,7 @@ impl Client {
             ..
         } = &download.access;
         if method != "GET" {
-            return Err(ClientError::Http(format!(
+            return Err(ClientError::Protocol(format!(
                 "unsupported presigned download method `{method}`"
             )));
         }
@@ -1044,7 +1047,7 @@ impl Client {
             ..
         } = access;
         if method != "PUT" {
-            return Err(ClientError::Http(format!(
+            return Err(ClientError::Protocol(format!(
                 "unsupported presigned part method `{method}`"
             )));
         }
@@ -1062,7 +1065,7 @@ impl Client {
             .get(http::header::ETAG)
             .and_then(|value| value.to_str().ok())
             .ok_or_else(|| {
-                ClientError::Http(format!("part {part_number} upload returned no etag"))
+                ClientError::Protocol(format!("part {part_number} upload returned no etag"))
             })?
             .to_owned();
         Ok(CompletedUploadPart {
@@ -1820,8 +1823,9 @@ impl Client {
         part_size_bytes: u64,
         continuity: UploadContinuity<'_>,
     ) -> Result<UploadedObject> {
-        let part_size = usize::try_from(part_size_bytes)
-            .map_err(|_| ClientError::Http("part size does not fit this platform".to_owned()))?;
+        let part_size = usize::try_from(part_size_bytes).map_err(|_| {
+            ClientError::Protocol("part size does not fit this platform".to_owned())
+        })?;
         let landed = continuity
             .resume
             .map_or::<&[CompletedUploadPart], _>(&[], |resume| &resume.parts);
@@ -1888,9 +1892,15 @@ impl Client {
         let signed = self
             .sign_upload_parts(namespace_id, upload_id, claims)
             .await?;
+        let authorized = wave
+            .into_iter()
+            .map(|part| {
+                let access = signed_access(&signed.parts, part.claim.part_number)?;
+                Ok((part, access))
+            })
+            .collect::<Result<Vec<_>>>()?;
         let mut in_flight = tokio::task::JoinSet::new();
-        for part in wave {
-            let access = signed_access(&signed.parts, part.claim.part_number)?;
+        for (part, access) in authorized {
             let client = self.clone();
             let namespace_id = namespace_id.clone();
             let upload_id = upload_id.clone();
@@ -1903,8 +1913,7 @@ impl Client {
         let mut uploaded = Vec::new();
         let mut failure = None;
         while let Some(joined) = in_flight.join_next().await {
-            match joined.map_err(|err| ClientError::Http(format!("part upload task failed: {err}")))
-            {
+            match joined.map_err(|err| ClientError::Io(format!("part upload task failed: {err}"))) {
                 // Every task is drained before the first failure surfaces,
                 // so no part upload outlives the wave that started it.
                 Ok(Ok(part)) => uploaded.push(part),
@@ -1930,19 +1939,24 @@ impl Client {
         mut access: ObjectTransferAccess,
     ) -> Result<CompletedUploadPart> {
         let part_number = part.claim.part_number;
-        for attempt in 1..=DIRECT_MULTIPART_PART_ATTEMPTS {
-            let result = self
+        for attempt in 1..DIRECT_MULTIPART_PART_ATTEMPTS {
+            match self
                 .upload_part_via_presigned_url(
                     part_number,
                     &access,
                     part.claim.crc64nvme.clone(),
                     part.bytes.clone(),
                 )
-                .await;
-            match result {
+                .await
+            {
                 Ok(uploaded) => return Ok(uploaded),
-                Err(error) if attempt == DIRECT_MULTIPART_PART_ATTEMPTS => return Err(error),
-                Err(_) => {
+                Err(error) => {
+                    tracing::warn!(
+                        part_number,
+                        attempt,
+                        error = %error,
+                        "part upload failed; refreshing authorization before retry"
+                    );
                     let signed = self
                         .sign_upload_parts(namespace_id, upload_id, vec![part.claim.clone()])
                         .await?;
@@ -1950,10 +1964,8 @@ impl Client {
                 }
             }
         }
-        // The loop above returns on its last attempt.
-        Err(ClientError::Http(format!(
-            "part {part_number} upload made no attempt"
-        )))
+        self.upload_part_via_presigned_url(part_number, &access, part.claim.crc64nvme, part.bytes)
+            .await
     }
 
     async fn stage_bytes_via_server(
@@ -2730,6 +2742,27 @@ mod tests {
             ),
             "unexpected error: {error:?}"
         );
+    }
+
+    #[test]
+    fn client_and_config_debug_redact_the_auth_token() {
+        let raw_token = "client-debug-secret";
+        let config = ClientConfig {
+            server_url: "http://example.com".to_owned(),
+            auth_token: Some(raw_token.into()),
+            request_timeout_ms: None,
+            disable_transient_retry: false,
+            ca_cert_path: None,
+        };
+
+        let config_debug = format!("{config:?}");
+        assert!(!config_debug.contains(raw_token), "{config_debug}");
+        assert!(config_debug.contains("<redacted>"), "{config_debug}");
+
+        let client = Client::new(config).expect("valid client config");
+        let client_debug = format!("{client:?}");
+        assert!(!client_debug.contains(raw_token), "{client_debug}");
+        assert!(client_debug.contains("<redacted>"), "{client_debug}");
     }
 
     /// A CA bundle that cannot be read or is not PEM fails at construction,

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -316,7 +316,7 @@ impl Client {
         let mut builder = self.http.request(request.method.clone(), &request.url);
         if request.authenticate {
             if let Some(token) = &self.auth_token {
-                builder = builder.bearer_auth(token);
+                builder = builder.bearer_auth(token.expose());
             }
         }
         for (name, value) in &request.headers {

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -2,12 +2,12 @@
 
 use super::{ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::object_store::Result;
-use crate::secret::SecretString;
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use loonfs_api::SecretString;
 use object_store::azure::MicrosoftAzureBuilder;
 use std::sync::Arc;
 

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -29,7 +29,6 @@ pub mod probe;
 mod provider_object_store;
 mod retry;
 pub mod s3_compatible;
-mod secret;
 mod store_config;
 mod store_io_runtime;
 #[cfg(test)]
@@ -51,7 +50,6 @@ pub use provider_object_store::{
     PROVIDER_MULTIPART_THRESHOLD_BYTES, PROVIDER_OPERATION_DEADLINE, PROVIDER_STREAMED_PART_WINDOW,
     PROVIDER_TRANSFER_ATTEMPT_TIMEOUT,
 };
-pub use secret::SecretString;
 pub use store_config::{
     StoreConfig, StoreConfigError, ACCESS_KEY_ID_ENV, SECRET_ACCESS_KEY_ENV, SESSION_TOKEN_ENV,
 };

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -11,11 +11,10 @@ use crate::presign::v4::{
     canonical_query_string, hex_lower, normalize_header_value, percent_encode_path,
     percent_encode_segment, signing_dates, unix_ms,
 };
-use crate::secret::SecretString;
 use crate::ObjectStoreError;
 use base64::Engine as _;
 use loonfs_api::wire::hex::hex_decode_bytes;
-use loonfs_api::{ChecksumAlgorithm, ContentRef, ContentRefKind, StorageChecksum};
+use loonfs_api::{ChecksumAlgorithm, ContentRef, ContentRefKind, SecretString, StorageChecksum};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt::Write as _;

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -11,7 +11,6 @@ use crate::presign::{
     S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES,
     CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
 };
-use crate::secret::SecretString;
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ByteRange, ByteStream, MultipartCompletion, MultipartPart, ObjectBody, ObjectMetadata,
@@ -22,7 +21,7 @@ use async_trait::async_trait;
 use base64::Engine as _;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use loonfs_api::wire::hex::hex_encode_bytes;
+use loonfs_api::{wire::hex::hex_encode_bytes, SecretString};
 use loonfs_api::{ChecksumAlgorithm, StorageChecksum};
 use object_store::aws::{AmazonS3Builder, Checksum};
 use object_store::client::{HttpClient, HttpConnector, HttpRequestBody};

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -13,9 +13,9 @@ use crate::configured::{
 };
 use crate::gcs::GcpGcsStoreConfig;
 use crate::s3_compatible::{AwsS3StoreConfig, CloudflareR2StoreConfig};
-use crate::secret::SecretString;
 use crate::{ConfiguredObjectStore, ConfiguredObjectStoreKind};
 use http::Uri;
+use loonfs_api::SecretString;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -541,8 +541,8 @@ mod tests {
     // Config tests use panic in unexpected match arms for precise diagnostics.
 
     use super::{StoreConfig, StoreConfigError};
-    use crate::secret::SecretString;
     use crate::ConfiguredObjectStoreKind;
+    use loonfs_api::SecretString;
 
     fn parse(contents: &str) -> StoreConfig {
         toml::from_str(contents).expect("parse store config")

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -110,9 +110,9 @@ async fn aws_s3_real_provider_conformance() {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id.into(),
-        secret_access_key: config.secret_access_key.into(),
-        session_token: config.session_token.map(Into::into),
+        access_key_id: config.access_key_id,
+        secret_access_key: config.secret_access_key,
+        session_token: config.session_token,
         key_prefix: Some(config.prefix),
         force_path_style: false,
     })
@@ -133,9 +133,9 @@ async fn aws_s3_streamed_write_round_trips() {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id.into(),
-        secret_access_key: config.secret_access_key.into(),
-        session_token: config.session_token.map(Into::into),
+        access_key_id: config.access_key_id,
+        secret_access_key: config.secret_access_key,
+        session_token: config.session_token,
         key_prefix: Some(config.prefix),
         force_path_style: false,
     })
@@ -154,8 +154,8 @@ async fn cloudflare_r2_streamed_write_round_trips() {
         bucket: config.bucket,
         account_id: config.account_id,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id.into(),
-        secret_access_key: config.secret_access_key.into(),
+        access_key_id: config.access_key_id,
+        secret_access_key: config.secret_access_key,
         key_prefix: Some(config.prefix),
     })
     .expect("create Cloudflare R2 object store");
@@ -175,9 +175,9 @@ fn aws_s3_store_survives_alternating_current_thread_runtimes() {
         bucket: config.bucket,
         region: config.region,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id.into(),
-        secret_access_key: config.secret_access_key.into(),
-        session_token: config.session_token.map(Into::into),
+        access_key_id: config.access_key_id,
+        secret_access_key: config.secret_access_key,
+        session_token: config.session_token,
         key_prefix: Some(config.prefix),
         force_path_style: false,
     })
@@ -232,8 +232,8 @@ async fn cloudflare_r2_real_provider_conformance() {
         bucket: config.bucket,
         account_id: config.account_id,
         endpoint_url: config.endpoint,
-        access_key_id: config.access_key_id.into(),
-        secret_access_key: config.secret_access_key.into(),
+        access_key_id: config.access_key_id,
+        secret_access_key: config.secret_access_key,
         key_prefix: Some(config.prefix),
     })
     .expect("create Cloudflare R2 object store");
@@ -276,7 +276,7 @@ async fn azure_abs_real_provider_conformance() {
     let store = AzureAbsStore::new(AzureAbsStoreConfig {
         account_name: config.account_name,
         container_name: config.container_name,
-        access_key: config.access_key.into(),
+        access_key: config.access_key,
         endpoint_url: config.endpoint,
         key_prefix: Some(config.prefix),
     })
@@ -292,7 +292,7 @@ async fn azure_abs_streamed_write_round_trips() {
     let store = AzureAbsStore::new(AzureAbsStoreConfig {
         account_name: config.account_name,
         container_name: config.container_name,
-        access_key: config.access_key.into(),
+        access_key: config.access_key,
         endpoint_url: config.endpoint,
         key_prefix: Some(config.prefix),
     })

--- a/crates/loonfs-objectstore/tests/it/provider_env.rs
+++ b/crates/loonfs-objectstore/tests/it/provider_env.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 // This file is imported as a helper module by provider tests and also compiled as its own test target.
 
+use loonfs_api::SecretString;
 use std::fmt;
 use std::fs;
 use std::path::PathBuf;
@@ -53,9 +54,9 @@ pub(crate) struct AwsS3ConformanceConfig {
     pub bucket: String,
     pub region: String,
     pub endpoint: Option<String>,
-    pub access_key_id: String,
-    pub secret_access_key: String,
-    pub session_token: Option<String>,
+    pub access_key_id: SecretString,
+    pub secret_access_key: SecretString,
+    pub session_token: Option<SecretString>,
     pub prefix: String,
 }
 
@@ -64,8 +65,8 @@ pub(crate) struct CloudflareR2ConformanceConfig {
     pub bucket: String,
     pub account_id: String,
     pub endpoint: String,
-    pub access_key_id: String,
-    pub secret_access_key: String,
+    pub access_key_id: SecretString,
+    pub secret_access_key: SecretString,
     pub prefix: String,
 }
 
@@ -80,7 +81,7 @@ pub(crate) struct GcpGcsConformanceConfig {
 pub(crate) struct AzureAbsConformanceConfig {
     pub account_name: String,
     pub container_name: String,
-    pub access_key: String,
+    pub access_key: SecretString,
     pub endpoint: Option<String>,
     pub prefix: String,
 }
@@ -99,9 +100,9 @@ impl AwsS3ConformanceConfig {
             bucket: required_env("LOONFS_TEST_S3_BUCKET")?,
             region: required_env("LOONFS_TEST_S3_REGION")?,
             endpoint: optional_env("LOONFS_TEST_S3_ENDPOINT"),
-            access_key_id: required_env("LOONFS_TEST_S3_ACCESS_KEY_ID")?,
-            secret_access_key: required_env("LOONFS_TEST_S3_SECRET_ACCESS_KEY")?,
-            session_token: optional_env("LOONFS_TEST_S3_SESSION_TOKEN"),
+            access_key_id: required_env("LOONFS_TEST_S3_ACCESS_KEY_ID")?.into(),
+            secret_access_key: required_env("LOONFS_TEST_S3_SECRET_ACCESS_KEY")?.into(),
+            session_token: optional_env("LOONFS_TEST_S3_SESSION_TOKEN").map(Into::into),
             prefix: optional_env("LOONFS_TEST_S3_PREFIX")
                 .unwrap_or_else(|| default_prefix("aws-s3")),
         })
@@ -114,8 +115,8 @@ impl CloudflareR2ConformanceConfig {
             bucket: required_env("LOONFS_TEST_R2_BUCKET")?,
             account_id: required_env("LOONFS_TEST_R2_ACCOUNT_ID")?,
             endpoint: required_env("LOONFS_TEST_R2_ENDPOINT")?,
-            access_key_id: required_env("LOONFS_TEST_R2_ACCESS_KEY_ID")?,
-            secret_access_key: required_env("LOONFS_TEST_R2_SECRET_ACCESS_KEY")?,
+            access_key_id: required_env("LOONFS_TEST_R2_ACCESS_KEY_ID")?.into(),
+            secret_access_key: required_env("LOONFS_TEST_R2_SECRET_ACCESS_KEY")?.into(),
             prefix: optional_env("LOONFS_TEST_R2_PREFIX").unwrap_or_else(|| default_prefix("r2")),
         })
     }
@@ -137,7 +138,7 @@ impl AzureAbsConformanceConfig {
         Ok(Self {
             account_name: required_env("LOONFS_TEST_ABS_ACCOUNT_NAME")?,
             container_name: required_env("LOONFS_TEST_ABS_CONTAINER_NAME")?,
-            access_key: required_env("LOONFS_TEST_ABS_ACCESS_KEY")?,
+            access_key: required_env("LOONFS_TEST_ABS_ACCESS_KEY")?.into(),
             endpoint: optional_env("LOONFS_TEST_ABS_ENDPOINT"),
             prefix: optional_env("LOONFS_TEST_ABS_PREFIX")
                 .unwrap_or_else(|| default_prefix("azure-abs")),

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -3,8 +3,9 @@
 
 use crate::local_cache::{DISK_BLOCK_BYTES, MIN_DISK_BYTES};
 use loonfs::RuntimeCacheConfig;
+use loonfs_api::SecretString;
 use loonfs_grep::GrepWorkerConfig;
-use loonfs_objectstore::{ConfiguredObjectStore, SecretString, StoreConfigError};
+use loonfs_objectstore::{ConfiguredObjectStore, StoreConfigError};
 use serde::Deserialize;
 use std::env;
 use std::fs;
@@ -1310,7 +1311,7 @@ root = "/tmp/loonfs-server"
 
         // The environment fills fields the file left unset.
         config.auth_token = None;
-        config.content_token_secret = loonfs_objectstore::SecretString::default();
+        config.content_token_secret = loonfs_api::SecretString::default();
         config.apply_env_fallbacks(
             Some("env-auth-token".to_owned()),
             Some("env-content-token-secret".to_owned()),
@@ -1323,7 +1324,7 @@ root = "/tmp/loonfs-server"
 
         // Blank environment values are ignored.
         config.auth_token = None;
-        config.content_token_secret = loonfs_objectstore::SecretString::default();
+        config.content_token_secret = loonfs_api::SecretString::default();
         config.apply_env_fallbacks(Some("   ".to_owned()), Some(String::new()));
         assert!(config.auth_token.is_none());
         assert!(config.content_token_secret().is_empty());

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -726,7 +726,7 @@ async fn graceful_shutdown_drains_requests_and_settles_the_writer() {
     // The server accepts work while running.
     let client = Client::new(ClientConfig {
         server_url: format!("http://{addr}"),
-        auth_token: Some("test-token".to_owned()),
+        auth_token: Some("test-token".into()),
         request_timeout_ms: None,
         disable_transient_retry: false,
         ca_cert_path: None,
@@ -1585,7 +1585,7 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
     for auth_token in [None, Some("wrong-token".to_owned())] {
         let client = Client::new(ClientConfig {
             server_url: format!("http://{addr}"),
-            auth_token,
+            auth_token: auth_token.map(Into::into),
             request_timeout_ms: None,
             disable_transient_retry: false,
             ca_cert_path: None,
@@ -1742,7 +1742,7 @@ async fn http_upload_body_over_the_limit_answers_content_too_large() {
 
     let client = Client::new(ClientConfig {
         server_url: format!("http://{addr}"),
-        auth_token: Some("test-token".to_owned()),
+        auth_token: Some("test-token".into()),
         request_timeout_ms: None,
         disable_transient_retry: false,
         ca_cert_path: None,
@@ -2142,7 +2142,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
 
     let client_config = ClientConfig {
         server_url: format!("http://{addr}"),
-        auth_token: Some("test-token".to_owned()),
+        auth_token: Some("test-token".into()),
         request_timeout_ms: None,
         // These tests assert the raw concurrency-cap answer; the client's
         // transient retry would otherwise sleep through it.
@@ -2212,7 +2212,7 @@ async fn client_transient_retry_rides_out_a_briefly_full_upload_slot() {
 
     let client = Client::new(ClientConfig {
         server_url: format!("http://{addr}"),
-        auth_token: Some("test-token".to_owned()),
+        auth_token: Some("test-token".into()),
         request_timeout_ms: None,
         disable_transient_retry: false,
         ca_cert_path: None,
@@ -2261,7 +2261,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
 
     let client_config = ClientConfig {
         server_url: format!("http://{addr}"),
-        auth_token: Some("test-token".to_owned()),
+        auth_token: Some("test-token".into()),
         request_timeout_ms: None,
         // These tests assert the raw concurrency-cap answer; the client's
         // transient retry would otherwise sleep through it.
@@ -2386,7 +2386,7 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
 
     let client = Client::new(ClientConfig {
         server_url: format!("http://{addr}"),
-        auth_token: Some("test-token".to_owned()),
+        auth_token: Some("test-token".into()),
         request_timeout_ms: None,
         disable_transient_retry: false,
         ca_cert_path: None,
@@ -2633,7 +2633,7 @@ async fn start_server_with_config(store: SharedObjectStore, config: ServerConfig
     TestHarness {
         client: Client::new(ClientConfig {
             server_url: format!("http://{}", addr),
-            auth_token: Some("test-token".to_owned()),
+            auth_token: Some("test-token".into()),
             request_timeout_ms: None,
             disable_transient_retry: false,
             ca_cert_path: None,
@@ -2995,7 +2995,7 @@ mod direct_download {
         });
         Client::new(ClientConfig {
             server_url: format!("http://{addr}"),
-            auth_token: Some("test-token".to_owned()),
+            auth_token: Some("test-token".into()),
             request_timeout_ms: None,
             disable_transient_retry: false,
             ca_cert_path: None,

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -94,7 +94,7 @@ pub(crate) async fn start_server(config: ServerConfig) -> TestServer {
     TestServer {
         client: Client::new(ClientConfig {
             server_url: server_url.clone(),
-            auth_token,
+            auth_token: auth_token.map(Into::into),
             request_timeout_ms: None,
             disable_transient_retry: false,
             ca_cert_path: None,
@@ -158,7 +158,7 @@ pub(crate) async fn start_tls_server(mut config: ServerConfig) -> TlsTestServer 
     TlsTestServer {
         client: Client::new(ClientConfig {
             server_url: server_url.clone(),
-            auth_token: auth_token.clone(),
+            auth_token: auth_token.clone().map(Into::into),
             request_timeout_ms: None,
             disable_transient_retry: false,
             ca_cert_path: Some(ca_cert_path.clone()),
@@ -205,7 +205,7 @@ pub(crate) async fn start_graceful_server(mut config: ServerConfig) -> GracefulT
     GracefulTestServer {
         client: Client::new(ClientConfig {
             server_url: server_url.clone(),
-            auth_token,
+            auth_token: auth_token.map(Into::into),
             request_timeout_ms: None,
             disable_transient_retry: false,
             ca_cert_path: None,

--- a/crates/loonfs-server/tests/it/http_tls.rs
+++ b/crates/loonfs-server/tests/it/http_tls.rs
@@ -62,7 +62,7 @@ async fn a_client_without_the_certificate_authority_is_refused_at_the_handshake(
 
     let untrusting = Client::new(ClientConfig {
         server_url: harness.server_url.clone(),
-        auth_token: harness.auth_token.clone(),
+        auth_token: harness.auth_token.clone().map(Into::into),
         request_timeout_ms: None,
         disable_transient_retry: true,
         ca_cert_path: None,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -78,33 +78,35 @@ impl FsReader {
         absolute_path: &str,
     ) -> Result<ListPathEntriesResponse> {
         let limit = default_page_limit();
-        let mut cursor = None;
-        let mut entries = Vec::new();
-        let mut envelope = None;
-        loop {
-            let (page, next_cursor) = self
+        let (first_page, mut next_cursor) = self
+            .list_path_entries_page_typed(
+                namespace_id,
+                absolute_path,
+                PageRequest {
+                    limit,
+                    cursor: None,
+                },
+                ListPathEntriesOptions::default(),
+            )
+            .await?;
+        let mut envelope = first_page;
+        while let Some(cursor) = next_cursor {
+            let (page, page_next_cursor) = self
                 .list_path_entries_page_typed(
                     namespace_id,
                     absolute_path,
-                    PageRequest { limit, cursor },
+                    PageRequest {
+                        limit,
+                        cursor: Some(cursor),
+                    },
                     ListPathEntriesOptions::default(),
                 )
                 .await?;
-            let envelope_ref = envelope.get_or_insert_with(|| ListPathEntriesResponse {
-                namespace_id: page.namespace_id.clone(),
-                absolute_path: page.absolute_path.clone(),
-                head_seq: page.head_seq,
-                entries: Vec::new(),
-                next_cursor: None,
-            });
-            envelope_ref.head_seq = envelope_ref.head_seq.max(page.head_seq);
-            entries.extend(page.entries);
-            cursor = next_cursor;
-            if cursor.is_none() {
-                envelope_ref.entries = entries;
-                return Ok(envelope.expect("first page should initialize response envelope"));
-            }
+            envelope.head_seq = envelope.head_seq.max(page.head_seq);
+            envelope.entries.extend(page.entries);
+            next_cursor = page_next_cursor;
         }
+        Ok(envelope)
     }
 
     /// Lists one page of a directory together with the head the page was read


### PR DESCRIPTION
Moves SecretString into the shared API crate and keeps bearer tokens and live provider credentials wrapped in that type until they are used. Debug output from client and conformance configuration can no longer expose those values as ordinary strings.

Classifies client failures by their actual source. Invalid server responses use Protocol, local payload reads use Io, configuration construction uses the configuration error path, and task failures retain their runtime classification. The client module documentation now describes the current async implementation.

Simplifies client and runtime pagination by fetching the first page before entering the loop. Multipart uploads now resolve every signed part request before starting any upload task, and retry logs include the part, attempt, and error.