### PR TITLE
feat(cli): surface listing head drift and resume bounded gc passes

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -255,13 +255,14 @@ Maintenance
     Advance the retention floor, surrendering replay history below the
     flushed manifest head; file revision history is never affected
 
-  loonfs admin gc [--grace-window-ms <ms>] [--max-objects <n>]
+  loonfs admin gc [--grace-window-ms <ms>] [--max-objects <n>] [--cursor <token>]
     Run mark-and-sweep collection, looping bounded passes through
     completion; --max-objects examines at most that many candidates and
-    returns after one pass, and --grace-window-ms protects objects younger
-    than the window. A run that takes more than one pass reports each pass
-    on standard error as it lands, and the summary says what the pass kept
-    and mostly why; --json carries every retention reason
+    returns after one pass, --cursor resumes from a previous pass's
+    next_cursor for the same namespace, and --grace-window-ms protects
+    objects younger than the window. A run that takes more than one pass
+    reports each pass on standard error as it lands, and the summary says
+    what the pass kept and mostly why; --json carries every retention reason
 
   loonfs admin store-probe
     Prove the profile's object store honours the contract LoonFS depends on

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -864,6 +864,10 @@ pub(crate) struct AdminGcArgs {
     /// pass. Omit to loop bounded passes through completion.
     #[arg(long)]
     pub max_objects: Option<u64>,
+    /// Resume token from a previous pass's next_cursor; only valid for the
+    /// same namespace.
+    #[arg(long, value_name = "TOKEN")]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -741,7 +741,7 @@ pub(crate) struct AdminRunArgs {
     /// namespaces.
     #[arg(long = "namespace", required = true)]
     pub namespaces: Vec<String>,
-    /// Maintenance job to host. Repeat the flag to select more; all three
+    /// Maintenance job to host. Repeat the flag to select more; all four
     /// when omitted. `core-gc` selects the runtime's collection job, which
     /// logs and settles under its own name, `gc`.
     #[arg(long = "job")]

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -946,7 +946,10 @@ fn store_probe_response(report: StoreProbeReport) -> StoreProbeResponse {
 #[cfg(test)]
 #[allow(clippy::panic)]
 mod tests {
-    use super::{map_runtime_error, resolve_cli_page_limit, GrepError, StepBudget, GREP_INDEX_JOB};
+    use super::{
+        map_runtime_error, resolve_cli_page_limit, GrepError, StepBudget, GREP_GC_JOB,
+        GREP_INDEX_JOB,
+    };
     use crate::backend_error::map_namespace_scoped_grep_error;
     use crate::config::StoreConfig;
     use crate::resolve::EmbeddedTarget;
@@ -974,13 +977,14 @@ mod tests {
             .get()
     }
 
-    /// The three jobs `admin run` hosts by default, in the order it drives
+    /// The four jobs `admin run` hosts by default, in the order it drives
     /// them.
-    fn every_job() -> [MaintenanceJobId; 3] {
+    fn every_job() -> [MaintenanceJobId; 4] {
         [
             MaintenanceJobId::METADATA,
             MaintenanceJobId::GC,
             GREP_INDEX_JOB,
+            GREP_GC_JOB,
         ]
     }
 
@@ -1069,8 +1073,8 @@ mod tests {
             "an unbudgeted drain settles every key: {:?}",
             progress.keys
         );
-        assert_eq!(progress.keys.len(), 6, "three jobs over two namespaces");
-        assert!(progress.steps >= 6, "every key took at least one step");
+        assert_eq!(progress.keys.len(), 8, "four jobs over two namespaces");
+        assert!(progress.steps >= 8, "every key took at least one step");
         // A namespace with no grep root has nothing for that job to
         // maintain, and saying so is a settled conclusion like any other.
         let unindexed_grep = progress

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -192,13 +192,11 @@ impl EmbeddedBackend {
     pub(super) async fn list_path_entries_all(
         &self,
         spec: &NamespacePath,
-    ) -> Result<Vec<AuthoritativePathEntry>, BackendError> {
-        Ok(self
-            .reader
+    ) -> Result<ListPathEntriesResponse, BackendError> {
+        self.reader
             .list_path_entries_all(spec.namespace(), spec.absolute_path().as_str())
             .await
-            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))?
-            .entries)
+            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
     }
 
     pub(super) async fn list_path_entries_page(

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -313,14 +313,13 @@ impl ResolvedTarget {
     pub(crate) async fn list_path_entries_all(
         &self,
         spec: &NamespacePath,
-    ) -> Result<Vec<AuthoritativePathEntry>, BackendError> {
+    ) -> Result<ListPathEntriesResponse, BackendError> {
         match self {
             Self::Embedded(target) => target.backend.list_path_entries_all(spec).await,
             Self::Remote(target) => Ok(target
                 .client
                 .list_path_entries_all(spec, &ListPathEntriesOptions::default())
-                .await?
-                .entries),
+                .await?),
         }
     }
 

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -101,7 +101,7 @@ async fn run_admin_gc(
     let mut request = GcRequest {
         grace_window_ms: args.grace_window_ms,
         max_objects: Some(args.max_objects.unwrap_or(loonfs::DEFAULT_GC_MAX_OBJECTS)),
-        cursor: None,
+        cursor: args.cursor,
     };
     let mut progress = PassProgress::new(runtime);
     let mut response = None;

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -6,7 +6,10 @@ use super::context::{
     fail, namespace_path, parse_user_path, render_target, resolve_command_context, CommandContext,
     UndeleteHint,
 };
-use super::output::{CommandData, CommandFailure, CommandOutput, TrashListing};
+use super::output::{
+    CommandData, CommandFailure, CommandOutput, ListingHeadDrift, ListingHeadObservation,
+    TrashListing,
+};
 use super::partial::{self, PartialDownload, PartialMeta};
 use super::recursive;
 use crate::args::{
@@ -23,8 +26,9 @@ use crate::progress::{ProgressOp, ProgressReporter};
 use crate::uploads::{SourceIdentity, UploadJournal};
 use loonfs_api::v0::UploadSessionStatus;
 use loonfs_api::{
-    AttributeKey, AttributeRevisionNo, AttributeValue, CommitId, CommitResponse,
-    DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeId, InodeKind, RevisionNo,
+    AbsolutePath, AttributeKey, AttributeRevisionNo, AttributeValue, ChangeSeq, CommitId,
+    CommitResponse, DeleteDirectoryBehavior, DestinationBehavior, ErrorCode, InodeId, InodeKind,
+    ListPathEntriesResponse, NamespaceId, RevisionNo,
 };
 use loonfs_client::{
     CreateDirectoryOptions, DeleteOptions, NamespacePath, PutFileOptions, UpdateAttributesOptions,
@@ -46,6 +50,14 @@ fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliE
         .transpose()
 }
 
+struct FollowedPathEntryPages {
+    namespace_id: NamespaceId,
+    absolute_path: AbsolutePath,
+    head_seq: ChangeSeq,
+    head_drift: Option<ListingHeadDrift>,
+    next_cursor: Option<String>,
+}
+
 async fn follow_path_entry_pages(
     context: &CommandContext,
     kind: CommandKind,
@@ -54,9 +66,10 @@ async fn follow_path_entry_pages(
     cursor: Option<&str>,
     follow: bool,
     mut visit: impl FnMut(Vec<loonfs_api::AuthoritativePathEntry>) -> Result<(), CliError>,
-) -> Result<Option<String>, CommandFailure> {
+) -> Result<FollowedPathEntryPages, CommandFailure> {
     let mut visited = 0_u32;
     let mut cursor = cursor.map(ToOwned::to_owned);
+    let mut heads = ListingHeadObservation::default();
     loop {
         let page_limit = limit.map(|limit| {
             limit
@@ -68,13 +81,29 @@ async fn follow_path_entry_pages(
             .list_path_entries_page(spec, page_limit, cursor.as_deref())
             .await
             .map_err(|error| context.fail(kind, error))?;
-        visited = visited.saturating_add(page.entries.len() as u32);
-        visit(page.entries).map_err(|error| context.fail(kind, error))?;
-        cursor = page.next_cursor;
+        let ListPathEntriesResponse {
+            namespace_id,
+            absolute_path,
+            head_seq,
+            entries,
+            next_cursor,
+        } = page;
+        heads.observe(head_seq);
+        visited = visited.saturating_add(entries.len() as u32);
+        visit(entries).map_err(|error| context.fail(kind, error))?;
+        cursor = next_cursor;
 
         let filled = limit.is_some_and(|limit| visited >= limit);
         if filled || !follow || cursor.is_none() {
-            return Ok(cursor);
+            return Ok(FollowedPathEntryPages {
+                namespace_id,
+                absolute_path,
+                head_seq: heads
+                    .last()
+                    .expect("a listing observes the page it just received"),
+                head_drift: heads.drift(),
+                next_cursor: cursor,
+            });
         }
     }
 }
@@ -98,7 +127,7 @@ pub(crate) async fn run_filesystem_ls(
     if streams_pages {
         let stdout = io::stdout();
         let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
-        let next_cursor = follow_path_entry_pages(
+        let followed = follow_path_entry_pages(
             &context,
             kind,
             &spec,
@@ -110,12 +139,17 @@ pub(crate) async fn run_filesystem_ls(
             },
         )
         .await?;
-        if let Some(cursor) = next_cursor {
+        if let Some(cursor) = followed.next_cursor {
             // Standard output stays machine-pure in `--jsonl`, so the
             // continuation signal goes to standard error, where this CLI
             // already reports progress. Without it a one-page stream would
             // truncate silently.
             crate::render::write_stderr_progress(crate::render::more_entries_hint(&cursor));
+        }
+        // Like the continuation signal above, the drift note is operational
+        // and goes to standard error in every streaming mode.
+        if let Some(drift) = followed.head_drift {
+            crate::render::write_listing_drift_warning(&drift);
         }
         return Ok(CommandOutput {
             kind,
@@ -126,7 +160,7 @@ pub(crate) async fn run_filesystem_ls(
     }
 
     let mut entries = Vec::new();
-    let next_cursor = follow_path_entry_pages(
+    let followed = follow_path_entry_pages(
         &context,
         kind,
         &spec,
@@ -139,13 +173,22 @@ pub(crate) async fn run_filesystem_ls(
         },
     )
     .await?;
+    if !runtime.json {
+        if let Some(drift) = followed.head_drift.as_ref() {
+            crate::render::write_listing_drift_warning(drift);
+        }
+    }
     Ok(CommandOutput {
         kind,
         profile: Some(context.profile_name),
         mode: Some(context.mode),
         data: CommandData::PathEntries {
+            namespace_id: followed.namespace_id,
+            absolute_path: followed.absolute_path,
+            head_seq: followed.head_seq,
+            head_drift: followed.head_drift,
             entries,
-            next_cursor,
+            next_cursor: followed.next_cursor,
         },
     })
 }

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -11,7 +11,9 @@ mod profile;
 mod profile_config;
 mod recursive;
 
-pub(crate) use self::output::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
+pub(crate) use self::output::{
+    CommandData, CommandFailure, CommandOutput, ListingHeadDrift, MaintenanceKeyReport,
+};
 
 use crate::args::{Cli, Command, RuntimeBehavior};
 use crate::config::resolve_config_location;

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -9,11 +9,43 @@ use loonfs_api::v0::{
     GrepIndexStatusResponse, StoreProbeCheckOutcome, StoreProbeResponse,
 };
 use loonfs_api::{
-    AuthoritativePathEntry, ChangeSeq, CommitId, CreateCheckpointResponse, DeleteNamespaceResponse,
-    FileRevision, GcResponse, GrepMatch, InodeId, ListCheckpointsResponse, MaintenanceStepResponse,
-    NamespaceId, NamespaceSummary, ReleaseCheckpointResponse,
+    AbsolutePath, AuthoritativePathEntry, ChangeSeq, CommitId, CreateCheckpointResponse,
+    DeleteNamespaceResponse, FileRevision, GcResponse, GrepMatch, InodeId, ListCheckpointsResponse,
+    MaintenanceStepResponse, NamespaceId, NamespaceSummary, ReleaseCheckpointResponse,
 };
 use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) struct ListingHeadDrift {
+    pub first_head_seq: ChangeSeq,
+    pub last_head_seq: ChangeSeq,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ListingHeadObservation {
+    first_head_seq: Option<ChangeSeq>,
+    last_head_seq: Option<ChangeSeq>,
+}
+
+impl ListingHeadObservation {
+    pub(crate) fn observe(&mut self, head_seq: ChangeSeq) {
+        self.first_head_seq.get_or_insert(head_seq);
+        self.last_head_seq = Some(head_seq);
+    }
+
+    pub(crate) fn last(&self) -> Option<ChangeSeq> {
+        self.last_head_seq
+    }
+
+    pub(crate) fn drift(&self) -> Option<ListingHeadDrift> {
+        let first_head_seq = self.first_head_seq?;
+        let last_head_seq = self.last_head_seq?;
+        (first_head_seq != last_head_seq).then_some(ListingHeadDrift {
+            first_head_seq,
+            last_head_seq,
+        })
+    }
+}
 
 /// One failed item inside a recursive transfer.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -142,6 +174,13 @@ pub(crate) enum CommandData {
     Changes(ChangesResponse),
     Trash(TrashListing),
     PathEntries {
+        namespace_id: NamespaceId,
+        absolute_path: AbsolutePath,
+        /// Namespace head the final page was read from.
+        head_seq: ChangeSeq,
+        /// Heads observed when this invocation crossed namespace states.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        head_drift: Option<ListingHeadDrift>,
         entries: Vec<AuthoritativePathEntry>,
         /// Where a bounded listing stopped, and how to resume it.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -180,6 +219,9 @@ pub(crate) enum CommandData {
         destination: String,
         files: u64,
         directories: u64,
+        /// Heads observed while listing the source tree.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        head_drift: Option<ListingHeadDrift>,
         failures: Vec<TreeTransferFailure>,
     },
     FileMutation {
@@ -268,5 +310,42 @@ impl CommandData {
                 .any(|check| check.outcome == StoreProbeCheckOutcome::Failed),
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path_entries(head_drift: Option<ListingHeadDrift>) -> CommandData {
+        CommandData::PathEntries {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            absolute_path: AbsolutePath::parse("/docs").expect("absolute path"),
+            head_seq: ChangeSeq(8),
+            head_drift,
+            entries: Vec::new(),
+            next_cursor: None,
+        }
+    }
+
+    #[test]
+    fn listing_head_drift_serializes_only_after_the_head_moves() {
+        let mut heads = ListingHeadObservation::default();
+        heads.observe(ChangeSeq(5));
+        assert_eq!(heads.last(), Some(ChangeSeq(5)));
+        assert_eq!(heads.drift(), None);
+
+        let settled = serde_json::to_value(path_entries(heads.drift())).expect("serialize listing");
+        assert!(settled.get("head_drift").is_none(), "{settled}");
+
+        heads.observe(ChangeSeq(8));
+        let drifted = serde_json::to_value(path_entries(heads.drift())).expect("serialize listing");
+        assert_eq!(
+            drifted["head_drift"],
+            serde_json::json!({
+                "first_head_seq": 5,
+                "last_head_seq": 8,
+            })
+        );
     }
 }

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -10,7 +10,10 @@
 //! aborting a giant transaction.
 
 use super::context::CommandContext;
-use super::output::{CommandData, CommandFailure, CommandOutput, TreeTransferFailure};
+use super::output::{
+    CommandData, CommandFailure, CommandOutput, ListingHeadDrift, ListingHeadObservation,
+    TreeTransferFailure,
+};
 use crate::args::{CommandKind, RuntimeBehavior};
 use crate::error::CliError;
 use crate::payload::LocalPayload;
@@ -96,6 +99,7 @@ fn output(
     source: String,
     destination: String,
     tally: TreeTally,
+    head_drift: Option<ListingHeadDrift>,
 ) -> CommandOutput {
     CommandOutput {
         kind,
@@ -106,6 +110,7 @@ fn output(
             destination,
             files: tally.files,
             directories: tally.directories,
+            head_drift,
             failures: tally.failures,
         },
     }
@@ -246,6 +251,7 @@ pub(crate) async fn run_put_tree(
         local_root.display().to_string(),
         format!("{}:{}", context.namespace, remote_root),
         tally,
+        None,
     ))
 }
 
@@ -273,6 +279,12 @@ pub(crate) async fn run_get_tree(
         .map_err(|error| context.fail(kind, CliError::io_for_path(local_root, error)))?;
     tally.directories += 1;
     let listing = walk_remote_tree(context, kind, remote_root).await?;
+    if !runtime.json {
+        if let Some(drift) = listing.head_drift.as_ref() {
+            crate::render::write_listing_drift_warning(drift);
+        }
+    }
+    let head_drift = listing.head_drift;
 
     for components in &listing.directories {
         let local_dir = local_root.join(components.join("/"));
@@ -359,6 +371,7 @@ pub(crate) async fn run_get_tree(
         format!("{}:{}", context.namespace, remote_root),
         local_root.display().to_string(),
         tally,
+        head_drift,
     ))
 }
 
@@ -374,6 +387,12 @@ pub(crate) async fn run_copy_tree(
     runtime: RuntimeBehavior,
 ) -> Result<CommandOutput, CommandFailure> {
     let listing = walk_remote_tree(context, kind, source_root).await?;
+    if !runtime.json {
+        if let Some(drift) = listing.head_drift.as_ref() {
+            crate::render::write_listing_drift_warning(drift);
+        }
+    }
+    let head_drift = listing.head_drift;
     let mut tally = TreeTally::new();
 
     // The destination root materializes its own ancestors; every deeper
@@ -474,6 +493,7 @@ pub(crate) async fn run_copy_tree(
         format!("{}:{}", context.namespace, source_root),
         format!("{}:{}", context.namespace, destination_root),
         tally,
+        head_drift,
     ))
 }
 
@@ -567,6 +587,7 @@ struct RemoteTree {
     /// File jobs: `local` holds the relative path, `remote` the absolute
     /// namespace path.
     files: Vec<FileJob>,
+    head_drift: Option<ListingHeadDrift>,
 }
 
 /// Breadth-first remote walk from `root`. Each directory lists at its own
@@ -580,7 +601,9 @@ async fn walk_remote_tree(
     let mut tree = RemoteTree {
         directories: Vec::new(),
         files: Vec::new(),
+        head_drift: None,
     };
+    let mut heads = ListingHeadObservation::default();
     let mut queue = std::collections::VecDeque::new();
     queue.push_back((root.trim_end_matches('/').to_owned(), Vec::<String>::new()));
     while let Some((remote_dir, components)) = queue.pop_front() {
@@ -591,12 +614,16 @@ async fn walk_remote_tree(
         };
         let spec = NamespacePath::parse(context.namespace.as_str(), listed)
             .map_err(|error| context.fail(kind, CliError::invalid_input(error.to_string())))?;
-        let entries = context
+        let response = context
             .target
             .list_path_entries_all(&spec)
             .await
             .map_err(|error| context.fail(kind, error))?;
-        for entry in entries {
+        let response_head_seq = response.head_seq;
+        for entry in response.entries {
+            // Aggregated entries retain the head of the page that supplied
+            // them, in page order; the envelope carries the final page head.
+            heads.observe(entry.head_seq);
             let Some(name) = entry.display_name.as_ref() else {
                 continue;
             };
@@ -621,7 +648,9 @@ async fn walk_remote_tree(
                 }),
             }
         }
+        heads.observe(response_head_seq);
     }
+    tree.head_drift = heads.drift();
     Ok(tree)
 }
 

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -1,7 +1,9 @@
 //! Renders command outcomes as human-readable text or `--json`.
 
 use crate::args::CommandKind;
-use crate::commands::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
+use crate::commands::{
+    CommandData, CommandFailure, CommandOutput, ListingHeadDrift, MaintenanceKeyReport,
+};
 use crate::config::ConfigSource;
 use crate::error::CliError;
 use loonfs_api::v0::{GrepIndexLifecycle, StoreProbeCheckOutcome, StoreProbeCheckResult};
@@ -314,6 +316,17 @@ pub(crate) fn write_stderr_progress(message: impl std::fmt::Display) {
     let _ = writeln!(io::stderr().lock(), "{message}");
 }
 
+pub(crate) fn listing_drift_warning(drift: &ListingHeadDrift) -> String {
+    format!(
+        "namespace advanced during the listing (head seq {} to {}); entries may mix states; re-run for a settled view",
+        drift.first_head_seq.0, drift.last_head_seq.0
+    )
+}
+
+pub(crate) fn write_listing_drift_warning(drift: &ListingHeadDrift) {
+    write_stderr_warning(listing_drift_warning(drift));
+}
+
 pub(crate) fn more_entries_hint(cursor: &str) -> String {
     format!("more entries exist; continue with --cursor {cursor} or stream everything with --all")
 }
@@ -590,6 +603,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         CommandData::PathEntries {
             entries,
             next_cursor,
+            ..
         } => {
             let mut lines: Vec<String> = entries.iter().map(human_path_entry).collect();
             if let Some(cursor) = next_cursor {
@@ -804,6 +818,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             files,
             directories,
             failures,
+            ..
         } => {
             let verb = match output.kind {
                 CommandKind::FilesystemGet => "downloaded",
@@ -950,7 +965,10 @@ fn escape_control_characters(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{human_success, json_error, json_success, AttributeValue};
+    use super::{
+        human_success, json_error, json_success, listing_drift_warning, AttributeValue,
+        ListingHeadDrift,
+    };
     use crate::args::CommandKind;
     use crate::commands::{CommandData, CommandFailure, CommandOutput};
     use crate::config::{ProfileConfig, StoreConfig};
@@ -1152,5 +1170,16 @@ mod tests {
             &json_error(&failure).expect("json error renders")
         )
         .expect("rendered error is valid json"));
+    }
+
+    #[test]
+    fn listing_drift_warning_names_the_span_and_recovery() {
+        assert_eq!(
+            listing_drift_warning(&ListingHeadDrift {
+                first_head_seq: loonfs_api::ChangeSeq(5),
+                last_head_seq: loonfs_api::ChangeSeq(8),
+            }),
+            "namespace advanced during the listing (head seq 5 to 8); entries may mix states; re-run for a settled view"
+        );
     }
 }

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 use std::env;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
@@ -4772,8 +4772,9 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
 
     let default_human = harness.run(&["ls", "/listing"]);
     assert_success(&default_human);
-    let default_human = stdout_string(&default_human);
-    let human_lines = default_human.lines().collect::<Vec<_>>();
+    assert!(stderr_string(&default_human).is_empty());
+    let default_human_stdout = stdout_string(&default_human);
+    let human_lines = default_human_stdout.lines().collect::<Vec<_>>();
     assert_eq!(
         human_lines.len(),
         loonfs_api::DEFAULT_PAGE_LIMIT as usize + 1
@@ -4790,6 +4791,10 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     let first = harness.run(&["--json", "ls", "/listing"]);
     assert_success(&first);
     let first_data = json_data(&first);
+    assert_eq!(first_data["namespace_id"], "demo");
+    assert_eq!(first_data["absolute_path"], "/listing");
+    assert!(first_data["head_seq"].is_u64());
+    assert!(first_data.get("head_drift").is_none());
     let first_entries = first_data["entries"].as_array().expect("first page");
     assert_eq!(first_entries.len(), loonfs_api::DEFAULT_PAGE_LIMIT as usize);
     let cursor = first_data["next_cursor"]
@@ -4814,6 +4819,10 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     let all_json = harness.run(&["--json", "ls", "/listing", "--all"]);
     assert_success(&all_json);
     let all_json_data = json_data(&all_json);
+    assert_eq!(all_json_data["namespace_id"], "demo");
+    assert_eq!(all_json_data["absolute_path"], "/listing");
+    assert!(all_json_data["head_seq"].is_u64());
+    assert!(all_json_data.get("head_drift").is_none());
     assert_eq!(
         all_json_data["entries"]
             .as_array()
@@ -4855,6 +4864,136 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
         "/listing/f0999.txt"
     );
     assert_eq!(second_entries[0]["absolute_path"], "/listing/f1000.txt");
+}
+
+/// A two-page wire fixture makes the otherwise racy between-page commit
+/// deterministic while still exercising the CLI process, client, command,
+/// JSON envelope, and standard-error rendering together.
+#[test]
+fn ls_surfaces_head_drift_from_paged_responses() {
+    let harness = Harness::new();
+
+    let (server_url, server) = json_response_server(vec![
+        serde_json::json!({
+            "namespace_id": "demo",
+            "absolute_path": "/docs",
+            "head_seq": 5,
+            "entries": [],
+            "next_cursor": "resume-after-first-page",
+        }),
+        serde_json::json!({
+            "namespace_id": "demo",
+            "absolute_path": "/docs",
+            "head_seq": 8,
+            "entries": [],
+        }),
+    ]);
+    harness.write_remote_listing_config(&server_url);
+    let json = harness.run(&["--json", "ls", "/docs", "--all"]);
+    assert_success(&json);
+    assert!(json.stderr.is_empty());
+    let data = json_data(&json);
+    assert_eq!(data["namespace_id"], "demo");
+    assert_eq!(data["absolute_path"], "/docs");
+    assert_eq!(data["head_seq"], 8);
+    assert_eq!(
+        data["head_drift"],
+        serde_json::json!({
+            "first_head_seq": 5,
+            "last_head_seq": 8,
+        })
+    );
+    server.join().expect("listing server");
+
+    let (server_url, server) = json_response_server(vec![
+        serde_json::json!({
+            "namespace_id": "demo",
+            "absolute_path": "/docs",
+            "head_seq": 11,
+            "entries": [],
+            "next_cursor": "resume-after-first-page",
+        }),
+        serde_json::json!({
+            "namespace_id": "demo",
+            "absolute_path": "/docs",
+            "head_seq": 12,
+            "entries": [],
+        }),
+    ]);
+    harness.write_remote_listing_config(&server_url);
+    let human = harness.run(&["ls", "/docs", "--all"]);
+    assert_success(&human);
+    let stderr = stderr_string(&human);
+    assert_eq!(
+        stderr,
+        "warning: namespace advanced during the listing (head seq 11 to 12); entries may mix states; re-run for a settled view\n"
+    );
+    assert_eq!(
+        stderr
+            .matches("namespace advanced during the listing")
+            .count(),
+        1
+    );
+    server.join().expect("listing server");
+}
+
+#[test]
+fn recursive_get_surfaces_drift_across_directory_listings() {
+    let harness = Harness::new();
+    let (server_url, server) = json_response_server(vec![
+        serde_json::json!({
+            "namespace_id": "demo",
+            "absolute_path": "/docs",
+            "inode_id": 2,
+            "inode_kind": "directory",
+            "head_seq": 20,
+            "parent_inode_id": 1,
+            "display_name": "docs",
+        }),
+        serde_json::json!({
+            "namespace_id": "demo",
+            "absolute_path": "/docs",
+            "head_seq": 20,
+            "entries": [{
+                "namespace_id": "demo",
+                "absolute_path": "/docs/sub",
+                "inode_id": 3,
+                "inode_kind": "directory",
+                "head_seq": 20,
+                "parent_inode_id": 2,
+                "display_name": "sub",
+            }],
+        }),
+        serde_json::json!({
+            "namespace_id": "demo",
+            "absolute_path": "/docs/sub",
+            "head_seq": 21,
+            "entries": [],
+        }),
+    ]);
+    harness.write_remote_listing_config(&server_url);
+    let destination = harness.temp_dir.path().join("drifted-download");
+    let get = harness.run(&[
+        "--json",
+        "--no-progress",
+        "get",
+        "-r",
+        "/docs",
+        destination.to_str().expect("utf-8 destination"),
+    ]);
+    assert_success(&get);
+    assert!(get.stderr.is_empty());
+    let data = json_data(&get);
+    assert_eq!(data["files"], 0);
+    assert_eq!(data["directories"], 2);
+    assert_eq!(
+        data["head_drift"],
+        serde_json::json!({
+            "first_head_seq": 20,
+            "last_head_seq": 21,
+        })
+    );
+    server.join().expect("listing server");
 }
 
 /// `ls --limit` bounds the total, and incompatible output bounds fail in
@@ -5241,9 +5380,33 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
             profile,
         ]);
         assert_success(&bounded_gc);
-        assert!(json_data(&bounded_gc)["next_cursor"]
+        let bounded_data = json_data(&bounded_gc);
+        let cursor = bounded_data["next_cursor"]
             .as_str()
-            .is_some_and(|cursor| !cursor.is_empty()));
+            .filter(|cursor| !cursor.is_empty())
+            .expect("bounded pass returns a cursor")
+            .to_owned();
+
+        // Resumption skips the candidates the first pass enumerated. A
+        // restart over this unchanged keyspace would return the same token.
+        let resumed_gc = harness.run(&[
+            "--json",
+            "admin",
+            "gc",
+            "--max-objects",
+            "8",
+            "--cursor",
+            &cursor,
+            "--profile",
+            profile,
+        ]);
+        assert_success(&resumed_gc);
+        assert_ne!(
+            json_data(&resumed_gc)
+                .get("next_cursor")
+                .and_then(Value::as_str),
+            Some(cursor.as_str())
+        );
 
         // Admin failures surface the registry code in both modes.
         let missing = harness.run(&[
@@ -5408,6 +5571,20 @@ impl Harness {
         fs::write(&self.config_path, contents).expect("write cli config");
     }
 
+    fn write_remote_listing_config(&self, server_url: &str) {
+        self.write_cli_config(format!(
+            r#"config_version = 1
+default_profile = "remote"
+
+[profiles.remote]
+mode = "remote"
+server_url = "{server_url}"
+default_namespace = "demo"
+auth_token = "test-token"
+"#,
+        ));
+    }
+
     fn write_server_config(&self, name: &str, key_prefix: &str) -> PathBuf {
         self.write_server_config_with(name, key_prefix, "")
     }
@@ -5462,6 +5639,33 @@ key_prefix = "{key_prefix}"
             server_config_path.display()
         );
     }
+}
+
+fn json_response_server(responses: Vec<Value>) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind JSON server");
+    let address = listener.local_addr().expect("JSON server address");
+    let server = thread::spawn(move || {
+        for response in responses {
+            let (mut stream, _) = listener.accept().expect("accept JSON request");
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream.read(&mut chunk).expect("read JSON request");
+                assert!(read > 0, "JSON request ended before its headers");
+                request.extend_from_slice(&chunk[..read]);
+            }
+
+            let body = serde_json::to_vec(&response).expect("encode JSON response");
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("write JSON response headers");
+            stream.write_all(&body).expect("write JSON response");
+        }
+    });
+    (format!("http://{address}"), server)
 }
 
 struct ExternalServer {

--- a/crates/loonfs-server/config/local-fs.example.toml
+++ b/crates/loonfs-server/config/local-fs.example.toml
@@ -26,8 +26,9 @@ writer_id = "loonfs-server-local"
 #maintenance = "automatic"
 
 # Largest request body accepted for service-proxied upload content, in
-# bytes; the server buffers each upload in memory. Advertised to clients as
-# the `upload.max_content_bytes` capability limit. Defaults to 256 MiB.
+# bytes. The server never holds the body whole. It forwards one transfer
+# part at a time while counting the bytes. Advertised to clients as the
+# `upload.max_content_bytes` capability limit. Defaults to 256 MiB.
 #max_upload_bytes = 268435456
 
 # Largest file content a service-proxied read will buffer and return, in
@@ -35,9 +36,10 @@ writer_id = "loonfs-server-local"
 # as the `download.max_content_bytes` capability limit. Defaults to 256 MiB.
 #max_download_bytes = 268435456
 
-# How many proxied upload bodies / content reads the server will hold in
-# memory at once; requests past a cap answer 503 `server_busy`. Worst-case
-# transfer memory is the count cap times the matching byte cap.
+# How many proxied upload bodies the server will stream at once and how many
+# content reads it will buffer at once. Requests past a cap answer 503
+# `server_busy`. Upload memory tracks one transfer part per admitted body.
+# Download memory tracks the bounded file size of each admitted read.
 #max_concurrent_uploads = 8
 #max_concurrent_downloads = 16
 

--- a/crates/loonfs-server/deploy/helm/loonfs-server/README.md
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/README.md
@@ -66,6 +66,9 @@ That config names them at `/etc/loonfs/gcs-service-account.json`,
 `config.key` names the entry holding the TOML, and the container reads
 `/etc/loonfs/<key>`. The default is `config.toml`.
 
+The init container must repeat the server container's `env` and `envFrom`
+entries because Kubernetes containers do not inherit each other's environment.
+
 Patch this optional init container into the Deployment pod spec to gate startup:
 
 ```yaml
@@ -74,6 +77,12 @@ Patch this optional init container into the Deployment pod spec to gate startup:
 #   - name: probe-store
 #     image: ghcr.io/loonfs/loonfs-server:vX.Y.Z
 #     args: ["--probe-store", "--config", "/etc/loonfs/config.toml"]
+#     env:
+#       - name: AWS_REGION
+#         value: us-east-1
+#     envFrom:
+#       - secretRef:
+#           name: loonfs-server-secrets
 #     volumeMounts:
 #       - {name: config, mountPath: /etc/loonfs, readOnly: true}
 ```
@@ -132,8 +141,9 @@ for 6400 files.
 
 Changing `disk_bytes` across a restart is safe either way. Growing it keeps
 what the directory already holds. Shrinking it starts the directory empty.
-Nothing in the cache is durable, so deleting it is always safe, and the pod
-deletes it every time it stops.
+Nothing in the cache is durable, so deleting it is always safe. A process
+restart with the same directory preserves cache entries, but a replacement
+pod gets a new `emptyDir` and starts cold.
 
 ## Values
 
@@ -187,6 +197,9 @@ config itself with the server's own flag:
 ```bash
 loonfs-server --config /etc/loonfs/config.toml --check-config
 ```
+
+Validate chart changes with `helm template` or a real install. `helm lint`
+does not fail on template-level errors.
 
 ## Shutdown
 

--- a/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/values.yaml
@@ -47,6 +47,9 @@ localCache:
   # Mount an emptyDir at /var/cache/loonfs for the server's disk cache. The
   # chart writes nothing into the config: the config's [local_cache] table
   # has to name /var/cache/loonfs as its `path`.
+  # The cache holds every 16 MiB disk block file open. Set the process's
+  # open-file limit above disk_bytes divided by 16 MiB; 100 GiB needs about
+  # 6400 files.
   enabled: false
   # The emptyDir's sizeLimit, as a quantity such as "100Gi". The chart
   # requires it when the cache is enabled, and it must comfortably exceed

--- a/crates/loonfs-server/docs/self-hosting.md
+++ b/crates/loonfs-server/docs/self-hosting.md
@@ -125,6 +125,14 @@ The crate's [`config/`](../config) directory holds one worked example per
 object store, each documenting its provider credentials and the optional
 settings this guide leaves out.
 
+### Cloud bucket setup
+
+Configure the provider's incomplete multipart upload lifecycle rule.
+Amazon S3 and Google Cloud Storage both name the action
+`AbortIncompleteMultipartUpload`. It removes provider parts when an abort
+fails or an abandoned session stays open until its 24-hour lease and GC grace
+pass.
+
 ## Running it in a container
 
 Every release publishes the server image:
@@ -490,6 +498,16 @@ expose the two-job limit either, so the lever for everything a step does —
 flushing, folding, collecting — remains how often maintenance runs, not how
 much each run may do. The rebuild above is the one piece of upkeep that lever
 does not pace, because it is not paced at all.
+
+## Resource sizing
+
+A defensible memory limit starts above `max_concurrent_uploads` (8 by default)
+times the 8 MiB upload part, plus `max_concurrent_downloads` (16 by default)
+times `max_download_bytes` (256 MiB by default), plus configured
+`local_cache.memory_bytes` and headroom for metadata maintenance. This sum is
+a sizing floor, not a guarantee, so the limit should comfortably exceed it.
+
+Example: 8 x 8 MiB + 16 x 256 MiB + 64 MiB = 4224 MiB before maintenance headroom.
 
 ## The optional local cache
 

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -93,6 +93,7 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "from_parent_inode_id",
     "grace_window",
     "grace_window_ms",
+    "head_drift",
     "head_seq",
     "include_attributes",
     "inode_id",

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -6,7 +6,8 @@
 use crate::common::*;
 use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
 use loonfs::{
-    ChangeSeq, CommitId, CreateNamespaceOptions, ErrorCode, MaintenancePlan, ManifestId,
+    ChangeSeq, CheckpointOwnerSummary, CommitId, CreateCheckpointOptions, CreateNamespaceOptions,
+    DeleteNamespaceOptions, ErrorCode, FsAdmin, FsWriter, MaintenancePlan, ManifestId,
     MetadataCompactionOutcome, NamespaceId, PutFileOptions, ReorganizeStepOutcome, RuntimeError,
     SharedObjectStore, WalFlushStepOutcome,
 };
@@ -728,4 +729,94 @@ fn checkpoint_and_retention_hooks_are_available() {
         .advance_retention_floor_blocking(&namespace_id)
         .expect("advance retention");
     assert_eq!(retention.retention_floor_seq, checkpoint.checkpoint_seq);
+}
+
+#[test]
+fn tombstoned_namespace_keeps_checkpoint_inventory_and_user_release_available() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = store(temp_dir.path());
+    let fs = open_runtime(store.clone(), "checkpoint-tombstone-setup");
+    let source = namespace_id("source");
+    let target = namespace_id("target");
+
+    fs.create_namespace_blocking(&source, CreateNamespaceOptions::default())
+        .expect("create source namespace");
+    fs.put_file_bytes_blocking(
+        &source,
+        "/docs/hello.txt",
+        b"hello",
+        PutFileOptions::default(),
+    )
+    .expect("put source file");
+    fs.fork_namespace_blocking(&source, &target)
+        .expect("fork source namespace");
+    let user_checkpoint = fs
+        .create_checkpoint_blocking(&source)
+        .expect("create user checkpoint");
+
+    let before_delete =
+        block_on(fs.admin.list_checkpoints(&source)).expect("list checkpoints before deletion");
+    let fork_checkpoint = before_delete
+        .checkpoints
+        .iter()
+        .find(|checkpoint| {
+            matches!(
+                &checkpoint.owner,
+                CheckpointOwnerSummary::Fork {
+                    target_namespace_id
+                } if target_namespace_id == &target
+            )
+        })
+        .expect("fork-owned checkpoint")
+        .checkpoint_id
+        .clone();
+
+    let deleter = block_on(
+        FsWriter::builder_with_store(store.clone())
+            .writer_id("checkpoint-tombstone-deleter")
+            .build(),
+    )
+    .expect("build deleting writer");
+    block_on(deleter.delete_namespace(&source, DeleteNamespaceOptions::default()))
+        .expect("delete source namespace");
+
+    let admin = block_on(
+        FsAdmin::builder_with_store(store)
+            .actor_id("checkpoint-tombstone-observer")
+            .build(),
+    )
+    .expect("build post-delete admin");
+    let listed =
+        block_on(admin.list_checkpoints(&source)).expect("list checkpoints on deleted namespace");
+    assert_eq!(listed.checkpoints.len(), 2);
+    assert!(listed
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint.checkpoint_id == user_checkpoint.checkpoint_id));
+    assert!(listed
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint.checkpoint_id == fork_checkpoint));
+
+    let released = block_on(admin.release_checkpoint(&source, &user_checkpoint.checkpoint_id))
+        .expect("release user checkpoint on deleted namespace");
+    assert!(released.was_active);
+    assert_core_error_kind(
+        block_on(admin.release_checkpoint(&source, &fork_checkpoint)),
+        ErrorCode::InvalidRequest,
+    );
+    assert_core_error_kind(
+        block_on(admin.namespace_status(&source)),
+        ErrorCode::NamespaceDeleted,
+    );
+    assert_core_error_kind(
+        block_on(admin.create_checkpoint(
+            &source,
+            CreateCheckpointOptions {
+                name: "after-delete".to_owned(),
+                ttl_ms: None,
+            },
+        )),
+        ErrorCode::NamespaceDeleted,
+    );
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -24,7 +24,7 @@ within a plane is expressed as **named features** (section 2).
 
 | Profile | Plane | Ops | Status |
 | --- | --- | --- | --- |
-| `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, the change feed, namespace status by id, `GET /v0/capabilities`, and the standard error contract. Namespace `list`, `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
+| `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, the change feed, namespace status by id, `GET /v0/capabilities`, and the standard error contract. Namespace `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
 | `admin/v0` | Maintenance plane | Create and release checkpoints; run one-shot maintenance steps that select any of metadata upkeep (WAL flush plus reorganization), retention-floor advancement, and garbage collection. Maintenance triggers for derived indexes arrive as features in this plane: grep-index administration is the `admin.grep.index` **feature**. | Optional |
 | `query/v0` | Query plane | Content search over derived indexes (`POST /v0/namespaces/{namespace}/query/grep`). Grep-index search is the `query.grep` **feature** within this profile; using it also requires a materialized steady-state grep root for the namespace. | Optional |
 | `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. Clients must tolerate unknown error codes, so authorization errors can land with this plane without breaking anyone. |
@@ -1299,6 +1299,10 @@ stay committed; everything that observes the deleted namespace afterwards —
 reads, commits, forks, status, re-creation of the id — fails with
 `namespace_deleted` (410). Deleting an already-deleted namespace is also
 `namespace_deleted`.
+
+Checkpoint listing and user-checkpoint release are explicit exceptions. They
+remain available because permanent user pins must stay discoverable and
+releasable after deletion. Releasing a fork-owned checkpoint remains rejected.
 
 Deletion itself reclaims nothing, but a deleted namespace's derived state —
 WAL segments, metadata tables and manifests, and checkpoint records that

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1420,6 +1420,10 @@ changes between pages. Only a cursor minted ahead of the serving head
 answers `rebootstrap_required` — drift tolerance runs forward, never
 backward. (A malformed cursor, or one replayed against a different target,
 stays `invalid_request`.)
+The CLI reports the last page's head as `head_seq` and, for multi-page and
+recursive reads, reports the first and last observed heads as `head_drift`
+when they differ; a caller that needs a settled tree re-lists until the
+observed heads stop moving.
 An unrecognized cursor version is also rejected as `invalid_request`.
 
 ```json


### PR DESCRIPTION
Preserve listing metadata in CLI output so callers can tell which namespace state produced the results. JSON output now includes the namespace, path, and final `head_seq`. When a multi-page listing observes different namespace heads, it also includes `head_drift` with the first and last sequence numbers. Human-readable and JSONL commands print a warning to standard error instead of treating the change as a failure.

Track the same head information across recursive directory walks used by commands such as recursive get and copy. Recursive transfer summaries report `head_drift` when the namespace changes during traversal, allowing backup and synchronization tools to detect mixed-state results and retry after activity settles.

Add `--cursor` to `loonfs admin gc` so a bounded garbage-collection pass can resume from a previous response's `next_cursor`. Invalid cursors remain server errors, and existing behavior for automatically running unbounded passes to completion is unchanged. Update the CLI and API documentation and add coverage for paginated listings, recursive traversal, output formats, and resumed collection passes.