### PR TITLE
refactor(client,core): centralize PUT retry checks and bound request retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ dependencies = [
  "ciborium",
  "crc32c",
  "crc64fast-nvme",
+ "futures",
  "getrandom 0.3.4",
  "serde",
  "serde_bytes",

--- a/crates/loonfs-api/Cargo.toml
+++ b/crates/loonfs-api/Cargo.toml
@@ -34,5 +34,8 @@ zstd.workspace = true
 [features]
 openapi = ["dep:utoipa"]
 
+[dev-dependencies]
+futures.workspace = true
+
 [lints]
 workspace = true

--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -1,17 +1,15 @@
-//! Commit identity fingerprints (format spec, "Commit identity
-//! fingerprints"): a stable digest over a mutation's semantic content, used
-//! to decide whether a reused commit id carries the same mutation or a
-//! conflicting one.
+//! Generates stable fingerprints for filesystem mutations (format spec,
+//! "Commit identity fingerprints"). A fingerprint lets LoonFS determine
+//! whether two requests that use the same commit ID describe the same
+//! mutation.
 //!
-//! This lives beside [`FilesystemOperation`], the one operation language it
-//! hashes, because every surface has to compute the same value from it: the
-//! engine stamps it on a commit receipt, and a client reconciling a
-//! reused-id conflict recomputes it to prove the retry is the same request.
-//! One function is the authority; nobody re-derives the rules.
+//! The runtime and HTTP client use the functions in this module so that they
+//! apply the same identity rules. The runtime stores a fingerprint in the
+//! commit receipt. A client can later recompute it when retrying a request.
 //!
-//! The commit id is not in the preimage. The id is the key a mutation is
-//! filed under; the fingerprint is what was filed. Comparing the two is the
-//! whole of the reuse check.
+//! The commit ID is not part of the fingerprint input. The commit ID selects
+//! a receipt, while the fingerprint describes the mutation stored in that
+//! receipt.
 
 use crate::{
     AbsolutePath, AttributeRevisionNo, AttributeValue, ChangeSeq, CommitId, ContentEvidence,
@@ -25,31 +23,29 @@ use std::fmt::Write as _;
 use std::future::Future;
 use thiserror::Error;
 
-/// Domain separator for the one mutation fingerprint preimage.
+/// Domain separator included in every mutation fingerprint input.
 const COMMIT_FINGERPRINT_DOMAIN: &str = "loonfs.commit.semantic.v0";
 
-/// Scheme-and-algorithm tag carried by every stored fingerprint value.
+/// Scheme and hash algorithm included in every stored fingerprint.
 ///
-/// `v0` names the canonicalization rules (domain string plus the frozen v0
-/// preimage encoding; format spec, "Commit identity fingerprints") and
-/// `sha256` the digest algorithm, so either can change later without
-/// re-interpreting values already stored in WAL records and commit receipts.
+/// `v0` identifies the canonical encoding rules, and `sha256` identifies the
+/// hash algorithm. Including both values allows future versions to change
+/// either rule without changing the meaning of existing fingerprints.
 const FINGERPRINT_SCHEME: &str = "v0:sha256";
 
-/// A canonical preimage that could not be encoded.
+/// Error returned when the canonical fingerprint input cannot be encoded.
 ///
-/// The preimage is built here from validated types with no encoding failure
-/// modes, so this reports a bug in the encoder rather than anything a caller
-/// did.
+/// The input contains validated types, so this error indicates an internal
+/// encoding bug rather than invalid caller data.
 #[derive(Debug, Error)]
 #[error("failed to encode the commit fingerprint preimage: {0}")]
 pub struct SemanticFingerprintError(#[from] serde_json::Error);
 
-/// Computes a stored fingerprint value (`v0:sha256:<64 lowercase hex>`) from
-/// a canonical preimage.
+/// Computes a stored fingerprint (`v0:sha256:<64 lowercase hex>`) from a
+/// canonical input.
 ///
-/// The preimage's compact JSON encoding is the durable contract: the
-/// pinned-value tests below fail if it drifts.
+/// The compact JSON encoding is part of the durable format. The fixed-value
+/// tests detect changes to that encoding.
 fn fingerprint_digest<T>(preimage: &T) -> Result<String, SemanticFingerprintError>
 where
     T: Serialize,
@@ -272,9 +268,10 @@ fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFing
             expected_inode_id,
             expected_attributes_revision_no,
         } => {
-            // Canonicalizing the removal list is this function's job, not the
-            // wire type's: the wire keeps the caller's list so a duplicate can
-            // be rejected by name, and identity is what the list asks for.
+            // The wire type preserves the caller's list so validation can
+            // report duplicate keys. The fingerprint uses the sorted, unique
+            // set because order and duplicate entries do not change the
+            // requested mutation.
             let mut remove: Vec<&str> = remove.iter().map(|key| key.as_str()).collect();
             remove.sort_unstable();
             remove.dedup();
@@ -292,12 +289,10 @@ fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFing
     }
 }
 
-/// The semantic identity of one mutation request: what a reused commit id is
-/// compared against.
+/// Computes the semantic fingerprint used to validate a reused commit ID.
 ///
-/// A one-operation convenience call and a one-element batch are the same
-/// request, so they reach this function with the same shape and fingerprint
-/// identically; there is no separate single-operation form to keep in step.
+/// A single-operation helper and a one-item batch produce the same input and
+/// therefore the same fingerprint.
 pub fn semantic_commit_fingerprint(
     namespace_id: &NamespaceId,
     message: Option<&str>,
@@ -319,17 +314,15 @@ pub fn semantic_commit_fingerprint(
     })
 }
 
-/// The fingerprint the original request must have had, if this retry is the
-/// same single put with only the content id renamed.
+/// Computes the fingerprint for a retried single-file PUT using the content
+/// reference from the original commit.
 ///
-/// Rerunning a whole upload-then-commit sequence stages a fresh content
-/// object, so the retry's own fingerprint can never match a landed one. This
-/// substitutes the committed reference for the staged one and fingerprints
-/// the request that results: everything else a put can ask for — the path,
-/// the replacement behavior, the expected revision, the annotation, and that
-/// the commit was this one operation and nothing more — has to agree for the
-/// value to match. Whether the two content objects hold the same bytes is a
-/// separate question, answered by digest evidence rather than by this.
+/// Retrying an upload creates a new content object, so its content ID differs
+/// from the ID stored by the original commit. This function substitutes the
+/// original content reference before computing the fingerprint. The path,
+/// destination behavior, expected revision, message, and operation count must
+/// still match. The caller must separately verify that both content objects
+/// contain the same bytes.
 pub fn put_retry_fingerprint(
     namespace_id: &NamespaceId,
     path: &AbsolutePath,
@@ -347,49 +340,54 @@ pub fn put_retry_fingerprint(
     semantic_commit_fingerprint(namespace_id, message, std::slice::from_ref(&operation))
 }
 
-/// Receipt fields required to reconcile a put rejected for reusing a commit id.
+/// Receipt data needed to verify a PUT that reused a commit ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PutRetryReceipt {
-    /// Sequence at which the earlier commit landed.
+    /// Sequence number assigned to the original commit.
     pub committed_seq: ChangeSeq,
-    /// Semantic fingerprint stored with the earlier commit.
+    /// Semantic fingerprint stored in the original commit receipt.
     pub committed_fingerprint: String,
 }
 
-/// Meaning of a surface-specific error during put retry reconciliation.
+/// Classification of an error encountered while verifying a retried PUT.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum PutRetryErrorClassification {
-    /// The put reused a commit id, with a durable receipt when one was available.
+    /// The commit ID was already used. The receipt is included when available.
     CommitIdReuseConflict(Option<PutRetryReceipt>),
-    /// Retention removed the change-feed evidence needed for reconciliation.
+    /// Retention removed the change record needed to verify the retry.
     RebootstrapRequired,
-    /// Any error unrelated to commit-id reuse reconciliation.
+    /// Any error that does not have special handling during retry verification.
     Other,
 }
 
-/// Concrete put attempt being compared with a reused commit id's receipt.
+/// Details of the retried PUT being compared with an existing receipt.
 #[derive(Debug, Clone, Copy)]
 pub struct PutRetryAttempt<'a> {
-    /// Namespace the put targeted.
+    /// Namespace targeted by the PUT.
     pub namespace_id: &'a NamespaceId,
-    /// Absolute path the put targeted.
+    /// Absolute path targeted by the PUT.
     pub path: &'a AbsolutePath,
-    /// Commit id rejected as already used.
+    /// Commit ID that was already used.
     pub commit_id: &'a CommitId,
-    /// Semantic put options supplied by the caller.
+    /// PUT options supplied by the caller.
     pub options: &'a crate::options::PutFileOptions,
-    /// Evidence about the newly staged payload.
+    /// Checksum or byte evidence for the new upload.
     pub staged: ContentEvidence<'a>,
 }
 
-/// Reconciles a put rejected for reusing a commit id against durable evidence.
+/// Checks whether a PUT rejected for commit-ID reuse is an exact retry of an
+/// earlier successful PUT.
 ///
