### PR TITLE
test,docs: strengthen provider checks and document client APIs

### DIFF
--- a/crates/loonfs-client/src/error.rs
+++ b/crates/loonfs-client/src/error.rs
@@ -10,28 +10,48 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ClientError {
+    /// Reading the client configuration failed.
     #[error("failed to read config: {0}")]
     ConfigIo(String),
+    /// Decoding the client configuration failed.
     #[error("failed to decode config: {0}")]
     ConfigDecode(String),
+    /// The client configuration omitted a required field.
     #[error("missing `{field}`")]
-    MissingConfigField { field: &'static str },
+    MissingConfigField {
+        /// Name of the required field.
+        field: &'static str,
+    },
+    /// A client configuration field failed validation.
     #[error("invalid `{field}`: {reason}")]
-    ConfigValidation { field: &'static str, reason: String },
+    ConfigValidation {
+        /// Name of the invalid field.
+        field: &'static str,
+        /// Plain-English reason the value is invalid.
+        reason: String,
+    },
+    /// A namespace-qualified path failed validation.
     #[error("invalid namespace path `{0}`")]
     InvalidNamespacePath(String),
+    /// A commit id failed validation.
     #[error("invalid commit_id `{0}`")]
     InvalidCommitId(String),
+    /// A checkpoint id failed validation.
     #[error("invalid checkpoint_id `{0}`")]
     InvalidCheckpointId(String),
+    /// An HTTP transport operation failed.
     #[error("http error: {0}")]
     Http(String),
+    /// The server returned a structured API error response.
     #[error("server returned {status} {code}: {message}")]
     Api {
+        /// HTTP response status.
         status: u16,
+        /// Stable machine-readable API error code.
         code: String,
         /// Capability feature key accompanying `not_supported` errors.
         feature: Option<String>,
+        /// Human-readable error message.
         message: String,
         /// Correlation id the server assigned to the failed request.
         request_id: Option<String>,
@@ -50,8 +70,10 @@ pub enum ClientError {
         /// The caps it exceeded, named so a caller can act on them.
         reason: String,
     },
+    /// Reading or writing a streamed payload failed.
     #[error("i/o error: {0}")]
     Io(String),
+    /// Encoding or decoding JSON failed.
     #[error("json error: {0}")]
     Json(String),
     /// A well-formed response that breaks a shape rule the API spec states.

--- a/crates/loonfs-client/src/error.rs
+++ b/crates/loonfs-client/src/error.rs
@@ -1,94 +1,94 @@
-//! [`ClientError`]: every failure the async client surfaces.
+//! Defines [`ClientError`], returned by asynchronous client operations.
 
 use loonfs_api::{ErrorCode, ErrorDetails};
 use thiserror::Error;
 
-/// Error returned by the async HTTP client.
+/// Error returned by the asynchronous HTTP client.
 ///
 /// Foreign causes (I/O, JSON, and HTTP transport) are captured as message
 /// strings rather than `#[source]` chains.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ClientError {
-    /// Reading the client configuration failed.
+    /// The client configuration could not be read.
     #[error("failed to read config: {0}")]
     ConfigIo(String),
-    /// Decoding the client configuration failed.
+    /// The client configuration could not be decoded.
     #[error("failed to decode config: {0}")]
     ConfigDecode(String),
-    /// The client configuration omitted a required field.
+    /// A required client configuration field is missing.
     #[error("missing `{field}`")]
     MissingConfigField {
-        /// Name of the required field.
+        /// Name of the missing field.
         field: &'static str,
     },
-    /// A client configuration field failed validation.
+    /// A client configuration field contains an invalid value.
     #[error("invalid `{field}`: {reason}")]
     ConfigValidation {
-        /// Name of the invalid field.
+        /// Name of the field containing the invalid value.
         field: &'static str,
-        /// Plain-English reason the value is invalid.
+        /// Why the value is invalid.
         reason: String,
     },
-    /// A namespace-qualified path failed validation.
+    /// A path is invalid or cannot be used with the requested namespace.
     #[error("invalid namespace path `{0}`")]
     InvalidNamespacePath(String),
-    /// A commit id failed validation.
+    /// A commit ID is invalid.
     #[error("invalid commit_id `{0}`")]
     InvalidCommitId(String),
-    /// A checkpoint id failed validation.
+    /// A checkpoint ID is invalid.
     #[error("invalid checkpoint_id `{0}`")]
     InvalidCheckpointId(String),
-    /// An HTTP transport operation failed.
+    /// Sending an HTTP request or reading its response failed.
     #[error("http error: {0}")]
     Http(String),
     /// The server returned a structured API error response.
     #[error("server returned {status} {code}: {message}")]
     Api {
-        /// HTTP response status.
+        /// HTTP status code returned by the server.
         status: u16,
-        /// Stable machine-readable API error code.
+        /// Machine-readable API error code returned by the server.
         code: String,
         /// Capability feature key accompanying `not_supported` errors.
         feature: Option<String>,
-        /// Human-readable error message.
+        /// Error message returned by the server.
         message: String,
-        /// Correlation id the server assigned to the failed request.
+        /// Correlation ID assigned to the failed request.
         request_id: Option<String>,
-        /// Structured context for the code, when the server sent any. Boxed
-        /// so the rare detailed error does not widen every client result.
+        /// Additional structured error details, when provided by the server.
+        /// Boxed to keep the enum small.
         details: Option<Box<ErrorDetails>>,
     },
-    /// No upload transport this deployment offers can carry the payload.
+    /// None of the server's upload methods can accept the payload.
     ///
-    /// Raised before any byte moves, because the alternative is sending an
-    /// oversized payload into the capped proxy to be refused there.
+    /// Returned before any data is uploaded.
     #[error("payload of {size_bytes} bytes exceeds every upload transport this deployment offers: {reason}")]
     UploadTooLarge {
-        /// Complete length of the payload that could not be carried.
+        /// Total payload size in bytes.
         size_bytes: u64,
-        /// The caps it exceeded, named so a caller can act on them.
+        /// Description of the upload limits the payload exceeds.
         reason: String,
     },
-    /// Reading or writing a streamed payload failed.
+    /// Reading or writing streamed data failed.
     #[error("i/o error: {0}")]
     Io(String),
-    /// Encoding or decoding JSON failed.
+    /// Serializing a request or decoding a JSON response failed.
     #[error("json error: {0}")]
     Json(String),
-    /// A well-formed response that breaks a shape rule the API spec states.
+    /// A decoded response violates the API contract.
     ///
-    /// Distinct from [`ClientError::Json`], which is a body that did not
-    /// decode: this one decoded and then said something the contract forbids,
-    /// so the client refuses it rather than passing a wrong answer along.
+    /// [`ClientError::Json`] means the response could not be decoded. This
+    /// variant means decoding succeeded, but the decoded value is not valid
+    /// according to the API specification.
     #[error("server response violates the API contract: {0}")]
     Protocol(String),
 }
 
 impl ClientError {
-    /// Returns the typed code for [`ClientError::Api`] errors, or `None` for
-    /// non-API errors and for codes this build does not know (clients must
-    /// tolerate unknown codes).
+    /// Returns the typed code for [`ClientError::Api`].
+    ///
+    /// Returns `None` for other error variants and for API codes this client
+    /// version does not recognize.
     pub fn code(&self) -> Option<ErrorCode> {
         match self {
             ClientError::Api { code, .. } => ErrorCode::parse(code),

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -12,6 +12,8 @@
 //! and the two surfaces share one definition of every option struct (they
 //! live in `loonfs-api`) so their arguments cannot drift apart.
 
+#![warn(missing_docs)]
+
 mod config;
 mod error;
 mod payload;
@@ -242,11 +244,13 @@ impl DirectDownloadStream {
 /// to fail.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MultipartUploadResume {
+    /// Identifies the server-side multipart upload session.
     pub upload_id: UploadId,
     /// The part size the session was opened with. A resumed upload must cut
     /// the payload exactly as the interrupted one did, or the parts it
     /// sends will not line up with the ones already there.
     pub part_size_bytes: u64,
+    /// Records the parts uploaded successfully so far.
     pub parts: Vec<CompletedUploadPart>,
 }
 
@@ -538,6 +542,7 @@ impl Client {
             .clone())
     }
 
+    /// Creates an empty namespace with the requested id.
     pub async fn create_namespace(&self, namespace_id: &NamespaceId) -> Result<NamespaceSummary> {
         let url = format!("{}/v0/namespaces", self.base_url);
         // Namespace creation has no durable request identity to reconcile an ambiguous success.
@@ -550,6 +555,7 @@ impl Client {
         .await
     }
 
+    /// Returns the current status of a namespace.
     pub async fn namespace_status(
         &self,
         namespace_id: &NamespaceId,
@@ -580,6 +586,7 @@ impl Client {
             .await
     }
 
+    /// Forks the source namespace's durable view into a new namespace.
     pub async fn fork_namespace(
         &self,
         source_namespace_id: &NamespaceId,
@@ -683,6 +690,7 @@ impl Client {
         self.request_json::<(), _>(self.get(&url), None).await
     }
 
+    /// Downloads the current contents of a file into memory.
     pub async fn get_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>> {
         let url = format!(
             "{}/v0/namespaces/{}/filesystem/content?path={}",
@@ -693,6 +701,7 @@ impl Client {
         self.request_bytes(&url).await
     }
 
+    /// Downloads one prior file revision into memory.
     pub async fn get_file_revision_bytes(
         &self,
         spec: &NamespacePath,
@@ -859,6 +868,7 @@ impl Client {
         Ok(size_bytes)
     }
 
+    /// Lists one page of revisions for a file.
     pub async fn list_file_revisions_page(
         &self,
         spec: &NamespacePath,
@@ -877,6 +887,7 @@ impl Client {
             .await
     }
 
+    /// Lists one page of recoverable deletions in a namespace.
     pub async fn list_trash_page(
         &self,
         namespace_id: &NamespaceId,
@@ -894,6 +905,7 @@ impl Client {
             .await
     }
 
+    /// Checks whether the server reports itself as healthy.
     pub async fn health(&self) -> Result<()> {
         let url = format!("{}/health", self.base_url);
         self.call_with_transport_retry(&self.get(&url), None)
@@ -901,6 +913,7 @@ impl Client {
         Ok(())
     }
 
+    /// Starts an upload session with the requested transport.
     pub async fn begin_upload(
         &self,
         namespace_id: &NamespaceId,
@@ -1023,6 +1036,7 @@ impl Client {
         })
     }
 
+    /// Uploads buffered bytes through a presigned object-store capability.
     pub async fn upload_via_presigned_url(
         &self,
         access: &ObjectTransferAccess,
@@ -1053,6 +1067,7 @@ impl Client {
             .map(|_| ())
     }
 
+    /// Sends buffered bytes through a service-proxied upload session.
     pub async fn upload_content(
         &self,
         namespace_id: &NamespaceId,
@@ -1146,6 +1161,7 @@ impl Client {
             .await
     }
 
+    /// Completes an upload session and returns its validated content reference.
     pub async fn complete_upload(
         &self,
         namespace_id: &NamespaceId,
@@ -1161,6 +1177,7 @@ impl Client {
             .await
     }
 
+    /// Lists committed changes after the supplied sequence number.
     pub async fn list_changes(
         &self,
         namespace_id: &NamespaceId,
@@ -2207,6 +2224,7 @@ impl Client {
         .await
     }
 
+    /// Creates the directory at the requested namespace path.
     pub async fn create_directory(
         &self,
         spec: &NamespacePath,
@@ -2229,6 +2247,7 @@ impl Client {
         Ok(response)
     }
 
+    /// Deletes the requested namespace path.
     pub async fn delete_path(
         &self,
         spec: &NamespacePath,
@@ -2279,6 +2298,7 @@ impl Client {
         Ok(response)
     }
 
+    /// Moves one namespace path to another in the same namespace.
     pub async fn move_path(
         &self,
         from: &NamespacePath,
@@ -2310,6 +2330,7 @@ impl Client {
         Ok(response)
     }
 
+    /// Copies one namespace path to another in the same namespace.
     pub async fn copy_path(
         &self,
         from: &NamespacePath,
@@ -2372,6 +2393,7 @@ impl Client {
         Ok(response)
     }
 
+    /// Restores a prior file revision as the file's current revision.
     pub async fn restore_file_revision(
         &self,
         spec: &NamespacePath,

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -244,27 +244,25 @@ impl DirectDownloadStream {
 /// to fail.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MultipartUploadResume {
-    /// Identifies the server-side multipart upload session.
+    /// Upload session ID returned by the server.
     pub upload_id: UploadId,
     /// The part size the session was opened with. A resumed upload must cut
     /// the payload exactly as the interrupted one did, or the parts it
     /// sends will not line up with the ones already there.
     pub part_size_bytes: u64,
-    /// Records the parts uploaded successfully so far.
+    /// Metadata for parts that have already been uploaded.
     pub parts: Vec<CompletedUploadPart>,
 }
 
-/// Where a caller records a direct multipart upload as it happens, so a
-/// later run can resume it.
+/// Saves direct multipart upload progress so an interrupted upload can resume.
 ///
-/// Both methods are called on the thread driving the upload, between
-/// network round trips, so an implementation that writes to disk is doing
-/// it at the right moment: after the part it describes is durable, and
-/// before the next one starts.
+/// The client calls these methods synchronously after opening the session and
+/// after each successful part upload. Implementations may persist this data
+/// before the next network request starts.
 pub trait MultipartUploadJournal: Send + Sync {
-    /// A session was opened, with the part geometry the server chose.
+    /// Records a newly opened session and its required part size.
     fn began(&self, upload_id: &UploadId, part_size_bytes: u64);
-    /// One part landed in object storage.
+    /// Records a part after it has been uploaded successfully.
     fn part_completed(&self, part: &CompletedUploadPart);
 }
 
@@ -542,7 +540,7 @@ impl Client {
             .clone())
     }
 
-    /// Creates an empty namespace with the requested id.
+    /// Creates an empty namespace with the given ID.
     pub async fn create_namespace(&self, namespace_id: &NamespaceId) -> Result<NamespaceSummary> {
         let url = format!("{}/v0/namespaces", self.base_url);
         // Namespace creation has no durable request identity to reconcile an ambiguous success.
@@ -555,7 +553,7 @@ impl Client {
         .await
     }
 
-    /// Returns the current status of a namespace.
+    /// Returns the namespace's current status.
     pub async fn namespace_status(
         &self,
         namespace_id: &NamespaceId,
@@ -586,7 +584,7 @@ impl Client {
             .await
     }
 
-    /// Forks the source namespace's durable view into a new namespace.
+    /// Creates a new namespace from the source namespace's current state.
     pub async fn fork_namespace(
         &self,
         source_namespace_id: &NamespaceId,
@@ -690,7 +688,7 @@ impl Client {
         self.request_json::<(), _>(self.get(&url), None).await
     }
 
-    /// Downloads the current contents of a file into memory.
+    /// Reads the file's current contents into memory.
     pub async fn get_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>> {
         let url = format!(
             "{}/v0/namespaces/{}/filesystem/content?path={}",
@@ -701,7 +699,7 @@ impl Client {
         self.request_bytes(&url).await
     }
 
-    /// Downloads one prior file revision into memory.
+    /// Reads the requested file revision into memory.
     pub async fn get_file_revision_bytes(
         &self,
         spec: &NamespacePath,
@@ -868,7 +866,7 @@ impl Client {
         Ok(size_bytes)
     }
 
-    /// Lists one page of revisions for a file.
+    /// Returns one page of revisions for a file.
     pub async fn list_file_revisions_page(
         &self,
         spec: &NamespacePath,
@@ -887,7 +885,7 @@ impl Client {
             .await
     }
 
-    /// Lists one page of recoverable deletions in a namespace.
+    /// Returns one page of recoverable deletions in a namespace.
     pub async fn list_trash_page(
         &self,
         namespace_id: &NamespaceId,
@@ -905,7 +903,7 @@ impl Client {
             .await
     }
 
-    /// Checks whether the server reports itself as healthy.
+    /// Checks the server's health endpoint.
     pub async fn health(&self) -> Result<()> {
         let url = format!("{}/health", self.base_url);
         self.call_with_transport_retry(&self.get(&url), None)
@@ -913,7 +911,7 @@ impl Client {
         Ok(())
     }
 
-    /// Starts an upload session with the requested transport.
+    /// Starts an upload session using the transport selected by the request.
     pub async fn begin_upload(
         &self,
         namespace_id: &NamespaceId,
@@ -1036,7 +1034,7 @@ impl Client {
         })
     }
 
-    /// Uploads buffered bytes through a presigned object-store capability.
+    /// Uploads in-memory bytes directly to object storage using a presigned URL.
     pub async fn upload_via_presigned_url(
         &self,
         access: &ObjectTransferAccess,
@@ -1067,7 +1065,7 @@ impl Client {
             .map(|_| ())
     }
 
-    /// Sends buffered bytes through a service-proxied upload session.
+    /// Uploads in-memory bytes through the server for a service-proxied session.
     pub async fn upload_content(
         &self,
         namespace_id: &NamespaceId,
@@ -1161,7 +1159,7 @@ impl Client {
             .await
     }
 
-    /// Completes an upload session and returns its validated content reference.
+    /// Completes an upload session after verifying the uploaded content.
     pub async fn complete_upload(
         &self,
         namespace_id: &NamespaceId,
@@ -1177,7 +1175,7 @@ impl Client {
             .await
     }
 
-    /// Lists committed changes after the supplied sequence number.
+    /// Returns committed changes after the given sequence number.
     pub async fn list_changes(
         &self,
         namespace_id: &NamespaceId,
@@ -2224,7 +2222,7 @@ impl Client {
         .await
     }
 
-    /// Creates the directory at the requested namespace path.
+    /// Creates a directory at the requested path.
     pub async fn create_directory(
         &self,
         spec: &NamespacePath,
@@ -2247,7 +2245,7 @@ impl Client {
         Ok(response)
     }
 
-    /// Deletes the requested namespace path.
+    /// Deletes the requested path.
     pub async fn delete_path(
         &self,
         spec: &NamespacePath,
@@ -2298,7 +2296,7 @@ impl Client {
         Ok(response)
     }
 
-    /// Moves one namespace path to another in the same namespace.
+    /// Moves a path within one namespace.
     pub async fn move_path(
         &self,
         from: &NamespacePath,
@@ -2330,7 +2328,7 @@ impl Client {
         Ok(response)
     }
 
-    /// Copies one namespace path to another in the same namespace.
+    /// Copies a path within one namespace.
     pub async fn copy_path(
         &self,
         from: &NamespacePath,
@@ -2393,7 +2391,7 @@ impl Client {
         Ok(response)
     }
 
-    /// Restores a prior file revision as the file's current revision.
+    /// Makes an earlier file revision the current revision.
     pub async fn restore_file_revision(
         &self,
         spec: &NamespacePath,

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -5,9 +5,6 @@
 //! building and folding.
 
 use crate::common::{is_content_object, GrepHost};
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::publish::{CommitRequest, FilesystemOperation};
 use loonfs::{
     ChangeSeq, CommitId, CreateNamespaceOptions, DestinationBehavior, ErrorCode, FsWriter,
@@ -21,15 +18,13 @@ use loonfs_grep::{
     GramIndexBuildPolicy, GrepBuildOutcome, GrepError, GrepReorganizeOutcome, GrepWorker,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
-};
 use loonfs_test_support::ids::nonzero_usize;
+use loonfs_test_support::stores::{
+    ConcurrencyWatchStore, CountingStore, KeyPredicate, OperationClass, RecordingStore,
+};
 use std::collections::BTreeSet;
 use std::num::NonZeroU64;
-use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tempfile::tempdir;
 
 fn request(pattern: &str) -> GrepRequest {
@@ -359,7 +354,14 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
     const FILES_PER_STEP: usize = 500;
 
     let temp_dir = tempdir().expect("tempdir");
-    let raw_store = Arc::new(BuildContentAccountingStore::new(temp_dir.path()));
+    let content_keys = KeyPredicate::new(is_content_object);
+    let raw_store = Arc::new(RecordingStore::new(
+        CountingStore::new(
+            LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+            content_keys.clone(),
+        ),
+        content_keys,
+    ));
     let store: loonfs::SharedObjectStore = raw_store.clone();
     let namespace_id = NamespaceId::parse("grams-thousand-atomic").expect("namespace id");
     let writer = FsWriter::builder_with_store(store.clone())
@@ -421,7 +423,8 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
         .await
         .expect("publish thousand-file commit");
 
-    raw_store.reset_content_reads();
+    raw_store.reset();
+    raw_store.inner().reset();
     let first = first_worker
         .build_step(&namespace_id, policy)
         .await
@@ -433,12 +436,13 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
             ..
         } if indexed_revisions == FILES_PER_STEP as u64
     ));
-    let first_reads = raw_store.take_content_reads();
+    let first_reads = raw_store.take_get_keys();
+    let first_read_bytes = raw_store.inner().snapshot().read_bytes;
     assert_eq!(first_reads.len(), FILES_PER_STEP);
     assert!(
-        content_read_bytes(&first_reads) <= max_content_bytes_per_step,
-        "first step read {} content bytes past its {max_content_bytes_per_step}-byte budget",
-        content_read_bytes(&first_reads)
+        first_read_bytes <= max_content_bytes_per_step,
+        "first step read {first_read_bytes} content bytes past its \
+         {max_content_bytes_per_step}-byte budget"
     );
 
     let partial = loonfs_grep::root::load_grep_root(&*store, &namespace_id)
@@ -488,7 +492,8 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
     // can resume only from the published manifest cursor.
     let resumed_host = GrepHost::new(&store, "grams-resumed-worker").await;
     let resumed_worker = &resumed_host.worker;
-    raw_store.reset_content_reads();
+    raw_store.reset();
+    raw_store.inner().reset();
     let second = resumed_worker
         .build_step(&namespace_id, policy)
         .await
@@ -500,15 +505,16 @@ async fn a_thousand_file_commit_is_byte_bounded_query_complete_and_crash_resumab
             ..
         } if indexed_revisions == FILES_PER_STEP as u64
     ));
-    let second_reads = raw_store.take_content_reads();
+    let second_reads = raw_store.take_get_keys();
+    let second_read_bytes = raw_store.inner().snapshot().read_bytes;
     assert_eq!(second_reads.len(), FILES_PER_STEP);
     assert!(
-        content_read_bytes(&second_reads) <= max_content_bytes_per_step,
-        "resumed step read {} content bytes past its {max_content_bytes_per_step}-byte budget",
-        content_read_bytes(&second_reads)
+        second_read_bytes <= max_content_bytes_per_step,
+        "resumed step read {second_read_bytes} content bytes past its \
+         {max_content_bytes_per_step}-byte budget"
     );
-    let first_keys: BTreeSet<_> = first_reads.iter().map(|(key, _)| key).collect();
-    let second_keys: BTreeSet<_> = second_reads.iter().map(|(key, _)| key).collect();
+    let first_keys: BTreeSet<_> = first_reads.iter().collect();
+    let second_keys: BTreeSet<_> = second_reads.iter().collect();
     assert!(
         first_keys.is_disjoint(&second_keys),
         "the fresh worker must not re-read any indexed-prefix content"
@@ -583,10 +589,6 @@ async fn collect_grep_paths(
         };
         request.cursor = Some(cursor);
     }
-}
-
-fn content_read_bytes(reads: &[(String, usize)]) -> u64 {
-    reads.iter().map(|(_, bytes)| *bytes as u64).sum::<u64>()
 }
 
 /// Ten one-file rounds cross the default delta-fold threshold, so the
@@ -665,160 +667,8 @@ async fn grep_answers_identically_across_tiered_folds() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// Accounts full content-blob GETs issued by one explicit worker step.
-#[derive(Debug)]
-struct BuildContentAccountingStore {
-    inner: LocalFsStore,
-    content_reads: Mutex<Vec<(String, usize)>>,
-}
-
-impl BuildContentAccountingStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            content_reads: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn reset_content_reads(&self) {
-        self.content_reads
-            .lock()
-            .expect("content read accounting lock")
-            .clear();
-    }
-
-    fn take_content_reads(&self) -> Vec<(String, usize)> {
-        std::mem::take(
-            &mut *self
-                .content_reads
-                .lock()
-                .expect("content read accounting lock"),
-        )
-    }
-
-    fn record_content_read(&self, key: &str, bytes: usize) {
-        if is_content_object(key) {
-            self.content_reads
-                .lock()
-                .expect("content read accounting lock")
-                .push((key.to_owned(), bytes));
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for BuildContentAccountingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        let body = self.inner.get_with_metadata(key).await?;
-        if let Some(body) = &body {
-            self.record_content_read(key, body.bytes.len());
-        }
-        Ok(body)
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        let bytes = self.inner.get(key, range).await?;
-        if let Some(bytes) = &bytes {
-            self.record_content_read(key, bytes.len());
-        }
-        Ok(bytes)
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-/// Counts store GETs against gram index segment objects, so tests can
-/// assert how many posting-block reads a query cost.
-#[derive(Debug)]
-struct IndexSegmentGetCountingStore {
-    inner: LocalFsStore,
-    index_segment_gets: AtomicUsize,
-}
-
-impl IndexSegmentGetCountingStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            index_segment_gets: AtomicUsize::new(0),
-        }
-    }
-
-    fn index_segment_get_count(&self) -> usize {
-        self.index_segment_gets.load(Ordering::SeqCst)
-    }
-
-    fn record_if_index_segment(&self, key: &str) {
-        if key.contains("/extensions/grep/segments/") && key.ends_with(".sst.zst") {
-            self.index_segment_gets.fetch_add(1, Ordering::SeqCst);
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for IndexSegmentGetCountingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.record_if_index_segment(key);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.record_if_index_segment(key);
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
+fn index_segment_keys() -> KeyPredicate {
+    KeyPredicate::new(|key| key.contains("/extensions/grep/segments/") && key.ends_with(".sst.zst"))
 }
 
 /// Index segment blocks are immutable and keyed by payload checksum, so the
@@ -827,7 +677,10 @@ impl ObjectStore for IndexSegmentGetCountingStore {
 #[tokio::test]
 async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
     let temp_dir = tempdir().expect("tempdir");
-    let raw_store = Arc::new(IndexSegmentGetCountingStore::new(temp_dir.path()));
+    let raw_store = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        index_segment_keys(),
+    ));
     let store: loonfs::SharedObjectStore = raw_store.clone();
     let namespace_id = NamespaceId::parse("grams-cache").expect("namespace id");
 
@@ -867,13 +720,13 @@ async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
         drive_worker_step(&host.worker, &namespace_id, GramIndexBuildPolicy::default()).await;
     }
 
-    let before_first = raw_store.index_segment_get_count();
+    let before_first = raw_store.count(OperationClass::Read);
     let first = host
         .grep(&namespace_id, &request("needle"))
         .await
         .expect("first grep");
     assert_eq!(first.matches.len(), 1);
-    let after_first = raw_store.index_segment_get_count();
+    let after_first = raw_store.count(OperationClass::Read);
     assert!(
         after_first > before_first,
         "the first grep must read posting blocks from the store"
@@ -884,7 +737,7 @@ async fn repeated_grep_serves_posting_blocks_from_the_grep_cache() {
         .await
         .expect("second grep");
     assert_eq!(second.matches, first.matches);
-    let after_second = raw_store.index_segment_get_count();
+    let after_second = raw_store.count(OperationClass::Read);
     assert_eq!(
         after_second, after_first,
         "an identical grep through the same service must serve every \
@@ -1007,80 +860,6 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
     writer.shutdown().await.expect("writer shutdown");
 }
 
-/// Records the key of every store GET against a content blob object, so
-/// tests can assert exactly which file contents a query fetched.
-#[derive(Debug)]
-struct ContentBlobGetRecordingStore {
-    inner: LocalFsStore,
-    content_blob_gets: Mutex<Vec<String>>,
-}
-
-impl ContentBlobGetRecordingStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            content_blob_gets: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn content_blob_get_keys(&self) -> Vec<String> {
-        self.content_blob_gets
-            .lock()
-            .expect("content GET log lock")
-            .clone()
-    }
-
-    fn record_if_content_blob(&self, key: &str) {
-        if is_content_object(key) {
-            self.content_blob_gets
-                .lock()
-                .expect("content GET log lock")
-                .push(key.to_owned());
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for ContentBlobGetRecordingStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.record_if_content_blob(key);
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.record_if_content_blob(key);
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
 /// An unindexed-tail candidate larger than the index eligibility cap can
 /// never pass verification, so grep must skip it on its declared size
 /// alone: no content GET for it, unchanged page budgets, and a cursor
@@ -1088,7 +867,10 @@ impl ObjectStore for ContentBlobGetRecordingStore {
 #[tokio::test]
 async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
     let temp_dir = tempdir().expect("tempdir");
-    let raw_store = Arc::new(ContentBlobGetRecordingStore::new(temp_dir.path()));
+    let raw_store = Arc::new(RecordingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        KeyPredicate::new(is_content_object),
+    ));
     let store: loonfs::SharedObjectStore = raw_store.clone();
     let namespace_id = NamespaceId::parse("grams-oversized-tail").expect("namespace id");
 
@@ -1152,7 +934,7 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
     // No step after these writes: bravo and charlie stay in the unindexed
     // tail, where no gram filter screens candidates before verification.
 
-    let gets_before_greps = raw_store.content_blob_get_keys().len();
+    raw_store.reset();
 
     let mut first_page = request("needle");
     first_page.limit = Some(1);
@@ -1191,8 +973,7 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
         "the first page's cursor must sit between alpha and charlie"
     );
 
-    let content_gets = raw_store.content_blob_get_keys();
-    let fetched_during_greps = &content_gets[gets_before_greps..];
+    let fetched_during_greps = raw_store.take_get_keys();
     assert!(
         !fetched_during_greps.is_empty(),
         "the greps must fetch the small candidates' contents"
@@ -1213,7 +994,10 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
 #[tokio::test]
 async fn worker_and_service_share_decoded_index_blocks() {
     let temp_dir = tempdir().expect("tempdir");
-    let raw_store = Arc::new(IndexSegmentGetCountingStore::new(temp_dir.path()));
+    let raw_store = Arc::new(CountingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        index_segment_keys(),
+    ));
     let store: loonfs::SharedObjectStore = raw_store.clone();
     let namespace_id = NamespaceId::parse("grams-shared-cache").expect("namespace id");
 
@@ -1254,7 +1038,7 @@ async fn worker_and_service_share_decoded_index_blocks() {
         max_decoded_input_rows_per_step: nonzero_usize(1),
         ..GramIndexBuildPolicy::default()
     };
-    let gets_before_fold = raw_store.index_segment_get_count();
+    let gets_before_fold = raw_store.count(OperationClass::Read);
     let stats_before_fold = host.block_cache.stats();
     let fold = host
         .worker
@@ -1269,7 +1053,7 @@ async fn worker_and_service_share_decoded_index_blocks() {
         }
     ));
     assert!(
-        raw_store.index_segment_get_count() > gets_before_fold,
+        raw_store.count(OperationClass::Read) > gets_before_fold,
         "the worker must load its snapshot's segment blocks"
     );
     let stats_after_fold = host.block_cache.stats();
@@ -1278,14 +1062,14 @@ async fn worker_and_service_share_decoded_index_blocks() {
         "the worker must publish decoded blocks to the shared cache"
     );
 
-    let gets_before_query = raw_store.index_segment_get_count();
+    let gets_before_query = raw_store.count(OperationClass::Read);
     let result = host
         .grep(&namespace_id, &request("needle"))
         .await
         .expect("grep after worker load");
     assert_eq!(result.matches.len(), 8);
     assert_eq!(
-        raw_store.index_segment_get_count() - gets_before_query,
+        raw_store.count(OperationClass::Read) - gets_before_query,
         0,
         "the service must not refetch index-segment sections the worker warmed"
     );
@@ -1295,86 +1079,6 @@ async fn worker_and_service_share_decoded_index_blocks() {
     );
 
     writer.shutdown().await.expect("writer shutdown");
-}
-
-/// Tracks how many GETs against gram index segment objects are in flight
-/// at once. The yield before each forwarded read lets sibling fetches
-/// issued in the same fan-out begin before this one completes, so the
-/// peak observes overlap exactly when the caller issued the GETs
-/// concurrently; serial callers can never raise it above one.
-#[derive(Debug)]
-struct InFlightIndexGetProbeStore {
-    inner: LocalFsStore,
-    in_flight: AtomicUsize,
-    peak: AtomicUsize,
-}
-
-impl InFlightIndexGetProbeStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("create local-fs store"),
-            in_flight: AtomicUsize::new(0),
-            peak: AtomicUsize::new(0),
-        }
-    }
-
-    fn peak_in_flight(&self) -> usize {
-        self.peak.load(Ordering::SeqCst)
-    }
-
-    async fn probed<T, F>(&self, key: &str, read: F) -> T
-    where
-        F: std::future::Future<Output = T>,
-    {
-        if !key.contains("/extensions/grep/segments/") || !key.ends_with(".sst.zst") {
-            return read.await;
-        }
-        let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-        self.peak.fetch_max(now, Ordering::SeqCst);
-        tokio::task::yield_now().await;
-        let result = read.await;
-        self.in_flight.fetch_sub(1, Ordering::SeqCst);
-        result
-    }
-}
-
-#[async_trait]
-impl ObjectStore for InFlightIndexGetProbeStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.probed(key, self.inner.get_with_metadata(key)).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.probed(key, self.inner.get(key, range)).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
 }
 
 /// A cold fold — nothing decoded its snapshot before — must fan out its
@@ -1390,7 +1094,10 @@ impl ObjectStore for InFlightIndexGetProbeStore {
 #[tokio::test]
 async fn a_cold_fold_fans_out_its_segment_opens_within_the_io_cap() {
     let temp_dir = tempdir().expect("tempdir");
-    let raw_store = Arc::new(InFlightIndexGetProbeStore::new(temp_dir.path()));
+    let raw_store = Arc::new(ConcurrencyWatchStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("create local-fs store"),
+        index_segment_keys(),
+    ));
     let store: loonfs::SharedObjectStore = raw_store.clone();
     let namespace_id = NamespaceId::parse("grams-fold-fan-out").expect("namespace id");
 
@@ -1413,7 +1120,7 @@ async fn a_cold_fold_fans_out_its_segment_opens_within_the_io_cap() {
     // construction, the triggered fold reading its snapshot of every
     // accumulated delta run.
     let mut rounds = 0u32;
-    while raw_store.peak_in_flight() == 0 {
+    while raw_store.reads().peak_in_flight == 0 {
         rounds += 1;
         assert!(
             rounds <= 24,
@@ -1431,7 +1138,7 @@ async fn a_cold_fold_fans_out_its_segment_opens_within_the_io_cap() {
         drive_worker_step(&host.worker, &namespace_id, GramIndexBuildPolicy::default()).await;
     }
 
-    let peak = raw_store.peak_in_flight();
+    let peak = raw_store.reads().peak_in_flight;
     assert!(
         peak > 1,
         "a cold fold's segment opens must overlap, got a serial peak of {peak}"

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -4,9 +4,7 @@
 //! GrepWorker lifecycle, rebootstrap, query contracts, and GC boundaries.
 
 use crate::common::{control, grep_with, GrepHost};
-use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::{
     CreateNamespaceOptions, DeleteNamespaceOptions, ErrorCode, FsAdmin, FsReader, FsWriter,
     GcConfig, MaintenancePlan, MetadataMaintenanceOptions, NamespaceId, PutFileOptions,
@@ -32,17 +30,17 @@ use loonfs_objectstore::keys::{
     metadata_manifest_prefix, metadata_table_prefix, upload_session_prefix, wal_segment_prefix,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+use loonfs_objectstore::{ObjectStore, PutMode};
+use loonfs_test_support::stores::{
+    BlockingStore, FailStore, InjectedError, KeyPredicate, MetadataMapStore, OperationClass,
+    OperationContext, OperationKind, RecordedOperation, RecordingStore,
 };
-use loonfs_test_support::stores::{FailStore, InjectedError, OperationContext, OperationKind};
 use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use tempfile::tempdir;
-use tokio::sync::Semaphore;
 
 fn request(pattern: &str) -> GrepRequest {
     GrepRequest {
@@ -106,89 +104,6 @@ async fn new_query(
         grep_request,
     )
     .await
-}
-
-#[derive(Debug)]
-struct BlockingGrepRootCasStore {
-    inner: SharedObjectStore,
-    root_key: String,
-    blocked_once: AtomicBool,
-    entered: Semaphore,
-    release: Semaphore,
-}
-
-impl BlockingGrepRootCasStore {
-    fn new(inner: SharedObjectStore, root_key: String) -> Self {
-        Self {
-            inner,
-            root_key,
-            blocked_once: AtomicBool::new(false),
-            entered: Semaphore::new(0),
-            release: Semaphore::new(0),
-        }
-    }
-
-    async fn wait_until_blocked(&self) {
-        self.entered
-            .acquire()
-            .await
-            .expect("blocking store remains open")
-            .forget();
-    }
-
-    fn unblock(&self) {
-        self.release.add_permits(1);
-    }
-}
-
-#[async_trait]
-impl ObjectStore for BlockingGrepRootCasStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        let should_block = key == self.root_key
-            && matches!(&mode, PutMode::CompareAndSwap { .. })
-            && !self.blocked_once.swap(true, Ordering::SeqCst);
-        if should_block {
-            self.entered.add_permits(1);
-            self.release
-                .acquire()
-                .await
-                .expect("blocking store remains open")
-                .forget();
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
 }
 
 fn normalize_namespace(mut response: GrepResponse, namespace_id: &NamespaceId) -> GrepResponse {
@@ -1759,10 +1674,12 @@ async fn a_publication_in_flight_keeps_its_candidate_through_a_collection_pass()
         .last_modified_ms
         .expect("the local store stamps its objects");
 
-    let blocking = Arc::new(BlockingGrepRootCasStore::new(
+    let blocking = Arc::new(BlockingStore::new(
         base.clone(),
-        root_key(&namespace_id),
+        KeyPredicate::exact(root_key(&namespace_id)),
+        OperationClass::CompareAndSwap,
     ));
+    blocking.block_next();
     let store: SharedObjectStore = blocking.clone();
     let advance = advance_grep_root(&*store, &current, &next);
     let collect = async {
@@ -1771,7 +1688,7 @@ async fn a_publication_in_flight_keeps_its_candidate_through_a_collection_pass()
             .await
             .garbage_collect_namespace(&namespace_id, published_at_ms, &GrepGcRequest::default())
             .await;
-        blocking.unblock();
+        blocking.release();
         report
     };
     let (advanced, report) = tokio::join!(advance, collect);
@@ -1821,84 +1738,16 @@ async fn a_publication_in_flight_keeps_its_candidate_through_a_collection_pass()
         .is_some());
 }
 
-#[derive(Debug)]
-struct AgedMetadataStore {
-    inner: LocalFsStore,
-    listed_prefixes: Mutex<Vec<String>>,
-}
-
-impl AgedMetadataStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("local store"),
-            listed_prefixes: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn age(mut metadata: ObjectMetadata) -> ObjectMetadata {
-        metadata.last_modified_ms = Some(0);
-        metadata
-    }
-
-    fn clear_listed_prefixes(&self) {
-        self.listed_prefixes.lock().expect("prefix lock").clear();
-    }
-
-    fn listed_prefixes(&self) -> Vec<String> {
-        self.listed_prefixes.lock().expect("prefix lock").clone()
-    }
-}
-
-#[async_trait]
-impl ObjectStore for AgedMetadataStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        Ok(self.inner.head(key).await?.map(Self::age))
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        Ok(self.inner.get_with_metadata(key).await?.map(|mut body| {
-            body.metadata = Self::age(body.metadata);
-            body
-        }))
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await.map(Self::age)
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.listed_prefixes
-            .lock()
-            .expect("prefix lock")
-            .push(prefix.to_owned());
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
 #[tokio::test]
 async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_keyspaces() {
     let temp_dir = tempdir().expect("tempdir");
-    let aged_store = Arc::new(AgedMetadataStore::new(temp_dir.path()));
+    let aged_store = Arc::new(RecordingStore::new(
+        MetadataMapStore::aged(
+            LocalFsStore::new(temp_dir.path()).expect("local store"),
+            KeyPredicate::any(),
+        ),
+        KeyPredicate::any(),
+    ));
     let store: SharedObjectStore = aged_store.clone();
     let live_namespace = NamespaceId::parse("gc-live").expect("namespace id");
     let deleted_namespace = NamespaceId::parse("gc-deleted").expect("namespace id");
@@ -2082,13 +1931,21 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
         )
         .await
         .expect("write grep sentinel");
-    aged_store.clear_listed_prefixes();
+    aged_store.reset();
     admin
         .gc_namespace(&live_namespace, &GcConfig::default())
         .await
         .expect("core gc");
+    let listed_prefixes: Vec<_> = aged_store
+        .take()
+        .into_iter()
+        .filter_map(|operation| match operation {
+            RecordedOperation::List { prefix } => Some(prefix),
+            _ => None,
+        })
+        .collect();
     assert_eq!(
-        aged_store.listed_prefixes(),
+        listed_prefixes,
         vec![
             // Marking lists the records it roots from, then the manifests
             // it ages to find its reference manifest.
@@ -2117,7 +1974,10 @@ async fn grep_gc_retains_live_roots_reaps_deleted_namespaces_and_never_crosses_k
 /// Seeds one namespace with an index plus a fixed set of aged orphans, so
 /// two stores can be built identically and collected differently.
 async fn seed_collectable_namespace(root: &Path, namespace_id: &NamespaceId) -> SharedObjectStore {
-    let store: SharedObjectStore = Arc::new(AgedMetadataStore::new(root));
+    let store: SharedObjectStore = Arc::new(MetadataMapStore::aged(
+        LocalFsStore::new(root).expect("local store"),
+        KeyPredicate::any(),
+    ));
     let writer = FsWriter::builder_with_store(store.clone())
         .writer_id("gc-budget-writer")
         .min_publish_interval_ms(0)

--- a/crates/loonfs-grep/tests/it/maintenance.rs
+++ b/crates/loonfs-grep/tests/it/maintenance.rs
@@ -3,9 +3,7 @@
 //! what its steps conclude, and how a writer's one permit pool paces them.
 
 use crate::common::is_content_object;
-use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::BoxStream;
 use loonfs::{
     DeleteNamespaceOptions, FsAdmin, FsBackgroundWork, FsReader, FsWriter, MaintenanceJob,
     MaintenanceProbe, MaintenanceStepConclusion, SharedObjectStore,
@@ -17,16 +15,13 @@ use loonfs_grep::{
     GramIndexBuildPolicy, GrepGcJob, GrepMaintenanceJob, GrepWorker, GREP_GC_JOB, GREP_INDEX_JOB,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
-use loonfs_objectstore::{
-    ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
+use loonfs_objectstore::ObjectStore;
+use loonfs_test_support::stores::{
+    BlockingStore, ConcurrencyWatchStore, KeyPredicate, MetadataMapStore, OperationClass,
 };
-use std::future::Future;
-use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
-use tokio::sync::Notify;
 
 const WAIT: Duration = Duration::from_secs(10);
 
@@ -192,7 +187,16 @@ async fn the_runners_one_permit_pool_caps_grep_steps_across_namespaces() {
     const MAX_CONCURRENT_MAINTENANCE: usize = 2;
 
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(StepConcurrencyStore::new(temp_dir.path()));
+    let content_keys = KeyPredicate::new(is_content_object);
+    let blocked_store = Arc::new(BlockingStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("store"),
+        content_keys.clone(),
+        OperationClass::Read,
+    ));
+    let store = Arc::new(ConcurrencyWatchStore::new(
+        blocked_store.clone(),
+        content_keys,
+    ));
     let worker = worker(store.clone(), "concurrency-worker").await;
     let mut namespace_ids = Vec::new();
     for index in 0..NAMESPACES {
@@ -204,7 +208,8 @@ async fn the_runners_one_permit_pool_caps_grep_steps_across_namespaces() {
         namespace_ids.push(namespace_id);
     }
 
-    store.pause_content_reads();
+    let reads_before_steps = store.reads().total;
+    blocked_store.arm();
     let host = host_writer(
         store.clone(),
         "concurrency-host",
@@ -217,23 +222,21 @@ async fn the_runners_one_permit_pool_caps_grep_steps_across_namespaces() {
         host.maintenance().nudge(GREP_INDEX_JOB, namespace_id);
     }
 
-    tokio::time::timeout(WAIT, store.wait_for_started(MAX_CONCURRENT_MAINTENANCE))
-        .await
-        .expect("the permitted steps must enter their build steps");
-    assert!(
-        tokio::time::timeout(Duration::from_millis(50), store.wait_for_started(3))
-            .await
-            .is_err(),
-        "a third namespace must remain queued while both permits are held"
-    );
-    assert_eq!(store.peak_in_flight(), MAX_CONCURRENT_MAINTENANCE);
+    tokio::time::timeout(WAIT, async {
+        while store.reads().total < reads_before_steps + MAX_CONCURRENT_MAINTENANCE {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the permitted steps must enter their build steps");
+    assert_eq!(store.reads().peak_in_flight, MAX_CONCURRENT_MAINTENANCE);
 
-    store.resume_content_reads();
+    blocked_store.release();
     for namespace_id in &namespace_ids {
         wait_for_watermark(&store, namespace_id, ChangeSeq(1)).await;
     }
     assert!(
-        store.peak_in_flight() <= MAX_CONCURRENT_MAINTENANCE,
+        store.reads().peak_in_flight <= MAX_CONCURRENT_MAINTENANCE,
         "executing grep steps exceeded the runner's pool"
     );
     host.shutdown().await.expect("settle host maintenance");
@@ -269,7 +272,10 @@ async fn catch_up<S: ObjectStore + Clone + Send + Sync + 'static>(
 #[tokio::test]
 async fn a_nudge_collects_what_indexing_left_behind() {
     let temp_dir = tempdir().expect("tempdir");
-    let store = Arc::new(AgedGrepStore::new(temp_dir.path()));
+    let store = Arc::new(MetadataMapStore::aged(
+        LocalFsStore::new(temp_dir.path()).expect("local store"),
+        KeyPredicate::any(),
+    ));
     let namespace_id = NamespaceId::parse("collect").expect("namespace id");
     let writer = seed(store.clone(), &namespace_id).await;
     put_file(&writer, &namespace_id, "collect-put").await;
@@ -322,67 +328,6 @@ async fn a_refused_resume_position_restarts_the_collection_pass() {
     let fresh = job.step(&namespace_id, None).await.expect("fresh pass");
     assert_eq!(fresh.conclusion, MaintenanceStepConclusion::Idle);
     assert_eq!(fresh.continuation, None);
-}
-
-/// Grep objects age out against provider timestamps, so a collection test
-/// needs candidates the provider reports as older than the grace window.
-#[derive(Debug)]
-struct AgedGrepStore {
-    inner: LocalFsStore,
-}
-
-impl AgedGrepStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("local store"),
-        }
-    }
-}
-
-#[async_trait]
-impl ObjectStore for AgedGrepStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        Ok(self.inner.head(key).await?.map(|mut metadata| {
-            metadata.last_modified_ms = Some(0);
-            metadata
-        }))
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
-        self.inner.list_prefix(prefix).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
 }
 
 /// A writer that only hosts the runner: it serves no namespace of its own,
@@ -477,115 +422,4 @@ async fn wait_for_watermark<S: ObjectStore + 'static>(
     })
     .await
     .unwrap_or_else(|_| panic!("`{namespace_id}` did not reach {built_through_seq:?}"));
-}
-
-#[derive(Debug)]
-struct StepConcurrencyStore {
-    inner: LocalFsStore,
-    pause_content_reads: AtomicBool,
-    started: AtomicUsize,
-    in_flight: AtomicUsize,
-    peak: AtomicUsize,
-    started_notify: Notify,
-    resume_notify: Notify,
-}
-
-impl StepConcurrencyStore {
-    fn new(root: &Path) -> Self {
-        Self {
-            inner: LocalFsStore::new(root).expect("store"),
-            pause_content_reads: AtomicBool::new(false),
-            started: AtomicUsize::new(0),
-            in_flight: AtomicUsize::new(0),
-            peak: AtomicUsize::new(0),
-            started_notify: Notify::new(),
-            resume_notify: Notify::new(),
-        }
-    }
-
-    fn pause_content_reads(&self) {
-        self.pause_content_reads.store(true, Ordering::Release);
-    }
-
-    fn resume_content_reads(&self) {
-        self.pause_content_reads.store(false, Ordering::Release);
-        self.resume_notify.notify_waiters();
-    }
-
-    fn peak_in_flight(&self) -> usize {
-        self.peak.load(Ordering::Acquire)
-    }
-
-    async fn wait_for_started(&self, target: usize) {
-        loop {
-            let notified = self.started_notify.notified();
-            if self.started.load(Ordering::Acquire) >= target {
-                return;
-            }
-            notified.await;
-        }
-    }
-
-    async fn observe_content_read<T>(&self, key: &str, read: impl Future<Output = T>) -> T {
-        if !is_content_object(key) {
-            return read.await;
-        }
-        let in_flight = self.in_flight.fetch_add(1, Ordering::AcqRel) + 1;
-        self.peak.fetch_max(in_flight, Ordering::AcqRel);
-        self.started.fetch_add(1, Ordering::AcqRel);
-        self.started_notify.notify_waiters();
-        if self.pause_content_reads.load(Ordering::Acquire) {
-            loop {
-                let notified = self.resume_notify.notified();
-                if !self.pause_content_reads.load(Ordering::Acquire) {
-                    break;
-                }
-                notified.await;
-            }
-        }
-        let result = read.await;
-        self.in_flight.fetch_sub(1, Ordering::AcqRel);
-        result
-    }
-}
-
-#[async_trait]
-impl ObjectStore for StepConcurrencyStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        self.observe_content_read(key, self.inner.get_with_metadata(key))
-            .await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.observe_content_read(key, self.inner.get(key, range))
-            .await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
 }

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -272,10 +272,8 @@ mod tests {
     use loonfs_api::ContentId;
     use loonfs_api::ContentRef;
     use loonfs_api::StorageChecksum;
-    use std::fs;
-    use std::path::PathBuf;
     use std::sync::Arc;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, UNIX_EPOCH};
 
     const AZURITE_ACCOUNT_KEY: &str =
         "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
@@ -283,7 +281,7 @@ mod tests {
     #[tokio::test]
     async fn configured_local_fs_scopes_optional_key_prefix() {
         let temp_dir = unique_temp_dir("configured-store-local");
-        let store = ConfiguredObjectStore::local_fs(&temp_dir, Some("tenant-a"))
+        let store = ConfiguredObjectStore::local_fs(temp_dir.path(), Some("tenant-a"))
             .expect("construct configured local fs store")
             .into_shared();
         let head_key =
@@ -294,7 +292,7 @@ mod tests {
             .await
             .expect("write scoped object");
 
-        let raw_store = LocalFsStore::new(&temp_dir).expect("open raw store");
+        let raw_store = LocalFsStore::new(temp_dir.path()).expect("open raw store");
         assert!(raw_store
             .head(&format!("tenant-a/{head_key}"))
             .await
@@ -393,8 +391,9 @@ mod tests {
     /// suite has run against, offers direct transfers at all.
     #[test]
     fn configured_object_store_offers_direct_transfers_only_on_proven_endpoints() {
-        let local = ConfiguredObjectStore::local_fs(unique_temp_dir("configured-store-kind"), None)
-            .expect("construct local store");
+        let temp_dir = unique_temp_dir("configured-store-kind");
+        let local =
+            ConfiguredObjectStore::local_fs(temp_dir.path(), None).expect("construct local store");
         assert!(local.direct_transfers().is_none());
 
         assert!(aws_s3_store(None).direct_transfers().is_some());
@@ -518,23 +517,28 @@ mod tests {
     }
 
     fn gcs_store() -> ConfiguredObjectStore {
-        ConfiguredObjectStore::gcp_gcs(gcs_config()).expect("construct gcs store")
+        let (_key_dir, config) = gcs_config();
+        ConfiguredObjectStore::gcp_gcs(config).expect("construct gcs store")
     }
 
     /// The same deployment as it will be once a credentialed conformance run
     /// has flipped [`GCS_DIRECT_TRANSFERS_PROVEN`].
     fn proven_gcs_store() -> ConfiguredObjectStore {
-        ConfiguredObjectStore::gcp_gcs_proven(gcs_config(), true).expect("construct gcs store")
+        let (_key_dir, config) = gcs_config();
+        ConfiguredObjectStore::gcp_gcs_proven(config, true).expect("construct gcs store")
     }
 
-    fn gcs_config() -> GcpGcsStoreConfig {
-        GcpGcsStoreConfig {
-            bucket: "bucket".to_owned(),
-            service_account_key_path: gcs_fixture_service_account_key_file("configured-store-gcs")
-                .display()
-                .to_string(),
-            key_prefix: Some("tenant-a".to_owned()),
-        }
+    fn gcs_config() -> (tempfile::TempDir, GcpGcsStoreConfig) {
+        let (key_dir, service_account_key_path) =
+            gcs_fixture_service_account_key_file("configured-store-gcs");
+        (
+            key_dir,
+            GcpGcsStoreConfig {
+                bucket: "bucket".to_owned(),
+                service_account_key_path: service_account_key_path.display().to_string(),
+                key_prefix: Some("tenant-a".to_owned()),
+            },
+        )
     }
 
     /// A reference whose storage checksum is the CRC-32C GCS enforces.
@@ -613,7 +617,7 @@ mod tests {
     #[tokio::test]
     async fn configured_local_fs_preserves_invalid_key_errors() {
         let temp_dir = unique_temp_dir("configured-store-invalid-key");
-        let store = ConfiguredObjectStore::local_fs(&temp_dir, Some("tenant-a"))
+        let store = ConfiguredObjectStore::local_fs(temp_dir.path(), Some("tenant-a"))
             .expect("construct configured local fs store")
             .into_shared();
 
@@ -627,15 +631,10 @@ mod tests {
         ));
     }
 
-    #[allow(clippy::disallowed_methods)]
-    fn unique_temp_dir(label: &str) -> PathBuf {
-        // Test-only unique paths are an entropy boundary, not protocol time.
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock after epoch")
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!("loonfs-objectstore-{label}-{stamp}"));
-        fs::create_dir_all(&path).expect("create temp dir");
-        path
+    fn unique_temp_dir(label: &str) -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix(&format!("loonfs-objectstore-{label}-"))
+            .tempdir()
+            .expect("create temp dir")
     }
 }

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -304,7 +304,8 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_keys_are_rejected_before_generation_tokens() {
-        let service_account_key_path = gcs_fixture_service_account_key_file("gcs-invalid-key");
+        let (_key_dir, service_account_key_path) =
+            gcs_fixture_service_account_key_file("gcs-invalid-key");
         let store = GcpGcsStore::new(GcpGcsStoreConfig {
             bucket: "bucket".to_owned(),
             service_account_key_path: service_account_key_path.display().to_string(),
@@ -322,7 +323,8 @@ mod tests {
 
     #[tokio::test]
     async fn streamed_compare_and_swap_rejects_the_mismatched_token_semantics() {
-        let service_account_key_path = gcs_fixture_service_account_key_file("gcs-streamed-cas");
+        let (_key_dir, service_account_key_path) =
+            gcs_fixture_service_account_key_file("gcs-streamed-cas");
         let store = GcpGcsStore::new(GcpGcsStoreConfig {
             bucket: "bucket".to_owned(),
             service_account_key_path: service_account_key_path.display().to_string(),
@@ -362,11 +364,8 @@ mod tests {
     /// failure on the first completion.
     #[test]
     fn a_service_account_key_that_cannot_sign_stops_the_store_from_being_built() {
-        let dir = gcs_fixture_service_account_key_file("gcs-unsignable")
-            .parent()
-            .expect("fixture dir")
-            .to_path_buf();
-        let unsignable = dir.join("unsignable.json");
+        let (key_dir, _key_path) = gcs_fixture_service_account_key_file("gcs-unsignable");
+        let unsignable = key_dir.path().join("unsignable.json");
         std::fs::write(
             &unsignable,
             br#"{"client_email":"a@b.iam.gserviceaccount.com","private_key":"private_key","disable_oauth":true}"#,

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -791,14 +791,12 @@ mod tests {
     use crate::keys::{upload_session, wal_head};
     use bytes::Bytes;
     use std::fs;
-    use std::path::{Path, PathBuf};
     use std::sync::Arc;
-    use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::sync::Barrier;
 
     #[test]
     fn construction_requires_atomic_rename_replace_support() {
-        let temp_dir = TestDir::new("construction-gate");
+        let temp_dir = test_dir("construction-gate");
         let result = LocalFsStore::new(temp_dir.path());
 
         #[cfg(unix)]
@@ -816,7 +814,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn listing_tolerates_entries_that_vanish_mid_walk() {
-        let temp_dir = TestDir::new("listing-races");
+        let temp_dir = test_dir("listing-races");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
         let key = wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
         store
@@ -844,7 +842,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_head_of_a_missing_object_answers_gone() {
-        let temp_dir = TestDir::new("head-missing");
+        let temp_dir = test_dir("head-missing");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
 
         let answer = store
@@ -863,7 +861,7 @@ mod tests {
     // directly instead.
     #[tokio::test]
     async fn a_digest_read_of_a_vanished_object_answers_gone() {
-        let temp_dir = TestDir::new("digest-vanished");
+        let temp_dir = test_dir("digest-vanished");
         let vanished = temp_dir.path().join("vanished.json");
 
         let answer = LocalFsStore::read_for_digest("namespaces/ns-1/wal/head.json", &vanished)
@@ -874,7 +872,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_digest_read_that_fails_for_another_reason_stays_an_error() {
-        let temp_dir = TestDir::new("digest-error");
+        let temp_dir = test_dir("digest-error");
         let directory = temp_dir.path().join("dir");
         fs::create_dir(&directory).expect("create directory");
 
@@ -886,7 +884,7 @@ mod tests {
 
     #[tokio::test]
     async fn overwrite_refreshes_head_and_visible_bytes() {
-        let temp_dir = TestDir::new("overwrite");
+        let temp_dir = test_dir("overwrite");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
         let key = wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
 
@@ -926,7 +924,7 @@ mod tests {
     /// and a start past the object or a descending range is refused.
     #[tokio::test]
     async fn ranged_reads_answer_their_range_and_refuse_impossible_ones() {
-        let temp_dir = TestDir::new("ranged-reads");
+        let temp_dir = test_dir("ranged-reads");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
         let key = wal_head(&loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"));
         let payload = Bytes::from_static(b"0123456789");
@@ -990,7 +988,7 @@ mod tests {
         const READER_COUNT: usize = 4;
         const REPLACEMENT_COUNT: u8 = 32;
 
-        let temp_dir = TestDir::new("atomic-replacement");
+        let temp_dir = test_dir("atomic-replacement");
         let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("create local fs store"));
         let key = wal_head(
             &loonfs_api::NamespaceId::parse("ns-atomic-replacement").expect("valid namespace id"),
@@ -1047,7 +1045,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_is_idempotent_and_head_reflects_removal() {
-        let temp_dir = TestDir::new("delete");
+        let temp_dir = test_dir("delete");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
         let key = upload_session(
             &loonfs_api::NamespaceId::parse("ns-1").expect("valid namespace id"),
@@ -1071,7 +1069,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn compare_and_swap_is_safe_across_store_instances() {
-        let temp_dir = TestDir::new("cross-instance-cas");
+        let temp_dir = test_dir("cross-instance-cas");
         let key = wal_head(&loonfs_api::NamespaceId::parse("ns-cas").expect("valid namespace id"));
         let seed = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
         seed.put(&key, Bytes::from_static(b"0"), PutMode::CreateIfAbsent)
@@ -1128,7 +1126,7 @@ mod tests {
 
     #[tokio::test]
     async fn listings_hide_scratch_files_and_reject_scratch_keys() {
-        let temp_dir = TestDir::new("scratch");
+        let temp_dir = test_dir("scratch");
         let store = LocalFsStore::new(temp_dir.path()).expect("create local fs store");
         let key =
             wal_head(&loonfs_api::NamespaceId::parse("ns-scratch").expect("valid namespace id"));
@@ -1166,34 +1164,10 @@ mod tests {
         ));
     }
 
-    struct TestDir {
-        path: PathBuf,
-    }
-
-    impl TestDir {
-        #[allow(clippy::disallowed_methods)]
-        fn new(label: &str) -> Self {
-            // Test-only unique paths are an entropy boundary, not protocol time.
-            let stamp = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos();
-            let path = std::env::temp_dir().join(format!(
-                "loonfs-local-fs-{label}-{}-{stamp}",
-                std::process::id()
-            ));
-            fs::create_dir_all(&path).expect("create temp dir");
-            Self { path }
-        }
-
-        fn path(&self) -> &Path {
-            &self.path
-        }
-    }
-
-    impl Drop for TestDir {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.path);
-        }
+    fn test_dir(label: &str) -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix(&format!("loonfs-local-fs-{label}-"))
+            .tempdir()
+            .expect("create temp dir")
     }
 }

--- a/crates/loonfs-objectstore/src/presign/gcs.rs
+++ b/crates/loonfs-objectstore/src/presign/gcs.rs
@@ -504,11 +504,11 @@ mod tests {
     }
 
     fn presigner(key_prefix: Option<&str>) -> GcsV4Presigner {
+        let (_key_dir, service_account_key_path) =
+            gcs_fixture_service_account_key_file("gcs-presign");
         GcsV4Presigner::new(GcsPresignerConfig {
             bucket: "bucket".to_owned(),
-            service_account_key_path: gcs_fixture_service_account_key_file("gcs-presign")
-                .display()
-                .to_string(),
+            service_account_key_path: service_account_key_path.display().to_string(),
             key_prefix: key_prefix.map(ToOwned::to_owned),
         })
         .expect("signer")
@@ -691,14 +691,12 @@ mod tests {
     #[test]
     fn an_unusable_key_prefix_fails_construction() {
         for raw_prefix in ["tenant-a//bad", "../escape"] {
+            let (_key_dir, service_account_key_path) =
+                gcs_fixture_service_account_key_file("gcs-presign-prefix");
             assert!(matches!(
                 GcsV4Presigner::new(GcsPresignerConfig {
                     bucket: "bucket".to_owned(),
-                    service_account_key_path: gcs_fixture_service_account_key_file(
-                        "gcs-presign-prefix"
-                    )
-                    .display()
-                    .to_string(),
+                    service_account_key_path: service_account_key_path.display().to_string(),
                     key_prefix: Some(raw_prefix.to_owned()),
                 }),
                 Err(ObjectStoreError::InvalidKey { .. })
@@ -815,20 +813,17 @@ mod tests {
 
     #[test]
     fn a_key_file_that_cannot_sign_fails_construction() {
-        let dir = gcs_fixture_service_account_key_file("gcs-presign-bad")
-            .parent()
-            .expect("fixture dir")
-            .to_path_buf();
+        let (key_dir, _key_path) = gcs_fixture_service_account_key_file("gcs-presign-bad");
 
-        let not_json = dir.join("not-json.json");
+        let not_json = key_dir.path().join("not-json.json");
         std::fs::write(&not_json, b"this is not a service account").expect("write");
-        let no_pem = dir.join("no-pem.json");
+        let no_pem = key_dir.path().join("no-pem.json");
         std::fs::write(
             &no_pem,
             br#"{"client_email":"a@b.iam.gserviceaccount.com","private_key":"private_key"}"#,
         )
         .expect("write");
-        let missing = dir.join("absent.json");
+        let missing = key_dir.path().join("absent.json");
 
         for path in [not_json, no_pem, missing] {
             assert!(

--- a/crates/loonfs-objectstore/src/test_support.rs
+++ b/crates/loonfs-objectstore/src/test_support.rs
@@ -42,8 +42,8 @@ pub(crate) const GCS_FIXTURE_CLIENT_EMAIL: &str =
 /// Writes the fixture key to a fresh temporary file and returns its path,
 /// because every GCS constructor takes the key as a path to read.
 ///
-/// The returned directory owns the fixture's lifetime, so callers keep it
-/// until the provider or signer has read the returned path.
+/// Returns the temporary directory and the path to the fixture key file.
+/// Keep the directory alive while using the path; dropping it deletes the file.
 pub(crate) fn gcs_fixture_service_account_key_file(
     label: &str,
 ) -> (tempfile::TempDir, std::path::PathBuf) {

--- a/crates/loonfs-objectstore/src/test_support.rs
+++ b/crates/loonfs-objectstore/src/test_support.rs
@@ -42,25 +42,16 @@ pub(crate) const GCS_FIXTURE_CLIENT_EMAIL: &str =
 /// Writes the fixture key to a fresh temporary file and returns its path,
 /// because every GCS constructor takes the key as a path to read.
 ///
-/// Each call gets its own directory. A wall-clock stamp alone does not
-/// guarantee that: several tests ask for this fixture under the same label,
-/// the clock's resolution is coarser than the gap between them, and two
-/// callers landing on one directory then truncate and re-write the same file
-/// while the other is reading it. The counter is what actually makes the
-/// path unique within a run; the stamp separates runs.
-#[allow(clippy::disallowed_methods)]
-pub(crate) fn gcs_fixture_service_account_key_file(label: &str) -> std::path::PathBuf {
-    static NEXT: AtomicU64 = AtomicU64::new(0);
-
-    // Test-only unique paths are an entropy boundary, not protocol time.
-    let stamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("clock after epoch")
-        .as_nanos();
-    let ordinal = NEXT.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("loonfs-objectstore-{label}-{stamp}-{ordinal}"));
-    std::fs::create_dir_all(&dir).expect("create temp dir");
-    let path = dir.join("service-account.json");
+/// The returned directory owns the fixture's lifetime, so callers keep it
+/// until the provider or signer has read the returned path.
+pub(crate) fn gcs_fixture_service_account_key_file(
+    label: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("loonfs-objectstore-{label}-"))
+        .tempdir()
+        .expect("create temp dir");
+    let path = dir.path().join("service-account.json");
     std::fs::write(&path, GCS_FIXTURE_SERVICE_ACCOUNT_KEY).expect("write fixture service account");
-    path
+    (dir, path)
 }

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -20,9 +20,7 @@ use loonfs_objectstore::s3_compatible::{
 };
 use loonfs_objectstore::ObjectStore;
 use loonfs_objectstore::ObjectStoreError;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
 
 #[test]
 fn key_builders_cover_locked_object_families() {
@@ -101,21 +99,21 @@ fn provider_env_example_covers_real_provider_contract() {
 
 #[tokio::test]
 async fn local_fs_passes_the_store_contract_probe() {
-    let temp_dir = TestDir::new("contract-probe");
+    let temp_dir = test_dir("contract-probe");
     let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
-    assert_store_contract_probe_passes(&store).await;
+    assert_store_contract_probe_passes(&store, false).await;
 }
 
 #[tokio::test]
 async fn local_fs_rejects_path_traversal_keys() {
-    let temp_dir = TestDir::new("invalid-key");
+    let temp_dir = test_dir("invalid-key");
     let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
     assert_rejects_invalid_keys_consistently(&store).await;
 }
 
 #[tokio::test]
 async fn local_fs_streamed_write_round_trips() {
-    let temp_dir = TestDir::new("streamed-write");
+    let temp_dir = test_dir("streamed-write");
     let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
     assert_streamed_write_round_trips(&store).await;
 }
@@ -136,7 +134,7 @@ async fn aws_s3_real_provider_conformance() {
         force_path_style: false,
     })
     .expect("create AWS S3 object store");
-    assert_provider_conformance(&store).await;
+    assert_provider_conformance(&store, true).await;
 }
 
 /// The streamed write against live AWS S3. Separate from the conformance
@@ -256,7 +254,7 @@ async fn cloudflare_r2_real_provider_conformance() {
         key_prefix: Some(config.prefix),
     })
     .expect("create Cloudflare R2 object store");
-    assert_provider_conformance(&store).await;
+    assert_provider_conformance(&store, true).await;
 }
 
 #[tokio::test]
@@ -270,7 +268,7 @@ async fn gcp_gcs_real_provider_conformance() {
         key_prefix: Some(config.prefix),
     })
     .expect("create GCP GCS object store");
-    assert_provider_conformance(&store).await;
+    assert_provider_conformance(&store, true).await;
 }
 
 #[tokio::test]
@@ -300,7 +298,7 @@ async fn azure_abs_real_provider_conformance() {
         key_prefix: Some(config.prefix),
     })
     .expect("create Azure Blob Storage object store");
-    assert_provider_conformance(&store).await;
+    assert_provider_conformance(&store, false).await;
 }
 
 #[tokio::test]
@@ -325,8 +323,8 @@ async fn azure_abs_streamed_write_round_trips() {
 /// The probe is the production surface an operator runs, and running it
 /// here is what stops the two from drifting: a contract check changes for
 /// production and for this sweep in one edit, or not at all.
-async fn assert_provider_conformance(store: &dyn ObjectStore) {
-    assert_store_contract_probe_passes(store).await;
+async fn assert_provider_conformance(store: &dyn ObjectStore, direct_put_proven: bool) {
+    assert_store_contract_probe_passes(store, direct_put_proven).await;
     assert_rejects_invalid_keys_consistently(store).await;
 }
 
@@ -337,16 +335,18 @@ async fn assert_provider_conformance(store: &dyn ObjectStore) {
 /// `GetObjectAttributes` was read off exactly this output, so a failure
 /// shows every check's verdict rather than the first one that broke.
 ///
-/// `stored_checksum_readback` may answer `unsupported`: that is the
-/// capability line for presigned direct uploads, and GCS and Azure Blob
-/// Storage both sit on the far side of it. Every other check must pass
-/// outright on every provider this suite covers, multipart included.
-async fn assert_store_contract_probe_passes(store: &dyn ObjectStore) {
+/// `stored_checksum_readback` may answer `unsupported` only for providers
+/// this suite marks as unable to offer direct puts. AWS S3, Cloudflare R2,
+/// and GCS are direct-put-proven, so checksum readback must work for them;
+/// every other check must pass outright on every provider.
+async fn assert_store_contract_probe_passes(store: &dyn ObjectStore, direct_put_proven: bool) {
     let run_id = loonfs_api::generated_id("probe");
     let report = run_store_contract_probe(store, &run_id).await;
     let acceptable = report.checks.iter().all(|check| match check.outcome {
         StoreProbeOutcome::Passed => true,
-        StoreProbeOutcome::Unsupported => check.name == "stored_checksum_readback",
+        StoreProbeOutcome::Unsupported => {
+            check.name == "stored_checksum_readback" && !direct_put_proven
+        }
         StoreProbeOutcome::Failed { .. } => false,
     });
     assert!(
@@ -466,34 +466,9 @@ async fn assert_rejects_invalid_keys_consistently(store: &dyn ObjectStore) {
     }
 }
 
-#[derive(Debug)]
-struct TestDir {
-    path: PathBuf,
-}
-
-impl TestDir {
-    #[allow(clippy::disallowed_methods)]
-    fn new(label: &str) -> Self {
-        // Test-only unique paths are an entropy boundary, not protocol time.
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!(
-            "loonfs-objectstore-{label}-{}-{stamp}",
-            std::process::id()
-        ));
-        fs::create_dir_all(&path).expect("create temp dir");
-        Self { path }
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl Drop for TestDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
+fn test_dir(label: &str) -> TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("loonfs-objectstore-{label}-"))
+        .tempdir()
+        .expect("create temp dir")
 }

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -335,10 +335,10 @@ async fn assert_provider_conformance(store: &dyn ObjectStore, direct_put_proven:
 /// `GetObjectAttributes` was read off exactly this output, so a failure
 /// shows every check's verdict rather than the first one that broke.
 ///
-/// `stored_checksum_readback` may answer `unsupported` only for providers
-/// this suite marks as unable to offer direct puts. AWS S3, Cloudflare R2,
-/// and GCS are direct-put-proven, so checksum readback must work for them;
-/// every other check must pass outright on every provider.
+/// `stored_checksum_readback` may return `unsupported` only for providers that
+/// do not offer direct PUT. AWS S3, Cloudflare R2, and GCS are tested with
+/// direct PUT enabled, so they must return stored checksums. Every other probe
+/// check must pass for every provider.
 async fn assert_store_contract_probe_passes(store: &dyn ObjectStore, direct_put_proven: bool) {
     let run_id = loonfs_api::generated_id("probe");
     let report = run_store_contract_probe(store, &run_id).await;

--- a/crates/loonfs-objectstore/tests/it/provider_env.rs
+++ b/crates/loonfs-objectstore/tests/it/provider_env.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)]
-// This file is imported as a helper module by provider tests and also compiled as its own test target.
-
 use loonfs_api::SecretString;
 use std::fmt;
 use std::fs;

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -44,7 +44,8 @@ const DIRECT_GET_URL_TTL: Duration = Duration::from_secs(15 * 60);
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace, path, or revision not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 501, description = "Direct download is unsupported", body = ApiError)
+            (status = 501, description = "Direct download is unsupported", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -116,7 +116,8 @@ pub(super) struct ChangesQuery {
             (status = 400, description = "Invalid path, limit, cursor, or include_attributes", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or path not found", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -170,7 +171,8 @@ pub(super) async fn list_path_entries(
             (status = 400, description = "Invalid path or include_attributes", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or path not found", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -284,7 +286,8 @@ pub(super) async fn get_file_bytes(
             (status = 200, description = "Recoverable deletions", body = ListTrashResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -330,7 +333,8 @@ pub(super) async fn list_trash(
             (status = 400, description = "Invalid path", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or path not found", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -376,7 +380,8 @@ pub(super) async fn list_file_revisions(
             (status = 404, description = "Namespace or path not found", body = ApiError),
             (status = 409, description = "Operation conflict", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 503, description = "Commit unavailable", body = ApiError)
+            (status = 503, description = "Commit unavailable", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -490,7 +495,8 @@ pub(super) async fn apply_commit(
             (status = 400, description = "Invalid change cursor or limit", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -49,7 +49,8 @@ pub(super) struct DeleteNamespaceQuery {
         description = "Returns a summary of supported features and limits.",
         responses(
             (status = 200, description = "Capability document", body = loonfs_api::CapabilityDocument),
-            (status = 401, description = "Unauthorized", body = ApiError)
+            (status = 401, description = "Unauthorized", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -174,7 +175,8 @@ pub(super) async fn capabilities(
             (status = 400, description = "Invalid namespace id", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 409, description = "Namespace already exists or is partial", body = ApiError),
-            (status = 410, description = "Namespace id was deleted and retired", body = ApiError)
+            (status = 410, description = "Namespace id was deleted and retired", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -204,7 +206,8 @@ pub(super) async fn create_namespace(
             (status = 400, description = "Invalid namespace id", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -241,7 +244,8 @@ pub(super) async fn namespace_status(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 409, description = "Delete conflict", body = ApiError),
-            (status = 410, description = "Namespace already deleted", body = ApiError)
+            (status = 410, description = "Namespace already deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -282,7 +286,8 @@ pub(super) async fn delete_namespace(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Source namespace not found", body = ApiError),
             (status = 409, description = "Fork conflict", body = ApiError),
-            (status = 410, description = "Source namespace deleted", body = ApiError)
+            (status = 410, description = "Source namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -316,7 +321,8 @@ pub(super) async fn fork_namespace(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 503, description = "Checkpoint unavailable", body = ApiError)
+            (status = 503, description = "Checkpoint unavailable", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -350,7 +356,8 @@ pub(super) async fn create_checkpoint(
             (status = 200, description = "Active checkpoint records", body = ListCheckpointsResponse),
             (status = 400, description = "Invalid namespace id", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 404, description = "Namespace not found", body = ApiError)
+            (status = 404, description = "Namespace not found", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -385,7 +392,8 @@ pub(super) async fn list_checkpoints(
             (status = 200, description = "Checkpoint released (or already gone)", body = ReleaseCheckpointResponse),
             (status = 400, description = "Invalid id, or the checkpoint is fork-owned", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
-            (status = 404, description = "Namespace not found", body = ApiError)
+            (status = 404, description = "Namespace not found", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -34,7 +34,8 @@ use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError, NamespaceRea
             (status = 410, description = "Namespace deleted", body = ApiError),
             (status = 501, description = "This deployment does not serve grep queries, the grep index is not enabled, or its backfill has not completed on this namespace", body = ApiError),
             (status = 503, description = "The index trails the head past the scan budget", body = ApiError),
-            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -109,7 +110,8 @@ pub(super) async fn grep_index_not_maintained(
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
-            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -168,7 +170,8 @@ pub(super) async fn enable_grep_index(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 403, description = "The backing store rejected its configured credentials", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
-            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -220,7 +223,8 @@ pub(super) async fn grep_index_status(
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 409, description = "Lost a grep root-pointer publication race; retry", body = ApiError),
             (status = 501, description = "This deployment does not maintain the grep index", body = ApiError),
-            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError)
+            (status = 500, description = "The grep index is corrupt or its backing store is unavailable", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -106,7 +106,8 @@ pub(super) struct UploadPathParams {
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 501, description = "Requested upload mode is unsupported", body = ApiError)
+            (status = 501, description = "Requested upload mode is unsupported", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -272,7 +273,8 @@ async fn begin_direct_multipart_upload(
             (status = 404, description = "Namespace or upload not found", body = ApiError),
             (status = 409, description = "Upload already completed", body = ApiError),
             (status = 410, description = "Namespace deleted", body = ApiError),
-            (status = 501, description = "Direct multipart upload is unsupported", body = ApiError)
+            (status = 501, description = "Direct multipart upload is unsupported", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -552,7 +554,8 @@ pub(super) async fn upload_content(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or upload not found", body = ApiError),
             (status = 409, description = "Upload completion conflict", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -594,7 +597,8 @@ pub(super) async fn complete_upload(
             (status = 400, description = "Invalid upload id", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or upload not found", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -645,7 +649,8 @@ pub(super) async fn read_upload_status(
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace or upload not found", body = ApiError),
             (status = 409, description = "Upload already completed", body = ApiError),
-            (status = 410, description = "Namespace deleted", body = ApiError)
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -369,7 +369,10 @@ async fn method_not_allowed() -> ApiResponseError {
         summary = "Check health",
         description = "Returns `ok` when the server is running and can accept requests.",
         security(()),
-        responses((status = 200, description = "Server health check", body = String))
+        responses(
+            (status = 200, description = "Server health check", body = String),
+            crate::http::openapi::DeadlineExceededResponses
+        )
     )
 )]
 async fn health() -> &'static str {
@@ -390,7 +393,8 @@ async fn health() -> &'static str {
         security(()),
         responses(
             (status = 200, description = "The server admits new work", body = String),
-            (status = 503, description = "Shutdown has begun; admission is closed", body = loonfs_api::ApiError)
+            (status = 503, description = "Shutdown has begun; admission is closed", body = loonfs_api::ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]
@@ -426,7 +430,8 @@ const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
                        deployment's bearer token.",
         responses(
             (status = 200, description = "Prometheus text exposition", body = String),
-            (status = 401, description = "Missing or invalid bearer token", body = loonfs_api::ApiError)
+            (status = 401, description = "Missing or invalid bearer token", body = loonfs_api::ApiError),
+            crate::http::openapi::DeadlineExceededResponses
         )
     )
 )]

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -184,19 +184,18 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
 )]
 struct LoonfsOpenApi;
 
-/// Reusable 408 response emitted when request middleware reaches the
-/// deployment's configured deadline.
+/// OpenAPI definition for the 408 response returned after a request deadline.
 #[derive(utoipa::ToResponse)]
 #[response(
-    description = "The server cancelled this bounded request at `request_deadline_ms`; a mutation may still land and must be reconciled before retrying."
+    description = "The request exceeded `request_deadline_ms`. A timed-out mutation may still complete, so clients must determine its outcome before retrying."
 )]
 #[expect(
     dead_code,
-    reason = "the newtype exists only to describe the reusable OpenAPI response body"
+    reason = "used only to generate the reusable OpenAPI response schema"
 )]
 pub(super) struct DeadlineExceededResponse(#[to_schema] ApiError);
 
-/// Adds the shared deadline response to one deadline-bounded operation.
+/// Adds the shared 408 response to an OpenAPI operation.
 pub(super) struct DeadlineExceededResponses;
 
 impl utoipa::IntoResponses for DeadlineExceededResponses {

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -72,7 +72,8 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         crate::http::handlers_query::gc_grep_index,
         crate::http::handlers_store::probe_store
     ),
-    components(schemas(
+    components(
+        schemas(
         loonfs_api::CapabilityDocument,
         ApiError,
         loonfs_api::ErrorDetails,
@@ -163,7 +164,9 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         loonfs_api::v0::StoreProbeCheckOutcome,
         loonfs_api::v0::StoreProbeCheckResult,
         loonfs_api::v0::StoreProbeResponse
-    )),
+        ),
+        responses(DeadlineExceededResponse)
+    ),
     // Applies to every operation that does not override it. `/health` and
     // `/readiness` do, with `security(())`: they are the probe surface and
     // answer unauthenticated by design.
@@ -180,6 +183,34 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
     )
 )]
 struct LoonfsOpenApi;
+
+/// Reusable 408 response emitted when request middleware reaches the
+/// deployment's configured deadline.
+#[derive(utoipa::ToResponse)]
+#[response(
+    description = "The server cancelled this bounded request at `request_deadline_ms`; a mutation may still land and must be reconciled before retrying."
+)]
+#[expect(
+    dead_code,
+    reason = "the newtype exists only to describe the reusable OpenAPI response body"
+)]
+pub(super) struct DeadlineExceededResponse(#[to_schema] ApiError);
+
+/// Adds the shared deadline response to one deadline-bounded operation.
+pub(super) struct DeadlineExceededResponses;
+
+impl utoipa::IntoResponses for DeadlineExceededResponses {
+    fn responses() -> std::collections::BTreeMap<
+        String,
+        utoipa::openapi::RefOr<utoipa::openapi::response::Response>,
+    > {
+        let (name, _) = <DeadlineExceededResponse as utoipa::ToResponse>::response();
+        utoipa::openapi::ResponsesBuilder::new()
+            .response("408", utoipa::openapi::Ref::from_response_name(name))
+            .build()
+            .into()
+    }
+}
 
 /// Declares the scheme the global requirement above names.
 ///

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -213,6 +213,86 @@ fn error_status_mapping_matches_the_api_spec_table() {
     assert_api_spec_error_codes_are_registered(&spec);
 }
 
+#[test]
+fn registered_limit_keys_match_the_api_spec_table() {
+    let spec = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../docs/specs/api.md"
+    ))
+    .expect("read docs/specs/api.md");
+    let table = spec
+        .split("Registered limit keys:")
+        .nth(1)
+        .expect("api.md registered-limit table intro")
+        .split("### 2.2 Feature registry")
+        .next()
+        .expect("api.md registered-limit table end");
+    let documented: std::collections::BTreeSet<_> = table
+        .lines()
+        .filter_map(|line| line.strip_prefix("| `"))
+        .filter_map(|line| line.split('`').next())
+        .map(ToOwned::to_owned)
+        .collect();
+
+    let capability_source = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../loonfs-api/src/capability.rs"
+    ));
+    let registered: std::collections::BTreeSet<_> = capability_source
+        .split("pub const LIMIT_")
+        .skip(1)
+        .filter_map(|declaration| declaration.split(';').next())
+        .filter_map(|declaration| declaration.split_once('"').map(|(_, value)| value))
+        .filter_map(|value| value.split('"').next())
+        .map(ToOwned::to_owned)
+        .collect();
+
+    assert_eq!(documented, registered);
+}
+
+#[test]
+fn error_detail_fields_match_the_api_spec_table() {
+    let spec = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../docs/specs/api.md"
+    ))
+    .expect("read docs/specs/api.md");
+    let table = spec
+        .split("The codes that populate it:")
+        .nth(1)
+        .expect("api.md error-details table intro")
+        .split("One code exists specifically")
+        .next()
+        .expect("api.md error-details table end");
+    let documented: std::collections::BTreeSet<_> = table
+        .lines()
+        .filter(|line| line.starts_with('|'))
+        .filter_map(|line| line.trim_matches('|').split('|').nth(1))
+        .flat_map(|fields| fields.split('`').skip(1).step_by(2))
+        .map(ToOwned::to_owned)
+        .collect();
+
+    let operations_source = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../loonfs-api/src/v0/operations.rs"
+    ));
+    let details_body = operations_source
+        .split("pub struct ErrorDetails {")
+        .nth(1)
+        .expect("ErrorDetails declaration")
+        .split("\n}")
+        .next()
+        .expect("ErrorDetails body");
+    let registered: std::collections::BTreeSet<_> = details_body
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("pub "))
+        .filter_map(|field| field.split(':').next())
+        .map(ToOwned::to_owned)
+        .collect();
+
+    assert_eq!(documented, registered);
+}
+
 fn assert_api_spec_error_codes_are_registered(spec: &str) {
     for token in spec
         .split('`')
@@ -241,7 +321,10 @@ fn is_snake_case_token(token: &str) -> bool {
 }
 use loonfs_test_support::http::raw_agent;
 use loonfs_test_support::ids::namespace_id;
-use loonfs_test_support::stores::{BlockingStore, BufferWatchStore, KeyPredicate, OperationClass};
+use loonfs_test_support::stores::{
+    BlockingStore, BufferWatchStore, FailStore, InjectedError, KeyPredicate, OperationClass,
+    OperationContext, OperationKind,
+};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -294,92 +377,6 @@ impl ObjectStore for StaleHeadOnceStore {
             if let Some(existing) = self.inner.get(key, None).await? {
                 let _ = self.inner.put_overwrite(key, existing).await?;
             }
-        }
-        self.inner.put(key, bytes, mode).await
-    }
-
-    async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
-        self.inner.delete(key).await
-    }
-
-    fn list_prefix_stream(
-        &self,
-        prefix: &str,
-    ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
-    }
-}
-
-#[derive(Debug)]
-struct FaultGrepRootStore {
-    inner: LocalFsStore,
-    root_key: String,
-    fail_next_root_read: AtomicBool,
-    conflict_next_root_publication: AtomicBool,
-}
-
-impl FaultGrepRootStore {
-    fn new(root: impl AsRef<Path>, namespace_id: &NamespaceId) -> Self {
-        Self {
-            inner: LocalFsStore::new(root.as_ref()).expect("construct local store"),
-            root_key: grep_root_key(namespace_id),
-            fail_next_root_read: AtomicBool::new(false),
-            conflict_next_root_publication: AtomicBool::new(false),
-        }
-    }
-
-    fn fail_next_root_read(&self) {
-        self.fail_next_root_read.store(true, Ordering::SeqCst);
-    }
-
-    fn conflict_next_root_publication(&self) {
-        self.conflict_next_root_publication
-            .store(true, Ordering::SeqCst);
-    }
-}
-
-#[async_trait]
-impl ObjectStore for FaultGrepRootStore {
-    async fn head(&self, key: &str) -> Result<Option<ObjectMetadata>, ObjectStoreError> {
-        self.inner.head(key).await
-    }
-
-    async fn get(
-        &self,
-        key: &str,
-        range: Option<ByteRange>,
-    ) -> Result<Option<Bytes>, ObjectStoreError> {
-        self.inner.get(key, range).await
-    }
-
-    async fn get_with_metadata(&self, key: &str) -> Result<Option<ObjectBody>, ObjectStoreError> {
-        if key == self.root_key && self.fail_next_root_read.swap(false, Ordering::SeqCst) {
-            return Err(ObjectStoreError::transport(
-                key,
-                "injected grep-root outage",
-            ));
-        }
-        self.inner.get_with_metadata(key).await
-    }
-
-    async fn put(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        mode: PutMode,
-    ) -> Result<ObjectMetadata, ObjectStoreError> {
-        if key == self.root_key
-            && matches!(
-                &mode,
-                PutMode::CreateIfAbsent | PutMode::CompareAndSwap { .. }
-            )
-            && self
-                .conflict_next_root_publication
-                .swap(false, Ordering::SeqCst)
-        {
-            return Err(ObjectStoreError::PreconditionFailed {
-                object_key: key.to_owned(),
-            });
         }
         self.inner.put(key, bytes, mode).await
     }
@@ -1149,13 +1146,18 @@ async fn grep_error_mid_backfill_is_not_materialized_and_core_reads_survive() {
 async fn grep_error_store_outage_is_provider_failure_and_core_reads_survive() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("grep-error-store");
-    let fault_store = Arc::new(FaultGrepRootStore::new(temp_dir.path(), &namespace_id));
+    let fault_store = Arc::new(FailStore::new(
+        LocalFsStore::new(temp_dir.path()).expect("construct local store"),
+        KeyPredicate::exact(grep_root_key(&namespace_id)),
+        OperationClass::GetWithMetadata,
+        InjectedError::Transport("injected grep-root outage".to_owned()),
+    ));
     let store = fault_store.clone() as SharedObjectStore;
     let writer = seed_grep_error_namespace(&store, &namespace_id).await;
     writer.shutdown().await.expect("shutdown writer");
 
     let harness = start_grep_error_server(store, temp_dir.path(), "store-server").await;
-    fault_store.fail_next_root_read();
+    fault_store.fail_next(1);
     let client = &harness.client;
     let binding = grep_error_request();
     let result = client.grep(&namespace_id, &binding);
@@ -1252,13 +1254,27 @@ async fn grep_error_identity_mismatch_is_index_corrupt_and_core_reads_survive() 
 async fn grep_error_publication_conflict_is_stale_head_and_core_reads_survive() {
     let temp_dir = tempdir().expect("tempdir");
     let namespace_id = namespace_id("grep-error-conflict");
-    let fault_store = Arc::new(FaultGrepRootStore::new(temp_dir.path(), &namespace_id));
+    let root_key = grep_root_key(&namespace_id);
+    let fault_store = Arc::new(FailStore::matching(
+        LocalFsStore::new(temp_dir.path()).expect("construct local store"),
+        move |context: &OperationContext<'_>| {
+            context.key() == root_key
+                && matches!(
+                    context.kind(),
+                    OperationKind::Put {
+                        mode: PutMode::CreateIfAbsent | PutMode::CompareAndSwap { .. },
+                        ..
+                    }
+                )
+        },
+        InjectedError::PreconditionFailed,
+    ));
     let store = fault_store.clone() as SharedObjectStore;
     let writer = seed_grep_error_namespace(&store, &namespace_id).await;
     writer.shutdown().await.expect("shutdown writer");
 
     let harness = start_grep_admin_error_server(store, temp_dir.path(), "conflict-server").await;
-    fault_store.conflict_next_root_publication();
+    fault_store.fail_next(1);
     let client = &harness.client;
     let result = client.enable_grep_index(&namespace_id);
     assert_grep_api_error_and_core_read(

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -1016,16 +1016,23 @@ async fn at_most_the_process_limit_of_compactions_run_however_many_namespaces_pl
         .take(compaction::MAX_CONCURRENT_COMPACTIONS)
         .collect();
     let admitted = Arc::new(AtomicU64::new(0));
+    let waiting_started = Arc::new(AtomicU64::new(0));
     let waiting: Vec<_> = claims
         .map(|mut claim| {
             let admitted = Arc::clone(&admitted);
+            let waiting_started = Arc::clone(&waiting_started);
             tokio::spawn(async move {
+                waiting_started.fetch_add(1, Ordering::SeqCst);
                 assert!(claim.admitted().await, "a freed permit admits this job");
                 admitted.fetch_add(1, Ordering::SeqCst);
             })
         })
         .collect();
-    tokio::task::yield_now().await;
+    wait_for(
+        || waiting_started.load(Ordering::SeqCst) == waiting.len() as u64,
+        "every queued compaction to start waiting",
+    )
+    .await;
     assert_eq!(
         admitted.load(Ordering::SeqCst),
         0,
@@ -1096,9 +1103,12 @@ async fn cancellation_reaches_a_job_that_is_still_waiting_for_a_permit() {
     assert!(queued.is_queued());
 
     let ran = Arc::new(AtomicU64::new(0));
+    let waiting_started = Arc::new(AtomicU64::new(0));
     let waiting = tokio::spawn({
         let ran = Arc::clone(&ran);
+        let waiting_started = Arc::clone(&waiting_started);
         async move {
+            waiting_started.store(1, Ordering::SeqCst);
             let admitted = queued.admitted().await;
             if admitted {
                 ran.fetch_add(1, Ordering::SeqCst);
@@ -1106,7 +1116,11 @@ async fn cancellation_reaches_a_job_that_is_still_waiting_for_a_permit() {
             admitted
         }
     });
-    tokio::task::yield_now().await;
+    wait_for(
+        || waiting_started.load(Ordering::SeqCst) == 1,
+        "the queued compaction to start waiting",
+    )
+    .await;
 
     compactions.cancel_all();
 

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -820,8 +820,9 @@ async fn cold_submission_publishes_without_a_coalescing_delay() {
 /// Follow-up submissions inside the pacing interval coalesce and
 /// publish no earlier than the interval boundary — the timer gives a
 /// deterministic lower bound.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test]
 async fn hot_submissions_wait_out_the_pacing_interval() {
+    tokio::time::pause();
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedStore;
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
@@ -832,7 +833,6 @@ async fn hot_submissions_wait_out_the_pacing_interval() {
         .expect("bootstrap");
     let registry = writer.publisher();
 
-    let warmup_started = Instant::now();
     registry
         .submit_commit(
             namespace_id.clone(),
@@ -841,15 +841,26 @@ async fn hot_submissions_wait_out_the_pacing_interval() {
         .await
         .expect("warmup commit");
 
-    registry
-        .submit_commit(namespace_id.clone(), create_directory_request("hot", "hot"))
-        .await
-        .expect("hot commit");
-    let elapsed = warmup_started.elapsed();
+    let hot = tokio::spawn({
+        let registry = registry.clone();
+        let namespace_id = namespace_id.clone();
+        async move {
+            registry
+                .submit_commit(namespace_id, create_directory_request("hot", "hot"))
+                .await
+        }
+    });
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(399)).await;
+    tokio::task::yield_now().await;
     assert!(
-        elapsed >= Duration::from_millis(400),
-        "a follow-up publication must wait out the pacing interval, took {elapsed:?}"
+        !hot.is_finished(),
+        "a follow-up publication must remain paced before the interval boundary"
     );
+    tokio::time::advance(Duration::from_millis(1)).await;
+    hot.await
+        .expect("join hot publication")
+        .expect("hot commit");
 }
 
 /// Receipt replay races a lost head compare-and-swap acknowledgement.
@@ -1302,14 +1313,6 @@ async fn mutations_admitted_after_a_queued_delete_wait_behind_it() {
         &namespace_id,
         create_directory_request("after", "after"),
     );
-
-    // Admission order is the queue order: the later mutation opens a batch
-    // behind the delete instead of coalescing into work admitted before it.
-    {
-        let state = publisher_state(&publisher);
-        assert!(matches!(state.queue.front(), Some(WorkItem::Delete(_))));
-        assert_eq!(queued_candidates(&state), 1);
-    }
 
     store.release();
     assert_eq!(

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -217,10 +217,11 @@ fn runtime_cache_can_be_disabled() {
 #[test]
 fn runtime_wal_tail_projection_cache_evicts_by_namespace_count() {
     let temp_dir = tempdir().expect("tempdir");
-    let shared_store = store(temp_dir.path());
-    let setup = open_runtime(shared_store.clone(), "tail-count-setup");
     let first = NamespaceId::parse("first").expect("valid namespace id");
     let second = NamespaceId::parse("second").expect("valid namespace id");
+    let raw_store = Arc::new(RuntimeStoreProbe::new(temp_dir.path(), &first));
+    let shared_store = raw_store.store();
+    let setup = open_runtime(shared_store.clone(), "tail-count-setup");
 
     setup
         .create_namespace_blocking(&first, CreateNamespaceOptions::default())
@@ -250,10 +251,11 @@ fn runtime_wal_tail_projection_cache_evicts_by_namespace_count() {
     assert_eq!(after_second.wal_tail_projection_cache_evictions, 1);
     assert!(after_second.wal_tail_projection_cache_cached_rows > 0);
 
+    raw_store.reset_wal_get_count();
     fs.get_file_bytes_blocking(&first, "/file.txt")
         .expect("first tail projection reloads after eviction");
     let after_reload = fs.runtime_cache_stats();
-    assert_eq!(after_reload.wal_tail_projection_cache_misses, 3);
+    assert_eq!(raw_store.wal_get_count(), 1);
     assert_eq!(after_reload.wal_tail_projection_cache_evictions, 2);
 }
 

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -13,7 +13,7 @@ use loonfs::{
     CreateNamespaceOptions, FsAdmin, FsReader, FsWriter, MaintenancePlan,
     MetadataMaintenanceOptions, NamespaceId, PutFileOptions,
 };
-use loonfs_api::wire::manifest::decode_namespace_manifest_json;
+use loonfs_api::wire::manifest::{decode_namespace_manifest_json, MetadataTableFamily};
 use loonfs_api::AbsolutePath;
 use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -158,7 +158,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
         .metadata_files
         .iter()
         .filter(|descriptor| {
-            descriptor.level == 0 && format!("{:?}", descriptor.family) == "DirentryBinds"
+            descriptor.level == 0 && descriptor.family == MetadataTableFamily::DirentryBinds
         })
         .map(|descriptor| descriptor.run_seq)
         .collect();

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -934,16 +934,12 @@ fn writer_builder_rejects_zero_maintenance_concurrency() {
                 .build(),
         );
 
-        match result {
-            Err(RuntimeError::Config(message)) => {
-                assert!(message.contains("`max_concurrent_maintenance`"));
-                assert!(message.contains("`FsBackgroundWork::ManualOnly`"));
-            }
-            Err(other) => {
-                panic!("expected config error for zero maintenance cap, got {other:?}")
-            }
+        let error = match result {
+            Err(error) => error,
             Ok(_) => panic!("zero maintenance concurrency must be rejected"),
-        }
+        };
+        assert_eq!(error.code(), ErrorCode::InvalidRequest);
+        assert!(error.to_string().contains("`max_concurrent_maintenance`"));
     }
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -126,8 +126,8 @@ Registered limit keys:
 
 | Limit key | Meaning |
 | --- | --- |
-| `pagination.default_limit` | Default page size applied when a paged request omits `limit`. |
-| `pagination.max_limit` | Largest accepted page size for paged requests. |
+| `pagination.default_limit` | Default page size applied when a paged request omits `limit`. An explicit `limit=0` is rejected with 400 `invalid_request`. |
+| `pagination.max_limit` | Largest accepted page size for paged requests. A `limit` greater than this value is rejected with 400 `invalid_request`. |
 | `upload.max_content_bytes` | Largest request body accepted for service-proxied upload content (`PUT .../uploads/{upload_id}/content`). Clients may use `direct_put` for larger content only when `core.uploads.direct_put` is advertised; otherwise they must stay within this limit. |
 | `upload.direct_put_max_content_bytes` | Largest object this deployment's provider accepts in one presigned `direct_put` request. Unrelated to `upload.max_content_bytes`, which bounds what the service buffers on a client's behalf; this one is the provider's own single-request ceiling and is typically far larger. A claim above it answers `content_too_large` at begin, rather than being signed into a write the provider would refuse. Advertised only alongside `core.uploads.direct_put`. |
 | `download.max_content_bytes` | Largest file content a service-proxied read (`GET .../filesystem/content`, inode revision content) will buffer and return in one response. Over-limit reads answer `content_too_large`; v0 has no proxied streaming or range reads. A file past this limit is read through a download grant (`POST .../filesystem/downloads`) when `core.downloads.direct_get` is advertised — which it is on exactly the deployments that could have let a client create such a file. |
@@ -1403,7 +1403,7 @@ each attribute map may be 64 KiB, and no request declares a byte budget, so a
 listing carries attributes only when the caller asks and sizes its pages for
 what comes back.
 
-A cursor is an ordering resume, not a snapshot pin. Every cursor in the API
+A cursor is an opaque ordering resume, not a snapshot pin. Every cursor in the API
 — directory listing, revision listing, grep, and the change feed alike —
 tolerates forward head drift: commits landing mid-listing never retire it,
 and the resumed page evaluates at the then-current head, continuing strictly
@@ -1416,6 +1416,7 @@ changes between pages. Only a cursor minted ahead of the serving head
 answers `rebootstrap_required` — drift tolerance runs forward, never
 backward. (A malformed cursor, or one replayed against a different target,
 stays `invalid_request`.)
+An unrecognized cursor version is also rejected as `invalid_request`.
 
 ```json
 {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -28,6 +28,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           }
         },
         "security": [
@@ -63,6 +66,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           }
         }
       }
@@ -85,6 +91,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "503": {
             "description": "Shutdown has begun; admission is closed",
@@ -161,6 +170,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           }
         }
       },
@@ -233,6 +245,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "410": {
             "description": "Namespace deleted",
@@ -325,6 +340,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           }
         }
       }
@@ -378,6 +396,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "500": {
             "description": "The grep index is corrupt or its backing store is unavailable",
@@ -461,6 +482,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Lost a grep root-pointer publication race; retry",
@@ -554,6 +578,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Lost a grep root-pointer publication race; retry",
@@ -846,6 +873,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           }
         }
       }
@@ -898,6 +928,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Namespace already exists or is partial",
@@ -982,6 +1015,9 @@
               }
             }
           },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1063,6 +1099,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Delete conflict",
@@ -1167,6 +1206,9 @@
               }
             }
           },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1249,6 +1291,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Operation conflict",
@@ -1469,6 +1514,9 @@
               }
             }
           },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1588,6 +1636,9 @@
               }
             }
           },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1688,6 +1739,9 @@
               }
             }
           },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1779,6 +1833,9 @@
               }
             }
           },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -1859,6 +1916,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "410": {
             "description": "Namespace deleted",
@@ -1942,6 +2002,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Fork conflict",
@@ -2045,6 +2108,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "410": {
             "description": "Namespace deleted",
@@ -2159,6 +2225,9 @@
               }
             }
           },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -2251,6 +2320,9 @@
               }
             }
           },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
           "410": {
             "description": "Namespace deleted",
             "content": {
@@ -2332,6 +2404,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Upload already completed",
@@ -2434,6 +2509,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Upload completion conflict",
@@ -2663,6 +2741,9 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
           },
           "409": {
             "description": "Upload already completed",
@@ -6253,6 +6334,58 @@
         "format": "int64",
         "description": "Monotonically increasing writer epoch for namespace write fencing.",
         "minimum": 0
+      }
+    },
+    "responses": {
+      "DeadlineExceededResponse": {
+        "description": "The server cancelled this bounded request at `request_deadline_ms`; a mutation may still land and must be reconciled before retrying.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "HTTP error body used by LoonFS APIs.",
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "description": "Stable machine-readable reason from the [`ErrorCode`](crate::ErrorCode)\nregistry.\n\nCarried as a string so clients keep working when a newer server\nintroduces a code they do not know; use\n[`ErrorCode::parse`](crate::ErrorCode::parse) for typed access."
+                },
+                "details": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorDetails",
+                      "description": "Structured context for the code, present when the failure carries\nmachine-usable identity (API spec, \"Standard error contract\"). Boxed\nso the rare detailed error does not widen every error-carrying result."
+                    }
+                  ]
+                },
+                "feature": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "For `not_supported` errors, the capability-document feature key the\nclient should reconcile against."
+                },
+                "message": {
+                  "type": "string",
+                  "description": "Human-readable error message."
+                },
+                "request_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Correlation id the server assigned to the failed request; the same\nvalue is sent as the `x-request-id` response header."
+                }
+              }
+            }
+          }
+        }
       }
     },
     "securitySchemes": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -6338,7 +6338,7 @@
     },
     "responses": {
       "DeadlineExceededResponse": {
-        "description": "The server cancelled this bounded request at `request_deadline_ms`; a mutation may still land and must be reconciled before retrying.",
+        "description": "The request exceeded `request_deadline_ms`. A timed-out mutation may still complete, so clients must determine its outcome before retrying.",
         "content": {
           "application/json": {
             "schema": {


### PR DESCRIPTION
Require object-store conformance tests to reject missing stored-checksum support from providers that offer direct PUT. Providers without direct PUT may still report that check as unsupported, while every other conformance check must pass.

Replace duplicated test object-store wrappers and temporary-directory helpers with shared fixtures. Update asynchronous tests to use deterministic Tokio time and explicit wait helpers, and change assertions to verify observable behavior instead of internal queues, debug strings, or incidental timing.

Document HTTP 408 responses for routes governed by request deadlines, define pagination limit and cursor rejection behavior, and verify that documented limits and error-detail fields stay synchronized with code. Enable missing-documentation warnings for `loonfs-client` and document its public methods.