### PR TITLE
refactor(storage,api): use typed IDs and non-exhaustive public errors

### DIFF
--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -151,6 +151,7 @@ enum OperationFingerprintInput<'a> {
 /// every already-published update. The kind is part of the value, so a text
 /// and a one-member list fingerprint differently.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+// The fingerprint discriminator is frozen as `type` for this deliberate exception.
 #[serde(tag = "type", rename_all = "snake_case")]
 enum AttributeValueFingerprintInput<'a> {
     Text { text: &'a str },

--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -143,15 +143,15 @@ enum OperationFingerprintInput<'a> {
     },
 }
 
-/// Canonical preimage for one attribute value.
+/// Stable fingerprint input for one attribute value.
 ///
-/// Restated here rather than embedding [`AttributeValue`]'s own encoding, for
-/// the same reason the content reference above is restated: the wire spelling
-/// of a value has to be free to change without restating the identity of
-/// every already-published update. The kind is part of the value, so a text
-/// and a one-member list fingerprint differently.
+/// This private representation keeps commit fingerprints independent of the
+/// wire encoding for [`AttributeValue`]. The variant remains part of the
+/// fingerprint, so a string and a one-item string list produce different
+/// fingerprints.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-// The fingerprint discriminator is frozen as `type` for this deliberate exception.
+// Keep `type` as the discriminator because changing it would alter existing
+// commit fingerprints.
 #[serde(tag = "type", rename_all = "snake_case")]
 enum AttributeValueFingerprintInput<'a> {
     Text { text: &'a str },

--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -150,8 +150,6 @@ enum OperationFingerprintInput<'a> {
 /// fingerprint, so a string and a one-item string list produce different
 /// fingerprints.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-// Keep `type` as the discriminator because changing it would alter existing
-// commit fingerprints.
 #[serde(tag = "type", rename_all = "snake_case")]
 enum AttributeValueFingerprintInput<'a> {
     Text { text: &'a str },

--- a/crates/loonfs-api/src/envelope.rs
+++ b/crates/loonfs-api/src/envelope.rs
@@ -38,6 +38,7 @@ pub struct EnvelopeProbe {
 /// envelope-generic; the wrapping error names the object (and its key) the
 /// bytes came from.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum EnvelopeCodecError {
     /// Reports a payload that cannot be serialized into its family's durable encoding.
     #[error("failed to encode envelope payload: {0}")]

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -109,6 +109,7 @@ impl Default for PaginationPolicy {
 
 /// Invalid caller-supplied page size.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum LimitError {
     /// The caller supplied `limit=0`.
     #[error("limit must be greater than zero")]
@@ -350,6 +351,7 @@ pub fn decode_namespace_cursor<C: NamespaceCursor>(
 
 /// Why a namespace-bound cursor cannot resume the enumeration replaying it.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum NamespaceCursorError {
     /// Not a cursor this enumeration issued: unreadable, or from another
     /// endpoint, job, or cursor version.
@@ -365,6 +367,7 @@ pub enum NamespaceCursorError {
 
 /// Invalid opaque page cursor.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum PageCursorError {
     /// The cursor was not hex-encoded JSON.
     #[error("invalid page cursor encoding")]

--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -46,6 +46,7 @@ pub const MAX_PATH_DEPTH: usize = 128;
 
 /// Describes why caller-supplied path or display-name text is not admissible.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum PathError {
     /// Reports an empty string where an absolute path was required.
     #[error("absolute path must not be empty")]

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -127,6 +127,7 @@ pub struct SegmentFilter {
 ///
 /// See [metadata segments](../../../docs/specs/format.md#421-metadata-segments).
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum SstBlockCodecError {
     /// Reports a request to finish a segment before any row was supplied.
     #[error("segment must contain at least one row")]

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -780,7 +780,6 @@ impl GcResponse {
 /// variant is the field of [`RetainedCandidates`] it counts into, where the
 /// reason itself is described.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum RetainedReason {
     /// Counts into [`RetainedCandidates::referenced`].
     Referenced,

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -124,7 +124,6 @@ pub struct GrepResponse {
 /// when the index is in the `Steady` phase.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// Keep `phase` as the discriminator for wire-format compatibility.
 #[serde(tag = "phase", rename_all = "snake_case")]
 pub enum GrepIndexLifecycle {
     /// No index is maintained for this namespace.

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -125,6 +125,7 @@ pub struct GrepResponse {
 /// `steady` phase and nothing else.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+// The wire discriminator is frozen as `phase` for this deliberate exception.
 #[serde(tag = "phase", rename_all = "snake_case")]
 pub enum GrepIndexLifecycle {
     /// No index is maintained for this namespace.

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -118,14 +118,13 @@ pub struct GrepResponse {
 
 /// Where a namespace's grep index is in its lifecycle.
 ///
-/// The phases carry different facts and never share a field: a backfill
-/// reports the sequence it is walking toward and how far the walk got, and
-/// only a steady index reports a watermark it has actually built through.
-/// A reader that wants "is this searchable, and through what?" asks the
-/// `steady` phase and nothing else.
+/// Each phase contains only the fields valid for that phase. `Backfilling`
+/// reports its target and current position. `Steady` reports how far the
+/// index has been built. Clients should treat a namespace as searchable only
+/// when the index is in the `Steady` phase.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// The wire discriminator is frozen as `phase` for this deliberate exception.
+// Keep `phase` as the discriminator for wire-format compatibility.
 #[serde(tag = "phase", rename_all = "snake_case")]
 pub enum GrepIndexLifecycle {
     /// No index is maintained for this namespace.

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -89,6 +89,7 @@ pub enum UploadMode {
 /// combinations are rejected during decoding. The `mode` field is required.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+// The wire discriminator is frozen as `mode` for this deliberate exception.
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
 pub enum BeginUploadRequest {
     // Empty braces make serde reject fields from another transport. A unit
@@ -256,6 +257,7 @@ pub struct ValidatedContentToken {
 /// response fields are accepted for forward compatibility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+// The wire discriminator is frozen as `mode` for this deliberate exception.
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum BeginUploadResponse {
     /// The service will receive the bytes and write the content object.
@@ -353,6 +355,7 @@ pub struct UploadContentResponse {
 /// against the durable record.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+// The wire discriminator is frozen as `completion` for this deliberate exception.
 #[serde(tag = "completion", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CompleteUploadRequest {
     /// Completes a session the server named a content object for: the
@@ -417,6 +420,7 @@ pub struct CompleteUploadResponse {
 /// retransfer.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+// The wire discriminator is frozen as `state` for this deliberate exception.
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum UploadSessionStatus {
     /// Accepting content until its lease passes.

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -89,7 +89,7 @@ pub enum UploadMode {
 /// combinations are rejected during decoding. The `mode` field is required.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// The wire discriminator is frozen as `mode` for this deliberate exception.
+// Keep `mode` as the discriminator for wire-format compatibility.
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
 pub enum BeginUploadRequest {
     // Empty braces make serde reject fields from another transport. A unit
@@ -257,7 +257,7 @@ pub struct ValidatedContentToken {
 /// response fields are accepted for forward compatibility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// The wire discriminator is frozen as `mode` for this deliberate exception.
+// Keep `mode` as the discriminator for wire-format compatibility.
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum BeginUploadResponse {
     /// The service will receive the bytes and write the content object.
@@ -339,23 +339,19 @@ pub struct UploadContentResponse {
     pub content_ref: ContentRef,
 }
 
-/// Request to complete an upload, tagged by which of its two shapes it is.
+/// Request to complete an upload.
 ///
-/// The shapes correspond to who knew the content identity first. A
-/// service-proxied or `direct_put` session was handed its reference before
-/// any byte moved, so its completion names that reference back. A
-/// `direct_multipart` session was never told one — there was nothing to
-/// tell — so its completion carries the claim and its parts instead, and
-/// the server builds the reference from the identity it has held all along.
+/// A service-proxied or `direct_put` session receives its content reference
+/// before the upload and returns that reference at completion. A
+/// `direct_multipart` session instead provides the completed parts and a
+/// claim describing the assembled object.
 ///
-/// The two share no fields, so a completion carrying one shape's fields
-/// under the other's tag does not decode. What decoding cannot settle is
-/// whether the shape matches the *session*, because only the server knows
-/// which transport the session was opened with; that one check is made
-/// against the durable record.
+/// The variants share no fields, so fields from one completion type are
+/// rejected when used with the other type. The server also checks that the
+/// completion type matches the transport stored in the upload session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// The wire discriminator is frozen as `completion` for this deliberate exception.
+// Keep `completion` as the discriminator for wire-format compatibility.
 #[serde(tag = "completion", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CompleteUploadRequest {
     /// Completes a session the server named a content object for: the
@@ -414,13 +410,13 @@ pub struct CompleteUploadResponse {
 
 /// Observed state of an upload session.
 ///
-/// A session is `open`, then `completed` or `aborted`, and both of those are
-/// final. Reading a completed session mints a fresh receipt for content that
-/// is already durable, which is why losing a commit response never costs a
-/// retransfer.
+/// A session starts as `Open` and ends as either `Completed` or `Aborted`.
+/// Both final states are permanent. Reading a completed session issues a new
+/// receipt for the durable content, so a lost commit response does not require
+/// the content to be uploaded again.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// The wire discriminator is frozen as `state` for this deliberate exception.
+// Keep `state` as the discriminator for wire-format compatibility.
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum UploadSessionStatus {
     /// Accepting content until its lease passes.

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -89,7 +89,6 @@ pub enum UploadMode {
 /// combinations are rejected during decoding. The `mode` field is required.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// Keep `mode` as the discriminator for wire-format compatibility.
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
 pub enum BeginUploadRequest {
     // Empty braces make serde reject fields from another transport. A unit
@@ -257,7 +256,6 @@ pub struct ValidatedContentToken {
 /// response fields are accepted for forward compatibility.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// Keep `mode` as the discriminator for wire-format compatibility.
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum BeginUploadResponse {
     /// The service will receive the bytes and write the content object.
@@ -351,7 +349,6 @@ pub struct UploadContentResponse {
 /// completion type matches the transport stored in the upload session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// Keep `completion` as the discriminator for wire-format compatibility.
 #[serde(tag = "completion", rename_all = "snake_case", deny_unknown_fields)]
 pub enum CompleteUploadRequest {
     /// Completes a session the server named a content object for: the
@@ -416,7 +413,6 @@ pub struct CompleteUploadResponse {
 /// the content to be uploaded again.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-// Keep `state` as the discriminator for wire-format compatibility.
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum UploadSessionStatus {
     /// Accepting content until its lease passes.

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -225,6 +225,7 @@ fn profile_store_error(profile_name: &str, error: &StoreConfigError) -> CliError
         StoreConfigError::InvalidField { field, reason } => {
             CliError::invalid_config(format!("invalid `{profile_name}.{field}`: {reason}"))
         }
+        error => CliError::invalid_config(format!("invalid `{profile_name}.store`: {error}")),
     }
 }
 

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -1,7 +1,7 @@
 //! [`CliError`]: the structured failure every command surfaces.
 
 use crate::config::NAMESPACE_ENV;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// Structured failure surfaced by every CLI command (`--json` renders it verbatim).
 ///
@@ -25,16 +25,16 @@ use serde::{Deserialize, Serialize};
 ///   in both layers. A local configuration failure is `invalid_config`
 ///   whether the CLI or backend detects it, and registry codes are reserved
 ///   for failures a server could also produce.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct CliError {
     pub code: String,
     pub message: String,
     /// Correlation id the server assigned to the failed request; absent for
     /// embedded and local failures, which have no server hop.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
     /// Structured context for the code, when the backend carried any.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<Box<loonfs_api::ErrorDetails>>,
 }
 

--- a/crates/loonfs-cli/src/profiles.rs
+++ b/crates/loonfs-cli/src/profiles.rs
@@ -2,13 +2,13 @@
 
 use crate::config::{validate_profile_name, CliConfig, ProfileConfig};
 use crate::error::CliError;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct ProfileSummary {
     pub name: String,
     pub mode: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub store_kind: Option<String>,
 }
 

--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -188,15 +188,11 @@ impl<'a> MetadataTableDestination<'a> {
 
     fn object_key(self, table_id: &MetadataTableId) -> String {
         match self {
-            Self::Published { namespace_id } => {
-                metadata_table(namespace_id.as_str(), table_id.as_str())
-            }
+            Self::Published { namespace_id } => metadata_table(namespace_id, table_id),
             Self::CompactionStaging {
                 namespace_id,
                 job_id,
-            } => {
-                metadata_compaction_table(namespace_id.as_str(), job_id.as_str(), table_id.as_str())
-            }
+            } => metadata_compaction_table(namespace_id, job_id, table_id),
         }
     }
 

--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -71,9 +71,9 @@ pub(crate) enum CompactionPrefixOwner {
 /// Reads the lease of one job and says who owns that job's prefix, claiming
 /// an expired lease on the way.
 ///
-/// `job_id` is the path component, not a parsed identity: a collector reads
-/// it off the key it is deciding. A lease naming a different job or namespace
-/// is corrupt because the key and embedded fence disagree.
+/// A collector parses `metadata_compaction_id` from the key it is deciding.
+/// A lease naming a different job or namespace is corrupt because the key
+/// and embedded fence disagree.
 ///
 /// The claim is the whole point of reading it. An expired `Active` lease
 /// alone proves nothing — the job may be resuming from a long stall right
@@ -82,17 +82,21 @@ pub(crate) enum CompactionPrefixOwner {
 pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    job_id: &str,
+    metadata_compaction_id: &MetadataCompactionId,
     now_ms: u64,
 ) -> Result<CompactionPrefixOwner> {
-    let object_key = metadata_compaction_lease(namespace_id.as_str(), job_id);
+    let object_key = metadata_compaction_lease(namespace_id, metadata_compaction_id);
     let loaded = load_control_object(
         store,
         object_key,
         ControlObjectKind::CompactionLease,
         |state: &MetadataCompactionLeaseState| {
             expect_namespace(namespace_id, &state.namespace_id)?;
-            expect_identity_field("compaction job id", job_id, state.job_id.as_str())
+            expect_identity_field(
+                "compaction job id",
+                metadata_compaction_id.as_str(),
+                state.job_id.as_str(),
+            )
         },
     )
     .await;
@@ -131,7 +135,7 @@ pub(crate) async fn claim_compaction_prefix<S: ObjectStore + ?Sized>(
             tracing::info!(
                 namespace_id = namespace_id.as_str(),
                 object_key = object_key.as_str(),
-                job_id,
+                job_id = metadata_compaction_id.as_str(),
                 owner_id = reaping.owner_id.as_str(),
                 heartbeat_at_ms = reaping.heartbeat_at_ms,
                 "a streaming metadata compaction lease expired; garbage collection claimed its \
@@ -187,7 +191,7 @@ impl<'a> CompactionLease<'a> {
     ) -> Self {
         let started_monotonic_ms = timer.monotonic_now_ms();
         Self {
-            object_key: metadata_compaction_lease(namespace_id.as_str(), job_id.as_str()),
+            object_key: metadata_compaction_lease(namespace_id, job_id),
             state: MetadataCompactionLeaseState {
                 job_id: job_id.clone(),
                 namespace_id: namespace_id.clone(),

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -46,7 +46,7 @@ pub(crate) async fn list_checkpoints<S: ObjectStore + ?Sized>(
         .await
         .map_err(CoreError::load_head)?;
 
-    let prefix = checkpoint_prefix(namespace_id.as_str());
+    let prefix = checkpoint_prefix(namespace_id);
     let mut keys = store.list_prefix_stream(&prefix);
     let mut checkpoints = Vec::new();
     while let Some(item) = keys.next().await {

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -26,7 +26,9 @@ use loonfs_api::wire::manifest::{
     NamespaceManifestEnvelope, NamespaceManifestKind, NamespaceManifestPayload,
     NAMESPACE_MANIFEST_FORMAT_VERSION,
 };
-use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId, WriterEpoch};
+use loonfs_api::{
+    ChangeSeq, ManifestId, ManifestObjectId, MetadataCompactionId, NamespaceId, WriterEpoch,
+};
 use loonfs_objectstore::keys::{
     metadata_compaction_job_id_from_key, metadata_compaction_table, metadata_manifest_object,
     metadata_table,
@@ -163,7 +165,7 @@ pub(crate) async fn load_namespace_manifest_envelope<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     manifest_object_id: &ManifestObjectId,
 ) -> Result<NamespaceManifestEnvelope, ManifestLoadError> {
-    let manifest_key = metadata_manifest_object(namespace_id.as_str(), manifest_object_id);
+    let manifest_key = metadata_manifest_object(namespace_id, manifest_object_id);
     load_namespace_manifest_envelope_if_present(
         store,
         namespace_id,
@@ -192,7 +194,7 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
     namespace_id: &NamespaceId,
     manifest_object_id: &ManifestObjectId,
 ) -> Result<VerifiedMetadataTables<'a, S>, ManifestLoadError> {
-    let manifest_key = metadata_manifest_object(namespace_id.as_str(), manifest_object_id);
+    let manifest_key = metadata_manifest_object(namespace_id, manifest_object_id);
     // Manifests are immutable per object key, so the decoded and validated
     // envelope is cacheable forever under that key.
     let fetch = || async {
@@ -570,10 +572,7 @@ fn validate_one_base_run_per_family_group(
 }
 
 pub(super) fn metadata_file_object_key(descriptor: &MetadataFileRef) -> String {
-    metadata_table(
-        descriptor.owner_namespace_id.as_str(),
-        descriptor.table_id.as_str(),
-    )
+    metadata_table(&descriptor.owner_namespace_id, &descriptor.table_id)
 }
 
 /// Checks that a descriptor names one of the two keys a segment of its
@@ -593,13 +592,15 @@ pub(super) fn ensure_segment_object_key(
     descriptor: &MetadataFileRef,
 ) -> Result<(), ManifestLoadError> {
     let expected = metadata_file_object_key(descriptor);
-    let staged = metadata_compaction_job_id_from_key(&descriptor.object_key).map(|job_id| {
-        metadata_compaction_table(
-            descriptor.owner_namespace_id.as_str(),
-            job_id,
-            descriptor.table_id.as_str(),
-        )
-    });
+    let staged = metadata_compaction_job_id_from_key(&descriptor.object_key)
+        .and_then(|job_id| MetadataCompactionId::parse(job_id).ok())
+        .map(|metadata_compaction_id| {
+            metadata_compaction_table(
+                &descriptor.owner_namespace_id,
+                &metadata_compaction_id,
+                &descriptor.table_id,
+            )
+        });
     if descriptor.object_key == expected || staged.as_deref() == Some(&descriptor.object_key) {
         return Ok(());
     }

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -36,7 +36,7 @@ pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
     manifest: &NamespaceManifestEnvelope,
 ) -> std::result::Result<(), MetadataProjectionLoadError> {
     let manifest_key = metadata_manifest_object(
-        manifest.payload.namespace_id.as_str(),
+        &manifest.payload.namespace_id,
         &manifest.payload.manifest_object_id,
     );
     let manifest_bytes = Bytes::from(encode_namespace_manifest_json(manifest).map_err(|err| {
@@ -211,7 +211,7 @@ async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
     manifest: &NamespaceManifestEnvelope,
     updated_at_ms: u64,
 ) -> Result<Option<MetadataRootState>> {
-    let object_key = loonfs_objectstore::keys::metadata_root(namespace_id.as_str());
+    let object_key = loonfs_objectstore::keys::metadata_root(namespace_id);
     let next = MetadataRootState {
         namespace_id: namespace_id.clone(),
         manifest_id: manifest.payload.manifest_id,

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -58,7 +58,7 @@ pub(crate) async fn write_checkpoint_record<S: ObjectStore + ?Sized>(
     record: &CheckpointRecordState,
 ) -> Result<()> {
     let encoded = encode_checkpoint_record(record)?;
-    let object_key = checkpoint_record(record.namespace_id.as_str(), record.checkpoint_id.as_str());
+    let object_key = checkpoint_record(&record.namespace_id, &record.checkpoint_id);
     // A checkpoint record is mutable control state, so its first lifecycle state is a conditional create.
     match store.put_if_absent(&object_key, encoded).await {
         Ok(_) => Ok(()),
@@ -150,7 +150,7 @@ pub(crate) async fn read_checkpoint_record<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     checkpoint_id: &CheckpointId,
 ) -> Result<Option<LoadedCheckpointRecord>> {
-    let object_key = checkpoint_record(namespace_id.as_str(), checkpoint_id.as_str());
+    let object_key = checkpoint_record(namespace_id, checkpoint_id);
     let loaded = load_checkpoint_record_at_key(store, &object_key).await;
     match loaded {
         Ok(loaded) => Ok(Some(loaded)),
@@ -173,7 +173,7 @@ pub(crate) async fn release_checkpoint_record<S: ObjectStore + ?Sized>(
     released_at_ms: u64,
 ) -> Result<()> {
     const RELEASE_CAS_ATTEMPTS: usize = 4;
-    let object_key = checkpoint_record(namespace_id.as_str(), checkpoint_id.as_str());
+    let object_key = checkpoint_record(namespace_id, checkpoint_id);
     for _attempt in 0..RELEASE_CAS_ATTEMPTS {
         let Some(loaded) = read_checkpoint_record(store, namespace_id, checkpoint_id).await? else {
             // Reaped underneath us: no active pin under this id is exactly
@@ -309,7 +309,8 @@ mod tests {
     #[tokio::test]
     async fn listed_loader_rejects_a_different_durable_family() {
         let (_directory, store) = local_store();
-        let object_key = wal_head("demo");
+        let object_key =
+            wal_head(&loonfs_api::NamespaceId::parse("demo").expect("valid namespace id"));
 
         let error = load_checkpoint_record_at_key(&store, &object_key)
             .await
@@ -341,7 +342,7 @@ mod tests {
         let key_namespace_id = namespace("demo");
         let embedded_namespace_id = namespace("other");
         let checkpoint_id = checkpoint("chk_00000000000000000000000000000001");
-        let object_key = checkpoint_record(key_namespace_id.as_str(), checkpoint_id.as_str());
+        let object_key = checkpoint_record(&key_namespace_id, &checkpoint_id);
         let bytes = encode_checkpoint_record(&record(embedded_namespace_id, checkpoint_id))
             .expect("record bytes");
         store
@@ -365,7 +366,7 @@ mod tests {
         let namespace_id = namespace("demo");
         let key_checkpoint_id = checkpoint("chk_00000000000000000000000000000001");
         let embedded_checkpoint_id = checkpoint("chk_00000000000000000000000000000002");
-        let object_key = checkpoint_record(namespace_id.as_str(), key_checkpoint_id.as_str());
+        let object_key = checkpoint_record(&namespace_id, &key_checkpoint_id);
         let bytes = encode_checkpoint_record(&record(namespace_id, embedded_checkpoint_id))
             .expect("record bytes");
         store

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -99,7 +99,7 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
         let encoded = encode_control_object(&envelope).map_err(|err| {
             CoreError::Internal(format!("failed to encode wal floor object: {err}"))
         })?;
-        let object_key = loonfs_objectstore::keys::wal_floor(namespace_id.as_str());
+        let object_key = loonfs_objectstore::keys::wal_floor(namespace_id);
         let published = match &loaded {
             Some(loaded) => {
                 store

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -49,7 +49,7 @@ impl ManifestSwapOnCasConflictStore {
             loonfs_api::wire::control::encode_control_object(&envelope).expect("root bytes");
         self.inner
             .put(
-                &loonfs_objectstore::keys::metadata_root(self.namespace_id.as_str()),
+                &loonfs_objectstore::keys::metadata_root(&self.namespace_id),
                 Bytes::from(bytes),
                 PutMode::Overwrite,
             )
@@ -144,7 +144,7 @@ impl FloorRaiseOnCasConflictStore {
             loonfs_api::wire::control::encode_control_object(&envelope).expect("floor bytes");
         self.inner
             .put(
-                &loonfs_objectstore::keys::wal_floor(self.namespace_id.as_str()),
+                &loonfs_objectstore::keys::wal_floor(&self.namespace_id),
                 Bytes::from(bytes),
                 PutMode::Overwrite,
             )
@@ -181,7 +181,7 @@ impl ObjectStore for FloorRaiseOnCasConflictStore {
         // The first advance creates the floor object, so the competing
         // writer has to be able to win that race too.
         if mode == PutMode::CreateIfAbsent
-            && key == loonfs_objectstore::keys::wal_floor(self.namespace_id.as_str())
+            && key == loonfs_objectstore::keys::wal_floor(&self.namespace_id)
             && self.remaining_conflicts.load(Ordering::SeqCst) > 0
         {
             self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
@@ -200,7 +200,7 @@ impl ObjectStore for FloorRaiseOnCasConflictStore {
         bytes: Bytes,
     ) -> Result<ObjectMetadata, ObjectStoreError> {
         use std::sync::atomic::Ordering;
-        if key == loonfs_objectstore::keys::wal_floor(self.namespace_id.as_str())
+        if key == loonfs_objectstore::keys::wal_floor(&self.namespace_id)
             && self.remaining_conflicts.load(Ordering::SeqCst) > 0
         {
             self.remaining_conflicts.fetch_sub(1, Ordering::SeqCst);
@@ -513,11 +513,7 @@ async fn create_checkpoint_fails_when_its_manifest_key_holds_a_different_payload
     // so rather than generate another id.
     let store = ConflictOnManifestCreateStore::mutate_next_inode(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        format!(
-            "{}{:020}-",
-            metadata_manifest_prefix(namespace_id.as_str()),
-            2
-        ),
+        format!("{}{:020}-", metadata_manifest_prefix(&namespace_id), 2),
     );
 
     let error = create_checkpoint(&store, &namespace_id, &context)
@@ -527,7 +523,7 @@ async fn create_checkpoint_fails_when_its_manifest_key_holds_a_different_payload
     match error {
         CoreError::NamespaceCorrupt(message) => {
             assert!(
-                message.contains(&metadata_manifest_prefix(namespace_id.as_str())),
+                message.contains(&metadata_manifest_prefix(&namespace_id)),
                 "the error must name the manifest key, got {message}"
             );
         }
@@ -624,7 +620,7 @@ async fn same_root_checkpoint_builders_write_distinct_manifest_objects_and_loser
     }
 
     let manifest_objects = store
-        .list_prefix(&metadata_manifest_prefix(namespace_id.as_str()))
+        .list_prefix(&metadata_manifest_prefix(&namespace_id))
         .await
         .expect("list manifest objects");
     assert_eq!(
@@ -724,7 +720,7 @@ async fn current_manifest_cas_retry_exhaustion_reports_head_race() {
     let context = test_context();
     let store = FailStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        KeyPredicate::metadata_root(namespace_id.as_str()),
+        KeyPredicate::metadata_root(&namespace_id),
         OperationClass::CompareAndSwap,
         InjectedError::PreconditionFailed,
     );
@@ -783,7 +779,7 @@ async fn root_cas_transport_error_recovers_when_candidate_was_published() {
     let context = test_context();
     let store = RootCasTransportAfterApplyStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        loonfs_objectstore::keys::metadata_root(namespace_id.as_str()),
+        loonfs_objectstore::keys::metadata_root(&namespace_id),
     );
     bootstrap_namespace(&store, &namespace_id, &context, false)
         .await
@@ -885,7 +881,7 @@ async fn root_cas_transport_error_recovers_when_newer_root_was_published() {
     };
     let store = RootCasTransportAfterCompetingRootStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        loonfs_objectstore::keys::metadata_root(namespace_id.as_str()),
+        loonfs_objectstore::keys::metadata_root(&namespace_id),
         competing_root,
     );
 
@@ -1046,7 +1042,7 @@ async fn read_anchor_reloads_the_head_when_the_root_is_ahead() {
         .await
         .expect("bootstrap");
     let stale_head = inner
-        .get_with_metadata(&wal_head(namespace_id.as_str()))
+        .get_with_metadata(&wal_head(&namespace_id))
         .await
         .expect("read bootstrap head")
         .expect("bootstrap head exists");
@@ -1067,7 +1063,7 @@ async fn read_anchor_reloads_the_head_when_the_root_is_ahead() {
 
     let store = StaleHeadOnceStore {
         inner,
-        head_key: wal_head(namespace_id.as_str()),
+        head_key: wal_head(&namespace_id),
         stale_head: std::sync::Mutex::new(Some(stale_head)),
     };
     let projection = load_current_projection(&store, &namespace_id)

--- a/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/index_parity.rs
@@ -118,8 +118,7 @@ pub(super) async fn overwrite_manifest(
     namespace_id: &NamespaceId,
     manifest: NamespaceManifestEnvelope,
 ) {
-    let manifest_key =
-        metadata_manifest_object(namespace_id.as_str(), &manifest.payload.manifest_object_id);
+    let manifest_key = metadata_manifest_object(namespace_id, &manifest.payload.manifest_object_id);
     let manifest_id = manifest.payload.manifest_id;
     let manifest_object_id = manifest.payload.manifest_object_id.clone();
     let updated_manifest =
@@ -149,7 +148,7 @@ pub(super) async fn overwrite_manifest(
             loonfs_api::wire::control::encode_control_object(&envelope).expect("root bytes");
         store
             .put_overwrite(
-                &loonfs_objectstore::keys::metadata_root(namespace_id.as_str()),
+                &loonfs_objectstore::keys::metadata_root(namespace_id),
                 Bytes::from(bytes),
             )
             .await
@@ -190,7 +189,7 @@ fn segment_modelled_on(
 ) -> MetadataFileRef {
     let table_id = loonfs_api::MetadataTableId::generate();
     MetadataFileRef {
-        object_key: metadata_table(namespace_id.as_str(), table_id.as_str()),
+        object_key: metadata_table(namespace_id, &table_id),
         table_id,
         run_seq,
         level,
@@ -917,7 +916,7 @@ async fn manifest_rejects_segment_whose_index_fails_its_descriptor_checksum() {
     descriptor.index_block.crc32c ^= 0xffff_ffff;
 
     let manifest_key =
-        metadata_manifest_object(namespace_id.as_str(), &manifest.payload.manifest_object_id);
+        metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id);
     let manifest_id = manifest.payload.manifest_id;
     let updated_manifest =
         NamespaceManifestEnvelope::from_payload(manifest.payload).expect("updated manifest");
@@ -1068,7 +1067,7 @@ async fn manifest_rejects_child_bind_index_that_diverges_from_canonical_binds() 
     .await;
 
     let manifest_key =
-        metadata_manifest_object(namespace_id.as_str(), &manifest.payload.manifest_object_id);
+        metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id);
     let manifest_id = manifest.payload.manifest_id;
     let updated_manifest =
         NamespaceManifestEnvelope::from_payload(manifest.payload).expect("updated manifest");

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -42,7 +42,7 @@ pub(crate) async fn load_manifest_materialization_for_inspection<S: ObjectStore 
     )
     .await?
     .ok_or_else(|| ManifestLoadError::MissingManifest {
-        object_key: metadata_manifest_object(namespace_id.as_str(), &manifest_object_id),
+        object_key: metadata_manifest_object(namespace_id, &manifest_object_id),
     })
 }
 
@@ -52,7 +52,7 @@ async fn manifest_object_id_for_manifest_id<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     manifest_id: ManifestId,
 ) -> Result<ManifestObjectId, ManifestLoadError> {
-    let prefix = metadata_manifest_prefix(namespace_id.as_str());
+    let prefix = metadata_manifest_prefix(namespace_id);
     let keys =
         store
             .list_prefix(&prefix)
@@ -88,7 +88,7 @@ pub(super) async fn load_manifest_materialization_for_inspection_if_present<
     namespace_id: &NamespaceId,
     manifest_object_id: &ManifestObjectId,
 ) -> Result<Option<ManifestMaterializationForInspection>, ManifestLoadError> {
-    let manifest_key = metadata_manifest_object(namespace_id.as_str(), manifest_object_id);
+    let manifest_key = metadata_manifest_object(namespace_id, manifest_object_id);
     let manifest = load_namespace_manifest_envelope_if_present(
         store,
         namespace_id,

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -184,11 +184,7 @@ async fn create_checkpoint_surfaces_conflicting_invalid_manifest() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let context = test_context();
-    let manifest_key = format!(
-        "{}{:020}-",
-        metadata_manifest_prefix(namespace_id.as_str()),
-        2
-    );
+    let manifest_key = format!("{}{:020}-", metadata_manifest_prefix(&namespace_id), 2);
     let store = ConflictOnManifestCreateStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
         manifest_key,
@@ -283,8 +279,9 @@ async fn maintenance_and_status_do_not_make_orphan_wal_visible() {
     .expect("write second");
 
     let orphan_key = wal_segment(
-        namespace_id.as_str(),
-        "00000000000000000002-deadbeefdeadbeef",
+        &namespace_id,
+        &loonfs_api::WalSegmentId::parse("00000000000000000002-deadbeefdeadbeef")
+            .expect("valid WAL segment id"),
     );
     store
         .put_overwrite(&orphan_key, Bytes::from_static(b"not a wal envelope"))
@@ -603,10 +600,8 @@ async fn manifest_materialization_rejects_off_pattern_table_keys() {
             .await
             .expect("load first manifest");
     let mut bad_base_manifest = first_materialized.manifest.clone();
-    let manifest_key = metadata_manifest_object(
-        namespace_id.as_str(),
-        &bad_base_manifest.payload.manifest_object_id,
-    );
+    let manifest_key =
+        metadata_manifest_object(&namespace_id, &bad_base_manifest.payload.manifest_object_id);
     let expected_base_key = {
         let base_descriptor = bad_base_manifest
             .payload
@@ -618,8 +613,8 @@ async fn manifest_materialization_rejects_off_pattern_table_keys() {
             })
             .expect("base metadata file");
         let expected = metadata_table(
-            base_descriptor.owner_namespace_id.as_str(),
-            base_descriptor.table_id.as_str(),
+            &base_descriptor.owner_namespace_id,
+            &base_descriptor.table_id,
         );
         base_descriptor.object_key = format!("{}-wrong", base_descriptor.object_key);
         expected
@@ -645,10 +640,8 @@ async fn manifest_materialization_rejects_off_pattern_table_keys() {
             .await
             .expect("load second manifest");
     let mut bad_l0_manifest = second_materialized.manifest.clone();
-    let manifest_key = metadata_manifest_object(
-        namespace_id.as_str(),
-        &bad_l0_manifest.payload.manifest_object_id,
-    );
+    let manifest_key =
+        metadata_manifest_object(&namespace_id, &bad_l0_manifest.payload.manifest_object_id);
     let expected_l0_key = {
         let l0_descriptor = bad_l0_manifest
             .payload
@@ -659,10 +652,7 @@ async fn manifest_materialization_rejects_off_pattern_table_keys() {
                     && metadata_file.family == ApiMetadataTableFamily::Inodes
             })
             .expect("l0 metadata file");
-        let expected = metadata_table(
-            l0_descriptor.owner_namespace_id.as_str(),
-            l0_descriptor.table_id.as_str(),
-        );
+        let expected = metadata_table(&l0_descriptor.owner_namespace_id, &l0_descriptor.table_id);
         l0_descriptor.object_key = format!("{}-wrong", l0_descriptor.object_key);
         expected
     };
@@ -750,7 +740,7 @@ async fn manifest_run_rejects_rows_after_run_seq() {
     match load_manifest_metadata_state_for_inspection_from_manifest(
         &store,
         &namespace_id,
-        &metadata_manifest_object(namespace_id.as_str(), &manifest.payload.manifest_object_id),
+        &metadata_manifest_object(&namespace_id, &manifest.payload.manifest_object_id),
         &manifest,
     )
     .await

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -456,8 +456,7 @@ pub(crate) async fn staged_keys_of_the_current_manifest<S: ObjectStore + ?Sized>
     store: &S,
     namespace_id: &NamespaceId,
 ) -> BTreeSet<String> {
-    let staging_prefix =
-        loonfs_objectstore::keys::metadata_compaction_prefix(namespace_id.as_str());
+    let staging_prefix = loonfs_objectstore::keys::metadata_compaction_prefix(namespace_id);
     let manifest_object_id = current_manifest_object_id(store, namespace_id).await;
     let staged: BTreeSet<String> =
         load_verified_manifest_tables(store, namespace_id, &manifest_object_id)
@@ -508,7 +507,7 @@ async fn current_manifest_key<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
 ) -> String {
     metadata_manifest_object(
-        namespace_id.as_str(),
+        namespace_id,
         &current_manifest_object_id(store, namespace_id).await,
     )
 }

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -24,7 +24,7 @@ impl ManifestChecksumMismatchOnceStore {
     ) -> Self {
         Self {
             inner,
-            checkpoint_prefix: checkpoint_prefix(namespace_id.as_str()),
+            checkpoint_prefix: checkpoint_prefix(namespace_id),
             manifest_key,
             mismatched_manifest,
             mismatch_armed: AtomicBool::new(false),
@@ -814,7 +814,7 @@ async fn checkpoint_basis_verification_store_failure_surfaces_and_releases_recor
 
     let record_keys = store
         .inner()
-        .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+        .list_prefix(&checkpoint_prefix(&namespace_id))
         .await
         .expect("list checkpoint records");
     assert_eq!(record_keys.len(), 1, "the failed create wrote one record");
@@ -889,7 +889,7 @@ async fn checkpoint_checksum_disagreement_is_terminal_corruption_and_releases_re
 
     let record_keys = store
         .inner()
-        .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+        .list_prefix(&checkpoint_prefix(&namespace_id))
         .await
         .expect("list checkpoint records");
     assert_eq!(record_keys.len(), 1, "the failed create wrote one record");
@@ -914,7 +914,7 @@ async fn checkpoint_checksum_disagreement_is_terminal_corruption_and_releases_re
 
 async fn wal_segment_count(store: &LocalFsStore, namespace_id: &NamespaceId) -> usize {
     store
-        .list_prefix(&wal_segment_prefix(namespace_id.as_str()))
+        .list_prefix(&wal_segment_prefix(namespace_id))
         .await
         .expect("list wal segments")
         .len()
@@ -1634,7 +1634,7 @@ async fn a_missing_floor_reads_as_retain_everything() {
         .expect("bootstrap");
     assert!(
         store
-            .head(&loonfs_objectstore::keys::wal_floor(namespace_id.as_str()))
+            .head(&loonfs_objectstore::keys::wal_floor(&namespace_id))
             .await
             .expect("probe floor")
             .is_none(),

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -793,7 +793,7 @@ async fn staged_object_keys<S: ObjectStore + ?Sized>(
 ) -> BTreeSet<String> {
     use futures::StreamExt;
     store
-        .list_prefix_stream(&metadata_compaction_prefix(namespace_id.as_str()))
+        .list_prefix_stream(&metadata_compaction_prefix(namespace_id))
         .map(|key| key.expect("list staged objects"))
         .collect()
         .await
@@ -1233,7 +1233,7 @@ async fn a_background_compaction_and_a_step_contained_merge_reach_the_same_rows(
     assert!(
         result.output_segments.iter().all(|descriptor| descriptor
             .object_key
-            .starts_with(&metadata_compaction_prefix(namespace_id.as_str()))),
+            .starts_with(&metadata_compaction_prefix(&namespace_id))),
         "every output segment is written to the staging directory"
     );
     // Every reverse row the floor covers costs one point read, and no other
@@ -2262,7 +2262,7 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
     let group = MetadataFamilyGroup::Bindings;
     let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
     let spec = step_until_a_compaction_is_planned(&store, &namespace_id, &context, policy).await;
-    let lease_key = metadata_compaction_lease(namespace_id.as_str(), spec.job_id().as_str());
+    let lease_key = metadata_compaction_lease(&namespace_id, spec.job_id());
 
     let outcome = run_metadata_compaction_job(
         &store,
@@ -2285,7 +2285,7 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
     let referenced = referenced_segment_keys(&store, &namespace_id).await;
     let job_prefix = format!(
         "{}{}/",
-        metadata_compaction_prefix(namespace_id.as_str()),
+        metadata_compaction_prefix(&namespace_id),
         spec.job_id().as_str()
     );
     assert!(
@@ -2322,7 +2322,7 @@ async fn a_cancelled_job_leaves_its_claim_standing() {
     let group = MetadataFamilyGroup::Bindings;
     let policy = policy_that_starves_the_group(&store, &namespace_id, group).await;
     let spec = step_until_a_compaction_is_planned(&store, &namespace_id, &context, policy).await;
-    let lease_key = metadata_compaction_lease(namespace_id.as_str(), spec.job_id().as_str());
+    let lease_key = metadata_compaction_lease(&namespace_id, spec.job_id());
 
     let cancellation = MetadataCompactionCancellation::default();
     let dying_store = CancelAfterReadsStore {
@@ -2393,7 +2393,7 @@ async fn a_worker_whose_expired_lease_was_claimed_is_fenced_and_publishes_nothin
     // stamped its lease off a real clock, so the pass's clock has to clear
     // whatever it spent running.
     let expired_ms = test_context().now_ms + METADATA_COMPACTION_LEASE_EXPIRY_MS * 2;
-    let owner = claim_compaction_prefix(&store, &namespace_id, spec.job_id().as_str(), expired_ms)
+    let owner = claim_compaction_prefix(&store, &namespace_id, spec.job_id(), expired_ms)
         .await
         .expect("claim the expired prefix");
     assert_eq!(
@@ -2457,7 +2457,7 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
     seed_bindings_workload(&store, &namespace_id).await;
     let spec =
         compaction_spec_for_group(&store, &namespace_id, MetadataFamilyGroup::Bindings).await;
-    let lease_key = metadata_compaction_lease(namespace_id.as_str(), spec.job_id().as_str());
+    let lease_key = metadata_compaction_lease(&namespace_id, spec.job_id());
     // The stepping clock below moves each heartbeat's stamp forward a few
     // seconds, so the pass's clock is set well past the expiry rather than one
     // millisecond past it.
@@ -2477,7 +2477,7 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
     );
     gated.block_next();
     let (claimed, beat) = tokio::join!(
-        claim_compaction_prefix(&gated, &namespace_id, spec.job_id().as_str(), expired_ms),
+        claim_compaction_prefix(&gated, &namespace_id, spec.job_id(), expired_ms),
         async {
             gated.wait_until_blocked().await;
             let beat = lease.heartbeat(&store).await.expect("heartbeat the lease");
@@ -2499,7 +2499,7 @@ async fn exactly_one_of_a_heartbeat_and_a_reaping_claim_wins() {
     // The other order, on the same lease: the claim lands, and the heartbeat
     // behind it finds an etag it does not hold.
     assert_eq!(
-        claim_compaction_prefix(&store, &namespace_id, spec.job_id().as_str(), expired_ms)
+        claim_compaction_prefix(&store, &namespace_id, spec.job_id(), expired_ms)
             .await
             .expect("claim the prefix"),
         CompactionPrefixOwner::ThisCollector

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -86,7 +86,7 @@ pub(crate) fn prepare_commit_head_publish(
         });
     }
 
-    let object_key = wal_head(current_head.namespace_id.as_str());
+    let object_key = wal_head(&current_head.namespace_id);
     let new_tip = wal.envelope.pointer(wal.object_key.clone());
     let resulting_head = HeadState {
         namespace_id: current_head.namespace_id.clone(),
@@ -293,7 +293,7 @@ mod tests {
         };
         let envelope = WalSegmentEnvelope::from_payload(payload).expect("wal envelope");
         PreparedWalSegment {
-            object_key: wal_segment_key(namespace_id.as_str(), segment_id.as_str()),
+            object_key: wal_segment_key(&namespace_id, &segment_id),
             segment_id,
             envelope,
             encoded_bytes: Vec::new(),
@@ -317,7 +317,7 @@ mod tests {
         );
         assert_eq!(
             prepared.write.object_key,
-            wal_head(prepared.resulting_head.namespace_id.as_str()),
+            wal_head(&prepared.resulting_head.namespace_id),
         );
         let expected_envelope = HeadStateEnvelope::from_state(
             ControlObjectKind::WalHead,
@@ -511,7 +511,7 @@ mod tests {
                 let segment_id = WalSegmentId::parse(format!("{:020}-{offset:016x}", seq.0))
                     .expect("valid segment id");
                 WalSegmentPointer {
-                    object_key: wal_segment_key(namespace_id.as_str(), segment_id.as_str()),
+                    object_key: wal_segment_key(&namespace_id, &segment_id),
                     segment_id,
                     start_seq: seq,
                     end_seq: seq,

--- a/crates/loonfs-core/src/commit_engine.rs
+++ b/crates/loonfs-core/src/commit_engine.rs
@@ -733,7 +733,7 @@ mod tests {
 
     async fn wal_segment_count(store: &LocalFsStore, namespace_id: &NamespaceId) -> usize {
         store
-            .list_prefix_stream(&wal_segment_prefix(namespace_id.as_str()))
+            .list_prefix_stream(&wal_segment_prefix(namespace_id))
             .collect::<Vec<_>>()
             .await
             .len()
@@ -820,7 +820,7 @@ mod tests {
         // fence check uses and the closing etag recheck.
         let store = StdArc::new(BlockingStore::new(
             LocalFsStore::new(temp_dir.path()).expect("store"),
-            KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+            KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
             OperationClass::Read,
         ));
 

--- a/crates/loonfs-core/src/control_object/load.rs
+++ b/crates/loonfs-core/src/control_object/load.rs
@@ -215,7 +215,7 @@ mod tests {
     async fn absence_is_missing_object() {
         let (_directory, store) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
 
         let error = load_head(&store, &object_key, &namespace_id)
             .await
@@ -228,7 +228,7 @@ mod tests {
     async fn permission_failure_preserves_its_store_class() {
         let (_directory, inner) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
         let store = FailStore::new(
             inner,
             KeyPredicate::exact(object_key.clone()),
@@ -254,7 +254,7 @@ mod tests {
     async fn other_provider_failure_preserves_its_store_class() {
         let (_directory, inner) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
         let store = FailStore::new(
             inner,
             KeyPredicate::exact(object_key.clone()),
@@ -280,7 +280,7 @@ mod tests {
     async fn missing_etag_is_a_store_failure() {
         let (_directory, inner) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
         let (_, bytes) = encoded_head(&namespace_id);
         write_bytes(&inner, &object_key, bytes).await;
         let store = MetadataMapStore::without_etag(inner, KeyPredicate::exact(object_key.clone()));
@@ -303,7 +303,7 @@ mod tests {
     async fn malformed_envelope_is_a_codec_error() {
         let (_directory, store) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
         write_bytes(&store, &object_key, b"not json".to_vec()).await;
 
         let error = load_head(&store, &object_key, &namespace_id)
@@ -317,7 +317,7 @@ mod tests {
     async fn wrong_envelope_kind_is_a_codec_error() {
         let (_directory, store) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
         let (_, bytes) = encoded_head(&namespace_id);
         let mut document: Value = serde_json::from_slice(&bytes).expect("envelope json");
         document["kind"] = Value::String(ControlObjectKind::WalFloor.as_str().to_owned());
@@ -343,7 +343,7 @@ mod tests {
     async fn checksum_disagreement_has_its_own_error() {
         let (_directory, store) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
         let (_, bytes) = encoded_head(&namespace_id);
         let mut document: Value = serde_json::from_slice(&bytes).expect("envelope json");
         let recorded = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
@@ -374,7 +374,7 @@ mod tests {
         let (_directory, store) = local_store();
         let expected_namespace_id = namespace("demo");
         let actual_namespace_id = namespace("other");
-        let object_key = wal_head(expected_namespace_id.as_str());
+        let object_key = wal_head(&expected_namespace_id);
         let (_, bytes) = encoded_head(&actual_namespace_id);
         write_bytes(&store, &object_key, bytes).await;
 
@@ -396,7 +396,7 @@ mod tests {
     async fn other_identity_disagreement_is_not_a_codec_error() {
         let (_directory, store) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
         let (_, bytes) = encoded_head(&namespace_id);
         write_bytes(&store, &object_key, bytes).await;
 
@@ -424,7 +424,7 @@ mod tests {
     async fn successful_load_returns_state_key_and_etag() {
         let (_directory, store) = local_store();
         let namespace_id = namespace("demo");
-        let object_key = wal_head(namespace_id.as_str());
+        let object_key = wal_head(&namespace_id);
         let (state, bytes) = encoded_head(&namespace_id);
         write_bytes(&store, &object_key, bytes).await;
 

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -199,7 +199,7 @@ async fn read_upload_session_object<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
 ) -> crate::error::Result<LoadedUploadSessionObject> {
-    let object_key = upload_session(namespace_id.as_str(), upload_id.as_str());
+    let object_key = upload_session(namespace_id, upload_id);
     let loaded = load_control_object(
         store,
         object_key,
@@ -240,7 +240,7 @@ mod tests {
         .expect("head envelope");
         let bytes = encode_control_object(&envelope).expect("head bytes");
         store
-            .put_if_absent(&wal_head(namespace_id.as_str()), Bytes::from(bytes))
+            .put_if_absent(&wal_head(namespace_id), Bytes::from(bytes))
             .await
             .expect("write head");
     }

--- a/crates/loonfs-core/src/gc/compaction_staging.rs
+++ b/crates/loonfs-core/src/gc/compaction_staging.rs
@@ -25,7 +25,7 @@
 
 use crate::checkpoint::{claim_compaction_prefix, CompactionPrefixOwner};
 use crate::error::{CoreError, Result};
-use loonfs_api::NamespaceId;
+use loonfs_api::{MetadataCompactionId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_compaction_job_id_from_key, metadata_compaction_lease};
 use loonfs_objectstore::ObjectStore;
 
@@ -67,20 +67,26 @@ impl CompactionLeases {
         key: &str,
         now_ms: u64,
     ) -> Result<StagedObject> {
-        let Some(job_id) = metadata_compaction_job_id_from_key(key) else {
+        let Some(metadata_compaction_id) = metadata_compaction_job_id_from_key(key)
+            .and_then(|job_id| MetadataCompactionId::parse(job_id).ok())
+        else {
             return Ok(StagedObject::UnrecognizedKey);
         };
         let owner = match &self.last_read {
-            Some((read_job_id, owner)) if read_job_id == job_id => *owner,
+            Some((read_job_id, owner)) if read_job_id == metadata_compaction_id.as_str() => *owner,
             _ => {
                 // The walk has left whatever job it was on, so the lease that
                 // job's reap was holding may go now.
                 self.delete_claimed_lease(store).await?;
-                let owner = claim_compaction_prefix(store, namespace_id, job_id, now_ms).await?;
-                self.last_read = Some((job_id.to_owned(), owner));
+                let owner =
+                    claim_compaction_prefix(store, namespace_id, &metadata_compaction_id, now_ms)
+                        .await?;
+                self.last_read = Some((metadata_compaction_id.to_string(), owner));
                 if owner == CompactionPrefixOwner::ThisCollector {
-                    self.claimed_lease =
-                        Some(metadata_compaction_lease(namespace_id.as_str(), job_id));
+                    self.claimed_lease = Some(metadata_compaction_lease(
+                        namespace_id,
+                        &metadata_compaction_id,
+                    ));
                 }
                 owner
             }

--- a/crates/loonfs-core/src/gc/compaction_staging.rs
+++ b/crates/loonfs-core/src/gc/compaction_staging.rs
@@ -1,27 +1,23 @@
-//! Deciding one streaming compaction's objects: the lease says who owns them,
-//! and claiming it is what makes the answer safe to act on.
+//! Determines whether staged output from a streaming compaction can be collected.
 //!
 //! A job writes its output under `metadata/compactions/{job_id}/` and refreshes
-//! its lease beside it by compare-and-swap while it runs (format spec,
-//! "Garbage collection", rule 12). A pass sweeping that prefix therefore asks
-//! one question per job: does the job that owns these keys still hold its
-//! lease? A fresh lease retains the whole prefix however old the objects under
-//! it are. An expired one is not an answer on its own — the job may be
-//! resuming from a long stall — so the pass claims it, moving it from `Active`
-//! to `Reaping` by compare-and-swap. Winning that claim fences the job: its
-//! next heartbeat fails, it publishes nothing, and only then are the objects
-//! under the prefix ordinary orphans.
+//! its lease with compare-and-swap while it runs (format spec, "Garbage
+//! collection", rule 12). A current lease means every object under the job's
+//! prefix must be retained. An expired lease is not sufficient evidence for
+//! collection because the job may resume. The collector must first change the
+//! lease from `Active` to `Reaping` with compare-and-swap. After that succeeds,
+//! the job's next heartbeat fails and it can no longer publish the staged
+//! output, so those objects can be treated as unreferenced.
 //!
-//! The claimed lease is deleted last, after the segments it covers. The lease
-//! of a job sorts before that job's `tables/` directory, so the pass reads it
-//! first and holds the deletion until the walk leaves the prefix. A pass that
-//! stops in between leaves a `Reaping` lease behind, which is exactly what a
-//! later pass needs to finish the reap without deciding anything again.
+//! A job's lease sorts before its `tables/` directory. The collector reads the
+//! lease first and deletes it only after processing the staged tables. If the
+//! pass stops midway through the prefix, the `Reaping` lease remains so a
+//! later pass can safely continue.
 //!
-//! Because a job's objects are contiguous, remembering the answer for the job
-//! being walked turns one lease read per object into one lease read per job.
-//! The memo holds only answers a compare-and-swap settled — a fresh `Active`
-//! read or a won claim — never a merely expired read.
+//! Objects for one job are contiguous in key order. The pass caches the
+//! confirmed ownership result for the current job, reducing lease reads from
+//! one per object to one per job. It caches only a current `Active` lease or a
+//! successful claim, never an expired lease that was only observed.
 
 use crate::checkpoint::{claim_compaction_prefix, CompactionPrefixOwner};
 use crate::error::{CoreError, Result};
@@ -29,37 +25,36 @@ use loonfs_api::{MetadataCompactionId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_compaction_job_id_from_key, metadata_compaction_lease};
 use loonfs_objectstore::ObjectStore;
 
-/// What one pass has learned about the compaction job it is walking, and the
-/// claimed lease it still owes a deletion.
+/// Tracks the confirmed owner of the current job prefix and any claimed lease
+/// that must be deleted after that prefix is processed.
 #[derive(Debug, Default)]
 pub(super) struct CompactionLeases {
-    /// The job this pass last read a lease for, and who owns its prefix.
+    /// The most recently checked job and the confirmed owner of its prefix.
     last_read: Option<(String, CompactionPrefixOwner)>,
-    /// The lease key of a claimed prefix, held until the walk leaves that
-    /// prefix so the segments under it go first.
+    /// A successfully claimed lease, retained until all earlier staged objects
+    /// in the same job prefix have been processed.
     claimed_lease: Option<String>,
 }
 
 /// What the sweep should do with one key under the compaction prefix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum StagedObject {
-    /// A live job owns it. Nothing about its age matters.
+    /// The job has a current lease, so the object must be retained.
     OwnedByALiveJob,
-    /// No job owns it: it belongs to a job that finished, died, or was
-    /// fenced. It ages out as an ordinary unreferenced orphan.
+    /// No active job can publish the object. Apply the normal grace period for
+    /// unreferenced objects.
     Orphaned,
-    /// The lease of a prefix this pass claimed. It is deleted when the walk
-    /// leaves the prefix, after the orphans under it.
+    /// The collector claimed this lease. Delete it after processing the
+    /// remaining objects in the job prefix.
     ClaimedLease,
-    /// The key is under the prefix but is neither a job's lease nor one of
-    /// its staged segments, so this pass cannot tell what wrote it and
-    /// retains it.
+    /// The key is neither a recognized lease nor a staged table, so the
+    /// collector retains it.
     UnrecognizedKey,
 }
 
 impl CompactionLeases {
-    /// Reads `key`'s owning job, and the lease of that job unless this pass
-    /// has already settled it.
+    /// Returns the collection state for `key`, reusing the current job's
+    /// confirmed lease state when possible.
     pub(super) async fn owner_of<S: ObjectStore + ?Sized>(
         &mut self,
         store: &S,
@@ -75,8 +70,8 @@ impl CompactionLeases {
         let owner = match &self.last_read {
             Some((read_job_id, owner)) if read_job_id == metadata_compaction_id.as_str() => *owner,
             _ => {
-                // The walk has left whatever job it was on, so the lease that
-                // job's reap was holding may go now.
+                // A different job prefix has started, so the previously
+                // claimed lease can now be deleted.
                 self.delete_claimed_lease(store).await?;
                 let owner =
                     claim_compaction_prefix(store, namespace_id, &metadata_compaction_id, now_ms)
@@ -102,14 +97,11 @@ impl CompactionLeases {
         })
     }
 
-    /// Deletes the lease of the prefix this pass claimed, now that the walk
-    /// has left it.
+    /// Deletes a claimed lease after its job prefix has been processed.
     ///
-    /// Called when the walk reaches another job and once more when it ends, so
-    /// a pass never leaves behind a lease whose prefix it finished reaping. It
-    /// is not aged: the claim is a compare-and-swap this pass won, which is a
-    /// stronger statement about ownership than any timestamp, and the swap
-    /// itself would have reset the object's write time anyway.
+    /// This runs when the pass reaches another job and again when the pass
+    /// ends. The lease does not need an age check because this collector
+    /// already claimed it with compare-and-swap.
     pub(super) async fn finish<S: ObjectStore + ?Sized>(&mut self, store: &S) -> Result<()> {
         self.delete_claimed_lease(store).await
     }

--- a/crates/loonfs-core/src/gc/cursor.rs
+++ b/crates/loonfs-core/src/gc/cursor.rs
@@ -47,12 +47,12 @@ impl CandidateFamily {
 
     pub(super) fn prefix(self, namespace_id: &NamespaceId) -> String {
         match self {
-            Self::WalSegments => wal_segment_prefix(namespace_id.as_str()),
-            Self::MetadataTables => metadata_table_prefix(namespace_id.as_str()),
-            Self::CompactionStaging => metadata_compaction_prefix(namespace_id.as_str()),
-            Self::Manifests => metadata_manifest_prefix(namespace_id.as_str()),
-            Self::Checkpoints => checkpoint_prefix(namespace_id.as_str()),
-            Self::UploadSessions => upload_session_prefix(namespace_id.as_str()),
+            Self::WalSegments => wal_segment_prefix(namespace_id),
+            Self::MetadataTables => metadata_table_prefix(namespace_id),
+            Self::CompactionStaging => metadata_compaction_prefix(namespace_id),
+            Self::Manifests => metadata_manifest_prefix(namespace_id),
+            Self::Checkpoints => checkpoint_prefix(namespace_id),
+            Self::UploadSessions => upload_session_prefix(namespace_id),
         }
     }
 }
@@ -108,6 +108,7 @@ impl GcCursor {
             NamespaceCursorError::Malformed(_) | NamespaceCursorError::OutsideKeyspace => {
                 invalid_cursor()
             }
+            _ => invalid_cursor(),
         })
     }
 

--- a/crates/loonfs-core/src/gc/fork_checkpoints.rs
+++ b/crates/loonfs-core/src/gc/fork_checkpoints.rs
@@ -52,7 +52,7 @@ pub(super) async fn release_missing_basis_checkpoint<S: ObjectStore + ?Sized>(
     if context.now_ms.saturating_sub(record.created_at_ms) < grace_window_ms {
         return Ok(false);
     }
-    let manifest_key = metadata_manifest_object(namespace_id.as_str(), &record.manifest_object_id);
+    let manifest_key = metadata_manifest_object(namespace_id, &record.manifest_object_id);
     if store
         .head(&manifest_key)
         .await

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -329,7 +329,7 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
     // first and records last, so a record still on the store never has its
     // basis pulled out from under it inside a pass. State, expiry, and owner
     // fate gate only whether the record itself is a candidate.
-    let checkpoints_prefix = checkpoint_prefix(namespace_id.as_str());
+    let checkpoints_prefix = checkpoint_prefix(namespace_id);
     let mut checkpoint_keys = store.list_prefix_stream(&checkpoints_prefix);
     while let Some(item) = checkpoint_keys.next().await {
         let key = item.map_err(|error| CoreError::store(&checkpoints_prefix, &error))?;
@@ -397,7 +397,7 @@ pub(super) async fn collect_live_set<S: ObjectStore + ?Sized>(
         if !budget.try_charge() {
             return Ok(LiveSetCollection::BudgetExhausted);
         }
-        let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
+        let manifest_key = metadata_manifest_object(namespace_id, &manifest_object_id);
         match load_namespace_manifest_envelope_if_present(
             store,
             namespace_id,
@@ -563,7 +563,7 @@ pub(super) async fn select_reference_anchor<S: ObjectStore + ?Sized>(
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> Result<Option<ReferenceAnchor>> {
-    let prefix = metadata_manifest_prefix(namespace_id.as_str());
+    let prefix = metadata_manifest_prefix(namespace_id);
     let mut keys = store.list_prefix_stream(&prefix);
     let mut published_any = false;
     let mut aged = None;

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -2100,8 +2100,8 @@ fn reason_total(report: &GcResponse) -> u64 {
         .sum()
 }
 
-/// A namespace with one staged segment under `metadata_compaction_id`, aged
-/// so the pass has a reference anchor, and the lease key that job would hold.
+/// Creates a namespace with one aged staged segment and returns the keys for
+/// the segment and its compaction lease.
 async fn namespace_with_staged_output(
     temp_dir: &tempfile::TempDir,
     namespace_id: &NamespaceId,
@@ -2135,8 +2135,7 @@ async fn namespace_with_staged_output(
     (store, staged_key, lease_key)
 }
 
-/// Writes the lease a job holding `metadata_compaction_id` would have written at
-/// `heartbeat_at_ms`, in the state a running job leaves it in.
+/// Writes an active compaction lease with the given heartbeat time.
 async fn write_compaction_lease<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -2153,7 +2152,7 @@ async fn write_compaction_lease<S: ObjectStore + ?Sized>(
     .await;
 }
 
-/// The same, in whichever lifecycle state the test needs.
+/// Writes a compaction lease in the lifecycle state required by the test.
 async fn write_compaction_lease_in_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -345,7 +345,7 @@ async fn write_upload_session(store: &LocalFsStore, namespace_id: &NamespaceId) 
     .expect("session envelope");
     let bytes =
         loonfs_api::wire::control::encode_control_object(&envelope).expect("encode session");
-    let key = loonfs_objectstore::keys::upload_session(namespace_id.as_str(), upload_id.as_str());
+    let key = loonfs_objectstore::keys::upload_session(namespace_id, &upload_id);
     store
         .put_if_absent(&key, bytes::Bytes::from(bytes))
         .await
@@ -391,7 +391,7 @@ async fn read_upload_session<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
 ) -> Option<UploadSessionState> {
-    let key = loonfs_objectstore::keys::upload_session(namespace_id.as_str(), upload_id.as_str());
+    let key = loonfs_objectstore::keys::upload_session(namespace_id, upload_id);
     let body = store.get(&key, None).await.expect("read upload session")?;
     Some(
         decode_control_object::<UploadSessionState>(&body, ControlObjectKind::UploadSession)
@@ -446,7 +446,7 @@ async fn active_record_with_a_missing_basis_is_released_not_degrading() {
     .expect("read record")
     .expect("record exists")
     .state;
-    let basis_key = metadata_manifest_object(namespace_id.as_str(), &record.manifest_object_id);
+    let basis_key = metadata_manifest_object(&namespace_id, &record.manifest_object_id);
     store.delete(&basis_key).await.expect("drop basis manifest");
 
     let aged = context(now_after_newest_object(&store, &namespace_id, GRACE_MS + 1).await);
@@ -531,10 +531,10 @@ async fn deleted_namespace_reclaims_down_to_its_tombstone() {
     assert!(!report.degraded_retention);
 
     for prefix in [
-        wal_segment_prefix(namespace_id.as_str()),
-        metadata_table_prefix(namespace_id.as_str()),
-        metadata_manifest_prefix(namespace_id.as_str()),
-        checkpoint_prefix(namespace_id.as_str()),
+        wal_segment_prefix(&namespace_id),
+        metadata_table_prefix(&namespace_id),
+        metadata_manifest_prefix(&namespace_id),
+        checkpoint_prefix(&namespace_id),
     ] {
         assert!(
             store.list_prefix(&prefix).await.expect("list").is_empty(),
@@ -545,8 +545,8 @@ async fn deleted_namespace_reclaims_down_to_its_tombstone() {
     // wherever the namespace published them, because neither is ever a
     // collection candidate.
     for key in [
-        loonfs_objectstore::keys::wal_head(namespace_id.as_str()),
-        loonfs_objectstore::keys::metadata_root(namespace_id.as_str()),
+        loonfs_objectstore::keys::wal_head(&namespace_id),
+        loonfs_objectstore::keys::metadata_root(&namespace_id),
     ] {
         assert!(
             store.head(&key).await.expect("head").is_some(),
@@ -584,7 +584,7 @@ async fn fork_protected_bases_survive_source_deletion_until_the_target_dies() {
 
     // The deleted source keeps exactly what the living clone needs.
     let fork_record = read_fork_record(&store, &source).await;
-    let basis_key = metadata_manifest_object(source.as_str(), &fork_record.manifest_object_id);
+    let basis_key = metadata_manifest_object(&source, &fork_record.manifest_object_id);
     let aged = context(now_after_newest_object(&store, &source, GRACE_MS + 1).await);
     let report = gc_namespace(&store, &source, &config(), &aged)
         .await
@@ -647,10 +647,9 @@ async fn upload_gc_aborts_an_expired_session_then_reaps_it() {
     write_test_file(&store, &namespace_id, "/docs/one.txt", "gc-one", &setup).await;
     let (upload_id, content_ref, content_store_id) =
         stage_upload(&store, &namespace_id, &setup).await;
-    let session_key =
-        loonfs_objectstore::keys::upload_session(namespace_id.as_str(), upload_id.as_str());
+    let session_key = loonfs_objectstore::keys::upload_session(&namespace_id, &upload_id);
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
 
     // Inside the lease nothing happens, however old the object looks: the
     // session carries its own expiry, so no provider timestamp decides this.
@@ -759,8 +758,7 @@ async fn an_aborted_session_is_reclaimed_from_the_deadline_the_pass_reported() {
         .await
         .expect("bootstrap");
     let (upload_id, ..) = stage_upload(&store, &namespace_id, &setup).await;
-    let session_key =
-        loonfs_objectstore::keys::upload_session(namespace_id.as_str(), upload_id.as_str());
+    let session_key = loonfs_objectstore::keys::upload_session(&namespace_id, &upload_id);
 
     // The pass that aborts the session is the only thing that knows the
     // record now ages out a grace window from this instant.
@@ -860,7 +858,7 @@ async fn upload_completion_wins_before_gc_abort_and_the_session_is_retained() {
         stage_upload(&store, &namespace_id, &setup).await;
     let aged = context(setup.now_ms + UPLOAD_SESSION_LEASE_MS + GRACE_MS + 1);
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let store = blocking_control_cas_store(store, BlockingControlCasTarget::UploadAborted);
     let gc_config = config();
     let gc = gc_namespace(&store, &namespace_id, &gc_config, &aged);
@@ -908,7 +906,7 @@ async fn gc_abort_wins_before_completion_and_completion_reports_not_found() {
         stage_upload(&store, &namespace_id, &setup).await;
     let aged = context(setup.now_ms + UPLOAD_SESSION_LEASE_MS + GRACE_MS + 1);
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let store = blocking_control_cas_store(store, BlockingControlCasTarget::UploadCompleted);
     let request = loonfs_api::v0::CompleteUploadRequest::for_content_ref(content_ref.clone());
     let completion = crate::protocol::complete_upload(
@@ -1039,7 +1037,7 @@ async fn content_gc_retains_completed_content_inside_its_grace() {
     let (upload_id, content_ref, content_store_id, _prepared) =
         complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
 
     let inside = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS - 1);
     let report = gc_namespace(&store, &namespace_id, &config(), &inside)
@@ -1070,7 +1068,7 @@ async fn content_gc_reclaims_completed_content_nothing_references() {
     let (upload_id, content_ref, content_store_id, _prepared) =
         complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
 
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
     let report = gc_namespace(&store, &namespace_id, &config(), &past)
@@ -1123,10 +1121,8 @@ async fn content_gc_never_reclaims_published_content() {
                 .await
                 .expect("advance floor");
         }
-        let content_key = loonfs_objectstore::keys::content_blob(
-            content_store_id.as_str(),
-            &content_ref.content_id,
-        );
+        let content_key =
+            loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
 
         let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
         let report = gc_namespace(&store, &namespace_id, &config(), &past)
@@ -1197,7 +1193,7 @@ async fn content_reference_scan_surfaces_a_manifest_corrupted_after_marking() {
     namespace_with_a_scan_worth_bounding(&store, &namespace_id, &setup).await;
     let live = live_set(&store, &namespace_id, &setup).await;
     let manifest_object_id = live.manifests.iter().next().expect("live manifest").clone();
-    let manifest_key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
+    let manifest_key = metadata_manifest_object(&namespace_id, &manifest_object_id);
     store
         .put_overwrite(&manifest_key, Bytes::from_static(b"not json"))
         .await
@@ -1221,7 +1217,7 @@ async fn content_reference_scan_is_unavailable_when_a_marked_manifest_does_not_r
     let live = live_set(&inner, &namespace_id, &setup).await;
     let store = FailStore::new(
         inner,
-        KeyPredicate::prefix(metadata_manifest_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_id)),
         OperationClass::Read,
         InjectedError::Transport("marked manifest timed out".to_owned()),
     );
@@ -1244,7 +1240,7 @@ async fn content_reference_scan_surfaces_corrupt_metadata_rows() {
     let (upload_id, content_ref, content_store_id, _) =
         complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
     let table_keys = store
-        .list_prefix(&metadata_table_prefix(namespace_id.as_str()))
+        .list_prefix(&metadata_table_prefix(&namespace_id))
         .await
         .expect("list metadata tables");
     assert!(
@@ -1265,7 +1261,7 @@ async fn content_reference_scan_surfaces_corrupt_metadata_rows() {
             .expect("corrupt metadata table");
     }
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
 
     let error = gc_namespace(&store, &namespace_id, &config(), &past)
@@ -1293,10 +1289,10 @@ async fn content_reference_scan_retains_content_when_metadata_rows_do_not_read()
     let (upload_id, content_ref, content_store_id, _) =
         complete_upload_for_gc(&inner, &namespace_id, b"unpublished\n", &setup).await;
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let store = FailStore::new(
         inner,
-        KeyPredicate::prefix(metadata_table_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(metadata_table_prefix(&namespace_id)),
         OperationClass::Read,
         InjectedError::Transport("metadata rows timed out".to_owned()),
     );
@@ -1336,7 +1332,7 @@ async fn a_budget_that_dies_inside_the_reference_scan_defers_and_walks_on() {
     let (upload_id, content_ref, content_store_id, _prepared) =
         complete_upload_for_gc(&store, &namespace_id, b"unpublished\n", &setup).await;
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let live = live_set(&store, &namespace_id, &setup).await;
     assert!(
         !live.manifests.is_empty() && !live.wal_segments.is_empty(),
@@ -1449,10 +1445,7 @@ async fn a_budget_below_the_roots_reads_no_chain_and_says_it_ran_out() {
     read.sort();
     assert_eq!(
         read,
-        vec![
-            metadata_root(namespace_id.as_str()),
-            wal_head(namespace_id.as_str())
-        ],
+        vec![metadata_root(&namespace_id), wal_head(&namespace_id)],
         "the pair the pass charged itself for is all it read"
     );
 }
@@ -1475,7 +1468,7 @@ async fn a_budget_that_dies_at_the_chain_gate_sweeps_nothing() {
     let chain_units = u64::try_from(live.wal_segments.len()).expect("segment count fits");
     assert!(chain_units > 0, "the fixture must retain a chain");
 
-    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str()));
+    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(&namespace_id));
     let store = CountingStore::new(inner, segment_reads);
     let mut at_the_gate = config();
     at_the_gate.max_objects = Some(marking - chain_units);
@@ -1528,7 +1521,7 @@ async fn a_chain_longer_than_the_budget_is_not_read_past_the_budget() {
     // wants more than two.
     let at_the_gate = 2;
 
-    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str()));
+    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(&namespace_id));
     let store = RecordingStore::new(inner, segment_reads);
     let mut bounded = config();
     bounded.max_objects = Some(marking - chain_units + at_the_gate);
@@ -1634,7 +1627,7 @@ async fn a_budget_that_covers_the_roots_exactly_finishes_marking() {
     let retained = live.wal_segments;
     assert!(!retained.is_empty(), "the fixture must retain a chain");
 
-    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str()));
+    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(&namespace_id));
     let store = RecordingStore::new(inner, segment_reads);
     let mut exact = config();
     exact.max_objects = Some(marking);
@@ -1742,12 +1735,12 @@ async fn a_complete_pass_fetches_each_retained_segment_once() {
     )
     .await;
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
     let retained = live_set(&inner, &namespace_id, &past).await.wal_segments;
     assert!(!retained.is_empty(), "the fixture must retain a chain");
 
-    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str()));
+    let segment_reads = KeyPredicate::prefix(wal_segment_prefix(&namespace_id));
     let store = RecordingStore::new(inner, segment_reads);
     let report = gc_namespace(&store, &namespace_id, &config(), &past)
         .await
@@ -1799,7 +1792,7 @@ async fn a_budget_that_dies_among_the_checkpoint_records_decides_nothing() {
         .await,
     );
 
-    let record_reads = KeyPredicate::prefix(checkpoint_prefix(namespace_id.as_str()));
+    let record_reads = KeyPredicate::prefix(checkpoint_prefix(&namespace_id));
     let store = CountingStore::new(inner, record_reads);
     let mut bounded = config();
     bounded.max_objects = Some(3);
@@ -1859,7 +1852,7 @@ async fn no_budget_lets_a_partial_reference_set_decide_a_deletion() {
     )
     .await;
     let content_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let past = context(setup.now_ms + CONTENT_RECLAMATION_GRACE_MS + 1);
     let marking = marking_units(&seed, &namespace_id, &past).await;
     let mut some_budget_reached_the_verdict = false;
@@ -2107,12 +2100,12 @@ fn reason_total(report: &GcResponse) -> u64 {
         .sum()
 }
 
-/// A namespace with one staged segment under `job_id`, aged so the pass has a
-/// reference anchor, and the lease key that job would hold.
+/// A namespace with one staged segment under `metadata_compaction_id`, aged
+/// so the pass has a reference anchor, and the lease key that job would hold.
 async fn namespace_with_staged_output(
     temp_dir: &tempfile::TempDir,
     namespace_id: &NamespaceId,
-    job_id: &str,
+    metadata_compaction_id: &loonfs_api::MetadataCompactionId,
 ) -> (MetadataMapStore<LocalFsStore>, String, String) {
     let inner = LocalFsStore::new(temp_dir.path()).expect("store");
     let setup = context(1_000);
@@ -2129,30 +2122,31 @@ async fn namespace_with_staged_output(
     let published = namespace_key_set(&inner, namespace_id).await;
     let store = aged_before_now(inner, published);
     let staged_key = metadata_compaction_table(
-        namespace_id.as_str(),
-        job_id,
-        "tbl_0123456789abcdef0123456789abcdef",
+        namespace_id,
+        metadata_compaction_id,
+        &loonfs_api::MetadataTableId::parse("tbl_0123456789abcdef0123456789abcdef")
+            .expect("valid metadata table id"),
     );
     store
         .put_if_absent(&staged_key, Bytes::from_static(b"staged segment"))
         .await
         .expect("write a staged segment");
-    let lease_key = metadata_compaction_lease(namespace_id.as_str(), job_id);
+    let lease_key = metadata_compaction_lease(namespace_id, metadata_compaction_id);
     (store, staged_key, lease_key)
 }
 
-/// Writes the lease a job holding `job_id` would have written at
+/// Writes the lease a job holding `metadata_compaction_id` would have written at
 /// `heartbeat_at_ms`, in the state a running job leaves it in.
 async fn write_compaction_lease<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    job_id: &str,
+    metadata_compaction_id: &loonfs_api::MetadataCompactionId,
     heartbeat_at_ms: u64,
 ) {
     write_compaction_lease_in_state(
         store,
         namespace_id,
-        job_id,
+        metadata_compaction_id,
         heartbeat_at_ms,
         loonfs_api::wire::control::MetadataCompactionLeaseStatus::Active,
     )
@@ -2163,14 +2157,14 @@ async fn write_compaction_lease<S: ObjectStore + ?Sized>(
 async fn write_compaction_lease_in_state<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    job_id: &str,
+    metadata_compaction_id: &loonfs_api::MetadataCompactionId,
     heartbeat_at_ms: u64,
     status: loonfs_api::wire::control::MetadataCompactionLeaseStatus,
 ) {
     let envelope = loonfs_api::wire::control::MetadataCompactionLeaseEnvelope::from_state(
         loonfs_api::wire::control::ControlObjectKind::CompactionLease,
         loonfs_api::wire::control::MetadataCompactionLeaseState {
-            job_id: loonfs_api::MetadataCompactionId::parse(job_id).expect("job id"),
+            job_id: metadata_compaction_id.clone(),
             namespace_id: namespace_id.clone(),
             owner_id: "writer".to_owned(),
             status,
@@ -2183,7 +2177,7 @@ async fn write_compaction_lease_in_state<S: ObjectStore + ?Sized>(
         loonfs_api::wire::control::encode_control_object(&envelope).expect("encode a lease");
     store
         .put(
-            &metadata_compaction_lease(namespace_id.as_str(), job_id),
+            &metadata_compaction_lease(namespace_id, metadata_compaction_id),
             Bytes::from(bytes),
             PutMode::Overwrite,
         )
@@ -2191,7 +2185,10 @@ async fn write_compaction_lease_in_state<S: ObjectStore + ?Sized>(
         .expect("write a lease");
 }
 
-const TEST_JOB_ID: &str = "cmp_0123456789abcdef0123456789abcdef";
+fn test_metadata_compaction_id() -> loonfs_api::MetadataCompactionId {
+    loonfs_api::MetadataCompactionId::parse("cmp_0123456789abcdef0123456789abcdef")
+        .expect("valid metadata compaction id")
+}
 
 /// A running job's output survives however old it is, because its lease says
 /// the job that wrote it is still running.
@@ -2204,12 +2201,19 @@ async fn a_live_jobs_staged_output_survives_however_old_it_is() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let (store, staged_key, lease_key) =
-        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+        namespace_with_staged_output(&temp_dir, &namespace_id, &test_metadata_compaction_id())
+            .await;
 
     // A day past the window the design used to apply here, with the job's
     // lease refreshed a moment ago.
     let now_ms = now_after_newest_object(store.inner(), &namespace_id, 24 * 60 * 60 * 1000).await;
-    write_compaction_lease(&store, &namespace_id, TEST_JOB_ID, now_ms).await;
+    write_compaction_lease(
+        &store,
+        &namespace_id,
+        &test_metadata_compaction_id(),
+        now_ms,
+    )
+    .await;
 
     let report = gc_namespace(&store, &namespace_id, &config(), &context(now_ms))
         .await
@@ -2238,12 +2242,19 @@ async fn a_dead_jobs_staged_output_is_reclaimed_after_the_staging_window() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let (store, staged_key, lease_key) =
-        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+        namespace_with_staged_output(&temp_dir, &namespace_id, &test_metadata_compaction_id())
+            .await;
 
     // The job's last heartbeat, and then a pass one lease expiry later. The
     // lease is stale, but the objects are still inside the staging window.
     let died_at_ms = now_after_newest_object(store.inner(), &namespace_id, 0).await;
-    write_compaction_lease(&store, &namespace_id, TEST_JOB_ID, died_at_ms).await;
+    write_compaction_lease(
+        &store,
+        &namespace_id,
+        &test_metadata_compaction_id(),
+        died_at_ms,
+    )
+    .await;
     let expired_ms = died_at_ms + METADATA_COMPACTION_LEASE_EXPIRY_MS + 1;
     let report = gc_namespace(&store, &namespace_id, &config(), &context(expired_ms))
         .await
@@ -2290,7 +2301,8 @@ async fn staged_output_with_no_lease_at_all_is_reclaimed() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let (store, staged_key, _) =
-        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+        namespace_with_staged_output(&temp_dir, &namespace_id, &test_metadata_compaction_id())
+            .await;
 
     let reclaimable_ms = now_after_newest_object(
         store.inner(),
@@ -2316,7 +2328,8 @@ async fn a_lease_that_does_not_decode_fails_the_pass() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let (store, staged_key, lease_key) =
-        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+        namespace_with_staged_output(&temp_dir, &namespace_id, &test_metadata_compaction_id())
+            .await;
     store
         .put(
             &lease_key,
@@ -2353,10 +2366,17 @@ async fn a_candidate_error_still_finishes_the_claimed_compaction_lease() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let (inner, staged_key, lease_key) =
-        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+        namespace_with_staged_output(&temp_dir, &namespace_id, &test_metadata_compaction_id())
+            .await;
 
     let died_at_ms = now_after_newest_object(inner.inner(), &namespace_id, 0).await;
-    write_compaction_lease(&inner, &namespace_id, TEST_JOB_ID, died_at_ms).await;
+    write_compaction_lease(
+        &inner,
+        &namespace_id,
+        &test_metadata_compaction_id(),
+        died_at_ms,
+    )
+    .await;
     let reclaimable_ms = now_after_newest_object(
         inner.inner(),
         &namespace_id,
@@ -2406,10 +2426,17 @@ async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let (store, staged_key, lease_key) =
-        namespace_with_staged_output(&temp_dir, &namespace_id, TEST_JOB_ID).await;
+        namespace_with_staged_output(&temp_dir, &namespace_id, &test_metadata_compaction_id())
+            .await;
 
     let died_at_ms = now_after_newest_object(store.inner(), &namespace_id, 0).await;
-    write_compaction_lease(&store, &namespace_id, TEST_JOB_ID, died_at_ms).await;
+    write_compaction_lease(
+        &store,
+        &namespace_id,
+        &test_metadata_compaction_id(),
+        died_at_ms,
+    )
+    .await;
     let reclaimable = context(
         now_after_newest_object(
             store.inner(),
@@ -2428,7 +2455,7 @@ async fn a_budget_stop_finishes_the_claimed_compaction_lease() {
         GcCursor::after(
             &namespace_id,
             CandidateFamily::MetadataTables,
-            format!("{}~", metadata_table_prefix(namespace_id.as_str())),
+            format!("{}~", metadata_table_prefix(&namespace_id)),
         )
         .encode()
         .expect("encode cursor"),
@@ -2561,7 +2588,7 @@ async fn a_publication_during_a_pass_never_costs_the_job_its_segments() {
     // job does happens in that gap, on a store the gate does not hold.
     let gated = BlockingStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
         OperationClass::List,
     );
     gated.block_next();
@@ -2640,7 +2667,7 @@ async fn a_published_jobs_lease_expires_and_the_pass_removes_only_the_lease() {
     .await;
     let staged =
         crate::checkpoint::tests::staged_keys_of_the_current_manifest(&store, &namespace_id).await;
-    let lease_key = metadata_compaction_lease(namespace_id.as_str(), spec.job_id().as_str());
+    let lease_key = metadata_compaction_lease(&namespace_id, spec.job_id());
     assert!(
         store
             .head(&lease_key)
@@ -2707,8 +2734,9 @@ async fn an_object_the_anchor_predates_is_kept_by_its_own_age_alone() {
     let published = namespace_key_set(&inner, &namespace_id).await;
     let store = aged_before_now(inner, published);
     let orphan_key = metadata_table(
-        namespace_id.as_str(),
-        "tbl_0123456789abcdef0123456789abcdef",
+        &namespace_id,
+        &loonfs_api::MetadataTableId::parse("tbl_0123456789abcdef0123456789abcdef")
+            .expect("valid metadata table id"),
     );
     store
         .put_if_absent(&orphan_key, Bytes::from_static(b"orphan table"))
@@ -2756,8 +2784,9 @@ async fn a_pass_with_no_aged_manifest_reaps_nothing_and_says_why() {
         .await
         .expect("flush wal");
     let orphan_key = metadata_table(
-        namespace_id.as_str(),
-        "tbl_0123456789abcdef0123456789abcdef",
+        &namespace_id,
+        &loonfs_api::MetadataTableId::parse("tbl_0123456789abcdef0123456789abcdef")
+            .expect("valid metadata table id"),
     );
     inner
         .put_if_absent(&orphan_key, Bytes::from_static(b"orphan table"))
@@ -2806,8 +2835,9 @@ async fn a_budget_that_dies_before_the_anchor_sweeps_nothing() {
     let setup = context(1_000);
     namespace_with_a_scan_worth_bounding(&inner, &namespace_id, &setup).await;
     let orphan_key = wal_segment(
-        namespace_id.as_str(),
-        "00000000000000000000-0123456789abcdef",
+        &namespace_id,
+        &loonfs_api::WalSegmentId::parse("00000000000000000000-0123456789abcdef")
+            .expect("valid WAL segment id"),
     );
     inner
         .put_if_absent(&orphan_key, Bytes::from_static(b"orphan"))
@@ -3010,7 +3040,7 @@ async fn gc_retains_unrecognized_manifest_keys() {
         .await
         .expect("bootstrap");
 
-    let manifest_prefix = metadata_manifest_prefix(namespace_id.as_str());
+    let manifest_prefix = metadata_manifest_prefix(&namespace_id);
     let foreign_objects = [
         (
             format!("{manifest_prefix}notes.txt"),
@@ -3073,7 +3103,7 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
     // Record-less maintenance: nothing accumulates under `checkpoints/`.
     assert!(
         store
-            .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+            .list_prefix(&checkpoint_prefix(&namespace_id))
             .await
             .expect("list checkpoint records")
             .is_empty(),
@@ -3091,7 +3121,7 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
     assert_eq!(report.deleted_manifests, 2);
     assert!(!report.degraded_retention);
     let manifests_left = store
-        .list_prefix(&metadata_manifest_prefix(namespace_id.as_str()))
+        .list_prefix(&metadata_manifest_prefix(&namespace_id))
         .await
         .expect("list manifests");
     assert_eq!(manifests_left.len(), 1, "only the live root manifest stays");
@@ -3642,7 +3672,7 @@ async fn gc_retains_active_checkpoint_bases() {
 /// Reads the single fork-owned record a fork left under the source.
 async fn read_fork_record(store: &LocalFsStore, source: &NamespaceId) -> CheckpointRecordState {
     for key in store
-        .list_prefix(&checkpoint_prefix(source.as_str()))
+        .list_prefix(&checkpoint_prefix(source))
         .await
         .expect("list checkpoints")
     {
@@ -3761,7 +3791,7 @@ async fn gc_surfaces_a_corrupt_fork_target_head() {
         .await
         .expect("fork");
     store
-        .put_overwrite(&wal_head(clone.as_str()), Bytes::from_static(b"not json"))
+        .put_overwrite(&wal_head(&clone), Bytes::from_static(b"not json"))
         .await
         .expect("corrupt target head");
     let before = namespace_keys(&store, &source).await;
@@ -3770,7 +3800,7 @@ async fn gc_surfaces_a_corrupt_fork_target_head() {
         .await
         .expect_err("a corrupt target head must fail the source pass");
     assert_eq!(error.code(), crate::error::ErrorCode::NamespaceCorrupt);
-    assert!(error.message().contains(&wal_head(clone.as_str())));
+    assert!(error.message().contains(&wal_head(&clone)));
     assert_eq!(namespace_keys(&store, &source).await, before);
 }
 
@@ -3791,7 +3821,7 @@ async fn gc_retains_a_fork_checkpoint_when_the_target_head_does_not_read() {
     let fork_record = read_fork_record(&inner, &source).await;
     let store = FailStore::new(
         inner,
-        KeyPredicate::exact(wal_head(clone.as_str())),
+        KeyPredicate::exact(wal_head(&clone)),
         OperationClass::Read,
         InjectedError::Transport("target head timed out".to_owned()),
     );
@@ -3991,7 +4021,7 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
         .await
         .expect("fork retry after abandonment");
     let retry = store
-        .list_prefix(&checkpoint_prefix(source.as_str()))
+        .list_prefix(&checkpoint_prefix(&source))
         .await
         .expect("list checkpoints")
         .len();
@@ -4028,7 +4058,7 @@ async fn gc_fails_the_pass_on_a_corrupt_checkpoint_record() {
         .expect("checkpoint");
 
     let record_keys = store
-        .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+        .list_prefix(&checkpoint_prefix(&namespace_id))
         .await
         .expect("list checkpoints");
     let corrupt_key = record_keys
@@ -4068,7 +4098,7 @@ async fn gc_fails_the_pass_when_a_checkpoint_record_does_not_read() {
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let store = FailStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        KeyPredicate::prefix(checkpoint_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(checkpoint_prefix(&namespace_id)),
         OperationClass::Read,
         InjectedError::Transport("checkpoint record read timed out".to_owned()),
     );
@@ -4083,7 +4113,7 @@ async fn gc_fails_the_pass_when_a_checkpoint_record_does_not_read() {
 
     let record_keys = store
         .inner()
-        .list_prefix(&checkpoint_prefix(namespace_id.as_str()))
+        .list_prefix(&checkpoint_prefix(&namespace_id))
         .await
         .expect("list checkpoints");
     let record_key = record_keys
@@ -4123,7 +4153,7 @@ async fn corrupt_reference_anchor_manifest_fails_instead_of_becoming_missing() {
         .await
         .expect("checkpoint");
     let manifest_key = store
-        .list_prefix(&metadata_manifest_prefix(namespace_id.as_str()))
+        .list_prefix(&metadata_manifest_prefix(&namespace_id))
         .await
         .expect("list manifests")
         .into_iter()
@@ -4159,7 +4189,7 @@ async fn unreadable_reference_anchor_manifest_remains_conservative() {
     let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
     let store = FailStore::new(
         inner,
-        KeyPredicate::prefix(metadata_manifest_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_id)),
         OperationClass::Read,
         InjectedError::Transport("reference manifest timed out".to_owned()),
     );
@@ -4189,7 +4219,7 @@ async fn gc_fails_the_pass_on_a_corrupt_root_manifest() {
         .expect("checkpoint");
 
     let manifest_keys = store
-        .list_prefix(&metadata_manifest_prefix(namespace_id.as_str()))
+        .list_prefix(&metadata_manifest_prefix(&namespace_id))
         .await
         .expect("list manifests");
     assert!(
@@ -4232,7 +4262,7 @@ async fn gc_degrades_when_a_root_manifest_does_not_read() {
     let namespace_id = NamespaceId::parse("demo").expect("namespace id");
     let store = FailStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        KeyPredicate::prefix(metadata_manifest_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(metadata_manifest_prefix(&namespace_id)),
         OperationClass::Read,
         InjectedError::Transport("manifest read timed out".to_owned()),
     );
@@ -4384,7 +4414,7 @@ async fn gc_fails_the_pass_when_a_fork_pin_record_is_corrupt() {
         .expect("fork");
 
     let record_keys = store
-        .list_prefix(&checkpoint_prefix(source.as_str()))
+        .list_prefix(&checkpoint_prefix(&source))
         .await
         .expect("list checkpoints");
     let corrupt_key = record_keys.first().expect("the fork pinned").clone();
@@ -4446,13 +4476,18 @@ async fn add_bounded_gc_fixture(
     for index in 0..6 {
         for key in [
             wal_segment(
-                namespace_id.as_str(),
-                &format!("00000000000000000000-orphan-{index:02}"),
+                namespace_id,
+                &loonfs_api::WalSegmentId::parse(format!("{index:020}-0000000000000000"))
+                    .expect("valid WAL segment id"),
             ),
-            metadata_table(namespace_id.as_str(), &format!("000-orphan-{index:02}")),
+            metadata_table(
+                namespace_id,
+                &loonfs_api::MetadataTableId::parse(format!("tbl_{index:032x}"))
+                    .expect("valid metadata table id"),
+            ),
             format!(
                 "{}000-orphan-{index:02}.manifest.json",
-                metadata_manifest_prefix(namespace_id.as_str())
+                metadata_manifest_prefix(namespace_id)
             ),
         ] {
             store
@@ -4602,8 +4637,9 @@ async fn budget_caps_candidate_operations_and_cursor_resumes_mid_family() {
     let orphan_keys: Vec<String> = (0..5)
         .map(|index| {
             wal_segment(
-                namespace_id.as_str(),
-                &format!("00000000000000000000-orphan-{index:02}"),
+                &namespace_id,
+                &loonfs_api::WalSegmentId::parse(format!("{index:020}-0000000000000000"))
+                    .expect("valid WAL segment id"),
             )
         })
         .collect();
@@ -4614,7 +4650,7 @@ async fn budget_caps_candidate_operations_and_cursor_resumes_mid_family() {
             .expect("write orphan");
     }
     let aged = context(now_after_newest_object(&inner, &namespace_id, GRACE_MS + 1).await);
-    let wal_prefix = wal_segment_prefix(namespace_id.as_str());
+    let wal_prefix = wal_segment_prefix(&namespace_id);
     let store = CountingStore::new(inner, KeyPredicate::prefix(wal_prefix));
     let mut bounded = config();
     // Two candidates a pass, plus the roots the pass marks before it walks.
@@ -4679,8 +4715,9 @@ async fn stale_cursor_rebuilds_roots_before_resuming() {
         .expect("bootstrap");
     for index in 0..2 {
         let key = wal_segment(
-            namespace_id.as_str(),
-            &format!("00000000000000000000-orphan-{index:02}"),
+            &namespace_id,
+            &loonfs_api::WalSegmentId::parse(format!("{index:020}-0000000000000000"))
+                .expect("valid WAL segment id"),
         );
         store
             .put_if_absent(&key, Bytes::from_static(b"orphan"))
@@ -4729,7 +4766,7 @@ async fn stale_cursor_rebuilds_roots_before_resuming() {
         );
     }
     for manifest_object_id in live.manifests {
-        let key = metadata_manifest_object(namespace_id.as_str(), &manifest_object_id);
+        let key = metadata_manifest_object(&namespace_id, &manifest_object_id);
         assert!(
             store
                 .head(&key)

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -139,7 +139,7 @@ pub(crate) fn metadata_basis_without_root(
     };
     let manifest_id = manifest_object_id_manifest_id(fork_basis.source_manifest_object_id.as_str())
         .ok_or_else(|| ControlObjectLoadError::Codec {
-            object_key: loonfs_objectstore::keys::wal_head(head.namespace_id.as_str()),
+            object_key: loonfs_objectstore::keys::wal_head(&head.namespace_id),
             message: format!(
                 "fork basis manifest object id `{}` does not encode a manifest id",
                 fork_basis.source_manifest_object_id

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -146,7 +146,7 @@ pub(super) async fn install_namespace_head<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     head: &HeadState,
 ) -> Result<NamespaceHeadInstall, CoreError> {
-    let object_key = wal_head(namespace_id.as_str());
+    let object_key = wal_head(namespace_id);
     let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head.clone())
         .map_err(|err| CoreError::Internal(format!("failed to build head envelope: {err}")))?;
     let bytes = encode_control_object(&envelope)

--- a/crates/loonfs-core/src/namespace/control.rs
+++ b/crates/loonfs-core/src/namespace/control.rs
@@ -38,7 +38,7 @@ pub(crate) async fn read_wal_floor_object<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedWalFloorObject, ControlObjectLoadError> {
-    let object_key = wal_floor(expected_namespace_id.as_str());
+    let object_key = wal_floor(expected_namespace_id);
     load_control_object(
         store,
         object_key,
@@ -52,7 +52,7 @@ pub(crate) async fn read_metadata_root_object<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedMetadataRootObject, ControlObjectLoadError> {
-    let object_key = metadata_root(expected_namespace_id.as_str());
+    let object_key = metadata_root(expected_namespace_id);
     load_control_object(
         store,
         object_key,
@@ -112,7 +112,7 @@ pub(crate) async fn read_head_object<S: ObjectStore + ?Sized>(
     store: &S,
     expected_namespace_id: &NamespaceId,
 ) -> Result<LoadedHeadObject, ControlObjectLoadError> {
-    let object_key = wal_head(expected_namespace_id.as_str());
+    let object_key = wal_head(expected_namespace_id);
     load_control_object(
         store,
         object_key,

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -218,14 +218,14 @@ mod tests {
             HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
         let bytes = encode_control_object(&envelope).expect("head bytes");
         store
-            .put_if_absent(&wal_head(namespace_id.as_str()), Bytes::from(bytes))
+            .put_if_absent(&wal_head(namespace_id), Bytes::from(bytes))
             .await
             .expect("write head");
     }
 
     async fn head_etag(store: &LocalFsStore, namespace_id: &NamespaceId) -> String {
         store
-            .head(&wal_head(namespace_id.as_str()))
+            .head(&wal_head(namespace_id))
             .await
             .expect("head metadata")
             .expect("head exists")
@@ -280,7 +280,7 @@ mod tests {
         .await;
         let store = FailStore::new(
             inner,
-            KeyPredicate::exact(wal_head(namespace_id.as_str())),
+            KeyPredicate::exact(wal_head(&namespace_id)),
             OperationClass::CompareAndSwap,
             InjectedError::PermissionDenied("head write forbidden".to_owned()),
         );
@@ -480,7 +480,7 @@ mod tests {
         // its epoch (head read #1) — the stalled-deleter interleaving.
         let store = TakeoverBetweenHeadReadsStore {
             inner: LocalFsStore::new(temp_dir.path()).expect("store"),
-            head_key: wal_head(namespace_id.as_str()),
+            head_key: wal_head(&namespace_id),
             head_reads: AtomicUsize::new(0),
         };
 
@@ -640,7 +640,7 @@ mod tests {
             let bytes = encode_control_object(&envelope).expect("head bytes");
             self.inner
                 .put(
-                    &wal_head(self.namespace_id.as_str()),
+                    &wal_head(&self.namespace_id),
                     Bytes::from(bytes),
                     PutMode::Overwrite,
                 )

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -281,7 +281,7 @@ async fn ensure_publish_head_etag_still_current<S: ObjectStore + ?Sized>(
     loaded_head_etag: &str,
     acquired_writer: &AcquiredWriter,
 ) -> Result<()> {
-    let object_key = wal_head(namespace_id.as_str());
+    let object_key = wal_head(namespace_id);
     let metadata = store
         .head(&object_key)
         .await

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -150,7 +150,7 @@ pub(crate) async fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
     let content_id = ContentId::generate();
     let content_ref = direct_put_content_ref(content_id.clone(), &claim)?;
-    let object_key = content_blob(content_store_id.as_str(), &content_id);
+    let object_key = content_blob(&content_store_id, &content_id);
     let upload_id = create_upload_session(
         store,
         namespace_id,
@@ -184,7 +184,7 @@ pub(crate) async fn begin_direct_multipart_upload_target<S: ObjectStore + ?Sized
     let part_size_bytes = multipart_part_size(options.part_size_bytes)?;
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
     let content_id = ContentId::generate();
-    let object_key = content_blob(content_store_id.as_str(), &content_id);
+    let object_key = content_blob(&content_store_id, &content_id);
 
     let provider_upload_id = store
         .create_multipart_upload(&object_key)
@@ -280,7 +280,7 @@ pub(crate) async fn direct_multipart_part_targets<S: ObjectStore + ?Sized>(
     }
 
     Ok(MultipartPartTargets {
-        object_key: content_blob(content_store_id.as_str(), &session.content_id),
+        object_key: content_blob(&content_store_id, &session.content_id),
         provider_upload_id: provider_upload_id.to_owned(),
         parts,
     })
@@ -465,7 +465,7 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
     let encoded = encode_control_object(&envelope).map_err(|err| {
         CoreError::Internal(format!("failed to encode upload session envelope: {err}"))
     })?;
-    let object_key = upload_session(namespace_id.as_str(), upload_id.as_str());
+    let object_key = upload_session(namespace_id, &upload_id);
     // An upload session is mutable control state, so its first lifecycle state is a conditional create.
     store
         .put_if_absent(&object_key, Bytes::from(encoded))
@@ -1024,10 +1024,7 @@ pub(crate) async fn stage_owned_stream<S: ObjectStore + ?Sized>(
         // replay, and it fails loudly.
         return Err(CoreError::Internal(format!(
             "content object `{}` already holds bytes under a freshly minted identity",
-            content_blob(
-                catalog.content_store_id().as_str(),
-                &staged.content_ref.content_id
-            )
+            content_blob(catalog.content_store_id(), &staged.content_ref.content_id)
         )));
     }
     complete_owned_staging(
@@ -1521,7 +1518,7 @@ async fn assemble_multipart_upload<S: ObjectStore + ?Sized>(
     expected: &ContentRef,
 ) -> Result<CompletionOutcome> {
     let parts = multipart_parts(parts)?;
-    let object_key = content_blob(content_store_id.as_str(), &expected.content_id);
+    let object_key = content_blob(content_store_id, &expected.content_id);
 
     match store
         .complete_multipart_upload(
@@ -1607,7 +1604,7 @@ mod tests {
         let content_store_id = load_namespace_content_store_id(store, &namespace_id)
             .await
             .expect("content store id");
-        let content_key = content_blob(content_store_id.as_str(), &staged.content_ref.content_id);
+        let content_key = content_blob(&content_store_id, &staged.content_ref.content_id);
         (
             namespace_id,
             content_store_id,

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -186,7 +186,7 @@ pub(crate) async fn delete_unpublished_content_object<S: ObjectStore + ?Sized>(
     content_store_id: &ContentStoreId,
     content_id: &ContentId,
 ) {
-    let object_key = content_blob(content_store_id.as_str(), content_id);
+    let object_key = content_blob(content_store_id, content_id);
     if let Err(error) = store.delete(&object_key).await {
         tracing::warn!(
             content_id = %content_id,
@@ -210,7 +210,7 @@ pub(crate) async fn abort_unpublished_multipart_upload<S: ObjectStore + ?Sized>(
     content_id: &ContentId,
     provider_upload_id: &str,
 ) {
-    let object_key = content_blob(content_store_id.as_str(), content_id);
+    let object_key = content_blob(content_store_id, content_id);
     if let Err(error) = store
         .abort_multipart_upload(&object_key, provider_upload_id)
         .await
@@ -505,10 +505,7 @@ pub(crate) fn content_object_key_for_ref(
     content_ref
         .validate()
         .map_err(DurableContentValidationError::InvalidContentRef)?;
-    Ok(content_blob(
-        content_store_id.as_str(),
-        &content_ref.content_id,
-    ))
+    Ok(content_blob(content_store_id, &content_ref.content_id))
 }
 
 /// Checks fetched bytes against everything the reference claims about them.
@@ -674,7 +671,7 @@ pub(crate) async fn stage_streamed_under_content_id<S: ObjectStore + ?Sized>(
     content_id: ContentId,
     body: ByteStream,
 ) -> Result<StagedStream, CoreError> {
-    let object_key = content_blob(content_store_id.as_str(), &content_id);
+    let object_key = content_blob(&content_store_id, &content_id);
     let observed = Arc::new(Mutex::new(StreamedPayload::default()));
     let hashed = {
         let observed = Arc::clone(&observed);
@@ -752,7 +749,7 @@ pub(crate) async fn stage_bytes_under_content_id<S: ObjectStore + ?Sized>(
     bytes: &[u8],
 ) -> Result<StoredContent, CoreError> {
     let content_ref = ContentRef::blob_v1(content_id, bytes);
-    let object_key = content_blob(content_store_id.as_str(), &content_ref.content_id);
+    let object_key = content_blob(&content_store_id, &content_ref.content_id);
     // Create-only plus the byte check stay on this write even though a
     // random id cannot collide: if this key is ever occupied by different
     // bytes, that is corruption, and it must fail loudly rather than be
@@ -1626,7 +1623,7 @@ mod tests {
         content_ref: &ContentRef,
         bytes: &[u8],
     ) {
-        let key = content_blob(content_store_id.as_str(), &content_ref.content_id);
+        let key = content_blob(content_store_id, &content_ref.content_id);
         store
             .put_if_absent(&key, Bytes::copy_from_slice(bytes))
             .await

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -104,10 +104,8 @@ pub(super) fn validate_wal_segment_for_replay(
 ) -> Result<(), WalReplayError> {
     // The id shape is validated on decode: `segment_id` is a typed
     // `WalSegmentId`, so only well-formed ids can reach this point.
-    let expected_object_key = wal_segment(
-        envelope.payload.namespace_id.as_str(),
-        envelope.payload.segment_id.as_str(),
-    );
+    let expected_object_key =
+        wal_segment(&envelope.payload.namespace_id, &envelope.payload.segment_id);
 
     if object_key != expected_object_key {
         return Err(WalReplayError::ObjectKeyMismatch {

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -349,17 +349,18 @@ async fn validated_wal_chain_reports_missing_previous_link_truthfully() {
 #[tokio::test]
 async fn validated_wal_chain_rejects_corrupt_visible_segments() {
     assert_wal_chain_corruption_rejected(|object_key, _envelope, pointer| {
-        *object_key = wal_segment("other", "seg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        *object_key = wal_segment(
+            &loonfs_api::NamespaceId::parse("other").expect("valid namespace id"),
+            &loonfs_api::WalSegmentId::parse("00000000000000000001-5f33f9a12dd767df")
+                .expect("valid WAL segment id"),
+        );
         pointer.object_key = object_key.clone();
     })
     .await;
     assert_wal_chain_corruption_rejected(|object_key, envelope, pointer| {
         envelope.payload.namespace_id = NamespaceId::parse("other").expect("valid namespace id");
         rewrap_envelope(envelope);
-        *object_key = wal_segment(
-            envelope.payload.namespace_id.as_str(),
-            envelope.payload.segment_id.as_str(),
-        );
+        *object_key = wal_segment(&envelope.payload.namespace_id, &envelope.payload.segment_id);
         *pointer = envelope.pointer(object_key.clone());
     })
     .await;
@@ -382,10 +383,7 @@ async fn validated_wal_chain_rejects_corrupt_visible_segments() {
     assert_wal_chain_corruption_rejected(|object_key, envelope, pointer| {
         envelope.payload.end_seq = ChangeSeq(2);
         rewrap_envelope(envelope);
-        *object_key = wal_segment(
-            envelope.payload.namespace_id.as_str(),
-            envelope.payload.segment_id.as_str(),
-        );
+        *object_key = wal_segment(&envelope.payload.namespace_id, &envelope.payload.segment_id);
         *pointer = envelope.pointer(object_key.clone());
     })
     .await;
@@ -395,10 +393,7 @@ async fn validated_wal_chain_rejects_corrupt_visible_segments() {
         envelope.payload.records.push(skipped);
         envelope.payload.end_seq = ChangeSeq(3);
         rewrap_envelope(envelope);
-        *object_key = wal_segment(
-            envelope.payload.namespace_id.as_str(),
-            envelope.payload.segment_id.as_str(),
-        );
+        *object_key = wal_segment(&envelope.payload.namespace_id, &envelope.payload.segment_id);
         *pointer = envelope.pointer(object_key.clone());
     })
     .await;
@@ -408,10 +403,7 @@ async fn validated_wal_chain_rejects_corrupt_visible_segments() {
         envelope.payload.end_seq = ChangeSeq(2);
         envelope.payload.records[0].seq = ChangeSeq(2);
         rewrap_envelope(envelope);
-        *object_key = wal_segment(
-            envelope.payload.namespace_id.as_str(),
-            envelope.payload.segment_id.as_str(),
-        );
+        *object_key = wal_segment(&envelope.payload.namespace_id, &envelope.payload.segment_id);
         *pointer = envelope.pointer(object_key.clone());
     })
     .await;
@@ -560,7 +552,7 @@ async fn chain_load_with_recent_segment_hints_matches_the_unhinted_chain() {
         WalSegmentId::parse("00000000000000000001-00000000deadbeef").expect("valid segment id");
     let garbage = [
         WalSegmentPointer {
-            object_key: wal_segment(namespace_id.as_str(), missing_segment_id.as_str()),
+            object_key: wal_segment(&namespace_id, &missing_segment_id),
             segment_id: missing_segment_id,
             start_seq: ChangeSeq(1),
             end_seq: ChangeSeq(1),
@@ -743,7 +735,7 @@ async fn a_failed_prefetch_costs_its_own_request_and_the_walk_loads_the_chain() 
     // walk's own fetches to succeed.
     let failing = FailStore::new(
         inner,
-        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
         OperationClass::Get,
         InjectedError::Transport("the store is flaky".to_owned()),
     );
@@ -802,7 +794,7 @@ async fn failed_prefetch_requests_count_against_the_limit() {
 
     let failing = FailStore::new(
         inner,
-        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
         OperationClass::Get,
         InjectedError::Transport("the store is flaky".to_owned()),
     );
@@ -1128,7 +1120,7 @@ async fn boundary_length_replay_fetches_every_segment_once_in_bounded_waves() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = ConcurrencyWatchStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
     );
     let segments =
         usize::try_from(crate::limits::MAX_UNFLUSHED_WAL_SEGMENTS).expect("a segment count");
@@ -1170,7 +1162,7 @@ async fn prefetch_fetches_only_the_segments_the_gap_intersects() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
     let store = RecordingStore::new(
         LocalFsStore::new(temp_dir.path()).expect("store"),
-        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
     );
     let chain = prepared_unstored_chain(&namespace_id, 5);
     store_chain(&store, &chain).await;

--- a/crates/loonfs-core/src/wal/writer.rs
+++ b/crates/loonfs-core/src/wal/writer.rs
@@ -79,7 +79,7 @@ pub(crate) fn prepare_wal_segment(
         .map_err(|err| WalBuildError::Codec(err.to_string()))?;
     let encoded_bytes = encode_wal_segment_envelope_zstd(&envelope)
         .map_err(|err| WalBuildError::Codec(err.to_string()))?;
-    let object_key = wal_segment(envelope.payload.namespace_id.as_str(), segment_id.as_str());
+    let object_key = wal_segment(&envelope.payload.namespace_id, &segment_id);
 
     Ok(PreparedWalSegment {
         object_key,

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -83,7 +83,7 @@ impl StaleHeadGetStore {
     fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
         Self {
             inner: LocalFsStore::new(root.as_ref()).expect("store"),
-            head_key: wal_head(namespace_id.as_str()),
+            head_key: wal_head(namespace_id),
             state: Mutex::new(StaleHeadGetState {
                 stale_head_body: None,
                 clean_head_gets_before_injection: None,
@@ -198,7 +198,7 @@ fn ack_lost_head_cas_store(
     root: impl AsRef<Path>,
     namespace_id: &NamespaceId,
 ) -> FailStore<LocalFsStore> {
-    let head_key = wal_head(namespace_id.as_str());
+    let head_key = wal_head(namespace_id);
     let store = FailStore::matching(
         LocalFsStore::new(root.as_ref()).expect("store"),
         move |operation: &OperationContext<'_>| {
@@ -244,7 +244,7 @@ impl StaleHeadAfterWalWriteStore {
     fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
         Self {
             inner: LocalFsStore::new(root.as_ref()).expect("store"),
-            head_key: wal_head(namespace_id.as_str()),
+            head_key: wal_head(namespace_id),
             injected_stale_head: Mutex::new(false),
         }
     }

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -458,7 +458,7 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
 
     store
         .delete(&content_blob(
-            first.content_store_id.as_str(),
+            &first.content_store_id,
             &first.content_ref.content_id,
         ))
         .await

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -107,7 +107,7 @@ async fn a_created_namespace_is_one_object_until_its_first_flush() {
         .expect("bootstrap namespace");
     assert_eq!(
         namespace_keys(&store, &namespace_id).await,
-        vec![wal_head(namespace_id.as_str())],
+        vec![wal_head(&namespace_id)],
         "creation writes the head and nothing else"
     );
     assert!(
@@ -150,12 +150,11 @@ async fn a_created_namespace_is_one_object_until_its_first_flush() {
     );
     let keys = namespace_keys(&store, &namespace_id).await;
     assert!(
-        keys.iter()
-            .all(|key| key == &wal_head(namespace_id.as_str())
-                || key.starts_with(&format!(
-                    "namespaces/{}/wal/segments/",
-                    namespace_id.as_str()
-                ))),
+        keys.iter().all(|key| key == &wal_head(&namespace_id)
+            || key.starts_with(&format!(
+                "namespaces/{}/wal/segments/",
+                namespace_id.as_str()
+            ))),
         "before the first flush a namespace is a head plus its WAL: {keys:?}"
     );
 
@@ -166,7 +165,7 @@ async fn a_created_namespace_is_one_object_until_its_first_flush() {
         .expect("flush");
     assert!(
         store
-            .head(&metadata_root(namespace_id.as_str()))
+            .head(&metadata_root(&namespace_id))
             .await
             .expect("probe root")
             .is_some(),
@@ -210,7 +209,7 @@ async fn concurrent_creates_of_one_id_leave_exactly_one_winner() {
     assert_eq!(loser.code(), ErrorCode::NamespaceExists);
     assert_eq!(
         namespace_keys(store.as_ref(), &namespace_id).await,
-        vec![wal_head(namespace_id.as_str())]
+        vec![wal_head(&namespace_id)]
     );
 }
 
@@ -361,7 +360,7 @@ async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
     assert_eq!(blobs_after, blobs_before, "fork must not copy content");
     assert_eq!(
         namespace_keys(&store, &clone_namespace_id).await,
-        vec![wal_head(clone_namespace_id.as_str())],
+        vec![wal_head(&clone_namespace_id)],
         "a fork target is its head and nothing else"
     );
 
@@ -490,10 +489,7 @@ async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
             .expect("clone metadata root");
     let clone_manifest_bytes = store
         .get(
-            &metadata_manifest_object(
-                clone_namespace_id.as_str(),
-                &clone_root.state.manifest_object_id,
-            ),
+            &metadata_manifest_object(&clone_namespace_id, &clone_root.state.manifest_object_id),
             None,
         )
         .await
@@ -574,7 +570,7 @@ async fn a_fork_basis_checksum_mismatch_is_corruption() {
         HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head).expect("head envelope");
     store
         .put_overwrite(
-            &wal_head(clone.as_str()),
+            &wal_head(&clone),
             Bytes::from(encode_control_object(&envelope).expect("encode head")),
         )
         .await
@@ -602,7 +598,7 @@ async fn checkpointing_an_unflushed_fork_materializes_its_first_manifest() {
         .expect("fork");
     assert!(
         store
-            .head(&metadata_root(clone.as_str()))
+            .head(&metadata_root(&clone))
             .await
             .expect("probe clone root")
             .is_none(),
@@ -621,7 +617,7 @@ async fn checkpointing_an_unflushed_fork_materializes_its_first_manifest() {
     .await
     .expect("read record")
     .expect("record exists");
-    let manifest_key = metadata_manifest_object(clone.as_str(), &record.manifest_object_id);
+    let manifest_key = metadata_manifest_object(&clone, &record.manifest_object_id);
     assert!(
         store
             .head(&manifest_key)
@@ -632,7 +628,7 @@ async fn checkpointing_an_unflushed_fork_materializes_its_first_manifest() {
     );
     assert!(
         store
-            .head(&metadata_root(clone.as_str()))
+            .head(&metadata_root(&clone))
             .await
             .expect("probe clone root")
             .is_some(),
@@ -763,10 +759,8 @@ async fn fork_namespace_rejects_corrupt_source_manifest_descriptors() {
     .await
     .expect("read source checkpoint record")
     .expect("source checkpoint record exists");
-    let manifest_key = metadata_manifest_object(
-        source_namespace_id.as_str(),
-        &source_record.manifest_object_id,
-    );
+    let manifest_key =
+        metadata_manifest_object(&source_namespace_id, &source_record.manifest_object_id);
     let manifest_bytes = store
         .get(&manifest_key, None)
         .await
@@ -826,7 +820,7 @@ async fn fork_source_checkpoint_failure_leaves_target_namespace_absent() {
     );
     assert!(
         store
-            .head(&wal_head(source_namespace_id.as_str()))
+            .head(&wal_head(&source_namespace_id))
             .await
             .expect("head source head")
             .is_some(),
@@ -851,10 +845,10 @@ async fn a_create_losing_to_a_foreign_head_reports_the_id_as_taken() {
     .expect("encode foreign head");
     let store = InjectCreateFailureStore::new(
         inner,
-        KeyMatcher::Exact(wal_head(namespace_id.as_str())),
+        KeyMatcher::Exact(wal_head(&namespace_id)),
         InjectedCreateFailure::PreconditionFailed {
             write_attempted_object: false,
-            additional_writes: vec![(wal_head(namespace_id.as_str()), foreign_bytes.clone())],
+            additional_writes: vec![(wal_head(&namespace_id), foreign_bytes.clone())],
         },
     );
 
@@ -864,7 +858,7 @@ async fn a_create_losing_to_a_foreign_head_reports_the_id_as_taken() {
     assert_eq!(error.code(), ErrorCode::NamespaceExists);
     assert_eq!(
         store
-            .get(&wal_head(namespace_id.as_str()), None)
+            .get(&wal_head(&namespace_id), None)
             .await
             .expect("read head")
             .expect("head exists")
@@ -1021,11 +1015,11 @@ async fn gc_handles_a_namespace_with_no_root_and_then_its_tombstone() {
     let surviving = namespace_keys(&store, &namespace_id).await;
     assert_eq!(
         surviving,
-        vec![wal_head(namespace_id.as_str())],
+        vec![wal_head(&namespace_id)],
         "reclamation leaves the tombstone head and nothing else"
     );
     assert!(store
-        .head(&wal_floor(namespace_id.as_str()))
+        .head(&wal_floor(&namespace_id))
         .await
         .expect("probe floor")
         .is_none());
@@ -1060,7 +1054,7 @@ impl ReleasePinAfterHeadStore {
     ) -> Self {
         Self {
             inner,
-            target_head_key: wal_head(target_namespace_id.as_str()),
+            target_head_key: wal_head(&target_namespace_id),
             after_head,
         }
     }

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -85,7 +85,7 @@ async fn reads_commits_and_change_feed_never_list() {
     // hot path.
     store
         .put_if_absent(
-            &format!("{}zz-junk.tmp", wal_segment_prefix(namespace_id.as_str())),
+            &format!("{}zz-junk.tmp", wal_segment_prefix(&namespace_id)),
             Bytes::from_static(b"junk"),
         )
         .await
@@ -178,7 +178,7 @@ async fn maintenance_never_touches_the_wal_head() {
     )
     .await;
 
-    let head_key = wal_head(namespace_id.as_str());
+    let head_key = wal_head(&namespace_id);
     let before = store
         .get_with_metadata(&head_key)
         .await

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -202,7 +202,7 @@ async fn begin_direct_put_rejects_a_malformed_claim_without_creating_a_session()
     assert_eq!(error.code(), ErrorCode::InvalidRequest);
     assert_eq!(
         store
-            .list_prefix(&upload_session_prefix(namespace_id.as_str()))
+            .list_prefix(&upload_session_prefix(&namespace_id))
             .await
             .expect("list upload sessions"),
         Vec::<String>::new()
@@ -350,7 +350,7 @@ async fn upload_content_rejects_invalid_upload_id_before_key_construction() {
     assert_eq!(error.code(), ErrorCode::InvalidRequest);
     assert_eq!(
         store
-            .list_prefix(&upload_session_prefix(namespace_id.as_str()))
+            .list_prefix(&upload_session_prefix(&namespace_id))
             .await
             .expect("list upload sessions"),
         Vec::<String>::new()
@@ -477,10 +477,7 @@ mod streamed_content {
         let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
             .await
             .expect("catalog");
-        let object_key = content_blob(
-            catalog.content_store_id().as_str(),
-            &first.content_ref.content_id,
-        );
+        let object_key = content_blob(catalog.content_store_id(), &first.content_ref.content_id);
         assert_eq!(
             store
                 .get(&object_key, None)
@@ -587,10 +584,7 @@ mod streamed_content {
             loonfs_core::control::load_namespace_catalog_entry(blocking.as_ref(), &namespace_id)
                 .await
                 .expect("catalog");
-        let object_key = content_blob(
-            catalog.content_store_id().as_str(),
-            &staged.content_ref.content_id,
-        );
+        let object_key = content_blob(catalog.content_store_id(), &staged.content_ref.content_id);
         let stored = blocking
             .get(&object_key, None)
             .await
@@ -665,7 +659,7 @@ mod direct_multipart {
         let catalog = loonfs_core::control::load_namespace_catalog_entry(store, &namespace_id)
             .await
             .expect("catalog");
-        let object_key = content_blob(catalog.content_store_id().as_str(), &state.content_id);
+        let object_key = content_blob(catalog.content_store_id(), &state.content_id);
 
         Session {
             namespace_id,
@@ -685,7 +679,7 @@ mod direct_multipart {
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
     ) -> UploadSessionState {
-        let key = upload_session(namespace_id.as_str(), upload_id.as_str());
+        let key = upload_session(namespace_id, upload_id);
         let bytes = store
             .get(&key, None)
             .await

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -1487,6 +1487,7 @@ impl GrepGcCursor {
             NamespaceCursorError::Malformed(_) | NamespaceCursorError::OutsideKeyspace => {
                 malformed_gc_cursor()
             }
+            _ => malformed_gc_cursor(),
         })
     }
 

--- a/crates/loonfs-grep/tests/it/common/mod.rs
+++ b/crates/loonfs-grep/tests/it/common/mod.rs
@@ -183,7 +183,7 @@ pub(crate) mod control {
     }
 
     pub(crate) async fn head(store: &SharedObjectStore, namespace_id: &NamespaceId) -> HeadState {
-        let bytes = control_bytes(store, &keys::wal_head(namespace_id.as_str()))
+        let bytes = control_bytes(store, &keys::wal_head(namespace_id))
             .await
             .expect("namespace head exists");
         decode_control_object::<HeadState>(&bytes, ControlObjectKind::WalHead)
@@ -195,7 +195,7 @@ pub(crate) mod control {
         store: &SharedObjectStore,
         namespace_id: &NamespaceId,
     ) -> MetadataRootState {
-        let bytes = control_bytes(store, &keys::metadata_root(namespace_id.as_str()))
+        let bytes = control_bytes(store, &keys::metadata_root(namespace_id))
             .await
             .expect("metadata root exists");
         decode_control_object::<MetadataRootState>(&bytes, ControlObjectKind::MetadataRoot)
@@ -208,11 +208,8 @@ pub(crate) mod control {
         namespace_id: &NamespaceId,
         checkpoint_id: &CheckpointId,
     ) -> Option<CheckpointRecordState> {
-        let bytes = control_bytes(
-            store,
-            &keys::checkpoint_record(namespace_id.as_str(), checkpoint_id.as_str()),
-        )
-        .await?;
+        let bytes =
+            control_bytes(store, &keys::checkpoint_record(namespace_id, checkpoint_id)).await?;
         Some(
             decode_control_object::<CheckpointRecordState>(
                 &bytes,

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -650,7 +650,7 @@ async fn an_expired_but_unreleased_backfill_pin_keeps_enumerating() {
     let checkpoint_id = assert_fresh_backfill_attempt(&store, &namespace_id).await;
 
     // Age the pin out from under the backfill without releasing it.
-    let key = checkpoint_record(namespace_id.as_str(), checkpoint_id.as_str());
+    let key = checkpoint_record(&namespace_id, &checkpoint_id);
     let mut record = control::checkpoint_record(&store, &namespace_id, &checkpoint_id)
         .await
         .expect("backfill checkpoint record");
@@ -1580,7 +1580,7 @@ async fn fork_of_grep_enabled_namespace_starts_unmaterialized_without_manifest_s
         .fork_basis
         .expect("a fork target has a basis manifest");
     let manifest_key = metadata_manifest_object(
-        target_basis.source_namespace_id.as_str(),
+        &target_basis.source_namespace_id,
         &target_basis.source_manifest_object_id,
     );
     let manifest_bytes = store
@@ -2092,14 +2092,14 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         vec![
             // Marking lists the records it roots from, then the manifests
             // it ages to find its reference manifest.
-            checkpoint_prefix(live_namespace.as_str()),
-            metadata_manifest_prefix(live_namespace.as_str()),
-            wal_segment_prefix(live_namespace.as_str()),
-            metadata_table_prefix(live_namespace.as_str()),
-            metadata_compaction_prefix(live_namespace.as_str()),
-            metadata_manifest_prefix(live_namespace.as_str()),
-            checkpoint_prefix(live_namespace.as_str()),
-            upload_session_prefix(live_namespace.as_str()),
+            checkpoint_prefix(&live_namespace),
+            metadata_manifest_prefix(&live_namespace),
+            wal_segment_prefix(&live_namespace),
+            metadata_table_prefix(&live_namespace),
+            metadata_compaction_prefix(&live_namespace),
+            metadata_manifest_prefix(&live_namespace),
+            checkpoint_prefix(&live_namespace),
+            upload_session_prefix(&live_namespace),
         ],
         "core GC must list only its own core prefixes"
     );

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -286,7 +286,8 @@ mod tests {
         let store = ConfiguredObjectStore::local_fs(&temp_dir, Some("tenant-a"))
             .expect("construct configured local fs store")
             .into_shared();
-        let head_key = wal_head("ns-1");
+        let head_key =
+            wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
 
         store
             .put_overwrite(&head_key, Bytes::from_static(br#"{"ok":true}"#))

--- a/crates/loonfs-objectstore/src/keys.rs
+++ b/crates/loonfs-objectstore/src/keys.rs
@@ -1,41 +1,44 @@
 //! Key construction for every durable object family.
 
 use crate::layout::ObjectLayout;
-use loonfs_api::{ContentId, ManifestObjectId, NamespaceId};
+use loonfs_api::{
+    CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
+    MetadataTableId, NamespaceId, UploadId, WalSegmentId,
+};
 
 /// Builds the listing prefix containing every durable object owned by one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
 pub fn namespace_prefix(namespace_id: &NamespaceId) -> String {
-    ObjectLayout::new().namespace_root_prefix(namespace_id.as_str())
+    ObjectLayout::new().namespace_root_prefix(namespace_id)
 }
 
 /// Builds the authoritative WAL head key for one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn wal_head(namespace: &str) -> String {
-    ObjectLayout::new().wal_head(namespace)
+pub fn wal_head(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().wal_head(namespace_id)
 }
 
 /// Builds the retained-history floor key for one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn wal_floor(namespace: &str) -> String {
-    ObjectLayout::new().wal_floor(namespace)
+pub fn wal_floor(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().wal_floor(namespace_id)
 }
 
 /// Builds the immutable WAL object key for a segment identity.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn wal_segment(namespace: &str, segment_id: &str) -> String {
-    ObjectLayout::new().wal_segment(namespace, segment_id)
+pub fn wal_segment(namespace_id: &NamespaceId, wal_segment_id: &WalSegmentId) -> String {
+    ObjectLayout::new().wal_segment(namespace_id, wal_segment_id)
 }
 
 /// Builds the listing prefix containing only WAL segment objects for one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn wal_segment_prefix(namespace: &str) -> String {
-    ObjectLayout::new().wal_segment_prefix(namespace)
+pub fn wal_segment_prefix(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().wal_segment_prefix(namespace_id)
 }
 
 /// Extracts a segment identity from a current-format WAL object key.
@@ -49,60 +52,74 @@ pub fn wal_segment_id_from_key(key: &str) -> Option<&str> {
 /// Builds the materialized metadata-root key for one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_root(namespace: &str) -> String {
-    ObjectLayout::new().metadata_root(namespace)
+pub fn metadata_root(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().metadata_root(namespace_id)
 }
 
 /// Builds the listing prefix containing namespace-manifest candidates.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_manifest_prefix(namespace: &str) -> String {
-    ObjectLayout::new().metadata_manifest_prefix(namespace)
+pub fn metadata_manifest_prefix(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().metadata_manifest_prefix(namespace_id)
 }
 
 /// Builds the listing prefix containing metadata SST objects owned by one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_table_prefix(namespace: &str) -> String {
-    ObjectLayout::new().metadata_table_prefix(namespace)
+pub fn metadata_table_prefix(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().metadata_table_prefix(namespace_id)
 }
 
 /// Builds the immutable manifest key for one speculative manifest identity.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_manifest_object(namespace: &str, manifest_object_id: &ManifestObjectId) -> String {
-    ObjectLayout::new().metadata_manifest_object(namespace, manifest_object_id)
+pub fn metadata_manifest_object(
+    namespace_id: &NamespaceId,
+    manifest_object_id: &ManifestObjectId,
+) -> String {
+    ObjectLayout::new().metadata_manifest_object(namespace_id, manifest_object_id)
 }
 
 /// Builds the immutable metadata SST key for one table identity.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_table(namespace: &str, table_id: &str) -> String {
-    ObjectLayout::new().metadata_table(namespace, table_id)
+pub fn metadata_table(namespace_id: &NamespaceId, metadata_table_id: &MetadataTableId) -> String {
+    ObjectLayout::new().metadata_table(namespace_id, metadata_table_id)
 }
 
 /// Builds the immutable staging key one streaming compaction job writes a
 /// metadata segment to before any manifest references it.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_compaction_table(namespace: &str, job_id: &str, table_id: &str) -> String {
-    ObjectLayout::new().metadata_compaction_table(namespace, job_id, table_id)
+pub fn metadata_compaction_table(
+    namespace_id: &NamespaceId,
+    metadata_compaction_id: &MetadataCompactionId,
+    metadata_table_id: &MetadataTableId,
+) -> String {
+    ObjectLayout::new().metadata_compaction_table(
+        namespace_id,
+        metadata_compaction_id,
+        metadata_table_id,
+    )
 }
 
 /// Builds the mutable lease key one streaming compaction job holds over its
 /// own prefix.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_compaction_lease(namespace: &str, job_id: &str) -> String {
-    ObjectLayout::new().metadata_compaction_lease(namespace, job_id)
+pub fn metadata_compaction_lease(
+    namespace_id: &NamespaceId,
+    metadata_compaction_id: &MetadataCompactionId,
+) -> String {
+    ObjectLayout::new().metadata_compaction_lease(namespace_id, metadata_compaction_id)
 }
 
 /// Builds the listing prefix containing every streaming compaction job's
 /// objects for one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn metadata_compaction_prefix(namespace: &str) -> String {
-    ObjectLayout::new().metadata_compaction_prefix(namespace)
+pub fn metadata_compaction_prefix(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().metadata_compaction_prefix(namespace_id)
 }
 
 /// Extracts the job id from a key under one namespace's compaction prefix.
@@ -117,36 +134,36 @@ pub fn metadata_compaction_job_id_from_key(key: &str) -> Option<&str> {
 /// Builds the mutable lifecycle key for one checkpoint record.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn checkpoint_record(namespace: &str, checkpoint_id: &str) -> String {
-    ObjectLayout::new().checkpoint_record(namespace, checkpoint_id)
+pub fn checkpoint_record(namespace_id: &NamespaceId, checkpoint_id: &CheckpointId) -> String {
+    ObjectLayout::new().checkpoint_record(namespace_id, checkpoint_id)
 }
 
 /// Builds the listing prefix containing checkpoint records for one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn checkpoint_prefix(namespace: &str) -> String {
-    ObjectLayout::new().checkpoint_prefix(namespace)
+pub fn checkpoint_prefix(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().checkpoint_prefix(namespace_id)
 }
 
 /// Builds the listing prefix containing durable upload sessions for one namespace.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn upload_session_prefix(namespace: &str) -> String {
-    ObjectLayout::new().upload_session_prefix(namespace)
+pub fn upload_session_prefix(namespace_id: &NamespaceId) -> String {
+    ObjectLayout::new().upload_session_prefix(namespace_id)
 }
 
 /// Builds the mutable lifecycle key for one upload session.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn upload_session(namespace: &str, upload_id: &str) -> String {
-    ObjectLayout::new().upload_session(namespace, upload_id)
+pub fn upload_session(namespace_id: &NamespaceId, upload_id: &UploadId) -> String {
+    ObjectLayout::new().upload_session(namespace_id, upload_id)
 }
 
 /// Builds the immutable content-object key for one content identity.
 ///
 /// See [durable object families](../../../docs/specs/format.md#12-durable-object-families).
-pub fn content_blob(content_store: &str, content_id: &ContentId) -> String {
-    ObjectLayout::new().content_blob(content_store, content_id)
+pub fn content_blob(content_store_id: &ContentStoreId, content_id: &ContentId) -> String {
+    ObjectLayout::new().content_blob(content_store_id, content_id)
 }
 
 #[cfg(test)]
@@ -158,12 +175,46 @@ mod tests {
         wal_segment_id_from_key, wal_segment_prefix,
     };
     use crate::layout::ObjectLayout;
-    use loonfs_api::{ContentId, ManifestObjectId, NamespaceId};
+    use loonfs_api::{
+        CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
+        MetadataTableId, NamespaceId, UploadId, WalSegmentId,
+    };
 
     const CONTENT_ID: &str = "con_abcdef0123456789abcdef0123456789";
 
     fn content_id() -> ContentId {
         ContentId::parse(CONTENT_ID).expect("valid content id")
+    }
+
+    fn namespace_id() -> NamespaceId {
+        NamespaceId::parse("ns-1").expect("valid namespace id")
+    }
+
+    fn content_store_id() -> ContentStoreId {
+        ContentStoreId::parse("cs_00000000000000000000000000000001")
+            .expect("valid content store id")
+    }
+
+    fn checkpoint_id() -> CheckpointId {
+        CheckpointId::parse("chk_00000000000000000000000000000001").expect("valid checkpoint id")
+    }
+
+    fn metadata_compaction_id() -> MetadataCompactionId {
+        MetadataCompactionId::parse("cmp_00000000000000000000000000000001")
+            .expect("valid metadata compaction id")
+    }
+
+    fn metadata_table_id() -> MetadataTableId {
+        MetadataTableId::parse("tbl_00000000000000000000000000000001")
+            .expect("valid metadata table id")
+    }
+
+    fn upload_id() -> UploadId {
+        UploadId::parse("upl_00000000000000000000000000000001").expect("valid upload id")
+    }
+
+    fn wal_segment_id(value: &str) -> WalSegmentId {
+        WalSegmentId::parse(value).expect("valid WAL segment id")
     }
 
     #[test]
@@ -172,7 +223,7 @@ mod tests {
 
         assert_eq!(
             namespace_prefix(&namespace_id),
-            ObjectLayout::new().namespace_root_prefix(namespace_id.as_str())
+            ObjectLayout::new().namespace_root_prefix(&namespace_id)
         );
     }
 
@@ -220,50 +271,70 @@ mod tests {
                 .replace("{namespace_id}", "ns-1")
                 .replace("{owner_namespace_id}", "ns-1")
                 .replace("{source_namespace_id}", "ns-1")
-                .replace("{content_store_id}", "cs-1")
+                .replace("{content_store_id}", "cs_00000000000000000000000000000001")
                 .replace("{start_seq:020}", &format!("{:020}", 42))
                 .replace("{suffix}", "0123456789abcdef")
                 .replace(
                     "{manifest_object_id}",
                     "00000000000000000400-0123456789abcdef",
                 )
-                .replace("{checkpoint_id}", "chk-1")
-                .replace("{job_id}", "cmp-1")
-                .replace("{table_id}", "tbl-1")
-                .replace("{upload_id}", "up-1")
+                .replace("{checkpoint_id}", "chk_00000000000000000000000000000001")
+                .replace("{job_id}", "cmp_00000000000000000000000000000001")
+                .replace("{table_id}", "tbl_00000000000000000000000000000001")
+                .replace("{upload_id}", "upl_00000000000000000000000000000001")
                 .replace("{content_id[4..6]}", &CONTENT_ID[4..6])
                 .replace("{content_id[6..8]}", &CONTENT_ID[6..8])
                 .replace("{content_id}", CONTENT_ID)
         };
 
         let built = [
-            ("WAL head", wal_head("ns-1")),
+            ("WAL head", wal_head(&namespace_id())),
             (
                 "WAL segments",
-                wal_segment("ns-1", &format!("{:020}-{}", 42, "0123456789abcdef")),
+                wal_segment(
+                    &namespace_id(),
+                    &WalSegmentId::parse(format!("{:020}-{}", 42, "0123456789abcdef"))
+                        .expect("valid WAL segment id"),
+                ),
             ),
             (
                 "Namespace manifests",
                 metadata_manifest_object(
-                    "ns-1",
+                    &namespace_id(),
                     &ManifestObjectId::parse("00000000000000000400-0123456789abcdef")
                         .expect("valid manifest object id"),
                 ),
             ),
-            ("Checkpoint records", checkpoint_record("ns-1", "chk-1")),
-            ("Metadata tables", metadata_table("ns-1", "tbl-1")),
+            (
+                "Checkpoint records",
+                checkpoint_record(&namespace_id(), &checkpoint_id()),
+            ),
+            (
+                "Metadata tables",
+                metadata_table(&namespace_id(), &metadata_table_id()),
+            ),
             (
                 "Compaction staging",
-                metadata_compaction_table("ns-1", "cmp-1", "tbl-1"),
+                metadata_compaction_table(
+                    &namespace_id(),
+                    &metadata_compaction_id(),
+                    &metadata_table_id(),
+                ),
             ),
             (
                 "Compaction leases",
-                metadata_compaction_lease("ns-1", "cmp-1"),
+                metadata_compaction_lease(&namespace_id(), &metadata_compaction_id()),
             ),
-            ("Upload sessions", upload_session("ns-1", "up-1")),
-            ("Metadata root", metadata_root("ns-1")),
-            ("WAL floor", wal_floor("ns-1")),
-            ("Content objects", content_blob("cs-1", &content_id())),
+            (
+                "Upload sessions",
+                upload_session(&namespace_id(), &upload_id()),
+            ),
+            ("Metadata root", metadata_root(&namespace_id())),
+            ("WAL floor", wal_floor(&namespace_id())),
+            (
+                "Content objects",
+                content_blob(&content_store_id(), &content_id()),
+            ),
         ];
 
         let expected: std::collections::BTreeMap<String, String> = built
@@ -283,21 +354,30 @@ mod tests {
 
     #[test]
     fn key_builders_match_spec_examples() {
-        assert_eq!(wal_head("ns-1"), "namespaces/ns-1/wal/head.json");
-        assert_eq!(wal_floor("ns-1"), "namespaces/ns-1/wal/floor.json");
+        assert_eq!(wal_head(&namespace_id()), "namespaces/ns-1/wal/head.json");
+        assert_eq!(wal_floor(&namespace_id()), "namespaces/ns-1/wal/floor.json");
         assert_eq!(
-            wal_segment("ns-1", "seg_00000000000000000000000000000001"),
-            "namespaces/ns-1/wal/segments/seg_00000000000000000000000000000001.wal.zst"
+            wal_segment(
+                &namespace_id(),
+                &wal_segment_id("00000000000000000001-0123456789abcdef")
+            ),
+            "namespaces/ns-1/wal/segments/00000000000000000001-0123456789abcdef.wal.zst"
         );
-        assert_eq!(wal_segment_prefix("ns-1"), "namespaces/ns-1/wal/segments/");
-        assert!(wal_segment("ns-1", "00000000000000000042-0123456789abcdef")
-            .starts_with(&wal_segment_prefix("ns-1")));
-        assert!(!wal_head("ns-1").starts_with(&wal_segment_prefix("ns-1")));
-        assert!(!wal_floor("ns-1").starts_with(&wal_segment_prefix("ns-1")));
+        assert_eq!(
+            wal_segment_prefix(&namespace_id()),
+            "namespaces/ns-1/wal/segments/"
+        );
+        assert!(wal_segment(
+            &namespace_id(),
+            &wal_segment_id("00000000000000000042-0123456789abcdef")
+        )
+        .starts_with(&wal_segment_prefix(&namespace_id())));
+        assert!(!wal_head(&namespace_id()).starts_with(&wal_segment_prefix(&namespace_id())));
+        assert!(!wal_floor(&namespace_id()).starts_with(&wal_segment_prefix(&namespace_id())));
         assert_eq!(
             wal_segment_id_from_key(&wal_segment(
-                "ns-1",
-                "00000000000000000042-0123456789abcdef"
+                &namespace_id(),
+                &wal_segment_id("00000000000000000042-0123456789abcdef")
             )),
             Some("00000000000000000042-0123456789abcdef")
         );
@@ -305,43 +385,46 @@ mod tests {
             wal_segment_id_from_key("namespaces/ns-1/wal/segments/random.tmp"),
             None
         );
-        assert_eq!(metadata_root("ns-1"), "namespaces/ns-1/metadata/root.json");
+        assert_eq!(
+            metadata_root(&namespace_id()),
+            "namespaces/ns-1/metadata/root.json"
+        );
         let manifest_object_id = ManifestObjectId::parse("00000000000000000400-0123456789abcdef")
             .expect("valid manifest object id");
         assert_eq!(
-            metadata_manifest_object("ns-1", &manifest_object_id),
+            metadata_manifest_object(&namespace_id(), &manifest_object_id),
             "namespaces/ns-1/metadata/manifests/00000000000000000400-0123456789abcdef.manifest.json"
         );
         assert_eq!(
-            metadata_table("ns-1", "tbl_00000000000000000000000000000001"),
+            metadata_table(&namespace_id(), &metadata_table_id()),
             "namespaces/ns-1/metadata/tables/tbl_00000000000000000000000000000001.sst.zst"
         );
         assert_eq!(
-            metadata_compaction_prefix("ns-1"),
+            metadata_compaction_prefix(&namespace_id()),
             "namespaces/ns-1/metadata/compactions/"
         );
         assert_eq!(
             metadata_compaction_table(
-                "ns-1",
-                "cmp_00000000000000000000000000000001",
-                "tbl_00000000000000000000000000000001"
+                &namespace_id(),
+                &metadata_compaction_id(),
+                &metadata_table_id(),
             ),
             "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/tables/tbl_00000000000000000000000000000001.sst.zst"
         );
         assert_eq!(
-            metadata_compaction_lease("ns-1", "cmp_00000000000000000000000000000001"),
+            metadata_compaction_lease(&namespace_id(), &metadata_compaction_id()),
             "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/lease.json"
         );
         assert_eq!(
-            checkpoint_record("ns-1", "chk_00000000000000000000000000000001"),
+            checkpoint_record(&namespace_id(), &checkpoint_id()),
             "namespaces/ns-1/checkpoints/chk_00000000000000000000000000000001.json"
         );
         assert_eq!(
-            content_blob("cs_00000000000000000000000000000001", &content_id()),
+            content_blob(&content_store_id(), &content_id()),
             "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
         );
         assert_eq!(
-            upload_session("ns-1", "upl_00000000000000000000000000000001"),
+            upload_session(&namespace_id(), &upload_id()),
             "namespaces/ns-1/uploads/upl_00000000000000000000000000000001.json"
         );
     }
@@ -351,7 +434,7 @@ mod tests {
     #[test]
     fn content_keys_shard_on_the_content_id_prefix() {
         let id = content_id();
-        let key = content_blob("cs-1", &id);
+        let key = content_blob(&content_store_id(), &id);
         let [first_shard, second_shard] = id.shard_prefixes();
         assert!(key.ends_with(&format!("/{first_shard}/{second_shard}/{}", id.as_str())));
     }

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -144,7 +144,8 @@ mod tests {
 
     #[test]
     fn scoped_key_helpers_keep_prefix_isolation() {
-        let head_key = wal_head("ns-1");
+        let head_key =
+            wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
         assert!(matches!(
             scope_object_key(Some("tenant-a"), &head_key),
             Ok(scoped) if scoped == format!("tenant-a/{head_key}")

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -1,7 +1,10 @@
 //! The durable key grammar: object families, their path shapes, and
 //! parsing keys back into classified families.
 
-use loonfs_api::{ContentId, ManifestObjectId};
+use loonfs_api::{
+    CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
+    MetadataTableId, NamespaceId, UploadId, WalSegmentId,
+};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct ObjectLayout;
@@ -85,23 +88,27 @@ impl ObjectLayout {
         Self
     }
 
-    pub(crate) fn namespace_root_prefix(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/")
+    pub(crate) fn namespace_root_prefix(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/")
     }
 
     /// Hot head of the semantic commit stream: the only object whose CAS
     /// gates user-write throughput.
-    pub(crate) fn wal_head(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/wal/head.json")
+    pub(crate) fn wal_head(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/wal/head.json")
     }
 
     /// Cold lower bound of retained WAL/change history.
-    pub(crate) fn wal_floor(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/wal/floor.json")
+    pub(crate) fn wal_floor(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/wal/floor.json")
     }
 
-    pub(crate) fn wal_segment(&self, namespace: &str, segment_id: &str) -> String {
-        format!("namespaces/{namespace}/wal/segments/{segment_id}.wal.zst")
+    pub(crate) fn wal_segment(
+        &self,
+        namespace_id: &NamespaceId,
+        wal_segment_id: &WalSegmentId,
+    ) -> String {
+        format!("namespaces/{namespace_id}/wal/segments/{wal_segment_id}.wal.zst")
     }
 
     /// Listing prefix that contains every WAL segment of `namespace` and
@@ -110,8 +117,8 @@ impl ObjectLayout {
     ///
     /// Segment file names start with the segment's 20-digit `start_seq` as
     /// an operator/GC convenience; no protocol depends on listing order.
-    pub(crate) fn wal_segment_prefix(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/wal/segments/")
+    pub(crate) fn wal_segment_prefix(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/wal/segments/")
     }
 
     /// Extracts the WAL segment id from a listed object key.
@@ -124,31 +131,32 @@ impl ObjectLayout {
     }
 
     /// Cold pointer to the best known materialized metadata root.
-    pub(crate) fn metadata_root(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/metadata/root.json")
+    pub(crate) fn metadata_root(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/metadata/root.json")
     }
 
     pub(crate) fn metadata_manifest_object(
         &self,
-        namespace: &str,
+        namespace_id: &NamespaceId,
         manifest_object_id: &ManifestObjectId,
     ) -> String {
-        format!(
-            "namespaces/{namespace}/metadata/manifests/{}.manifest.json",
-            manifest_object_id.as_str()
-        )
+        format!("namespaces/{namespace_id}/metadata/manifests/{manifest_object_id}.manifest.json")
     }
 
-    pub(crate) fn metadata_manifest_prefix(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/metadata/manifests/")
+    pub(crate) fn metadata_manifest_prefix(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/metadata/manifests/")
     }
 
-    pub(crate) fn metadata_table(&self, namespace: &str, table_id: &str) -> String {
-        format!("namespaces/{namespace}/metadata/tables/{table_id}.sst.zst")
+    pub(crate) fn metadata_table(
+        &self,
+        namespace_id: &NamespaceId,
+        metadata_table_id: &MetadataTableId,
+    ) -> String {
+        format!("namespaces/{namespace_id}/metadata/tables/{metadata_table_id}.sst.zst")
     }
 
-    pub(crate) fn metadata_table_prefix(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/metadata/tables/")
+    pub(crate) fn metadata_table_prefix(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/metadata/tables/")
     }
 
     /// A metadata segment a streaming compaction has written but no manifest
@@ -161,22 +169,30 @@ impl ObjectLayout {
     /// rather than one object at a time.
     pub(crate) fn metadata_compaction_table(
         &self,
-        namespace: &str,
-        job_id: &str,
-        table_id: &str,
+        namespace_id: &NamespaceId,
+        metadata_compaction_id: &MetadataCompactionId,
+        metadata_table_id: &MetadataTableId,
     ) -> String {
-        format!("namespaces/{namespace}/metadata/compactions/{job_id}/tables/{table_id}.sst.zst")
+        format!(
+            "namespaces/{namespace_id}/metadata/compactions/{metadata_compaction_id}/tables/{metadata_table_id}.sst.zst"
+        )
     }
 
     /// The lease one job holds over its own prefix. It sorts before that
     /// job's `tables/` directory, so an ascending listing of the compaction
     /// prefix reads a job's lease before the objects it protects.
-    pub(crate) fn metadata_compaction_lease(&self, namespace: &str, job_id: &str) -> String {
-        format!("namespaces/{namespace}/metadata/compactions/{job_id}/lease.json")
+    pub(crate) fn metadata_compaction_lease(
+        &self,
+        namespace_id: &NamespaceId,
+        metadata_compaction_id: &MetadataCompactionId,
+    ) -> String {
+        format!(
+            "namespaces/{namespace_id}/metadata/compactions/{metadata_compaction_id}/lease.json"
+        )
     }
 
-    pub(crate) fn metadata_compaction_prefix(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/metadata/compactions/")
+    pub(crate) fn metadata_compaction_prefix(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/metadata/compactions/")
     }
 
     /// The job id of a key under one namespace's compaction prefix, for the
@@ -198,31 +214,42 @@ impl ObjectLayout {
     }
 
     /// Durable stable-view pin to a metadata manifest.
-    pub(crate) fn checkpoint_record(&self, namespace: &str, checkpoint_id: &str) -> String {
-        format!("namespaces/{namespace}/checkpoints/{checkpoint_id}.json")
+    pub(crate) fn checkpoint_record(
+        &self,
+        namespace_id: &NamespaceId,
+        checkpoint_id: &CheckpointId,
+    ) -> String {
+        format!("namespaces/{namespace_id}/checkpoints/{checkpoint_id}.json")
     }
 
-    pub(crate) fn checkpoint_prefix(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/checkpoints/")
+    pub(crate) fn checkpoint_prefix(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/checkpoints/")
     }
 
-    pub(crate) fn upload_session(&self, namespace: &str, upload_id: &str) -> String {
-        format!("namespaces/{namespace}/uploads/{upload_id}.json")
+    pub(crate) fn upload_session(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+    ) -> String {
+        format!("namespaces/{namespace_id}/uploads/{upload_id}.json")
     }
 
-    pub(crate) fn upload_session_prefix(&self, namespace: &str) -> String {
-        format!("namespaces/{namespace}/uploads/")
+    pub(crate) fn upload_session_prefix(&self, namespace_id: &NamespaceId) -> String {
+        format!("namespaces/{namespace_id}/uploads/")
     }
 
     /// Content objects shard across two directory levels selected by the
     /// content id's leading characters. Those characters are random, so
     /// ingest spreads evenly and filesystem-backed stores keep bounded
     /// directory fanout.
-    pub(crate) fn content_blob(&self, content_store: &str, content_id: &ContentId) -> String {
+    pub(crate) fn content_blob(
+        &self,
+        content_store_id: &ContentStoreId,
+        content_id: &ContentId,
+    ) -> String {
         let [first_shard, second_shard] = content_id.shard_prefixes();
         format!(
-            "content-stores/{content_store}/objects/{first_shard}/{second_shard}/{}",
-            content_id.as_str()
+            "content-stores/{content_store_id}/objects/{first_shard}/{second_shard}/{content_id}"
         )
     }
 }
@@ -290,80 +317,120 @@ fn parsed(
 #[cfg(test)]
 mod tests {
     use super::{parse_object_key, DurableObjectFamily, ObjectLayout};
-    use loonfs_api::{ContentId, ManifestObjectId};
+    use loonfs_api::{
+        CheckpointId, ContentId, ContentStoreId, ManifestObjectId, MetadataCompactionId,
+        MetadataTableId, NamespaceId, UploadId, WalSegmentId,
+    };
 
     fn content_id() -> ContentId {
         ContentId::parse("con_abcdef0123456789abcdef0123456789").expect("valid content id")
+    }
+
+    fn namespace_id() -> NamespaceId {
+        NamespaceId::parse("ns-1").expect("valid namespace id")
+    }
+
+    fn content_store_id() -> ContentStoreId {
+        ContentStoreId::parse("cs_00000000000000000000000000000001")
+            .expect("valid content store id")
+    }
+
+    fn checkpoint_id() -> CheckpointId {
+        CheckpointId::parse("chk_00000000000000000000000000000001").expect("valid checkpoint id")
+    }
+
+    fn metadata_compaction_id(value: u128) -> MetadataCompactionId {
+        MetadataCompactionId::parse(format!("cmp_{value:032x}"))
+            .expect("valid metadata compaction id")
+    }
+
+    fn metadata_table_id() -> MetadataTableId {
+        MetadataTableId::parse("tbl_00000000000000000000000000000001")
+            .expect("valid metadata table id")
+    }
+
+    fn upload_id() -> UploadId {
+        UploadId::parse("upl_00000000000000000000000000000001").expect("valid upload id")
+    }
+
+    fn wal_segment_id(value: &str) -> WalSegmentId {
+        WalSegmentId::parse(value).expect("valid WAL segment id")
     }
 
     #[test]
     fn layout_golden_tree_matches_target_paths() {
         let layout = ObjectLayout::new();
 
-        assert_eq!(layout.namespace_root_prefix("ns-1"), "namespaces/ns-1/");
         assert_eq!(
-            layout.wal_head("ns-1").as_str(),
+            layout.namespace_root_prefix(&namespace_id()),
+            "namespaces/ns-1/"
+        );
+        assert_eq!(
+            layout.wal_head(&namespace_id()).as_str(),
             "namespaces/ns-1/wal/head.json"
         );
         assert_eq!(
-            layout.wal_floor("ns-1").as_str(),
+            layout.wal_floor(&namespace_id()).as_str(),
             "namespaces/ns-1/wal/floor.json"
         );
         assert_eq!(
             layout
-                .wal_segment("ns-1", "seg_00000000000000000000000000000001")
+                .wal_segment(
+                    &namespace_id(),
+                    &wal_segment_id("00000000000000000001-0123456789abcdef")
+                )
                 .as_str(),
-            "namespaces/ns-1/wal/segments/seg_00000000000000000000000000000001.wal.zst"
+            "namespaces/ns-1/wal/segments/00000000000000000001-0123456789abcdef.wal.zst"
         );
         assert_eq!(
-            layout.metadata_root("ns-1").as_str(),
+            layout.metadata_root(&namespace_id()).as_str(),
             "namespaces/ns-1/metadata/root.json"
         );
         let manifest_object_id = ManifestObjectId::parse("00000000000000000400-0123456789abcdef")
             .expect("valid manifest object id");
         assert_eq!(
             layout
-                .metadata_manifest_object("ns-1", &manifest_object_id)
+                .metadata_manifest_object(&namespace_id(), &manifest_object_id)
                 .as_str(),
             "namespaces/ns-1/metadata/manifests/00000000000000000400-0123456789abcdef.manifest.json"
         );
         assert_eq!(
             layout
-                .metadata_table("ns-1", "tbl_00000000000000000000000000000001")
+                .metadata_table(&namespace_id(), &metadata_table_id())
                 .as_str(),
             "namespaces/ns-1/metadata/tables/tbl_00000000000000000000000000000001.sst.zst"
         );
         assert_eq!(
             layout
                 .metadata_compaction_table(
-                    "ns-1",
-                    "cmp_00000000000000000000000000000001",
-                    "tbl_00000000000000000000000000000001"
+                    &namespace_id(),
+                    &metadata_compaction_id(1),
+                    &metadata_table_id()
                 )
                 .as_str(),
             "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/tables/tbl_00000000000000000000000000000001.sst.zst"
         );
         assert_eq!(
             layout
-                .metadata_compaction_lease("ns-1", "cmp_00000000000000000000000000000001")
+                .metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1))
                 .as_str(),
             "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/lease.json"
         );
         assert_eq!(
             layout
-                .checkpoint_record("ns-1", "chk_00000000000000000000000000000001")
+                .checkpoint_record(&namespace_id(), &checkpoint_id())
                 .as_str(),
             "namespaces/ns-1/checkpoints/chk_00000000000000000000000000000001.json"
         );
         assert_eq!(
             layout
-                .upload_session("ns-1", "upl_00000000000000000000000000000001")
+                .upload_session(&namespace_id(), &upload_id())
                 .as_str(),
             "namespaces/ns-1/uploads/upl_00000000000000000000000000000001.json"
         );
         assert_eq!(
             layout
-                .content_blob("cs_00000000000000000000000000000001", &content_id())
+                .content_blob(&content_store_id(), &content_id())
                 .as_str(),
             "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
         );
@@ -372,12 +439,21 @@ mod tests {
     #[test]
     fn control_objects_live_outside_the_segment_listing_prefix() {
         let layout = ObjectLayout::new();
-        let prefix = layout.wal_segment_prefix("ns-1");
+        let prefix = layout.wal_segment_prefix(&namespace_id());
         assert_eq!(prefix, "namespaces/ns-1/wal/segments/");
-        assert!(!layout.wal_head("ns-1").as_str().starts_with(&prefix));
-        assert!(!layout.wal_floor("ns-1").as_str().starts_with(&prefix));
+        assert!(!layout
+            .wal_head(&namespace_id())
+            .as_str()
+            .starts_with(&prefix));
+        assert!(!layout
+            .wal_floor(&namespace_id())
+            .as_str()
+            .starts_with(&prefix));
         assert!(layout
-            .wal_segment("ns-1", "seg_1")
+            .wal_segment(
+                &namespace_id(),
+                &wal_segment_id("00000000000000000002-0123456789abcdef")
+            )
             .as_str()
             .starts_with(&prefix));
     }
@@ -389,21 +465,29 @@ mod tests {
     #[test]
     fn staged_compaction_segments_live_outside_the_table_listing_prefix() {
         let layout = ObjectLayout::new();
-        let tables = layout.metadata_table_prefix("ns-1");
-        let staging = layout.metadata_compaction_prefix("ns-1");
+        let tables = layout.metadata_table_prefix(&namespace_id());
+        let staging = layout.metadata_compaction_prefix(&namespace_id());
 
         assert!(!staging.starts_with(&tables));
         assert!(!layout
-            .metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc")
+            .metadata_compaction_table(
+                &namespace_id(),
+                &metadata_compaction_id(1),
+                &metadata_table_id()
+            )
             .starts_with(&tables));
         assert!(layout
-            .metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc")
+            .metadata_compaction_table(
+                &namespace_id(),
+                &metadata_compaction_id(1),
+                &metadata_table_id()
+            )
             .starts_with(&staging));
         assert!(layout
-            .metadata_compaction_lease("ns-1", "cmp_abc")
+            .metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1))
             .starts_with(&staging));
         assert!(!layout
-            .metadata_table("ns-1", "tbl_abc")
+            .metadata_table(&namespace_id(), &metadata_table_id())
             .starts_with(&staging));
     }
 
@@ -412,12 +496,18 @@ mod tests {
     #[test]
     fn a_jobs_lease_sorts_before_its_staged_segments() {
         let layout = ObjectLayout::new();
-        let lease = layout.metadata_compaction_lease("ns-1", "cmp_abc");
-        let table = layout.metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc");
+        let lease = layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1));
+        let table = layout.metadata_compaction_table(
+            &namespace_id(),
+            &metadata_compaction_id(1),
+            &metadata_table_id(),
+        );
         assert!(lease < table);
         // And one job's objects are contiguous: the next job's lease sorts
         // above every object of the job before it.
-        assert!(table < layout.metadata_compaction_lease("ns-1", "cmp_abd"));
+        assert!(
+            table < layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(2))
+        );
     }
 
     /// Both key shapes under the compaction prefix name their job; anything
@@ -427,21 +517,23 @@ mod tests {
         let layout = ObjectLayout::new();
         assert_eq!(
             layout.metadata_compaction_job_id_from_key(
-                &layout.metadata_compaction_lease("ns-1", "cmp_abc")
+                &layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1))
             ),
-            Some("cmp_abc")
+            Some("cmp_00000000000000000000000000000001")
         );
         assert_eq!(
-            layout.metadata_compaction_job_id_from_key(
-                &layout.metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc")
-            ),
-            Some("cmp_abc")
+            layout.metadata_compaction_job_id_from_key(&layout.metadata_compaction_table(
+                &namespace_id(),
+                &metadata_compaction_id(1),
+                &metadata_table_id()
+            )),
+            Some("cmp_00000000000000000000000000000001")
         );
         for foreign in [
-            "namespaces/ns-1/metadata/compactions/cmp_abc/tables/tbl_abc.tmp",
-            "namespaces/ns-1/metadata/compactions/cmp_abc/notes.json",
+            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/tables/tbl_00000000000000000000000000000001.tmp",
+            "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/notes.json",
             "namespaces/ns-1/metadata/compactions/stray.json",
-            "namespaces/ns-1/metadata/tables/tbl_abc.sst.zst",
+            "namespaces/ns-1/metadata/tables/tbl_00000000000000000000000000000001.sst.zst",
         ] {
             assert_eq!(layout.metadata_compaction_job_id_from_key(foreign), None);
         }
@@ -451,42 +543,55 @@ mod tests {
     fn parse_build_round_trips_for_namespace_key_families() {
         let layout = ObjectLayout::new();
         let cases = [
-            (layout.wal_head("ns-1"), DurableObjectFamily::WalHead),
-            (layout.wal_floor("ns-1"), DurableObjectFamily::WalFloor),
             (
-                layout.wal_segment("ns-1", "seg_00000000000000000000000000000001"),
+                layout.wal_head(&namespace_id()),
+                DurableObjectFamily::WalHead,
+            ),
+            (
+                layout.wal_floor(&namespace_id()),
+                DurableObjectFamily::WalFloor,
+            ),
+            (
+                layout.wal_segment(
+                    &namespace_id(),
+                    &wal_segment_id("00000000000000000001-0123456789abcdef"),
+                ),
                 DurableObjectFamily::WalSegment,
             ),
             (
-                layout.metadata_root("ns-1"),
+                layout.metadata_root(&namespace_id()),
                 DurableObjectFamily::MetadataRoot,
             ),
             (
                 layout.metadata_manifest_object(
-                    "ns-1",
+                    &namespace_id(),
                     &ManifestObjectId::parse("00000000000000000001-0123456789abcdef")
                         .expect("valid manifest object id"),
                 ),
                 DurableObjectFamily::MetadataManifest,
             ),
             (
-                layout.metadata_table("ns-1", "tbl_abc"),
+                layout.metadata_table(&namespace_id(), &metadata_table_id()),
                 DurableObjectFamily::MetadataTable,
             ),
             (
-                layout.metadata_compaction_table("ns-1", "cmp_abc", "tbl_abc"),
+                layout.metadata_compaction_table(
+                    &namespace_id(),
+                    &metadata_compaction_id(1),
+                    &metadata_table_id(),
+                ),
                 DurableObjectFamily::MetadataCompactionStaging,
             ),
             (
-                layout.metadata_compaction_lease("ns-1", "cmp_abc"),
+                layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1)),
                 DurableObjectFamily::MetadataCompactionLease,
             ),
             (
-                layout.checkpoint_record("ns-1", "chk_00000000000000000000000000000001"),
+                layout.checkpoint_record(&namespace_id(), &checkpoint_id()),
                 DurableObjectFamily::CheckpointRecord,
             ),
             (
-                layout.upload_session("ns-1", "upl_00000000000000000000000000000001"),
+                layout.upload_session(&namespace_id(), &upload_id()),
                 DurableObjectFamily::UploadSession,
             ),
         ];
@@ -504,13 +609,13 @@ mod tests {
             "namespaces/ns-1/descriptor.json",
             "namespaces/ns-1/control/head.json",
             "namespaces/ns-1/control/lease.json",
-            "namespaces/ns-1/wal/seg_00000000000000000000000000000001.wal.zst",
+            "namespaces/ns-1/wal/00000000000000000001-0123456789abcdef.wal.zst",
             "namespaces/ns-1/manifest/00000000000000000400.manifest.json",
-            "namespaces/ns-1/tables/metadata/tbl_abc.sst.zst",
+            "namespaces/ns-1/tables/metadata/tbl_00000000000000000000000000000001.sst.zst",
             "namespaces/ns-1/gc/manifest.boundary.json",
             "namespaces/ns-1/gc/pins/pin_00000000000000000000000000000001.json",
             "namespaces/ns-1/pins/pin_00000000000000000000000000000001.json",
-            "namespaces/ns-1/metadata/compaction-staging/tbl_abc.sst.zst",
+            "namespaces/ns-1/metadata/compaction-staging/tbl_00000000000000000000000000000001.sst.zst",
         ] {
             assert!(
                 parse_object_key(old).is_none(),
@@ -522,14 +627,14 @@ mod tests {
     #[test]
     fn parse_wal_segment_requires_current_wal_suffix() {
         let parsed = parse_object_key(
-            "namespaces/ns-1/wal/segments/seg_00000000000000000000000000000001.wal.zst",
+            "namespaces/ns-1/wal/segments/00000000000000000001-0123456789abcdef.wal.zst",
         )
         .expect("current WAL key parses");
         assert_eq!(parsed.family(), DurableObjectFamily::WalSegment);
         assert_eq!(parsed.owner_namespace_id(), Some("ns-1"));
 
         assert!(parse_object_key(
-            "namespaces/ns-1/wal/segments/seg_00000000000000000000000000000001.sst"
+            "namespaces/ns-1/wal/segments/00000000000000000001-0123456789abcdef.sst"
         )
         .is_none());
         assert!(parse_object_key("namespaces/ns-1/wal/segments/random.tmp").is_none());
@@ -538,7 +643,7 @@ mod tests {
     #[test]
     fn parse_build_round_trips_for_global_key_families() {
         let layout = ObjectLayout::new();
-        let content_key = layout.content_blob("cs_00000000000000000000000000000001", &content_id());
+        let content_key = layout.content_blob(&content_store_id(), &content_id());
         let cases = [(content_key, DurableObjectFamily::ContentBlob)];
 
         for (key, family) in cases {

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -818,7 +818,7 @@ mod tests {
     async fn listing_tolerates_entries_that_vanish_mid_walk() {
         let temp_dir = TestDir::new("listing-races");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
-        let key = wal_head("ns-1");
+        let key = wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
         store
             .put(&key, Bytes::from_static(b"{}"), PutMode::Overwrite)
             .await
@@ -847,7 +847,12 @@ mod tests {
         let temp_dir = TestDir::new("head-missing");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
 
-        let answer = store.head(&wal_head("ns-1")).await.expect("head succeeds");
+        let answer = store
+            .head(&wal_head(
+                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+            ))
+            .await
+            .expect("head succeeds");
         assert!(answer.is_none());
     }
 
@@ -883,7 +888,7 @@ mod tests {
     async fn overwrite_refreshes_head_and_visible_bytes() {
         let temp_dir = TestDir::new("overwrite");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
-        let key = wal_head("ns-1");
+        let key = wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
 
         let first = store
             .put(
@@ -923,7 +928,7 @@ mod tests {
     async fn ranged_reads_answer_their_range_and_refuse_impossible_ones() {
         let temp_dir = TestDir::new("ranged-reads");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
-        let key = wal_head("ns-1");
+        let key = wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
         let payload = Bytes::from_static(b"0123456789");
         store
             .put(&key, payload.clone(), PutMode::Overwrite)
@@ -967,7 +972,12 @@ mod tests {
             Err(ObjectStoreError::InvalidRange { .. })
         ));
         assert!(store
-            .get(&wal_head("ns-missing"), range(0, 4))
+            .get(
+                &wal_head(
+                    &loonfs_api::NamespaceId::parse("ns-missing").expect("valid namespace id")
+                ),
+                range(0, 4)
+            )
             .await
             .expect("a ranged read of a missing object is absent, not an error")
             .is_none());
@@ -982,7 +992,9 @@ mod tests {
 
         let temp_dir = TestDir::new("atomic-replacement");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local fs store"));
-        let key = wal_head("ns-atomic-replacement");
+        let key = wal_head(
+            &loonfs_api::NamespaceId::parse("ns-atomic-replacement").expect("valid namespace id"),
+        );
         store
             .put(
                 &key,
@@ -1037,7 +1049,11 @@ mod tests {
     async fn delete_is_idempotent_and_head_reflects_removal() {
         let temp_dir = TestDir::new("delete");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
-        let key = upload_session("ns-1", "upl_00000000000000000000000000000001");
+        let key = upload_session(
+            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+            &loonfs_api::UploadId::parse("upl_00000000000000000000000000000001")
+                .expect("valid upload id"),
+        );
 
         store
             .put_if_absent(&key, Bytes::from_static(br#"{"created":true}"#))
@@ -1056,7 +1072,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn compare_and_swap_is_safe_across_store_instances() {
         let temp_dir = TestDir::new("cross-instance-cas");
-        let key = wal_head("ns-cas");
+        let key = wal_head(&loonfs_api::NamespaceId::parse("ns-cas").expect("valid namespace id"));
         let seed = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
         seed.put(&key, Bytes::from_static(b"0"), PutMode::CreateIfAbsent)
             .await
@@ -1114,7 +1130,8 @@ mod tests {
     async fn listings_hide_scratch_files_and_reject_scratch_keys() {
         let temp_dir = TestDir::new("scratch");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
-        let key = wal_head("ns-scratch");
+        let key =
+            wal_head(&loonfs_api::NamespaceId::parse("ns-scratch").expect("valid namespace id"));
         store
             .put(&key, Bytes::from_static(b"{}"), PutMode::Overwrite)
             .await

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{BoxStream, TryStreamExt};
 use loonfs_api::StorageChecksum;
-use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::sync::Arc;
 use thiserror::Error;
@@ -21,7 +20,7 @@ pub type SharedObjectStore = Arc<dyn ObjectStore>;
 pub type ByteStream = BoxStream<'static, Result<Bytes>>;
 
 /// Metadata returned by a successful `head`, full-object `get`, or `put` call.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectMetadata {
     /// Opaque compare token for one object version.
     ///
@@ -36,7 +35,6 @@ pub struct ObjectMetadata {
     ///
     /// Advisory: garbage collection uses it for grace/reap age checks and
     /// treats an absent value as "young" (retain). Never a validity input.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_modified_ms: Option<u64>,
 }
 
@@ -45,7 +43,7 @@ pub struct ObjectMetadata {
 ///
 /// This is the evidence a completion check needs to decide whether the
 /// object at a key is the object that was promised, without downloading it.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoredObjectChecksum {
     /// Complete object length the provider reports.
     pub size_bytes: u64,
@@ -59,7 +57,7 @@ pub struct StoredObjectChecksum {
 /// LoonFS keeps no durable record of any part. Parts are the uploader's
 /// bookkeeping, exactly as they are in the provider's own multipart API, and
 /// this is the shape they come back in at completion.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MultipartPart {
     /// One-based part number.
     pub part_number: u32,
@@ -70,7 +68,7 @@ pub struct MultipartPart {
 }
 
 /// What a provider said about an attempt to assemble a multipart upload.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MultipartCompletion {
     /// The provider accepted the assembly on this call.
     Assembled,
@@ -84,7 +82,7 @@ pub enum MultipartCompletion {
 }
 
 /// Full object bytes returned with metadata from the same read operation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectBody {
     /// Identity, size, and modification metadata observed with these exact bytes.
     pub metadata: ObjectMetadata,
@@ -93,7 +91,7 @@ pub struct ObjectBody {
 }
 
 /// Controls the write semantics of a `put` call.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PutMode {
     /// Unconditionally overwrite any existing object.
     Overwrite,
@@ -107,7 +105,7 @@ pub enum PutMode {
 }
 
 /// A byte range for partial object reads.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ByteRange {
     /// First byte to read (inclusive, zero-based).
     pub start_inclusive: u64,

--- a/crates/loonfs-objectstore/src/store_config.rs
+++ b/crates/loonfs-objectstore/src/store_config.rs
@@ -142,6 +142,7 @@ pub enum StoreConfig {
 /// Field paths are rooted at the store table (`store.bucket`, ...) so callers
 /// can report them directly or prefix them with their own config path.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum StoreConfigError {
     /// Reports a required field whose value is absent or blank.
     #[error("missing `{field}`")]

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -28,7 +28,11 @@ async fn records_put_success() {
     let store = instrumented_object_store(temp_dir.path(), recorder.clone());
 
     store
-        .put(&wal_head("ns-1"), bytes(b"head"), PutMode::CreateIfAbsent)
+        .put(
+            &wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id")),
+            bytes(b"head"),
+            PutMode::CreateIfAbsent,
+        )
         .await
         .expect("put object");
 
@@ -51,15 +55,25 @@ async fn convenience_writes_funnel_through_put_with_distinct_modes() {
     let store = InstrumentedObjectStore::new(DelegatingWriteStore::default(), recorder.clone());
 
     store
-        .put_overwrite(&wal_head("ns-1"), bytes(b"overwrite"))
+        .put_overwrite(
+            &wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id")),
+            bytes(b"overwrite"),
+        )
         .await
         .expect("put overwrite");
     store
-        .put_if_absent(&wal_head("ns-1"), bytes(b"create"))
+        .put_if_absent(
+            &wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id")),
+            bytes(b"create"),
+        )
         .await
         .expect("put if absent");
     store
-        .compare_and_swap(&wal_head("ns-1"), "etag-old", bytes(b"swap"))
+        .compare_and_swap(
+            &wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id")),
+            "etag-old",
+            bytes(b"swap"),
+        )
         .await
         .expect("compare and swap");
 
@@ -163,7 +177,10 @@ async fn records_list_count() {
         .await
         .expect("put descriptor");
     store
-        .put_overwrite(&wal_head("ns-1"), bytes(b"head"))
+        .put_overwrite(
+            &wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id")),
+            bytes(b"head"),
+        )
         .await
         .expect("put head");
     let keys = store
@@ -187,7 +204,11 @@ async fn classifies_wal_and_manifest_key_families() {
 
     store
         .put_overwrite(
-            &wal_segment("ns-1", "seg_00000000000000000000000000000001"),
+            &wal_segment(
+                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+                &loonfs_api::WalSegmentId::parse("00000000000000000001-644e4d336fd4ee33")
+                    .expect("valid WAL segment id"),
+            ),
             bytes(b"wal"),
         )
         .await
@@ -195,7 +216,7 @@ async fn classifies_wal_and_manifest_key_families() {
     store
         .put_overwrite(
             &metadata_manifest_object(
-                "ns-1",
+                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
                 &ManifestObjectId::parse("00000000000000000002-0123456789abcdef")
                     .expect("valid manifest object id"),
             ),
@@ -205,7 +226,11 @@ async fn classifies_wal_and_manifest_key_families() {
         .expect("put manifest");
     store
         .put_overwrite(
-            &metadata_table("ns-1", "tbl_00000000000000000000000000000001"),
+            &metadata_table(
+                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+                &loonfs_api::MetadataTableId::parse("tbl_00000000000000000000000000000001")
+                    .expect("valid metadata table id"),
+            ),
             bytes(b"table"),
         )
         .await
@@ -226,7 +251,7 @@ async fn classifies_gc_namespace_layout_family() {
     store
         .put_overwrite(
             &metadata_manifest_object(
-                "ns-1",
+                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
                 &ManifestObjectId::parse("00000000000000000001-0123456789abcdef")
                     .expect("valid manifest object id"),
             ),
@@ -236,14 +261,22 @@ async fn classifies_gc_namespace_layout_family() {
         .expect("put namespace manifest");
     store
         .put_overwrite(
-            &metadata_table("ns-1", "tbl_00000000000000000000000000000001"),
+            &metadata_table(
+                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+                &loonfs_api::MetadataTableId::parse("tbl_00000000000000000000000000000001")
+                    .expect("valid metadata table id"),
+            ),
             bytes(b"metadata"),
         )
         .await
         .expect("put metadata sst");
     store
         .put_overwrite(
-            &checkpoint_record("ns-1", "chk_00000000000000000000000000000001"),
+            &checkpoint_record(
+                &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+                &loonfs_api::CheckpointId::parse("chk_00000000000000000000000000000001")
+                    .expect("valid checkpoint id"),
+            ),
             bytes(b"checkpoint"),
         )
         .await
@@ -265,7 +298,10 @@ async fn jsonl_recorder_writes_privacy_safe_samples() {
     let raw_key = "namespaces/ns-1/wal/seg_secret.wal.zst";
 
     store
-        .put_overwrite(&wal_head("ns-1"), bytes(b"head"))
+        .put_overwrite(
+            &wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id")),
+            bytes(b"head"),
+        )
         .await
         .expect("put object");
     assert!(store

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -26,36 +26,55 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn key_builders_cover_locked_object_families() {
-    assert_eq!(wal_head("ns-1"), "namespaces/ns-1/wal/head.json");
+    assert_eq!(
+        wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id")),
+        "namespaces/ns-1/wal/head.json"
+    );
     assert_eq!(
         content_blob(
-            "cs_00000000000000000000000000000001",
+            &loonfs_api::ContentStoreId::parse("cs_00000000000000000000000000000001").expect("valid content store id"),
             &ContentId::parse("con_abcdef0123456789abcdef0123456789").expect("valid content id"),
         ),
         "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
     );
     assert_eq!(
-        wal_segment("ns-1", "seg_00000000000000000000000000000001"),
-        "namespaces/ns-1/wal/segments/seg_00000000000000000000000000000001.wal.zst"
+        wal_segment(
+            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+            &loonfs_api::WalSegmentId::parse("00000000000000000001-644e4d336fd4ee33")
+                .expect("valid WAL segment id")
+        ),
+        "namespaces/ns-1/wal/segments/00000000000000000001-644e4d336fd4ee33.wal.zst"
     );
     assert_eq!(
         metadata_manifest_object(
-            "ns-1",
+            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
             &ManifestObjectId::parse("00000000000000000420-0123456789abcdef")
                 .expect("valid manifest object id"),
         ),
         "namespaces/ns-1/metadata/manifests/00000000000000000420-0123456789abcdef.manifest.json"
     );
     assert_eq!(
-        metadata_table("ns-1", "tbl_00000000000000000000000000000001"),
+        metadata_table(
+            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+            &loonfs_api::MetadataTableId::parse("tbl_00000000000000000000000000000001")
+                .expect("valid metadata table id")
+        ),
         "namespaces/ns-1/metadata/tables/tbl_00000000000000000000000000000001.sst.zst"
     );
     assert_eq!(
-        metadata_table("source-ns", "tbl_00000000000000000000000000000002"),
+        metadata_table(
+            &loonfs_api::NamespaceId::parse("source-ns").expect("valid namespace id"),
+            &loonfs_api::MetadataTableId::parse("tbl_00000000000000000000000000000002")
+                .expect("valid metadata table id")
+        ),
         "namespaces/source-ns/metadata/tables/tbl_00000000000000000000000000000002.sst.zst"
     );
     assert_eq!(
-        metadata_table("ns-1", "tbl_ffffffffffffffffffffffffffffffff"),
+        metadata_table(
+            &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
+            &loonfs_api::MetadataTableId::parse("tbl_ffffffffffffffffffffffffffffffff")
+                .expect("valid metadata table id")
+        ),
         "namespaces/ns-1/metadata/tables/tbl_ffffffffffffffffffffffffffffffff.sst.zst"
     );
 }
@@ -349,7 +368,8 @@ fn probe_report_lines(report: &StoreProbeReport) -> String {
 /// The content key a streamed-write exercise writes to and cleans up.
 fn streamed_write_key() -> String {
     content_blob(
-        "cs_00000000000000000000000000000001",
+        &loonfs_api::ContentStoreId::parse("cs_00000000000000000000000000000001")
+            .expect("valid content store id"),
         &ContentId::parse("con_5723ea9d1c4b48f0a1d2e3f4a5b6c7d8").expect("valid content id"),
     )
 }

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -562,6 +562,10 @@ impl From<StoreConfigError> for ServerConfigError {
             StoreConfigError::InvalidField { field, reason } => {
                 ServerConfigError::InvalidField { field, reason }
             }
+            error => ServerConfigError::InvalidField {
+                field: "store",
+                reason: error.to_string(),
+            },
         }
     }
 }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -254,10 +254,10 @@ struct StaleHeadOnceStore {
 }
 
 impl StaleHeadOnceStore {
-    fn new(root: impl AsRef<Path>, namespace: &str) -> Self {
+    fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
         Self {
             inner: LocalFsStore::new(root.as_ref()).expect("construct local store"),
-            head_key: wal_head(namespace),
+            head_key: wal_head(namespace_id),
             armed: AtomicBool::new(true),
         }
     }
@@ -897,7 +897,7 @@ async fn shutdown_closes_maintenance_admission_before_draining_publications() {
     let namespace_id = namespace_id("shutdown-order");
     let blocking = Arc::new(BlockingStore::new(
         LocalFsStore::new(temp_dir.path()).expect("construct local store"),
-        KeyPredicate::wal_head(namespace_id.as_str()),
+        KeyPredicate::wal_head(&namespace_id),
         OperationClass::CompareAndSwap,
     ));
     let config = test_config(temp_dir.path(), "shutdown-order-server");
@@ -1565,8 +1565,10 @@ async fn http_put_and_move_under_deleted_ancestor_create_fresh_subtrees() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_path_mutation_retries_transient_stale_head_cas() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(StaleHeadOnceStore::new(temp_dir.path(), "demo")) as SharedObjectStore;
-    bootstrap_namespace(&store, "server-writer", &namespace_id("demo")).await;
+    let namespace_id = namespace_id("demo");
+    let store =
+        Arc::new(StaleHeadOnceStore::new(temp_dir.path(), &namespace_id)) as SharedObjectStore;
+    bootstrap_namespace(&store, "server-writer", &namespace_id).await;
 
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
     let target = NamespacePath::parse("demo", "/notes/race.txt").expect("target");
@@ -1916,7 +1918,8 @@ async fn put_streamed_writes_a_multi_part_payload_one_part_at_a_time() {
 
     let payload = distinct_bytes(MEMORY_BOUND_PAYLOAD_BYTES);
     let key = loonfs_objectstore::keys::content_blob(
-        "cs_00000000000000000000000000000001",
+        &loonfs_api::ContentStoreId::parse("cs_00000000000000000000000000000001")
+            .expect("valid content store id"),
         &loonfs_api::ContentId::parse("con_0123456789abcdef0123456789abcdef").expect("content id"),
     );
     // Chunks the size of an HTTP body's, not the store's: the boundaries a

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -475,7 +475,7 @@ async fn http_checkpoint_manifest_consumption_is_strict_when_manifest_is_corrupt
         .expect("metadata root");
     store
         .put_overwrite(
-            &metadata_manifest_object(namespace.as_str(), &root.state.manifest_object_id),
+            &metadata_manifest_object(&namespace, &root.state.manifest_object_id),
             Bytes::from_static(br#"{"bad":"json"}"#),
         )
         .await

--- a/crates/loonfs-server/tests/logging.rs
+++ b/crates/loonfs-server/tests/logging.rs
@@ -206,7 +206,9 @@ async fn store_fault_has_one_error_from_the_boundary() {
 
     let failing = Arc::new(FailStore::new(
         LocalFsStore::with_key_prefix(&store_root, Some(key_prefix)).expect("build local store"),
-        KeyPredicate::wal_head("faulty"),
+        KeyPredicate::wal_head(
+            &loonfs_api::NamespaceId::parse("faulty").expect("valid namespace id"),
+        ),
         OperationClass::Read,
         InjectedError::Transport("injected WAL-head read failure".to_owned()),
     ));

--- a/crates/loonfs-sim/src/namespace_summary.rs
+++ b/crates/loonfs-sim/src/namespace_summary.rs
@@ -102,17 +102,15 @@ mod tests {
         let namespace_id = NamespaceId::parse("sim").expect("valid namespace id");
 
         store
-            .put_overwrite(
-                &wal_head(namespace_id.as_str()),
-                Bytes::from_static(b"head"),
-            )
+            .put_overwrite(&wal_head(&namespace_id), Bytes::from_static(b"head"))
             .await
             .expect("head");
         store
             .put_overwrite(
                 &wal_segment(
-                    namespace_id.as_str(),
-                    "seg_00000000000000000000000000000001",
+                    &namespace_id,
+                    &loonfs_api::WalSegmentId::parse("00000000000000000001-644e4d336fd4ee33")
+                        .expect("valid WAL segment id"),
                 ),
                 Bytes::from_static(b"wal"),
             )

--- a/crates/loonfs-test-support/src/stores/key_predicate.rs
+++ b/crates/loonfs-test-support/src/stores/key_predicate.rs
@@ -54,12 +54,12 @@ impl KeyPredicate {
         Self::family(DurableObjectFamily::MetadataTable)
     }
 
-    /// Selects the WAL head for `namespace_id`.
+    /// Selects the WAL head key for the given namespace.
     pub fn wal_head(namespace_id: &NamespaceId) -> Self {
         Self::exact(wal_head(namespace_id))
     }
 
-    /// Selects the metadata root for `namespace_id`.
+    /// Selects the metadata root key for the given namespace.
     pub fn metadata_root(namespace_id: &NamespaceId) -> Self {
         Self::exact(metadata_root(namespace_id))
     }

--- a/crates/loonfs-test-support/src/stores/key_predicate.rs
+++ b/crates/loonfs-test-support/src/stores/key_predicate.rs
@@ -1,5 +1,6 @@
 //! Reusable key predicates for object-store wrappers.
 
+use loonfs_api::NamespaceId;
 use loonfs_objectstore::keys::{metadata_root, wal_head};
 use loonfs_objectstore::layout::{parse_object_key, DurableObjectFamily};
 use std::fmt;
@@ -53,14 +54,14 @@ impl KeyPredicate {
         Self::family(DurableObjectFamily::MetadataTable)
     }
 
-    /// Selects the WAL head for `namespace`.
-    pub fn wal_head(namespace: &str) -> Self {
-        Self::exact(wal_head(namespace))
+    /// Selects the WAL head for `namespace_id`.
+    pub fn wal_head(namespace_id: &NamespaceId) -> Self {
+        Self::exact(wal_head(namespace_id))
     }
 
-    /// Selects the metadata root for `namespace`.
-    pub fn metadata_root(namespace: &str) -> Self {
-        Self::exact(metadata_root(namespace))
+    /// Selects the metadata root for `namespace_id`.
+    pub fn metadata_root(namespace_id: &NamespaceId) -> Self {
+        Self::exact(metadata_root(namespace_id))
     }
 
     pub(crate) fn matches(&self, key: &str) -> bool {

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -240,10 +240,7 @@ impl ReadCore {
         let cached = self.inner.control_cache().wal_head(namespace_id);
         if let Some(head) = cached {
             match self
-                .cached_control_identity_matches(
-                    &wal_head(namespace_id.as_str()),
-                    &head.head.identity,
-                )
+                .cached_control_identity_matches(&wal_head(namespace_id), &head.head.identity)
                 .await
             {
                 Ok(true) => return Ok(head),

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -240,7 +240,7 @@ async fn manifest_runs<S: ObjectStore + ?Sized>(
     let root = loonfs_core::control::load_namespace_metadata_root_control(store, namespace_id)
         .await
         .expect("read the metadata root");
-    let key = metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let key = metadata_manifest_object(namespace_id, &root.state.manifest_object_id);
     let bytes = store
         .get(&key, None)
         .await

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -488,7 +488,7 @@ mod tests {
     ) -> (FsWriter, Arc<BlockingStore<LocalFsStore>>) {
         let blocking = Arc::new(BlockingStore::new(
             LocalFsStore::new(temp_dir).expect("create local-fs store"),
-            KeyPredicate::wal_head(namespace_id.as_str()),
+            KeyPredicate::wal_head(namespace_id),
             OperationClass::CompareAndSwap,
         ));
         let writer = FsWriter::builder_with_store(blocking.clone())

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -38,7 +38,7 @@ fn blocking_head_cas_store(
 ) -> BlockingStore<LocalFsStore> {
     BlockingStore::new(
         LocalFsStore::new(root.as_ref()).expect("store"),
-        KeyPredicate::wal_head(namespace_id.as_str()),
+        KeyPredicate::wal_head(namespace_id),
         OperationClass::CompareAndSwap,
     )
 }
@@ -67,7 +67,7 @@ impl PanicHeadCasStore {
     fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
         Self {
             inner: LocalFsStore::new(root.as_ref()).expect("store"),
-            head_key: wal_head(namespace_id.as_str()),
+            head_key: wal_head(namespace_id),
             gate: Arc::new(PanicGate {
                 state: Mutex::new(PanicGateState {
                     armed: false,
@@ -183,7 +183,7 @@ fn lost_head_cas_ack_store(
 ) -> FailStore<LocalFsStore> {
     FailStore::new(
         LocalFsStore::new(root.as_ref()).expect("store"),
-        KeyPredicate::wal_head(namespace_id.as_str()),
+        KeyPredicate::wal_head(namespace_id),
         OperationClass::CompareAndSwap,
         InjectedError::Transport("injected lost head CAS acknowledgement".to_owned()),
     )
@@ -628,7 +628,9 @@ async fn publisher_admits_pending_batch_while_active_publish_blocks() {
     assert_eq!(pending_response.committed_seq, ChangeSeq(2));
 
     let wal_keys = shared
-        .list_prefix(&wal_segment_prefix("demo"))
+        .list_prefix(&wal_segment_prefix(
+            &loonfs_api::NamespaceId::parse("demo").expect("valid namespace id"),
+        ))
         .await
         .expect("list wal");
     assert_eq!(wal_keys.len(), 2);
@@ -1393,7 +1395,9 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
     // The warmup published alone; the two concurrent submissions share
     // one segment.
     let wal_keys = shared
-        .list_prefix(&wal_segment_prefix("demo"))
+        .list_prefix(&wal_segment_prefix(
+            &loonfs_api::NamespaceId::parse("demo").expect("valid namespace id"),
+        ))
         .await
         .expect("list wal");
     assert_eq!(wal_keys.len(), 2);
@@ -1496,7 +1500,9 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
     assert_eq!(committed_seqs, [ChangeSeq(2), ChangeSeq(3)]);
 
     let wal_keys = shared
-        .list_prefix(&wal_segment_prefix("demo"))
+        .list_prefix(&wal_segment_prefix(
+            &loonfs_api::NamespaceId::parse("demo").expect("valid namespace id"),
+        ))
         .await
         .expect("list wal");
     let mut record_counts = Vec::new();

--- a/crates/loonfs/tests/it/bulk_file_reads.rs
+++ b/crates/loonfs/tests/it/bulk_file_reads.rs
@@ -492,10 +492,8 @@ async fn foreign_metadata_file_owners(
             .await
             .expect("load metadata root")
             .state;
-    let key = loonfs_objectstore::keys::metadata_manifest_object(
-        namespace_id.as_str(),
-        &root.manifest_object_id,
-    );
+    let key =
+        loonfs_objectstore::keys::metadata_manifest_object(namespace_id, &root.manifest_object_id);
     let bytes = store
         .get(&key, None)
         .await
@@ -871,7 +869,7 @@ async fn read_content_ref_refuses_bytes_that_do_not_match_the_reference() {
             .content_store_id()
             .clone();
     let object_key =
-        loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id);
+        loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     store
         .put_overwrite(&object_key, bytes::Bytes::from_static(b"other bytes"))
         .await

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -22,10 +22,7 @@ use tempfile::tempdir;
 fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let fs = open_runtime(object_store, "tail-projection-cache-test");
 
@@ -78,10 +75,7 @@ fn runtime_cache_reuses_wal_tail_projection_for_repeated_reads() {
 fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let setup = open_runtime(object_store.clone(), "publish-tail");
     let measured = open_runtime(object_store, "publish-tail");
@@ -128,10 +122,7 @@ fn runtime_publish_reuses_wal_tail_projection_for_sequential_writes() {
 fn runtime_publish_allows_multi_segment_wal_tail() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let setup = open_runtime(object_store.clone(), "publish-tail");
     let measured = open_runtime(object_store, "publish-tail");
@@ -159,10 +150,7 @@ fn runtime_publish_allows_multi_segment_wal_tail() {
 fn runtime_cache_observes_head_advanced_by_another_runtime() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let reader = open_runtime(object_store.clone(), "tail-cache-reader");
     let writer = open_runtime(object_store, "tail-cache-writer");
@@ -199,10 +187,7 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
 fn runtime_cache_can_be_disabled() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let fs = open_runtime_with(object_store, "tail-cache-disabled-test", |builder| {
         builder.runtime_cache(RuntimeCacheConfig::disabled())
@@ -276,10 +261,7 @@ fn runtime_wal_tail_projection_cache_evicts_by_namespace_count() {
 fn runtime_wal_tail_projection_cache_skips_oversized_projection() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let fs = open_runtime_with(object_store, "tail-oversized-test", |builder| {
         builder.runtime_cache(RuntimeCacheConfig {
@@ -332,10 +314,7 @@ fn runtime_read_allows_multi_segment_wal_tail() {
 fn stale_head_write_error_recovers_and_reseeds_caches() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let fs = open_runtime(object_store, "tail-cache-stale-test");
 
@@ -506,10 +485,7 @@ fn repeated_materialized_stat_uses_metadata_table_cache() {
 fn runtime_control_cache_reuses_head_for_materialization_validation() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let fs = open_runtime(object_store, "control-cache-head-test");
 
@@ -535,10 +511,7 @@ fn control_cache_eviction_reloads_head_for_materialization_validation() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
     let other_namespace = NamespaceId::parse("other").expect("valid namespace id");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let fs = open_runtime_with(object_store, "control-cache-eviction-test", |builder| {
         builder.runtime_cache(RuntimeCacheConfig {
@@ -574,10 +547,7 @@ fn control_cache_eviction_reloads_head_for_materialization_validation() {
 fn runtime_control_cache_reloads_head_after_external_change() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let reader = open_runtime(object_store.clone(), "control-cache-reader");
     let writer = open_runtime(object_store, "control-cache-writer");

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -146,8 +146,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
     let root = loonfs_core::control::load_namespace_metadata_root_control(&store, &namespace_id)
         .await
         .expect("load metadata root");
-    let manifest_key =
-        metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let manifest_key = metadata_manifest_object(&namespace_id, &root.state.manifest_object_id);
     let manifest_bytes = store
         .get(&manifest_key, None)
         .await

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -581,24 +581,24 @@ pub(crate) struct RuntimeStoreProbe {
 }
 
 impl RuntimeStoreProbe {
-    pub(crate) fn new(root: &Path, namespace: &str) -> Self {
+    pub(crate) fn new(root: &Path, namespace_id: &NamespaceId) -> Self {
         let inner: SharedObjectStore =
             Arc::new(LocalFsStore::new(root).expect("create local-fs store"));
         let wal_gets = Arc::new(CountingStore::new(
             inner,
-            KeyPredicate::prefix(format!("namespaces/{namespace}/wal/segments/")),
+            KeyPredicate::prefix(format!("namespaces/{namespace_id}/wal/segments/")),
         ));
         let manifest_gets = Arc::new(CountingStore::new(
             wal_gets.clone() as SharedObjectStore,
-            KeyPredicate::prefix(format!("namespaces/{namespace}/metadata/manifests/")),
+            KeyPredicate::prefix(format!("namespaces/{namespace_id}/metadata/manifests/")),
         ));
         let head_gets = Arc::new(CountingStore::new(
             manifest_gets.clone() as SharedObjectStore,
-            KeyPredicate::wal_head(namespace),
+            KeyPredicate::wal_head(namespace_id),
         ));
         let fail_head_cas = Arc::new(FailStore::new(
             head_gets.clone() as SharedObjectStore,
-            KeyPredicate::wal_head(namespace),
+            KeyPredicate::wal_head(namespace_id),
             OperationClass::CompareAndSwap,
             InjectedError::PreconditionFailed,
         ));
@@ -606,7 +606,7 @@ impl RuntimeStoreProbe {
         // namespace that has never flushed, compare-and-swap after that.
         let fail_root_cas = Arc::new(FailStore::new(
             fail_head_cas.clone() as SharedObjectStore,
-            KeyPredicate::metadata_root(namespace),
+            KeyPredicate::metadata_root(namespace_id),
             OperationClass::Put,
             InjectedError::PreconditionFailed,
         ));

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -180,7 +180,7 @@ async fn bind_namespace_to_content_store(
         .expect("build namespace head");
     store
         .put_overwrite(
-            &wal_head(namespace_id.as_str()),
+            &wal_head(namespace_id),
             Bytes::from(encode_control_object(&envelope).expect("encode namespace head")),
         )
         .await
@@ -942,7 +942,7 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
     let recording = RequestLog::new(temp_dir.path());
     let blocking = Arc::new(BlockingStore::new(
         recording.store(),
-        KeyPredicate::wal_head(namespace_id.as_str()),
+        KeyPredicate::wal_head(&namespace_id),
         OperationClass::CompareAndSwap,
     ));
     let store: SharedObjectStore = blocking.clone();
@@ -1010,7 +1010,7 @@ async fn stale_head_retry_preserves_content_admission() {
     let recording = RequestLog::new(temp_dir.path());
     let conflicting = Arc::new(FailStore::new(
         recording.store(),
-        KeyPredicate::wal_head(namespace_id.as_str()),
+        KeyPredicate::wal_head(&namespace_id),
         OperationClass::CompareAndSwap,
         InjectedError::PreconditionFailed,
     ));
@@ -1047,7 +1047,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
     let recording = RequestLog::new(temp_dir.path());
     let blocking = Arc::new(BlockingStore::new(
         recording.store(),
-        KeyPredicate::wal_head(namespace_id.as_str()),
+        KeyPredicate::wal_head(&namespace_id),
         OperationClass::CompareAndSwap,
     ));
     let store: SharedObjectStore = blocking.clone();

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -248,10 +248,8 @@ async fn put_file_content_ref_validates_content_before_publication() {
     let content_ref = harness.stage_content(bytes).await;
     harness.recording.reset();
 
-    // These global counts show the explicitly slow helper still validates
-    // exactly once, but not where. The plain-candidate seam below proves the
-    // publisher itself performs no content-key I/O, locating this read before
-    // publication.
+    // The convenience method should validate the referenced content exactly
+    // once before publishing it.
     harness
         .writer
         .put_file_content_ref(

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -582,10 +582,10 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         puts.2.expect("put c");
         puts.3.expect("put d");
 
-        // The already-proven candidates reach publisher admission together
-        // and publish as one batch: one WAL segment, one head CAS. The slow
-        // content-ref helper validates before admission and is intentionally
-        // outside this batching seam.
+        // The four prepared candidates are admitted together and published
+        // in one batch, producing one WAL segment and one head CAS. The slower
+        // content-reference helper validates before admission, so it is not
+        // part of this batching test.
         let segments_after = wal_segment_count(&object_store, &namespace_id).await;
         assert_eq!(segments_after - segments_before, 1);
 

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -688,10 +688,7 @@ fn concurrent_puts_both_commit_after_one_transient_content_failure() {
 fn begin_upload_validates_controls_without_replay_reads() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let fs = open_runtime(object_store, "begin-upload-cache-test");
 
@@ -749,7 +746,7 @@ fn begin_upload_rejects_missing_and_unreadable_namespaces() {
     fs.begin_upload_blocking(&namespace_id)
         .expect("a live namespace admits uploads");
 
-    block_on(raw_store.delete(&wal_head(namespace_id.as_str()))).expect("delete head");
+    block_on(raw_store.delete(&wal_head(&namespace_id))).expect("delete head");
     assert_core_error_kind(
         fs.begin_upload_blocking(&namespace_id),
         ErrorCode::NamespaceNotFound,
@@ -771,7 +768,7 @@ fn begin_upload_rejects_malformed_head_and_lease_when_cache_disabled() {
     fs.create_namespace_blocking(&head_bad, CreateNamespaceOptions::default())
         .expect("create head-bad namespace");
     block_on(raw_store.put_overwrite(
-        &wal_head(head_bad.as_str()),
+        &wal_head(&head_bad),
         Bytes::from_static(br#"{"not":"a head"}"#),
     ))
     .expect("corrupt head");

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -105,7 +105,7 @@ fn a_threshold_crossing_during_an_active_step_still_bounds_the_tail() {
         // holds.
         let blocking = Arc::new(BlockingStore::new(
             LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::metadata_root(namespace_id.as_str()),
+            KeyPredicate::metadata_root(&namespace_id),
             OperationClass::Put,
         ));
         let store: SharedObjectStore = blocking.clone();
@@ -178,7 +178,7 @@ fn a_step_queued_at_the_global_cap_runs_without_another_publish() {
         // holds.
         let blocking = Arc::new(BlockingStore::new(
             LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::metadata_root(active_namespace.as_str()),
+            KeyPredicate::metadata_root(&active_namespace),
             OperationClass::Put,
         ));
         let store: SharedObjectStore = blocking.clone();
@@ -239,7 +239,7 @@ fn a_write_stopped_namespace_queued_at_the_global_cap_unblocks_itself() {
         // holds.
         let blocking = Arc::new(BlockingStore::new(
             LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::metadata_root(active_namespace.as_str()),
+            KeyPredicate::metadata_root(&active_namespace),
             OperationClass::Put,
         ));
         let store: SharedObjectStore = blocking.clone();
@@ -319,7 +319,7 @@ fn shutdown_clears_a_non_empty_maintenance_queue_without_spawning_it() {
         // holds.
         let blocking = Arc::new(BlockingStore::new(
             LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-            KeyPredicate::metadata_root(active_namespace.as_str()),
+            KeyPredicate::metadata_root(&active_namespace),
             OperationClass::Put,
         ));
         let store: SharedObjectStore = blocking.clone();
@@ -1038,8 +1038,7 @@ fn enabled_writer_drains_reorganization_backlog_without_admin() {
         let root = load_namespace_metadata_root_control(&store, &namespace_id)
             .await
             .expect("load metadata root");
-        let manifest_key =
-            metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+        let manifest_key = metadata_manifest_object(&namespace_id, &root.state.manifest_object_id);
         let bytes = store
             .get(&manifest_key, None)
             .await

--- a/crates/loonfs/tests/it/invalidation.rs
+++ b/crates/loonfs/tests/it/invalidation.rs
@@ -211,7 +211,7 @@ async fn fenced_writer_stays_fenced_after_its_tail_projection_is_evicted() {
     let ns_other = NamespaceId::parse("other").expect("valid namespace id");
     let counting = Arc::new(CountingStore::new(
         LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-        KeyPredicate::wal_head(ns_fence.as_str()),
+        KeyPredicate::wal_head(&ns_fence),
     ));
     let store: SharedObjectStore = counting.clone();
 
@@ -313,7 +313,7 @@ async fn fenced_writer_stays_fenced_with_runtime_caches_disabled() {
     let namespace_id = NamespaceId::parse("nocache").expect("valid namespace id");
     let counting = Arc::new(CountingStore::new(
         LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-        KeyPredicate::wal_head(namespace_id.as_str()),
+        KeyPredicate::wal_head(&namespace_id),
     ));
     let store: SharedObjectStore = counting.clone();
 
@@ -408,7 +408,7 @@ async fn read_after_write_is_served_from_seeded_caches() {
     // upload session that owns the staged content has to be read to be
     // completed on its own etag. One of each, and nothing else.
     let write_gets = recording.take_get_keys();
-    let uploads_prefix = loonfs_objectstore::keys::upload_session_prefix(namespace_id.as_str());
+    let uploads_prefix = loonfs_objectstore::keys::upload_session_prefix(&namespace_id);
     let classify = |suffix: &str| {
         write_gets
             .iter()

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -74,7 +74,7 @@ fn namespace_status_counts_wal_tail_without_reading_segments() {
     // enough to size a hint-covered tail.
     let store = Arc::new(CountingStore::new(
         LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
-        KeyPredicate::prefix(wal_segment_prefix(namespace_id.as_str())),
+        KeyPredicate::prefix(wal_segment_prefix(&namespace_id)),
     ));
     let fs = open_runtime(store.clone(), "status-count-test");
 
@@ -105,7 +105,7 @@ const LEGACY_RECENT_SEGMENTS: usize = 32;
 /// Rewrites a head's replay accelerator to its newest `keep` pointers,
 /// which is the shape a head published by an older build carries.
 fn truncate_recent_segments(store: &SharedObjectStore, namespace_id: &NamespaceId, keep: usize) {
-    let key = wal_head(namespace_id.as_str());
+    let key = wal_head(namespace_id);
     let bytes = block_on(store.get(&key, None))
         .expect("read head")
         .expect("head exists");
@@ -213,7 +213,7 @@ fn namespace_status_and_step_reject_a_namespace_whose_head_is_gone() {
 
     fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
         .expect("create namespace");
-    block_on(raw_store.delete(&wal_head(namespace_id.as_str()))).expect("delete head");
+    block_on(raw_store.delete(&wal_head(&namespace_id))).expect("delete head");
 
     assert_core_error_kind(
         fs.namespace_status_blocking(&namespace_id),
@@ -286,9 +286,7 @@ fn maintenance_step_at_segment_threshold_flushes_the_wal() {
     // under `checkpoints/`.
     let raw_store = LocalFsStore::new(temp_dir.path()).expect("store");
     let records = block_on(
-        raw_store.list_prefix(&loonfs_objectstore::keys::checkpoint_prefix(
-            namespace_id.as_str(),
-        )),
+        raw_store.list_prefix(&loonfs_objectstore::keys::checkpoint_prefix(&namespace_id)),
     )
     .expect("list checkpoint records");
     assert!(
@@ -541,8 +539,7 @@ fn maintenance_step_after_existing_manifest_writes_l0_manifest() {
         &namespace_id,
     ))
     .expect("metadata root");
-    let manifest_key =
-        metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let manifest_key = metadata_manifest_object(&namespace_id, &root.state.manifest_object_id);
     let manifest_bytes = block_on(raw_store.get(&manifest_key, None))
         .expect("read namespace manifest")
         .expect("namespace manifest exists");
@@ -676,10 +673,7 @@ fn maintenance_step_counts_segments_not_commits() {
 fn maintenance_step_treats_metadata_root_cas_loss_as_benign_race() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("demo");
-    let raw_store = Arc::new(RuntimeStoreProbe::new(
-        temp_dir.path(),
-        namespace_id.as_str(),
-    ));
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &namespace_id));
     let object_store = raw_store.store();
     let fs = open_runtime(object_store, "step-race-test");
 

--- a/crates/loonfs/tests/it/publication.rs
+++ b/crates/loonfs/tests/it/publication.rs
@@ -43,7 +43,7 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
     let namespace_id = NamespaceId::parse("parked").expect("valid namespace id");
     let store_impl = Arc::new(BlockingStore::new(
         LocalFsStore::new(temp_dir).expect("create local-fs store"),
-        KeyPredicate::wal_head(namespace_id.as_str()),
+        KeyPredicate::wal_head(&namespace_id),
         OperationClass::CompareAndSwap,
     ));
     let store: SharedObjectStore = store_impl.clone();

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -33,8 +33,7 @@ async fn table_map(store: &SharedObjectStore, namespace_id: &NamespaceId) -> Tab
     let root = loonfs_core::control::load_namespace_metadata_root_control(store, namespace_id)
         .await
         .expect("load metadata root");
-    let manifest_key =
-        metadata_manifest_object(namespace_id.as_str(), &root.state.manifest_object_id);
+    let manifest_key = metadata_manifest_object(namespace_id, &root.state.manifest_object_id);
     let bytes = store
         .get(&manifest_key, None)
         .await

--- a/crates/loonfs/tests/it/staged_content_reclamation.rs
+++ b/crates/loonfs/tests/it/staged_content_reclamation.rs
@@ -81,7 +81,7 @@ async fn content_key(
             .expect("load namespace catalog")
             .content_store_id()
             .clone();
-    loonfs_objectstore::keys::content_blob(content_store_id.as_str(), &content_ref.content_id)
+    loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id)
 }
 
 async fn exists(store: &SharedObjectStore, key: &str) -> bool {
@@ -92,7 +92,7 @@ async fn exists(store: &SharedObjectStore, key: &str) -> bool {
 async fn session_keys(store: &SharedObjectStore, namespace_id: &NamespaceId) -> Vec<String> {
     store
         .list_prefix(&loonfs_objectstore::keys::upload_session_prefix(
-            namespace_id.as_str(),
+            namespace_id,
         ))
         .await
         .expect("list upload sessions")

--- a/crates/loonfs/tests/it/streamed_read.rs
+++ b/crates/loonfs/tests/it/streamed_read.rs
@@ -171,7 +171,7 @@ async fn a_streamed_read_rejects_content_that_stopped_matching_its_reference() {
         loonfs::control::load_namespace_catalog_entry(&store(temp_dir.path()), &namespace_id)
             .await
             .expect("load catalog");
-    let key = content_blob(catalog.content_store_id().as_str(), &content_ref.content_id);
+    let key = content_blob(catalog.content_store_id(), &content_ref.content_id);
     let mut corrupted = payload.clone();
     corrupted[0] ^= 0xff;
     store(temp_dir.path())

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3572,7 +3572,7 @@
             }
           }
         ],
-        "description": "Request to complete an upload, tagged by which of its two shapes it is.\n\nThe shapes correspond to who knew the content identity first. A\nservice-proxied or `direct_put` session was handed its reference before\nany byte moved, so its completion names that reference back. A\n`direct_multipart` session was never told one — there was nothing to\ntell — so its completion carries the claim and its parts instead, and\nthe server builds the reference from the identity it has held all along.\n\nThe two share no fields, so a completion carrying one shape's fields\nunder the other's tag does not decode. What decoding cannot settle is\nwhether the shape matches the *session*, because only the server knows\nwhich transport the session was opened with; that one check is made\nagainst the durable record."
+        "description": "Request to complete an upload.\n\nA service-proxied or `direct_put` session receives its content reference\nbefore the upload and returns that reference at completion. A\n`direct_multipart` session instead provides the completed parts and a\nclaim describing the assembled object.\n\nThe variants share no fields, so fields from one completion type are\nrejected when used with the other type. The server also checks that the\ncompletion type matches the transport stored in the upload session."
       },
       "CompleteUploadResponse": {
         "type": "object",
@@ -5025,7 +5025,7 @@
             }
           }
         ],
-        "description": "Where a namespace's grep index is in its lifecycle.\n\nThe phases carry different facts and never share a field: a backfill\nreports the sequence it is walking toward and how far the walk got, and\nonly a steady index reports a watermark it has actually built through.\nA reader that wants \"is this searchable, and through what?\" asks the\n`steady` phase and nothing else."
+        "description": "Where a namespace's grep index is in its lifecycle.\n\nEach phase contains only the fields valid for that phase. `Backfilling`\nreports its target and current position. `Steady` reports how far the\nindex has been built. Clients should treat a namespace as searchable only\nwhen the index is in the `Steady` phase."
       },
       "GrepIndexStatusResponse": {
         "type": "object",
@@ -6119,7 +6119,7 @@
             }
           }
         ],
-        "description": "Observed state of an upload session.\n\nA session is `open`, then `completed` or `aborted`, and both of those are\nfinal. Reading a completed session mints a fresh receipt for content that\nis already durable, which is why losing a commit response never costs a\nretransfer."
+        "description": "Observed state of an upload session.\n\nA session starts as `Open` and ends as either `Completed` or `Aborted`.\nBoth final states are permanent. Reading a completed session issues a new\nreceipt for the durable content, so a lost commit response does not require\nthe content to be uploaded again."
       },
       "UploadStatusResponse": {
         "type": "object",


### PR DESCRIPTION
Change durable object-key builders to accept `NamespaceId` and the appropriate family-specific ID types instead of plain strings. This prevents callers from swapping same-shaped arguments or constructing keys from unvalidated identifiers.

Mark cross-crate public error enums as non-exhaustive so downstream callers remain compatible when new variants are added. Remove unused serde implementations from object-store runtime values and remove unused deserialization support from CLI output types.

Update the affected call sites and tests to use typed identifiers.