### PR TITLE
refactor(metrics,core): unify cache recency and metric reporting

### DIFF
--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -52,7 +52,7 @@ pub struct MetadataTableCacheStats {
     pub filter_false_positives: usize,
 }
 
-/// Receives decoded metadata-table cache events for runtime metrics.
+/// Receives decoded metadata-table cache events so they can be recorded as metrics.
 pub trait MetadataTableCacheObserver: Send + Sync + 'static {
     fn hit(&self);
     fn miss(&self);
@@ -136,11 +136,8 @@ pub struct MetadataTableCache {
     /// One cell per in-flight block fetch, keyed by the block's cache key,
     /// so concurrent readers share a single ranged GET per block.
     in_flight: Mutex<HashMap<MetadataTableCacheKey, Arc<OnceCell<DecodedMetadataTableBlock>>>>,
-    /// The node-local cache of encoded stored blocks this cache misses
-    /// into, when the runtime was built with one. It lives here so the two
-    /// tiers are available together: a path that carries no table cache —
-    /// maintenance, reorganization, collection, and retention all pass
-    /// none — reaches neither tier, and needs no separate wiring to say so.
+    /// Optional node-local cache for encoded blocks. Keeping it with the
+    /// decoded cache ensures callers use both cache tiers or neither tier.
     stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
 }
 
