### PR TITLE
refactor: idiom polish and dead-surface deletion from the sweep

### DIFF
--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -22,7 +22,7 @@
 mod block_fetch;
 mod block_load;
 mod build;
-mod cache;
+pub(crate) mod cache;
 mod compaction_lease;
 mod compaction_merge;
 mod compaction_output;
@@ -52,8 +52,7 @@ mod validate;
 pub use self::cache::{
     MetadataTableCache, MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
     WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
-    DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-    DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+    DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -185,6 +185,16 @@ pub struct MetadataReorganizeReport {
     pub outcome: MetadataReorganizeOutcome,
 }
 
+fn report(
+    namespace_id: &NamespaceId,
+    outcome: MetadataReorganizeOutcome,
+) -> MetadataReorganizeReport {
+    MetadataReorganizeReport {
+        namespace_id: namespace_id.clone(),
+        outcome,
+    }
+}
+
 /// Runs at most one reorganization step against the current manifest. Each
 /// call reloads durable state, so callers may repeat it safely across process
 /// restarts.
@@ -230,10 +240,10 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         .map_err(CoreError::load_head)?
         .map(|loaded| loaded.state)
     else {
-        return Ok(MetadataReorganizeReport {
-            namespace_id: namespace_id.clone(),
-            outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs: 0 },
-        });
+        return Ok(report(
+            namespace_id,
+            MetadataReorganizeOutcome::NotNeeded { l0_runs: 0 },
+        ));
     };
     let tables = load_verified_manifest_tables(store, namespace_id, &root.manifest_object_id)
         .await
@@ -246,10 +256,10 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     if l0_runs < policy.max_l0_runs.get()
         && !manifest_has_partial_reorganization(tables.scan_runs.as_ref())
     {
-        return Ok(MetadataReorganizeReport {
-            namespace_id: namespace_id.clone(),
-            outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
-        });
+        return Ok(report(
+            namespace_id,
+            MetadataReorganizeOutcome::NotNeeded { l0_runs },
+        ));
     }
     let Some(group) = select_family_group(
         &previous.payload,
@@ -257,10 +267,10 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     ) else {
         // L0 runs exist but hold no rows (empty families), or the only group
         // with rows is the one a job is rebuilding; nothing to fold here.
-        return Ok(MetadataReorganizeReport {
-            namespace_id: namespace_id.clone(),
-            outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
-        });
+        return Ok(report(
+            namespace_id,
+            MetadataReorganizeOutcome::NotNeeded { l0_runs },
+        ));
     };
     // The floor is read before the plan rather than after it, because a plan
     // that hands the group to a streaming compaction carries the floor that
@@ -286,18 +296,18 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     let input = match selection.plan {
         Some(ReorganizationPlan::BoundedMerge(input)) => input,
         Some(ReorganizationPlan::FullCompaction(spec)) => {
-            return Ok(MetadataReorganizeReport {
-                namespace_id: namespace_id.clone(),
-                outcome: MetadataReorganizeOutcome::CompactionPlanned { group, spec },
-            })
+            return Ok(report(
+                namespace_id,
+                MetadataReorganizeOutcome::CompactionPlanned { group, spec },
+            ))
         }
         // A selected group holds L0 rows, so it holds runs, so the planner
         // always answers with one of the two plans above.
         None => {
-            return Ok(MetadataReorganizeReport {
-                namespace_id: namespace_id.clone(),
-                outcome: MetadataReorganizeOutcome::NotNeeded { l0_runs },
-            })
+            return Ok(report(
+                namespace_id,
+                MetadataReorganizeOutcome::NotNeeded { l0_runs },
+            ))
         }
     };
 
@@ -360,9 +370,9 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
     )
     .await?
     {
-        ManifestPublicationOutcome::Published(_) => Ok(MetadataReorganizeReport {
-            namespace_id: namespace_id.clone(),
-            outcome: MetadataReorganizeOutcome::UnitPublished {
+        ManifestPublicationOutcome::Published(_) => Ok(report(
+            namespace_id,
+            MetadataReorganizeOutcome::UnitPublished {
                 group,
                 folded_l0_rows: input.folded_l0_rows,
                 input_runs: input.runs.len(),
@@ -371,12 +381,9 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
                 manifest_id: manifest.payload.manifest_id,
                 bottom_anchored_merge_blocked,
             },
-        }),
+        )),
         ManifestPublicationOutcome::Superseded(_) | ManifestPublicationOutcome::RootCasRaceLost => {
-            Ok(MetadataReorganizeReport {
-                namespace_id: namespace_id.clone(),
-                outcome: MetadataReorganizeOutcome::Superseded,
-            })
+            Ok(report(namespace_id, MetadataReorganizeOutcome::Superseded))
         }
     }
 }

--- a/crates/loonfs-core/src/commit/mod.rs
+++ b/crates/loonfs-core/src/commit/mod.rs
@@ -29,8 +29,9 @@ pub(crate) use self::materialize::{materialize_commit, MaterializedCommit};
 pub(crate) use self::ops::{CommitOp, CommitPrecondition, PlannedOp};
 pub use self::plan::{CommitPlan, ResolvedBinding};
 pub(crate) use self::plan::{ValidatedCommitPlan, ValidatedOp};
