### PR TITLE
fix(server,core): reach the documented shutdown 503 and record admin gc passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,7 @@ dependencies = [
  "fs4",
  "futures",
  "http",
+ "http-body",
  "loonfs",
  "loonfs-api",
  "loonfs-client",

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -26,6 +26,7 @@ clap.workspace = true
 foyer.workspace = true
 fs4.workspace = true
 futures.workspace = true
+http-body.workspace = true
 http.workspace = true
 loonfs-api.workspace = true
 loonfs.workspace = true

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -6,6 +6,10 @@ use super::router;
 use super::tls::{self, TlsConfigError, TlsListener};
 use crate::config::{ServerConfig, ServerConfigError};
 use crate::local_cache::FoyerStoredMetadataBlockCache;
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
 use axum::Router;
 use loonfs::metrics::{JsonlObjectStoreMetricsRecorder, ObjectStoreMetricsRecorder};
 use loonfs::{
@@ -23,12 +27,99 @@ use loonfs_objectstore::{run_store_contract_probe, StoreProbeReport};
 use std::ffi::OsString;
 use std::future::IntoFuture;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
-use tokio::sync::Semaphore;
+use tokio::sync::{Notify, Semaphore};
 
 const OBJECT_STORE_METRICS_JSONL_ENV: &str = "LOONFS_OBJECT_STORE_METRICS_JSONL";
+
+#[derive(Clone, Default)]
+struct RequestDrain {
+    inner: Arc<RequestDrainInner>,
+}
+
+#[derive(Default)]
+struct RequestDrainInner {
+    active: AtomicUsize,
+    idle: Notify,
+}
+
+impl RequestDrain {
+    fn start(&self) -> ActiveRequest {
+        self.inner.active.fetch_add(1, Ordering::AcqRel);
+        ActiveRequest {
+            drain: self.clone(),
+        }
+    }
+
+    async fn settle(&self) {
+        loop {
+            let idle = self.inner.idle.notified();
+            if self.inner.active.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            idle.await;
+        }
+    }
+}
+
+struct ActiveRequest {
+    drain: RequestDrain,
+}
+
+impl Drop for ActiveRequest {
+    fn drop(&mut self) {
+        if self.drain.inner.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.drain.inner.idle.notify_waiters();
+        }
+    }
+}
+
+async fn track_request(
+    State(drain): State<RequestDrain>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let active = drain.start();
+    let response = next.run(request).await;
+    response.map(|body| {
+        Body::new(DrainedBody {
+            body,
+            _active: active,
+        })
+    })
+}
+
+/// A response body whose request stays active until the last frame is sent.
+///
+/// Framing passes through untouched — in particular the exact size hint — so
+/// a sized response keeps its `Content-Length` instead of turning chunked.
+struct DrainedBody {
+    body: Body,
+    _active: ActiveRequest,
+}
+
+impl http_body::Body for DrainedBody {
+    type Data = axum::body::Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        std::pin::Pin::new(&mut self.get_mut().body).poll_frame(cx)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.body.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.body.size_hint()
+    }
+}
 
 /// Request handles built over one shared store client.
 ///
@@ -462,10 +553,9 @@ pub async fn probe_store(config: &ServerConfig) -> Result<StoreProbeReport, Serv
     Ok(run_store_contract_probe(store.as_ref(), &run_id).await)
 }
 
-/// Serves until ctrl-c or SIGTERM, then shuts down gracefully: the listener
-/// stops accepting, in-flight requests drain, publisher work finishes, and
-/// writer maintenance — the runtime's steps and grep's alike — settles
-/// before this returns.
+/// Serves until ctrl-c or SIGTERM, then shuts down gracefully. Admission
+/// closes while the listener remains available to reads and probes. After
+/// active requests drain, the listener closes and writer-owned work settles.
 pub async fn serve(config: ServerConfig) -> Result<(), ServeError> {
     serve_with_shutdown(config, shutdown_signal()).await
 }
@@ -499,9 +589,9 @@ pub async fn serve_with_shutdown(
 }
 
 /// The one serving body, over whichever listener the deployment configured.
