### PR TITLE
fix(maintenance,grep): panic accounting, pin leaks, dead guards, honest outcomes

### DIFF
--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -31,8 +31,8 @@ use loonfs_api::{
 use loonfs_client::NamespacePath;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBlockCache, GrepDisableOutcome, GrepEnableOutcome, GrepError,
-    GrepGcJob, GrepIndexSnapshot, GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
-    GREP_GC_JOB, GREP_INDEX_JOB,
+    GrepGcJob, GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads, GREP_GC_JOB,
+    GREP_INDEX_JOB,
 };
 use loonfs_objectstore::probe::{run_store_contract_probe, StoreProbeOutcome, StoreProbeReport};
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
@@ -279,9 +279,8 @@ impl EmbeddedBackend {
     ) -> Result<GrepResponse, BackendError> {
         let store = self.writer.object_store();
         let reads = NamespaceReads::new(&self.reader, namespace_id);
-        let snapshot = GrepIndexSnapshot::from_grep_root(&*store, namespace_id, &self.grep).await;
         self.grep
-            .query(request, &snapshot, &reads, &store)
+            .query(request, &reads, &store)
             .await
             .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))
     }

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -4,6 +4,10 @@
 //! remote profiles that talk to a LoonFS server. It keeps command output stable
 //! for humans and scripts.
 
+// The embedded runtime's composed async graph keeps growing; even with
+// the boxed entrypoint, rustc's future-layout query depth needs headroom
+// here. This is the raise rustc itself prescribes.
+#![recursion_limit = "256"]
 mod args;
 mod backend;
 mod backend_error;

--- a/crates/loonfs-cli/src/main.rs
+++ b/crates/loonfs-cli/src/main.rs
@@ -1,6 +1,11 @@
 //! The `loonfs` CLI binary: parse arguments, run the command, render the
 //! result.
 
+// The embedded runtime's composed async graph outgrew rustc's default
+// future-layout query depth while building this binary. This is the raise
+// rustc itself prescribes.
+#![recursion_limit = "256"]
+
 use std::process::ExitCode;
 
 #[tokio::main]

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -74,6 +74,7 @@ use loonfs_api::{ChangeSeq, ManifestId, MetadataCompactionId, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::Notify;
@@ -323,10 +324,7 @@ pub(super) async fn merge_group_in_step<S: ObjectStore + ?Sized>(
     frozen_floor_seq: ChangeSeq,
     policy: MetadataLsmPolicy,
 ) -> Result<MetadataMergeResult> {
-    // A step-contained merge has nothing to cancel it: it holds the step, and
-    // a shutdown waits for the step it is in.
-    let cancellation = MetadataCompactionCancellation::default();
-    let merge = GroupMerge::new(
+    let merge = StepGroupMerge(GroupMerge::new(
         store,
         namespace_id,
         group,
@@ -334,7 +332,6 @@ pub(super) async fn merge_group_in_step<S: ObjectStore + ?Sized>(
         frozen_floor_seq,
         MetadataTableDestination::Published { namespace_id },
         policy,
-        &cancellation,
         runs.to_vec(),
         // The window is capped by the step's budgets, so the set of below-floor
         // unbound generations is capped with it and costs no store reads.
@@ -343,17 +340,8 @@ pub(super) async fn merge_group_in_step<S: ObjectStore + ?Sized>(
         // ends in the step's own publication, so it has nothing to report
         // progress about.
         None,
-    );
-    match merge.run(None).await? {
-        MetadataCompactionOutcome::Completed(result) => Ok(result),
-        // Neither ending is reachable without a token to set and a lease to
-        // lose, and this merge has neither.
-        MetadataCompactionOutcome::Cancelled | MetadataCompactionOutcome::Fenced => {
-            Err(CoreError::Internal(
-                "a step-contained metadata merge cannot be cancelled or fenced".to_owned(),
-            ))
-        }
-    }
+    ));
+    merge.run().await
 }
 
 /// Rebuilds `spec`'s group from `spec`'s runs.
@@ -380,21 +368,25 @@ pub(super) async fn run_metadata_compaction<S: ObjectStore + ?Sized>(
             job_id: spec.job_id(),
         },
         policy,
-        cancellation,
         resolve_snapshot_runs(tables, spec)?,
         // A job has no bound on the group it rebuilds, so it reads the
         // snapshot per reverse row rather than holding a set that would follow
         // the group's size.
         ReverseBindResolution::PointProbeSnapshot,
-        Some(spec.input_rows()),
+        Some(ProgressReporter::new(spec.input_rows())),
     );
-    merge.run(Some(lease)).await
+    let mut control = JobMergeControl {
+        cancellation,
+        lease,
+    };
+    match merge.run(&mut control).await? {
+        Ok(result) => Ok(MetadataCompactionOutcome::Completed(result)),
+        Err(MergeStop::Cancelled) => Ok(MetadataCompactionOutcome::Cancelled),
+        Err(MergeStop::Fenced) => Ok(MetadataCompactionOutcome::Fenced),
+    }
 }
 
-/// How one cluster's merge ended.
-enum ClusterEnd {
-    /// Every row of the cluster was merged and its segments written.
-    Merged,
+enum MergeStop {
     Cancelled,
     Fenced,
 }
@@ -501,7 +493,7 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
     )
     .await?
     {
-        MetadataCompactionOutcome::Completed(result) if !cancellation.is_cancelled() => result,
+        MetadataCompactionOutcome::Completed(result) => result,
         // The prefix belongs to garbage collection now, and the segments the
         // job wrote are being reaped. Publishing descriptors naming them is
         // exactly what the fence exists to stop.
@@ -515,10 +507,7 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
             );
             return Ok(MetadataCompactionJobOutcome::Fenced);
         }
-        // A token set after the last row still costs the job. Checked here so
-        // a shutdown does not spend the drain building a manifest and taking
-        // races for a publication it has already decided against.
-        MetadataCompactionOutcome::Completed(_) | MetadataCompactionOutcome::Cancelled => {
+        MetadataCompactionOutcome::Cancelled => {
             // The executor stops between block fetches, so what it wrote is
             // whatever segments had already filled. They are staged and named
             // by nothing. The lease is left where it is: it expires on its
@@ -919,7 +908,6 @@ struct GroupMerge<'a, S: ObjectStore + ?Sized> {
     frozen_floor_seq: ChangeSeq,
     destination: MetadataTableDestination<'a>,
     policy: MetadataLsmPolicy,
-    cancellation: &'a MetadataCompactionCancellation,
     snapshot: Vec<MetadataRunManifest>,
     reverse_binds: ReverseBindResolution,
     probe_cache: MetadataTableCache,
@@ -929,10 +917,88 @@ struct GroupMerge<'a, S: ObjectStore + ?Sized> {
     /// The last input row key seen in each family, which is what lets the merge
     /// refuse a family that holds one row key twice. One string per family.
     last_input_key_by_family: BTreeMap<MetadataTableFamily, String>,
-    /// The rows the input runs hold, and the read count the next progress line
-    /// is owed at. `None` for a merge short enough to have nothing to report.
-    input_rows: Option<u64>,
-    next_progress_rows: Option<u64>,
+    /// Progress state for an unbounded background merge. `None` for a merge
+    /// short enough to have nothing to report.
+    progress: Option<ProgressReporter>,
+}
+
+/// A merge owned by one bounded maintenance step. Its control type cannot
+/// produce cancellation or fencing, so its result carries neither state.
+struct StepGroupMerge<'a, S: ObjectStore + ?Sized>(GroupMerge<'a, S>);
+
+impl<'a, S: ObjectStore + ?Sized> StepGroupMerge<'a, S> {
+    async fn run(self) -> Result<MetadataMergeResult> {
+        let mut control = StepMergeControl;
+        match self.0.run(&mut control).await? {
+            Ok(result) => Ok(result),
+            Err(never) => match never {},
+        }
+    }
+}
+
+trait MergeControl {
+    type Stop;
+
+    fn cancellation(&self) -> Option<Self::Stop>;
+
+    async fn heartbeat<S: ObjectStore + ?Sized>(&mut self, store: &S)
+        -> Result<Option<Self::Stop>>;
+}
+
+struct StepMergeControl;
+
+impl MergeControl for StepMergeControl {
+    type Stop = Infallible;
+
+    fn cancellation(&self) -> Option<Self::Stop> {
+        None
+    }
+
+    async fn heartbeat<S: ObjectStore + ?Sized>(
+        &mut self,
+        _store: &S,
+    ) -> Result<Option<Self::Stop>> {
+        Ok(None)
+    }
+}
+
+struct JobMergeControl<'a, 'lease> {
+    cancellation: &'a MetadataCompactionCancellation,
+    lease: &'a mut CompactionLease<'lease>,
+}
+
+impl MergeControl for JobMergeControl<'_, '_> {
+    type Stop = MergeStop;
+
+    fn cancellation(&self) -> Option<Self::Stop> {
+        self.cancellation
+            .is_cancelled()
+            .then_some(MergeStop::Cancelled)
+    }
+
+    async fn heartbeat<S: ObjectStore + ?Sized>(
+        &mut self,
+        store: &S,
+    ) -> Result<Option<Self::Stop>> {
+        Ok(
+            (self.lease.heartbeat_if_due(store).await? == LeaseHold::Fenced)
+                .then_some(MergeStop::Fenced),
+        )
+    }
+}
+
+struct ProgressReporter {
+    input_rows: u64,
+    next_rows: u64,
+}
+
+impl ProgressReporter {
+    fn new(input_rows: u64) -> Self {
+        Self {
+            input_rows,
+            next_rows: PROGRESS_ROW_INTERVAL,
+        }
+    }
 }
 
 impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