-pub(crate) use self::publish::PreparedCommitHeadPublish;
-pub use self::publish::{prepare_commit_head_publish, publish_commit_head};
+pub(crate) use self::publish::{
+    prepare_commit_head_publish, publish_commit_head, PreparedCommitHeadPublish,
+};
 pub use self::publish_error::CommitHeadPublishError;
 pub(crate) use self::validate::{
     validate_commit_for_publish, validate_ops, OpValidationCursor, PublishValidationView,

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -15,20 +15,20 @@ use loonfs_objectstore::{ObjectMetadata, ObjectStore};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PreparedControlWrite {
+pub(crate) struct PreparedControlWrite {
     pub object_key: String,
     pub encoded_bytes: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PreparedCommitHeadPublish {
+pub(crate) struct PreparedCommitHeadPublish {
     pub resulting_head: HeadState,
     /// The physical write is kept together because its key and bytes are the
     /// only encoded representation the store operation needs.
     pub write: PreparedControlWrite,
 }
 
-pub fn prepare_commit_head_publish(
+pub(crate) fn prepare_commit_head_publish(
     current_head: &HeadState,
     plan: &CommitPlan,
     wal: &PreparedWalSegment,
@@ -146,7 +146,7 @@ fn next_recent_segments(
     recent
 }
 
-pub async fn publish_commit_head<S: ObjectStore + ?Sized>(
+pub(crate) async fn publish_commit_head<S: ObjectStore + ?Sized>(
     store: &S,
     expected_head_etag: &str,
     prepared: &PreparedCommitHeadPublish,

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -198,7 +198,11 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
             } => {
                 let source_binding =
                     resolve_current_binding_for_mutation(metadata_state, *inode_id).await?;
-                validate_rename_source(metadata_state, *inode_id).await?;
+                let inode = metadata_state.inode_at_seq(*inode_id).await?.ok_or(
+                    CommitValidationError::RenameInodeMissing {
+                        inode_id: *inode_id,
+                    },
+                )?;
                 let new_name_key = validate_rename_target_name_absent(
                     metadata_state,
                     *inode_id,
@@ -206,7 +210,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     new_display_name,
                 )
                 .await?;
-                validate_rename_does_not_cycle(metadata_state, *inode_id, *new_parent_inode_id)
+                validate_rename_does_not_cycle(metadata_state, &inode, *new_parent_inode_id)
                     .await?;
                 validate_not_covered_by_tombstone(metadata_state, *inode_id, |tombstone| {
                     CommitValidationError::RenameInodeUnderSubtreeTombstone {
@@ -275,49 +279,13 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                 parent_inode_id,
                 display_name,
             } => {
-                // The target must exist and be the root of the newest,
-                // still-live deletion. A child of a deleted directory is
-                // covered by its ancestor's tombstone, not its own —
-                // recover the directory, not the child.
-                if metadata_state.inode_at_seq(*inode_id).await?.is_none() {
-                    return Err(CommitValidationError::UndeleteInodeMissing {
-                        inode_id: *inode_id,
-                    }
-                    .into());
-                }
-                // Only a deletion from a strictly earlier commit is
-                // recoverable. Assigned sequences are guessable (head + 1),
-                // so without this bound one multi-op commit could delete,
-                // undelete, and re-delete an inode — minting two deletion
-                // generations that share a sequence and making the public
-                // `(inode, deleted_at_seq)` handle ambiguous. With it, two
-                // live deletions of one root can never share a sequence.
-                if *deleted_at_seq >= committed_seq {
-                    return Err(CommitValidationError::UndeleteTargetsCurrentCommit {
-                        inode_id: *inode_id,
-                        requested_seq: *deleted_at_seq,
-                    }
-                    .into());
-                }
-                let Some(active) = metadata_state.active_subtree_tombstone(*inode_id).await? else {
-                    return Err(CommitValidationError::UndeleteTargetNotDeleted {
-                        inode_id: *inode_id,
-                    }
-                    .into());
-                };
-                // Recovery is scoped to the deletion the caller observed,
-                // never "whatever is active now": a stale handle must not
-                // cancel a later delete of the same inode. The rule
-                // re-applies unchanged on every stale-head revalidation
-                // because the requested generation rides in the op.
-                if active.generation.seq != *deleted_at_seq {
-                    return Err(CommitValidationError::UndeleteGenerationMismatch {
-                        inode_id: *inode_id,
-                        requested_seq: *deleted_at_seq,
-                        active_seq: active.generation.seq,
-                    }
-                    .into());
-                }
+                let active = validate_undelete_target(
+                    metadata_state,
+                    *inode_id,
+                    *deleted_at_seq,
+                    committed_seq,
+                )
+                .await?;
                 // The new home mirrors create validation: an existing,
                 // visible directory parent (visibility rules out a parent
                 // inside the recovered subtree, so the bind cannot cycle),
@@ -342,14 +310,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                 base_attributes_revision_no,
                 attributes,
             } => {
-                // The target is any visible inode, file or directory: an
-                // attribute belongs to the resource, not to file content.
-                if metadata_state.visible_inode(*inode_id).await?.is_none() {
-                    return Err(CommitValidationError::UpdateAttributesInodeMissing {
-                        inode_id: *inode_id,
-                    }
-                    .into());
-                }
+                validate_attributes_target_visible(metadata_state, *inode_id).await?;
                 validate_inode_attributes_revision_is(
                     metadata_state,
                     *inode_id,
@@ -464,6 +425,57 @@ fn next_attributes_revision_no(
             inode_id,
             base_attributes_revision_no,
         })
+}
+
+/// Requires the target to be the root of the requested live deletion.
+async fn validate_undelete_target<S: ObjectStore + ?Sized>(
+    metadata_state: &PublishValidationView<'_, S>,
+    inode_id: InodeId,
+    deleted_at_seq: ChangeSeq,
+    committed_seq: ChangeSeq,
+) -> Result<SubtreeTombstoneRecord, CoreError> {
+    // A child of a deleted directory is covered by its ancestor's tombstone,
+    // not its own — recover the directory, not the child.
+    if metadata_state.inode_at_seq(inode_id).await?.is_none() {
+        return Err(CommitValidationError::UndeleteInodeMissing { inode_id }.into());
+    }
+    // Only a deletion from a strictly earlier commit is recoverable.
+    // Assigned sequences are guessable (head + 1), so this prevents one
+    // multi-op commit from minting ambiguous deletion generations.
+    if deleted_at_seq >= committed_seq {
+        return Err(CommitValidationError::UndeleteTargetsCurrentCommit {
+            inode_id,
+            requested_seq: deleted_at_seq,
+        }
+        .into());
+    }
+    let Some(active) = metadata_state.active_subtree_tombstone(inode_id).await? else {
+        return Err(CommitValidationError::UndeleteTargetNotDeleted { inode_id }.into());
+    };
+    // Recovery is scoped to the deletion the caller observed, never whatever
+    // deletion is active now, and revalidation applies the same generation.
+    if active.generation.seq != deleted_at_seq {
+        return Err(CommitValidationError::UndeleteGenerationMismatch {
+            inode_id,
+            requested_seq: deleted_at_seq,
+            active_seq: active.generation.seq,
+        }
+        .into());
+    }
+
+    Ok(active)
+}
+
+/// Requires an attribute target to be visible, whether file or directory.
+async fn validate_attributes_target_visible<S: ObjectStore + ?Sized>(
+    metadata_state: &PublishValidationView<'_, S>,
+    inode_id: InodeId,
+) -> Result<(), CoreError> {
+    if metadata_state.visible_inode(inode_id).await?.is_none() {
+        return Err(CommitValidationError::UpdateAttributesInodeMissing { inode_id }.into());
+    }
+
+    Ok(())
 }
 
 /// The base-revision guard every `UpdateAttributes` op carries, whether or
@@ -854,43 +866,20 @@ async fn validate_restore_source_revision<S: ObjectStore + ?Sized>(
         )?)
 }
 
-async fn validate_rename_source<S: ObjectStore + ?Sized>(
-    metadata_state: &PublishValidationView<'_, S>,
-    inode_id: InodeId,
-) -> Result<(), CoreError> {
-    metadata_state
-        .inode_at_seq(inode_id)
-        .await?
-        .ok_or(CommitValidationError::RenameInodeMissing { inode_id })?;
-    if metadata_state
-        .current_parent_binding_for_child(inode_id)
-        .await?
-        .is_none()
-    {
-        return Err(CommitValidationError::RenameSourceBindingMissing { inode_id }.into());
-    }
-
-    Ok(())
-}
-
 async fn validate_rename_does_not_cycle<S: ObjectStore + ?Sized>(
     metadata_state: &PublishValidationView<'_, S>,
-    inode_id: InodeId,
+    inode: &InodeRecord,
     new_parent_inode_id: InodeId,
 ) -> Result<(), CoreError> {
-    let inode = metadata_state
-        .inode_at_seq(inode_id)
-        .await?
-        .ok_or(CommitValidationError::RenameInodeMissing { inode_id })?;
     if inode.inode_kind != InodeKind::Directory {
         return Ok(());
     }
     if metadata_state
-        .would_create_directory_cycle(inode_id, new_parent_inode_id)
+        .would_create_directory_cycle(inode.inode_id, new_parent_inode_id)
         .await?
     {
         return Err(CommitValidationError::RenameWouldCycleDirectory {
-            inode_id,
+            inode_id: inode.inode_id,
             new_parent_inode_id,
         }
         .into());

--- a/crates/loonfs-core/src/commit/validate_error.rs
+++ b/crates/loonfs-core/src/commit/validate_error.rs
@@ -147,8 +147,6 @@ pub enum CommitValidationError {
     },
     #[error("rename source inode `{inode_id}` is missing")]
     RenameInodeMissing { inode_id: InodeId },
-    #[error("rename source inode `{inode_id}` has no current binding")]
-    RenameSourceBindingMissing { inode_id: InodeId },
     #[error("source inode `{inode_id}` has no current binding")]
     SourceBindingMissing { inode_id: InodeId },
     #[error("rename target parent inode `{parent_inode_id}` is missing")]

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -35,7 +35,7 @@ pub struct CommitCandidate {
 
 /// The result of preparing external content referenced by a mutation.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ContentPreparation {
+pub(crate) enum ContentPreparation {
     Ready(Vec<ContentAdmission>),
     Rejected(ContentPreparationError),
 }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -13,7 +13,10 @@ use crate::options::{BootstrapOptions, DeleteNamespaceOptions};
 use crate::path::read::{
     load_metadata_view, CurrentFileState, DirectDownloadTarget, LoadedMetadataView, ReadLoadContext,
 };
-use crate::protocol::CompletedUpload;
+use crate::protocol::{
+    BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
+    MultipartPartTargets,
+};
 use crate::storage::content::FileContentStream;
 use crate::storage::content_admission::{CompletedUploadReceipt, PreparedContent};
 use crate::time::current_time_ms;
@@ -30,7 +33,7 @@ use loonfs_api::{
     CheckpointId, ContentRef, CreateCheckpointResponse, DeleteNamespaceResponse,
     DirectoryPageCursor, FileRevision, FileRevisionsPageCursor, FlushWalResponse, InodeId,
     ListCheckpointsResponse, NamespaceId, NamespaceSummary, Page, PageRequest,
-    ReleaseCheckpointResponse, RevisionNo, StorageChecksum, TrashEntry, TrashPageCursor, UploadId,
+    ReleaseCheckpointResponse, RevisionNo, TrashEntry, TrashPageCursor, UploadId,
 };
 use loonfs_objectstore::{ByteStream, ObjectStore};
 use std::num::NonZeroU64;
@@ -62,54 +65,6 @@ fn runtime_read_load_context(context: &RuntimeReadContext) -> ReadLoadContext<'_
         Some(&context.table_cache),
         Some(&context.tail_cache),
     )
-}
-
-/// Internal target used by server integrations before they mint a presigned URL.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DirectPutUploadTarget {
-    pub content_ref: ContentRef,
-    pub object_key: String,
-}
-
-/// Internal response for preparing a direct_put session before URL signing.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BeginDirectPutUploadTargetResponse {
-    pub namespace_id: NamespaceId,
-    pub upload_id: UploadId,
-    pub target: DirectPutUploadTarget,
-}
-
-/// Internal multipart target used by the server before signing part URLs.
-///
-/// The session has an object identity but no content reference yet because
-/// the payload size and checksum are supplied at completion.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DirectMultipartUploadTarget {
-    pub object_key: String,
-    pub part_size_bytes: u64,
-}
-
-/// Internal response for preparing a direct_multipart session.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BeginDirectMultipartUploadTargetResponse {
-    pub namespace_id: NamespaceId,
-    pub upload_id: UploadId,
-    pub target: DirectMultipartUploadTarget,
-}
-
-/// One part a server integration is about to sign.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MultipartPartTarget {
-    pub part_number: u32,
-    pub checksum: StorageChecksum,
-}
-
-/// Everything a server integration needs to sign one wave of part uploads.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MultipartPartTargets {
-    pub object_key: String,
-    pub provider_upload_id: String,
-    pub parts: Vec<MultipartPartTarget>,
 }
 
 /// The actor identity a mutating engine publishes under.

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -771,7 +771,6 @@ fn classify_commit_validation_error(error: &CommitValidationError) -> ErrorCode 
         | CommitValidationError::RestoreRevisionInodeMissing { .. }
         | CommitValidationError::DeleteFileInodeMissing { .. }
         | CommitValidationError::RenameInodeMissing { .. }
-        | CommitValidationError::RenameSourceBindingMissing { .. }
         | CommitValidationError::SourceBindingMissing { .. }
         | CommitValidationError::RenameTargetParentMissing { .. }
         | CommitValidationError::DeleteSubtreeRootMissing { .. }

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -110,13 +110,13 @@ pub mod time;
 pub mod cache {
     pub use crate::recency::Recency;
 
+    pub use crate::checkpoint::cache::DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES;
     pub use crate::checkpoint::{
         ManifestLoadError, ManifestLoadFailureClass, MetadataTableCache, MetadataTableCacheConfig,
         MetadataTableCacheStats, StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError,
         StoredMetadataBlockKey, StoredMetadataBlockKind, WalTailProjectionCache,
         WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
-        DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES,
-        DEFAULT_WAL_TAIL_PROJECTION_ROWS,
+        DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_ROWS,
     };
     pub use crate::namespace::status::{
         load_deleted_namespace_head_summary, load_namespace_fold_basis,
@@ -133,9 +133,8 @@ pub mod control {
     };
     pub use crate::namespace::control::{
         load_namespace_checkpoint_record_control, load_namespace_head_control,
-        load_namespace_metadata_root_control, load_namespace_read_anchor,
-        load_namespace_wal_floor_control, ControlObjectIdentity, LoadedHeadControl,
-        LoadedMetadataRootControl, LoadedWalFloorControl,
+        load_namespace_metadata_root_control, load_namespace_read_anchor, ControlObjectIdentity,
+        LoadedHeadControl, LoadedMetadataRootControl,
     };
     pub use crate::namespace::{BasisManifest, MetadataBasis};
 }
@@ -146,7 +145,7 @@ pub mod control {
 pub mod publish {
     pub use crate::commit::{CommitFingerprint, CommitHeadPublishError};
     pub use crate::commit_engine::{
-        CommitCandidate, ContentPreparation, ContentPreparationError, NamespaceCommitEngine,
+        CommitCandidate, ContentPreparationError, NamespaceCommitEngine,
         NamespaceCommitEnginePublishResult, ResultingReadState, SharedWriterSessionState,
         WalTailPolicy, WriterSessionState,
     };
@@ -166,7 +165,7 @@ pub use checkpoint::{
 };
 pub use context::MutationContext;
 pub use engine::RuntimeReadContext;
-pub use engine::{
+pub use protocol::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse,
     DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget, MultipartPartTargets,
 };

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -4,7 +4,7 @@
 use super::visibility::unbind_matches_binding;
 use super::{
     AttributesRevisionRecord, CommitReceiptRecord, DirentryBindRecord, DirentryUnbindRecord,
-    InodeRecord, RevisionRecord, SubtreeTombstoneAction, SubtreeTombstoneRecord,
+    InodeRecord, MetadataState, RevisionRecord, SubtreeTombstoneAction, SubtreeTombstoneRecord,
 };
 use loonfs_api::{ChangeSeq, CommitId, InodeId, NameKey};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -40,25 +40,16 @@ impl Default for MetadataIndexes {
 }
 
 impl MetadataIndexes {
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn rebuild(
-        inodes: &[InodeRecord],
-        binds: &[DirentryBindRecord],
-        unbinds: &[DirentryUnbindRecord],
-        revisions: &[RevisionRecord],
-        tombstones: &[SubtreeTombstoneRecord],
-        receipts: &[CommitReceiptRecord],
-        attributes_revisions: &[AttributesRevisionRecord],
-    ) -> Self {
+    pub(super) fn rebuild(state: &MetadataState) -> Self {
         let mut indexes = Self::default();
 
-        for inode in inodes {
+        for inode in &state.inodes {
             indexes.record_inode(inode);
         }
 
         let mut latest_by_parent_name = HashMap::<(InodeId, NameKey), DirentryBindRecord>::new();
         let mut latest_by_child = HashMap::<InodeId, DirentryBindRecord>::new();
-        for bind in binds {
+        for bind in &state.direntry_binds {
             indexes.indexed_seq = indexes.indexed_seq.max(bind.bind_seq);
             replace_if_newer_bind(
                 &mut latest_by_parent_name,
@@ -68,7 +59,7 @@ impl MetadataIndexes {
             replace_if_newer_bind(&mut latest_by_child, bind.child_inode_id, bind.clone());
         }
 
-        for unbind in unbinds {
+        for unbind in &state.direntry_unbinds {
             indexes.record_unbind(unbind);
         }
 
@@ -91,19 +82,19 @@ impl MetadataIndexes {
         }
         indexes.latest_bind_by_parent_name = latest_by_parent_name;
 
-        for revision in revisions {
+        for revision in &state.revisions {
             indexes.record_revision(revision);
         }
 
-        for tombstone in tombstones {
+        for tombstone in &state.subtree_tombstones {
             indexes.record_tombstone(tombstone);
         }
 
-        for receipt in receipts {
+        for receipt in &state.commit_receipts {
             indexes.record_commit_receipt(receipt);
         }
 
-        for attributes_revision in attributes_revisions {
+        for attributes_revision in &state.attributes_revisions {
             indexes.record_attributes_revision(attributes_revision);
         }
 

--- a/crates/loonfs-core/src/metadata/mod.rs
+++ b/crates/loonfs-core/src/metadata/mod.rs
@@ -54,8 +54,10 @@ pub(crate) use self::rows::{
 #[cfg(test)]
 pub(crate) use self::view::InMemoryMetadataView;
 pub(crate) use self::view::MetadataView;
-pub(crate) use self::view_session::VisibleChildEntry;
-pub use self::view_session::{LeafRevisionPrefetch, MetadataViewSession};
+pub(crate) use self::view_session::{
+    LeafRevisionPrefetch, MetadataViewSession, VisibleChildEntry,
+    METADATA_VIEW_SESSION_COUNTER_FIELDS,
+};
 pub(crate) use self::visibility::{unbind_matches_binding, BindingIdentity};
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/metadata/rows.rs
+++ b/crates/loonfs-core/src/metadata/rows.rs
@@ -346,33 +346,9 @@ impl MetadataState {
     }
 
     fn rebuild_indexes(&mut self) {
-        self.row_count = metadata_row_count(
-            &self.inodes,
-            &self.direntry_binds,
-            &self.direntry_unbinds,
-            &self.revisions,
-            &self.subtree_tombstones,
-            &self.commit_receipts,
-            &self.attributes_revisions,
-        );
-        self.decoded_bytes = metadata_decoded_bytes(
-            &self.inodes,
-            &self.direntry_binds,
-            &self.direntry_unbinds,
-            &self.revisions,
-            &self.subtree_tombstones,
-            &self.commit_receipts,
-            &self.attributes_revisions,
-        );
-        self.indexes = MetadataIndexes::rebuild(
-            &self.inodes,
-            &self.direntry_binds,
-            &self.direntry_unbinds,
-            &self.revisions,
-            &self.subtree_tombstones,
-            &self.commit_receipts,
-            &self.attributes_revisions,
-        );
+        self.row_count = metadata_row_count(self);
+        self.decoded_bytes = metadata_decoded_bytes(self);
+        self.indexes = MetadataIndexes::rebuild(self);
     }
 
     pub(crate) fn push_inode_record(&mut self, record: InodeRecord) {
@@ -465,59 +441,52 @@ impl MetadataStateBuilder {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn metadata_row_count(
-    inodes: &[InodeRecord],
-    direntry_binds: &[DirentryBindRecord],
-    direntry_unbinds: &[DirentryUnbindRecord],
-    revisions: &[RevisionRecord],
-    subtree_tombstones: &[SubtreeTombstoneRecord],
-    commit_receipts: &[CommitReceiptRecord],
-    attributes_revisions: &[AttributesRevisionRecord],
-) -> usize {
-    inodes
+fn metadata_row_count(state: &MetadataState) -> usize {
+    state
+        .inodes
         .len()
-        .saturating_add(direntry_binds.len())
-        .saturating_add(direntry_unbinds.len())
-        .saturating_add(revisions.len())
-        .saturating_add(subtree_tombstones.len())
-        .saturating_add(commit_receipts.len())
-        .saturating_add(attributes_revisions.len())
+        .saturating_add(state.direntry_binds.len())
+        .saturating_add(state.direntry_unbinds.len())
+        .saturating_add(state.revisions.len())
+        .saturating_add(state.subtree_tombstones.len())
+        .saturating_add(state.commit_receipts.len())
+        .saturating_add(state.attributes_revisions.len())
 }
 
-#[allow(clippy::too_many_arguments)]
-fn metadata_decoded_bytes(
-    inodes: &[InodeRecord],
-    direntry_binds: &[DirentryBindRecord],
-    direntry_unbinds: &[DirentryUnbindRecord],
-    revisions: &[RevisionRecord],
-    subtree_tombstones: &[SubtreeTombstoneRecord],
-    commit_receipts: &[CommitReceiptRecord],
-    attributes_revisions: &[AttributesRevisionRecord],
-) -> usize {
-    size_of_val(inodes)
+fn metadata_decoded_bytes(state: &MetadataState) -> usize {
+    size_of_val(state.inodes.as_slice())
         .saturating_add(
-            direntry_binds
+            state
+                .direntry_binds
                 .iter()
                 .map(direntry_bind_decoded_bytes)
                 .sum::<usize>(),
         )
         .saturating_add(
-            direntry_unbinds
+            state
+                .direntry_unbinds
                 .iter()
                 .map(direntry_unbind_decoded_bytes)
                 .sum::<usize>(),
         )
-        .saturating_add(revisions.iter().map(revision_decoded_bytes).sum::<usize>())
-        .saturating_add(size_of_val(subtree_tombstones))
         .saturating_add(
-            commit_receipts
+            state
+                .revisions
+                .iter()
+                .map(revision_decoded_bytes)
+                .sum::<usize>(),
+        )
+        .saturating_add(size_of_val(state.subtree_tombstones.as_slice()))
+        .saturating_add(
+            state
+                .commit_receipts
                 .iter()
                 .map(commit_receipt_decoded_bytes)
                 .sum::<usize>(),
         )
         .saturating_add(
-            attributes_revisions
+            state
+                .attributes_revisions
                 .iter()
                 .map(attributes_revision_decoded_bytes)
                 .sum::<usize>(),

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -72,7 +72,6 @@ pub(crate) struct MetadataSourceStack<'a, 'store, S: ObjectStore + ?Sized> {
     overlay: Option<&'a MetadataState>,
     wal_tail: Option<&'a MetadataState>,
     manifest: Option<&'a VerifiedMetadataTables<'store, S>>,
-    in_memory_base: Option<&'a MetadataState>,
     durable_cache: Option<&'a DurableVisibilityCache>,
 }
 
@@ -111,9 +110,8 @@ impl<'a> InMemoryMetadataView<'a> {
             snapshot: MetadataSnapshot { visible_seq },
             sources: MetadataSourceStack {
                 overlay,
-                wal_tail: None,
+                wal_tail: Some(base),
                 manifest: None,
-                in_memory_base: Some(base),
                 durable_cache: None,
             },
         }
@@ -134,7 +132,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                 overlay: None,
                 wal_tail: Some(wal_tail_rows),
                 manifest: Some(tables),
-                in_memory_base: None,
                 durable_cache: None,
             },
         }
@@ -157,7 +154,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                 overlay: None,
                 wal_tail: None,
                 manifest: Some(tables),
-                in_memory_base: None,
                 durable_cache: None,
             },
         }
@@ -174,7 +170,6 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                 overlay: Some(overlay),
                 wal_tail: self.sources.wal_tail,
                 manifest: self.sources.manifest,
-                in_memory_base: self.sources.in_memory_base,
                 durable_cache: self.sources.durable_cache,
             },
         }
@@ -198,13 +193,9 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     }
 
     pub(super) fn row_states(&self) -> impl Iterator<Item = &'a MetadataState> + '_ {
-        [
-            self.sources.overlay,
-            self.sources.wal_tail,
-            self.sources.in_memory_base,
-        ]
-        .into_iter()
-        .flatten()
+        [self.sources.overlay, self.sources.wal_tail]
+            .into_iter()
+            .flatten()
     }
 
     fn overlay_state(&self) -> Option<&'a MetadataState> {
@@ -212,9 +203,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
     }
 
     fn durable_row_states(&self) -> impl Iterator<Item = &'a MetadataState> + '_ {
-        [self.sources.wal_tail, self.sources.in_memory_base]
-            .into_iter()
-            .flatten()
+        self.sources.wal_tail.into_iter()
     }
 
     pub(super) fn manifest_tables(&self) -> Option<&'a VerifiedMetadataTables<'store, S>> {

--- a/crates/loonfs-core/src/metadata/view_session.rs
+++ b/crates/loonfs-core/src/metadata/view_session.rs
@@ -63,7 +63,7 @@ pub(crate) struct VisibleChildEntry {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LeafRevisionPrefetch {
+pub(crate) enum LeafRevisionPrefetch {
     Prefetch,
     Skip,
 }
@@ -84,11 +84,45 @@ pub(crate) struct MetadataViewSessionCounters {
     pub(crate) list_preload_child_lookups: u64,
 }
 
+pub(crate) const METADATA_VIEW_SESSION_COUNTER_FIELDS: [&str; 12] = [
+    "list_page_visible_child_calls",
+    "list_page_visible_inode_calls",
+    "list_page_current_parent_binding_calls",
+    "list_page_covering_tombstone_calls",
+    "list_page_latest_revision_calls",
+    "list_page_latest_attributes_calls",
+    "list_page_direntry_child_scan_calls",
+    "list_page_scan_prefix_calls",
+    "list_page_scan_range_page_calls",
+    "list_page_preload_unbind_range_scans",
+    "list_page_preload_child_lookups",
+    "list_page_preload_attribute_lookups",
+];
+
+impl MetadataViewSessionCounters {
+    pub(crate) fn record_on(self, span: &tracing::Span) {
+        let values = [
+            self.visible_child_calls,
+            self.visible_inode_calls,
+            self.current_parent_binding_calls,
+            self.covering_tombstone_calls,
+            self.latest_revision_calls,
+            self.latest_attributes_calls,
+            self.direntry_child_scan_calls,
+            self.scan_prefix_calls,
+            self.scan_range_page_calls,
+            self.list_preload_unbind_range_scans,
+            self.list_preload_child_lookups,
+            self.preload_attribute_lookups,
+        ];
+        for (field, value) in METADATA_VIEW_SESSION_COUNTER_FIELDS.iter().zip(values) {
+            span.record(*field, value);
+        }
+    }
+}
+
 /// One loaded-view session with memoized visibility reads.
-///
-/// This is part of the read surface consumed by `loonfs-grep`; construction
-/// stays on the loaded view so callers cannot assemble incoherent sessions.
-pub struct MetadataViewSession<'a, 'store, S: ObjectStore + ?Sized> {
+pub(crate) struct MetadataViewSession<'a, 'store, S: ObjectStore + ?Sized> {
     base: MetadataView<'a, 'store, S>,
     inode_at_seq_cache: HashMap<InodeId, Option<InodeRecord>>,
     visible_inode_cache: HashMap<InodeId, Option<InodeRecord>>,
@@ -410,8 +444,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     /// have fetched. The canonical rules then decide over cache hits, so a
     /// cold resolution costs one round-trip wave per path component instead
     /// of five-plus sequential lookups each.
-    /// This is part of the read surface consumed by `loonfs-grep`.
-    pub async fn resolve_visible_path(
+    pub(crate) async fn resolve_visible_path(
         &mut self,
         absolute_path: &AbsolutePath,
         prefetch_leaf_revision: LeafRevisionPrefetch,
@@ -584,8 +617,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
 
     /// Returns the inode when it is visible in this session's snapshot.
     ///
-    /// This is part of the read surface consumed by `loonfs-grep`.
-    pub async fn visible_inode(
+    pub(crate) async fn visible_inode(
         &mut self,
         inode_id: InodeId,
     ) -> Result<Option<InodeRecord>, CoreError> {
@@ -618,8 +650,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
     /// and it cannot disagree with the enumeration that admitted the entry
     /// at the same seq.
     ///
-    /// This is part of the read surface consumed by `loonfs-grep`.
-    pub async fn latest_revision_head_of_visible(
+    pub(crate) async fn latest_revision_head_of_visible(
         &mut self,
         inode_id: InodeId,
     ) -> Result<Option<RevisionRecord>, CoreError> {
@@ -706,8 +737,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataViewSession<'a, 'store, S> {
 
     /// Returns the child's active parent binding at the visible sequence.
     ///
-    /// This is part of the read surface consumed by `loonfs-grep`.
-    pub async fn current_parent_binding_for_child(
+    pub(crate) async fn current_parent_binding_for_child(
         &mut self,
         child_inode_id: InodeId,
     ) -> Result<Option<DirentryBindRecord>, CoreError> {

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -28,13 +28,6 @@ pub struct LoadedMetadataRootControl {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadedWalFloorControl {
-    pub object_key: String,
-    pub identity: ControlObjectIdentity,
-    pub state: loonfs_api::wire::control::WalFloorState,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadedHeadControl {
     pub object_key: String,
     pub identity: ControlObjectIdentity,
@@ -127,18 +120,6 @@ pub(crate) async fn read_head_object<S: ObjectStore + ?Sized>(
         |state: &HeadState| expect_namespace(expected_namespace_id, &state.namespace_id),
     )
     .await
-}
-
-pub async fn load_namespace_wal_floor_control<S: ObjectStore + ?Sized>(
-    store: &S,
-    expected_namespace_id: &NamespaceId,
-) -> Result<LoadedWalFloorControl, ControlObjectLoadError> {
-    let loaded = read_wal_floor_object(store, expected_namespace_id).await?;
-    Ok(LoadedWalFloorControl {
-        object_key: loaded.object_key,
-        identity: ControlObjectIdentity { etag: loaded.etag },
-        state: loaded.state,
-    })
 }
 
 pub async fn load_namespace_checkpoint_record_control<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -10,7 +10,7 @@ use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, MetadataViewError, Result};
 use crate::metadata::{
     LeafRevisionPrefetch, MetadataState, MetadataView, MetadataViewSession, ResolvedVisiblePath,
-    RevisionRecord, VisibleChildEntry,
+    RevisionRecord, VisibleChildEntry, METADATA_VIEW_SESSION_COUNTER_FIELDS,
 };
 #[cfg(test)]
 use crate::namespace::basis::read_head_and_metadata_basis;
@@ -738,18 +738,18 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             "loonfs.phase",
             phase = "list_page_build_entries",
             list_page_children_returned = children.len() as u64,
-            list_page_visible_child_calls = tracing::field::Empty,
-            list_page_visible_inode_calls = tracing::field::Empty,
-            list_page_current_parent_binding_calls = tracing::field::Empty,
-            list_page_covering_tombstone_calls = tracing::field::Empty,
-            list_page_latest_revision_calls = tracing::field::Empty,
-            list_page_latest_attributes_calls = tracing::field::Empty,
-            list_page_direntry_child_scan_calls = tracing::field::Empty,
-            list_page_scan_prefix_calls = tracing::field::Empty,
-            list_page_scan_range_page_calls = tracing::field::Empty,
-            list_page_preload_unbind_range_scans = tracing::field::Empty,
-            list_page_preload_child_lookups = tracing::field::Empty,
-            list_page_preload_attribute_lookups = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[0] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[1] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[2] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[3] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[4] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[5] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[6] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[7] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[8] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[9] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[10] } = tracing::field::Empty,
+            { METADATA_VIEW_SESSION_COUNTER_FIELDS[11] } = tracing::field::Empty,
         );
         let entries = async {
             // A projected page reads every child's attributes as one wave,
@@ -778,52 +778,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         }
         .instrument(build_span.clone())
         .await?;
-        let counters = session.counters();
-        build_span.record(
-            "list_page_visible_child_calls",
-            counters.visible_child_calls,
-        );
-        build_span.record(
-            "list_page_visible_inode_calls",
-            counters.visible_inode_calls,
-        );
-        build_span.record(
-            "list_page_current_parent_binding_calls",
-            counters.current_parent_binding_calls,
-        );
-        build_span.record(
-            "list_page_covering_tombstone_calls",
-            counters.covering_tombstone_calls,
-        );
-        build_span.record(
-            "list_page_latest_revision_calls",
-            counters.latest_revision_calls,
-        );
-        build_span.record(
-            "list_page_latest_attributes_calls",
-            counters.latest_attributes_calls,
-        );
-        build_span.record(
-            "list_page_direntry_child_scan_calls",
-            counters.direntry_child_scan_calls,
-        );
-        build_span.record("list_page_scan_prefix_calls", counters.scan_prefix_calls);
-        build_span.record(
-            "list_page_scan_range_page_calls",
-            counters.scan_range_page_calls,
-        );
-        build_span.record(
-            "list_page_preload_unbind_range_scans",
-            counters.list_preload_unbind_range_scans,
-        );
-        build_span.record(
-            "list_page_preload_child_lookups",
-            counters.list_preload_child_lookups,
-        );
-        build_span.record(
-            "list_page_preload_attribute_lookups",
-            counters.preload_attribute_lookups,
-        );
+        session.counters().record_on(&build_span);
 
         Ok(Page {
             items: entries,

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -33,10 +33,13 @@ pub(crate) use self::batch::{
 pub(crate) use self::changes::list_changes_after;
 pub(crate) use self::publish_view::{load_publish_metadata_view, PublishTailProjection};
 pub use self::publish_view::{PublishTailOptions, PublishTailWeight};
-pub use self::uploads::CompletedUpload;
 pub(crate) use self::uploads::{
     abort_upload, begin_direct_multipart_upload_target, begin_direct_put_upload_target,
     begin_upload, complete_upload, direct_multipart_part_targets, read_upload_status,
     stage_owned_bytes, stage_owned_stream, upload_content, upload_streamed_content,
     AbandonedUpload,
+};
+pub use self::uploads::{
+    BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
+    DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget, MultipartPartTargets,
 };

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -13,10 +13,6 @@ use crate::context::MutationContext;
 use crate::control_update::{
     read_upload_session_state, update_upload_session, UploadSessionUpdate,
 };
-use crate::engine::{
-    BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse,
-    DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget, MultipartPartTargets,
-};
 use crate::error::MetadataProjectionLoadError;
 use crate::error::{CoreError, Result};
 use crate::limits::{
@@ -54,6 +50,54 @@ use loonfs_objectstore::{
     ByteStream, MultipartCompletion, MultipartPart, ObjectStore, PROVIDER_MULTIPART_PART_BYTES,
 };
 use std::num::NonZeroU64;
+
+/// Internal target used by server integrations before they mint a presigned URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectPutUploadTarget {
+    pub content_ref: ContentRef,
+    pub object_key: String,
+}
+
+/// Internal response for preparing a direct_put session before URL signing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BeginDirectPutUploadTargetResponse {
+    pub namespace_id: NamespaceId,
+    pub upload_id: UploadId,
+    pub target: DirectPutUploadTarget,
+}
+
+/// Internal multipart target used by the server before signing part URLs.
+///
+/// The session has an object identity but no content reference yet because
+/// the payload size and checksum are supplied at completion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectMultipartUploadTarget {
+    pub object_key: String,
+    pub part_size_bytes: u64,
+}
+
+/// Internal response for preparing a direct_multipart session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BeginDirectMultipartUploadTargetResponse {
+    pub namespace_id: NamespaceId,
+    pub upload_id: UploadId,
+    pub target: DirectMultipartUploadTarget,
+}
+
+/// One part a server integration is about to sign.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultipartPartTarget {
+    pub part_number: u32,
+    pub checksum: StorageChecksum,
+}
+
+/// Everything a server integration needs to sign one wave of part uploads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultipartPartTargets {
+    pub object_key: String,
+    pub provider_upload_id: String,
+    pub parts: Vec<MultipartPartTarget>,
+}
 
 pub(crate) async fn begin_upload<S: ObjectStore + ?Sized>(
     store: &S,
@@ -468,25 +512,6 @@ fn terminal_session_error(
     }
 }
 
-/// Returns the staged-content slot for an open session.
-///
-/// Completed and aborted sessions return their corresponding terminal
-/// errors.
-fn open_staging_slot<'a>(
-    state: &'a mut UploadSessionLifecycle,
-    upload_id: &UploadId,
-) -> Result<&'a mut Option<ContentRef>> {
-    match state {
-        UploadSessionLifecycle::Open { staged_content, .. } => Ok(staged_content),
-        UploadSessionLifecycle::Completed { .. } => Err(CoreError::UploadAlreadyCompleted {
-            upload_id: upload_id.clone(),
-        }),
-        UploadSessionLifecycle::Aborted { .. } => Err(CoreError::UploadNotFound {
-            upload_id: upload_id.clone(),
-        }),
-    }
-}
-
 /// What an open session has already staged, or `None` for one that has
 /// staged nothing — or that is past staging entirely.
 fn staged_content(state: &UploadSessionLifecycle) -> Option<&ContentRef> {
@@ -705,26 +730,30 @@ async fn record_staged_content<S: ObjectStore + ?Sized>(
                 if let Some(error) = terminal_session_error(&state.state, upload_id.clone()) {
                     return Err(error);
                 }
+                let UploadSessionLifecycle::Open {
+                    staged_content,
+                    staging_claimed_at_ms,
+                    ..
+                } = &mut state.state
+                else {
+                    return Err(CoreError::Internal(
+                        "upload session changed after its terminal-state check".to_owned(),
+                    ));
+                };
                 let response = UploadContentResponse {
                     namespace_id,
                     upload_id: upload_id.clone(),
                     content_ref: content_ref.clone(),
                 };
-                match staged_content(&state.state) {
+                match staged_content {
                     Some(existing) if existing == &content_ref => {
                         Ok(UploadSessionUpdate::Noop(response))
                     }
                     Some(_) => Err(CoreError::UploadContentConflict { upload_id }),
                     None if already_present => Err(CoreError::UploadContentConflict { upload_id }),
                     None => {
-                        if let UploadSessionLifecycle::Open {
-                            staging_claimed_at_ms,
-                            ..
-                        } = &mut state.state
-                        {
-                            *staging_claimed_at_ms = None;
-                        }
-                        *open_staging_slot(&mut state.state, &upload_id)? = Some(content_ref);
+                        *staging_claimed_at_ms = None;
+                        *staged_content = Some(content_ref);
                         Ok(UploadSessionUpdate::Replace {
                             next: Box::new(state),
                             outcome: response,

--- a/crates/loonfs-core/src/storage/content_admission.rs
+++ b/crates/loonfs-core/src/storage/content_admission.rs
@@ -47,7 +47,7 @@ impl CompletedUploadReceipt {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ContentAdmission {
+pub(crate) struct ContentAdmission {
     content_store_id: ContentStoreId,
     content_ref: ContentRef,
 }

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PreparedWalSegment {
+pub(crate) struct PreparedWalSegment {
     pub object_key: String,
     pub segment_id: WalSegmentId,
     pub envelope: WalSegmentEnvelope,

--- a/crates/loonfs-server/src/http/metrics.rs
+++ b/crates/loonfs-server/src/http/metrics.rs
@@ -321,14 +321,8 @@ fn render_scrape_gauges(
     upload_permits: usize,
     download_permits: usize,
 ) {
-    for (field, value) in cache_gauges(cache) {
-        let name = format!("loonfs_cache_{field}");
-        write_gauge(
-            rendered,
-            &name,
-            &format!("Runtime cache counter `{field}`"),
-            value,
-        );
+    for (name, description, value) in cache_gauges(cache) {
+        write_gauge(rendered, name, description, value);
     }
     // Absent when this deployment keeps no local cache, so a scrape reports
     // nothing about a tier that does not exist rather than reporting zeros
@@ -444,7 +438,7 @@ fn local_cache_gauges(stats: &FoyerCacheStats) -> [(&'static str, &'static str, 
 ///
 /// Destructured without a rest pattern on purpose: a counter added to
 /// [`RuntimeCacheStats`] and not exported here fails to compile.
-fn cache_gauges(stats: &RuntimeCacheStats) -> [(&'static str, usize); 18] {
+fn cache_gauges(stats: &RuntimeCacheStats) -> [(&'static str, &'static str, usize); 18] {
     let RuntimeCacheStats {
         latest_metadata_view_reads,
         wal_tail_projection_cache_hits,
@@ -466,64 +460,94 @@ fn cache_gauges(stats: &RuntimeCacheStats) -> [(&'static str, usize); 18] {
         metadata_table_cache_filter_false_positives,
     } = *stats;
     [
-        ("latest_metadata_view_reads", latest_metadata_view_reads),
         (
-            "wal_tail_projection_cache_hits",
+            "loonfs_cache_latest_metadata_view_reads",
+            "Runtime cache counter `latest_metadata_view_reads`",
+            latest_metadata_view_reads,
+        ),
+        (
+            "loonfs_cache_wal_tail_projection_cache_hits",
+            "Runtime cache counter `wal_tail_projection_cache_hits`",
             wal_tail_projection_cache_hits,
         ),
         (
-            "wal_tail_projection_cache_misses",
+            "loonfs_cache_wal_tail_projection_cache_misses",
+            "Runtime cache counter `wal_tail_projection_cache_misses`",
             wal_tail_projection_cache_misses,
         ),
         (
-            "wal_tail_projection_cache_inserts",
+            "loonfs_cache_wal_tail_projection_cache_inserts",
+            "Runtime cache counter `wal_tail_projection_cache_inserts`",
             wal_tail_projection_cache_inserts,
         ),
         (
-            "wal_tail_projection_cache_evictions",
+            "loonfs_cache_wal_tail_projection_cache_evictions",
+            "Runtime cache counter `wal_tail_projection_cache_evictions`",
             wal_tail_projection_cache_evictions,
         ),
         (
-            "wal_tail_projection_cache_evicted_rows",
+            "loonfs_cache_wal_tail_projection_cache_evicted_rows",
+            "Runtime cache counter `wal_tail_projection_cache_evicted_rows`",
             wal_tail_projection_cache_evicted_rows,
         ),
         (
-            "wal_tail_projection_cache_evicted_decoded_bytes",
+            "loonfs_cache_wal_tail_projection_cache_evicted_decoded_bytes",
+            "Runtime cache counter `wal_tail_projection_cache_evicted_decoded_bytes`",
             wal_tail_projection_cache_evicted_decoded_bytes,
         ),
         (
-            "wal_tail_projection_cache_uncacheable_count",
+            "loonfs_cache_wal_tail_projection_cache_uncacheable_count",
+            "Runtime cache counter `wal_tail_projection_cache_uncacheable_count`",
             wal_tail_projection_cache_uncacheable_count,
         ),
         (
-            "wal_tail_projection_cache_uncacheable_rows",
+            "loonfs_cache_wal_tail_projection_cache_uncacheable_rows",
+            "Runtime cache counter `wal_tail_projection_cache_uncacheable_rows`",
             wal_tail_projection_cache_uncacheable_rows,
         ),
         (
-            "wal_tail_projection_cache_uncacheable_decoded_bytes",
+            "loonfs_cache_wal_tail_projection_cache_uncacheable_decoded_bytes",
+            "Runtime cache counter `wal_tail_projection_cache_uncacheable_decoded_bytes`",
             wal_tail_projection_cache_uncacheable_decoded_bytes,
         ),
         (
-            "wal_tail_projection_cache_cached_rows",
+            "loonfs_cache_wal_tail_projection_cache_cached_rows",
+            "Runtime cache counter `wal_tail_projection_cache_cached_rows`",
             wal_tail_projection_cache_cached_rows,
         ),
         (
-            "wal_tail_projection_cache_cached_decoded_bytes",
+            "loonfs_cache_wal_tail_projection_cache_cached_decoded_bytes",
+            "Runtime cache counter `wal_tail_projection_cache_cached_decoded_bytes`",
             wal_tail_projection_cache_cached_decoded_bytes,
         ),
-        ("metadata_table_cache_hits", metadata_table_cache_hits),
-        ("metadata_table_cache_misses", metadata_table_cache_misses),
-        ("metadata_table_cache_inserts", metadata_table_cache_inserts),
         (
-            "metadata_table_cache_evictions",
+            "loonfs_cache_metadata_table_cache_hits",
+            "Runtime cache counter `metadata_table_cache_hits`",
+            metadata_table_cache_hits,
+        ),
+        (
+            "loonfs_cache_metadata_table_cache_misses",
+            "Runtime cache counter `metadata_table_cache_misses`",
+            metadata_table_cache_misses,
+        ),
+        (
+            "loonfs_cache_metadata_table_cache_inserts",
+            "Runtime cache counter `metadata_table_cache_inserts`",
+            metadata_table_cache_inserts,
+        ),
+        (
+            "loonfs_cache_metadata_table_cache_evictions",
+            "Runtime cache counter `metadata_table_cache_evictions`",
             metadata_table_cache_evictions,
         ),
         (
-            "metadata_table_cache_filter_skips",
+            "loonfs_cache_metadata_table_cache_filter_skips",
+            "Runtime cache counter `metadata_table_cache_filter_skips`",
             metadata_table_cache_filter_skips,
         ),
         (
-            "metadata_table_cache_filter_false_positives",
+            "loonfs_cache_metadata_table_cache_filter_false_positives",
+            "Runtime cache counter `metadata_table_cache_filter_false_positives`",
             metadata_table_cache_filter_false_positives,
         ),
     ]

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -111,8 +111,8 @@ pub mod publish {
     };
     pub use loonfs_core::path::parse_mutation_path;
     pub use loonfs_core::publish::{
-        CommitCandidate, CommitRequest, ContentPreparation, ContentPreparationError,
-        FilesystemOperation, PreparedContent,
+        CommitCandidate, CommitRequest, ContentPreparationError, FilesystemOperation,
+        PreparedContent,
     };
 }
 

--- a/crates/loonfs/src/metrics.rs
+++ b/crates/loonfs/src/metrics.rs
@@ -56,7 +56,7 @@ pub use loonfs_objectstore::metrics::{
     RangeClass, VecObjectStoreMetricsRecorder,
 };
 
-pub(crate) use instruments::{fan_out_object_store_recorder, RuntimeInstruments};
+pub(crate) use instruments::{fan_out_object_store_recorder, PublishOutcome, RuntimeInstruments};
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -47,6 +47,22 @@ impl CompactionOutcome {
     }
 }
 
+/// The closed outcome vocabulary for a publication delivered to its caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PublishOutcome {
+    Ok,
+    Error,
+}
+
+impl PublishOutcome {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Error => "error",
+        }
+    }
+}
+
 /// One reclaimable family: its label, and the count a pass reports for it.
 type GcCategory = (&'static str, fn(&GcResponse) -> u64);
 
@@ -267,11 +283,11 @@ impl RuntimeInstruments {
     }
 
     /// Reports one publication result delivered to its caller.
-    pub(crate) fn publisher_publish(&self, result: &'static str) {
+    pub(crate) fn publisher_publish(&self, outcome: PublishOutcome) {
         let Some(installed) = &self.installed else {
             return;
         };
-        installed.publisher.publish(result).increment(1);
+        installed.publisher.publish(outcome).increment(1);
     }
 
     /// Reports what one collection pass reclaimed and retained.
@@ -622,11 +638,11 @@ struct PublisherInstruments {
 
 impl PublisherInstruments {
     fn register(recorder: &dyn MetricsRecorder) -> Self {
-        let publishes = |result: &'static str| {
+        let publishes = |outcome: PublishOutcome| {
             recorder.register_counter(
                 "loonfs.publisher.publishes",
                 "Publication results delivered to their callers",
-                &[("result", result)],
+                &[("result", outcome.as_str())],
             )
         };
         Self {
@@ -661,16 +677,15 @@ impl PublisherInstruments {
                 "Decoded bytes held by the retained WAL-tail projections",
                 &[],
             ),
-            published_ok: publishes("ok"),
-            published_error: publishes("error"),
+            published_ok: publishes(PublishOutcome::Ok),
+            published_error: publishes(PublishOutcome::Error),
         }
     }
 
-    fn publish(&self, result: &'static str) -> &Arc<dyn CounterHandle> {
-        if result == "ok" {
-            &self.published_ok
-        } else {
-            &self.published_error
+    fn publish(&self, outcome: PublishOutcome) -> &Arc<dyn CounterHandle> {
+        match outcome {
+            PublishOutcome::Ok => &self.published_ok,
+            PublishOutcome::Error => &self.published_error,
         }
     }
 }
@@ -908,7 +923,7 @@ mod tests {
         assert!(fan_out_object_store_recorder(None, instruments.object_store_recorder()).is_none());
 
         instruments.publisher_batch(4);
-        instruments.publisher_publish("ok");
+        instruments.publisher_publish(PublishOutcome::Ok);
         instruments.maintenance_step(MaintenanceJobId::GC, MaintenanceStepConclusion::Idle, 1, 2);
     }
 

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -22,6 +22,7 @@
 //! shutdown with the maintenance runner.
 
 use crate::fs::{ReadCore, WriterBits};
+use crate::metrics::PublishOutcome;
 use crate::publish::{CommitCandidate, CommitRequest, PreparedContent};
 use crate::{
     CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeCacheConfig, RuntimeError,
@@ -941,7 +942,7 @@ impl NamespacePublisher {
         }
         .instrument(publish_span.clone())
         .await;
-        publish_span.record("result", batch_result_label(&results));
+        publish_span.record("result", batch_result_label(&results).as_str());
         publish_span.record("retry_count", retry_count);
         drop(publish_span);
 
@@ -1151,7 +1152,7 @@ impl NamespacePublisher {
                 phase = "wait_for_result",
                 mode = self.trace_mode,
                 store_kind = self.trace_store_kind,
-                result,
+                result = result.as_str(),
                 wait_ms,
                 "publisher.wait_for_result"
             );
@@ -1240,19 +1241,19 @@ fn queued_candidates(state: &NamespacePublisherState) -> usize {
         .sum()
 }
 
-fn result_label<T, E>(result: &Result<T, E>) -> &'static str {
+fn result_label<T, E>(result: &Result<T, E>) -> PublishOutcome {
     if result.is_ok() {
-        "ok"
+        PublishOutcome::Ok
     } else {
-        "error"
+        PublishOutcome::Error
     }
 }
 
-fn batch_result_label(results: &[CommitResult]) -> &'static str {
+fn batch_result_label(results: &[CommitResult]) -> PublishOutcome {
     if results.iter().all(Result::is_ok) {
-        "ok"
+        PublishOutcome::Ok
     } else {
-        "error"
+        PublishOutcome::Error
     }
 }
 

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -501,11 +501,12 @@ fn publisher_trace_labels_are_low_cardinality() {
     // A result label says only whether the publication succeeded. The error
     // text is caller data and must never reach a trace label, where it would
     // make the label set unbounded.
-    assert_eq!(result_label(&Ok::<_, CoreError>(())), "ok");
+    assert_eq!(result_label(&Ok::<_, CoreError>(())).as_str(), "ok");
     assert_eq!(
         result_label(&Err::<(), _>(CoreError::Internal(
             "private error".to_owned()
-        ))),
+        )))
+        .as_str(),
         "error"
     );
     assert_eq!(usize_to_u64(7), 7);


### PR DESCRIPTION
Consolidates metadata accounting and index rebuild helpers around MetadataState instead of passing each family separately. Publisher outcomes use a closed enum, and exported scrape gauges use explicit static names and descriptions so internal field renames cannot change metric names.

Removes unused read state and dead internal APIs, narrows items that have no external consumers, and places presigned-upload request types in the protocol module that constructs them. Existing re-exports preserve the supported public API.

Centralizes metadata-view counters beside the counters they record, moves the remaining validation branches into named helpers, reuses facts already resolved during rename validation, and simplifies staged-content and reorganization result construction. These changes reduce duplicate state and branching without changing storage or protocol behavior.