-/// The read closure receives the exclusive change-feed cursor immediately
-/// before the receipt's sequence and must return one page containing at most
-/// the requested row. A missing row, unavailable retained history, malformed
-/// receipt, fingerprint mismatch, or payload mismatch preserves the original
-/// conflict. Other read failures are returned directly.
+/// `read_change` receives the change-feed sequence immediately before the
+/// sequence in the receipt. It must return a page containing at most the
+/// expected change.
+///
+/// The function returns the original commit response only when both the
+/// request fingerprint and the uploaded content match the original commit.
+/// It returns the original conflict when the receipt or change record is
+/// missing, the retained history is unavailable, or either comparison fails.
+/// Other errors from `read_change` are returned unchanged.
 pub async fn reconcile_put_commit_id_reuse<E, ReadChange, ReadChangeFuture, ClassifyError>(
     attempt: PutRetryAttempt<'_>,
     conflict: E,
@@ -447,7 +445,8 @@ where
     })
 }
 
-/// Returns the content one committed change wrote when it wrote exactly one.
+/// Returns the content reference when a committed change wrote exactly one
+/// file.
 fn sole_committed_content_ref(change: &crate::v0::CommittedChange) -> Option<&ContentRef> {
     let mut content = change.events.iter().filter_map(|event| match event {
         crate::v0::FilesystemChange::Created { content_ref, .. } => content_ref.as_ref(),
@@ -1043,8 +1042,8 @@ mod tests {
         }
     }
 
-    /// Pins the shared reconciliation verdicts independently of either the
-    /// embedded or HTTP surface adapter.
+    /// Tests the shared retry logic without using the HTTP or embedded-runtime
+    /// adapters.
     #[test]
     fn put_retry_reconciliation_agrees_on_receipt_mismatch_and_unavailable_evidence() {
         #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -14,14 +14,15 @@
 //! whole of the reuse check.
 
 use crate::{
-    AbsolutePath, AttributeRevisionNo, AttributeValue, ChangeSeq, ContentRef,
-    DeleteDirectoryBehavior, DestinationBehavior, FilesystemOperation, InodeId, NamespaceId,
-    RevisionNo,
+    AbsolutePath, AttributeRevisionNo, AttributeValue, ChangeSeq, CommitId, ContentEvidence,
+    ContentRef, DeleteDirectoryBehavior, DestinationBehavior, FilesystemOperation, InodeId,
+    NamespaceId, RevisionNo,
 };
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
+use std::future::Future;
 use thiserror::Error;
 
 /// Domain separator for the one mutation fingerprint preimage.
@@ -344,6 +345,117 @@ pub fn put_retry_fingerprint(
         expected_revision_no,
     };
     semantic_commit_fingerprint(namespace_id, message, std::slice::from_ref(&operation))
+}
+
+/// Receipt fields required to reconcile a put rejected for reusing a commit id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PutRetryReceipt {
+    /// Sequence at which the earlier commit landed.
+    pub committed_seq: ChangeSeq,
+    /// Semantic fingerprint stored with the earlier commit.
+    pub committed_fingerprint: String,
+}
+
+/// Meaning of a surface-specific error during put retry reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PutRetryErrorClassification {
+    /// The put reused a commit id, with a durable receipt when one was available.
+    CommitIdReuseConflict(Option<PutRetryReceipt>),
+    /// Retention removed the change-feed evidence needed for reconciliation.
+    RebootstrapRequired,
+    /// Any error unrelated to commit-id reuse reconciliation.
+    Other,
+}
+
+/// Concrete put attempt being compared with a reused commit id's receipt.
+#[derive(Debug, Clone, Copy)]
+pub struct PutRetryAttempt<'a> {
+    /// Namespace the put targeted.
+    pub namespace_id: &'a NamespaceId,
+    /// Absolute path the put targeted.
+    pub path: &'a AbsolutePath,
+    /// Commit id rejected as already used.
+    pub commit_id: &'a CommitId,
+    /// Semantic put options supplied by the caller.
+    pub options: &'a crate::options::PutFileOptions,
+    /// Evidence about the newly staged payload.
+    pub staged: ContentEvidence<'a>,
+}
+
+/// Reconciles a put rejected for reusing a commit id against durable evidence.
+///
+/// The read closure receives the exclusive change-feed cursor immediately
+/// before the receipt's sequence and must return one page containing at most
+/// the requested row. A missing row, unavailable retained history, malformed
+/// receipt, fingerprint mismatch, or payload mismatch preserves the original
+/// conflict. Other read failures are returned directly.
+pub async fn reconcile_put_commit_id_reuse<E, ReadChange, ReadChangeFuture, ClassifyError>(
+    attempt: PutRetryAttempt<'_>,
+    conflict: E,
+    read_change: ReadChange,
+    classify_error: ClassifyError,
+) -> Result<crate::v0::CommitResponse, E>
+where
+    ReadChange: FnOnce(ChangeSeq) -> ReadChangeFuture,
+    ReadChangeFuture: Future<Output = Result<crate::v0::ChangesResponse, E>>,
+    ClassifyError: Fn(&E) -> PutRetryErrorClassification,
+{
+    let PutRetryErrorClassification::CommitIdReuseConflict(Some(receipt)) =
+        classify_error(&conflict)
+    else {
+        return Err(conflict);
+    };
+    let after_seq = ChangeSeq(receipt.committed_seq.0.saturating_sub(1));
+    let page = match read_change(after_seq).await {
+        Ok(page) => page,
+        Err(error)
+            if matches!(
+                classify_error(&error),
+                PutRetryErrorClassification::RebootstrapRequired
+            ) =>
+        {
+            return Err(conflict);
+        }
+        Err(error) => return Err(error),
+    };
+    let Some(committed) = page.changes.into_iter().find(|change| {
+        change.seq == receipt.committed_seq && &change.commit_id == attempt.commit_id
+    }) else {
+        return Err(conflict);
+    };
+    let Some(content_ref) = sole_committed_content_ref(&committed) else {
+        return Err(conflict);
+    };
+    let retried = put_retry_fingerprint(
+        attempt.namespace_id,
+        attempt.path,
+        attempt.options.behavior,
+        attempt.options.expected_revision_no,
+        attempt.options.message.as_deref(),
+        content_ref,
+    );
+    if retried.ok().as_deref() != Some(receipt.committed_fingerprint.as_str())
+        || !content_ref.matches_evidence(attempt.staged)
+    {
+        return Err(conflict);
+    }
+    Ok(crate::v0::CommitResponse {
+        namespace_id: attempt.namespace_id.clone(),
+        commit_id: committed.commit_id,
+        committed_seq: committed.seq,
+    })
+}
+
+/// Returns the content one committed change wrote when it wrote exactly one.
+fn sole_committed_content_ref(change: &crate::v0::CommittedChange) -> Option<&ContentRef> {
+    let mut content = change.events.iter().filter_map(|event| match event {
+        crate::v0::FilesystemChange::Created { content_ref, .. } => content_ref.as_ref(),
+        crate::v0::FilesystemChange::ContentChanged { content_ref, .. } => Some(content_ref),
+        _ => None,
+    });
+    let only = content.next()?;
+    content.next().is_none().then_some(only)
 }
 
 #[cfg(test)]
@@ -929,5 +1041,109 @@ mod tests {
                 "a changed {label} must change the fingerprint"
             );
         }
+    }
+
+    /// Pins the shared reconciliation verdicts independently of either the
+    /// embedded or HTTP surface adapter.
+    #[test]
+    fn put_retry_reconciliation_agrees_on_receipt_mismatch_and_unavailable_evidence() {
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        enum ReconciliationError {
+            Conflict(PutRetryReceipt),
+            EvidenceUnavailable,
+        }
+
+        fn classify(error: &ReconciliationError) -> PutRetryErrorClassification {
+            match error {
+                ReconciliationError::Conflict(receipt) => {
+                    PutRetryErrorClassification::CommitIdReuseConflict(Some(receipt.clone()))
+                }
+                ReconciliationError::EvidenceUnavailable => {
+                    PutRetryErrorClassification::RebootstrapRequired
+                }
+            }
+        }
+
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let path = AbsolutePath::parse("/report.txt").expect("valid path");
+        let commit_id = CommitId::parse("pinned-put").expect("valid commit id");
+        let committed_seq = ChangeSeq(7);
+        let bytes = b"stable bytes";
+        let content_ref = ContentRef::blob_v1(ContentId::generate(), bytes);
+        let options = crate::options::PutFileOptions {
+            commit_id: Some(commit_id.clone()),
+            ..crate::options::PutFileOptions::default()
+        };
+        let receipt = PutRetryReceipt {
+            committed_seq,
+            committed_fingerprint: put_retry_fingerprint(
+                &namespace_id,
+                &path,
+                options.behavior,
+                options.expected_revision_no,
+                options.message.as_deref(),
+                &content_ref,
+            )
+            .expect("fingerprint"),
+        };
+        let page = crate::v0::ChangesResponse {
+            namespace_id: namespace_id.clone(),
+            after_seq: ChangeSeq(6),
+            through_seq: committed_seq,
+            next_after_seq: None,
+            changes: vec![crate::v0::CommittedChange {
+                seq: committed_seq,
+                commit_id: commit_id.clone(),
+                committed_at_ms: 1,
+                message: None,
+                events: vec![crate::v0::FilesystemChange::ContentChanged {
+                    inode_id: InodeId(2),
+                    revision_no: RevisionNo(1),
+                    content_ref,
+                }],
+            }],
+        };
+
+        let matching_attempt = PutRetryAttempt {
+            namespace_id: &namespace_id,
+            path: &path,
+            commit_id: &commit_id,
+            options: &options,
+            staged: ContentEvidence::Bytes(bytes),
+        };
+        let reconciled = futures::executor::block_on(reconcile_put_commit_id_reuse(
+            matching_attempt,
+            ReconciliationError::Conflict(receipt.clone()),
+            |after_seq| {
+                assert_eq!(after_seq, ChangeSeq(6));
+                std::future::ready(Ok(page.clone()))
+            },
+            classify,
+        ))
+        .expect("matching receipt and evidence reconcile");
+        assert_eq!(reconciled.commit_id, commit_id);
+        assert_eq!(reconciled.committed_seq, committed_seq);
+
+        let mismatch = futures::executor::block_on(reconcile_put_commit_id_reuse(
+            PutRetryAttempt {
+                staged: ContentEvidence::Bytes(b"different bytes"),
+                ..matching_attempt
+            },
+            ReconciliationError::Conflict(receipt.clone()),
+            |_| std::future::ready(Ok(page.clone())),
+            classify,
+        ));
+        assert_eq!(
+            mismatch,
+            Err(ReconciliationError::Conflict(receipt.clone()))
+        );
+
+        let unavailable = futures::executor::block_on(reconcile_put_commit_id_reuse(
+            matching_attempt,
+            ReconciliationError::Conflict(receipt.clone()),
+            |_| std::future::ready(Err(ReconciliationError::EvidenceUnavailable)),
+            classify,
+        ));
+        assert_eq!(unavailable, Err(ReconciliationError::Conflict(receipt)));
     }
 }

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -13,12 +13,11 @@
 //! surfaces, so this crate — the shared vocabulary — owns the single
 //! definition rather than each surface keeping its own copy to drift.
 //!
