### PR TITLE
refactor(api): retryability in the registry, the pagination knob deleted, one method per operation

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -43,7 +43,11 @@ pub enum ErrorKind {
     /// The server cancelled work that exceeded its configured request
     /// deadline. Reconcile any mutation before deciding whether to retry.
     DeadlineExceeded,
-    /// The system is temporarily unavailable. Back off and retry.
+    /// Status grouping for conditions served as unavailable.
+    ///
+    /// This kind is not a retry predicate: some grouped conditions require
+    /// maintenance before another attempt can succeed. Use
+    /// [`ErrorCode::retryable_without_operator_action`] for that decision.
     Unavailable,
     /// The operation may have committed: its acknowledgment was lost. Retry
     /// with the same commit id or reconcile against namespace state; do not
@@ -191,8 +195,6 @@ impl ErrorCode {
             ErrorCode::NamespaceDeleted => ErrorKind::Gone,
             ErrorCode::NamespaceExists => ErrorKind::AlreadyExists,
             ErrorCode::DeadlineExceeded => ErrorKind::DeadlineExceeded,
-            // `index_lagging` clears once maintenance catches the index up,
-            // so it is served as retryable unavailability.
             ErrorCode::CommitQueueFull
             | ErrorCode::ServerBusy
             | ErrorCode::ShuttingDown
@@ -226,6 +228,54 @@ impl ErrorCode {
             | ErrorCode::RebootstrapRequired => ErrorKind::Conflict,
         }
     }
+
+    /// Returns whether this condition can clear without caller or operator action.
+    ///
+    /// This predicate is deliberately narrower than [`ErrorKind::Unavailable`]:
+    /// it includes only admission pressure and shutdown handoff that settle on
+    /// their own. Transport failures are classified separately by clients.
+    /// Reconciliation, request changes, and maintenance are caller or operator
+    /// actions and therefore return `false` here.
+    pub fn retryable_without_operator_action(self) -> bool {
+        match self {
+            ErrorCode::CommitQueueFull | ErrorCode::ServerBusy | ErrorCode::ShuttingDown => true,
+            ErrorCode::InvalidRequest
+            | ErrorCode::Unauthorized
+            | ErrorCode::PermissionDenied
+            | ErrorCode::ContentTooLarge
+            | ErrorCode::NotSupported
+            | ErrorCode::RouteNotFound
+            | ErrorCode::MethodNotAllowed
+            | ErrorCode::NamespaceNotFound
+            | ErrorCode::NamespaceDeleted
+            | ErrorCode::NamespaceExists
+            | ErrorCode::ContentNotPrepared
+            | ErrorCode::PathNotFound
+            | ErrorCode::RevisionNotFound
+            | ErrorCode::PathConflict
+            | ErrorCode::DirectoryNotEmpty
+            | ErrorCode::StaleHead
+            | ErrorCode::StaleRevision
+            | ErrorCode::StaleAttributes
+            | ErrorCode::NotDeleted
+            | ErrorCode::WriterFenced
+            | ErrorCode::WouldCycle
+            | ErrorCode::CommitIdReuseConflict
+            | ErrorCode::CommitOutcomeUnknown
+            | ErrorCode::DeadlineExceeded
+            | ErrorCode::CheckpointUnavailable
+            | ErrorCode::MaintenanceRequired
+            | ErrorCode::UploadNotFound
+            | ErrorCode::UploadAlreadyCompleted
+            | ErrorCode::UploadContentConflict
+            | ErrorCode::RebootstrapRequired
+            | ErrorCode::QueryUnindexable
+            | ErrorCode::IndexLagging
+            | ErrorCode::IndexCorrupt
+            | ErrorCode::NamespaceCorrupt
+            | ErrorCode::ServerError => false,
+        }
+    }
 }
 
 impl fmt::Display for ErrorCode {
@@ -255,5 +305,22 @@ mod tests {
             assert_eq!(parsed, code);
         }
         assert!(serde_json::from_str::<ErrorCode>("\"not_a_code\"").is_err());
+    }
+
+    #[test]
+    fn retryability_is_limited_to_self_clearing_admission_conditions() {
+        let retryable: Vec<_> = ErrorCode::ALL
+            .into_iter()
+            .filter(|code| code.retryable_without_operator_action())
+            .collect();
+
+        assert_eq!(
+            retryable,
+            [
+                ErrorCode::CommitQueueFull,
+                ErrorCode::ServerBusy,
+                ErrorCode::ShuttingDown,
+            ]
+        );
     }
 }

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -133,8 +133,8 @@ pub use name_policy::name_key_for_display_name;
 pub use pagination::{
     decode_cursor, decode_namespace_cursor, encode_cursor, DirectoryPageCursor, EffectiveLimit,
     FileRevisionsPageCursor, GrepPageCursor, LimitError, NamespaceCursor, NamespaceCursorError,
-    Page, PageCursor, PageCursorError, PageRequest, PaginationPolicy, PaginationPolicyError,
-    TrashPageCursor, DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, PAGE_CURSOR_VERSION,
+    Page, PageCursor, PageCursorError, PageRequest, PaginationPolicy, TrashPageCursor,
+    DEFAULT_MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT, PAGE_CURSOR_VERSION,
 };
 pub use path::{
     AbsolutePath, DisplayName, PathComponent, PathError, MAX_DISPLAY_NAME_BYTES, MAX_PATH_BYTES,

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -8,9 +8,13 @@ use std::collections::BTreeMap;
 use std::num::NonZeroU32;
 use thiserror::Error;
 
-/// Default page size for endpoints that can return unbounded result sets.
+/// Contract page size for endpoints that omit a caller-supplied limit.
+///
+/// This value is deliberately fixed and advertised through capabilities.
 pub const DEFAULT_PAGE_LIMIT: u32 = 1_000;
-/// Default maximum accepted page size.
+/// Contract maximum accepted page size.
+///
+/// This value is deliberately fixed and advertised through capabilities.
 pub const DEFAULT_MAX_PAGE_LIMIT: u32 = 1_000;
 
 /// Wire cursor format version.
@@ -42,7 +46,7 @@ impl EffectiveLimit {
     }
 }
 
-/// Deployment or namespace policy for paginated endpoints.
+/// Fixed pagination contract for endpoints with potentially unbounded results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PaginationPolicy {
     default_limit: NonZeroU32,