@@ -167,8 +164,8 @@ struct MetadataTableCacheInner {
 #[derive(Debug)]
 struct CacheSlot {
     block: DecodedMetadataTableBlock,
-    /// Stamp of this entry's newest queue position; older positions for the
-    /// same key are ghosts.
+    /// Recency stamp assigned on the most recent access. Recency records with
+    /// an older stamp for this key are ignored.
     last_touch: u64,
 }
 
@@ -187,8 +184,8 @@ impl MetadataTableCache {
         Self::with_stored_block_cache(config, None)
     }
 
-    /// Sizes a cache that also carries a node-local cache of encoded stored
-    /// blocks beneath it. Passing `None` is exactly [`Self::new`].
+    /// Creates a decoded-block cache with an optional encoded-block cache.
+    /// Passing `None` is equivalent to [`Self::new`].
     pub fn with_stored_block_cache(
         config: MetadataTableCacheConfig,
         stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
@@ -196,7 +193,7 @@ impl MetadataTableCache {
         Self::with_stored_block_cache_and_observer(config, stored_block_cache, None)
     }
 
-    /// Sizes a cache and reports its activity to `observer`.
+    /// Creates a cache that reports activity to the optional `observer`.
     pub fn with_stored_block_cache_and_observer(
         config: MetadataTableCacheConfig,
         stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
@@ -212,8 +209,7 @@ impl MetadataTableCache {
         }
     }
 
-    /// The node-local stored-block cache this cache misses into, if the
-    /// runtime was built with one.
+    /// Returns the node-local encoded-block cache, if one was configured.
     pub fn stored_block_cache(&self) -> Option<&Arc<dyn StoredMetadataBlockCache>> {
         self.stored_block_cache.as_ref()
     }
@@ -373,8 +369,8 @@ impl MetadataTableCacheInner {
     }
 }
 
-/// Whether a queue position still names the entry's newest access. An entry
-/// that was replaced, evicted, or re-touched leaves stale positions behind.
+/// Returns `true` when `stamp` matches the key's most recent access.
+/// Replacing, evicting, or accessing an entry can leave older recency records.
 fn slot_is_live(
     entries: &HashMap<MetadataTableCacheKey, CacheSlot>,
     key: &MetadataTableCacheKey,
@@ -414,7 +410,7 @@ pub struct WalTailProjectionCacheStats {
     pub cached_decoded_bytes: usize,
 }
 
-/// Receives WAL-tail projection cache events for runtime metrics.
+/// Receives WAL-tail projection cache events so they can be recorded as metrics.
 pub trait WalTailProjectionCacheObserver: Send + Sync + 'static {
     fn hit(&self);
     fn miss(&self);
@@ -433,9 +429,7 @@ pub struct WalTailProjectionCacheKey {
     pub head_etag: String,
 }
 
-/// What one entry counts against the row and byte budgets. The projection
-/// carries both totals, and a projection in the cache is immutable, so the
-/// cache reads them rather than keeping its own copies.
+/// Returns the row count and decoded size charged to the cache budgets.
 fn projection_weight(rows: &MetadataState) -> (usize, usize) {
     (rows.row_count(), rows.decoded_bytes())
 }
@@ -469,8 +463,8 @@ struct WalTailProjectionCacheInner {
 #[derive(Debug)]
 struct WalTailProjectionCacheSlot {
     rows: Arc<MetadataState>,
-    /// Stamp of this entry's newest queue position; older positions for the
-    /// same key are ghosts.
+    /// Recency stamp assigned on the most recent access. Recency records with
+    /// an older stamp for this key are ignored.
     last_touch: u64,
 }
 
@@ -492,7 +486,7 @@ impl WalTailProjectionCache {
         Self::with_observer(config, None)
     }
 
-    /// Sizes a cache and reports its activity to `observer`.
+    /// Creates a cache that reports activity to the optional `observer`.
     pub fn with_observer(
         config: WalTailProjectionCacheConfig,
         observer: Option<Arc<dyn WalTailProjectionCacheObserver>>,

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -13,7 +13,7 @@ use loonfs_api::wire::manifest::NamespaceManifestEnvelope;
 use loonfs_api::wire::sst_blocks::{DecodedDataBlock, SegmentFilter, SegmentIndexEntry};
 use loonfs_api::{ChangeSeq, ManifestId, NamespaceId};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::OnceCell;
@@ -50,6 +50,16 @@ pub struct MetadataTableCacheStats {
     /// Approximate: a lookup narrower than the filter key (an exact unbind,
     /// a single revision) can count a true admission here.
     pub filter_false_positives: usize,
+}
+
+/// Receives decoded metadata-table cache events for runtime metrics.
+pub trait MetadataTableCacheObserver: Send + Sync + 'static {
+    fn hit(&self);
+    fn miss(&self);
+    fn insert(&self);
+    fn evict(&self);
+    fn filter_skip(&self);
+    fn filter_false_positive(&self);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -118,11 +128,11 @@ impl DecodedMetadataTableBlock {
     }
 }
 
-#[derive(Debug)]
 pub struct MetadataTableCache {
     config: MetadataTableCacheConfig,
     inner: Mutex<MetadataTableCacheInner>,
     stats: MetadataTableCacheStatsInner,
+    observer: Option<Arc<dyn MetadataTableCacheObserver>>,
     /// One cell per in-flight block fetch, keyed by the block's cache key,
     /// so concurrent readers share a single ranged GET per block.
     in_flight: Mutex<HashMap<MetadataTableCacheKey, Arc<OnceCell<DecodedMetadataTableBlock>>>>,
@@ -132,6 +142,19 @@ pub struct MetadataTableCache {
     /// maintenance, reorganization, collection, and retention all pass
     /// none — reaches neither tier, and needs no separate wiring to say so.
     stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
+}
+
+impl std::fmt::Debug for MetadataTableCache {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MetadataTableCache")
+            .field("config", &self.config)
+            .field("inner", &self.inner)
+            .field("stats", &self.stats)
+            .field("in_flight", &self.in_flight)
+            .field("stored_block_cache", &self.stored_block_cache)
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug, Default)]
@@ -170,10 +193,20 @@ impl MetadataTableCache {
         config: MetadataTableCacheConfig,
         stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
     ) -> Self {
+        Self::with_stored_block_cache_and_observer(config, stored_block_cache, None)
+    }
+
+    /// Sizes a cache and reports its activity to `observer`.
+    pub fn with_stored_block_cache_and_observer(
+        config: MetadataTableCacheConfig,
+        stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
+        observer: Option<Arc<dyn MetadataTableCacheObserver>>,
+    ) -> Self {
         Self {
             config,
             inner: Mutex::new(MetadataTableCacheInner::default()),
             stats: MetadataTableCacheStatsInner::default(),
+            observer,
             in_flight: Mutex::new(HashMap::new()),
             stored_block_cache,
         }
@@ -243,12 +276,18 @@ impl MetadataTableCache {
 
     pub(super) fn record_filter_skip(&self) {
         self.stats.filter_skips.fetch_add(1, Ordering::SeqCst);
+        if let Some(observer) = &self.observer {
+            observer.filter_skip();
+        }
     }
 
     pub(super) fn record_filter_false_positive(&self) {
         self.stats
             .filter_false_positives
             .fetch_add(1, Ordering::SeqCst);
+        if let Some(observer) = &self.observer {
+            observer.filter_false_positive();
+        }
     }
 
     pub(super) fn get(&self, key: &MetadataTableCacheKey) -> Option<DecodedMetadataTableBlock> {
@@ -261,10 +300,16 @@ impl MetadataTableCache {
             .expect("metadata table cache lock should not be poisoned");
         let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
             self.stats.misses.fetch_add(1, Ordering::SeqCst);
+            if let Some(observer) = &self.observer {
+                observer.miss();
+            }
             return None;
         };
         inner.touch(key);
         self.stats.hits.fetch_add(1, Ordering::SeqCst);
+        if let Some(observer) = &self.observer {
+            observer.hit();
+        }
         Some(block)
     }
 
@@ -291,6 +336,9 @@ impl MetadataTableCache {
         inner.decoded_byte_len = inner.decoded_byte_len.saturating_add(decoded_byte_len);
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
+        if let Some(observer) = &self.observer {
+            observer.insert();
+        }
         let MetadataTableCacheInner {
             entries,
             order,
@@ -304,6 +352,9 @@ impl MetadataTableCache {
             if let Some(slot) = entries.remove(&candidate) {
                 *decoded_byte_len = decoded_byte_len.saturating_sub(slot.block.decoded_byte_len());
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);
+                if let Some(observer) = &self.observer {
+                    observer.evict();
+                }
             }
         }
     }
@@ -363,6 +414,16 @@ pub struct WalTailProjectionCacheStats {
     pub cached_decoded_bytes: usize,
 }
 
+/// Receives WAL-tail projection cache events for runtime metrics.
+pub trait WalTailProjectionCacheObserver: Send + Sync + 'static {
+    fn hit(&self);
+    fn miss(&self);
+    fn insert(&self);
+    fn evict(&self, rows: usize, decoded_bytes: usize);
+    fn reject(&self, rows: usize, decoded_bytes: usize);
+    fn retained(&self, rows: usize, decoded_bytes: usize);
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WalTailProjectionCacheKey {
     pub namespace_id: NamespaceId,
@@ -379,19 +440,38 @@ fn projection_weight(rows: &MetadataState) -> (usize, usize) {
     (rows.row_count(), rows.decoded_bytes())
 }
 
-#[derive(Debug)]
 pub struct WalTailProjectionCache {
     config: WalTailProjectionCacheConfig,
     inner: Mutex<WalTailProjectionCacheInner>,
     stats: WalTailProjectionCacheStatsInner,
+    observer: Option<Arc<dyn WalTailProjectionCacheObserver>>,
+}
+
+impl std::fmt::Debug for WalTailProjectionCache {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WalTailProjectionCache")
+            .field("config", &self.config)
+            .field("inner", &self.inner)
+            .field("stats", &self.stats)
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug, Default)]
 struct WalTailProjectionCacheInner {
-    entries: HashMap<WalTailProjectionCacheKey, Arc<MetadataState>>,
-    order: VecDeque<WalTailProjectionCacheKey>,
+    entries: HashMap<WalTailProjectionCacheKey, WalTailProjectionCacheSlot>,
+    order: Recency<WalTailProjectionCacheKey>,
     cached_rows: usize,
     cached_decoded_bytes: usize,
+}
+
+#[derive(Debug)]
+struct WalTailProjectionCacheSlot {
+    rows: Arc<MetadataState>,
+    /// Stamp of this entry's newest queue position; older positions for the
+    /// same key are ghosts.
+    last_touch: u64,
 }
 
 #[derive(Debug, Default)]
@@ -409,10 +489,19 @@ struct WalTailProjectionCacheStatsInner {
 
 impl WalTailProjectionCache {
     pub fn new(config: WalTailProjectionCacheConfig) -> Self {
+        Self::with_observer(config, None)
+    }
+
+    /// Sizes a cache and reports its activity to `observer`.
+    pub fn with_observer(
+        config: WalTailProjectionCacheConfig,
+        observer: Option<Arc<dyn WalTailProjectionCacheObserver>>,
+    ) -> Self {
         Self {
             config,
             inner: Mutex::new(WalTailProjectionCacheInner::default()),
             stats: WalTailProjectionCacheStatsInner::default(),
+            observer,
         }
     }
 
@@ -444,12 +533,18 @@ impl WalTailProjectionCache {
             .inner
             .lock()
             .expect("wal tail projection cache lock should not be poisoned");
-        let Some(rows) = inner.entries.get(key).map(Arc::clone) else {
+        let Some(rows) = inner.entries.get(key).map(|slot| Arc::clone(&slot.rows)) else {
             self.stats.misses.fetch_add(1, Ordering::SeqCst);
+            if let Some(observer) = &self.observer {
+                observer.miss();
+            }
             return None;
         };
         inner.touch(key);
         self.stats.hits.fetch_add(1, Ordering::SeqCst);
+        if let Some(observer) = &self.observer {
+            observer.hit();
+        }
         Some(rows)
     }
 
@@ -466,6 +561,9 @@ impl WalTailProjectionCache {
             self.stats
                 .uncacheable_decoded_bytes
                 .fetch_add(decoded_bytes, Ordering::SeqCst);
+            if let Some(observer) = &self.observer {
+                observer.reject(row_count, decoded_bytes);
+            }
             return;
         }
 
@@ -473,8 +571,14 @@ impl WalTailProjectionCache {
             .inner
             .lock()
             .expect("wal tail projection cache lock should not be poisoned");
-        if let Some(previous) = inner.entries.insert(key.clone(), rows) {
-            let (previous_rows, previous_bytes) = projection_weight(&previous);
+        if let Some(previous) = inner.entries.insert(
+            key.clone(),
+            WalTailProjectionCacheSlot {
+                rows,
+                last_touch: 0,
+            },
+        ) {
+            let (previous_rows, previous_bytes) = projection_weight(&previous.rows);
             inner.cached_rows = inner.cached_rows.saturating_sub(previous_rows);
             inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(previous_bytes);
         }
@@ -482,16 +586,22 @@ impl WalTailProjectionCache {
         inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_add(decoded_bytes);
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
+        if let Some(observer) = &self.observer {
+            observer.insert();
+        }
 
         while inner.entries.len() > self.config.max_entries
             || inner.cached_rows > self.config.max_rows
             || inner.cached_decoded_bytes > self.config.max_decoded_bytes
         {
-            let Some(evicted) = inner.order.pop_front() else {
+            let WalTailProjectionCacheInner { entries, order, .. } = &mut *inner;
+            let Some(evicted) = order
+                .pop_oldest(|key, stamp| wal_tail_projection_slot_is_live(entries, key, stamp))
+            else {
                 break;
             };
-            if let Some(previous) = inner.entries.remove(&evicted) {
-                let (rows, bytes) = projection_weight(&previous);
+            if let Some(previous) = entries.remove(&evicted) {
+                let (rows, bytes) = projection_weight(&previous.rows);
                 inner.cached_rows = inner.cached_rows.saturating_sub(rows);
                 inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(bytes);
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);
@@ -499,7 +609,13 @@ impl WalTailProjectionCache {
                 self.stats
                     .evicted_decoded_bytes
                     .fetch_add(bytes, Ordering::SeqCst);
+                if let Some(observer) = &self.observer {
+                    observer.evict(rows, bytes);
+                }
             }
+        }
+        if let Some(observer) = &self.observer {
+            observer.retained(inner.cached_rows, inner.cached_decoded_bytes);
         }
     }
 
@@ -516,7 +632,7 @@ impl WalTailProjectionCache {
             .collect::<Vec<_>>();
         for key in keys {
             if let Some(previous) = inner.entries.remove(&key) {
-                let (rows, bytes) = projection_weight(&previous);
+                let (rows, bytes) = projection_weight(&previous.rows);
                 inner.cached_rows = inner.cached_rows.saturating_sub(rows);
                 inner.cached_decoded_bytes = inner.cached_decoded_bytes.saturating_sub(bytes);
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);
@@ -524,17 +640,38 @@ impl WalTailProjectionCache {
                 self.stats
                     .evicted_decoded_bytes
                     .fetch_add(bytes, Ordering::SeqCst);
+                if let Some(observer) = &self.observer {
+                    observer.evict(rows, bytes);
+                }
             }
         }
-        inner.order.retain(|key| &key.namespace_id != namespace_id);
+        if let Some(observer) = &self.observer {
+            observer.retained(inner.cached_rows, inner.cached_decoded_bytes);
+        }
     }
 }
 
 impl WalTailProjectionCacheInner {
     fn touch(&mut self, key: &WalTailProjectionCacheKey) {
-        self.order.retain(|candidate| candidate != key);
-        self.order.push_back(key.clone());
+        let stamp = self.order.touch(key);
+        if let Some(slot) = self.entries.get_mut(key) {
+            slot.last_touch = stamp;
+        }
+        let entries = &self.entries;
+        self.order.compact(entries.len(), |key, stamp| {
+            wal_tail_projection_slot_is_live(entries, key, stamp)
+        });
     }
+}
+
+fn wal_tail_projection_slot_is_live(
+    entries: &HashMap<WalTailProjectionCacheKey, WalTailProjectionCacheSlot>,
+    key: &WalTailProjectionCacheKey,
+    stamp: u64,
+) -> bool {
+    entries
+        .get(key)
+        .is_some_and(|slot| slot.last_touch == stamp)
 }
 
 #[cfg(test)]

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -50,8 +50,9 @@ pub(crate) mod tests;
 mod validate;
 
 pub use self::cache::{
-    MetadataTableCache, MetadataTableCacheConfig, MetadataTableCacheStats, WalTailProjectionCache,
-    WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+    MetadataTableCache, MetadataTableCacheConfig, MetadataTableCacheObserver,
+    MetadataTableCacheStats, WalTailProjectionCache, WalTailProjectionCacheConfig,
+    WalTailProjectionCacheKey, WalTailProjectionCacheObserver, WalTailProjectionCacheStats,
     DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_ROWS,
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -113,9 +113,10 @@ pub mod cache {
     pub use crate::checkpoint::cache::DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES;
     pub use crate::checkpoint::{
         ManifestLoadError, ManifestLoadFailureClass, MetadataTableCache, MetadataTableCacheConfig,
-        MetadataTableCacheStats, StoredMetadataBlockCache, StoredMetadataBlockCacheCloseError,
-        StoredMetadataBlockKey, StoredMetadataBlockKind, WalTailProjectionCache,
-        WalTailProjectionCacheConfig, WalTailProjectionCacheKey, WalTailProjectionCacheStats,
+        MetadataTableCacheObserver, MetadataTableCacheStats, StoredMetadataBlockCache,
+        StoredMetadataBlockCacheCloseError, StoredMetadataBlockKey, StoredMetadataBlockKind,
+        WalTailProjectionCache, WalTailProjectionCacheConfig, WalTailProjectionCacheKey,
+        WalTailProjectionCacheObserver, WalTailProjectionCacheStats,
         DEFAULT_WAL_TAIL_PROJECTION_DECODED_BYTES, DEFAULT_WAL_TAIL_PROJECTION_ROWS,
     };
     pub use crate::namespace::status::{

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -120,8 +120,8 @@ struct GrepBlockCacheInner {
 #[derive(Debug)]
 struct CacheSlot {
     block: DecodedGrepBlock,
-    /// Stamp of this entry's newest queue position; older positions for the
-    /// same key are ghosts.
+    /// Recency stamp assigned on the most recent access. Recency records with
+    /// an older stamp for this key are ignored.
     last_touch: u64,
 }
 
@@ -152,7 +152,7 @@ impl GrepBlockCache {
         }
     }
 
-    /// Creates a cache whose activity is registered with `recorder`.
+    /// Creates a cache and records its activity with `recorder`.
     pub fn with_metrics(max_decoded_bytes: usize, recorder: &dyn MetricsRecorder) -> Self {
         Self {
             max_decoded_bytes,
@@ -301,8 +301,8 @@ impl GrepBlockCacheInner {
     }
 }
 
-/// Whether a queue position still names the entry's newest access. An entry
-/// that was replaced, evicted, or re-touched leaves stale positions behind.
+/// Returns `true` when `stamp` matches the key's most recent access.
+/// Replacing, evicting, or accessing an entry can leave older recency records.
 fn slot_is_live(
     entries: &HashMap<GrepBlockCacheKey, CacheSlot>,
     key: &GrepBlockCacheKey,
@@ -342,7 +342,8 @@ impl GrepBlockCacheMetrics {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic)]
-    // A reading of the wrong kind is a bug in the test fixture.
+    // The metric helper below expects counters and panics if a test requests
+    // a metric of another type.
 
     use super::{DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind};
     use loonfs::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};

--- a/crates/loonfs-grep/src/cache.rs
+++ b/crates/loonfs-grep/src/cache.rs
@@ -2,6 +2,7 @@
 
 use crate::codec::IndexRow;
 use crate::root::GrepManifestState;
+use loonfs::metrics::{CounterHandle, MetricsRecorder};
 use loonfs::Recency;
 use loonfs_api::wire::sst_blocks::{
     DecodedDataBlock, SegmentFilter, SegmentIndexEntry, DEFAULT_TARGET_BLOCK_BYTES,
@@ -87,14 +88,26 @@ impl DecodedGrepBlock {
 }
 
 /// A process-shareable cache of immutable decoded grep blocks.
-#[derive(Debug)]
 pub struct GrepBlockCache {
     max_decoded_bytes: usize,
     inner: Mutex<GrepBlockCacheInner>,
     stats: GrepBlockCacheStatsInner,
+    metrics: Option<GrepBlockCacheMetrics>,
     /// One cell per in-flight block fetch, keyed by immutable block identity,
     /// so concurrent readers share a single object-store read per block.
     in_flight: Mutex<HashMap<GrepBlockCacheKey, Arc<OnceCell<DecodedGrepBlock>>>>,
+}
+
+impl std::fmt::Debug for GrepBlockCache {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GrepBlockCache")
+            .field("max_decoded_bytes", &self.max_decoded_bytes)
+            .field("inner", &self.inner)
+            .field("stats", &self.stats)
+            .field("in_flight", &self.in_flight)
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug, Default)]
@@ -120,6 +133,13 @@ struct GrepBlockCacheStatsInner {
     evictions: AtomicUsize,
 }
 
+struct GrepBlockCacheMetrics {
+    hits: Arc<dyn CounterHandle>,
+    misses: Arc<dyn CounterHandle>,
+    inserts: Arc<dyn CounterHandle>,
+    evictions: Arc<dyn CounterHandle>,
+}
+
 impl GrepBlockCache {
     /// Creates a cache with the supplied decoded-byte budget.
     pub fn new(max_decoded_bytes: usize) -> Self {
@@ -127,6 +147,18 @@ impl GrepBlockCache {
             max_decoded_bytes,
             inner: Mutex::new(GrepBlockCacheInner::default()),
             stats: GrepBlockCacheStatsInner::default(),
+            metrics: None,
+            in_flight: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Creates a cache whose activity is registered with `recorder`.
+    pub fn with_metrics(max_decoded_bytes: usize, recorder: &dyn MetricsRecorder) -> Self {
+        Self {
+            max_decoded_bytes,
+            inner: Mutex::new(GrepBlockCacheInner::default()),
+            stats: GrepBlockCacheStatsInner::default(),
+            metrics: Some(GrepBlockCacheMetrics::register(recorder)),
             in_flight: Mutex::new(HashMap::new()),
         }
     }
@@ -196,10 +228,16 @@ impl GrepBlockCache {
             .expect("grep block cache lock should not be poisoned");
         let Some(block) = inner.entries.get(key).map(|slot| slot.block.clone()) else {
             self.stats.misses.fetch_add(1, Ordering::SeqCst);
+            if let Some(metrics) = &self.metrics {
+                metrics.misses.increment(1);
+            }
             return None;
         };
         inner.touch(key);
         self.stats.hits.fetch_add(1, Ordering::SeqCst);
+        if let Some(metrics) = &self.metrics {
+            metrics.hits.increment(1);
+        }
         Some(block)
     }
 
@@ -226,6 +264,9 @@ impl GrepBlockCache {
         inner.decoded_byte_len = inner.decoded_byte_len.saturating_add(decoded_byte_len);
         inner.touch(&key);
         self.stats.inserts.fetch_add(1, Ordering::SeqCst);
+        if let Some(metrics) = &self.metrics {
+            metrics.inserts.increment(1);
+        }
         let GrepBlockCacheInner {
             entries,
             order,
@@ -239,6 +280,9 @@ impl GrepBlockCache {
             if let Some(slot) = entries.remove(&candidate) {
                 *decoded_byte_len = decoded_byte_len.saturating_sub(slot.block.decoded_byte_len());
                 self.stats.evictions.fetch_add(1, Ordering::SeqCst);
+                if let Some(metrics) = &self.metrics {
+                    metrics.evictions.increment(1);
+                }
             }
         }
     }
@@ -269,9 +313,39 @@ fn slot_is_live(
         .is_some_and(|slot| slot.last_touch == stamp)
 }
 
+impl GrepBlockCacheMetrics {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        let get = |result| {
+            recorder.register_counter(
+                "loonfs.grep_block_cache.gets",
+                "Decoded grep block cache lookups, by outcome",
+                &[("result", result)],
+            )
+        };
+        Self {
+            hits: get("hit"),
+            misses: get("miss"),
+            inserts: recorder.register_counter(
+                "loonfs.grep_block_cache.inserts",
+                "Blocks inserted into the decoded grep block cache",
+                &[],
+            ),
+            evictions: recorder.register_counter(
+                "loonfs.grep_block_cache.evictions",
+                "Blocks evicted from the decoded grep block cache",
+                &[],
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::panic)]
+    // A reading of the wrong kind is a bug in the test fixture.
+
     use super::{DecodedGrepBlock, GrepBlockCache, GrepBlockCacheKey, GrepBlockKind};
+    use loonfs::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};
     use loonfs_api::wire::sst_blocks::DecodedDataBlock;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -292,6 +366,53 @@ mod tests {
             block_kind: GrepBlockKind::Data,
             block_offset: 0,
         }
+    }
+
+    fn counter(snapshot: &MetricsSnapshot, name: &str, labels: &[(&str, &str)]) -> u64 {
+        let entry = snapshot
+            .by_name(name)
+            .find(|entry| entry.labels == labels)
+            .expect("grep cache counter should be registered");
+        match entry.value {
+            MetricValue::Counter(value) => value,
+            ref other => panic!("expected a counter, found {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cache_activity_reaches_the_metrics_recorder() {
+        let recorder = DefaultMetricsRecorder::new();
+        let cache = GrepBlockCache::with_metrics(1_000, &recorder);
+        cache.insert(key("a"), block(600));
+        cache.insert(key("b"), block(600));
+        assert!(cache.get(&key("a")).is_none());
+        assert!(cache.get(&key("b")).is_some());
+
+        let snapshot = recorder.snapshot();
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.grep_block_cache.gets",
+                &[("result", "hit")]
+            ),
+            1
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "loonfs.grep_block_cache.gets",
+                &[("result", "miss")]
+            ),
+            1
+        );
+        assert_eq!(
+            counter(&snapshot, "loonfs.grep_block_cache.inserts", &[]),
+            2
+        );
+        assert_eq!(
+            counter(&snapshot, "loonfs.grep_block_cache.evictions", &[]),
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/loonfs-server/src/http/metrics.rs
+++ b/crates/loonfs-server/src/http/metrics.rs
@@ -13,7 +13,6 @@ use loonfs::metrics::{
     CounterHandle, DefaultMetricsRecorder, HistogramHandle, MetricEntry, MetricValue,
     MetricsRecorder, MetricsSnapshot, LATENCY_SECONDS_BOUNDARIES,
 };
-use loonfs::RuntimeCacheStats;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -116,19 +115,12 @@ impl ServerMetrics {
     /// are read at scrape time rather than accumulated.
     pub(super) fn render(
         &self,
-        cache: &RuntimeCacheStats,
         local_cache: Option<FoyerCacheStats>,
         upload_permits: usize,
         download_permits: usize,
     ) -> String {
         let mut rendered = render_snapshot(&self.recorder.snapshot());
-        render_scrape_gauges(
-            &mut rendered,
-            cache,
-            local_cache,
-            upload_permits,
-            download_permits,
-        );
+        render_scrape_gauges(&mut rendered, local_cache, upload_permits, download_permits);
         rendered
     }
 
@@ -310,20 +302,15 @@ fn write_entry(rendered: &mut String, name: &str, entry: &MetricEntry) {
     }
 }
 
-/// Appends the values that are read when a scrape asks rather than
-/// accumulated as work happens: the runtime's cache counters, what foyer
-/// says about the local block cache, Linux process RSS, and the transfer
-/// slots this server has free.
+/// Appends values that are read when a scrape asks rather than accumulated:
+/// what foyer says about the local block cache, Linux process RSS, and the
+/// transfer slots this server has free.
 fn render_scrape_gauges(
     rendered: &mut String,
-    cache: &RuntimeCacheStats,
     local_cache: Option<FoyerCacheStats>,
     upload_permits: usize,
     download_permits: usize,
 ) {
-    for (name, description, value) in cache_gauges(cache) {
-        write_gauge(rendered, name, description, value);
-    }
     // Absent when this deployment keeps no local cache, so a scrape reports
     // nothing about a tier that does not exist rather than reporting zeros
     // that read like an idle one.
@@ -388,9 +375,8 @@ fn process_resident_bytes() -> Option<u64> {
 /// misses, and inserts are reported through the runtime's recorder like
 /// every other instrument and are already in the snapshot above.
 ///
-/// Destructured without a rest pattern for the same reason the runtime
-/// counters are: a field added to [`FoyerCacheStats`] and not exported here
-/// fails to compile.
+/// Destructured without a rest pattern so a field added to [`FoyerCacheStats`]
+/// and not exported here fails to compile.
 fn local_cache_gauges(stats: &FoyerCacheStats) -> [(&'static str, &'static str, u64); 6] {
     let FoyerCacheStats {
         memory_bytes,
@@ -430,125 +416,6 @@ fn local_cache_gauges(stats: &FoyerCacheStats) -> [(&'static str, &'static str, 
             "loonfs_local_cache_queue_channel_overflows",
             "Inserts the local block cache dropped with a full submit queue",
             queue_channel_overflows,
-        ),
-    ]
-}
-
-/// The runtime cache counters, named as their fields are.
-///
-/// Destructured without a rest pattern on purpose: a counter added to
-/// [`RuntimeCacheStats`] and not exported here fails to compile.
-fn cache_gauges(stats: &RuntimeCacheStats) -> [(&'static str, &'static str, usize); 18] {
-    let RuntimeCacheStats {
-        latest_metadata_view_reads,
-        wal_tail_projection_cache_hits,
-        wal_tail_projection_cache_misses,
-        wal_tail_projection_cache_inserts,
-        wal_tail_projection_cache_evictions,
-        wal_tail_projection_cache_evicted_rows,
-        wal_tail_projection_cache_evicted_decoded_bytes,
-        wal_tail_projection_cache_uncacheable_count,
-        wal_tail_projection_cache_uncacheable_rows,
-        wal_tail_projection_cache_uncacheable_decoded_bytes,
-        wal_tail_projection_cache_cached_rows,
-        wal_tail_projection_cache_cached_decoded_bytes,
-        metadata_table_cache_hits,
-        metadata_table_cache_misses,
-        metadata_table_cache_inserts,
-        metadata_table_cache_evictions,
-        metadata_table_cache_filter_skips,
-        metadata_table_cache_filter_false_positives,
-    } = *stats;
-    [
-        (
-            "loonfs_cache_latest_metadata_view_reads",
-            "Runtime cache counter `latest_metadata_view_reads`",
-            latest_metadata_view_reads,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_hits",
-            "Runtime cache counter `wal_tail_projection_cache_hits`",
-            wal_tail_projection_cache_hits,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_misses",
-            "Runtime cache counter `wal_tail_projection_cache_misses`",
-            wal_tail_projection_cache_misses,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_inserts",
-            "Runtime cache counter `wal_tail_projection_cache_inserts`",
-            wal_tail_projection_cache_inserts,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_evictions",
-            "Runtime cache counter `wal_tail_projection_cache_evictions`",
-            wal_tail_projection_cache_evictions,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_evicted_rows",
-            "Runtime cache counter `wal_tail_projection_cache_evicted_rows`",
-            wal_tail_projection_cache_evicted_rows,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_evicted_decoded_bytes",
-            "Runtime cache counter `wal_tail_projection_cache_evicted_decoded_bytes`",
-            wal_tail_projection_cache_evicted_decoded_bytes,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_uncacheable_count",
-            "Runtime cache counter `wal_tail_projection_cache_uncacheable_count`",
-            wal_tail_projection_cache_uncacheable_count,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_uncacheable_rows",
-            "Runtime cache counter `wal_tail_projection_cache_uncacheable_rows`",
-            wal_tail_projection_cache_uncacheable_rows,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_uncacheable_decoded_bytes",
-            "Runtime cache counter `wal_tail_projection_cache_uncacheable_decoded_bytes`",
-            wal_tail_projection_cache_uncacheable_decoded_bytes,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_cached_rows",
-            "Runtime cache counter `wal_tail_projection_cache_cached_rows`",
-            wal_tail_projection_cache_cached_rows,
-        ),
-        (
-            "loonfs_cache_wal_tail_projection_cache_cached_decoded_bytes",
-            "Runtime cache counter `wal_tail_projection_cache_cached_decoded_bytes`",
-            wal_tail_projection_cache_cached_decoded_bytes,
-        ),
-        (
-            "loonfs_cache_metadata_table_cache_hits",
-            "Runtime cache counter `metadata_table_cache_hits`",
-            metadata_table_cache_hits,
-        ),
-        (
-            "loonfs_cache_metadata_table_cache_misses",
-            "Runtime cache counter `metadata_table_cache_misses`",
-            metadata_table_cache_misses,
-        ),
-        (
-            "loonfs_cache_metadata_table_cache_inserts",
-            "Runtime cache counter `metadata_table_cache_inserts`",
-            metadata_table_cache_inserts,
-        ),
-        (
-            "loonfs_cache_metadata_table_cache_evictions",
-            "Runtime cache counter `metadata_table_cache_evictions`",
-            metadata_table_cache_evictions,
-        ),
-        (
-            "loonfs_cache_metadata_table_cache_filter_skips",
-            "Runtime cache counter `metadata_table_cache_filter_skips`",
-            metadata_table_cache_filter_skips,
-        ),
-        (
-            "loonfs_cache_metadata_table_cache_filter_false_positives",
-            "Runtime cache counter `metadata_table_cache_filter_false_positives`",
-            metadata_table_cache_filter_false_positives,
         ),
     ]
 }

--- a/crates/loonfs-server/src/http/metrics.rs
+++ b/crates/loonfs-server/src/http/metrics.rs
@@ -302,18 +302,16 @@ fn write_entry(rendered: &mut String, name: &str, entry: &MetricEntry) {
     }
 }
 
-/// Appends values that are read when a scrape asks rather than accumulated:
-/// what foyer says about the local block cache, Linux process RSS, and the
-/// transfer slots this server has free.
+/// Appends current gauge values sampled during a scrape: local cache state,
+/// Linux process RSS, and available transfer slots.
 fn render_scrape_gauges(
     rendered: &mut String,
     local_cache: Option<FoyerCacheStats>,
     upload_permits: usize,
     download_permits: usize,
 ) {
-    // Absent when this deployment keeps no local cache, so a scrape reports
-    // nothing about a tier that does not exist rather than reporting zeros
-    // that read like an idle one.
+    // Omit local-cache metrics when this server has no local cache. Reporting
+    // zeros would incorrectly suggest that an enabled cache is idle.
     if let Some(local_cache) = local_cache {
         for (name, description, value) in local_cache_gauges(&local_cache) {
             write_gauge(rendered, name, description, value);
@@ -369,14 +367,14 @@ fn process_resident_bytes() -> Option<u64> {
     None
 }
 
-/// What foyer says about the local block cache, as gauges.
+/// Converts the current Foyer local-cache statistics into gauges.
 ///
 /// These are foyer's own numbers, read at scrape time; the cache's hits,
 /// misses, and inserts are reported through the runtime's recorder like
 /// every other instrument and are already in the snapshot above.
 ///
-/// Destructured without a rest pattern so a field added to [`FoyerCacheStats`]
-/// and not exported here fails to compile.
+/// Listing every field makes this code fail to compile when `FoyerCacheStats`
+/// gains a field, which ensures new statistics are considered for export.
 fn local_cache_gauges(stats: &FoyerCacheStats) -> [(&'static str, &'static str, u64); 6] {
     let FoyerCacheStats {
         memory_bytes,

--- a/crates/loonfs-server/src/http/metrics/tests.rs
+++ b/crates/loonfs-server/src/http/metrics/tests.rs
@@ -134,15 +134,10 @@ fn rendering_the_same_readings_twice_produces_the_same_bytes() {
 }
 
 #[test]
-fn scrape_time_gauges_carry_every_runtime_cache_counter() {
+fn scrape_time_gauges_carry_permit_levels() {
     let mut rendered = String::new();
-    let cache = RuntimeCacheStats {
-        metadata_table_cache_hits: 12,
-        ..RuntimeCacheStats::default()
-    };
-    render_scrape_gauges(&mut rendered, &cache, None, 4, 2);
+    render_scrape_gauges(&mut rendered, None, 4, 2);
 
-    assert!(rendered.contains("loonfs_cache_metadata_table_cache_hits 12\n"));
     assert!(rendered.contains("loonfs_server_upload_permits_available 4\n"));
     assert!(rendered.contains("loonfs_server_download_permits_available 2\n"));
     assert_eq!(
@@ -150,8 +145,8 @@ fn scrape_time_gauges_carry_every_runtime_cache_counter() {
             .lines()
             .filter(|line| line.starts_with("# TYPE"))
             .count(),
-        if cfg!(target_os = "linux") { 21 } else { 20 },
-        "eighteen cache counters, the two permit pools, and Linux RSS where available"
+        if cfg!(target_os = "linux") { 3 } else { 2 },
+        "the two permit pools and Linux RSS where available"
     );
 }
 
@@ -159,7 +154,7 @@ fn scrape_time_gauges_carry_every_runtime_cache_counter() {
 #[test]
 fn a_scrape_reports_positive_process_resident_bytes() {
     let mut rendered = String::new();
-    render_scrape_gauges(&mut rendered, &RuntimeCacheStats::default(), None, 0, 0);
+    render_scrape_gauges(&mut rendered, None, 0, 0);
 
     let resident_bytes = rendered
         .lines()

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -435,10 +435,9 @@ async fn serve_metrics(
     headers: HeaderMap,
 ) -> Result<Response, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    // Read at scrape time rather than accumulated: these are levels, and a
-    // level is only true when it is asked for.
+    // Read the host-owned levels at scrape time. Cache activity is already
+    // accumulated by the recorder and included in its snapshot.
     let rendered = state.metrics.render(
-        &state.writer.runtime_cache_stats(),
         state
             .local_cache
             .as_ref()

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -435,8 +435,8 @@ async fn serve_metrics(
     headers: HeaderMap,
 ) -> Result<Response, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    // Read the host-owned levels at scrape time. Cache activity is already
-    // accumulated by the recorder and included in its snapshot.
+    // Sample server state here because these values can change between
+    // scrapes. Cache activity is already included in the recorder snapshot.
     let rendered = state.metrics.render(
         state
             .local_cache

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -185,7 +185,10 @@ pub(super) async fn app_with_store_and_direct_transfers(
     )
     .await?;
     let probe_store = writer.object_store();
-    let grep_block_cache = Arc::new(GrepBlockCache::new(DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES));
+    let grep_block_cache = Arc::new(GrepBlockCache::with_metrics(
+        DEFAULT_GREP_BLOCK_CACHE_DECODED_BYTES,
+        metrics.recorder().as_ref(),
+    ));
     // A deployment that maintains the index needs a worker whether or not it
     // answers queries with one. It runs on the writer's own instrumented
     // client, so the grep-owned traffic is measured like every other

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -551,10 +551,55 @@ async fn a_server_without_the_table_builds_no_local_cache() {
         .await
         .expect("build app");
     assert!(state.local_cache.is_none());
-    let rendered = state
-        .metrics
-        .render(&state.writer.runtime_cache_stats(), None, 0, 0);
+    let rendered = state.metrics.render(None, 0, 0);
     assert!(!rendered.contains("loonfs_local_cache_"));
+}
+
+#[tokio::test]
+async fn runtime_and_grep_cache_metrics_render_from_the_recorder() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
+    let config = test_config(temp_dir.path(), "cache-metrics-writer");
+
+    let (_router, state) = app_with_store_and_state(config, store)
+        .await
+        .expect("build app");
+    let rendered = state.metrics.render(None, 0, 0);
+
+    for name in [
+        "loonfs_runtime_cache_latest_metadata_view_reads_total",
+        "loonfs_metadata_table_cache_gets_total",
+        "loonfs_metadata_table_cache_inserts_total",
+        "loonfs_metadata_table_cache_evictions_total",
+        "loonfs_metadata_table_cache_filter_skips_total",
+        "loonfs_metadata_table_cache_filter_false_positives_total",
+        "loonfs_wal_tail_projection_cache_gets_total",
+        "loonfs_wal_tail_projection_cache_inserts_total",
+        "loonfs_wal_tail_projection_cache_evictions_total",
+        "loonfs_wal_tail_projection_cache_evicted_rows_total",
+        "loonfs_wal_tail_projection_cache_evicted_decoded_bytes_total",
+        "loonfs_wal_tail_projection_cache_rejections_total",
+        "loonfs_wal_tail_projection_cache_rejected_rows_total",
+        "loonfs_wal_tail_projection_cache_rejected_decoded_bytes_total",
+        "loonfs_grep_block_cache_gets_total",
+        "loonfs_grep_block_cache_inserts_total",
+        "loonfs_grep_block_cache_evictions_total",
+    ] {
+        assert!(
+            rendered.contains(&format!("# TYPE {name} counter\n")),
+            "missing counter `{name}`"
+        );
+    }
+    for name in [
+        "loonfs_wal_tail_projection_cache_retained_rows",
+        "loonfs_wal_tail_projection_cache_retained_decoded_bytes",
+    ] {
+        assert!(
+            rendered.contains(&format!("# TYPE {name} gauge\n")),
+            "missing gauge `{name}`"
+        );
+    }
+    assert!(!rendered.contains("loonfs_cache_metadata_table_cache_hits"));
 }
 
 /// A configured cache is built at startup and reports itself on every
@@ -571,12 +616,7 @@ async fn a_configured_local_cache_is_built_and_scraped() {
         .await
         .expect("build app");
     let local_cache = state.local_cache.clone().expect("a local cache");
-    let rendered = state.metrics.render(
-        &state.writer.runtime_cache_stats(),
-        Some(local_cache.foyer_stats()),
-        0,
-        0,
-    );
+    let rendered = state.metrics.render(Some(local_cache.foyer_stats()), 0, 0);
     assert!(rendered.contains("loonfs_local_cache_memory_capacity_bytes 4194304\n"));
     assert!(rendered.contains("loonfs_local_cache_disk_capacity_bytes 134217728\n"));
     assert!(rendered.contains("loonfs_local_cache_queue_buffer_overflows 0\n"));
@@ -2174,7 +2214,7 @@ async fn http_uploads_answer_server_busy_at_the_concurrency_cap() {
     // needs to know it is happening, not only that some clients saw 503.
     assert!(state
         .metrics
-        .render(&state.writer.runtime_cache_stats(), None, 0, 0)
+        .render(None, 0, 0)
         .contains("loonfs_server_busy_rejections_total{kind=\"upload\"} 1\n"));
 
     drop(held);
@@ -2289,7 +2329,7 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
     );
     assert!(state
         .metrics
-        .render(&state.writer.runtime_cache_stats(), None, 0, 0)
+        .render(None, 0, 0)
         .contains("loonfs_server_busy_rejections_total{kind=\"download\"} 1\n"));
 
     drop(held);

--- a/crates/loonfs-server/tests/it/http_metrics.rs
+++ b/crates/loonfs-server/tests/it/http_metrics.rs
@@ -42,7 +42,7 @@ async fn scraping_metrics_without_a_token_is_unauthorized() {
 /// served, the object-store calls they made, and the runtime caches those
 /// reads warmed.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_scrape_reports_requests_object_store_calls_and_cache_levels() {
+async fn a_scrape_reports_requests_object_store_calls_and_cache_metrics() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -96,7 +96,7 @@ async fn a_scrape_reports_requests_object_store_calls_and_cache_levels() {
         ) >= 1.0
     );
 
-    // The object-store bridge and the scrape-time cache gauges.
+    // Object-store and cache activity both arrive through the recorder.
     assert!(
         series(
             &first,
@@ -109,8 +109,10 @@ async fn a_scrape_reports_requests_object_store_calls_and_cache_levels() {
             "loonfs_object_store_bytes_in_total{operation=\"put\"}"
         ) > 0.0
     );
-    assert!(first.contains_key("loonfs_cache_metadata_table_cache_hits"));
-    assert!(first.contains_key("loonfs_cache_latest_metadata_view_reads"));
+    assert!(first.contains_key("loonfs_metadata_table_cache_gets_total{result=\"hit\"}"));
+    assert!(first.contains_key("loonfs_runtime_cache_latest_metadata_view_reads_total"));
+    assert!(first.contains_key("loonfs_grep_block_cache_gets_total{result=\"hit\"}"));
+    assert!(first.contains_key("loonfs_wal_tail_projection_cache_retained_rows"));
     assert_eq!(
         series(&first, "loonfs_server_upload_permits_available"),
         8.0,

--- a/crates/loonfs-server/tests/it/http_metrics.rs
+++ b/crates/loonfs-server/tests/it/http_metrics.rs
@@ -96,7 +96,7 @@ async fn a_scrape_reports_requests_object_store_calls_and_cache_metrics() {
         ) >= 1.0
     );
 
-    // Object-store and cache activity both arrive through the recorder.
+    // The recorder includes both object-store and cache activity.
     assert!(
         series(
             &first,

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -1,5 +1,5 @@
-//! Runtime caching: control-object reads and WAL-tail projections, plus the
-//! cache-management half of [`ReadCore`].
+//! Runtime caches for control-object reads and WAL-tail projections.
+//! This module also defines the cache-management methods on [`ReadCore`].
 //!
 //! Every cache revalidates against durable state before its contents are
 //! used; nothing here weakens read-after-write consistency.
@@ -29,8 +29,8 @@ pub(crate) struct RuntimeControlCache {
 #[derive(Debug, Default)]
 struct NamespaceControlCacheEntry {
     head: Option<CachedNamespaceAnchor>,
-    /// Stamp of this entry's newest queue position; older positions for the
-    /// same namespace are ghosts.
+    /// Recency stamp assigned on the most recent access. Recency records with
+    /// an older stamp for this namespace are ignored.
     last_touch: u64,
 }
 
@@ -40,10 +40,10 @@ pub(crate) struct CachedControl<T> {
     pub(crate) state: T,
 }
 
-/// Head snapshot pinned together with the metadata basis it authorized when
-/// the snapshot was taken. The pair stays consistent even when compaction
-/// moves the live root past this head; reads at the pin replay a little
-/// more WAL until the cache refreshes.
+/// A head snapshot and the metadata basis it authorized at that point.
+/// Keeping them together ensures reads use a consistent pair. If compaction
+/// advances the live root, reads may replay additional WAL entries until the
+/// cache refreshes.
 #[derive(Debug, Clone)]
 pub(crate) struct CachedNamespaceAnchor {
     pub(crate) head: CachedControl<HeadState>,
@@ -173,7 +173,7 @@ impl RuntimeControlCache {
         }
     }
 
-    /// Namespace-terminal removal: the whole entry goes.
+    /// Removes all cached control state for a deleted namespace.
     fn remove_namespace(&mut self, namespace_id: &NamespaceId) {
         self.namespaces.remove(namespace_id);
     }

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -5,7 +5,8 @@
 //! used; nothing here weakens read-after-write consistency.
 
 use crate::fs::{should_invalidate_after_result, ReadCore};
-use crate::{CommitResponse, CoreError, NamespaceId, RuntimeCacheConfig};
+use crate::metrics::RuntimeInstruments;
+use crate::{CommitResponse, CoreError, NamespaceId, Recency, RuntimeCacheConfig};
 use crate::{Result, RuntimeError};
 use loonfs_api::wire::control::HeadState;
 use loonfs_core::cache::{MetadataTableCacheStats, WalTailProjectionCacheStats};
@@ -15,19 +16,22 @@ use loonfs_core::control::{
 };
 use loonfs_core::{MetadataProjectionLoadError, RuntimeReadContext, StoreFailureClass};
 use loonfs_objectstore::keys::wal_head;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 #[derive(Debug, Default)]
 pub(crate) struct RuntimeControlCache {
     namespaces: HashMap<NamespaceId, NamespaceControlCacheEntry>,
-    namespace_order: VecDeque<NamespaceId>,
+    namespace_order: Recency<NamespaceId>,
 }
 
 #[derive(Debug, Default)]
 struct NamespaceControlCacheEntry {
     head: Option<CachedNamespaceAnchor>,
+    /// Stamp of this entry's newest queue position; older positions for the
+    /// same namespace are ghosts.
+    last_touch: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -90,12 +94,19 @@ pub struct RuntimeCacheStats {
     pub metadata_table_cache_filter_false_positives: usize,
 }
 
-#[derive(Debug, Default)]
 pub(crate) struct RuntimeCacheStatsInner {
     latest_metadata_view_reads: AtomicUsize,
+    instruments: Arc<RuntimeInstruments>,
 }
 
 impl RuntimeCacheStatsInner {
+    pub(crate) fn new(instruments: Arc<RuntimeInstruments>) -> Self {
+        Self {
+            latest_metadata_view_reads: AtomicUsize::new(0),
+            instruments,
+        }
+    }
+
     pub(crate) fn snapshot(
         &self,
         metadata_table_cache: MetadataTableCacheStats,
@@ -131,6 +142,7 @@ impl RuntimeCacheStatsInner {
     pub(crate) fn record_latest_metadata_view_read(&self) {
         self.latest_metadata_view_reads
             .fetch_add(1, Ordering::SeqCst);
+        self.instruments.latest_metadata_view_read();
     }
 }
 
@@ -164,8 +176,6 @@ impl RuntimeControlCache {
     /// Namespace-terminal removal: the whole entry goes.
     fn remove_namespace(&mut self, namespace_id: &NamespaceId) {
         self.namespaces.remove(namespace_id);
-        self.namespace_order
-            .retain(|candidate| candidate != namespace_id);
     }
 
     fn namespace_entry(
@@ -175,22 +185,44 @@ impl RuntimeControlCache {
     ) -> &mut NamespaceControlCacheEntry {
         self.namespaces.entry(namespace_id.clone()).or_default();
         self.touch_namespace(namespace_id);
-        while self.namespaces.len() > max_cached_namespaces {
-            let Some(evicted) = self.namespace_order.pop_front() else {
+        let Self {
+            namespaces,
+            namespace_order,
+        } = self;
+        while namespaces.len() > max_cached_namespaces {
+            let Some(evicted) = namespace_order
+                .pop_oldest(|key, stamp| namespace_slot_is_live(namespaces, key, stamp))
+            else {
                 break;
             };
-            self.namespaces.remove(&evicted);
+            namespaces.remove(&evicted);
         }
-        self.namespaces
+        namespaces
             .get_mut(namespace_id)
             .expect("namespace cache entry should exist")
     }
 
     fn touch_namespace(&mut self, namespace_id: &NamespaceId) {
+        let stamp = self.namespace_order.touch(namespace_id);
+        if let Some(entry) = self.namespaces.get_mut(namespace_id) {
+            entry.last_touch = stamp;
+        }
+        let namespaces = &self.namespaces;
         self.namespace_order
-            .retain(|candidate| candidate != namespace_id);
-        self.namespace_order.push_back(namespace_id.clone());
+            .compact(namespaces.len(), |key, stamp| {
+                namespace_slot_is_live(namespaces, key, stamp)
+            });
     }
+}
+
+fn namespace_slot_is_live(
+    namespaces: &HashMap<NamespaceId, NamespaceControlCacheEntry>,
+    namespace_id: &NamespaceId,
+    stamp: u64,
+) -> bool {
+    namespaces
+        .get(namespace_id)
+        .is_some_and(|entry| entry.last_touch == stamp)
 }
 
 impl ReadCore {

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -128,19 +128,22 @@ impl ReadCore {
         instruments: Arc<RuntimeInstruments>,
     ) -> Self {
         let metadata_table_cache = shared_metadata_table_cache.unwrap_or_else(|| {
-            Arc::new(MetadataTableCache::with_stored_block_cache(
+            Arc::new(MetadataTableCache::with_stored_block_cache_and_observer(
                 config.runtime_cache.metadata_table_cache.clone(),
                 stored_metadata_block_cache,
+                instruments.metadata_table_cache_observer(),
             ))
         });
-        let wal_tail_projection_cache =
-            Arc::new(WalTailProjectionCache::new(WalTailProjectionCacheConfig {
+        let wal_tail_projection_cache = Arc::new(WalTailProjectionCache::with_observer(
+            WalTailProjectionCacheConfig {
                 max_entries: config.runtime_cache.max_cached_namespaces,
                 max_rows: config.runtime_cache.max_cached_wal_tail_projection_rows,
                 max_decoded_bytes: config
                     .runtime_cache
                     .max_cached_wal_tail_projection_decoded_bytes,
-            }));
+            },
+            instruments.wal_tail_projection_cache_observer(),
+        ));
         Self {
             inner: Arc::new(ReadCoreInner {
                 store,
@@ -148,7 +151,7 @@ impl ReadCore {
                 control_cache: Mutex::new(RuntimeControlCache::default()),
                 metadata_table_cache,
                 wal_tail_projection_cache,
-                cache_stats: RuntimeCacheStatsInner::default(),
+                cache_stats: RuntimeCacheStatsInner::new(Arc::clone(&instruments)),
                 instruments,
             }),
         }

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -22,6 +22,7 @@ use crate::metrics::LATENCY_SECONDS_BOUNDARIES;
 use crate::{
     GcResponse, MaintenanceJobId, MaintenanceStepConclusion, MetadataCompactionJobOutcome,
 };
+use loonfs_core::cache::{MetadataTableCacheObserver, WalTailProjectionCacheObserver};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -100,6 +101,7 @@ struct Installed {
     compactions: CompactionInstruments,
     publisher: PublisherInstruments,
     gc: GcInstruments,
+    cache: RuntimeCacheInstruments,
 }
 
 impl RuntimeInstruments {
@@ -111,11 +113,35 @@ impl RuntimeInstruments {
                 compactions: CompactionInstruments::register(recorder.as_ref()),
                 publisher: PublisherInstruments::register(recorder.as_ref()),
                 gc: GcInstruments::register(recorder.as_ref()),
+                cache: RuntimeCacheInstruments::register(recorder.as_ref()),
                 object_store: Mutex::new(HashMap::new()),
                 maintenance: Mutex::new(HashMap::new()),
                 recorder,
             }),
         })
+    }
+
+    /// Reports one latest-view read through the runtime cache path.
+    pub(crate) fn latest_metadata_view_read(&self) {
+        if let Some(installed) = &self.installed {
+            installed.cache.latest_metadata_view_reads.increment(1);
+        }
+    }
+
+    /// The decoded metadata-table cache's metrics observer, when installed.
+    pub(crate) fn metadata_table_cache_observer(
+        &self,
+    ) -> Option<Arc<dyn MetadataTableCacheObserver>> {
+        let observer = Arc::clone(&self.installed.as_ref()?.cache.metadata_table);
+        Some(observer)
+    }
+
+    /// The WAL-tail projection cache's metrics observer, when installed.
+    pub(crate) fn wal_tail_projection_cache_observer(
+        &self,
+    ) -> Option<Arc<dyn WalTailProjectionCacheObserver>> {
+        let observer = Arc::clone(&self.installed.as_ref()?.cache.wal_tail_projection);
+        Some(observer)
     }
 
     /// An object-store recorder that bridges samples into these
@@ -540,6 +566,214 @@ impl MaintenanceJobInstruments {
     }
 }
 
+/// Runtime-owned cache instruments, registered as one closed set.
+struct RuntimeCacheInstruments {
+    latest_metadata_view_reads: Arc<dyn CounterHandle>,
+    metadata_table: Arc<MetadataTableCacheInstruments>,
+    wal_tail_projection: Arc<WalTailProjectionCacheInstruments>,
+}
+
+struct MetadataTableCacheInstruments {
+    hits: Arc<dyn CounterHandle>,
+    misses: Arc<dyn CounterHandle>,
+    inserts: Arc<dyn CounterHandle>,
+    evictions: Arc<dyn CounterHandle>,
+    filter_skips: Arc<dyn CounterHandle>,
+    filter_false_positives: Arc<dyn CounterHandle>,
+}
+
+struct WalTailProjectionCacheInstruments {
+    hits: Arc<dyn CounterHandle>,
+    misses: Arc<dyn CounterHandle>,
+    inserts: Arc<dyn CounterHandle>,
+    evictions: Arc<dyn CounterHandle>,
+    evicted_rows: Arc<dyn CounterHandle>,
+    evicted_decoded_bytes: Arc<dyn CounterHandle>,
+    rejections: Arc<dyn CounterHandle>,
+    rejected_rows: Arc<dyn CounterHandle>,
+    rejected_decoded_bytes: Arc<dyn CounterHandle>,
+    retained_rows: Arc<dyn GaugeHandle>,
+    retained_decoded_bytes: Arc<dyn GaugeHandle>,
+}
+
+impl RuntimeCacheInstruments {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        Self {
+            latest_metadata_view_reads: recorder.register_counter(
+                "loonfs.runtime_cache.latest_metadata_view_reads",
+                "Latest metadata reads served through the metadata-view path",
+                &[],
+            ),
+            metadata_table: Arc::new(MetadataTableCacheInstruments::register(recorder)),
+            wal_tail_projection: Arc::new(WalTailProjectionCacheInstruments::register(recorder)),
+        }
+    }
+}
+
+impl MetadataTableCacheInstruments {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        let get = |result| {
+            recorder.register_counter(
+                "loonfs.metadata_table_cache.gets",
+                "Decoded metadata-table cache lookups, by outcome",
+                &[("result", result)],
+            )
+        };
+        Self {
+            hits: get("hit"),
+            misses: get("miss"),
+            inserts: recorder.register_counter(
+                "loonfs.metadata_table_cache.inserts",
+                "Blocks inserted into the decoded metadata-table cache",
+                &[],
+            ),
+            evictions: recorder.register_counter(
+                "loonfs.metadata_table_cache.evictions",
+                "Blocks evicted from the decoded metadata-table cache",
+                &[],
+            ),
+            filter_skips: recorder.register_counter(
+                "loonfs.metadata_table_cache.filter_skips",
+                "Segments skipped after their filter ruled out a lookup",
+                &[],
+            ),
+            filter_false_positives: recorder.register_counter(
+                "loonfs.metadata_table_cache.filter_false_positives",
+                "Filter admissions that matched no metadata rows",
+                &[],
+            ),
+        }
+    }
+}
+
+impl MetadataTableCacheObserver for MetadataTableCacheInstruments {
+    fn hit(&self) {
+        self.hits.increment(1);
+    }
+
+    fn miss(&self) {
+        self.misses.increment(1);
+    }
+
+    fn insert(&self) {
+        self.inserts.increment(1);
+    }
+
+    fn evict(&self) {
+        self.evictions.increment(1);
+    }
+
+    fn filter_skip(&self) {
+        self.filter_skips.increment(1);
+    }
+
+    fn filter_false_positive(&self) {
+        self.filter_false_positives.increment(1);
+    }
+}
+
+impl WalTailProjectionCacheInstruments {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        let get = |result| {
+            recorder.register_counter(
+                "loonfs.wal_tail_projection_cache.gets",
+                "WAL-tail projection cache lookups, by outcome",
+                &[("result", result)],
+            )
+        };
+        Self {
+            hits: get("hit"),
+            misses: get("miss"),
+            inserts: recorder.register_counter(
+                "loonfs.wal_tail_projection_cache.inserts",
+                "WAL-tail projections inserted into the cache",
+                &[],
+            ),
+            evictions: recorder.register_counter(
+                "loonfs.wal_tail_projection_cache.evictions",
+                "WAL-tail projections evicted or invalidated",
+                &[],
+            ),
+            evicted_rows: recorder.register_counter(
+                "loonfs.wal_tail_projection_cache.evicted_rows",
+                "Metadata rows dropped with evicted WAL-tail projections",
+                &[],
+            ),
+            evicted_decoded_bytes: recorder.register_counter(
+                "loonfs.wal_tail_projection_cache.evicted_decoded_bytes",
+                "Decoded bytes dropped with evicted WAL-tail projections",
+                &[],
+            ),
+            rejections: recorder.register_counter(
+                "loonfs.wal_tail_projection_cache.rejections",
+                "WAL-tail projections rejected because they exceeded a cache limit",
+                &[],
+            ),
+            rejected_rows: recorder.register_counter(
+                "loonfs.wal_tail_projection_cache.rejected_rows",
+                "Metadata rows in rejected WAL-tail projections",
+                &[],
+            ),
+            rejected_decoded_bytes: recorder.register_counter(
+                "loonfs.wal_tail_projection_cache.rejected_decoded_bytes",
+                "Decoded bytes in rejected WAL-tail projections",
+                &[],
+            ),
+            retained_rows: recorder.register_gauge(
+                "loonfs.wal_tail_projection_cache.retained_rows",
+                "Metadata rows currently retained in WAL-tail projections",
+                &[],
+            ),
+            retained_decoded_bytes: recorder.register_gauge(
+                "loonfs.wal_tail_projection_cache.retained_decoded_bytes",
+                "Decoded bytes currently retained in WAL-tail projections",
+                &[],
+            ),
+        }
+    }
+}
+
+impl WalTailProjectionCacheObserver for WalTailProjectionCacheInstruments {
+    fn hit(&self) {
+        self.hits.increment(1);
+    }
+
+    fn miss(&self) {
+        self.misses.increment(1);
+    }
+
+    fn insert(&self) {
+        self.inserts.increment(1);
+    }
+
+    fn evict(&self, rows: usize, decoded_bytes: usize) {
+        self.evictions.increment(1);
+        self.evicted_rows.increment(metric_count(rows));
+        self.evicted_decoded_bytes
+            .increment(metric_count(decoded_bytes));
+    }
+
+    fn reject(&self, rows: usize, decoded_bytes: usize) {
+        self.rejections.increment(1);
+        self.rejected_rows.increment(metric_count(rows));
+        self.rejected_decoded_bytes
+            .increment(metric_count(decoded_bytes));
+    }
+
+    fn retained(&self, rows: usize, decoded_bytes: usize) {
+        self.retained_rows.set(metric_level(rows));
+        self.retained_decoded_bytes.set(metric_level(decoded_bytes));
+    }
+}
+
+fn metric_count(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn metric_level(value: usize) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
 /// The gauges and durable totals for this process's streaming compactions.
 struct CompactionInstruments {
     running: Arc<dyn GaugeHandle>,
@@ -772,6 +1006,113 @@ mod tests {
             MetricValue::Counter(value) => value,
             ref other => panic!("expected a counter, found {other:?}"),
         }
+    }
+
+    fn gauge(snapshot: &MetricsSnapshot, name: &str) -> i64 {
+        let entry = snapshot
+            .by_name(name)
+            .next()
+            .unwrap_or_else(|| panic!("no `{name}` registered"));
+        match entry.value {
+            MetricValue::Gauge(value) => value,
+            ref other => panic!("expected a gauge, found {other:?}"),
+        }
+    }
+
+    #[test]
+    fn runtime_cache_events_reach_the_registered_instruments() {
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let instruments = RuntimeInstruments::new(Some(recorder.clone()));
+        instruments.latest_metadata_view_read();
+
+        let metadata = instruments
+            .metadata_table_cache_observer()
+            .expect("metadata observer");
+        metadata.hit();
+        metadata.miss();
+        metadata.insert();
+        metadata.evict();
+        metadata.filter_skip();
+        metadata.filter_false_positive();
+
+        let wal = instruments
+            .wal_tail_projection_cache_observer()
+            .expect("WAL-tail observer");
+        wal.hit();
+        wal.miss();
+        wal.insert();
+        wal.evict(7, 70);
+        wal.reject(11, 110);
+        wal.retained(13, 130);
+
+        let snapshot = recorder.snapshot();
+        for (name, labels, value) in [
+            (
+                "loonfs.runtime_cache.latest_metadata_view_reads",
+                &[][..],
+                1,
+            ),
+            (
+                "loonfs.metadata_table_cache.gets",
+                &[("result", "hit")][..],
+                1,
+            ),
+            (
+                "loonfs.metadata_table_cache.gets",
+                &[("result", "miss")][..],
+                1,
+            ),
+            ("loonfs.metadata_table_cache.inserts", &[][..], 1),
+            ("loonfs.metadata_table_cache.evictions", &[][..], 1),
+            ("loonfs.metadata_table_cache.filter_skips", &[][..], 1),
+            (
+                "loonfs.metadata_table_cache.filter_false_positives",
+                &[][..],
+                1,
+            ),
+            (
+                "loonfs.wal_tail_projection_cache.gets",
+                &[("result", "hit")][..],
+                1,
+            ),
+            (
+                "loonfs.wal_tail_projection_cache.gets",
+                &[("result", "miss")][..],
+                1,
+            ),
+            ("loonfs.wal_tail_projection_cache.inserts", &[][..], 1),
+            ("loonfs.wal_tail_projection_cache.evictions", &[][..], 1),
+            ("loonfs.wal_tail_projection_cache.evicted_rows", &[][..], 7),
+            (
+                "loonfs.wal_tail_projection_cache.evicted_decoded_bytes",
+                &[][..],
+                70,
+            ),
+            ("loonfs.wal_tail_projection_cache.rejections", &[][..], 1),
+            (
+                "loonfs.wal_tail_projection_cache.rejected_rows",
+                &[][..],
+                11,
+            ),
+            (
+                "loonfs.wal_tail_projection_cache.rejected_decoded_bytes",
+                &[][..],
+                110,
+            ),
+        ] {
+            assert_eq!(counter(&snapshot, name, labels), value, "counter `{name}`");
+        }
+        assert_eq!(
+            gauge(&snapshot, "loonfs.wal_tail_projection_cache.retained_rows"),
+            13
+        );
+        assert_eq!(
+            gauge(
+                &snapshot,
+                "loonfs.wal_tail_projection_cache.retained_decoded_bytes"
+            ),
+            130
+        );
     }
 
     #[test]

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -121,14 +121,14 @@ impl RuntimeInstruments {
         })
     }
 
-    /// Reports one latest-view read through the runtime cache path.
+    /// Records one latest-view read handled by the runtime cache.
     pub(crate) fn latest_metadata_view_read(&self) {
         if let Some(installed) = &self.installed {
             installed.cache.latest_metadata_view_reads.increment(1);
         }
     }
 
-    /// The decoded metadata-table cache's metrics observer, when installed.
+    /// Returns the metadata-table cache metrics observer, if metrics are enabled.
     pub(crate) fn metadata_table_cache_observer(
         &self,
     ) -> Option<Arc<dyn MetadataTableCacheObserver>> {
@@ -136,7 +136,7 @@ impl RuntimeInstruments {
         Some(observer)
     }
 
-    /// The WAL-tail projection cache's metrics observer, when installed.
+    /// Returns the WAL-tail projection cache metrics observer, if metrics are enabled.
     pub(crate) fn wal_tail_projection_cache_observer(
         &self,
     ) -> Option<Arc<dyn WalTailProjectionCacheObserver>> {
@@ -566,7 +566,7 @@ impl MaintenanceJobInstruments {
     }
 }
 
-/// Runtime-owned cache instruments, registered as one closed set.
+/// Metrics for caches owned by the runtime. All instruments are registered together.
 struct RuntimeCacheInstruments {
     latest_metadata_view_reads: Arc<dyn CounterHandle>,
     metadata_table: Arc<MetadataTableCacheInstruments>,


### PR DESCRIPTION
Use the shared `Recency` tracker for the runtime control cache and WAL-tail projection cache. This removes the linear scan that ran on each access while preserving the existing entry, row, and decoded-byte limits.

Register runtime, metadata-table, WAL-tail projection, and grep cache activity with the metrics recorder. Cache events are exported as Prometheus counters, while the WAL-tail projection's current retained rows and bytes remain gauges. The server no longer converts cumulative runtime cache statistics into scrape-time gauges.

Tests cover recency-based eviction, recorder updates, metric types, and the cache metrics exposed by a running server.