-//! One module is a function rather than a shape: `commit_identity` computes
-//! the durable fingerprint of a mutation. It lives here for the same reason
-//! the operation language does — the engine that stamps a fingerprint on a
-//! commit receipt and the client that recomputes one to prove a retry is the
-//! same request must produce identical values, so there is one implementation
-//! and no second reading of the rules.
+//! One module holds procedures rather than shapes: `commit_identity` computes
+//! the durable fingerprint of a mutation and reconciles a retried put against
+//! its receipt. It lives here for the same reason the operation language does
+//! — every surface must apply identical identity and evidence rules, so there
+//! is one implementation and no second reading of them.
 //!
 //! Module rule: v0 HTTP shapes live in [`v0`]; the crate root keeps the
 //! ids/paths/errors/wire-format modules and re-exports the common v0
@@ -113,7 +112,8 @@ pub use capability::{
     PROFILE_QUERY_V0, PROTOCOL_VERSION, UPLOADS_DIRECT_PUT_CHECKSUM_FEATURES,
 };
 pub use commit_identity::{
-    put_retry_fingerprint, semantic_commit_fingerprint, SemanticFingerprintError,
+    put_retry_fingerprint, reconcile_put_commit_id_reuse, semantic_commit_fingerprint,
+    PutRetryAttempt, PutRetryErrorClassification, PutRetryReceipt, SemanticFingerprintError,
 };
 pub use content::{
     ChecksumAlgorithm, ContentEvidence, ContentRef, ContentRefKind, ContentRefValidationError,

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -13,11 +13,10 @@
 //! surfaces, so this crate — the shared vocabulary — owns the single
 //! definition rather than each surface keeping its own copy to drift.
 //!
-//! One module holds procedures rather than shapes: `commit_identity` computes
-//! the durable fingerprint of a mutation and reconciles a retried put against
-//! its receipt. It lives here for the same reason the operation language does
-//! — every surface must apply identical identity and evidence rules, so there
-//! is one implementation and no second reading of them.
+//! The `commit_identity` module contains shared logic rather than wire types.
+//! It computes durable mutation fingerprints and verifies retried PUT requests
+//! against existing commit receipts. Keeping this logic here ensures that the
+//! embedded runtime and HTTP client apply the same identity and content checks.
 //!
 //! Module rule: v0 HTTP shapes live in [`v0`]; the crate root keeps the
 //! ids/paths/errors/wire-format modules and re-exports the common v0

--- a/crates/loonfs-client/src/config.rs
+++ b/crates/loonfs-client/src/config.rs
@@ -20,10 +20,11 @@ pub struct ClientConfig {
     pub server_url: String,
     /// Optional bearer token.
     pub auth_token: Option<SecretString>,
-    /// Optional overall per-request deadline in milliseconds. Unset means no
-    /// whole-request deadline: requests are bounded only by the built-in
-    /// 60-second socket inactivity timeouts, so slow-but-progressing large
-    /// transfers are not cut off while a stalled connection still fails.
+    /// Optional caller-selected whole-request deadline in milliseconds.
+    /// Unset leaves content transfers bounded only by their attempt counts
+    /// and the built-in 60-second socket inactivity timeout, so a slow but
+    /// progressing transfer is not cut off. Replay-safe control calls also
+    /// carry the transport policy's built-in total operation deadline.
     #[serde(default)]
     pub request_timeout_ms: Option<u64>,
     /// Disables the bounded automatic retry of quick-clearing transient
@@ -75,7 +76,7 @@ impl ClientConfig {
         if self.request_timeout_ms == Some(0) {
             return Err(ClientError::ConfigValidation {
                 field: "request_timeout_ms",
-                reason: "must be greater than zero; omit it for no deadline".to_owned(),
+                reason: "must be greater than zero; omit it for built-in deadlines only".to_owned(),
             });
         }
         if let Some(path) = &self.ca_cert_path {

--- a/crates/loonfs-client/src/config.rs
+++ b/crates/loonfs-client/src/config.rs
@@ -20,11 +20,12 @@ pub struct ClientConfig {
     pub server_url: String,
     /// Optional bearer token.
     pub auth_token: Option<SecretString>,
-    /// Optional caller-selected whole-request deadline in milliseconds.
-    /// Unset leaves content transfers bounded only by their attempt counts
-    /// and the built-in 60-second socket inactivity timeout, so a slow but
-    /// progressing transfer is not cut off. Replay-safe control calls also
-    /// carry the transport policy's built-in total operation deadline.
+    /// Optional timeout for one HTTP request, in milliseconds.
+    ///
+    /// When this value is not set, content transfers may continue as long as
+    /// the connection makes progress. They still use a 60-second inactivity
+    /// timeout and a limited number of attempts. Other replay-safe requests
+    /// also have a built-in 90-second total retry limit.
     #[serde(default)]
     pub request_timeout_ms: Option<u64>,
     /// Disables the bounded automatic retry of quick-clearing transient

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -22,11 +22,11 @@ use futures::StreamExt as _;
 use loonfs_api::{
     v0::{
         AbortUploadResponse, BeginDownloadRequest, BeginDownloadResponse, BeginUploadRequest,
-        BeginUploadResponse, ChangesResponse, CommitResponse as ApiCommitResponse, CommittedChange,
+        BeginUploadResponse, ChangesResponse, CommitResponse as ApiCommitResponse,
         CompleteUploadRequest, CompleteUploadResponse, CompletedUploadPart,
         DirectMultipartContentClaim, DirectMultipartUploadOptions, DirectPutContentClaim,
-        DisableGrepIndexResponse, EnableGrepIndexResponse, FilesystemChange, GrepGcRequest,
-        GrepGcResponse, GrepIndexStatusResponse, ObjectTransferAccess, SignUploadPartsRequest,
+        DisableGrepIndexResponse, EnableGrepIndexResponse, GrepGcRequest, GrepGcResponse,
+        GrepIndexStatusResponse, ObjectTransferAccess, SignUploadPartsRequest,
         SignUploadPartsResponse, SignedUploadPart, StoreProbeRequest, StoreProbeResponse,
         UploadContentResponse, UploadPartChecksumClaim, UploadStatusResponse,
         ValidatedContentToken,
@@ -37,13 +37,15 @@ use loonfs_api::{
     DeleteNamespaceResponse, ErrorCode, FilesystemOperation, ForkNamespaceRequest, GrepRequest,
     GrepResponse, InodeId, ListCheckpointsResponse, ListFileRevisionsResponse,
     ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest, MaintenanceStepResponse,
-    NamespaceId, NamespaceStatusResponse, NamespaceSummary, ReleaseCheckpointResponse, RevisionNo,
+    NamespaceId, NamespaceStatusResponse, NamespaceSummary, PutRetryAttempt,
+    PutRetryErrorClassification, PutRetryReceipt, ReleaseCheckpointResponse, RevisionNo,
     SecretString, StorageChecksum, StreamingChecksum, UploadId, FEATURE_DOWNLOADS_DIRECT_GET,
     FEATURE_UPLOADS_DIRECT_MULTIPART, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES,
     LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES, LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
 use payload::PartReader;
 use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
 /// Payload size from which a put stops holding its bytes whole.
 ///
@@ -64,49 +66,29 @@ const DIRECT_MULTIPART_PARTS_IN_FLIGHT: usize = 4;
 /// its signature.
 const DIRECT_MULTIPART_PART_ATTEMPTS: usize = 3;
 
-/// What a reuse conflict says the commit id already landed as: where, and
-/// the semantic identity of the mutation that landed there.
-///
-/// The server decides the conflict against a durable receipt, and the
-/// receipt holds both, so the error body carries both. They are absent only
-/// when nothing has committed under the id yet — two conflicting requests
-/// claiming it at once — and then there is nothing to read back.
-fn reported_commit_receipt(error: &ClientError) -> Option<(ChangeSeq, String)> {
-    match error {
-        ClientError::Api { details, .. } => {
-            let details = details.as_ref()?;
-            Some((
-                details.committed_seq?,
-                details.committed_fingerprint.clone()?,
-            ))
+fn classify_put_retry_error(error: &ClientError) -> PutRetryErrorClassification {
+    match error.code() {
+        Some(ErrorCode::CommitIdReuseConflict) => {
+            let receipt = match error {
+                ClientError::Api { details, .. } => details.as_ref().and_then(|details| {
+                    Some(PutRetryReceipt {
+                        committed_seq: details.committed_seq?,
+                        committed_fingerprint: details.committed_fingerprint.clone()?,
+                    })
+                }),
+                _ => None,
+            };
+            PutRetryErrorClassification::CommitIdReuseConflict(receipt)
         }
-        _ => None,
+        Some(ErrorCode::RebootstrapRequired) => PutRetryErrorClassification::RebootstrapRequired,
+        _ => PutRetryErrorClassification::Other,
     }
-}
-
-/// The content one committed change wrote, when it wrote exactly one.
-///
-/// A single put's commit produces exactly one content-bearing event: the
-/// file's `created` or `content_changed`. Auto-created parent directories
-/// appear as `created` without a content ref, and no other change kind
-/// carries content at all, so "exactly one" holds for a put however many
-/// directories it had to make. Anything else — nothing, or several — is not
-/// the commit a single put produces, and the caller leaves the conflict
-/// standing rather than picking one.
-fn sole_committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
-    let mut content = change.events.iter().filter_map(|event| match event {
-        FilesystemChange::Created { content_ref, .. } => content_ref.as_ref(),
-        FilesystemChange::ContentChanged { content_ref, .. } => Some(content_ref),
-        _ => None,
-    });
-    let only = content.next()?;
-    content.next().is_none().then_some(only)
 }
 
 pub use config::ClientConfig;
 pub use error::ClientError;
 pub use payload::{PayloadSource, PayloadStream};
-use transport::{WireRequest, IO_INACTIVITY_TIMEOUT};
+use transport::{StdMonotonicTimer, TransportRetryPolicy, WireRequest, IO_INACTIVITY_TIMEOUT};
 pub use ClientError as Error;
 
 /// Per-operation options, defined once in `loonfs-api` and shared with the
@@ -129,9 +111,16 @@ pub struct Client {
     base_url: String,
     auth_token: Option<SecretString>,
     http: reqwest::Client,
-    /// Whether transient server errors are retried (see
+    /// Caller-selected whole-request deadline, retained so retry attempts can
+    /// use the stricter of it and the remaining operation budget.
+    request_timeout: Option<Duration>,
+    /// Whether retryable transport and server errors are retried (see
     /// [`ClientConfig::disable_transient_retry`]).
-    transient_retry: bool,
+    transport_retry_enabled: bool,
+    /// Count, backoff, and elapsed-time bounds for replay-safe control calls.
+    transport_retry: TransportRetryPolicy,
+    /// Monotonic elapsed-time source for the operation deadline.
+    timer: Arc<dyn transport::MonotonicTimer>,
     /// Capability document cache, shared by clones and filled on first use.
     capabilities: Arc<OnceLock<CapabilityDocument>>,
 }
@@ -484,13 +473,14 @@ impl Client {
     /// validation.
     pub fn new(config: ClientConfig) -> Result<Self> {
         config.validate()?;
+        let request_timeout = config.request_timeout_ms.map(Duration::from_millis);
         let mut builder = reqwest::Client::builder()
             // Bounds a stalled connection without cutting off a slow but
             // progressing transfer, which a whole-request deadline would.
             .read_timeout(IO_INACTIVITY_TIMEOUT)
             .connect_timeout(IO_INACTIVITY_TIMEOUT);
-        if let Some(timeout_ms) = config.request_timeout_ms {
-            builder = builder.timeout(std::time::Duration::from_millis(timeout_ms));
+        if let Some(request_timeout) = request_timeout {
+            builder = builder.timeout(request_timeout);
         }
         // Additive: the platform roots stay in place, so one configured
         // private CA does not cost this client every public one.
@@ -506,7 +496,10 @@ impl Client {
                     field: "http_client",
                     reason: format!("failed to build: {err}"),
                 })?,
-            transient_retry: !config.disable_transient_retry,
+            request_timeout,
+            transport_retry_enabled: !config.disable_transient_retry,
+            transport_retry: TransportRetryPolicy::DEFAULT,
+            timer: Arc::new(StdMonotonicTimer::default()),
             capabilities: Arc::new(OnceLock::new()),
         })
     }
@@ -901,7 +894,7 @@ impl Client {
 
     pub async fn health(&self) -> Result<()> {
         let url = format!("{}/health", self.base_url);
-        self.call_with_transient_retry(&self.get(&url), None)
+        self.call_with_transport_retry(&self.get(&url), None)
             .await?;
         Ok(())
     }
@@ -1012,7 +1005,7 @@ impl Client {
         // provider takes the last write, and the checksum rides the
         // signature either way.
         let response = self
-            .call_with_transient_retry_headers(&request, Some(&bytes))
+            .call_content_with_transport_retry_headers(&request, Some(&bytes))
             .await?;
         let etag = response
             .get(http::header::ETAG)
@@ -1068,7 +1061,7 @@ impl Client {
         // Proxied uploads are the request most likely to hit the server's
         // concurrency cap; staging the same bytes again is idempotent.
         let response = self
-            .call_with_transient_retry(&request, Some(&Bytes::copy_from_slice(bytes)))
+            .call_content_with_transport_retry(&request, Some(&Bytes::copy_from_slice(bytes)))
             .await?;
         serde_json::from_slice(&response).map_err(|err| ClientError::Json(err.to_string()))
     }
@@ -2207,68 +2200,19 @@ impl Client {
         conflict: ClientError,
     ) -> Result<ApiCommitResponse> {
         let namespace_id = spec.namespace();
-        let Some((committed_seq, committed_fingerprint)) = reported_commit_receipt(&conflict)
-        else {
-            return Err(conflict);
-        };
-        let Some(committed) = self
-            .read_committed_change(namespace_id, commit_id, committed_seq)
-            .await?
-        else {
-            return Err(conflict);
-        };
-        let Some(content_ref) = sole_committed_content_ref(&committed) else {
-            return Err(conflict);
-        };
-        let retried = loonfs_api::put_retry_fingerprint(
-            namespace_id,
-            spec.absolute_path(),
-            options.behavior,
-            options.expected_revision_no,
-            options.message.as_deref(),
-            content_ref,
-        );
-        if retried.ok().as_deref() != Some(committed_fingerprint.as_str()) {
-            return Err(conflict);
-        }
-        if !content_ref.matches_evidence(uploaded) {
-            return Err(conflict);
-        }
-        Ok(ApiCommitResponse {
-            namespace_id: namespace_id.clone(),
-            commit_id: committed.commit_id,
-            committed_seq: committed.seq,
-        })
-    }
-
-    /// Reads the one change a reuse conflict said the commit id landed at.
-    ///
-    /// There is no by-commit-id read on the wire, but the conflict already
-    /// named the sequence, so this is one feed page positioned on it rather
-    /// than a search. `None` means the evidence is not there to compare —
-    /// the sequence has fallen below the retention floor, or the row at it
-    /// belongs to some other commit — and the caller turns that into the
-    /// conflict rather than into a guess.
-    async fn read_committed_change(
-        &self,
-        namespace_id: &NamespaceId,
-        commit_id: &CommitId,
-        committed_seq: ChangeSeq,
-    ) -> Result<Option<CommittedChange>> {
-        let after_seq = ChangeSeq(committed_seq.0.saturating_sub(1));
-        let page = match self.list_changes(namespace_id, after_seq, Some(1)).await {
-            Ok(page) => page,
-            // Retention gave up the replay promise below the floor: the
-            // commit landed, but what it wrote can no longer be read back.
-            Err(error) if error.code() == Some(ErrorCode::RebootstrapRequired) => {
-                return Ok(None);
-            }
-            Err(error) => return Err(error),
-        };
-        Ok(page
-            .changes
-            .into_iter()
-            .find(|change| change.seq == committed_seq && &change.commit_id == commit_id))
+        loonfs_api::reconcile_put_commit_id_reuse(
+            PutRetryAttempt {
+                namespace_id,
+                path: spec.absolute_path(),
+                commit_id,
+                options,
+                staged: uploaded,
+            },
+            conflict,
+            |after_seq| self.list_changes(namespace_id, after_seq, Some(1)),
+            classify_put_retry_error,
+        )
+        .await
     }
 
     pub async fn create_directory(
@@ -2523,7 +2467,7 @@ mod streaming_tests;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::transport::{transient_failure, MAX_TRANSIENT_ATTEMPTS};
+    use crate::transport::{retryable_transport_failure, TransportRetryPolicy};
     use loonfs_api::{ContentId, ErrorCode};
     use std::fs;
     use tempfile::tempdir;
@@ -2638,7 +2582,7 @@ mod tests {
     /// a served status whose body was not the error envelope — surfaces
     /// immediately.
     #[test]
-    fn transient_failure_covers_transport_and_retryable_unavailability_only() {
+    fn retryable_transport_failure_covers_transport_and_unavailability_only() {
         let api = |code: &str| ClientError::Api {
             status: 503,
             code: code.to_owned(),
@@ -2647,18 +2591,27 @@ mod tests {
             request_id: None,
             details: None,
         };
-        assert!(transient_failure(
+        assert!(retryable_transport_failure(
             true,
             &ClientError::Http("reset".to_owned())
         ));
-        assert!(transient_failure(false, &api("server_busy")));
-        assert!(transient_failure(false, &api("commit_queue_full")));
-        assert!(transient_failure(false, &api("shutting_down")));
-        assert!(!transient_failure(false, &api("server_error")));
-        assert!(!transient_failure(false, &api("checkpoint_unavailable")));
-        assert!(!transient_failure(false, &api("maintenance_required")));
-        assert!(!transient_failure(false, &api("index_lagging")));
-        assert!(!transient_failure(
+        assert!(retryable_transport_failure(false, &api("server_busy")));
+        assert!(retryable_transport_failure(
+            false,
+            &api("commit_queue_full")
+        ));
+        assert!(retryable_transport_failure(false, &api("shutting_down")));
+        assert!(!retryable_transport_failure(false, &api("server_error")));
+        assert!(!retryable_transport_failure(
+            false,
+            &api("checkpoint_unavailable")
+        ));
+        assert!(!retryable_transport_failure(
+            false,
+            &api("maintenance_required")
+        ));
+        assert!(!retryable_transport_failure(false, &api("index_lagging")));
+        assert!(!retryable_transport_failure(
             false,
             &ClientError::Http("http status 502 with a non-envelope body".to_owned())
         ));
@@ -2669,7 +2622,8 @@ mod tests {
     #[tokio::test]
     async fn transport_failures_resend_up_to_the_attempt_cap() {
         let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-        let transport = crate::transport::test_transport::failures(MAX_TRANSIENT_ATTEMPTS as usize);
+        let max_attempts = TransportRetryPolicy::DEFAULT.max_retries as usize + 1;
+        let transport = crate::transport::test_transport::failures(max_attempts);
         let retrying = Client::new(ClientConfig {
             server_url: "http://example.invalid".to_owned(),
             auth_token: None,
@@ -2683,7 +2637,7 @@ mod tests {
             .await
             .expect_err("dropped connections must fail");
         assert!(matches!(error, ClientError::Http(_)), "{error:?}");
-        assert_eq!(transport.attempts(), MAX_TRANSIENT_ATTEMPTS as usize);
+        assert_eq!(transport.attempts(), max_attempts);
         drop(transport);
 
         let transport = crate::transport::test_transport::failures(1);

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -111,15 +111,17 @@ pub struct Client {
     base_url: String,
     auth_token: Option<SecretString>,
     http: reqwest::Client,
-    /// Caller-selected whole-request deadline, retained so retry attempts can
-    /// use the stricter of it and the remaining operation budget.
+    /// Optional timeout configured for each HTTP attempt.
+    ///
+    /// Replay-safe requests use the smaller of this value and the time left in
+    /// the total retry budget.
     request_timeout: Option<Duration>,
-    /// Whether retryable transport and server errors are retried (see
+    /// Whether the client retries eligible network and server errors (see
     /// [`ClientConfig::disable_transient_retry`]).
     transport_retry_enabled: bool,
-    /// Count, backoff, and elapsed-time bounds for replay-safe control calls.
+    /// Attempt count, delay, and total duration limits for replay-safe requests.
     transport_retry: TransportRetryPolicy,
-    /// Monotonic elapsed-time source for the operation deadline.
+    /// Monotonic clock used to enforce the total retry limit.
     timer: Arc<dyn transport::MonotonicTimer>,
     /// Capability document cache, shared by clones and filled on first use.
     capabilities: Arc<OnceLock<CapabilityDocument>>,
@@ -2174,23 +2176,13 @@ impl Client {
         }
     }
 
-    /// Decides whether a reused commit id already did this exact work.
+    /// Checks whether a commit-ID conflict came from retrying the same PUT.
     ///
-    /// The proof is the commit's whole semantic identity, not a selection of
-    /// its parts. The conflict reports the fingerprint the server's receipt
-    /// holds; this reads the one change that commit id landed, rebuilds this
-    /// request's fingerprint with the committed content reference in place
-    /// of the freshly uploaded one, and requires the two to be equal. That
-    /// covers the path, the replacement behavior, the expected revision, the
-    /// annotation, and that the original commit was this one put — every
-    /// field a future request gains is covered the day it joins the
-    /// preimage. What the fingerprint cannot speak to is whether the two
-    /// content objects hold the same bytes, so digest evidence answers that
-    /// separately.
-    ///
-    /// Nothing weaker counts: every way of failing to prove the two requests
-    /// are the same — including the upload having no answer to give — leaves
-    /// the original conflict standing, never agreement.
+    /// The shared helper loads the original change and compares the complete
+    /// request fingerprint. It also verifies that the new upload contains the
+    /// same bytes as the content from the original commit. If either check
+    /// cannot be completed or does not match, this method returns the original
+    /// conflict.
     async fn reconcile_commit_id_reuse(
         &self,
         spec: &NamespacePath,

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -1,4 +1,4 @@
-//! The HTTP transport: request building, the bounded transient retry, and
+//! The HTTP transport: request building, the bounded transport retry, and
 //! response-to-error mapping.
 
 use crate::{Client, ClientError, PayloadStream, Result};
@@ -6,21 +6,87 @@ use bytes::Bytes;
 use futures::StreamExt as _;
 use loonfs_api::{ApiError, ErrorCode};
 use reqwest::Method;
+use std::sync::OnceLock;
 use std::time::Duration;
+use std::time::Instant;
 
-/// Cap on attempts for transient-error retry: one initial try plus three
-/// retries, sleeping with doubling backoff in between.
-pub(crate) const MAX_TRANSIENT_ATTEMPTS: u32 = 4;
-/// First transient-retry sleep; doubles per retry up to
-/// [`MAX_TRANSIENT_RETRY_DELAY`].
-pub(crate) const INITIAL_TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(250);
-/// Ceiling for one transient-retry sleep.
-pub(crate) const MAX_TRANSIENT_RETRY_DELAY: Duration = Duration::from_secs(2);
+/// Bounded retry configuration for one replay-safe server request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TransportRetryPolicy {
+    pub(crate) max_retries: u32,
+    pub(crate) initial_backoff: Duration,
+    pub(crate) max_backoff: Duration,
+    pub(crate) operation_deadline: Duration,
+}
+
+impl TransportRetryPolicy {
+    pub(crate) const DEFAULT: Self = Self {
+        max_retries: 3,
+        initial_backoff: Duration::from_millis(250),
+        max_backoff: Duration::from_secs(2),
+        // The server gives ordinary requests 60 seconds. Ninety seconds lets
+        // a client absorb brief connect failures and backoff around that one
+        // request while staying below the larger provider operation budget.
+        // Content transfers are explicitly exempt below.
+        operation_deadline: Duration::from_secs(90),
+    };
+}
 
 /// Socket read/write inactivity timeout applied to every request. A
 /// connection that makes no progress for this long fails instead of hanging
 /// the caller forever.
 pub(crate) const IO_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Monotonic elapsed-time boundary used only by the transport retry budget.
+pub(crate) trait MonotonicTimer: std::fmt::Debug + Send + Sync {
+    fn monotonic_now_ms(&self) -> u64;
+}
+
+/// Process-clock implementation for client operation deadlines.
+#[derive(Debug, Default)]
+pub(crate) struct StdMonotonicTimer {
+    origin: OnceLock<Instant>,
+}
+
+impl MonotonicTimer for StdMonotonicTimer {
+    fn monotonic_now_ms(&self) -> u64 {
+        // This is the client's elapsed-time boundary for self-imposed
+        // transport deadlines; no protocol state observes the reading.
+        #[allow(clippy::disallowed_methods)]
+        let now = Instant::now();
+        let origin = self.origin.get_or_init(|| now);
+        u64::try_from(now.saturating_duration_since(*origin).as_millis()).unwrap_or(u64::MAX)
+    }
+}
+
+/// Elapsed-time state shared by every retry attempt of one request.
+struct OperationDeadline<'timer> {
+    timer: &'timer dyn MonotonicTimer,
+    started_ms: u64,
+    deadline: Duration,
+}
+
+impl<'timer> OperationDeadline<'timer> {
+    fn start(timer: &'timer dyn MonotonicTimer, deadline: Duration) -> Self {
+        Self {
+            timer,
+            started_ms: timer.monotonic_now_ms(),
+            deadline,
+        }
+    }
+
+    fn remaining(&self) -> Option<Duration> {
+        let elapsed_ms = self
+            .timer
+            .monotonic_now_ms()
+            .saturating_sub(self.started_ms);
+        let deadline_ms = u64::try_from(self.deadline.as_millis()).unwrap_or(u64::MAX);
+        if elapsed_ms >= deadline_ms {
+            return None;
+        }
+        Some(Duration::from_millis(deadline_ms - elapsed_ms))
+    }
+}
 
 /// Reusable description of an outbound request.
 ///
@@ -131,7 +197,7 @@ impl Client {
             None => request,
         };
         let bytes = if retry {
-            self.call_with_transient_retry(&request, body.as_ref())
+            self.call_with_transport_retry(&request, body.as_ref())
                 .await?
         } else {
             self.call_once(&request, body.as_ref()).await?
@@ -141,7 +207,7 @@ impl Client {
 
     pub(crate) async fn request_bytes(&self, url: &str) -> Result<Vec<u8>> {
         let request = self.get(url);
-        self.call_with_transient_retry(&request, None).await
+        self.call_content_with_transport_retry(&request, None).await
     }
 
     /// Sends one request without retrying. Callers use this path when an
@@ -151,7 +217,7 @@ impl Client {
         request: &WireRequest,
         body: Option<&Bytes>,
     ) -> Result<Vec<u8>> {
-        self.send(request, body)
+        self.send(request, body, None)
             .await
             .map(|response| response.bytes)
             .map_err(|attempt| attempt.error)
@@ -226,38 +292,90 @@ impl Client {
     /// [`Self::call_once`] so an ambiguous success is visible. Conditions that
     /// require maintenance, such as `maintenance_required` or `index_lagging`,
     /// are not retried.
-    pub(crate) async fn call_with_transient_retry(
+    pub(crate) async fn call_with_transport_retry(
         &self,
         request: &WireRequest,
         body: Option<&Bytes>,
     ) -> Result<Vec<u8>> {
-        self.call_with_transient_retry_headers(request, body)
+        self.call_with_transport_retry_headers(request, body)
             .await
             .map(|response| response.bytes)
     }
 
-    /// [`Self::call_with_transient_retry`], keeping the response headers.
+    /// Retries a content transfer by count without bounding total duration.
+    ///
+    /// A slow but progressing payload may outlive an ordinary request's
+    /// operation deadline. Its socket inactivity timeout and finite attempt
+    /// count still prevent an unbounded retry loop.
+    pub(crate) async fn call_content_with_transport_retry(
+        &self,
+        request: &WireRequest,
+        body: Option<&Bytes>,
+    ) -> Result<Vec<u8>> {
+        self.call_content_with_transport_retry_headers(request, body)
+            .await
+            .map(|response| response.bytes)
+    }
+
+    /// [`Self::call_with_transport_retry`], keeping the response headers.
     ///
     /// A multipart part upload is the one call whose answer lives in a
     /// header: the provider's etag for the accepted part, which the client
     /// carries to completion.
-    pub(crate) async fn call_with_transient_retry_headers(
+    pub(crate) async fn call_with_transport_retry_headers(
         &self,
         request: &WireRequest,
         body: Option<&Bytes>,
     ) -> Result<WireResponse> {
-        let mut attempts = 0;
+        let deadline =
+            OperationDeadline::start(self.timer.as_ref(), self.transport_retry.operation_deadline);
+        self.call_with_transport_retry_inner(request, body, Some(deadline))
+            .await
+    }
+
+    /// The content-transfer form of
+    /// [`Self::call_with_transport_retry_headers`].
+    pub(crate) async fn call_content_with_transport_retry_headers(
+        &self,
+        request: &WireRequest,
+        body: Option<&Bytes>,
+    ) -> Result<WireResponse> {
+        self.call_with_transport_retry_inner(request, body, None)
+            .await
+    }
+
+    async fn call_with_transport_retry_inner(
+        &self,
+        request: &WireRequest,
+        body: Option<&Bytes>,
+        deadline: Option<OperationDeadline<'_>>,
+    ) -> Result<WireResponse> {
+        let mut retries = 0;
+        let mut attempt_timeout = deadline.as_ref().map(|deadline| deadline.deadline);
         loop {
-            let attempt = match self.send(request, body).await {
+            let attempt = match self.send(request, body, attempt_timeout).await {
                 Ok(response) => return Ok(response),
                 Err(attempt) => attempt,
             };
-            attempts += 1;
-            let transient = transient_failure(attempt.transport, &attempt.error);
-            if !self.transient_retry || !transient || attempts >= MAX_TRANSIENT_ATTEMPTS {
+            let retryable = retryable_transport_failure(attempt.transport, &attempt.error);
+            if !self.transport_retry_enabled || !retryable {
                 return Err(attempt.error);
             }
-            transient_retry_pause(transient_retry_backoff(attempts)).await;
+            let Some(backoff) = next_transport_retry_backoff(
+                &self.transport_retry,
+                &mut retries,
+                deadline.as_ref(),
+            ) else {
+                return Err(attempt.error);
+            };
+            transport_retry_pause(backoff).await;
+            attempt_timeout = match deadline.as_ref() {
+                Some(deadline) => match deadline.remaining() {
+                    Some(remaining) => Some(remaining),
+                    None => return Err(attempt.error),
+                },
+                None => None,
+            };
         }
     }
 
@@ -268,6 +386,7 @@ impl Client {
         &self,
         request: &WireRequest,
         body: Option<&Bytes>,
+        attempt_timeout: Option<Duration>,
     ) -> std::result::Result<WireResponse, FailedAttempt> {
         #[cfg(test)]
         if let Some(outcome) = test_transport::next(request) {
@@ -279,6 +398,12 @@ impl Client {
             // it. That is what keeps a part upload's memory equal to the
             // part the caller is already holding, instead of twice it.
             builder = builder.body(bytes.clone());
+        }
+        if let Some(attempt_timeout) = attempt_timeout {
+            let attempt_timeout = self.request_timeout.map_or(attempt_timeout, |configured| {
+                configured.min(attempt_timeout)
+            });
+            builder = builder.timeout(attempt_timeout);
         }
         self.dispatch(request, builder).await
     }
@@ -445,7 +570,7 @@ fn render_send_error(
 /// network layer itself reported the failure (classified before the error
 /// is flattened by `map_status_error`), and served envelopes retry only on
 /// the retryable-unavailability codes.
-pub(crate) fn transient_failure(transport: bool, error: &ClientError) -> bool {
+pub(crate) fn retryable_transport_failure(transport: bool, error: &ClientError) -> bool {
     transport
         || error
             .code()
@@ -455,17 +580,35 @@ pub(crate) fn transient_failure(transport: bool, error: &ClientError) -> bool {
 /// Deterministic doubling, the same shape as the object-store transport
 /// retry: workspace policy avoids ambient randomness, and a bounded
 /// per-request retry does not need jitter.
-fn transient_retry_backoff(attempt: u32) -> Duration {
-    let doublings = attempt.saturating_sub(1).min(16);
-    INITIAL_TRANSIENT_RETRY_DELAY
+fn transport_retry_backoff(policy: &TransportRetryPolicy, retry: u32) -> Duration {
+    let doublings = retry.saturating_sub(1).min(16);
+    policy
+        .initial_backoff
         .saturating_mul(1u32 << doublings)
-        .min(MAX_TRANSIENT_RETRY_DELAY)
+        .min(policy.max_backoff)
+}
+
+/// Grants one retry under the count and optional operation-deadline budgets.
+fn next_transport_retry_backoff(
+    policy: &TransportRetryPolicy,
+    retries: &mut u32,
+    deadline: Option<&OperationDeadline<'_>>,
+) -> Option<Duration> {
+    if *retries >= policy.max_retries {
+        return None;
+    }
+    let remaining = match deadline {
+        Some(deadline) => deadline.remaining()?,
+        None => Duration::MAX,
+    };
+    *retries += 1;
+    Some(transport_retry_backoff(policy, *retries).min(remaining))
 }
 
 #[allow(clippy::disallowed_methods)]
 // The client's own retry pacing between bounded attempts of one request; no
 // protocol time depends on it and replay never observes it.
-async fn transient_retry_pause(backoff: Duration) {
+async fn transport_retry_pause(backoff: Duration) {
     tokio::time::sleep(backoff).await;
 }
 
@@ -646,7 +789,10 @@ pub(crate) mod test_transport {
 
 #[cfg(test)]
 mod tests {
-    use super::render_send_error;
+    use super::*;
+    use crate::ClientConfig;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
 
     #[derive(Debug)]
     struct Layered {
@@ -666,6 +812,42 @@ mod tests {
                 .as_deref()
                 .map(|cause| cause as &(dyn std::error::Error + 'static))
         }
+    }
+
+    /// First reading starts the operation; every later reading has exhausted
+    /// the injected deadline.
+    #[derive(Debug, Default)]
+    struct ExpiredAfterFirstRead {
+        reads: AtomicU64,
+    }
+
+    impl MonotonicTimer for ExpiredAfterFirstRead {
+        fn monotonic_now_ms(&self) -> u64 {
+            if self.reads.fetch_add(1, Ordering::SeqCst) == 0 {
+                0
+            } else {
+                100
+            }
+        }
+    }
+
+    fn deadline_client() -> Client {
+        let mut client = Client::new(ClientConfig {
+            server_url: "http://example.invalid".to_owned(),
+            auth_token: None,
+            request_timeout_ms: None,
+            disable_transient_retry: false,
+            ca_cert_path: None,
+        })
+        .expect("valid client config");
+        client.transport_retry = TransportRetryPolicy {
+            max_retries: 1,
+            initial_backoff: Duration::ZERO,
+            max_backoff: Duration::ZERO,
+            operation_deadline: Duration::from_millis(100),
+        };
+        client.timer = Arc::new(ExpiredAfterFirstRead::default());
+        client
     }
 
     #[test]
@@ -705,5 +887,32 @@ mod tests {
             rendered,
             "request to `http://h/v0` failed: outer: inner detail"
         );
+    }
+
+    #[tokio::test]
+    async fn transport_retries_stop_when_the_operation_deadline_is_spent() {
+        let client = deadline_client();
+        let transport = test_transport::failures(1);
+
+        client
+            .call_with_transport_retry(&client.get("http://example.invalid/control"), None)
+            .await
+            .expect_err("the spent deadline must preserve the first failure");
+
+        assert_eq!(transport.attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn content_transfer_retries_are_exempt_from_the_operation_deadline() {
+        let client = deadline_client();
+        let transport = test_transport::failure_then_success(b"content".to_vec());
+
+        let bytes = client
+            .call_content_with_transport_retry(&client.get("http://example.invalid/content"), None)
+            .await
+            .expect("the count-bounded content retry succeeds");
+
+        assert_eq!(bytes, b"content");
+        assert_eq!(transport.attempts(), 2);
     }
 }

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -1,5 +1,5 @@
-//! The HTTP transport: request building, the bounded transport retry, and
-//! response-to-error mapping.
+//! Builds HTTP requests, applies retry limits, and converts responses into
+//! client errors.
 
 use crate::{Client, ClientError, PayloadStream, Result};
 use bytes::Bytes;
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::Instant;
 
-/// Bounded retry configuration for one replay-safe server request.
+/// Retry limits for a request that is safe to send more than once.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TransportRetryPolicy {
     pub(crate) max_retries: u32,
@@ -24,10 +24,10 @@ impl TransportRetryPolicy {
         max_retries: 3,
         initial_backoff: Duration::from_millis(250),
         max_backoff: Duration::from_secs(2),
-        // The server gives ordinary requests 60 seconds. Ninety seconds lets
-        // a client absorb brief connect failures and backoff around that one
-        // request while staying below the larger provider operation budget.
-        // Content transfers are explicitly exempt below.
+        // The server limits most requests to 60 seconds. A 90-second client
+        // budget leaves time for short connection failures and retry delays
+        // while remaining below the longer provider operation limit. Content
+        // transfer retries do not use this total budget.
         operation_deadline: Duration::from_secs(90),
     };
 }
@@ -37,12 +37,12 @@ impl TransportRetryPolicy {
 /// the caller forever.
 pub(crate) const IO_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Monotonic elapsed-time boundary used only by the transport retry budget.
+/// Provides elapsed time from a monotonic clock for the total retry limit.
 pub(crate) trait MonotonicTimer: std::fmt::Debug + Send + Sync {
     fn monotonic_now_ms(&self) -> u64;
 }
 
-/// Process-clock implementation for client operation deadlines.
+/// Monotonic clock used by the production client.
 #[derive(Debug, Default)]
 pub(crate) struct StdMonotonicTimer {
     origin: OnceLock<Instant>,
@@ -50,8 +50,8 @@ pub(crate) struct StdMonotonicTimer {
 
 impl MonotonicTimer for StdMonotonicTimer {
     fn monotonic_now_ms(&self) -> u64 {
-        // This is the client's elapsed-time boundary for self-imposed
-        // transport deadlines; no protocol state observes the reading.
+        // This value is used only for local retry timing. It is never stored
+        // or returned through the protocol.
         #[allow(clippy::disallowed_methods)]
         let now = Instant::now();
         let origin = self.origin.get_or_init(|| now);
@@ -59,7 +59,7 @@ impl MonotonicTimer for StdMonotonicTimer {
     }
 }
 
-/// Elapsed-time state shared by every retry attempt of one request.
+/// Tracks the time remaining in one request's total retry budget.
 struct OperationDeadline<'timer> {
     timer: &'timer dyn MonotonicTimer,
     started_ms: u64,
@@ -284,8 +284,7 @@ impl Client {
             .boxed())
     }
 
-    /// Retries transient transport failures and selected temporary server
-    /// errors with bounded exponential backoff.
+    /// Retries eligible network and server errors with exponential backoff.
     ///
     /// Callers use this only for reads, replay-safe commits, and idempotent
     /// operations. Lifecycle changes and upload-session creation use
@@ -302,11 +301,12 @@ impl Client {
             .map(|response| response.bytes)
     }
 
-    /// Retries a content transfer by count without bounding total duration.
+    /// Retries a content transfer using the attempt limit but no total time
+    /// limit.
     ///
-    /// A slow but progressing payload may outlive an ordinary request's
-    /// operation deadline. Its socket inactivity timeout and finite attempt
-    /// count still prevent an unbounded retry loop.
+    /// A transfer can exceed the normal 90-second retry limit while data is
+    /// still moving. The 60-second inactivity timeout and attempt limit still
+    /// bound stalled or repeatedly failing transfers.
     pub(crate) async fn call_content_with_transport_retry(
         &self,
         request: &WireRequest,
@@ -317,11 +317,8 @@ impl Client {
             .map(|response| response.bytes)
     }
 
-    /// [`Self::call_with_transport_retry`], keeping the response headers.
-    ///
-    /// A multipart part upload is the one call whose answer lives in a
-    /// header: the provider's etag for the accepted part, which the client
-    /// carries to completion.
+    /// Same as [`Self::call_with_transport_retry`], but also returns response
+    /// headers.
     pub(crate) async fn call_with_transport_retry_headers(
         &self,
         request: &WireRequest,
@@ -333,8 +330,8 @@ impl Client {
             .await
     }
 
-    /// The content-transfer form of
-    /// [`Self::call_with_transport_retry_headers`].
+    /// Same as [`Self::call_content_with_transport_retry`], but also returns
+    /// response headers. Multipart uploads use this to read the part ETag.
     pub(crate) async fn call_content_with_transport_retry_headers(
         &self,
         request: &WireRequest,
@@ -379,9 +376,10 @@ impl Client {
         }
     }
 
-    /// One attempt: build, send, and read the body. A served non-success
-    /// status is an error but not a transport failure — that distinction is
-    /// what the retry policy keys on.
+    /// Sends one request and reads its response body.
+    ///
+    /// A non-success HTTP status is a server response, not a network failure.
+    /// The retry policy handles those two failure types differently.
     async fn send(
         &self,
         request: &WireRequest,
@@ -566,10 +564,11 @@ fn render_send_error(
     }
 }
 
-/// The retry policy for one failed attempt: `transport` is whether the
-/// network layer itself reported the failure (classified before the error
-/// is flattened by `map_status_error`), and served envelopes retry only on
-/// the retryable-unavailability codes.
+/// Returns whether a failed request is eligible for an automatic retry.
+///
+/// Network failures are retryable. Server responses are retryable only when
+/// their error code identifies a temporary condition that requires no
+/// operator action.
 pub(crate) fn retryable_transport_failure(transport: bool, error: &ClientError) -> bool {
     transport
         || error
@@ -577,9 +576,9 @@ pub(crate) fn retryable_transport_failure(transport: bool, error: &ClientError) 
             .is_some_and(ErrorCode::retryable_without_operator_action)
 }
 
-/// Deterministic doubling, the same shape as the object-store transport
-/// retry: workspace policy avoids ambient randomness, and a bounded
-/// per-request retry does not need jitter.
+/// Computes deterministic exponential backoff for the requested retry number.
+///
+/// The delay doubles after each failure and never exceeds `max_backoff`.
 fn transport_retry_backoff(policy: &TransportRetryPolicy, retry: u32) -> Duration {
     let doublings = retry.saturating_sub(1).min(16);
     policy
@@ -588,7 +587,7 @@ fn transport_retry_backoff(policy: &TransportRetryPolicy, retry: u32) -> Duratio
         .min(policy.max_backoff)
 }
 
-/// Grants one retry under the count and optional operation-deadline budgets.
+/// Returns the delay before the next retry, or `None` when a limit is reached.
 fn next_transport_retry_backoff(
     policy: &TransportRetryPolicy,
     retries: &mut u32,
@@ -606,8 +605,8 @@ fn next_transport_retry_backoff(
 }
 
 #[allow(clippy::disallowed_methods)]
-// The client's own retry pacing between bounded attempts of one request; no
-// protocol time depends on it and replay never observes it.
+// This delay affects only local retry scheduling. It is not stored or exposed
+// through the protocol.
 async fn transport_retry_pause(backoff: Duration) {
     tokio::time::sleep(backoff).await;
 }
@@ -814,8 +813,7 @@ mod tests {
         }
     }
 
-    /// First reading starts the operation; every later reading has exhausted
-    /// the injected deadline.
+    /// Test clock that reports an expired deadline after its first read.
     #[derive(Debug, Default)]
     struct ExpiredAfterFirstRead {
         reads: AtomicU64,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -703,7 +703,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             &self.namespace_id,
             &content_store_id,
             upload_id,
-            self.mutation_context()?.now_ms,
+            self.now_ms()?,
         )
         .await
     }
@@ -843,8 +843,13 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         })?;
         Ok(MutationContext {
             writer_id: writer.writer_id.clone(),
-            now_ms: current_time_ms()?,
+            now_ms: self.now_ms()?,
         })
+    }
+
+    /// Reads the wall-clock boundary independently of writer identity.
+    fn now_ms(&self) -> Result<u64> {
+        current_time_ms()
     }
 }
 
@@ -991,6 +996,39 @@ mod tests {
             .await
             .expect("a reader-built engine serves reads");
         assert_eq!(changes.namespace_id, namespace_id);
+    }
+
+    #[tokio::test]
+    async fn reader_engine_reads_upload_status_without_writer_identity() {
+        let temp_dir = tempdir().expect("tempdir");
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let writer =
+            NamespaceEngine::builder(LocalFsStore::new(temp_dir.path()).expect("writer store"))
+                .namespace_id(namespace_id.clone())
+                .writer_id("writer-a")
+                .build()
+                .expect("writer engine builds");
+        writer
+            .bootstrap_namespace(BootstrapOptions::default())
+            .await
+            .expect("bootstrap namespace");
+        let begun = writer
+            .begin_upload(BeginUploadRequest::ServiceProxied {})
+            .await
+            .expect("begin upload");
+
+        let reader =
+            NamespaceEngine::builder(LocalFsStore::new(temp_dir.path()).expect("reader store"))
+                .namespace_id(namespace_id)
+                .build_reader()
+                .expect("reader engine builds");
+        let (status, receipt) = reader
+            .read_upload_status(begun.upload_id())
+            .await
+            .expect("reader engine reads upload status");
+
+        assert_eq!(status.upload_id, *begun.upload_id());
+        assert!(receipt.is_none());
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -847,7 +847,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         })
     }
 
-    /// Reads the wall-clock boundary independently of writer identity.
+    /// Returns the current wall-clock time without requiring writer identity.
     fn now_ms(&self) -> Result<u64> {
         current_time_ms()
     }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -194,14 +194,13 @@ impl FsWriter {
         }
     }
 
-    /// Determines whether a commit-id conflict is an idempotent retry of the
-    /// same file write.
+    /// Checks whether a commit-ID conflict came from retrying the same file
+    /// write.
     ///
-    /// The runtime compares the durable receipt's full request fingerprint with a
-    /// fingerprint rebuilt using the committed content reference. It separately
-    /// verifies that the newly staged payload matches the committed bytes. If
-    /// either comparison is unavailable or differs, the original conflict is
-    /// returned.
+    /// The shared helper compares the full request fingerprint and verifies
+    /// that the new upload contains the same bytes as the original commit. If
+    /// either check cannot be completed or does not match, this method returns
+    /// the original conflict.
     async fn reconcile_commit_id_reuse(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -10,48 +10,29 @@ use crate::{
     MoveOptions, NamespaceId, PutFileOptions, RestoreRevisionOptions, RevisionNo, UndeleteOptions,
     UpdateAttributesOptions,
 };
-use crate::{CommittedChange, FilesystemChange};
 use crate::{Result, RuntimeError};
-use loonfs_api::{ContentEvidence, EffectiveLimit, ErrorCode};
+use loonfs_api::{
+    ContentEvidence, EffectiveLimit, ErrorCode, PutRetryAttempt, PutRetryErrorClassification,
+    PutRetryReceipt,
+};
 use loonfs_core::NamespaceEngine;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
-/// What a reuse conflict says the commit id already landed as: where, and
-/// the semantic identity of the mutation that landed there.
-///
-/// The publisher decides the conflict against a durable receipt, and the
-/// receipt holds both, so the error carries both. They are absent only when
-/// nothing has committed under the id yet — two conflicting requests
-/// claiming it at once — and then there is nothing to read back.
-fn reported_commit_receipt(error: &RuntimeError) -> Option<(ChangeSeq, String)> {
-    match error {
-        RuntimeError::Core(CoreError::CommitIdReuseConflict {
-            committed_seq,
-            committed_fingerprint,
-            ..
-        }) => Some(((*committed_seq)?, committed_fingerprint.clone()?)),
-        _ => None,
+fn classify_put_retry_error(error: &RuntimeError) -> PutRetryErrorClassification {
+    match error.code() {
+        ErrorCode::CommitIdReuseConflict => {
+            let receipt = error.details().and_then(|details| {
+                Some(PutRetryReceipt {
+                    committed_seq: details.committed_seq?,
+                    committed_fingerprint: details.committed_fingerprint?,
+                })
+            });
+            PutRetryErrorClassification::CommitIdReuseConflict(receipt)
+        }
+        ErrorCode::RebootstrapRequired => PutRetryErrorClassification::RebootstrapRequired,
+        _ => PutRetryErrorClassification::Other,
     }
-}
-
-/// The content one committed change wrote, when it wrote exactly one.
-///
-/// A single put's commit produces exactly one content-bearing event: the
-/// file's `Created` or `ContentChanged`. Auto-created parent directories
-/// appear as `Created` without a content ref, and no other change kind
-/// carries content at all, so "exactly one" holds for a put however many
-/// directories it had to make. Anything else — nothing, or several — is not
-/// the commit a single put produces, and the caller leaves the conflict
-/// standing rather than picking one.
-fn sole_committed_content_ref(change: &CommittedChange) -> Option<&ContentRef> {
-    let mut content = change.events.iter().filter_map(|event| match event {
-        FilesystemChange::Created { content_ref, .. } => content_ref.as_ref(),
-        FilesystemChange::ContentChanged { content_ref, .. } => Some(content_ref),
-        _ => None,
-    });
-    let only = content.next()?;
-    content.next().is_none().then_some(only)
 }
 
 impl FsWriter {
@@ -230,73 +211,28 @@ impl FsWriter {
         staged: ContentEvidence<'_>,
         conflict: RuntimeError,
     ) -> Result<CommitResponse> {
-        let Some((committed_seq, committed_fingerprint)) = reported_commit_receipt(&conflict)
-        else {
+        let Ok(path) = loonfs_core::path::parse_mutation_path(absolute_path) else {
             return Err(conflict);
         };
-        let Some(committed) = self
-            .read_committed_change(namespace_id, commit_id, committed_seq)
-            .await?
-        else {
-            return Err(conflict);
-        };
-        let Some(content_ref) = sole_committed_content_ref(&committed) else {
-            return Err(conflict);
-        };
-        let retried = loonfs_core::path::parse_mutation_path(absolute_path)
-            .ok()
-            .and_then(|path| {
-                loonfs_api::put_retry_fingerprint(
-                    namespace_id,
-                    &path,
-                    attempt.behavior,
-                    attempt.expected_revision_no,
-                    attempt.message.as_deref(),
-                    content_ref,
-                )
-                .ok()
-            });
-        if retried.as_deref() != Some(committed_fingerprint.as_str()) {
-            return Err(conflict);
-        }
-        if !content_ref.matches_evidence(staged) {
-            return Err(conflict);
-        }
-        Ok(CommitResponse {
-            namespace_id: namespace_id.clone(),
-            commit_id: committed.commit_id,
-            committed_seq: committed.seq,
-        })
-    }
-
-    /// Reads the committed change identified by a reuse conflict.
-    ///
-    /// The conflict supplies the sequence, so one change-feed page can read the
-    /// expected row directly. Returns `None` when retention removed the row or
-    /// when the row belongs to another commit; the caller then preserves the
-    /// original conflict.
-    async fn read_committed_change(
-        &self,
-        namespace_id: &NamespaceId,
-        commit_id: &CommitId,
-        committed_seq: ChangeSeq,
-    ) -> Result<Option<CommittedChange>> {
-        let after_seq = ChangeSeq(committed_seq.0.saturating_sub(1));
-        let page = match self
-            .engine(namespace_id)
-            .list_changes_after(after_seq, EffectiveLimit::new(NonZeroU32::MIN))
-            .await
-        {
-            Ok(page) => page,
-            // Retention gave up the replay promise below the floor: the
-            // commit landed, but what it wrote can no longer be read back.
-            Err(error) if error.code() == ErrorCode::RebootstrapRequired => return Ok(None),
-            Err(error) => return Err(error.into()),
-        };
-        Ok(page
-            .changes
-            .into_iter()
-            .find(|change| change.seq == committed_seq && &change.commit_id == commit_id))
+        let engine = self.engine(namespace_id);
+        loonfs_api::reconcile_put_commit_id_reuse(
+            PutRetryAttempt {
+                namespace_id,
+                path: &path,
+                commit_id,
+                options: attempt,
+                staged,
+            },
+            conflict,
+            |after_seq| async move {
+                engine
+                    .list_changes_after(after_seq, EffectiveLimit::new(NonZeroU32::MIN))
+                    .await
+                    .map_err(RuntimeError::from)
+            },
+            classify_put_retry_error,
+        )
+        .await
     }
 
     /// Stores file bytes and returns proof that they are ready to publish.


### PR DESCRIPTION
This change moves PUT retry verification into loonfs-api so the embedded runtime and HTTP client use the same implementation. When a commit ID has already been used, the shared code reads the original committed change, rebuilds the request fingerprint with the original content reference, and verifies that the new upload contains the same bytes. It returns the original commit response only when both checks succeed. Otherwise, it returns the original conflict.

Replay-safe client requests now have a 90-second total retry limit in addition to the existing retry count and exponential backoff. Each attempt is limited by the remaining retry time and by request_timeout_ms when configured. Content transfers do not use the 90-second total limit, which allows a large upload or download to continue while data is moving. They still have a 60-second inactivity timeout and a limited number of attempts.

Read-only namespace engines can now read upload status without a writer identity. The engine reads the current time directly for this operation, while mutation methods continue to require a writer.

Tests cover successful and failed PUT retry verification, expired retry budgets, content-transfer retries, and upload-status reads from a read-only engine.