@@ -50,31 +54,6 @@ pub struct PaginationPolicy {
 }
 
 impl PaginationPolicy {
-    /// Creates a policy, requiring the default to be no larger than the max.
-    pub fn new(
-        default_limit: NonZeroU32,
-        max_limit: NonZeroU32,
-    ) -> Result<Self, PaginationPolicyError> {
-        if default_limit > max_limit {
-            return Err(PaginationPolicyError::DefaultExceedsMax {
-                default_limit: default_limit.get(),
-                max_limit: max_limit.get(),
-            });
-        }
-        Ok(Self {
-            default_limit,
-            max_limit,
-        })
-    }
-
-    /// Creates a policy from raw integers.
-    pub fn from_values(default_limit: u32, max_limit: u32) -> Result<Self, PaginationPolicyError> {
-        let default_limit =
-            NonZeroU32::new(default_limit).ok_or(PaginationPolicyError::ZeroDefaultLimit)?;
-        let max_limit = NonZeroU32::new(max_limit).ok_or(PaginationPolicyError::ZeroMaxLimit)?;
-        Self::new(default_limit, max_limit)
-    }
-
     /// Returns the page size applied when callers omit `limit`.
     pub fn default_limit(self) -> NonZeroU32 {
         self.default_limit
@@ -116,6 +95,9 @@ impl PaginationPolicy {
 
 impl Default for PaginationPolicy {
     fn default() -> Self {
+        // These are protocol constants, not configuration defaults. Keeping
+        // them together here makes every consumer enforce and advertise the
+        // same deliberate contract.
         let default_limit = const { NonZeroU32::new(DEFAULT_PAGE_LIMIT).unwrap() };
         let max_limit = const { NonZeroU32::new(DEFAULT_MAX_PAGE_LIMIT).unwrap() };
         Self {
@@ -123,25 +105,6 @@ impl Default for PaginationPolicy {
             max_limit,
         }
     }
-}
-
-/// Invalid pagination policy configuration.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum PaginationPolicyError {
-    /// The configured default limit was zero.
-    #[error("pagination default limit must be greater than zero")]
-    ZeroDefaultLimit,
-    /// The configured max limit was zero.
-    #[error("pagination max limit must be greater than zero")]
-    ZeroMaxLimit,
-    /// The configured default limit exceeded the configured max.
-    #[error("pagination default limit `{default_limit}` exceeds max limit `{max_limit}`")]
-    DefaultExceedsMax {
-        /// Default page size rejected by policy construction.
-        default_limit: u32,
-        /// Maximum page size the rejected default exceeded.
-        max_limit: u32,
-    },
 }
 
 /// Invalid caller-supplied page size.
@@ -450,17 +413,6 @@ mod tests {
             Err(LimitError::ExceedsMax {
                 requested: DEFAULT_MAX_PAGE_LIMIT + 1,
                 max_limit: DEFAULT_MAX_PAGE_LIMIT,
-            })
-        );
-    }
-
-    #[test]
-    fn policy_rejects_default_above_max() {
-        assert_eq!(
-            PaginationPolicy::from_values(10, 5),
-            Err(PaginationPolicyError::DefaultExceedsMax {
-                default_limit: 10,
-                max_limit: 5,
             })
         );
     }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -10,10 +10,11 @@ use crate::render::write_stderr_warning;
 use loonfs::{
     ByteStream, ChangesResponse, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
     CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    FileContentStream, FsAdmin, FsReader, FsWriter, ListChangesOptions, MaintenanceHandle,
-    MaintenanceJob, MaintenanceJobId, MaintenancePlan, MaintenanceStepConclusion, MoveOptions,
-    PutFileOptions, ReadFileStreamOptions, RestoreRevisionOptions, RuntimeError, SharedObjectStore,
-    StatPathOptions, UndeleteOptions, UpdateAttributesOptions,
+    FileContentStream, FsAdmin, FsReader, FsWriter, ListChangesOptions, ListPathEntriesOptions,
+    MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenancePlan,
+    MaintenanceStepConclusion, MoveOptions, PutFileOptions, ReadFileStreamOptions,
+    RestoreRevisionOptions, RuntimeError, SharedObjectStore, StatPathOptions, UndeleteOptions,
+    UpdateAttributesOptions,
 };
 use loonfs_api::{
     v0::{
@@ -216,7 +217,12 @@ impl EmbeddedBackend {
                 })?,
         };
         self.reader
-            .list_path_entries_page(spec.namespace(), spec.absolute_path().as_str(), request)
+            .list_path_entries_page(
+                spec.namespace(),
+                spec.absolute_path().as_str(),
+                request,
+                ListPathEntriesOptions::default(),
+            )
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
     }
@@ -227,7 +233,7 @@ impl EmbeddedBackend {
         options: &StatPathOptions,
     ) -> Result<AuthoritativePathEntry, BackendError> {
         self.reader
-            .stat_path_with_options(
+            .stat_path(
                 spec.namespace(),
                 spec.absolute_path().as_str(),
                 options.clone(),

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -28,9 +28,9 @@ use loonfs_api::{
     UploadId,
 };
 use loonfs_client::{
-    CopyOptions, CreateDirectoryOptions, DeleteOptions, DirectDownloadStream, MoveOptions,
-    NamespacePath, PutFileOptions, RestoreRevisionOptions, StatPathOptions, UndeleteOptions,
-    UpdateAttributesOptions,
+    CopyOptions, CreateDirectoryOptions, DeleteOptions, DirectDownloadStream,
+    ListPathEntriesOptions, MoveOptions, NamespacePath, PutFileOptions, RestoreRevisionOptions,
+    StatPathOptions, UndeleteOptions, UpdateAttributesOptions,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::sync::Arc;
@@ -316,7 +316,11 @@ impl ResolvedTarget {
     ) -> Result<Vec<AuthoritativePathEntry>, BackendError> {
         match self {
             Self::Embedded(target) => target.backend.list_path_entries_all(spec).await,
-            Self::Remote(target) => Ok(target.client.list_path_entries_all(spec).await?.entries),
+            Self::Remote(target) => Ok(target
+                .client
+                .list_path_entries_all(spec, &ListPathEntriesOptions::default())
+                .await?
+                .entries),
         }
     }
 
@@ -336,7 +340,7 @@ impl ResolvedTarget {
             }
             Self::Remote(target) => Ok(target
                 .client
-                .list_path_entries_page(spec, limit, cursor)
+                .list_path_entries_page(spec, limit, cursor, &ListPathEntriesOptions::default())
                 .await?),
         }
     }
@@ -346,7 +350,7 @@ impl ResolvedTarget {
         &self,
         spec: &NamespacePath,
     ) -> Result<AuthoritativePathEntry, BackendError> {
-        self.stat_path_with_options(spec, &StatPathOptions::default())
+        self.stat_path_projected(spec, &StatPathOptions::default())
             .await
     }
 
@@ -357,7 +361,7 @@ impl ResolvedTarget {
         &self,
         spec: &NamespacePath,
     ) -> Result<AuthoritativePathEntry, BackendError> {
-        self.stat_path_with_options(
+        self.stat_path_projected(
             spec,
             &StatPathOptions {
                 include_attributes: false,
@@ -366,14 +370,14 @@ impl ResolvedTarget {
         .await
     }
 
-    async fn stat_path_with_options(
+    async fn stat_path_projected(
         &self,
         spec: &NamespacePath,
         options: &StatPathOptions,
     ) -> Result<AuthoritativePathEntry, BackendError> {
         match self {
             Self::Embedded(target) => target.backend.stat_path(spec, options).await,
-            Self::Remote(target) => Ok(target.client.stat_path_with_options(spec, options).await?),
+            Self::Remote(target) => Ok(target.client.stat_path(spec, options).await?),
         }
     }
 

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -394,7 +394,8 @@ async fn run_admin_run(
     let jobs = selected_jobs(&args.jobs);
     let fail_here = |error| fail_for(kind, &resolved.profile_name, &mode, error);
 
-    let (keys, steps, budget_exhausted) = if args.drain {
+    let job_names: Vec<String> = jobs.iter().map(|job| job.as_str().to_owned()).collect();
+    let data = if args.drain {
         let budget = StepBudget {
             max_steps: args.max_steps,
             deadline_ms: args.deadline_ms,
@@ -404,35 +405,30 @@ async fn run_admin_run(
             .drain_maintenance(&namespaces, &jobs, budget)
             .await
             .map_err(fail_here)?;
-        (
-            progress.keys.iter().map(key_report).collect(),
-            progress.steps,
-            progress.budget_exhausted(),
-        )
+        CommandData::MaintenanceDrained {
+            namespaces,
+            jobs: job_names,
+            keys: progress.keys.iter().map(key_report).collect(),
+            steps: progress.steps,
+            budget_exhausted: progress.budget_exhausted(),
+        }
     } else {
         resolved
             .target
             .host_maintenance(&namespaces, &jobs, args.poll_interval_ms, shutdown_signal())
             .await
             .map_err(fail_here)?;
-        // A hosted run reports no per-key outcome: the runner ran the steps,
-        // and where each namespace got to is durable state to read, not a
-        // tally this process kept.
-        (Vec::new(), 0, false)
+        CommandData::MaintenanceHosted {
+            namespaces,
+            jobs: job_names,
+        }
     };
 
     Ok(CommandOutput {
         kind,
         profile: Some(resolved.profile_name),
         mode: Some(mode),
-        data: CommandData::MaintenanceHosted {
-            namespaces,
-            jobs: jobs.iter().map(|job| job.as_str().to_owned()).collect(),
-            drained: args.drain,
-            keys,
-            steps,
-            budget_exhausted,
-        },
+        data,
     })
 }
 

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -115,16 +115,18 @@ pub(crate) enum CommandData {
         /// True when a budget stopped the wait before the target.
         budget_exhausted: bool,
     },
-    /// What an assigned-namespace maintenance host did.
+    /// Assignment a maintenance host ran until it received a signal.
     MaintenanceHosted {
         /// The assignment, sorted and deduplicated.
         namespaces: Vec<NamespaceId>,
         jobs: Vec<String>,
-        /// True when the host caught the assignment up and exited instead of
-        /// hosting until a signal.
-        drained: bool,
-        /// Where each key got to. Empty for a hosted run: the runner ran
-        /// those steps, and durable state is what reports them.
+    },
+    /// Measured report from a maintenance host that drained its assignment.
+    MaintenanceDrained {
+        /// The assignment, sorted and deduplicated.
+        namespaces: Vec<NamespaceId>,
+        jobs: Vec<String>,
+        /// Where each key got to.
         keys: Vec<MaintenanceKeyReport>,
         /// Steps the drain ran across every key.
         steps: u64,
@@ -254,7 +256,7 @@ impl CommandData {
             // Same for a drain that ran out of budget: the per-key progress
             // it prints is real, and the assignment it was asked to catch
             // up is not caught up.
-            | CommandData::MaintenanceHosted {
+            | CommandData::MaintenanceDrained {
                 budget_exhausted, ..
             } => *budget_exhausted,
             // A probe that found a broken store prints every check's verdict

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -110,6 +110,18 @@ fn steps_phrase(steps: u64) -> String {
     }
 }
 
+fn maintenance_assignment(namespaces: &[NamespaceId], jobs: &[String]) -> String {
+    format!(
+        "{} for {}",
+        jobs.join(", "),
+        namespaces
+            .iter()
+            .map(NamespaceId::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
 /// Who a checkpoint record answers to, in one column: the label a user pin
 /// carries, or the fork target that keeps a lease standing. A fork lease is
 /// marked as such because `admin checkpoint-release` refuses it — it goes
@@ -609,42 +621,33 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                 format!("{opening}; {}", grep_index_state_summary(state))
             }
         }
-        CommandData::MaintenanceHosted {
+        CommandData::MaintenanceHosted { namespaces, jobs } => format!(
+            "hosted {}; stopped on signal",
+            maintenance_assignment(namespaces, jobs)
+        ),
+        CommandData::MaintenanceDrained {
             namespaces,
             jobs,
-            drained,
             keys,
             steps,
             budget_exhausted,
         } => {
-            let assignment = format!(
-                "{} for {}",
-                jobs.join(", "),
-                namespaces
-                    .iter()
-                    .map(NamespaceId::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            if !*drained {
-                format!("hosted {assignment}; stopped on signal")
+            let assignment = maintenance_assignment(namespaces, jobs);
+            let settled = keys.iter().filter(|key| key.settled).count();
+            let mut lines: Vec<String> = keys.iter().map(maintenance_key_line).collect();
+            lines.push(if *budget_exhausted {
+                format!(
+                    "gave up on {assignment}: {settled} of {} keys settled after {}",
+                    keys.len(),
+                    steps_phrase(*steps)
+                )
             } else {
-                let settled = keys.iter().filter(|key| key.settled).count();
-                let mut lines: Vec<String> = keys.iter().map(maintenance_key_line).collect();
-                lines.push(if *budget_exhausted {
-                    format!(
-                        "gave up on {assignment}: {settled} of {} keys settled after {}",
-                        keys.len(),
-                        steps_phrase(*steps)
-                    )
-                } else {
-                    format!(
-                        "drained {assignment}: {settled} keys settled after {}",
-                        steps_phrase(*steps)
-                    )
-                });
-                lines.join("\n")
-            }
+                format!(
+                    "drained {assignment}: {settled} keys settled after {}",
+                    steps_phrase(*steps)
+                )
+            });
+            lines.join("\n")
         }
         CommandData::StoreProbed(response) => {
             let failed = response

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -4145,7 +4145,8 @@ fn admin_run_drains_an_assignment_and_leaves_the_work_done() {
     ]);
     assert_success(&drained);
     let data = json_data(&drained);
-    assert_eq!(data["drained"], true);
+    assert_eq!(data["kind"], "maintenance_drained");
+    assert!(data.get("drained").is_none());
     assert_eq!(data["budget_exhausted"], false);
     let keys = data["keys"].as_array().expect("json array");
     assert_eq!(keys.len(), 8, "four jobs over two namespaces: {data}");
@@ -4292,7 +4293,7 @@ fn admin_run_takes_a_poll_interval_with_a_floor_that_a_drain_ignores() {
     ]);
     assert_success(&paced);
     let (plain, paced) = (json_data(&plain), json_data(&paced));
-    for field in ["drained", "budget_exhausted", "jobs"] {
+    for field in ["budget_exhausted", "jobs"] {
         assert_eq!(
             paced[field], plain[field],
             "a drain reports the same `{field}` with the cadence flag as without it"

--- a/crates/loonfs-client/src/error.rs
+++ b/crates/loonfs-client/src/error.rs
@@ -1,6 +1,6 @@
 //! [`ClientError`]: every failure the async client surfaces.
 
-use loonfs_api::{ErrorCode, ErrorDetails, ErrorKind};
+use loonfs_api::{ErrorCode, ErrorDetails};
 use thiserror::Error;
 
 /// Error returned by the async HTTP client.
@@ -72,32 +72,5 @@ impl ClientError {
             ClientError::Api { code, .. } => ErrorCode::parse(code),
             _ => None,
         }
-    }
-
-    /// Returns the caller-action category for [`ClientError::Api`] errors.
-    ///
-    /// Known codes classify through [`ErrorCode::kind`]. Unknown codes (a
-    /// newer server) fall back to the HTTP status class, so retry decisions
-    /// still work: 503 is [`ErrorKind::Unavailable`], other 5xx are
-    /// [`ErrorKind::Internal`], and 4xx are [`ErrorKind::InvalidRequest`].
-    pub fn kind(&self) -> Option<ErrorKind> {
-        match self {
-            ClientError::Api { status, code, .. } => match ErrorCode::parse(code) {
-                Some(code) => Some(code.kind()),
-                None => kind_for_status_class(*status),
-            },
-            _ => None,
-        }
-    }
-}
-
-/// Coarse status-class fallback for error codes this build does not know.
-pub(crate) fn kind_for_status_class(status: u16) -> Option<ErrorKind> {
-    match status {
-        // 503 stays retryable even when the code is unknown.
-        503 => Some(ErrorKind::Unavailable),
-        400..=499 => Some(ErrorKind::InvalidRequest),
-        500..=599 => Some(ErrorKind::Internal),
-        _ => None,
     }
 }

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -303,13 +303,12 @@ enum UploadTransport {
     Proxied,
 }
 
-/// A payload length this client has actually measured, as against the one a
-/// source declared.
+/// A payload length this client has actually measured, as against a source's
+/// file-metadata hint.
 ///
-/// Only a measured length may end an upload. `PayloadSource::sized_stream`
-/// documents its length as a hint — a source is free to deliver a different
-/// number of bytes — so a refusal built on one would turn a wrong hint into
-/// a failed upload. Threading the distinction through the type is what makes
+/// Only a measured length may end an upload. A file can change before it is
+/// read, so a refusal built on metadata would turn a stale hint into a failed
+/// upload. Threading the distinction through the type is what makes
 /// [`ClientError::UploadTooLarge`] unconstructible from a hint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct MeasuredBytes(u64);
@@ -611,29 +610,15 @@ impl Client {
     /// resumes in name-key order against the head the server has loaded —
     /// so aggregation never restarts. The envelope's `head_seq` reports the
     /// newest head that served a page. Use
-    /// [`Self::list_path_entries_page`] for page-level control. Entries carry
-    /// no attributes; [`Self::list_path_entries_all_with_options`] projects
-    /// them.
+    /// [`Self::list_path_entries_page`] for page-level control. `options`
+    /// selects the entry projection.
     pub async fn list_path_entries_all(
-        &self,
-        spec: &NamespacePath,
-    ) -> Result<ListPathEntriesResponse> {
-        self.list_path_entries_all_with_options(spec, &ListPathEntriesOptions::default())
-            .await
-    }
-
-    /// [`Self::list_path_entries_all`], projecting what `options` asks for.
-    ///
-    /// Every entry it returns came through
-    /// [`Self::list_path_entries_page_with_options`], which checks each one
-    /// against the projection, so the aggregate does not re-check them.
-    pub async fn list_path_entries_all_with_options(
         &self,
         spec: &NamespacePath,
         options: &ListPathEntriesOptions,
     ) -> Result<ListPathEntriesResponse> {
         let first_page = self
-            .list_path_entries_page_with_options(spec, None, None, options)
+            .list_path_entries_page(spec, None, None, options)
             .await?;
         let mut envelope = ListPathEntriesResponse {
             namespace_id: first_page.namespace_id,
@@ -645,7 +630,7 @@ impl Client {
         let mut next_cursor = first_page.next_cursor;
         while let Some(cursor) = next_cursor {
             let page = self
-                .list_path_entries_page_with_options(spec, None, Some(&cursor), options)
+                .list_path_entries_page(spec, None, Some(&cursor), options)
                 .await?;
             envelope.head_seq = envelope.head_seq.max(page.head_seq);
             envelope.entries.extend(page.entries);
@@ -656,25 +641,8 @@ impl Client {
         Ok(envelope)
     }
 
-    /// Lists one page of a directory. Entries carry no attributes;
-    /// [`Self::list_path_entries_page_with_options`] projects them.
+    /// Lists one page of a directory, projecting what `options` asks for.
     pub async fn list_path_entries_page(
-        &self,
-        spec: &NamespacePath,
-        limit: Option<u32>,
-        cursor: Option<&str>,
-    ) -> Result<ListPathEntriesResponse> {
-        self.list_path_entries_page_with_options(
-            spec,
-            limit,
-            cursor,
-            &ListPathEntriesOptions::default(),
-        )
-        .await
-    }
-
-    /// [`Self::list_path_entries_page`], projecting what `options` asks for.
-    pub async fn list_path_entries_page_with_options(
         &self,
         spec: &NamespacePath,
         limit: Option<u32>,
@@ -698,15 +666,8 @@ impl Client {
         self.request_json::<(), _>(self.get(&url), None).await
     }
 
-    /// Stats one path, projecting the inode's attributes.
-    /// [`Self::stat_path_with_options`] chooses otherwise.
-    pub async fn stat_path(&self, spec: &NamespacePath) -> Result<AuthoritativePathEntry> {
-        self.stat_path_with_options(spec, &StatPathOptions::default())
-            .await
-    }
-
-    /// [`Self::stat_path`], projecting what `options` asks for.
-    pub async fn stat_path_with_options(
+    /// Stats one path, projecting what `options` asks for.
+    pub async fn stat_path(
         &self,
         spec: &NamespacePath,
         options: &StatPathOptions,
@@ -2563,7 +2524,7 @@ mod streaming_tests;
 mod tests {
     use super::*;
     use crate::transport::{transient_failure, MAX_TRANSIENT_ATTEMPTS};
-    use loonfs_api::{ContentId, ErrorCode, ErrorKind};
+    use loonfs_api::{ContentId, ErrorCode};
     use std::fs;
     use tempfile::tempdir;
 
@@ -2694,7 +2655,9 @@ mod tests {
         assert!(transient_failure(false, &api("commit_queue_full")));
         assert!(transient_failure(false, &api("shutting_down")));
         assert!(!transient_failure(false, &api("server_error")));
+        assert!(!transient_failure(false, &api("checkpoint_unavailable")));
         assert!(!transient_failure(false, &api("maintenance_required")));
+        assert!(!transient_failure(false, &api("index_lagging")));
         assert!(!transient_failure(
             false,
             &ClientError::Http("http status 502 with a non-envelope body".to_owned())
@@ -2967,47 +2930,27 @@ mod tests {
     }
 
     #[test]
-    fn api_errors_with_known_codes_classify_through_the_registry() {
-        let error = api_error(409, "stale_revision");
-        assert_eq!(error.code(), Some(ErrorCode::StaleRevision));
-        assert_eq!(error.kind(), Some(ErrorKind::Conflict));
-
-        let error = api_error(409, "content_not_prepared");
-        assert_eq!(error.code(), Some(ErrorCode::ContentNotPrepared));
-        assert_eq!(error.kind(), Some(ErrorKind::Conflict));
-
-        let error = api_error(410, "namespace_deleted");
-        assert_eq!(error.code(), Some(ErrorCode::NamespaceDeleted));
-        assert_eq!(error.kind(), Some(ErrorKind::Gone));
-
-        let error = api_error(503, "commit_outcome_unknown");
-        assert_eq!(error.code(), Some(ErrorCode::CommitOutcomeUnknown));
-        assert_eq!(error.kind(), Some(ErrorKind::OutcomeUnknown));
-
-        let error = api_error(500, "index_corrupt");
-        assert_eq!(error.code(), Some(ErrorCode::IndexCorrupt));
-        assert_eq!(error.kind(), Some(ErrorKind::DataCorruption));
-    }
-
-    #[test]
-    fn api_errors_with_unknown_codes_fall_back_to_the_status_class() {
-        for (status, kind) in [
-            (400, ErrorKind::InvalidRequest),
-            (404, ErrorKind::InvalidRequest),
-            (500, ErrorKind::Internal),
-            (503, ErrorKind::Unavailable),
+    fn api_errors_expose_known_registry_codes() {
+        for (wire, expected) in [
+            ("stale_revision", ErrorCode::StaleRevision),
+            ("content_not_prepared", ErrorCode::ContentNotPrepared),
+            ("namespace_deleted", ErrorCode::NamespaceDeleted),
+            ("commit_outcome_unknown", ErrorCode::CommitOutcomeUnknown),
+            ("index_corrupt", ErrorCode::IndexCorrupt),
         ] {
-            let error = api_error(status, "code_from_a_newer_server");
-            assert_eq!(error.code(), None);
-            assert_eq!(error.kind(), Some(kind), "status {status}");
+            assert_eq!(api_error(500, wire).code(), Some(expected));
         }
     }
 
     #[test]
-    fn non_api_errors_have_no_code_or_kind() {
+    fn api_errors_tolerate_unknown_registry_codes() {
+        assert_eq!(api_error(503, "code_from_a_newer_server").code(), None);
+    }
+
+    #[test]
+    fn non_api_errors_have_no_code() {
         let error = ClientError::Http("connection refused".to_owned());
         assert_eq!(error.code(), None);
-        assert_eq!(error.kind(), None);
     }
 
     #[test]

--- a/crates/loonfs-client/src/payload.rs
+++ b/crates/loonfs-client/src/payload.rs
@@ -58,19 +58,6 @@ impl PayloadSource {
         }
     }
 
-    /// A source whose complete length the caller already knows.
-    ///
-    /// The length is used to choose a transport and to frame the request; a
-    /// source that delivers a different number of bytes is still uploaded
-    /// faithfully, and it is the bytes that decide what is stored.
-    pub fn sized_stream(stream: PayloadStream, size_bytes: u64) -> Self {
-        Self {
-            stream,
-            size_bytes: Some(size_bytes),
-            rewind: None,
-        }
-    }
-
     /// A source of unknown length reading from anything asynchronous —
     /// standard input, a socket, a decompressor.
     pub fn reader<R>(reader: R) -> Self

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -111,20 +111,7 @@ fn watched_source(payload: &[u8], chunk_bytes: usize) -> (PayloadSource, Arc<Ret
         }))
     }))
     .boxed();
-    let size_bytes = payload.len() as u64;
-    (PayloadSource::sized_stream(stream, size_bytes), retention)
-}
-
-/// A source that declares a length it does not deliver.
-///
-/// `PayloadSource::sized_stream` documents its length as a hint, and this is
-/// what a wrong one looks like: the bytes are what they are, and only they
-/// may decide what is claimed or refused.
-fn source_declaring(payload: &[u8], declared: u64, chunk_bytes: usize) -> PayloadSource {
-    let chunks: Vec<Vec<u8>> = payload.chunks(chunk_bytes).map(<[u8]>::to_vec).collect();
-    let stream =
-        futures::stream::iter(chunks.into_iter().map(|bytes| Ok(Bytes::from(bytes)))).boxed();
-    PayloadSource::sized_stream(stream, declared)
+    (PayloadSource::stream(stream), retention)
 }
 
 fn payload(len: usize) -> Vec<u8> {
@@ -407,13 +394,12 @@ async fn a_resumed_multipart_put_uploads_only_the_parts_that_are_missing() {
     let interrupted = client_without_retry()
         .put_file_stream_resumable(
             &spec(),
-            PayloadSource::sized_stream(
+            PayloadSource::stream(
                 futures::stream::once({
                     let payload = payload.clone();
                     async move { Ok(Bytes::from(payload)) }
                 })
                 .boxed(),
-                payload.len() as u64,
             ),
             &PutFileOptions::default(),
             &journal,
@@ -493,33 +479,6 @@ async fn a_direct_multipart_put_holds_only_its_window() {
     );
 }
 
-/// Nothing about the flow depends on knowing the length first: a source
-/// that cannot say how long it is takes the same path and the same window.
-#[tokio::test]
-async fn an_unknown_length_source_uploads_the_same_way() {
-    let payload = payload(TEST_PAYLOAD_BYTES);
-    let (sized, retention) = watched_source(&payload, TEST_PART_BYTES as usize);
-    let (stream, size_bytes) = sized.into_stream();
-    assert_eq!(size_bytes, Some(TEST_PAYLOAD_BYTES as u64));
-    // Throw the length away: this is the pipe's view of the same bytes.
-    let source = PayloadSource::stream(stream);
-    assert_eq!(source.size_bytes(), None);
-    let _transport =
-        test_transport::script(multipart_script(TEST_PAYLOAD_PARTS, content_ref(&payload)));
-
-    client()
-        .put_file_stream(&spec(), source, &PutFileOptions::default())
-        .await
-        .expect("a length-less source should upload");
-
-    assert_eq!(retention.total_bytes(), TEST_PAYLOAD_BYTES as u64);
-    assert!(
-        retention.peak_live_bytes() <= DIRECT_MULTIPART_PARTS_IN_FLIGHT as u64 * TEST_PART_BYTES,
-        "peak was {}",
-        retention.peak_live_bytes()
-    );
-}
-
 /// A deployment that cannot authorize part uploads gets the same source as
 /// a request body, and the client accumulates none of it.
 #[tokio::test]
@@ -562,7 +521,7 @@ async fn a_proxied_put_streams_its_body() {
 /// The document is read once and cached, so the round trip is paid at most
 /// once per client however many puts follow.
 #[tokio::test]
-async fn a_small_sized_source_proxies_against_the_advertised_cap() {
+async fn a_small_streamed_source_proxies_against_the_advertised_cap() {
     let payload = payload(1_000);
     let uploaded = content_ref(&payload);
     let (source, _) = watched_source(&payload, 512);
@@ -647,10 +606,7 @@ async fn a_small_payload_past_the_proxy_cap_takes_direct_put() {
 async fn an_unknown_length_payload_past_the_proxy_cap_takes_direct_put() {
     let payload = payload(64 * 1024);
     let uploaded = content_ref(&payload);
-    let (sized, retention) = watched_source(&payload, 4 * 1024);
-    let (stream, _) = sized.into_stream();
-    // The pipe's view of the same bytes: no length to route on.
-    let source = PayloadSource::stream(stream);
+    let (source, retention) = watched_source(&payload, 4 * 1024);
     assert_eq!(source.size_bytes(), None);
 
     let transport = test_transport::script(vec![
@@ -699,9 +655,7 @@ async fn an_unknown_length_payload_past_the_proxy_cap_takes_direct_put() {
 async fn a_small_unknown_length_payload_still_proxies() {
     let payload = payload(1_000);
     let uploaded = content_ref(&payload);
-    let (sized, _) = watched_source(&payload, 512);
-    let (stream, _) = sized.into_stream();
-    let source = PayloadSource::stream(stream);
+    let (source, _) = watched_source(&payload, 512);
     assert_eq!(source.size_bytes(), None);
 
     let transport = test_transport::script(vec![
@@ -788,64 +742,6 @@ async fn a_direct_put_streams_its_payload_without_ever_holding_it() {
         "one body piece was larger than a source read: {} bytes",
         object_write.largest_body_chunk()
     );
-}
-
-/// A declared length is a hint, so a wrong one may not end an upload. Here
-/// it says nothing can carry the payload; the measuring pass finds that
-/// something can, and the upload lands.
-#[tokio::test]
-async fn a_wrong_size_hint_does_not_refuse_an_upload_that_actually_fits() {
-    let payload = payload(2_000);
-    let uploaded = content_ref(&payload);
-    // Declares far more than the largest transport would take.
-    let source = source_declaring(&payload, 100_000, 512);
-    let _transport = test_transport::script(vec![
-        capabilities_for(Advertised {
-            direct_put: Some(ChecksumAlgorithm::Sha256),
-            proxy_max_bytes: Some(1_024),
-            direct_put_max_bytes: Some(4_096),
-            ..Advertised::default()
-        }),
-        begin_direct_put(uploaded.clone()),
-        Outcome::Success(Vec::new()),
-        completed(uploaded),
-        commit_landed(),
-    ]);
-
-    client()
-        .put_file_stream(&spec(), source, &PutFileOptions::default())
-        .await
-        .expect("a payload that actually fits must not be refused on a hint");
-}
-
-/// When nothing really can carry the payload, the refusal reports what the
-/// client measured — never the length the source declared.
-#[tokio::test]
-async fn a_refusal_reports_the_measured_length_not_the_declared_one() {
-    let payload = payload(50_000);
-    let source = source_declaring(&payload, 100_000, 512);
-    let _transport = test_transport::script(vec![capabilities_for(Advertised {
-        direct_put: Some(ChecksumAlgorithm::Sha256),
-        proxy_max_bytes: Some(1_024),
-        direct_put_max_bytes: Some(4_096),
-        ..Advertised::default()
-    })]);
-
-    let error = client()
-        .put_file_stream(&spec(), source, &PutFileOptions::default())
-        .await
-        .expect_err("no transport can carry this payload");
-    match error {
-        ClientError::UploadTooLarge { size_bytes, reason } => {
-            assert_eq!(
-                size_bytes,
-                payload.len() as u64,
-                "the refusal must name the measured length, not the declared one"
-            );
-            assert!(reason.contains("4096"), "{reason}");
-        }
-        other => panic!("expected an upload-too-large refusal, got {other:?}"),
-    }
 }
 
 #[tokio::test]
@@ -952,8 +848,11 @@ async fn request_head_for(source: PayloadSource) -> String {
 /// oversized body before reading it.
 #[tokio::test]
 async fn a_sized_source_frames_its_body_with_a_content_length() {
-    let stream = futures::stream::iter(vec![Ok(Bytes::from_static(b"0123456789"))]).boxed();
-    let head = request_head_for(PayloadSource::sized_stream(stream, 10)).await;
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("payload.bin");
+    std::fs::write(&path, b"0123456789").expect("write payload");
+    let source = PayloadSource::open_file(path).await.expect("open payload");
+    let head = request_head_for(source).await;
 
     assert!(head.contains("content-length: 10"), "{head}");
     assert!(

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -447,13 +447,9 @@ fn render_send_error(
 /// the retryable-unavailability codes.
 pub(crate) fn transient_failure(transport: bool, error: &ClientError) -> bool {
     transport
-        || matches!(
-            error,
-            ClientError::Api { code, .. }
-                if code == ErrorCode::ServerBusy.as_str()
-                    || code == ErrorCode::CommitQueueFull.as_str()
-                    || code == ErrorCode::ShuttingDown.as_str()
-        )
+        || error
+            .code()
+            .is_some_and(ErrorCode::retryable_without_operator_action)
 }
 
 /// Deterministic doubling, the same shape as the object-store transport

--- a/crates/loonfs-grep/src/lib.rs
+++ b/crates/loonfs-grep/src/lib.rs
@@ -82,10 +82,7 @@ pub use error::GrepError as Error;
 pub use error::{GrepError, Result};
 pub use maintenance::{GrepGcJob, GrepMaintenanceJob, GREP_GC_JOB, GREP_INDEX_JOB};
 pub use reads::NamespaceReads;
-pub use service::{
-    GrepService, DEFAULT_GREP_PAGE_LIMIT, MAX_GREP_PAGE_LIMIT, MAX_GREP_SCAN_FILES,
-    MAX_GREP_TAIL_FILES,
-};
+pub use service::{GrepService, MAX_GREP_SCAN_FILES, MAX_GREP_TAIL_FILES};
 pub use worker::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepBuildReport, GrepDisableOutcome, GrepEnableOutcome,
     GrepGcReport, GrepGcRequest, GrepReorganizeOutcome, GrepReorganizeReport, GrepWorker,

--- a/crates/loonfs-grep/src/reads.rs
+++ b/crates/loonfs-grep/src/reads.rs
@@ -20,10 +20,9 @@ use loonfs::{
 use loonfs_api::v0::{ChangesResponse, FilesystemChange};
 use loonfs_api::{
     decode_cursor, AbsolutePath, AuthoritativePathEntry, ChangeSeq, CheckpointId, ContentRef,
-    DirectoryPageCursor, EffectiveLimit, InodeId, NamespaceId, Page, PageRequest, RevisionNo,
-    DEFAULT_MAX_PAGE_LIMIT,
+    DirectoryPageCursor, EffectiveLimit, InodeId, LimitError, NamespaceId, Page, PageRequest,
+    PaginationPolicy, RevisionNo,
 };
-use std::num::NonZeroU32;
 
 /// One namespace's filesystem reads, borrowed from a reader handle.
 ///
@@ -85,7 +84,7 @@ impl<'a> NamespaceReads<'a> {
                 self.namespace_id,
                 checkpoint_id,
                 PageRequest {
-                    limit: page_limit(limit),
+                    limit: page_limit(limit).map_err(invalid_page_limit)?,
                     cursor,
                 },
             )
@@ -108,7 +107,7 @@ impl<'a> NamespaceReads<'a> {
                 self.namespace_id,
                 after_seq,
                 ListChangesOptions {
-                    limit: Some(page_limit(limit)),
+                    limit: Some(page_limit(limit).map_err(invalid_page_limit)?),
                 },
             )
             .await?)
@@ -141,7 +140,7 @@ impl<'a> NamespaceReads<'a> {
     ) -> Result<AuthoritativePathEntry> {
         Ok(self
             .reader
-            .stat_path_with_options(
+            .stat_path(
                 self.namespace_id,
                 absolute_path.as_str(),
                 StatPathOptions {
@@ -164,9 +163,10 @@ impl<'a> NamespaceReads<'a> {
                 self.namespace_id,
                 absolute_path.as_str(),
                 PageRequest {
-                    limit: page_limit(limit),
+                    limit: page_limit(limit).map_err(invalid_page_limit)?,
                     cursor,
                 },
+                loonfs::ListPathEntriesOptions::default(),
             )
             .await?;
         // The handle hands back the wire cursor every client resumes with;
@@ -253,25 +253,33 @@ pub(crate) fn published_revision(event: &FilesystemChange) -> Option<PublishedRe
     }
 }
 
-/// Clamps a caller's page size to what a page request can carry.
-fn page_limit(limit: usize) -> EffectiveLimit {
-    let limit = u32::try_from(limit)
-        .unwrap_or(DEFAULT_MAX_PAGE_LIMIT)
-        .clamp(1, DEFAULT_MAX_PAGE_LIMIT);
-    EffectiveLimit::new(NonZeroU32::new(limit).expect("a clamped page limit is non-zero"))
+/// Validates an internal page request against the public pagination contract.
+fn page_limit(limit: usize) -> std::result::Result<EffectiveLimit, LimitError> {
+    let requested = u32::try_from(limit).unwrap_or(u32::MAX);
+    PaginationPolicy::default().resolve_limit(Some(requested))
+}
+
+fn invalid_page_limit(error: LimitError) -> GrepError {
+    CoreError::InvalidQuery(error.to_string()).into()
 }
 
 #[cfg(test)]
 mod tests {
     use super::{page_limit, resolve_batch_size};
     use loonfs::MAX_RESOLVE_CURRENT_FILES;
-    use loonfs_api::DEFAULT_MAX_PAGE_LIMIT;
+    use loonfs_api::{LimitError, DEFAULT_MAX_PAGE_LIMIT};
 
     #[test]
-    fn page_limits_clamp_into_the_pagination_policy() {
-        assert_eq!(page_limit(0).get(), 1);
-        assert_eq!(page_limit(7).get(), 7);
-        assert_eq!(page_limit(usize::MAX).get(), DEFAULT_MAX_PAGE_LIMIT);
+    fn page_limits_enforce_the_pagination_contract() {
+        assert_eq!(page_limit(0), Err(LimitError::Zero));
+        assert_eq!(page_limit(7).expect("valid limit").get(), 7);
+        assert_eq!(
+            page_limit(usize::MAX),
+            Err(LimitError::ExceedsMax {
+                requested: u32::MAX,
+                max_limit: DEFAULT_MAX_PAGE_LIMIT,
+            })
+        );
     }
 
     #[test]

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -24,16 +24,12 @@ use loonfs_api::wire::sst_blocks::{
 use loonfs_api::{
     decode_cursor, encode_cursor, AbsolutePath, AuthoritativePathEntry, ChangeSeq, ErrorCode,
     GrepMatch, GrepPageCursor, GrepRequest, GrepResponse, InodeId, InodeKind, NamespaceId,
-    RevisionNo,
+    PaginationPolicy, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 
-/// Matches returned per page when the request names no limit.
-pub const DEFAULT_GREP_PAGE_LIMIT: usize = 100;
-/// Largest per-page match limit a request may name.
-pub const MAX_GREP_PAGE_LIMIT: usize = 1000;
 /// Unindexed-tail revisions one query will scan exhaustively before
 /// failing with `index_lagging` (or skipping the tail under `allow_stale`).
 /// Advertised as the `query.grep.tail_budget_files` capability limit.
@@ -664,21 +660,10 @@ impl GrepService {
         store: &S,
     ) -> Result<GrepResponse> {
         let head_seq = reads.head_seq().await?;
-        let limit = match request.limit {
-            None => DEFAULT_GREP_PAGE_LIMIT,
-            Some(0) => {
-                return Err(
-                    CoreError::InvalidQuery("limit must be greater than zero".to_owned()).into(),
-                );
-            }
-            Some(limit) if limit as usize > MAX_GREP_PAGE_LIMIT => {
-                return Err(CoreError::InvalidQuery(format!(
-                    "limit {limit} exceeds the maximum of {MAX_GREP_PAGE_LIMIT}"
-                ))
-                .into());
-            }
-            Some(limit) => limit as usize,
-        };
+        let limit = PaginationPolicy::default()
+            .resolve_limit(request.limit)
+            .map_err(|error| CoreError::InvalidQuery(error.to_string()))?
+            .as_usize();
         let fingerprint = request.fingerprint();
         let resume = match &request.cursor {
             Some(cursor) => {
@@ -720,23 +705,10 @@ impl GrepService {
         // The scope filter resolves the requested prefix once, to the path
         // the namespace spells it as; every candidate is then tested against
         // that spelling, so name-policy folding and path normalization apply
-        // exactly as they do to every other read. A prefix that resolves to
-        // nothing has no matches.
+        // exactly as they do to every other read. A missing prefix is the
+        // same `path_not_found` failure as every other scoped read.
         let scope = match &request.path_prefix {
-            Some(prefix) => match reads.resolve_path(prefix).await {
-                Ok(entry) => Some(entry),
-                Err(error) if error.code() == ErrorCode::PathNotFound => {
-                    return Ok(GrepResponse {
-                        namespace_id: reads.namespace_id().clone(),
-                        head_seq,
-                        built_through_seq: snapshot.built_through_seq,
-                        tail_scanned: true,
-                        matches: Vec::new(),
-                        next_cursor: None,
-                    });
-                }
-                Err(error) => return Err(error),
-            },
+            Some(prefix) => Some(reads.resolve_path(prefix).await?),
             None => None,
         };
 

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -13,7 +13,9 @@ use loonfs::{
     ChangeSeq, CommitId, CreateNamespaceOptions, DestinationBehavior, ErrorCode, FsWriter,
     NamespaceId, PutFileOptions, SharedObjectStore,
 };
-use loonfs_api::{decode_cursor, AbsolutePath, GrepPageCursor, GrepRequest};
+use loonfs_api::{
+    decode_cursor, AbsolutePath, GrepPageCursor, GrepRequest, DEFAULT_MAX_PAGE_LIMIT,
+};
 use loonfs_grep::codec::INDEX_GRAMS_MAX_FILE_BYTES;
 use loonfs_grep::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepReorganizeOutcome, GrepWorker,
@@ -125,16 +127,18 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
 
     // Request validation precedes feature materialization; snapshot
     // construction must preserve that error ordering.
-    let mut invalid_limit = request("needle");
-    invalid_limit.limit = Some(0);
-    let error = host
-        .grep(&namespace_id, &invalid_limit)
-        .await
-        .expect_err("invalid limit must win before the missing feature");
-    let GrepError::Runtime(core) = &error else {
-        panic!("expected a grep core passthrough, got {error:?}");
-    };
-    assert_eq!(core.code(), ErrorCode::InvalidRequest);
+    for limit in [0, DEFAULT_MAX_PAGE_LIMIT + 1] {
+        let mut invalid_limit = request("needle");
+        invalid_limit.limit = Some(limit);
+        let error = host
+            .grep(&namespace_id, &invalid_limit)
+            .await
+            .expect_err("invalid limit must win before the missing feature");
+        let GrepError::Runtime(core) = &error else {
+            panic!("expected a grep core passthrough, got {error:?}");
+        };
+        assert_eq!(core.code(), ErrorCode::InvalidRequest);
+    }
 
     // Before enablement, grep names the missing data half.
     let error = host

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -13,7 +13,9 @@ use loonfs::{
     SharedObjectStore,
 };
 use loonfs_api::wire::control::CheckpointRecordLifecycle;
-use loonfs_api::{sha256_digest, ChangeSeq, GrepRequest, GrepResponse, IndexSegmentId};
+use loonfs_api::{
+    sha256_digest, AbsolutePath, ChangeSeq, GrepRequest, GrepResponse, IndexSegmentId,
+};
 use loonfs_grep::keyspace::{
     manifest_key, manifests_prefix, namespace_prefix, root_key, segment_key,
 };
@@ -979,7 +981,7 @@ async fn a_recursive_delete_hides_matches_and_an_undelete_restores_them() {
     drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
     let segments_before = grep_segment_ids(&store, &namespace_id).await;
     let docs_inode_id = reader
-        .stat_path(&namespace_id, "/docs")
+        .stat_path(&namespace_id, "/docs", Default::default())
         .await
         .expect("stat the directory")
         .inode_id;
@@ -1487,6 +1489,13 @@ async fn grep_worker_pins_fold_tail_and_pagination_results() {
         .expect("absent query");
     assert!(absent.matches.is_empty());
     assert!(absent.next_cursor.is_none());
+
+    let mut missing_scope = request("shared needle");
+    missing_scope.path_prefix = Some(AbsolutePath::parse("/missing").expect("scope path"));
+    let error = new_query(&store, &namespace_id, &missing_scope)
+        .await
+        .expect_err("a missing scope must remain a missing path");
+    assert_eq!(error.code(), ErrorCode::PathNotFound);
 
     let mut page_request = request("shared needle");
     page_request.limit = Some(1);

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -138,7 +138,7 @@ pub(super) async fn list_path_entries(
     }
     let listing = state
         .reader
-        .list_path_entries_page_with_options(
+        .list_path_entries_page(
             &namespace_id,
             &path,
             PageRequest {
@@ -190,7 +190,7 @@ pub(super) async fn stat_path(
     }
     let entry = state
         .reader
-        .stat_path_with_options(&namespace_id, &path, options)
+        .stat_path(&namespace_id, &path, options)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(entry))

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -13,7 +13,7 @@ use loonfs_api::ChangeSeq;
 use loonfs_api::{
     CapabilityDocument, CheckpointId, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, ErrorCode, ForkNamespaceRequest, ListCheckpointsResponse,
-    MaintenanceStepRequest, MaintenanceStepResponse, ReleaseCheckpointResponse,
+    MaintenanceStepRequest, MaintenanceStepResponse, PaginationPolicy, ReleaseCheckpointResponse,
     FEATURE_ADMIN_GREP_INDEX, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_QUERY_GREP,
     FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_DOWNLOAD_MAX_CONCURRENT,
     LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX,
@@ -135,17 +135,18 @@ pub(super) async fn capabilities(
         state.config.grep.mode.maintains_index(),
     );
     if state.config.grep.mode.serves_grep() {
+        let pagination = PaginationPolicy::default();
         capabilities.profiles.push(PROFILE_QUERY_V0.to_owned());
         capabilities
             .features
             .insert(FEATURE_QUERY_GREP.to_owned(), true);
         capabilities.limits.insert(
             LIMIT_QUERY_GREP_DEFAULT.to_owned(),
-            loonfs_grep::DEFAULT_GREP_PAGE_LIMIT as u64,
+            u64::from(pagination.default_limit().get()),
         );
         capabilities.limits.insert(
             LIMIT_QUERY_GREP_MAX.to_owned(),
-            loonfs_grep::MAX_GREP_PAGE_LIMIT as u64,
+            u64::from(pagination.max_limit().get()),
         );
         capabilities.limits.insert(
             LIMIT_QUERY_GREP_SCAN_BUDGET_FILES.to_owned(),

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1258,7 +1258,11 @@ async fn runtime_created_state_is_readable_through_http() {
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
     let target = NamespacePath::parse("demo", "/notes/hello.txt").expect("target");
-    let stat = harness.client.stat_path(&target).await.expect("stat file");
+    let stat = harness
+        .client
+        .stat_path(&target, &Default::default())
+        .await
+        .expect("stat file");
     assert_eq!(stat.absolute_path, "/notes/hello.txt");
     assert_eq!(stat.size_bytes(), Some(18));
     let bytes = harness
@@ -1358,7 +1362,10 @@ async fn http_missing_namespace_reads_return_namespace_not_found() {
 
     let target = NamespacePath::parse("missing", "/").expect("target");
     assert_api_error(
-        harness.client.list_path_entries_all(&target).await,
+        harness
+            .client
+            .list_path_entries_all(&target, &Default::default())
+            .await,
         404,
         "namespace_not_found",
         Some("namespace `missing` does not exist"),
@@ -1487,7 +1494,10 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
         .expect("put recreates the subtree");
     let old_child = NamespacePath::parse("demo", "/docs/old.txt").expect("old child");
     assert_api_error(
-        harness.client.stat_path(&old_child).await,
+        harness
+            .client
+            .stat_path(&old_child, &Default::default())
+            .await,
         404,
         "path_not_found",
         None,

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -481,14 +481,14 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
         .await
         .expect("corrupt manifest");
 
-    match cold_client.stat_path(&target).await {
+    match cold_client.stat_path(&target, &Default::default()).await {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "namespace_corrupt"),
         other => unreachable!("expected namespace_corrupt, got {other:?}"),
     }
     // The warm server keeps serving its pinned pair; the corruption is
     // surfaced by whoever actually consumes the manifest.
     client
-        .stat_path(&target)
+        .stat_path(&target, &Default::default())
         .await
         .expect("warm server reads from its pinned head-plus-manifest pair");
 

--- a/crates/loonfs-server/tests/it/http_attributes.rs
+++ b/crates/loonfs-server/tests/it/http_attributes.rs
@@ -218,7 +218,7 @@ async fn the_client_round_trips_the_read_options() {
     // this checks: each surface, once, against its own default.
     let stat = harness
         .client
-        .stat_path(&path("/docs/report.txt"))
+        .stat_path(&path("/docs/report.txt"), &Default::default())
         .await
         .expect("stat");
     assert_eq!(
@@ -237,7 +237,7 @@ async fn the_client_round_trips_the_read_options() {
 
     let without = harness
         .client
-        .stat_path_with_options(
+        .stat_path(
             &path("/docs/report.txt"),
             &StatPathOptions {
                 include_attributes: false,
@@ -249,7 +249,7 @@ async fn the_client_round_trips_the_read_options() {
 
     let listing = harness
         .client
-        .list_path_entries_all(&path("/docs"))
+        .list_path_entries_all(&path("/docs"), &Default::default())
         .await
         .expect("list");
     assert!(listing
@@ -259,7 +259,7 @@ async fn the_client_round_trips_the_read_options() {
 
     let projected = harness
         .client
-        .list_path_entries_all_with_options(
+        .list_path_entries_all(
             &path("/docs"),
             &ListPathEntriesOptions {
                 include_attributes: true,

--- a/crates/loonfs-server/tests/it/http_auth.rs
+++ b/crates/loonfs-server/tests/it/http_auth.rs
@@ -378,7 +378,10 @@ async fn puts_with_a_valid_token_reuse_the_ref_and_ignore_irrelevant_tokens() {
     assert_eq!(
         harness
             .client
-            .stat_path(&NamespacePath::parse("demo", "/first-copy.txt").expect("path"))
+            .stat_path(
+                &NamespacePath::parse("demo", "/first-copy.txt").expect("path"),
+                &Default::default(),
+            )
             .await
             .expect("repeated ref file")
             .content_ref()
@@ -421,7 +424,10 @@ async fn bare_operation_body_without_content_tokens_still_parses_and_commits_mkd
     assert_eq!(response.committed_seq, ChangeSeq(1));
     harness
         .client
-        .stat_path(&NamespacePath::parse("demo", "/docs").expect("path"))
+        .stat_path(
+            &NamespacePath::parse("demo", "/docs").expect("path"),
+            &Default::default(),
+        )
         .await
         .expect("mkdir committed");
 

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -288,7 +288,7 @@ async fn a_failing_operation_names_its_position_and_commits_nothing() {
         let spec = NamespacePath::parse("demo", path).expect("path");
         let missing = harness
             .client
-            .stat_path(&spec)
+            .stat_path(&spec, &Default::default())
             .await
             .expect_err("the aborted batch wrote nothing");
         match missing {
@@ -798,7 +798,10 @@ async fn a_misspelled_commit_guard_is_rejected_rather_than_dropped() {
     // create published.
     let unchanged = harness
         .client
-        .stat_path(&NamespacePath::parse("demo", FIRST_FILE).expect("path"))
+        .stat_path(
+            &NamespacePath::parse("demo", FIRST_FILE).expect("path"),
+            &Default::default(),
+        )
         .await
         .expect("the file is still there");
     assert_eq!(unchanged.revision_no(), Some(RevisionNo(1)));
@@ -814,7 +817,10 @@ async fn a_misspelled_commit_guard_is_rejected_rather_than_dropped() {
     .expect("the guard spelled correctly commits");
     let replaced = harness
         .client
-        .stat_path(&NamespacePath::parse("demo", FIRST_FILE).expect("path"))
+        .stat_path(
+            &NamespacePath::parse("demo", FIRST_FILE).expect("path"),
+            &Default::default(),
+        )
         .await
         .expect("the replace landed");
     assert_eq!(replaced.revision_no(), Some(RevisionNo(2)));

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -98,7 +98,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
 
     let first_page = harness
         .client
-        .list_path_entries_page(&docs, Some(2), None)
+        .list_path_entries_page(&docs, Some(2), None, &Default::default())
         .await
         .expect("first directory page");
     assert_eq!(entry_names(&first_page), vec!["a.txt", "b.txt"]);
@@ -106,7 +106,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
 
     let second_page = harness
         .client
-        .list_path_entries_page(&docs, Some(2), Some(&cursor))
+        .list_path_entries_page(&docs, Some(2), Some(&cursor), &Default::default())
         .await
         .expect("second directory page");
     assert_eq!(entry_names(&second_page), vec!["c.txt"]);
@@ -114,7 +114,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
 
     let full_listing = harness
         .client
-        .list_path_entries_all(&docs)
+        .list_path_entries_all(&docs, &Default::default())
         .await
         .expect("full directory list");
     assert_eq!(entry_names(&full_listing), vec!["a.txt", "b.txt", "c.txt"]);
@@ -122,7 +122,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
 
     let mismatch = harness
         .client
-        .list_path_entries_page(&other, Some(2), Some(&cursor))
+        .list_path_entries_page(&other, Some(2), Some(&cursor), &Default::default())
         .await
         .expect_err("directory cursor must match listed path");
     match mismatch {
@@ -193,7 +193,7 @@ async fn http_client_listing_preserves_canonical_name_key_order() {
 
     let listing = harness
         .client
-        .list_path_entries_all(&docs)
+        .list_path_entries_all(&docs, &Default::default())
         .await
         .expect("directory list");
     assert_eq!(entry_names(&listing), vec!["a.txt", "B.txt", "c.txt"]);
@@ -233,7 +233,7 @@ async fn http_restore_revision_appends_new_head_and_reports_change() {
         .expect("create file");
     let created = harness
         .client
-        .stat_path(&target)
+        .stat_path(&target, &Default::default())
         .await
         .expect("stat created file");
     let inode_id = created.inode_id;
@@ -273,7 +273,7 @@ async fn http_restore_revision_appends_new_head_and_reports_change() {
 
     let entry = harness
         .client
-        .stat_path(&target)
+        .stat_path(&target, &Default::default())
         .await
         .expect("stat restored file");
     assert_eq!(entry.inode_id, inode_id);
@@ -371,7 +371,11 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         .await
         .expect("replace file");
 
-    let entry = harness.client.stat_path(&target).await.expect("stat file");
+    let entry = harness
+        .client
+        .stat_path(&target, &Default::default())
+        .await
+        .expect("stat file");
     let revisions = harness
         .client
         .list_file_revisions_page(&target, None, None)

--- a/crates/loonfs-server/tests/it/http_paths.rs
+++ b/crates/loonfs-server/tests/it/http_paths.rs
@@ -106,12 +106,12 @@ async fn http_put_no_replace_and_copy_preserve_cli_semantics() {
 
     let source_entry = harness
         .client
-        .stat_path(&source)
+        .stat_path(&source, &Default::default())
         .await
         .expect("source stat");
     let dest_entry = harness
         .client
-        .stat_path(&destination)
+        .stat_path(&destination, &Default::default())
         .await
         .expect("dest stat");
     assert_ne!(source_entry.inode_id, dest_entry.inode_id);
@@ -236,7 +236,7 @@ async fn http_delete_path_behavior_controls_recursive_delete() {
         )
         .await
         .expect("recursive delete succeeds");
-    match harness.client.stat_path(&child).await {
+    match harness.client.stat_path(&child, &Default::default()).await {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
         other => unreachable!("expected path_not_found after recursive delete, got {other:?}"),
     }

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -167,7 +167,11 @@ async fn http_put_commit_id_is_idempotent_and_conflicts_on_different_bytes() {
         .expect("re-uploading identical bytes under a used commit id is idempotent");
     assert_eq!(reuploaded, first);
 
-    let entry = harness.client.stat_path(&target).await.expect("stat path");
+    let entry = harness
+        .client
+        .stat_path(&target, &Default::default())
+        .await
+        .expect("stat path");
     assert_eq!(entry.head_seq, first.committed_seq);
     let bytes = harness
         .client
@@ -286,7 +290,11 @@ async fn http_put_conflict_stands_when_only_the_message_changed() {
         Some("import batch"),
         "the refused rerun did not rewrite the annotation that landed"
     );
-    let entry = harness.client.stat_path(&target).await.expect("stat path");
+    let entry = harness
+        .client
+        .stat_path(&target, &Default::default())
+        .await
+        .expect("stat path");
     assert_eq!(
         entry.head_seq, first.committed_seq,
         "the refused rerun published no revision"
@@ -350,13 +358,17 @@ async fn http_put_conflict_stands_when_only_the_path_changed() {
         other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
     }
 
-    match harness.client.stat_path(&second_target).await {
+    match harness
+        .client
+        .stat_path(&second_target, &Default::default())
+        .await
+    {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
         other => unreachable!("the refused rerun wrote nothing, got {other:?}"),
     }
     let entry = harness
         .client
-        .stat_path(&first_target)
+        .stat_path(&first_target, &Default::default())
         .await
         .expect("stat path");
     assert_eq!(
@@ -433,7 +445,11 @@ async fn http_put_conflict_stands_when_only_a_guard_changed() {
         other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
     }
 
-    let entry = harness.client.stat_path(&target).await.expect("stat path");
+    let entry = harness
+        .client
+        .stat_path(&target, &Default::default())
+        .await
+        .expect("stat path");
     assert_eq!(
         entry.head_seq, first.committed_seq,
         "neither refused rerun published a revision"
@@ -514,7 +530,11 @@ async fn http_single_put_does_not_replay_a_multi_operation_commit() {
         other => unreachable!("expected commit_id_reuse_conflict, got {other:?}"),
     }
 
-    let entry = harness.client.stat_path(&target).await.expect("stat path");
+    let entry = harness
+        .client
+        .stat_path(&target, &Default::default())
+        .await
+        .expect("stat path");
     assert_eq!(
         entry.head_seq, first.committed_seq,
         "the refused rerun published no revision"
@@ -756,12 +776,12 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
     assert_eq!(copy_repeated, copy_first);
     let source_entry = harness
         .client
-        .stat_path(&source)
+        .stat_path(&source, &Default::default())
         .await
         .expect("source stat");
     let copied_entry = harness
         .client
-        .stat_path(&copied)
+        .stat_path(&copied, &Default::default())
         .await
         .expect("copied stat");
     assert_ne!(source_entry.inode_id, copied_entry.inode_id);
@@ -795,11 +815,15 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         .await
         .expect("move repeat");
     assert_eq!(move_repeated, move_first);
-    match harness.client.stat_path(&copied).await {
+    match harness.client.stat_path(&copied, &Default::default()).await {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
         other => unreachable!("expected path_not_found for moved-from path, got {other:?}"),
     }
-    let moved_entry = harness.client.stat_path(&moved).await.expect("moved stat");
+    let moved_entry = harness
+        .client
+        .stat_path(&moved, &Default::default())
+        .await
+        .expect("moved stat");
     assert_eq!(moved_entry.inode_id, copied_entry.inode_id);
 
     let delete_first = harness
@@ -827,7 +851,7 @@ async fn http_delete_move_and_copy_commit_ids_are_idempotent() {
         .await
         .expect("delete repeat");
     assert_eq!(delete_repeated, delete_first);
-    match harness.client.stat_path(&moved).await {
+    match harness.client.stat_path(&moved, &Default::default()).await {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "path_not_found"),
         other => unreachable!("expected path_not_found for deleted path, got {other:?}"),
     }
@@ -926,7 +950,7 @@ async fn two_servers_share_one_store_with_last_writer_wins_fencing() {
 
     // Fencing gates writes only; server A still reads the moved file.
     let host_b_entry = client_a
-        .stat_path(&host_b_target)
+        .stat_path(&host_b_target, &Default::default())
         .await
         .expect("stat host b file");
     assert_eq!(host_b_entry.head_seq.0, moved.committed_seq.0);

--- a/crates/loonfs-server/tests/it/http_smoke.rs
+++ b/crates/loonfs-server/tests/it/http_smoke.rs
@@ -238,7 +238,7 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
         .expect("create directory");
     let directory_entry = harness
         .client
-        .stat_path(&directory)
+        .stat_path(&directory, &Default::default())
         .await
         .expect("stat directory");
     assert_eq!(directory_entry.inode_kind(), InodeKind::Directory);
@@ -262,7 +262,11 @@ async fn http_round_trip_supports_namespace_create_and_file_read_write() {
     assert_eq!(written.commit_id.as_str(), "smoke-write-1");
     assert_eq!(written.committed_seq, ChangeSeq(2));
 
-    let entry = harness.client.stat_path(&target).await.expect("stat path");
+    let entry = harness
+        .client
+        .stat_path(&target, &Default::default())
+        .await
+        .expect("stat path");
     assert_eq!(entry.size_bytes(), Some(16));
 
     let bytes = harness
@@ -362,12 +366,12 @@ async fn http_namespace_fork_shares_content_and_diverges() {
 
     let source_entry = harness
         .client
-        .stat_path(&source_path)
+        .stat_path(&source_path, &Default::default())
         .await
         .expect("source stat");
     let clone_entry = harness
         .client
-        .stat_path(&clone_path)
+        .stat_path(&clone_path, &Default::default())
         .await
         .expect("clone stat");
     assert_eq!(source_entry.content_ref(), clone_entry.content_ref());

--- a/crates/loonfs-server/tests/it/http_tls.rs
+++ b/crates/loonfs-server/tests/it/http_tls.rs
@@ -37,7 +37,11 @@ async fn a_client_trusting_the_server_certificate_round_trips_over_tls() {
         .await
         .expect("write file");
 
-    let stat = harness.client.stat_path(&target).await.expect("stat file");
+    let stat = harness
+        .client
+        .stat_path(&target, &Default::default())
+        .await
+        .expect("stat file");
     assert_eq!(
         stat.size_bytes(),
         Some(b"ciphertext in flight".len() as u64)

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -213,7 +213,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
 
     let stat = harness
         .client
-        .stat_path(&target)
+        .stat_path(&target, &Default::default())
         .await
         .expect("stat committed file");
     assert_eq!(stat.inode_id, InodeId(2));

--- a/crates/loonfs-server/tests/it/local_cache.rs
+++ b/crates/loonfs-server/tests/it/local_cache.rs
@@ -100,7 +100,7 @@ async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
 
     let warmed = first
         .client
-        .list_path_entries_all(&listing)
+        .list_path_entries_all(&listing, &Default::default())
         .await
         .expect("warm the cache");
     assert_eq!(warmed.entries.len(), 5);
@@ -125,7 +125,7 @@ async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
     .await;
     let served = second
         .client
-        .list_path_entries_all(&listing)
+        .list_path_entries_all(&listing, &Default::default())
         .await
         .expect("list from the restarted server");
     assert_eq!(served.entries, warmed.entries);

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -20,17 +20,6 @@ use loonfs_api::{
 
 impl FsReader {
     /// Resolves an absolute path to its authoritative entry at the current
-    /// head, projecting the inode's attributes.
-    pub async fn stat_path(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-    ) -> Result<AuthoritativePathEntry> {
-        self.stat_path_with_options(namespace_id, absolute_path, StatPathOptions::default())
-            .await
-    }
-
-    /// Resolves an absolute path to its authoritative entry at the current
     /// head, projecting what `options` asks for.
     #[tracing::instrument(
         level = "debug",
@@ -44,7 +33,7 @@ impl FsReader {
             cache_path = tracing::field::Empty,
         )
     )]
-    pub async fn stat_path_with_options(
+    pub async fn stat_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
@@ -109,29 +98,12 @@ impl FsReader {
         Ok(envelope)
     }
 
-    /// Lists one page of a directory together with the head the page was read
-    /// from. Entries carry no attributes.
-    pub async fn list_path_entries_page(
-        &self,
-        namespace_id: &NamespaceId,
-        absolute_path: &str,
-        request: PageRequest<DirectoryPageCursor>,
-    ) -> Result<ListPathEntriesResponse> {
-        self.list_path_entries_page_with_options(
-            namespace_id,
-            absolute_path,
-            request,
-            ListPathEntriesOptions::default(),
-        )
-        .await
-    }
-
     /// Lists one page of a directory, projecting what `options` asks for.
     ///
     /// Asking for attributes costs one lookup per entry and adds an unbounded
     /// number of bytes to the page, so a caller that turns the projection on
     /// should also size its page for the maps it expects back.
-    pub async fn list_path_entries_page_with_options(
+    pub async fn list_path_entries_page(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -197,7 +197,7 @@ fn read_options_project_grouped_attributes_or_none() {
         .expect("stat");
     assert!(default_stat.attributes.is_some());
 
-    let opted_out = block_on(fs.reader.stat_path_with_options(
+    let opted_out = block_on(fs.reader.stat_path(
         &namespace_id,
         "/docs/report.txt",
         StatPathOptions {
@@ -214,7 +214,7 @@ fn read_options_project_grouped_attributes_or_none() {
         assert!(entry.attributes.is_none());
     }
 
-    let projected = block_on(fs.reader.list_path_entries_page_with_options(
+    let projected = block_on(fs.reader.list_path_entries_page(
         &namespace_id,
         "/docs",
         PageRequest {

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -202,7 +202,11 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .expect("build reader");
     let _ = log.take_gets();
     let entry = reader
-        .stat_path(&namespace_id, "/tree/dir-000000/file-000000042.txt")
+        .stat_path(
+            &namespace_id,
+            "/tree/dir-000000/file-000000042.txt",
+            Default::default(),
+        )
         .await
         .expect("cold stat");
     assert_eq!(

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -138,7 +138,9 @@ impl TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<AuthoritativePathEntry> {
-        self.reader.stat_path(namespace_id, absolute_path).await
+        self.reader
+            .stat_path(namespace_id, absolute_path, Default::default())
+            .await
     }
 
     pub(crate) async fn list_path(
@@ -170,7 +172,7 @@ impl TestRuntime {
         request: PageRequest<DirectoryPageCursor>,
     ) -> loonfs::Result<loonfs::ListPathEntriesResponse> {
         self.reader
-            .list_path_entries_page(namespace_id, absolute_path, request)
+            .list_path_entries_page(namespace_id, absolute_path, request, Default::default())
             .await
     }
 
@@ -380,7 +382,10 @@ impl RuntimeTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<AuthoritativePathEntry> {
-        block_on(self.reader.stat_path(namespace_id, absolute_path))
+        block_on(
+            self.reader
+                .stat_path(namespace_id, absolute_path, Default::default()),
+        )
     }
 
     fn list_path_blocking(

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -421,7 +421,7 @@ fn path_mutations_return_the_commit_id_they_committed_under() {
         // attaches, so the retry reuses the reference the first put landed.
         let landed = fs
             .reader
-            .stat_path(&namespace_id, "/docs/a.txt")
+            .stat_path(&namespace_id, "/docs/a.txt", Default::default())
             .await
             .expect("stat the committed file")
             .content_ref()

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -498,7 +498,7 @@ fn standalone_reader_builds_without_writer_identity() {
             .expect("build standalone reader");
         // The reader serves the full read surface without an identity.
         let stat = reader
-            .stat_path(&namespace_id, "/docs/hello.txt")
+            .stat_path(&namespace_id, "/docs/hello.txt", Default::default())
             .await
             .expect("stat through standalone reader");
         assert_eq!(stat.size_bytes(), Some(5));
@@ -570,7 +570,7 @@ fn admin_over_writer_core_invalidates_shared_caches() {
         // Reads and writes on the writer's own runtime see the state the
         // step left behind, with no stale-cache error in between.
         reader
-            .stat_path(&namespace_id, "/docs/file-0.txt")
+            .stat_path(&namespace_id, "/docs/file-0.txt", Default::default())
             .await
             .expect("read after maintenance is served from revalidated caches");
         writer
@@ -583,7 +583,11 @@ fn admin_over_writer_core_invalidates_shared_caches() {
             .await
             .expect("writes continue against the post-maintenance head");
         reader
-            .stat_path(&namespace_id, "/docs/after-maintenance.txt")
+            .stat_path(
+                &namespace_id,
+                "/docs/after-maintenance.txt",
+                Default::default(),
+            )
             .await
             .expect("read after write on the shared core");
 
@@ -635,11 +639,11 @@ fn put_file_bytes_and_prepare_then_put_commit_equivalent_state() {
 
         let reader = writer.reader();
         let simple_stat = reader
-            .stat_path(&simple_namespace, "/file.txt")
+            .stat_path(&simple_namespace, "/file.txt", Default::default())
             .await
             .expect("stat simple put");
         let prepared_stat = reader
-            .stat_path(&prepared_namespace, "/file.txt")
+            .stat_path(&prepared_namespace, "/file.txt", Default::default())
             .await
             .expect("stat prepared put");
         assert_eq!(simple_stat.revision_no(), prepared_stat.revision_no());

--- a/crates/loonfs/tests/it/immutable_view_inputs.rs
+++ b/crates/loonfs/tests/it/immutable_view_inputs.rs
@@ -75,7 +75,7 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
         .await
         .expect("build reader");
     reader
-        .stat_path(&namespace_id, "/docs/file-0.txt")
+        .stat_path(&namespace_id, "/docs/file-0.txt", Default::default())
         .await
         .expect("first stat");
     let warmup = immutable_input_gets(&recording.take_get_keys());
@@ -85,7 +85,7 @@ async fn warm_reader_stops_fetching_immutable_view_inputs() {
     );
 
     reader
-        .stat_path(&namespace_id, "/docs/file-1.txt")
+        .stat_path(&namespace_id, "/docs/file-1.txt", Default::default())
         .await
         .expect("second stat");
     let repeats = immutable_input_gets(&recording.take_get_keys());

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -390,7 +390,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
             .expect("warmup put");
     }
     reader
-        .stat_path(&namespace_id, "/docs/warm-0.txt")
+        .stat_path(&namespace_id, "/docs/warm-0.txt", Default::default())
         .await
         .expect("warmup stat");
 
@@ -432,7 +432,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
     );
 
     reader
-        .stat_path(&namespace_id, "/docs/fresh.txt")
+        .stat_path(&namespace_id, "/docs/fresh.txt", Default::default())
         .await
         .expect("read after write");
     let read_gets = recording.take_get_keys();

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -222,15 +222,19 @@ async fn warm_phase_request_accounting() {
         .build()
         .await
         .expect("build reader");
-    let limit = PaginationPolicy::from_values(1_000, 1_000)
-        .expect("valid pagination policy")
+    let limit = PaginationPolicy::default()
         .resolve_limit(Some(1_000))
         .expect("valid limit");
     let mut listed = 0usize;
     let mut cursor = None;
     loop {
         let page = reader
-            .list_path_entries_page(&namespace_id, "/hot", PageRequest { limit, cursor })
+            .list_path_entries_page(
+                &namespace_id,
+                "/hot",
+                PageRequest { limit, cursor },
+                Default::default(),
+            )
             .await
             .expect("list page");
         listed += page.entries.len();
@@ -245,7 +249,7 @@ async fn warm_phase_request_accounting() {
     report("warm full list", &log.take_gets(), &tables);
 
     reader
-        .stat_path(&namespace_id, "/hot/file-04999.txt")
+        .stat_path(&namespace_id, "/hot/file-04999.txt", Default::default())
         .await
         .expect("stat");
     report("warm stat", &log.take_gets(), &tables);

--- a/crates/loonfs/tests/it/runtime_config.rs
+++ b/crates/loonfs/tests/it/runtime_config.rs
@@ -158,9 +158,14 @@ async fn async_runtime_methods_are_the_engine_boundary() {
     .await
     .expect("put file");
 
-    let async_stat = FsReader::stat_path(&fs.reader, &namespace_id, "/docs/hello.txt")
-        .await
-        .expect("async stat");
+    let async_stat = FsReader::stat_path(
+        &fs.reader,
+        &namespace_id,
+        "/docs/hello.txt",
+        Default::default(),
+    )
+    .await
+    .expect("async stat");
 
     assert_eq!(async_stat.absolute_path, "/docs/hello.txt");
     assert_eq!(async_stat.size_bytes(), Some(5));

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -174,7 +174,7 @@ async fn a_published_put_keeps_its_content_and_loses_only_the_session_record() {
         .expect("published put");
     let content_ref = runtime
         .reader
-        .stat_path(&namespace_id, "/docs/kept.txt")
+        .stat_path(&namespace_id, "/docs/kept.txt", Default::default())
         .await
         .expect("stat file")
         .content_ref()
@@ -228,7 +228,7 @@ async fn a_retrys_duplicate_content_is_reclaimed_and_the_commit_it_matched_survi
         .expect("first put");
     let committed_content_ref = runtime
         .reader
-        .stat_path(&namespace_id, "/docs/retry.txt")
+        .stat_path(&namespace_id, "/docs/retry.txt", Default::default())
         .await
         .expect("stat file")
         .content_ref()

--- a/crates/loonfs/tests/it/streamed_read.rs
+++ b/crates/loonfs/tests/it/streamed_read.rs
@@ -163,7 +163,7 @@ async fn a_streamed_read_rejects_content_that_stopped_matching_its_reference() {
     // Same length, different bytes: nothing but the digest can tell, which
     // is the case the read exists to catch.
     let entry = reader
-        .stat_path(&namespace_id, PATH)
+        .stat_path(&namespace_id, PATH, Default::default())
         .await
         .expect("stat file");
     let content_ref = entry.content_ref().cloned().expect("a file has content");

--- a/crates/loonfs/tests/read_tracing_capture.rs
+++ b/crates/loonfs/tests/read_tracing_capture.rs
@@ -84,10 +84,12 @@ fn reads_name_their_anchor_and_the_lookup_that_came_back_empty() {
             .expect("put file");
         let reader = writer.reader();
         reader
-            .stat_path(&namespace_id, "/docs/report.txt")
+            .stat_path(&namespace_id, "/docs/report.txt", Default::default())
             .await
             .expect("stat the file that was just written");
-        let missing = reader.stat_path(&namespace_id, "/docs/missing.txt").await;
+        let missing = reader
+            .stat_path(&namespace_id, "/docs/missing.txt", Default::default())
+            .await;
         assert!(missing.is_err(), "a path that was never written is absent");
     });
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -95,7 +95,7 @@ either way.
     "maintenance.gc.min_grace_window_ms": 1230000,
     "pagination.default_limit": 1000,
     "pagination.max_limit": 1000,
-    "query.grep.default_limit": 100,
+    "query.grep.default_limit": 1000,
     "query.grep.max_limit": 1000,
     "query.grep.scan_budget_files": 4096,
     "query.grep.tail_budget_files": 512
@@ -139,7 +139,7 @@ Registered limit keys:
 | `commit.max_message_bytes` | Largest accepted commit `message`, in bytes; a longer one answers `invalid_request` before planning. |
 | `maintenance.gc.min_grace_window_ms` | Smallest accepted `grace_window_ms` on a `gc` request; smaller values answer `invalid_request`. Derived from the publication budgets, not tuned. |
 | `query.grep.default_limit` | Matches per grep page when the request omits `limit`. |
-| `query.grep.max_limit` | Largest accepted grep page limit; invalid limits are rejected as `invalid_request`. Distinct from the pagination keys because a grep item costs a verified file read, not a row. |
+| `query.grep.max_limit` | Largest accepted grep page limit; invalid limits are rejected as `invalid_request`. The query keys identify the operation's contract even though grep now shares the standard pagination values. |
 | `query.grep.scan_budget_files` | Files a plan-less `allow_scan` grep will scan before refusing with `query_unindexable`. |
 | `query.grep.tail_budget_files` | Unindexed-tail revisions one grep scans exhaustively before failing with `index_lagging`. |
 
@@ -280,6 +280,14 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `index_corrupt` | 500 | The grep index's derived state failed validation. Disable and re-enable grep on the namespace to rebuild it; core filesystem state remains available. |
 | `namespace_corrupt` | 500 | Durable namespace state failed validation. |
 | `server_error` | 500 | Unclassified internal failure. |
+
+Automated retry is deliberately narrower than the shared HTTP status. Raw
+transport failures may be retried, and among registered error codes only
+`commit_queue_full`, `server_busy`, and `shutting_down` can clear without
+caller or operator action. `checkpoint_unavailable`, `maintenance_required`,
+and `index_lagging` remain 503 status groupings but require maintenance before
+an unchanged request can succeed; `commit_outcome_unknown` and
+`deadline_exceeded` require reconciliation before retrying a mutation.
 
 Precondition failures surface as `409` resource-state conflicts
 (`stale_revision`, `stale_head`, `commit_id_reuse_conflict`) rather than
@@ -2185,7 +2193,8 @@ postdates it are omitted entirely rather than mixed in. The `path_prefix`
 value is a complete absolute path, not a partial textual segment prefix. Its
 scope resolves to an inode under the namespace's name policy and filters by
 ancestry, so it requires the same canonical spelling and validation as every
-other path read. A missing data half answers `not_supported` with the
+other path read. A scope that does not exist answers `path_not_found`; an
+empty existing scope answers successfully with no matches. A missing data half answers `not_supported` with the
 `feature` field naming `query.grep`, the same key capability discovery
 advertises the serving half under.
 


### PR DESCRIPTION
- The error registry gains `retryable_without_operator_action()`, classifying every code deliberately with the rule in its doc; `ErrorKind::Unavailable` stops claiming all six of its codes clear on their own (three need maintenance first). The client's hand-rolled three-code list uses the predicate, and the caller-less `ClientError::kind`/`kind_for_status_class` pair deletes with its false doc.
- `PaginationPolicy` loses the configuration surface nothing could configure (`new`, `from_values`, the unreachable error type); the constants are the documented contract. Grep's two divergent clamps — one erroring, one silently clamping — converge on the shared erroring `resolve_limit`.
- Every `foo()` + `foo_with_options()` pair collapses to one method under the short name, taking options; `sized_stream`, whose only consumer was its own test, deletes.
- Grep over a missing scope errors with `path_not_found` as api.md:2186 states, instead of answering 200 with zero matches.
- `MaintenanceHosted` stops emitting keys/steps/budget values nobody measured; the JSON now carries only what was observed.
