### PR TITLE
docs,cli: tell the truth about transfers, jobs, tombstones, and the chart

### DIFF
--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -741,7 +741,7 @@ pub(crate) struct AdminRunArgs {
     /// namespaces.
     #[arg(long = "namespace", required = true)]
     pub namespaces: Vec<String>,
-    /// Maintenance job to host. Repeat the flag to select more; all three
+    /// Maintenance job to host. Repeat the flag to select more; all four
     /// when omitted. `core-gc` selects the runtime's collection job, which
     /// logs and settles under its own name, `gc`.
     #[arg(long = "job")]

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -946,7 +946,10 @@ fn store_probe_response(report: StoreProbeReport) -> StoreProbeResponse {
 #[cfg(test)]
 #[allow(clippy::panic)]
 mod tests {
-    use super::{map_runtime_error, resolve_cli_page_limit, GrepError, StepBudget, GREP_INDEX_JOB};
+    use super::{
+        map_runtime_error, resolve_cli_page_limit, GrepError, StepBudget, GREP_GC_JOB,
+        GREP_INDEX_JOB,
+    };
     use crate::backend_error::map_namespace_scoped_grep_error;
     use crate::config::StoreConfig;
     use crate::resolve::EmbeddedTarget;
@@ -974,13 +977,14 @@ mod tests {
             .get()
     }
 
-    /// The three jobs `admin run` hosts by default, in the order it drives
+    /// The four jobs `admin run` hosts by default, in the order it drives
     /// them.
-    fn every_job() -> [MaintenanceJobId; 3] {
+    fn every_job() -> [MaintenanceJobId; 4] {
         [
             MaintenanceJobId::METADATA,
             MaintenanceJobId::GC,
             GREP_INDEX_JOB,
+            GREP_GC_JOB,
         ]
     }
 
@@ -1069,8 +1073,8 @@ mod tests {
             "an unbudgeted drain settles every key: {:?}",
             progress.keys
         );
-        assert_eq!(progress.keys.len(), 6, "three jobs over two namespaces");
-        assert!(progress.steps >= 6, "every key took at least one step");
+        assert_eq!(progress.keys.len(), 8, "four jobs over two namespaces");
+        assert!(progress.steps >= 8, "every key took at least one step");
         // A namespace with no grep root has nothing for that job to
         // maintain, and saying so is a settled conclusion like any other.
         let unindexed_grep = progress

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -26,8 +26,9 @@ writer_id = "loonfs-server-local"
 #maintenance = "automatic"
 
 # Largest request body accepted for service-proxied upload content, in
-# bytes; the server buffers each upload in memory. Advertised to clients as
-# the `upload.max_content_bytes` capability limit. Defaults to 256 MiB.
+# bytes. The server never holds the body whole. It forwards one transfer
+# part at a time while counting the bytes. Advertised to clients as the
+# `upload.max_content_bytes` capability limit. Defaults to 256 MiB.
 #max_upload_bytes = 268435456
 
 # Largest file content a service-proxied read will buffer and return, in
@@ -35,9 +36,10 @@ writer_id = "loonfs-server-local"
 # as the `download.max_content_bytes` capability limit. Defaults to 256 MiB.
 #max_download_bytes = 268435456
 
-# How many proxied upload bodies / content reads the server will hold in
-# memory at once; requests past a cap answer 503 `server_busy`. Worst-case
-# transfer memory is the count cap times the matching byte cap.
+# How many proxied upload bodies the server will stream at once and how many
+# content reads it will buffer at once. Requests past a cap answer 503
+# `server_busy`. Upload memory tracks one transfer part per admitted body.
+# Download memory tracks the bounded file size of each admitted read.
 #max_concurrent_uploads = 8
 #max_concurrent_downloads = 16
 

--- a/crates/loonfs-server/deploy/helm/loonfs-server/README.md
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/README.md
@@ -66,6 +66,9 @@ That config names them at `/etc/loonfs/gcs-service-account.json`,
 `config.key` names the entry holding the TOML, and the container reads
 `/etc/loonfs/<key>`. The default is `config.toml`.
 
+The init container must repeat the server container's `env` and `envFrom`
+entries because Kubernetes containers do not inherit each other's environment.
+
 Patch this optional init container into the Deployment pod spec to gate startup:
 
 ```yaml
@@ -74,6 +77,12 @@ Patch this optional init container into the Deployment pod spec to gate startup:
 #   - name: probe-store
 #     image: ghcr.io/loonfs/loonfs-server:vX.Y.Z
 #     args: ["--probe-store", "--config", "/etc/loonfs/config.toml"]
+#     env:
+#       - name: AWS_REGION
+#         value: us-east-1
+#     envFrom:
+#       - secretRef:
+#           name: loonfs-server-secrets
 #     volumeMounts:
 #       - {name: config, mountPath: /etc/loonfs, readOnly: true}
 ```
@@ -132,8 +141,9 @@ for 6400 files.
 
 Changing `disk_bytes` across a restart is safe either way. Growing it keeps
 what the directory already holds. Shrinking it starts the directory empty.
-Nothing in the cache is durable, so deleting it is always safe, and the pod
-deletes it every time it stops.
+Nothing in the cache is durable, so deleting it is always safe. A process
+restart with the same directory preserves cache entries, but a replacement
+pod gets a new `emptyDir` and starts cold.
 
 ## Values
 
@@ -187,6 +197,9 @@ config itself with the server's own flag:
 ```bash
 loonfs-server --config /etc/loonfs/config.toml --check-config
 ```
+
+Validate chart changes with `helm template` or a real install. `helm lint`
+does not fail on template-level errors.
 
 ## Shutdown
 

--- a/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
@@ -47,6 +47,9 @@ localCache:
   # Mount an emptyDir at /var/cache/loonfs for the server's disk cache. The
   # chart writes nothing into the config: the config's [local_cache] table
   # has to name /var/cache/loonfs as its `path`.
+  # The cache holds every 16 MiB disk block file open. Set the process's
+  # open-file limit above disk_bytes divided by 16 MiB; 100 GiB needs about
+  # 6400 files.
   enabled: false
   # The emptyDir's sizeLimit, as a quantity such as "100Gi". The chart
   # requires it when the cache is enabled, and it must comfortably exceed

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -125,6 +125,14 @@ The crate's [`config/`](../config) directory holds one worked example per
 object store, each documenting its provider credentials and the optional
 settings this guide leaves out.
 
+### Cloud bucket setup
+
+Configure the provider's incomplete multipart upload lifecycle rule.
+Amazon S3 and Google Cloud Storage both name the action
+`AbortIncompleteMultipartUpload`. It removes provider parts when an abort
+fails or an abandoned session stays open until its 24-hour lease and GC grace
+pass.
+
 ## Running it in a container
 
 Every release publishes the server image:
@@ -490,6 +498,16 @@ expose the two-job limit either, so the lever for everything a step does —
 flushing, folding, collecting — remains how often maintenance runs, not how
 much each run may do. The rebuild above is the one piece of upkeep that lever
 does not pace, because it is not paced at all.
+
+## Resource sizing
+
+A defensible memory limit starts above `max_concurrent_uploads` (8 by default)
+times the 8 MiB upload part, plus `max_concurrent_downloads` (16 by default)
+times `max_download_bytes` (256 MiB by default), plus configured
+`local_cache.memory_bytes` and headroom for metadata maintenance. This sum is
+a sizing floor, not a guarantee, so the limit should comfortably exceed it.
+
+Example: 8 x 8 MiB + 16 x 256 MiB + 64 MiB = 4224 MiB before maintenance headroom.
 
 ## The optional local cache
 

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -6,7 +6,8 @@
 use crate::common::*;
 use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
 use loonfs::{
-    ChangeSeq, CommitId, CreateNamespaceOptions, ErrorCode, MaintenancePlan, ManifestId,
+    ChangeSeq, CheckpointOwnerSummary, CommitId, CreateCheckpointOptions, CreateNamespaceOptions,
+    DeleteNamespaceOptions, ErrorCode, FsAdmin, FsWriter, MaintenancePlan, ManifestId,
     MetadataCompactionOutcome, NamespaceId, PutFileOptions, ReorganizeStepOutcome, RuntimeError,
     SharedObjectStore, WalFlushStepOutcome,
 };
@@ -728,4 +729,94 @@ fn checkpoint_and_retention_hooks_are_available() {
         .advance_retention_floor_blocking(&namespace_id)
         .expect("advance retention");
     assert_eq!(retention.retention_floor_seq, checkpoint.checkpoint_seq);
+}
+
+#[test]
+fn tombstoned_namespace_keeps_checkpoint_inventory_and_user_release_available() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let fs = open_runtime(store.clone(), "checkpoint-tombstone-setup");
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+
+    fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
+        .expect("create source namespace");
+    fs.put_file_bytes_blocking(
+        &source,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put source file");
+    fs.fork_namespace_blocking(&source, &target)
+        .expect("fork source namespace");
+    let user_checkpoint = fs
+        .create_checkpoint_blocking(&source)
+        .expect("create user checkpoint");
+
+    let before_delete =
+        block_on(fs.admin.list_checkpoints(&source)).expect("list checkpoints before deletion");
+    let fork_checkpoint = before_delete
+        .checkpoints
+        .iter()
+        .find(|checkpoint| {
+            matches!(
+                &checkpoint.owner,
+                CheckpointOwnerSummary::Fork {
+                    target_namespace_id
+                } if target_namespace_id == &target
+            )
+        })
+        .expect("fork-owned checkpoint")
+        .checkpoint_id
+        .clone();
+
+    let deleter = block_on(
+        FsWriter::builder_with_store(store.clone())
+            .writer_id("checkpoint-tombstone-deleter")
+            .build(),
+    )
+    .expect("build deleting writer");
+    block_on(deleter.delete_namespace(&source, DeleteNamespaceOptions::default()))
+        .expect("delete source namespace");
+
+    let admin = block_on(
+        FsAdmin::builder_with_store(store)
+            .actor_id("checkpoint-tombstone-observer")
+            .build(),
+    )
+    .expect("build post-delete admin");
+    let listed =
+        block_on(admin.list_checkpoints(&source)).expect("list checkpoints on deleted namespace");
+    assert_eq!(listed.checkpoints.len(), 2);
+    assert!(listed
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint.checkpoint_id == user_checkpoint.checkpoint_id));
+    assert!(listed
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint.checkpoint_id == fork_checkpoint));
+
+    let released = block_on(admin.release_checkpoint(&source, &user_checkpoint.checkpoint_id))
+        .expect("release user checkpoint on deleted namespace");
+    assert!(released.was_active);
+    assert_core_error_kind(
+        block_on(admin.release_checkpoint(&source, &fork_checkpoint)),
+        ErrorCode::InvalidRequest,
+    );
+    assert_core_error_kind(
+        block_on(admin.namespace_status(&source)),
+        ErrorCode::NamespaceDeleted,
+    );
+    assert_core_error_kind(
+        block_on(admin.create_checkpoint(
+            &source,
+            CreateCheckpointOptions {
+                name: "after-delete".to_owned(),
+                ttl_ms: None,
+            },
+        )),
+        ErrorCode::NamespaceDeleted,
+    );
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -24,7 +24,7 @@ within a plane is expressed as **named features** (section 2).
 
 | Profile | Plane | Ops | Status |
 | --- | --- | --- | --- |
-| `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, the change feed, namespace status by id, `GET /v0/capabilities`, and the standard error contract. Namespace `list`, `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
+| `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, the change feed, namespace status by id, `GET /v0/capabilities`, and the standard error contract. Namespace `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
 | `admin/v0` | Maintenance plane | Create and release checkpoints; run one-shot maintenance steps that select any of metadata upkeep (WAL flush plus reorganization), retention-floor advancement, and garbage collection. Maintenance triggers for derived indexes arrive as features in this plane: grep-index administration is the `admin.grep.index` **feature**. | Optional |
 | `query/v0` | Query plane | Content search over derived indexes (`POST /v0/namespaces/{namespace}/query/grep`). Grep-index search is the `query.grep` **feature** within this profile; using it also requires a materialized steady-state grep root for the namespace. | Optional |
 | `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. Clients must tolerate unknown error codes, so authorization errors can land with this plane without breaking anyone. |
@@ -1299,6 +1299,10 @@ stay committed; everything that observes the deleted namespace afterwards —
 reads, commits, forks, status, re-creation of the id — fails with
 `namespace_deleted` (410). Deleting an already-deleted namespace is also
 `namespace_deleted`.
+
+Checkpoint listing and user-checkpoint release are explicit exceptions. They
+remain available because permanent user pins must stay discoverable and
+releasable after deletion. Releasing a fork-owned checkpoint remains rejected.
 
 Deletion itself reclaims nothing, but a deleted namespace's derived state —
 WAL segments, metadata tables and manifests, and checkpoint records that


### PR DESCRIPTION
Correct the example server configuration to explain that proxied uploads stream one transfer part at a time, while proxied downloads buffer one bounded file per admitted request. Update the API feature table to remove unsupported namespace listing, and correct `admin run` help and test coverage so all four maintenance jobs are included.

Document that checkpoint listing and user-owned checkpoint release remain available after a namespace is deleted. Add a contract test confirming that user checkpoints can still be discovered and released, fork-owned checkpoints cannot be released manually, and other namespace operations continue to return `namespace_deleted`.

Improve self-hosting and Helm guidance for production deployments. The documentation now shows how the store-probe init container receives provider credentials, recommends incomplete multipart cleanup rules, explains local-cache file-descriptor and replacement-pod behavior, identifies `helm template` as the chart validation command, and provides a baseline calculation for memory sizing.