@@ -945,10 +1011,9 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         frozen_floor_seq: ChangeSeq,
         destination: MetadataTableDestination<'a>,
         policy: MetadataLsmPolicy,
-        cancellation: &'a MetadataCompactionCancellation,
         snapshot: Vec<MetadataRunManifest>,
         reverse_binds: ReverseBindResolution,
-        input_rows: Option<u64>,
+        progress: Option<ProgressReporter>,
     ) -> Self {
         let input_bytes = snapshot
             .iter()
@@ -963,7 +1028,6 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             frozen_floor_seq,
             destination,
             policy,
-            cancellation,
             snapshot,
             reverse_binds,
             probe_cache: MetadataTableCache::new(MetadataTableCacheConfig {
@@ -976,28 +1040,27 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
             canonical_digest: RowDigest::default(),
             index_digest: RowDigest::default(),
             last_input_key_by_family: BTreeMap::new(),
-            input_rows,
-            next_progress_rows: input_rows.map(|_| PROGRESS_ROW_INTERVAL),
+            progress,
         }
     }
 
     /// Merges every cluster of the group, in order.
-    ///
-    /// `lease` is the claim a caller that stages its output holds over it. A
-    /// merge that publishes inside its own step has none, and passes `None`.
-    async fn run(
+    async fn run<C: MergeControl>(
         mut self,
-        mut lease: Option<&mut CompactionLease<'_>>,
-    ) -> Result<MetadataCompactionOutcome> {
+        control: &mut C,
+    ) -> Result<std::result::Result<MetadataMergeResult, C::Stop>> {
         for cluster in retention_clusters(self.group) {
-            match self.run_cluster(cluster, lease.as_deref_mut()).await? {
-                ClusterEnd::Merged => {}
-                ClusterEnd::Cancelled => return Ok(MetadataCompactionOutcome::Cancelled),
-                ClusterEnd::Fenced => return Ok(MetadataCompactionOutcome::Fenced),
+            if let Err(stop) = self.run_cluster(cluster, control).await? {
+                return Ok(Err(stop));
             }
         }
         self.refuse_a_run_whose_index_disagrees()?;
-        Ok(MetadataCompactionOutcome::Completed(self.result))
+        // A token set after the final cluster still owns the outcome. The
+        // caller must not re-derive cancellation from a stale Completed value.
+        if let Some(stop) = control.cancellation() {
+            return Ok(Err(stop));
+        }
+        Ok(Ok(self.result))
     }
 
     /// Refuses a family that hands the merge one row key twice, and refuses a
@@ -1065,11 +1128,11 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
     }
 
     /// Merges one cluster end to end.
-    async fn run_cluster(
+    async fn run_cluster<C: MergeControl>(
         &mut self,
         cluster: &RetentionCluster,
-        mut lease: Option<&mut CompactionLease<'_>>,
-    ) -> Result<ClusterEnd> {
+        control: &mut C,
+    ) -> Result<std::result::Result<(), C::Stop>> {
         // The descriptors are cloned out of the snapshot rather than borrowed
         // from it: an iterator outlives every other borrow the merge takes, and
         // a cluster opens one per run per family, which is a handful.
@@ -1101,18 +1164,16 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
         let mut operator = rule.operator();
         let mut locality: Option<String> = None;
         loop {
-            if self.cancellation.is_cancelled() {
-                return Ok(ClusterEnd::Cancelled);
+            if let Some(stop) = control.cancellation() {
+                return Ok(Err(stop));
             }
             // The claim on a staged merge's prefix is refreshed where it checks
             // whether it should stop, which is the one place it is guaranteed
             // to reach however long a merge runs. Losing it is one more way the
             // merge has to stop: the segments it has written belong to the
             // collector now.
-            if let Some(lease) = lease.as_deref_mut() {
-                if lease.heartbeat_if_due(self.store).await? == LeaseHold::Fenced {
-                    return Ok(ClusterEnd::Fenced);
-                }
+            if let Some(stop) = control.heartbeat(self.store).await? {
+                return Ok(Err(stop));
             }
             self.refill(&mut iterators).await?;
             let Some(next) = select_next_iterator(&iterators, cluster.locality) else {
@@ -1168,7 +1229,7 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
                 .saturating_add(segments.iter().map(segment_object_len).sum());
             self.result.output_segments.extend(segments);
         }
-        Ok(ClusterEnd::Merged)
+        Ok(Ok(()))
     }
 
     /// Says where a long job has got to, at [`PROGRESS_ROW_INTERVAL`].
@@ -1180,15 +1241,14 @@ impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
     /// step's budgets and the step publishes it. The counters are the merge's
     /// own; nothing is measured for this.
     fn report_progress(&mut self) {
-        let (Some(next_progress_rows), Some(input_rows)) =
-            (self.next_progress_rows, self.input_rows)
-        else {
+        let Some(progress) = &mut self.progress else {
             return;
         };
-        if self.result.rows_read < next_progress_rows {
+        if self.result.rows_read < progress.next_rows {
             return;
         }
-        self.next_progress_rows = Some(self.result.rows_read.saturating_add(PROGRESS_ROW_INTERVAL));
+        progress.next_rows = self.result.rows_read.saturating_add(PROGRESS_ROW_INTERVAL);
+        let input_rows = progress.input_rows;
         tracing::info!(
             namespace_id = self.namespace_id.as_str(),
             families = ?self.group.families(),

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -73,37 +73,19 @@ async fn prefetch_recent_segments<S: ObjectStore + ?Sized>(
 }
 
 /// One walk down the chain links, from the visible tip towards the base.
-struct WalkedChain {
+enum WalkedChain {
     /// The segments the walk found, oldest first.
-    segments: Vec<ValidatedWalSegment>,
-    /// How many `get` requests the load issued, prefetch included. A
-    /// request that failed or missed counts, because the round trip
-    /// happened; a segment the prefetch delivered is not counted a second
-    /// time when the walk consumes it. This is never more than the
-    /// `max_segment_fetches` the caller gave.
-    fetches: usize,
-    /// `true` when the walk stopped at its fetch limit instead of reaching
-    /// the base. `segments` is then a partial chain. Nothing may replay
-    /// from it, and [`finish_chain`] rejects it.
-    stopped_at_limit: bool,
-}
-
-impl WalkedChain {
-    fn reached(segments: Vec<ValidatedWalSegment>, fetches: usize) -> Self {
-        Self {
-            segments,
-            fetches,
-            stopped_at_limit: false,
-        }
-    }
-
-    fn stopped_at_limit(fetches: usize) -> Self {
-        Self {
-            segments: Vec::new(),
-            fetches,
-            stopped_at_limit: true,
-        }
-    }
+    Reached {
+        segments: Vec<ValidatedWalSegment>,
+        /// How many `get` requests the load issued, prefetch included. A
+        /// request that failed or missed counts, because the round trip
+        /// happened; a segment the prefetch delivered is not counted a second
+        /// time when the walk consumes it.
+        fetches: usize,
+    },
+    /// The walk spent its fetch limit before reaching the base. Its partial
+    /// chain is dropped because nothing may replay from it.
+    LimitReached { fetches: usize },
 }
 
 /// Result of loading a WAL chain with a fetch limit.
@@ -140,16 +122,15 @@ pub(crate) async fn load_wal_chain_within<S: ObjectStore + ?Sized>(
     request: WalChainLoadRequest<'_>,
     max_segment_fetches: usize,
 ) -> Result<WalChainLoad, WalChainLoadError> {
-    let walked = walk_chain(store, &request, max_segment_fetches).await?;
-    if walked.stopped_at_limit {
-        return Ok(WalChainLoad::LimitReached {
-            requests_issued: walked.fetches,
-        });
+    match walk_chain(store, &request, max_segment_fetches).await? {
+        WalkedChain::Reached { segments, fetches } => Ok(WalChainLoad::Complete {
+            chain: finish_chain(&request, segments)?,
+            requests_issued: fetches,
+        }),
+        WalkedChain::LimitReached { fetches } => Ok(WalChainLoad::LimitReached {
+            requests_issued: fetches,
+        }),
     }
-    Ok(WalChainLoad::Complete {
-        chain: finish_chain(&request, walked.segments)?,
-        requests_issued: walked.fetches,
-    })
 }
 
 #[tracing::instrument(
@@ -163,12 +144,11 @@ pub(crate) async fn load_validated_wal_chain<S: ObjectStore + ?Sized>(
     store: &S,
     request: WalChainLoadRequest<'_>,
 ) -> Result<ValidatedWalChain, WalChainLoadError> {
-    // No caller here meters its own reads, so the walk runs to the base.
-    // A namespace cannot hold `usize::MAX` segments, so the walk never
-    // stops at this limit. If it somehow did, `finish_chain` would reject
-    // the partial chain rather than return it.
-    let walked = walk_chain(store, &request, usize::MAX).await?;
-    finish_chain(&request, walked.segments)
+    let WalkedChain::Reached { segments, .. } = walk_chain(store, &request, usize::MAX).await?
+    else {
+        unreachable!("a namespace cannot hold `usize::MAX` WAL segments")
+    };
+    finish_chain(&request, segments)
 }
 
 /// Walks the chain links from the visible tip down to the base, issuing at
@@ -185,7 +165,10 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
         });
     }
     if request.chain_base_seq == request.head_seq {
-        return Ok(WalkedChain::reached(Vec::new(), 0));
+        return Ok(WalkedChain::Reached {
+            segments: Vec::new(),
+            fetches: 0,
+        });
     }
 
     let mut pointer = request
@@ -228,7 +211,7 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
             Some(bytes) => bytes,
             None => {
                 if fetches >= max_segment_fetches {
-                    return Ok(WalkedChain::stopped_at_limit(fetches));
+                    return Ok(WalkedChain::LimitReached { fetches });
                 }
                 fetches += 1;
                 store
@@ -247,14 +230,11 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
             .map_err(|err| WalReplayError::Codec(err.to_string()))?;
         validate_pointer_matches_envelope(&pointer, &object_key, &envelope)?;
 
+        let reached_stop = envelope.payload.base_head_seq <= stop_after_seq;
         let prev = envelope.payload.prev_visible_segment.clone();
         reversed.push(ValidatedWalSegment::new(object_key.clone(), envelope));
 
-        if reversed
-            .last()
-            .map(|segment| segment.envelope().payload.base_head_seq <= stop_after_seq)
-            .unwrap_or(false)
-        {
+        if reached_stop {
             break;
         }
 
@@ -265,13 +245,13 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
     }
 
     reversed.reverse();
-    Ok(WalkedChain::reached(reversed, fetches))
+    Ok(WalkedChain::Reached {
+        segments: reversed,
+        fetches,
+    })
 }
 
 /// Validates one walked chain as a replayable run and hands it back.
-///
-/// A partial chain does not survive this: its oldest segment does not sit
-/// at the requested base, so the base check below rejects it.
 fn finish_chain(
     request: &WalChainLoadRequest<'_>,
     segments: Vec<ValidatedWalSegment>,

--- a/crates/loonfs-grep/src/error.rs
+++ b/crates/loonfs-grep/src/error.rs
@@ -94,11 +94,6 @@ impl From<GrepRootError> for GrepError {
                 message,
                 class,
             },
-            GrepRootError::MissingEtag { object_key } => Self::StoreUnavailable {
-                object_key,
-                message: "grep root has no etag for compare-and-swap".to_owned(),
-                class: StoreFailureClass::Other,
-            },
             GrepRootError::Conflict { object_key } => Self::PublicationConflict { object_key },
             error @ (GrepRootError::Corrupt { .. }
             | GrepRootError::MissingManifest { .. }

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -83,8 +83,8 @@ pub use error::{GrepError, Result};
 pub use maintenance::{GrepGcJob, GrepMaintenanceJob, GREP_GC_JOB, GREP_INDEX_JOB};
 pub use reads::NamespaceReads;
 pub use service::{
-    GrepIndexSnapshot, GrepService, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT,
-    MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES,
+    GrepService, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES,
+    MAX_GREP_TAIL_FILES,
 };
 pub use worker::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepBuildReport, GrepDisableOutcome, GrepEnableOutcome,

--- a/crates/loonfs-grep/src/root/error.rs
+++ b/crates/loonfs-grep/src/root/error.rs
@@ -92,8 +92,6 @@ pub enum GrepRootError {
         expected: NamespaceId,
         actual: NamespaceId,
     },
-    #[error("grep root `{object_key}` has no etag for compare-and-swap")]
-    MissingEtag { object_key: String },
     #[error("grep root publication conflict for `{object_key}`")]
     Conflict { object_key: String },
     #[error("grep root advance changes namespace from `{expected}` to `{actual}`")]

--- a/crates/loonfs-grep/src/root/store.rs
+++ b/crates/loonfs-grep/src/root/store.rs
@@ -15,16 +15,14 @@ use crate::keyspace::{manifest_key, root_key};
 use bytes::Bytes;
 use loonfs::StoreFailureClass;
 use loonfs_api::NamespaceId;
-use loonfs_objectstore::{
-    ImmutableWriteError, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
+use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError, PutMode};
 
 /// A verified grep root pointer and metadata from the same store read.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoadedGrepRootPointer {
     object_key: String,
     envelope: GrepRootEnvelope,
-    metadata: ObjectMetadata,
+    etag: String,
 }
 
 impl LoadedGrepRootPointer {
@@ -40,8 +38,8 @@ impl LoadedGrepRootPointer {
         self.envelope.pointer()
     }
 
-    pub fn metadata(&self) -> &ObjectMetadata {
-        &self.metadata
+    pub fn etag(&self) -> &str {
+        &self.etag
     }
 }
 
@@ -73,10 +71,6 @@ impl LoadedGrepRoot {
     pub fn manifest_state(&self) -> &GrepManifestState {
         self.manifest.manifest_state()
     }
-
-    pub fn metadata(&self) -> &ObjectMetadata {
-        self.pointer.metadata()
-    }
 }
 
 /// Loads and verifies one namespace's mutable grep root pointer.
@@ -92,6 +86,7 @@ pub async fn load_grep_root_pointer<S: ObjectStore + ?Sized>(
     else {
         return Ok(None);
     };
+    let etag = required_etag(&object_key, body.metadata.etag)?;
     let envelope = decode_grep_root(&body.bytes).map_err(|error| corrupt(&object_key, error))?;
     if envelope.pointer().namespace_id() != namespace_id {
         return Err(GrepRootError::IdentityMismatch {
@@ -103,7 +98,7 @@ pub async fn load_grep_root_pointer<S: ObjectStore + ?Sized>(
     Ok(Some(LoadedGrepRootPointer {
         object_key,
         envelope,
-        metadata: body.metadata,
+        etag,
     }))
 }
 
@@ -192,11 +187,12 @@ pub async fn seed_grep_root<S: ObjectStore + ?Sized>(
         }
         Err(error) => return Err(store_error(&object_key, &error)),
     };
+    let etag = required_etag(&object_key, metadata.etag)?;
     Ok(LoadedGrepRoot {
         pointer: LoadedGrepRootPointer {
             object_key,
             envelope,
-            metadata,
+            etag,
         },
         manifest,
     })
@@ -225,16 +221,6 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
             message: format!("loaded root key does not match `{expected_key}`"),
         });
     }
-    let expected_etag =
-        current
-            .pointer
-            .metadata
-            .etag
-            .as_deref()
-            .ok_or_else(|| GrepRootError::MissingEtag {
-                object_key: current.pointer.object_key.clone(),
-            })?;
-
     let written = write_grep_manifest(store, next).await?;
     let envelope = GrepRootEnvelope::from_pointer(GrepRootPointer::new(
         next.namespace_id().clone(),
@@ -249,7 +235,7 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
             &current.pointer.object_key,
             Bytes::from(bytes),
             PutMode::CompareAndSwap {
-                expected_etag: expected_etag.to_owned(),
+                expected_etag: current.pointer.etag.clone(),
             },
         )
         .await
@@ -262,11 +248,12 @@ pub async fn advance_grep_root<S: ObjectStore + ?Sized>(
         }
         Err(error) => return Err(store_error(&current.pointer.object_key, &error)),
     };
+    let etag = required_etag(&current.pointer.object_key, metadata.etag)?;
     Ok(LoadedGrepRoot {
         pointer: LoadedGrepRootPointer {
             object_key: current.pointer.object_key.clone(),
             envelope,
-            metadata,
+            etag,
         },
         manifest: written.envelope,
     })
@@ -319,6 +306,14 @@ fn store_error(object_key: &str, error: &ObjectStoreError) -> GrepRootError {
         message: error.message(),
         class: StoreFailureClass::of(error),
     }
+}
+
+fn required_etag(object_key: &str, etag: Option<String>) -> Result<String> {
+    etag.ok_or_else(|| GrepRootError::Store {
+        object_key: object_key.to_owned(),
+        message: "object store omitted the required grep-root etag".to_owned(),
+        class: StoreFailureClass::Other,
+    })
 }
 
 fn immutable_write_error(error: ImmutableWriteError) -> GrepRootError {

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -1,5 +1,4 @@
-//! [`GrepService`]: query planning and execution over one pinned snapshot
-//! of a namespace.
+//! [`GrepService`]: query planning and execution over grep index state.
 
 use crate::cache::{
     DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind,
@@ -75,12 +74,6 @@ pub(crate) const SCAN_DIRECTORY_PAGE_ENTRIES: usize = 1000;
 /// number of content reads.
 pub(crate) const MAX_GREP_CONTENT_IO: usize = 32;
 
-/// The immutable gram-index state one query reads.
-#[derive(Debug, Clone)]
-pub struct GrepIndexSnapshot {
-    state: Result<MaterializedGrepIndexSnapshot>,
-}
-
 #[derive(Debug, Clone)]
 struct MaterializedGrepIndexSnapshot {
     built_through_seq: ChangeSeq,
@@ -99,34 +92,25 @@ struct GrepQuerySegment {
     payload_checksum: String,
 }
 
-impl GrepIndexSnapshot {
-    /// Captures unreadable grep extension state while preserving error precedence.
-    pub fn from_error(error: GrepError) -> Self {
-        Self { state: Err(error) }
-    }
-
-    /// Freshly loads the grep pointer, then loads or reuses its immutable manifest.
-    ///
-    /// Missing or disabled roots and incomplete backfills remain
-    /// not-materialized. Unreadable derived state retains its actionable
-    /// grep-specific failure without changing core read behavior.
-    pub async fn from_grep_root<S: ObjectStore + ?Sized>(
+impl GrepService {
+    /// Freshly loads the grep pointer, then loads or reuses its immutable
+    /// manifest.
+    async fn load_index_snapshot<S: ObjectStore + ?Sized>(
+        &self,
         store: &S,
         namespace_id: &NamespaceId,
-        service: &GrepService,
-    ) -> Self {
-        let pointer = match load_grep_root_pointer(store, namespace_id).await {
-            Ok(Some(pointer)) => pointer,
-            Ok(None) => return Self::from_error(GrepError::NotEnabled),
-            Err(error) => return Self::from_error(error.into()),
-        };
+    ) -> Result<MaterializedGrepIndexSnapshot> {
+        let pointer = load_grep_root_pointer(store, namespace_id)
+            .await
+            .map_err(GrepError::from)?
+            .ok_or(GrepError::NotEnabled)?;
         let manifest_id = pointer.pointer().manifest_id();
         let cache_key = GrepBlockCacheKey {
             payload_checksum: pointer.pointer().manifest_payload_checksum().to_owned(),
             block_kind: GrepBlockKind::Manifest,
             block_offset: 0,
         };
-        let state = match service
+        let state = match self
             .block_cache
             .get_or_load(&cache_key, || async {
                 let manifest = load_grep_manifest(store, namespace_id, pointer.pointer())
@@ -165,17 +149,17 @@ impl GrepIndexSnapshot {
                 | DecodedGrepBlock::Index { .. }
                 | DecodedGrepBlock::Data { .. },
             ) => {
-                return Self::from_error(GrepError::CorruptIndex {
+                return Err(GrepError::CorruptIndex {
                     message: format!(
                         "grep manifest `{}` resolved to a non-manifest cache entry",
                         manifest_key(namespace_id, manifest_id)
                     ),
                 });
             }
-            Err(error) => return Self::from_error(error),
+            Err(error) => return Err(error),
         };
         if state.namespace_id() != namespace_id {
-            return Self::from_error(GrepError::CorruptIndex {
+            return Err(GrepError::CorruptIndex {
                 message: format!(
                     "grep manifest `{}` names namespace `{}` instead of requested namespace `{namespace_id}`",
                     manifest_key(namespace_id, manifest_id),
@@ -183,46 +167,42 @@ impl GrepIndexSnapshot {
                 ),
             });
         }
-        Self::from_state(&state)
+        materialized_snapshot_from_state(&state)
     }
+}
 
-    fn from_state(root: &GrepManifestState) -> Self {
-        // Only a steady root has a watermark, and only a watermark makes an
-        // index answerable: the other two phases refuse the query outright
-        // rather than borrow a sequence they do not own.
-        let (built_through_seq, next_event_index) = match root.lifecycle() {
-            GrepLifecycle::Disabled => return Self::from_error(GrepError::NotEnabled),
-            GrepLifecycle::Backfilling { .. } => return Self::from_error(GrepError::Backfilling),
-            GrepLifecycle::Steady {
-                built_through_seq,
-                next_event_index,
-            } => (*built_through_seq, *next_event_index),
-        };
-        let segments = root
-            .segments()
-            .iter()
-            .map(|segment| GrepQuerySegment {
-                object_key: segment_key(root.namespace_id(), &segment.segment_id),
-                min_key: segment.min_row_key.clone(),
-                max_key: segment.max_row_key.clone(),
-                index_block: segment.index_block,
-                filter_block: segment.filter_block,
-                filter_inline: segment.filter_inline.clone(),
-                payload_checksum: segment.payload_checksum.clone(),
-            })
-            .collect();
-        Self {
-            state: Ok(MaterializedGrepIndexSnapshot {
-                built_through_seq,
-                next_event_index,
-                segments,
-            }),
-        }
-    }
-
-    fn materialized(&self) -> Result<&MaterializedGrepIndexSnapshot> {
-        self.state.as_ref().map_err(Clone::clone)
-    }
+fn materialized_snapshot_from_state(
+    root: &GrepManifestState,
+) -> Result<MaterializedGrepIndexSnapshot> {
+    // Only a steady root has a watermark, and only a watermark makes an
+    // index answerable: the other two phases refuse the query outright
+    // rather than borrow a sequence they do not own.
+    let (built_through_seq, next_event_index) = match root.lifecycle() {
+        GrepLifecycle::Disabled => return Err(GrepError::NotEnabled),
+        GrepLifecycle::Backfilling { .. } => return Err(GrepError::Backfilling),
+        GrepLifecycle::Steady {
+            built_through_seq,
+            next_event_index,
+        } => (*built_through_seq, *next_event_index),
+    };
+    let segments = root
+        .segments()
+        .iter()
+        .map(|segment| GrepQuerySegment {
+            object_key: segment_key(root.namespace_id(), &segment.segment_id),
+            min_key: segment.min_row_key.clone(),
+            max_key: segment.max_row_key.clone(),
+            index_block: segment.index_block,
+            filter_block: segment.filter_block,
+            filter_inline: segment.filter_inline.clone(),
+            payload_checksum: segment.payload_checksum.clone(),
+        })
+        .collect();
+    Ok(MaterializedGrepIndexSnapshot {
+        built_through_seq,
+        next_event_index,
+        segments,
+    })
 }
 
 /// Namespace-independent grep execution over a decoded-block cache.
@@ -680,7 +660,6 @@ impl GrepService {
     pub async fn query<S: ObjectStore>(
         &self,
         request: &GrepRequest,
-        snapshot: &GrepIndexSnapshot,
         reads: &NamespaceReads<'_>,
         store: &S,
     ) -> Result<GrepResponse> {
@@ -725,7 +704,9 @@ impl GrepService {
             None => None,
         };
 
-        let snapshot = snapshot.materialized()?;
+        let snapshot = self
+            .load_index_snapshot(store, reads.namespace_id())
+            .await?;
 
         // Line-anchored semantics: `^` and `$` match line boundaries, the
         // grep-family contract. The planner parses with the same flags so

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -286,52 +286,47 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         }
 
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
-        let current = load_grep_root(&self.store, namespace_id)
-            .await
-            .map_err(GrepError::from)?;
-        if let Some(current) = &current {
-            if !matches!(
-                current.manifest_state().lifecycle(),
-                GrepLifecycle::Disabled
-            ) {
-                self.release_checkpoint_if_unreferenced(
-                    namespace_id,
-                    &checkpoint.checkpoint_id,
-                    current.manifest_state(),
-                )
-                .await?;
-                return Ok(GrepEnableOutcome::AlreadyEnabled {
-                    state: current.manifest_state().lifecycle().clone(),
-                });
+        let outcome = async {
+            let current = load_grep_root(&self.store, namespace_id)
+                .await
+                .map_err(GrepError::from)?;
+            if let Some(current) = &current {
+                if !matches!(
+                    current.manifest_state().lifecycle(),
+                    GrepLifecycle::Disabled
+                ) {
+                    return Ok(GrepEnableOutcome::AlreadyEnabled {
+                        state: current.manifest_state().lifecycle().clone(),
+                    });
+                }
+            }
+            let next_run_ordinal = current
+                .as_ref()
+                .map_or(0, |root| root.manifest_state().index().next_run_ordinal);
+            let next = backfilling_root(
+                namespace_id,
+                checkpoint.checkpoint_seq,
+                checkpoint.checkpoint_id.clone(),
+                next_run_ordinal,
+            )?;
+            let published = match current {
+                Some(current) => self.advance_root(&current, &next).await,
+                None => self.seed_root(&next).await,
+            };
+            match published {
+                Ok(published) => Ok(GrepEnableOutcome::Enabled {
+                    state: published.manifest_state().lifecycle().clone(),
+                }),
+                Err(GrepRootError::Conflict { .. }) => Ok(GrepEnableOutcome::Superseded),
+                Err(error) => Err(error.into()),
             }
         }
-        let next_run_ordinal = current
-            .as_ref()
-            .map_or(0, |root| root.manifest_state().index().next_run_ordinal);
-        let next = backfilling_root(
-            namespace_id,
-            checkpoint.checkpoint_seq,
-            checkpoint.checkpoint_id.clone(),
-            next_run_ordinal,
-        )?;
-        let published = match current {
-            Some(current) => self.advance_root(&current, &next).await,
-            None => self.seed_root(&next).await,
-        };
-        match published {
-            Ok(published) => Ok(GrepEnableOutcome::Enabled {
-                state: published.manifest_state().lifecycle().clone(),
-            }),
-            Err(GrepRootError::Conflict { .. }) => {
-                self.release_superseded_checkpoint_if_unreferenced(
-                    namespace_id,
-                    &checkpoint.checkpoint_id,
-                )
+        .await;
+        if !matches!(outcome, Ok(GrepEnableOutcome::Enabled { .. })) {
+            self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
                 .await?;
-                Ok(GrepEnableOutcome::Superseded)
-            }
-            Err(error) => Err(error.into()),
         }
+        outcome
     }
 
     /// Disables grep with one root CAS. Existing segments become grep-GC
@@ -515,38 +510,6 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         Ok(())
     }
 
-    async fn release_checkpoint_if_unreferenced(
-        &self,
-        namespace_id: &NamespaceId,
-        checkpoint_id: &CheckpointId,
-        root: &GrepManifestState,
-    ) -> Result<()> {
-        if !root_names_checkpoint(root, checkpoint_id) {
-            self.release_checkpoint(namespace_id, checkpoint_id).await?;
-        }
-        Ok(())
-    }
-
-    async fn release_superseded_checkpoint_if_unreferenced(
-        &self,
-        namespace_id: &NamespaceId,
-        checkpoint_id: &CheckpointId,
-    ) -> Result<()> {
-        let winner = load_grep_root(&self.store, namespace_id)
-            .await
-            .map_err(GrepError::from)?;
-        if let Some(winner) = winner {
-            self.release_checkpoint_if_unreferenced(
-                namespace_id,
-                checkpoint_id,
-                winner.manifest_state(),
-            )
-            .await
-        } else {
-            self.release_checkpoint(namespace_id, checkpoint_id).await
-        }
-    }
-
     async fn restart_backfill(
         &self,
         namespace_id: &NamespaceId,
@@ -557,19 +520,27 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             GrepLifecycle::Steady { .. } | GrepLifecycle::Disabled => None,
         };
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
-        let next = backfilling_root(
-            namespace_id,
-            checkpoint.checkpoint_seq,
-            checkpoint.checkpoint_id.clone(),
-            current.manifest_state().index().next_run_ordinal,
-        )?;
-        match self.advance_root(current, &next).await {
+        let published = async {
+            let next = backfilling_root(
+                namespace_id,
+                checkpoint.checkpoint_seq,
+                checkpoint.checkpoint_id.clone(),
+                current.manifest_state().index().next_run_ordinal,
+            )?;
+            self.advance_root(current, &next)
+                .await
+                .map_err(GrepError::from)
+        }
+        .await;
+        if published.is_err() {
+            self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
+                .await?;
+        }
+        match published {
             Ok(_) => {
                 if let Some(previous_checkpoint_id) = previous_checkpoint_id {
-                    if previous_checkpoint_id != checkpoint.checkpoint_id {
-                        self.release_checkpoint(namespace_id, &previous_checkpoint_id)
-                            .await?;
-                    }
+                    self.release_checkpoint(namespace_id, &previous_checkpoint_id)
+                        .await?;
                 }
                 Ok(build_report(
                     namespace_id,
@@ -578,15 +549,10 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     },
                 ))
             }
-            Err(GrepRootError::Conflict { .. }) => {
-                self.release_superseded_checkpoint_if_unreferenced(
-                    namespace_id,
-                    &checkpoint.checkpoint_id,
-                )
-                .await?;
+            Err(GrepError::PublicationConflict { .. }) => {
                 Ok(build_report(namespace_id, GrepBuildOutcome::Superseded))
             }
-            Err(error) => Err(error.into()),
+            Err(error) => Err(error),
         }
     }
 
@@ -626,61 +592,40 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         // the watermark it hands the change feed is the target it reached.
         let (lifecycle, completed_checkpoint_id, built_through_seq) = match progress {
             CollectedProgress::Backfill {
+                checkpoint_id,
                 target_seq,
                 next_cursor,
-            } => {
-                let checkpoint_id = match current.manifest_state().lifecycle() {
-                    GrepLifecycle::Backfilling { checkpoint_id, .. } => checkpoint_id.clone(),
-                    _ => {
-                        return Err(CoreError::Internal(
-                            "a collected grep backfill unit no longer matches its root".to_owned(),
-                        )
-                        .into())
-                    }
-                };
-                match next_cursor {
-                    Some(after_inode_id) => (
-                        GrepLifecycle::Backfilling {
-                            target_seq,
-                            cursor: Some(after_inode_id),
-                            checkpoint_id,
-                        },
-                        None,
+            } => match next_cursor {
+                Some(after_inode_id) => (
+                    GrepLifecycle::Backfilling {
                         target_seq,
-                    ),
-                    None => (
-                        GrepLifecycle::Steady {
-                            built_through_seq: target_seq,
-                            next_event_index: 0,
-                        },
-                        Some(checkpoint_id),
-                        target_seq,
-                    ),
-                }
-            }
+                        cursor: Some(after_inode_id),
+                        checkpoint_id,
+                    },
+                    None,
+                    target_seq,
+                ),
+                None => (
+                    GrepLifecycle::Steady {
+                        built_through_seq: target_seq,
+                        next_event_index: 0,
+                    },
+                    Some(checkpoint_id),
+                    target_seq,
+                ),
+            },
             CollectedProgress::Incremental {
                 run_seq: _,
                 built_through_seq,
                 next_event_index,
-            } => {
-                if !matches!(
-                    current.manifest_state().lifecycle(),
-                    GrepLifecycle::Steady { .. }
-                ) {
-                    return Err(CoreError::Internal(
-                        "a collected incremental grep unit no longer matches its root".to_owned(),
-                    )
-                    .into());
-                }
-                (
-                    GrepLifecycle::Steady {
-                        built_through_seq,
-                        next_event_index,
-                    },
-                    None,
+            } => (
+                GrepLifecycle::Steady {
                     built_through_seq,
-                )
-            }
+                    next_event_index,
+                },
+                None,
+                built_through_seq,
+            ),
         };
         let materialized = matches!(lifecycle, GrepLifecycle::Steady { .. });
         let next = GrepManifestState::new(
@@ -758,16 +703,6 @@ fn rebootstrap_required(error: &GrepError) -> bool {
     )
 }
 
-fn root_names_checkpoint(root: &GrepManifestState, checkpoint_id: &CheckpointId) -> bool {
-    matches!(
-        root.lifecycle(),
-        GrepLifecycle::Backfilling {
-            checkpoint_id: root_checkpoint_id,
-            ..
-        } if root_checkpoint_id == checkpoint_id
-    )
-}
-
 struct CollectedIndexUnit {
     postings: BTreeMap<Gram, Vec<GramPosting>>,
     stats: IndexingStats,
@@ -785,6 +720,7 @@ struct IndexingStats {
 /// progress, which used to be possible in the flat unit record.
 enum CollectedProgress {
     Backfill {
+        checkpoint_id: CheckpointId,
         target_seq: ChangeSeq,
         next_cursor: Option<InodeId>,
     },
@@ -880,6 +816,7 @@ async fn collect_backfill_unit(
         postings,
         stats,
         progress: CollectedProgress::Backfill {
+            checkpoint_id: checkpoint_id.clone(),
             target_seq,
             next_cursor,
         },

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -286,50 +286,60 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         }
 
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
-        let outcome = async {
-            let current = load_grep_root(&self.store, namespace_id)
-                .await
-                .map_err(GrepError::from)?;
-            if let Some(current) = &current {
-                if !matches!(
-                    current.manifest_state().lifecycle(),
-                    GrepLifecycle::Disabled
-                ) {
-                    return Ok(GrepEnableOutcome::AlreadyEnabled {
-                        state: current.manifest_state().lifecycle().clone(),
-                    });
-                }
+        let current = match load_grep_root(&self.store, namespace_id).await {
+            Ok(current) => current,
+            Err(error) => {
+                self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
+                    .await?;
+                return Err(error.into());
             }
-            let next_run_ordinal = current
-                .as_ref()
-                .map_or(0, |root| root.manifest_state().index().next_run_ordinal);
-            let next = backfilling_root(
-                namespace_id,
-                checkpoint.checkpoint_seq,
-                checkpoint.checkpoint_id.clone(),
-                next_run_ordinal,
-            )?;
-            let published = match current {
-                Some(current) => self.advance_root(&current, &next).await,
-                None => self.seed_root(&next).await,
-            };
-            match published {
-                Ok(published) => Ok(GrepEnableOutcome::Enabled {
-                    state: published.manifest_state().lifecycle().clone(),
-                }),
-                Err(GrepRootError::Conflict { .. }) => Ok(GrepEnableOutcome::Superseded),
-                Err(error) => Err(error.into()),
+        };
+        if let Some(current) = &current {
+            if !matches!(
+                current.manifest_state().lifecycle(),
+                GrepLifecycle::Disabled
+            ) {
+                self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
+                    .await?;
+                return Ok(GrepEnableOutcome::AlreadyEnabled {
+                    state: current.manifest_state().lifecycle().clone(),
+                });
             }
         }
-        .await;
-        if matches!(
-            &outcome,
-            Ok(GrepEnableOutcome::AlreadyEnabled { .. } | GrepEnableOutcome::Superseded)
+        let next_run_ordinal = current
+            .as_ref()
+            .map_or(0, |root| root.manifest_state().index().next_run_ordinal);
+        let next = match backfilling_root(
+            namespace_id,
+            checkpoint.checkpoint_seq,
+            checkpoint.checkpoint_id.clone(),
+            next_run_ordinal,
         ) {
-            self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
-                .await?;
+            Ok(next) => next,
+            Err(error) => {
+                self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
+                    .await?;
+                return Err(error);
+            }
+        };
+        let published = match current {
+            Some(current) => self.advance_root(&current, &next).await,
+            None => self.seed_root(&next).await,
+        };
+        match published {
+            Ok(published) => Ok(GrepEnableOutcome::Enabled {
+                state: published.manifest_state().lifecycle().clone(),
+            }),
+            Err(GrepRootError::Conflict { .. }) => {
+                self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
+                    .await?;
+                Ok(GrepEnableOutcome::Superseded)
+            }
+            // A non-conflict failure may be an acknowledgement failure after
+            // the root update landed. Keep the checkpoint because the root
+            // may already reference it.
+            Err(error) => Err(error.into()),
         }
-        outcome
     }
 
     /// Disables grep with one root CAS. Existing segments become grep-GC
@@ -523,23 +533,20 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             GrepLifecycle::Steady { .. } | GrepLifecycle::Disabled => None,
         };
         let checkpoint = self.create_backfill_checkpoint(namespace_id).await?;
-        let published = async {
-            let next = backfilling_root(
-                namespace_id,
-                checkpoint.checkpoint_seq,
-                checkpoint.checkpoint_id.clone(),
-                current.manifest_state().index().next_run_ordinal,
-            )?;
-            self.advance_root(current, &next)
-                .await
-                .map_err(GrepError::from)
-        }
-        .await;
-        if matches!(&published, Err(GrepError::PublicationConflict { .. })) {
-            self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
-                .await?;
-        }
-        match published {
+        let next = match backfilling_root(
+            namespace_id,
+            checkpoint.checkpoint_seq,
+            checkpoint.checkpoint_id.clone(),
+            current.manifest_state().index().next_run_ordinal,
+        ) {
+            Ok(next) => next,
+            Err(error) => {
+                self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
+                    .await?;
+                return Err(error);
+            }
+        };
+        match self.advance_root(current, &next).await {
             Ok(_) => {
                 if let Some(previous_checkpoint_id) = previous_checkpoint_id {
                     self.release_checkpoint(namespace_id, &previous_checkpoint_id)
@@ -552,10 +559,15 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     },
                 ))
             }
-            Err(GrepError::PublicationConflict { .. }) => {
+            Err(GrepRootError::Conflict { .. }) => {
+                self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
+                    .await?;
                 Ok(build_report(namespace_id, GrepBuildOutcome::Superseded))
             }
-            Err(error) => Err(error),
+            // A non-conflict failure may be an acknowledgement failure after
+            // the root update landed. Keep the checkpoint because the root
+            // may already reference it.
+            Err(error) => Err(error.into()),
         }
     }
 

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -322,7 +322,10 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             }
         }
         .await;
-        if !matches!(outcome, Ok(GrepEnableOutcome::Enabled { .. })) {
+        if matches!(
+            &outcome,
+            Ok(GrepEnableOutcome::AlreadyEnabled { .. } | GrepEnableOutcome::Superseded)
+        ) {
             self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
                 .await?;
         }
@@ -532,7 +535,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 .map_err(GrepError::from)
         }
         .await;
-        if published.is_err() {
+        if matches!(&published, Err(GrepError::PublicationConflict { .. })) {
             self.release_checkpoint(namespace_id, &checkpoint.checkpoint_id)
                 .await?;
         }

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -13,7 +13,7 @@ use loonfs_api::{ChangeSeq, GrepRequest, GrepResponse, NamespaceId};
 use loonfs_grep::root::GrepLifecycle;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBlockCache, GrepDisableOutcome, GrepEnableOutcome, GrepError,
-    GrepIndexSnapshot, GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
+    GrepMaintenanceJob, GrepService, GrepWorker, NamespaceReads,
     DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
 };
 use std::sync::Arc;
@@ -234,8 +234,7 @@ pub(crate) async fn grep_with(
     request: &GrepRequest,
 ) -> Result<GrepResponse, GrepError> {
     let reads = NamespaceReads::new(reader, namespace_id);
-    let snapshot = GrepIndexSnapshot::from_grep_root(&**store, namespace_id, service).await;
-    service.query(request, &snapshot, &reads, store).await
+    service.query(request, &reads, store).await
 }
 
 /// Classifies a key by durable family instead of by its spelling, so the

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -13,7 +13,9 @@ use loonfs::{
     SharedObjectStore,
 };
 use loonfs_api::wire::control::CheckpointRecordLifecycle;
-use loonfs_api::{sha256_digest, ChangeSeq, GrepRequest, GrepResponse, IndexSegmentId};
+use loonfs_api::{
+    sha256_digest, ChangeSeq, CheckpointId, GrepRequest, GrepResponse, IndexSegmentId,
+};
 use loonfs_grep::keyspace::{
     manifest_key, manifests_prefix, namespace_prefix, root_key, segment_key,
 };
@@ -33,6 +35,7 @@ use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
 };
+use loonfs_test_support::stores::{FailStore, InjectedError, OperationContext, OperationKind};
 use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::path::Path;
@@ -332,6 +335,74 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
     assert!(matches!(
         root.manifest_state().lifecycle(),
         GrepLifecycle::Backfilling { .. }
+    ));
+    writer.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn enable_releases_its_checkpoint_when_the_root_reload_fails() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("enable-root-failure").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("enable-root-failure-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let host = GrepHost::new(&store, "enable-root-failure-admin").await;
+    let grep_root_key = root_key(&namespace_id);
+    let root_loads = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let observed_root_loads = Arc::clone(&root_loads);
+    let failing_store = Arc::new(FailStore::matching(
+        store.clone(),
+        move |context: &OperationContext<'_>| {
+            context.key() == grep_root_key
+                && matches!(context.kind(), OperationKind::GetWithMetadata)
+                && observed_root_loads.fetch_add(1, Ordering::SeqCst) == 1
+        },
+        InjectedError::Transport("injected grep-root reload failure".to_owned()),
+    ));
+    failing_store.fail_all();
+    let worker = GrepWorker::with_block_cache(
+        failing_store,
+        host.reader.clone(),
+        host.admin.clone(),
+        Arc::clone(&host.block_cache),
+    );
+
+    let error = worker
+        .enable(&namespace_id)
+        .await
+        .expect_err("the second root load fails after checkpoint creation");
+    assert!(matches!(error, GrepError::StoreUnavailable { .. }));
+
+    let prefix = checkpoint_prefix(namespace_id.as_str());
+    let checkpoint_keys = store
+        .list_prefix(&prefix)
+        .await
+        .expect("list checkpoint records");
+    let [checkpoint_key] = checkpoint_keys.as_slice() else {
+        panic!("enable should have created exactly one checkpoint: {checkpoint_keys:?}");
+    };
+    let checkpoint_id = CheckpointId::parse(
+        checkpoint_key
+            .strip_prefix(&prefix)
+            .and_then(|name| name.strip_suffix(".json"))
+            .expect("checkpoint key uses the checkpoint layout"),
+    )
+    .expect("checkpoint id from key");
+    let checkpoint = control::checkpoint_record(&store, &namespace_id, &checkpoint_id)
+        .await
+        .expect("checkpoint record remains until core GC");
+    assert!(matches!(
+        checkpoint.state,
+        CheckpointRecordLifecycle::Released { .. }
     ));
     writer.shutdown().await.expect("shutdown");
 }

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -37,7 +37,7 @@ use loonfs_test_support::stores::{FailStore, InjectedError, OperationContext, Op
 use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 use tokio::sync::Semaphore;
@@ -338,6 +338,62 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
 }
 
 #[tokio::test]
+async fn enable_releases_its_checkpoint_when_root_reload_fails_before_publication() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("enable-root-failure").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("enable-root-failure-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    let host = GrepHost::new(&store, "enable-root-failure-admin").await;
+    let grep_root_key = root_key(&namespace_id);
+    let root_loads = Arc::new(AtomicUsize::new(0));
+    let observed_root_loads = Arc::clone(&root_loads);
+    let failing_store = Arc::new(FailStore::matching(
+        store.clone(),
+        move |context: &OperationContext<'_>| {
+            context.key() == grep_root_key
+                && matches!(context.kind(), OperationKind::GetWithMetadata)
+                && observed_root_loads.fetch_add(1, Ordering::SeqCst) == 1
+        },
+        InjectedError::Transport("injected grep-root reload failure".to_owned()),
+    ));
+    failing_store.fail_all();
+    let worker = GrepWorker::with_block_cache(
+        failing_store.clone(),
+        host.reader.clone(),
+        host.admin.clone(),
+        Arc::clone(&host.block_cache),
+    );
+
+    let error = worker
+        .enable(&namespace_id)
+        .await
+        .expect_err("the second root load fails after checkpoint creation");
+    assert!(matches!(error, GrepError::StoreUnavailable { .. }));
+    assert_eq!(failing_store.attempts(), 1);
+
+    let checkpoints = host
+        .admin
+        .list_checkpoints(&namespace_id)
+        .await
+        .expect("list checkpoints after failed enable");
+    assert!(
+        checkpoints.checkpoints.is_empty(),
+        "a failure before root publication must not leave an active checkpoint"
+    );
+    writer.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
 async fn enable_retains_its_checkpoint_when_the_root_write_result_is_ambiguous() {
     let temp_dir = tempdir().expect("tempdir");
     let store: SharedObjectStore =
@@ -387,20 +443,72 @@ async fn enable_retains_its_checkpoint_when_the_root_write_result_is_ambiguous()
     assert!(matches!(error, GrepError::StoreUnavailable { .. }));
     assert_eq!(failing_store.attempts(), 1);
 
-    let root = load_grep_root(&*store, &namespace_id)
+    assert_fresh_backfill_attempt(&store, &namespace_id).await;
+    writer.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn restart_retains_its_checkpoint_when_the_root_write_result_is_ambiguous() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("ambiguous-restart").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("ambiguous-restart-writer")
+        .min_publish_interval_ms(0)
+        .build()
         .await
-        .expect("load published root")
-        .expect("the root write landed");
-    let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.manifest_state().lifecycle() else {
-        panic!("published root should be backfilling");
-    };
-    let checkpoint = control::checkpoint_record(&store, &namespace_id, checkpoint_id)
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
-        .expect("published checkpoint remains readable");
-    assert!(matches!(
-        checkpoint.state,
-        CheckpointRecordLifecycle::Active {}
-    ));
+        .expect("create namespace");
+    let host = GrepHost::new(&store, "ambiguous-restart-admin").await;
+    host.worker
+        .enable(&namespace_id)
+        .await
+        .expect("enable grep");
+    let previous_checkpoint_id = assert_fresh_backfill_attempt(&store, &namespace_id).await;
+    host.admin
+        .release_checkpoint(&namespace_id, &previous_checkpoint_id)
+        .await
+        .expect("make the current backfill restart");
+
+    let grep_root_key = root_key(&namespace_id);
+    let failing_store = Arc::new(
+        FailStore::matching(
+            store.clone(),
+            move |context: &OperationContext<'_>| {
+                context.key() == grep_root_key
+                    && matches!(
+                        context.kind(),
+                        OperationKind::Put {
+                            mode: PutMode::CompareAndSwap { .. },
+                            ..
+                        }
+                    )
+            },
+            InjectedError::Transport("injected failure after root publication".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    failing_store.fail_next(1);
+    let worker = GrepWorker::with_block_cache(
+        failing_store.clone(),
+        host.reader.clone(),
+        host.admin.clone(),
+        Arc::clone(&host.block_cache),
+    );
+
+    let error = worker
+        .build_step(&namespace_id, GramIndexBuildPolicy::default())
+        .await
+        .expect_err("restart publication acknowledgement fails");
+    assert!(matches!(error, GrepError::StoreUnavailable { .. }));
+    assert_eq!(failing_store.attempts(), 1);
+
+    let checkpoint_id = assert_fresh_backfill_attempt(&store, &namespace_id).await;
+    assert_ne!(checkpoint_id, previous_checkpoint_id);
     writer.shutdown().await.expect("shutdown");
 }
 
@@ -603,7 +711,7 @@ async fn assert_fresh_backfill_attempt(
     };
     assert_eq!(
         *cursor, None,
-        "a rebootstrap restarts the walk from the beginning"
+        "a fresh backfill starts the walk from the beginning"
     );
     assert!(
         root.manifest_state().segments().is_empty(),

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -394,7 +394,7 @@ async fn enable_retains_its_checkpoint_when_the_root_write_result_is_ambiguous()
     let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.manifest_state().lifecycle() else {
         panic!("published root should be backfilling");
     };
-    let checkpoint = control::checkpoint_record(&store, &namespace_id, &checkpoint_id)
+    let checkpoint = control::checkpoint_record(&store, &namespace_id, checkpoint_id)
         .await
         .expect("published checkpoint remains readable");
     assert!(matches!(

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -13,9 +13,7 @@ use loonfs::{
     SharedObjectStore,
 };
 use loonfs_api::wire::control::CheckpointRecordLifecycle;
-use loonfs_api::{
-    sha256_digest, ChangeSeq, CheckpointId, GrepRequest, GrepResponse, IndexSegmentId,
-};
+use loonfs_api::{sha256_digest, ChangeSeq, GrepRequest, GrepResponse, IndexSegmentId};
 use loonfs_grep::keyspace::{
     manifest_key, manifests_prefix, namespace_prefix, root_key, segment_key,
 };
@@ -340,13 +338,13 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
 }
 
 #[tokio::test]
-async fn enable_releases_its_checkpoint_when_the_root_reload_fails() {
+async fn enable_retains_its_checkpoint_when_the_root_write_result_is_ambiguous() {
     let temp_dir = tempdir().expect("tempdir");
     let store: SharedObjectStore =
         Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
-    let namespace_id = NamespaceId::parse("enable-root-failure").expect("namespace id");
+    let namespace_id = NamespaceId::parse("ambiguous-enable").expect("namespace id");
     let writer = FsWriter::builder_with_store(store.clone())
-        .writer_id("enable-root-failure-writer")
+        .writer_id("ambiguous-enable-writer")
         .min_publish_interval_ms(0)
         .build()
         .await
@@ -355,22 +353,28 @@ async fn enable_releases_its_checkpoint_when_the_root_reload_fails() {
         .create_namespace(&namespace_id, CreateNamespaceOptions::default())
         .await
         .expect("create namespace");
-    let host = GrepHost::new(&store, "enable-root-failure-admin").await;
+    let host = GrepHost::new(&store, "ambiguous-enable-admin").await;
     let grep_root_key = root_key(&namespace_id);
-    let root_loads = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let observed_root_loads = Arc::clone(&root_loads);
-    let failing_store = Arc::new(FailStore::matching(
-        store.clone(),
-        move |context: &OperationContext<'_>| {
-            context.key() == grep_root_key
-                && matches!(context.kind(), OperationKind::GetWithMetadata)
-                && observed_root_loads.fetch_add(1, Ordering::SeqCst) == 1
-        },
-        InjectedError::Transport("injected grep-root reload failure".to_owned()),
-    ));
-    failing_store.fail_all();
+    let failing_store = Arc::new(
+        FailStore::matching(
+            store.clone(),
+            move |context: &OperationContext<'_>| {
+                context.key() == grep_root_key
+                    && matches!(
+                        context.kind(),
+                        OperationKind::Put {
+                            mode: PutMode::CreateIfAbsent,
+                            ..
+                        }
+                    )
+            },
+            InjectedError::Transport("injected failure after root publication".to_owned()),
+        )
+        .apply_then_fail(),
+    );
+    failing_store.fail_next(1);
     let worker = GrepWorker::with_block_cache(
-        failing_store,
+        failing_store.clone(),
         host.reader.clone(),
         host.admin.clone(),
         Arc::clone(&host.block_cache),
@@ -379,30 +383,23 @@ async fn enable_releases_its_checkpoint_when_the_root_reload_fails() {
     let error = worker
         .enable(&namespace_id)
         .await
-        .expect_err("the second root load fails after checkpoint creation");
+        .expect_err("root publication acknowledgement fails");
     assert!(matches!(error, GrepError::StoreUnavailable { .. }));
+    assert_eq!(failing_store.attempts(), 1);
 
-    let prefix = checkpoint_prefix(namespace_id.as_str());
-    let checkpoint_keys = store
-        .list_prefix(&prefix)
+    let root = load_grep_root(&*store, &namespace_id)
         .await
-        .expect("list checkpoint records");
-    let [checkpoint_key] = checkpoint_keys.as_slice() else {
-        panic!("enable should have created exactly one checkpoint: {checkpoint_keys:?}");
+        .expect("load published root")
+        .expect("the root write landed");
+    let GrepLifecycle::Backfilling { checkpoint_id, .. } = root.manifest_state().lifecycle() else {
+        panic!("published root should be backfilling");
     };
-    let checkpoint_id = CheckpointId::parse(
-        checkpoint_key
-            .strip_prefix(&prefix)
-            .and_then(|name| name.strip_suffix(".json"))
-            .expect("checkpoint key uses the checkpoint layout"),
-    )
-    .expect("checkpoint id from key");
     let checkpoint = control::checkpoint_record(&store, &namespace_id, &checkpoint_id)
         .await
-        .expect("checkpoint record remains until core GC");
+        .expect("published checkpoint remains readable");
     assert!(matches!(
         checkpoint.state,
-        CheckpointRecordLifecycle::Released { .. }
+        CheckpointRecordLifecycle::Active {}
     ));
     writer.shutdown().await.expect("shutdown");
 }

--- a/crates/loonfs-grep/tests/it/root_store.rs
+++ b/crates/loonfs-grep/tests/it/root_store.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::panic)]
 
 use bytes::Bytes;
+use loonfs::StoreFailureClass;
 use loonfs_api::{ChangeSeq, NamespaceId};
 use loonfs_grep::keyspace::{manifest_key, manifests_prefix, root_key};
 use loonfs_grep::root::{
@@ -13,6 +14,7 @@ use loonfs_grep::root::{
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, PutMode};
 use loonfs_test_support::ids::namespace_id;
+use loonfs_test_support::stores::{KeyPredicate, MetadataMapStore};
 
 #[tokio::test]
 async fn load_rejects_namespace_identity_mismatch() {
@@ -48,6 +50,29 @@ async fn load_rejects_namespace_identity_mismatch() {
         load_grep_root(&store, &requested).await,
         Err(GrepRootError::IdentityMismatch { expected, actual, .. })
             if expected.as_str() == "requested" && actual.as_str() == "other"
+    ));
+}
+
+#[tokio::test]
+async fn load_requires_the_root_etag_as_a_store_contract() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("local store");
+    let namespace_id = namespace_id("missing-etag");
+    seed_grep_root(&inner, &root(namespace_id.clone(), ChangeSeq(0)))
+        .await
+        .expect("seed root");
+    let store = MetadataMapStore::without_etag(inner, KeyPredicate::exact(root_key(&namespace_id)));
+
+    let error = load_grep_root(&store, &namespace_id)
+        .await
+        .expect_err("a loaded grep root requires its etag");
+    assert!(matches!(
+        error,
+        GrepRootError::Store {
+            class: StoreFailureClass::Other,
+            message,
+            ..
+        } if message.contains("required grep-root etag")
     ));
 }
 

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -13,9 +13,7 @@ use loonfs_api::v0::{
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::{FEATURE_ADMIN_GREP_INDEX, FEATURE_QUERY_GREP};
-use loonfs_grep::{
-    GrepDisableOutcome, GrepEnableOutcome, GrepError, GrepIndexSnapshot, NamespaceReads,
-};
+use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError, NamespaceReads};
 
 #[cfg_attr(
     feature = "openapi",
@@ -61,9 +59,8 @@ pub(super) async fn grep(
     // through the same reader handle the core planes serve from.
     let store = state.writer.object_store();
     let reads = NamespaceReads::new(&state.reader, &namespace_id);
-    let snapshot = GrepIndexSnapshot::from_grep_root(&*store, &namespace_id, service).await;
     let response = service
-        .query(&request, &snapshot, &reads, &store)
+        .query(&request, &reads, &store)
         .await
         .map_err(|error| map_grep_error(&namespace_id, error))?;
     Ok(Json(response))

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -26,7 +26,7 @@ use loonfs_grep::keyspace::{manifest_key as grep_manifest_key, root_key as grep_
 use loonfs_grep::root::{
     encode_grep_root, load_grep_root, GrepManifestId, GrepRootEnvelope, GrepRootPointer,
 };
-use loonfs_grep::{GrepIndexSnapshot, GrepWorker, NamespaceReads};
+use loonfs_grep::{GrepWorker, NamespaceReads};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
@@ -1027,9 +1027,8 @@ async fn the_publish_observer_nudges_the_enabled_namespaces_index() {
         .expect("a query-serving app carries a grep service");
     let store = state.writer.object_store();
     let reads = NamespaceReads::new(&state.reader, &namespace_id);
-    let snapshot = GrepIndexSnapshot::from_grep_root(&*store, &namespace_id, service).await;
     let response = service
-        .query(&request, &snapshot, &reads, &store)
+        .query(&request, &reads, &store)
         .await
         .expect("grep caught-up index");
     assert_eq!(response.matches.len(), 1);

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -27,6 +27,7 @@ use crate::metrics::RuntimeInstruments;
 use crate::{NamespaceId, Result, RuntimeError};
 use admission::{Admission, MaintenanceDispatch, MaintenanceKey, StepOutcome};
 pub(crate) use compaction::{BackgroundCompactions, CompactionStart};
+use futures::FutureExt as _;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::future::Future;
@@ -405,6 +406,9 @@ pub(crate) struct RunnerInner {
     state: Mutex<RunnerState>,
     wake: Arc<Notify>,
     counters: RunnerCounters,
+    /// Tasks a later spawn reaped after they panicked. Their join handles no
+    /// longer reach [`MaintenanceRunner::drain`], so the count does.
+    panicked_tasks: std::sync::atomic::AtomicUsize,
     /// Where settled steps report. The two [`RunnerCounters`] above stay
     /// where they are: they answer "is this happening at all", which a
     /// number on an existing trace answers for a reader with no metrics
@@ -471,6 +475,7 @@ impl MaintenanceRunner {
                 clock,
                 wake: Arc::new(Notify::new()),
                 counters: RunnerCounters::default(),
+                panicked_tasks: std::sync::atomic::AtomicUsize::new(0),
                 instruments,
                 compactions: Arc::new(Mutex::new(BTreeMap::new())),
                 compaction_permits: Arc::new(tokio::sync::Semaphore::new(
@@ -574,6 +579,10 @@ impl MaintenanceRunner {
                 }
             }
         }
+        panicked += self
+            .inner
+            .panicked_tasks
+            .load(std::sync::atomic::Ordering::SeqCst);
         if panicked > 0 {
             return Err(RuntimeError::RuntimeTask(format!(
                 "{panicked} background maintenance task(s) panicked"
@@ -692,7 +701,19 @@ impl RunnerInner {
             drop(future);
             return;
         }
-        state.tasks.retain(|task| !task.is_finished());
+        state.tasks.retain_mut(|task| {
+            if !task.is_finished() {
+                return true;
+            }
+            if task
+                .now_or_never()
+                .is_some_and(|outcome| outcome.is_err_and(|error| error.is_panic()))
+            {
+                self.panicked_tasks
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+            false
+        });
         state.tasks.push(runtime.spawn(future));
     }
 }

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -286,7 +286,7 @@ impl BackgroundCompactions {
     fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<NamespaceId, NamespaceCompactions>> {
         self.namespaces
             .lock()
-            .expect("background compaction lock poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -391,13 +391,10 @@ impl CompactionSlot {
         let claimed = self
             .namespaces
             .lock()
-            .map(|namespaces| {
-                namespaces
-                    .values()
-                    .filter(|entry| entry.active.is_some())
-                    .count()
-            })
-            .unwrap_or(0);
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .filter(|entry| entry.active.is_some())
+            .count();
         let running = MAX_CONCURRENT_COMPACTIONS.saturating_sub(self.permits.available_permits());
         runner
             .instruments
@@ -408,9 +405,10 @@ impl CompactionSlot {
 impl Drop for CompactionSlot {
     fn drop(&mut self) {
         {
-            let Ok(mut namespaces) = self.namespaces.lock() else {
-                return;
-            };
+            let mut namespaces = self
+                .namespaces
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let Some(entry) = namespaces.get_mut(&self.namespace_id) else {
                 return;
             };

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -766,19 +766,42 @@ async fn shutdown_clears_pending_work_and_refuses_later_nudges() {
 
 #[tokio::test]
 async fn drain_surfaces_a_panicked_step() {
-    let job = TestJob::answering(StepAnswer::Panic);
-    let runner = enabled_runner(job);
-    let namespace_id = namespace_id("panics");
+    let job = TestJob::scripted(
+        [StepAnswer::Panic],
+        StepAnswer::Conclude(MaintenanceStepConclusion::Idle),
+    );
+    let runner = enabled_runner(job.clone());
+    let panicked_namespace_id = namespace_id("panics");
+    let later_namespace_id = namespace_id("runs-later");
 
-    runner.handle().nudge(TEST_JOB, &namespace_id);
+    runner.handle().nudge(TEST_JOB, &panicked_namespace_id);
+    wait_for(
+        || {
+            runner
+                .inner
+                .lock_state()
+                .tasks
+                .iter()
+                .any(tokio::task::JoinHandle::is_finished)
+        },
+        "the panicked task to finish",
+    )
+    .await;
+    // Spawning this step reaps the finished panic before drain can join it.
+    runner.handle().nudge(TEST_JOB, &later_namespace_id);
     let error = runner.drain().await.expect_err("a panicked step surfaces");
     assert!(
         error.to_string().contains("panicked"),
         "drain reports panicked tasks: {error}"
     );
     assert!(
-        !runner.is_pending(TEST_JOB, &namespace_id),
+        !runner.is_pending(TEST_JOB, &panicked_namespace_id),
         "a panicked step releases its key and its permit"
+    );
+    assert_eq!(
+        job.stepped(),
+        vec!["panics".to_owned(), "runs-later".to_owned()],
+        "the interleaved spawn runs after reaping the panic"
     );
 }
 


### PR DESCRIPTION
Ensures maintenance shutdown reports panicked tasks even when they were reaped before drain, and applies the same poisoned-mutex recovery behavior to every compaction-slot access. A panic can no longer disappear from shutdown accounting, and a poisoned lock can no longer leave a namespace slot permanently occupied.

Grep enable and backfill restart release a new checkpoint when failure occurs before root publication or when the root update returns a definite conflict. They retain it after an ambiguous publication failure because the root update may already have succeeded. Backfill work carries its checkpoint ID directly, grep root loads require an ETag, and query snapshot loading occurs where the snapshot is used. This removes several checks for states the types no longer permit.

The WAL chain walk now returns its two meaningful outcomes directly. Compaction checks cancellation before reporting completion, which removes duplicate outcome logic from callers. The CLI retains the recursion-limit setting needed by the resulting async call graph.