-/// Plaintext and TLS differ in what `accept` returns and in nothing else:
-/// the same router, the same graceful shutdown, and the same writer settles
-/// after the listener drains or reaches its deadline.
+/// Plaintext and TLS differ in what `accept` returns and in nothing else.
+/// Both close admission, drain requests, close the listener, and settle the
+/// writer in the same order.
 pub(super) async fn serve_on<L>(
     listener: L,
     config: ServerConfig,
@@ -539,32 +629,60 @@ pub(super) async fn serve_and_settle<L>(
 where
     L: axum::serve::Listener<Addr = SocketAddr>,
 {
-    let (drain_started_tx, mut drain_started_rx) = tokio::sync::oneshot::channel();
-    let shutdown = async move {
-        shutdown.await;
-        let _ = drain_started_tx.send(());
-    };
+    let requests = RequestDrain::default();
+    let router = router.layer(axum::middleware::from_fn_with_state(
+        requests.clone(),
+        track_request,
+    ));
+    let (listener_close_tx, listener_close_rx) = tokio::sync::oneshot::channel();
     let mut server = Box::pin(
         axum::serve(listener, router)
-            .with_graceful_shutdown(shutdown)
+            .with_graceful_shutdown(async move {
+                let _ = listener_close_rx.await;
+            })
             .into_future(),
     );
-    // The budget starts when shutdown fires. It does not limit server uptime.
+    let mut shutdown = Box::pin(shutdown);
+    enum DrainOutcome {
+        Server(std::io::Result<()>),
+        Settled,
+        Deadline,
+    }
     let served = tokio::select! {
         result = server.as_mut() => result,
-        Ok(()) = &mut drain_started_rx => {
-            match tokio::time::timeout(
-                Duration::from_millis(shutdown_deadline_ms),
-                server.as_mut(),
-            )
-            .await
-            {
-                Ok(result) => result,
-                Err(_) => {
+        () = shutdown.as_mut() => {
+            // This is synchronous so readiness changes before the drain waits.
+            writer.close_admission_for_shutdown();
+            // The budget starts when shutdown fires. It does not limit uptime.
+            let deadline = tokio::time::Instant::now()
+                + Duration::from_millis(shutdown_deadline_ms);
+            let mut deadline = Box::pin(tokio::time::sleep_until(deadline));
+            let drain = tokio::select! {
+                result = server.as_mut() => DrainOutcome::Server(result),
+                () = requests.settle() => DrainOutcome::Settled,
+                () = deadline.as_mut() => DrainOutcome::Deadline,
+            };
+            match drain {
+                DrainOutcome::Server(result) => result,
+                DrainOutcome::Settled => {
+                    let _ = listener_close_tx.send(());
+                    tokio::select! {
+                        result = server.as_mut() => result,
+                        () = deadline.as_mut() => {
+                            tracing::warn!(
+                                shutdown_deadline_ms,
+                                "graceful drain deadline passed; remaining requests are abandoned"
+                            );
+                            Ok(())
+                        }
+                    }
+                }
+                DrainOutcome::Deadline => {
                     tracing::warn!(
                         shutdown_deadline_ms,
                         "graceful drain deadline passed; remaining requests are abandoned"
                     );
+                    let _ = listener_close_tx.send(());
                     Ok(())
                 }
             }
@@ -573,9 +691,8 @@ where
     // Dropping the server cancels requests left behind by an expired drain.
     drop(server);
     served.map_err(ServeError::Serve)?;
-    // Shut down the writer after the drain finishes or its deadline passes.
-    // Accepted requests keep mutation admission through the drain window.
-    // Task panics surface here.
+    // Admission is already closed on the signal path. This idempotent call
+    // drains publisher and maintenance work after the listener closes.
     let settled = writer.shutdown().await.map_err(ServeError::Shutdown);
     // Close the cache after writer shutdown, even when writer shutdown fails.
     // Closing flushes retained memory entries to disk. If both steps fail, report

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2481,10 +2481,32 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn readiness_answers_ready_then_shutting_down_once_admission_closes() {
+async fn shutdown_keeps_readiness_reachable_until_an_active_request_finishes() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn get(addr: std::net::SocketAddr, path: &str) -> Vec<u8> {
+        let mut stream = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("connect to serving listener");
+        let request =
+            format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+        stream
+            .write_all(request.as_bytes())
+            .await
+            .expect("send request");
+        let mut response = Vec::new();
+        stream
+            .read_to_end(&mut response)
+            .await
+            .expect("read response");
+        response
+    }
+
     let temp_dir = tempdir().expect("tempdir");
     let store = Arc::new(LocalFsStore::new(temp_dir.path()).expect("store")) as SharedObjectStore;
-    let config = test_config(temp_dir.path(), "server-writer");
+    let mut config = test_config(temp_dir.path(), "readiness-shutdown-writer");
+    config.shutdown_deadline_ms = 1_000;
+    let shutdown_deadline_ms = config.shutdown_deadline_ms;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");
@@ -2492,39 +2514,95 @@ async fn readiness_answers_ready_then_shutting_down_once_admission_closes() {
     let (router, state) = app_with_store_and_state(config, store)
         .await
         .expect("build app");
-    let server = tokio::spawn(async move {
-        axum::serve(listener, router).await.expect("serve app");
-    });
+    let slow_started = Arc::new(tokio::sync::Notify::new());
+    let slow_release = Arc::new(tokio::sync::Notify::new());
+    let router = router.route(
+        "/slow",
+        axum::routing::get({
+            let slow_started = Arc::clone(&slow_started);
+            let slow_release = Arc::clone(&slow_release);
+            move || {
+                let slow_started = Arc::clone(&slow_started);
+                let slow_release = Arc::clone(&slow_release);
+                async move {
+                    slow_started.notify_one();
+                    slow_release.notified().await;
+                    "slow request finished"
+                }
+            }
+        }),
+    );
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = tokio::spawn(super::serve::serve_and_settle(
+        listener,
+        router,
+        state.writer.clone(),
+        None,
+        shutdown_deadline_ms,
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    ));
 
-    let ready_url = format!("http://{addr}/readiness");
-    let url = ready_url.clone();
-    let body = raw_agent()
-        .get(&url)
-        .call()
-        .expect("an admitting server is ready")
-        .into_string()
-        .expect("readiness body");
-    assert_eq!(body, "ready");
+    let slow = tokio::spawn(get(addr, "/slow"));
+    tokio::time::timeout(std::time::Duration::from_secs(1), slow_started.notified())
+        .await
+        .expect("slow request starts");
 
-    // The production trigger, not a poke at the registry: readiness flips
-    // because the writer shut down. The listener stays up across it, which
-    // is the whole window this route exists for.
-    state.writer.shutdown().await.expect("shut down the writer");
-
-    tokio::task::spawn_blocking(move || match raw_agent().get(&ready_url).call() {
-        Err(ureq::Error::Status(503, response)) => {
-            let body = response.into_string().expect("readiness body");
-            assert!(
-                body.contains("shutting_down"),
-                "readiness names the shutdown: {body}"
-            );
+    let shutdown_started = tokio::time::Instant::now();
+    shutdown_tx.send(()).expect("trigger shutdown");
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while !state.writer.is_shutting_down() {
+            tokio::task::yield_now().await;
         }
-        other => panic!("expected 503 from a draining server, got {other:?}"),
     })
     .await
-    .expect("join blocking task");
+    .expect("shutdown closes admission");
 
-    server.abort();
+    let readiness = get(addr, "/readiness").await;
+    let readiness = String::from_utf8(readiness).expect("readiness is utf-8");
+    assert!(
+        readiness.starts_with("HTTP/1.1 503 Service Unavailable\r\n"),
+        "readiness returns 503 during drain: {readiness}"
+    );
+    assert!(
+        readiness.contains("\"code\":\"shutting_down\""),
+        "readiness names the shutdown: {readiness}"
+    );
+    assert!(
+        !slow.is_finished(),
+        "the original request is still in flight"
+    );
+    assert!(
+        !server.is_finished(),
+        "the listener remains serving while the request drains"
+    );
+
+    slow_release.notify_one();
+    let slow = tokio::time::timeout(std::time::Duration::from_secs(1), slow)
+        .await
+        .expect("slow request completes")
+        .expect("join slow request");
+    let slow = String::from_utf8(slow).expect("slow response is utf-8");
+    assert!(slow.starts_with("HTTP/1.1 200 OK\r\n"), "{slow}");
+    assert!(slow.contains("slow request finished"), "{slow}");
+
+    tokio::time::timeout(
+        std::time::Duration::from_millis(shutdown_deadline_ms),
+        server,
+    )
+    .await
+    .expect("serve_and_settle finishes within the configured deadline")
+    .expect("join server task")
+    .expect("shutdown settles the server");
+    assert!(
+        shutdown_started.elapsed() < std::time::Duration::from_millis(shutdown_deadline_ms),
+        "shutdown finishes inside its configured budget"
+    );
+    assert!(
+        tokio::net::TcpStream::connect(addr).await.is_err(),
+        "the listener stops accepting after the slow request finishes"
+    );
 }
 
 async fn seed_grep_error_namespace(

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -565,6 +565,9 @@ impl FsAdmin {
         )
         .await
         .map_err(RuntimeError::Core)?;
+        // A caller may drop the response, so its counts survive only when
+        // this shared pass records them here.
+        self.core.instruments().gc_pass(&report);
         // Sweeping can remove objects cached views still reference; drop the
         // namespace caches rather than trusting them across a collection.
         self.invalidate_namespace(namespace_id);

--- a/crates/loonfs/src/fs/maintenance/tests.rs
+++ b/crates/loonfs/src/fs/maintenance/tests.rs
@@ -9,7 +9,7 @@
 
 use crate::metrics::{DefaultMetricsRecorder, MetricValue, MetricsSnapshot};
 use crate::{
-    CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter,
+    CreateCheckpointOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter, GcConfig,
     MaintenancePlan, MetadataCompactionOutcome, MetadataMaintenanceOptions, MoveOptions,
     NamespaceId, PutFileOptions, ReorganizeStepOutcome, SharedObjectStore,
 };
@@ -90,6 +90,68 @@ fn metadata_plan() -> MaintenancePlan {
             max_wal_tail_segments: NonZeroU64::MIN,
         }),
         ..MaintenancePlan::default()
+    }
+}
+
+#[tokio::test]
+async fn an_admin_gc_step_records_the_pass_counters_once() {
+    let temp_dir = tempdir().expect("tempdir");
+    let (writer, admin, _scheduled, recorder) = manual_deployment(temp_dir.path()).await;
+    let namespace = namespace_id("admin-gc-metrics");
+    writer
+        .create_namespace(&namespace, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .put_file_bytes(&namespace, "/live.txt", b"live", PutFileOptions::default())
+        .await
+        .expect("write a live GC candidate");
+
+    assert_eq!(counter(&recorder.snapshot(), "loonfs.gc.retained", &[]), 0);
+    let step = admin
+        .maintenance_step_namespace(
+            &namespace,
+            MaintenancePlan {
+                gc: Some(GcConfig::default()),
+                ..MaintenancePlan::default()
+            },
+        )
+        .await
+        .expect("run the admin GC step");
+    let gc = step.gc.expect("a GC plan reports its pass");
+    assert!(
+        gc.retained_candidates > 0,
+        "the live namespace gives the pass candidates to retain"
+    );
+
+    let snapshot = recorder.snapshot();
+    assert_eq!(
+        counter(&snapshot, "loonfs.gc.retained", &[]),
+        gc.retained_candidates,
+        "the admin pass records its retained count exactly once"
+    );
+    for (category, reclaimed) in [
+        ("deleted_wal_segments", gc.deleted_wal_segments),
+        ("deleted_metadata_tables", gc.deleted_metadata_tables),
+        ("deleted_manifests", gc.deleted_manifests),
+        ("deleted_checkpoint_records", gc.deleted_checkpoint_records),
+        ("released_fork_checkpoints", gc.released_fork_checkpoints),
+        (
+            "released_expired_checkpoints",
+            gc.released_expired_checkpoints,
+        ),
+        ("deleted_upload_sessions", gc.deleted_upload_sessions),
+        ("deleted_content_objects", gc.deleted_content_objects),
+        (
+            "released_missing_basis_checkpoints",
+            gc.released_missing_basis_checkpoints,
+        ),
+    ] {
+        assert_eq!(
+            counter(&snapshot, "loonfs.gc.reclaimed", &[("category", category)],),
+            reclaimed,
+            "the admin pass records `{category}` exactly once"
+        );
     }
 }
 

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -90,10 +90,20 @@ impl FsWriter {
     /// Returns this writer's shared publication service.
     ///
     /// Direct mutation methods and integrations that submit classified
-    /// candidates use the same per-namespace publishers. [`Self::shutdown`]
-    /// closes the service; callers should not manage its lifecycle separately.
+    /// candidates use the same per-namespace publishers. Shutdown closes the
+    /// service; callers should not manage its lifecycle separately.
     pub fn publisher(&self) -> PublisherRegistry {
         self.publisher.clone()
+    }
+
+    /// Closes maintenance and publication admission before shutdown drains.
+    ///
+    /// Later mutations fail with `shutting_down`, maintenance nudges are
+    /// ignored, and work already admitted keeps running. Calling this more
+    /// than once has no additional effect.
+    pub fn close_admission_for_shutdown(&self) {
+        self.bits.maintenance.close_admission();
+        self.publisher.close_admission();
     }
 
     /// Whether [`Self::shutdown`] has begun on this writer or any clone of
@@ -189,10 +199,7 @@ impl FsWriter {
     /// may be called from any clone because all clones share the same shutdown
     /// state. Task panics are returned as runtime errors.
     pub async fn shutdown(&self) -> Result<()> {
-        // Both closes belong above the first await, for the reason the doc
-        // gives. Nothing may move below `drain`.
-        self.bits.maintenance.close_admission();
-        self.publisher.close_admission();
+        self.close_admission_for_shutdown();
         self.publisher.drain().await?;
         self.bits.maintenance.drain().await
     }

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -231,10 +231,6 @@ impl MaintenanceJob for GcJob {
         let gc = step
             .gc
             .expect("a plan selecting collection reports its pass");
-        // The counts a pass produced survive here or nowhere: the runner
-        // reads a pass as one conclusion, and everything it reclaimed is
-        // dropped with the response a line below.
-        self.context.core.instruments().gc_pass(&gc);
         Ok(gc_step_result(gc, continuation))
     }
 

--- a/crates/loonfs/src/metrics/instruments.rs
+++ b/crates/loonfs/src/metrics/instruments.rs
@@ -318,8 +318,8 @@ impl RuntimeInstruments {
 
     /// Reports what one collection pass reclaimed and retained.
     ///
-    /// The automatic path reads a pass as one conclusion and drops its
-    /// counts; this is where they survive.
+    /// Every runtime collection path records at the shared admin pass before
+    /// its caller can drop the response.
     pub(crate) fn gc_pass(&self, gc: &GcResponse) {
         let Some(installed) = &self.installed else {
             return;


### PR DESCRIPTION
Change server shutdown ordering so maintenance and publication admission close as soon as a shutdown signal is received, while the HTTP listener remains available during the drain period. Readiness checks can therefore return 503 with `shutting_down`, new writes are rejected, and requests accepted before shutdown can still complete.

Track active HTTP requests until their response bodies finish sending. The listener stops after all active responses complete or the existing shutdown deadline expires, then normal writer shutdown finishes the remaining cleanup. This preserves response framing and does not add a new configuration setting.

Record garbage-collection metrics inside the shared `gc_namespace` path used by both background maintenance and explicit admin collection. This makes `loonfs_gc_reclaimed_total` and `loonfs_gc_retained_total` reflect admin-triggered passes without counting background passes twice. Add tests covering readiness during a real graceful shutdown and GC metric updates through the admin path.