### PR TITLE
fix(api): standardize wire names and response behavior

### DIFF
--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -51,7 +51,7 @@ pub enum FilesystemChange {
         /// Directory the new entry was bound under.
         parent_inode_id: InodeId,
         /// User-facing spelling of the new entry.
-        name: DisplayName,
+        display_name: DisplayName,
         /// First revision number, for file creations.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         revision_no: Option<RevisionNo>,
@@ -78,11 +78,11 @@ pub enum FilesystemChange {
         /// Directory that held the old binding.
         from_parent_inode_id: InodeId,
         /// Spelling of the old binding.
-        from_name: DisplayName,
+        from_display_name: DisplayName,
         /// Directory holding the new binding.
         to_parent_inode_id: InodeId,
         /// Spelling of the new binding.
-        to_name: DisplayName,
+        to_display_name: DisplayName,
     },
     /// A file or directory subtree was deleted. The enclosing change's
     /// `seq` is the deletion generation an undelete request passes as
@@ -104,7 +104,7 @@ pub enum FilesystemChange {
         /// Directory the recovered entry was bound under.
         parent_inode_id: InodeId,
         /// Spelling of the recovered binding.
-        name: DisplayName,
+        display_name: DisplayName,
     },
     /// An inode's attributes changed.
     #[cfg_attr(
@@ -178,27 +178,27 @@ mod tests {
             inode_id: InodeId(2),
             inode_kind: InodeKind::Directory,
             parent_inode_id: InodeId(1),
-            name: crate::DisplayName::parse("Docs").expect("valid display name"),
+            display_name: crate::DisplayName::parse("Docs").expect("valid display name"),
             revision_no: None,
             content_ref: None,
         };
         assert_eq!(
             serde_json::to_string(&created).expect("serialize created event"),
-            r#"{"kind":"created","inode_id":2,"inode_kind":"dir","parent_inode_id":1,"name":"Docs"}"#
+            r#"{"kind":"created","inode_id":2,"inode_kind":"dir","parent_inode_id":1,"display_name":"Docs"}"#
         );
 
         let created_file = FilesystemChange::Created {
             inode_id: InodeId(2),
             inode_kind: InodeKind::File,
             parent_inode_id: InodeId(1),
-            name: crate::DisplayName::parse("a.txt").expect("valid display name"),
+            display_name: crate::DisplayName::parse("a.txt").expect("valid display name"),
             revision_no: Some(crate::RevisionNo(1)),
             content_ref: Some(sample_content_ref.clone()),
         };
         assert_eq!(
             serde_json::to_string(&created_file).expect("serialize created file event"),
             format!(
-                r#"{{"kind":"created","inode_id":2,"inode_kind":"file","parent_inode_id":1,"name":"a.txt","revision_no":1,"content_ref":{sample_content_ref_json}}}"#
+                r#"{{"kind":"created","inode_id":2,"inode_kind":"file","parent_inode_id":1,"display_name":"a.txt","revision_no":1,"content_ref":{sample_content_ref_json}}}"#
             )
         );
 
@@ -217,13 +217,13 @@ mod tests {
         let moved = FilesystemChange::Moved {
             inode_id: InodeId(2),
             from_parent_inode_id: InodeId(1),
-            from_name: crate::DisplayName::parse("a.txt").expect("valid display name"),
+            from_display_name: crate::DisplayName::parse("a.txt").expect("valid display name"),
             to_parent_inode_id: InodeId(3),
-            to_name: crate::DisplayName::parse("b.txt").expect("valid display name"),
+            to_display_name: crate::DisplayName::parse("b.txt").expect("valid display name"),
         };
         assert_eq!(
             serde_json::to_string(&moved).expect("serialize moved event"),
-            r#"{"kind":"moved","inode_id":2,"from_parent_inode_id":1,"from_name":"a.txt","to_parent_inode_id":3,"to_name":"b.txt"}"#
+            r#"{"kind":"moved","inode_id":2,"from_parent_inode_id":1,"from_display_name":"a.txt","to_parent_inode_id":3,"to_display_name":"b.txt"}"#
         );
 
         let deleted = FilesystemChange::Deleted {
@@ -242,11 +242,11 @@ mod tests {
         let undeleted = FilesystemChange::Undeleted {
             inode_id: InodeId(2),
             parent_inode_id: InodeId(1),
-            name: crate::DisplayName::parse("a.txt").expect("valid display name"),
+            display_name: crate::DisplayName::parse("a.txt").expect("valid display name"),
         };
         assert_eq!(
             serde_json::to_string(&undeleted).expect("serialize undeleted event"),
-            r#"{"kind":"undeleted","inode_id":2,"parent_inode_id":1,"name":"a.txt"}"#
+            r#"{"kind":"undeleted","inode_id":2,"parent_inode_id":1,"display_name":"a.txt"}"#
         );
 
         let attributes_changed = FilesystemChange::AttributesChanged {

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -90,10 +90,10 @@ pub struct ErrorDetails {
     pub inode_id: Option<InodeId>,
     /// Revision the request expected to be current.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expected_revision: Option<RevisionNo>,
+    pub expected_revision_no: Option<RevisionNo>,
     /// Revision that is actually current; absent when the inode has none.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub actual_revision: Option<RevisionNo>,
+    pub actual_revision_no: Option<RevisionNo>,
     /// Attribute revision the request expected to be current.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_attributes_revision_no: Option<AttributeRevisionNo>,
@@ -406,6 +406,8 @@ pub struct FileRevision {
 pub struct ListFileRevisionsResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
+    /// Absolute file path requested by the caller.
+    pub absolute_path: AbsolutePath,
     /// File inode whose revisions were returned.
     pub inode_id: InodeId,
     /// Namespace head sequence used for the read.
@@ -444,6 +446,7 @@ pub struct CreateCheckpointResponse {
     /// Manifest pinned by the checkpoint.
     pub manifest_id: ManifestId,
     /// Manifest `metadata/root.json` references after the operation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_manifest_id: Option<ManifestId>,
     /// Expiry recorded on the record, when the request carried a `ttl_ms`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -729,15 +732,9 @@ pub struct GcResponse {
     /// It reports what this pass saw and nothing more. A pass that stopped
     /// on `next_cursor` examined only part of the keyspace, and candidates
     /// that age out under a plain grace window on their object timestamps
-    /// carry no deadline here at all, so `None` is never a claim that
+    /// carry no deadline here at all, so absence is never a claim that
     /// nothing is owed.
-    ///
-    /// Always serialized, `null` included, unlike `next_cursor` beside it:
-    /// a cursor's presence is what says the enumeration is unfinished,
-    /// while this is an answer every pass has — and one whose absence
-    /// otherwise makes the response's shape depend on what happened to be
-    /// in the namespace.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_reclamation_at_ms: Option<u64>,
 }
 
@@ -1525,6 +1522,32 @@ mod tests {
                 "an unknown field in {level} decoded instead of failing the request"
             );
         }
+    }
+
+    #[test]
+    fn optional_response_fields_are_omitted_and_default_when_absent() {
+        let checkpoint = CreateCheckpointResponse {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            checkpoint_id: CheckpointId::parse("chk_00000000000000000000000000000001")
+                .expect("checkpoint id"),
+            checkpoint_seq: ChangeSeq(3),
+            manifest_id: ManifestId(3),
+            current_manifest_id: None,
+            expires_at_ms: None,
+        };
+        let checkpoint_json =
+            serde_json::to_value(checkpoint).expect("serialize checkpoint response");
+        assert!(checkpoint_json.get("current_manifest_id").is_none());
+        let checkpoint: CreateCheckpointResponse = serde_json::from_value(checkpoint_json)
+            .expect("decode checkpoint response without optional fields");
+        assert_eq!(checkpoint.current_manifest_id, None);
+
+        let gc = GcResponse::empty(NamespaceId::parse("demo").expect("namespace id"));
+        let gc_json = serde_json::to_value(gc).expect("serialize gc response");
+        assert!(gc_json.get("next_reclamation_at_ms").is_none());
+        let gc: GcResponse =
+            serde_json::from_value(gc_json).expect("decode gc response without optional fields");
+        assert_eq!(gc.next_reclamation_at_ms, None);
     }
 
     /// The maintenance bodies are optional selectors and overrides all the

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -29,6 +29,7 @@ pub struct AuthoritativePathEntry {
     /// Namespace head sequence this answer was read from.
     pub head_seq: ChangeSeq,
     /// Parent directory inode, or `None` for the root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_inode_id: Option<InodeId>,
     /// Stored display name for this path component, absent for the nameless root.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -85,6 +86,9 @@ impl AuthoritativePathEntry {
 #[serde(tag = "inode_kind", rename_all = "snake_case")]
 pub enum AuthoritativePathEntryKind {
     /// A directory, which has no revision payload in v0.
+    ///
+    /// The entry tag reuses [`InodeKind`]'s wire vocabulary.
+    #[serde(rename = "dir")]
     #[cfg_attr(feature = "openapi", schema(title = "AuthoritativePathEntryDirectory"))]
     Directory {},
     /// A file and its current revision summary.
@@ -192,7 +196,7 @@ mod tests {
                 "namespace_id": "demo",
                 "absolute_path": "/docs",
                 "inode_id": 2,
-                "inode_kind": "directory",
+                "inode_kind": "dir",
                 "head_seq": 3,
                 "parent_inode_id": 1,
                 "display_name": "docs"
@@ -216,7 +220,7 @@ mod tests {
                     "namespace_id": "demo",
                     "absolute_path": "/docs",
                     "inode_id": 2,
-                    "inode_kind": "directory",
+                    "inode_kind": "dir",
                     "head_seq": 3,
                     "parent_inode_id": 1,
                     "display_name": "docs"
@@ -255,13 +259,41 @@ mod tests {
     }
 
     #[test]
-    fn nameless_root_omits_display_name_while_named_entries_carry_it() {
+    fn nameless_root_omits_parent_inode_id_and_display_name() {
         let root_json = serde_json::to_value(entry("/", None, None)).expect("serialize root");
+        assert!(root_json.get("parent_inode_id").is_none());
         assert!(root_json.get("display_name").is_none());
+
+        let decoded: AuthoritativePathEntry =
+            serde_json::from_value(root_json).expect("decode root without optional fields");
+        assert_eq!(decoded.parent_inode_id, None);
+        assert_eq!(decoded.display_name, None);
 
         let named_json = serde_json::to_value(entry("/docs", Some(InodeId(1)), Some("docs")))
             .expect("serialize named entry");
+        assert_eq!(named_json["parent_inode_id"], 1);
         assert_eq!(named_json["display_name"], "docs");
+    }
+
+    #[test]
+    fn authoritative_entry_kinds_share_inode_kind_wire_values() {
+        let directory = AuthoritativePathEntryKind::Directory {};
+        assert_eq!(
+            serde_json::to_value(directory).expect("serialize directory entry kind")["inode_kind"],
+            serde_json::to_value(InodeKind::Directory).expect("serialize directory inode kind")
+        );
+
+        let content_ref = ContentRef::blob_v1(crate::ContentId::generate(), b"hello");
+        let file = AuthoritativePathEntryKind::File {
+            revision_no: RevisionNo(1),
+            size_bytes: 5,
+            content_ref,
+            committed_at_ms: 1,
+        };
+        assert_eq!(
+            serde_json::to_value(file).expect("serialize file entry kind")["inode_kind"],
+            serde_json::to_value(InodeKind::File).expect("serialize file inode kind")
+        );
     }
 
     /// An unprojected entry omits attributes; a projected one carries the

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -205,15 +205,19 @@ pub(crate) fn format_utc_ms(unix_ms: u64) -> String {
 fn event_descriptor(event: &loonfs_api::v0::FilesystemChange) -> String {
     use loonfs_api::v0::FilesystemChange;
     match event {
-        FilesystemChange::Created { name, .. } => format!("create '{name}'"),
+        FilesystemChange::Created { display_name, .. } => {
+            format!("create '{display_name}'")
+        }
         FilesystemChange::ContentChanged {
             inode_id,
             revision_no,
             ..
         } => format!("write inode {inode_id} rev #{}", revision_no.0),
         FilesystemChange::Moved {
-            from_name, to_name, ..
-        } => format!("move '{from_name}' -> '{to_name}'"),
+            from_display_name,
+            to_display_name,
+            ..
+        } => format!("move '{from_display_name}' -> '{to_display_name}'"),
         FilesystemChange::Deleted {
             inode_id,
             deleted_direntry,
@@ -221,7 +225,9 @@ fn event_descriptor(event: &loonfs_api::v0::FilesystemChange) -> String {
             Some(direntry) => format!("delete '{}'", direntry.display_name),
             None => format!("delete inode {inode_id}"),
         },
-        FilesystemChange::Undeleted { name, .. } => format!("undelete '{name}'"),
+        FilesystemChange::Undeleted { display_name, .. } => {
+            format!("undelete '{display_name}'")
+        }
         FilesystemChange::AttributesChanged {
             inode_id,
             attributes_revision_no,

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -422,7 +422,7 @@ fn embedded_profile_filesystem_flow_works_end_to_end() {
 
     let docs = harness.run(&["--json", "stat", "/docs"]);
     assert_success(&docs);
-    assert_eq!(json_data(&docs)["inode_kind"], "directory");
+    assert_eq!(json_data(&docs)["inode_kind"], "dir");
 
     let put = harness.run(&[
         "--json",
@@ -570,8 +570,8 @@ fn put_expected_revision_replaces_only_the_observed_revision() {
     // The embedded backend carries the same structured details a server's
     // envelope would, so `--json` consumers read one contract from both
     // profiles.
-    assert_eq!(stale_error["details"]["expected_revision"], 1);
-    assert_eq!(stale_error["details"]["actual_revision"], 2);
+    assert_eq!(stale_error["details"]["expected_revision_no"], 1);
+    assert_eq!(stale_error["details"]["actual_revision_no"], 2);
     let cat = harness.run(&["cat", "/doc.txt"]);
     assert_success(&cat);
     assert_eq!(cat.stdout, b"v2");
@@ -3592,7 +3592,7 @@ fn mkdir_parents_get_noclobber_and_version() {
     assert_eq!(json_data(&with_parents)["target"], "demo:/a/b/c");
     let created_ancestor = harness.run(&["--json", "stat", "/a/b"]);
     assert_success(&created_ancestor);
-    assert_eq!(json_data(&created_ancestor)["inode_kind"], "directory");
+    assert_eq!(json_data(&created_ancestor)["inode_kind"], "dir");
 
     // get refuses to clobber a local file unless forced.
     let payload = harness.temp_dir.path().join("f.txt");
@@ -4941,7 +4941,7 @@ fn recursive_get_surfaces_drift_across_directory_listings() {
             "namespace_id": "demo",
             "absolute_path": "/docs",
             "inode_id": 2,
-            "inode_kind": "directory",
+            "inode_kind": "dir",
             "head_seq": 20,
             "parent_inode_id": 1,
             "display_name": "docs",
@@ -4954,7 +4954,7 @@ fn recursive_get_surfaces_drift_across_directory_listings() {
                 "namespace_id": "demo",
                 "absolute_path": "/docs/sub",
                 "inode_id": 3,
-                "inode_kind": "directory",
+                "inode_kind": "dir",
                 "head_seq": 20,
                 "parent_inode_id": 2,
                 "display_name": "sub",

--- a/crates/loonfs-core/src/commit/validate_error.rs
+++ b/crates/loonfs-core/src/commit/validate_error.rs
@@ -286,7 +286,7 @@ pub enum CommitValidationError {
 /// The revision it found is absent when the file carries no revision at all,
 /// and that case reads as a sentence rather than printing the `Option` — a
 /// message is for a person, while the same pair rides the wire as typed
-/// `expected_revision` and `actual_revision` details for a program.
+/// `expected_revision_no` and `actual_revision_no` details for a program.
 fn revision_mismatch(expected: &RevisionNo, actual: &Option<RevisionNo>) -> String {
     match actual {
         Some(actual) => format!("expected revision {expected}, found revision {actual}"),

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -548,8 +548,8 @@ fn commit_validation_details(error: &CommitValidationError) -> Option<ErrorDetai
             actual,
         } => Some(ErrorDetails {
             inode_id: Some(*inode_id),
-            expected_revision: Some(*expected),
-            actual_revision: *actual,
+            expected_revision_no: Some(*expected),
+            actual_revision_no: *actual,
             ..ErrorDetails::default()
         }),
         CommitValidationError::StaleWriterEpoch { active, requested } => Some(ErrorDetails {
@@ -998,8 +998,8 @@ mod tests {
             });
         let details = stale.details().expect("stale-revision details");
         assert_eq!(details.inode_id, Some(InodeId(7)));
-        assert_eq!(details.expected_revision, Some(RevisionNo(2)));
-        assert_eq!(details.actual_revision, Some(RevisionNo(5)));
+        assert_eq!(details.expected_revision_no, Some(RevisionNo(2)));
+        assert_eq!(details.actual_revision_no, Some(RevisionNo(5)));
         // The prose says the same thing in words, so neither revision
         // reaches a reader as Rust formatting.
         assert!(
@@ -1027,7 +1027,7 @@ mod tests {
             unversioned
                 .details()
                 .expect("stale-revision details")
-                .actual_revision,
+                .actual_revision_no,
             None
         );
 

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -149,7 +149,7 @@ fn event_from_op_deltas(deltas: &[&WalDelta]) -> Result<FilesystemChange> {
             inode_id: *inode_id,
             inode_kind: *inode_kind,
             parent_inode_id: *parent_inode_id,
-            name: display_name.clone(),
+            display_name: display_name.clone(),
             revision_no: None,
             content_ref: None,
         },
@@ -173,7 +173,7 @@ fn event_from_op_deltas(deltas: &[&WalDelta]) -> Result<FilesystemChange> {
                 inode_id: *inode_id,
                 inode_kind: *inode_kind,
                 parent_inode_id: *parent_inode_id,
-                name: display_name.clone(),
+                display_name: display_name.clone(),
                 revision_no: Some(*revision_no),
                 content_ref: Some(content_ref.clone()),
             }
@@ -203,9 +203,9 @@ fn event_from_op_deltas(deltas: &[&WalDelta]) -> Result<FilesystemChange> {
         }] if child_inode_id == bound_inode_id => FilesystemChange::Moved {
             inode_id: *child_inode_id,
             from_parent_inode_id: *from_parent_inode_id,
-            from_name: from_name.clone(),
+            from_display_name: from_name.clone(),
             to_parent_inode_id: *to_parent_inode_id,
-            to_name: to_name.clone(),
+            to_display_name: to_name.clone(),
         },
         // DeleteFile / DeleteSubtree: retire the binding, hide the subtree.
         [WalDelta::UnbindDirentry { child_inode_id, .. }, WalDelta::TombstoneSubtree {
@@ -225,7 +225,7 @@ fn event_from_op_deltas(deltas: &[&WalDelta]) -> Result<FilesystemChange> {
         }] if root_inode_id == child_inode_id => FilesystemChange::Undeleted {
             inode_id: *root_inode_id,
             parent_inode_id: *parent_inode_id,
-            name: display_name.clone(),
+            display_name: display_name.clone(),
         },
         // UpdateAttributes, including the copy that carries a source's
         // attributes onto the inode it just created. The delta already holds

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -502,11 +502,11 @@ async fn batch_commit_writes_one_segment_and_expands_change_feed() {
         FilesystemChange::Created {
             inode_kind: InodeKind::Directory,
             parent_inode_id: InodeId(1),
-            name,
+            display_name,
             revision_no: None,
             content_ref: None,
             ..
-        } if name.as_str() == "alpha"
+        } if display_name.as_str() == "alpha"
     ));
 }
 

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -658,7 +658,7 @@ async fn a_batch_creates_a_directory_and_writes_into_it_in_one_commit() {
         .events
         .iter()
         .map(|event| match event {
-            FilesystemChange::Created { name, .. } => name.as_str().to_owned(),
+            FilesystemChange::Created { display_name, .. } => display_name.as_str().to_owned(),
             other => panic!("unexpected event: {other:?}"),
         })
         .collect::<Vec<_>>();

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -194,12 +194,13 @@ async fn list_file_revisions<S: ObjectStore + ?Sized>(
     absolute_path: &str,
 ) -> Result<loonfs_api::ListFileRevisionsResponse, CoreError> {
     let entry = resolve_path(store, namespace_id, absolute_path).await?;
-    list_file_revisions_for_inode(store, namespace_id, entry.inode_id).await
+    list_file_revisions_for_inode(store, namespace_id, absolute_path, entry.inode_id).await
 }
 
 async fn list_file_revisions_for_inode<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
+    absolute_path: &str,
     inode_id: InodeId,
 ) -> Result<loonfs_api::ListFileRevisionsResponse, CoreError> {
     let context = read_context(store, namespace_id).await;
@@ -222,6 +223,8 @@ async fn list_file_revisions_for_inode<S: ObjectStore + ?Sized>(
         if cursor.is_none() {
             return Ok(loonfs_api::ListFileRevisionsResponse {
                 namespace_id: namespace_id.clone(),
+                absolute_path: loonfs_api::AbsolutePath::parse(absolute_path)
+                    .expect("valid test path"),
                 inode_id,
                 head_seq: context.head.seq,
                 revisions,
@@ -944,9 +947,10 @@ async fn revision_queries_read_historical_bytes_and_path_restore_appends_revisio
             .code(),
         ErrorCode::PathNotFound
     );
-    let inode_revisions = list_file_revisions_for_inode(&store, &namespace_id, inode_id)
-        .await
-        .expect("inode revisions");
+    let inode_revisions =
+        list_file_revisions_for_inode(&store, &namespace_id, "/docs/moved.txt", inode_id)
+            .await
+            .expect("inode revisions");
     assert_eq!(inode_revisions.revisions.len(), 2);
 
     restore_file_revision(
@@ -963,9 +967,10 @@ async fn revision_queries_read_historical_bytes_and_path_restore_appends_revisio
         .await
         .expect("read restored");
     assert_eq!(restored.bytes, b"one");
-    let restored_revisions = list_file_revisions_for_inode(&store, &namespace_id, inode_id)
-        .await
-        .expect("restored revisions");
+    let restored_revisions =
+        list_file_revisions_for_inode(&store, &namespace_id, "/docs/moved.txt", inode_id)
+            .await
+            .expect("restored revisions");
     assert_eq!(
         restored_revisions
             .revisions

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -18,7 +18,7 @@ pub(super) struct ApiResponseError {
 
 impl ApiResponseError {
     pub(super) fn new(status: StatusCode, code: ErrorCode, message: &str) -> Self {
-        Self {
+        let response = Self {
             status,
             body: ApiError {
                 code: code.as_str().to_owned(),
@@ -28,6 +28,11 @@ impl ApiResponseError {
                 details: None,
             },
             retry_after_seconds: None,
+        };
+        if code.retryable_without_operator_action() {
+            response.with_retry_after(1)
+        } else {
+            response
         }
     }
 
@@ -165,5 +170,25 @@ impl IntoResponse for ApiResponseError {
             }
         }
         response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_immediately_retryable_code_answers_with_retry_after() {
+        for code in ErrorCode::ALL {
+            let response =
+                ApiResponseError::new(status_for_core_error_code(code), code, "test response")
+                    .into_response();
+            let retry_after = response
+                .headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .map(|value| value.to_str().expect("Retry-After is ASCII"));
+            let expected = code.retryable_without_operator_action().then_some("1");
+            assert_eq!(retry_after, expected, "unexpected Retry-After for {code}");
+        }
     }
 }

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -23,9 +23,6 @@ pub(super) fn server_busy_error(what: &str) -> ApiResponseError {
         ErrorCode::ServerBusy,
         &format!("the server is at its concurrency limit for {what}; retry shortly"),
     )
-    // Transfer slots clear in fractions of a second; one second is the
-    // smallest Retry-After HTTP can express.
-    .with_retry_after(1)
 }
 
 pub(super) fn authorize(

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -92,7 +92,7 @@ impl Stream for DownloadBodyStream {
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct ChangesQuery {
-    after_seq: u64,
+    after_seq: String,
     limit: Option<String>,
 }
 
@@ -487,7 +487,7 @@ pub(super) async fn apply_commit(
         description = "Returns committed changes from the write-ahead log. Callers can use this feed to keep another projection synchronized with WAL history.",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
-            ("after_seq" = u64, Query, description = "Return committed changes after this sequence"),
+            ("after_seq" = String, Query, description = "Return committed changes after this sequence"),
             ("limit" = Option<String>, Query, description = "Maximum page size")
         ),
         responses(
@@ -509,7 +509,7 @@ pub(super) async fn list_changes(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
-    let after_seq = loonfs_api::ChangeSeq(query.after_seq);
+    let after_seq = parse_after_seq(&query.after_seq)?;
     let limit = resolve_page_limit(query.limit)?;
     let response = state
         .reader
@@ -521,6 +521,19 @@ pub(super) async fn list_changes(
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
+}
+
+fn parse_after_seq(value: &str) -> Result<loonfs_api::ChangeSeq, ApiResponseError> {
+    value
+        .parse::<u64>()
+        .map(loonfs_api::ChangeSeq)
+        .map_err(|error| {
+            ApiResponseError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                &format!("invalid after_seq `{value}`: {error}"),
+            )
+        })
 }
 
 fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -36,7 +36,7 @@ fn set_feature(capabilities: &mut CapabilityDocument, feature: &str, supported: 
 pub(super) struct DeleteNamespaceQuery {
     /// Delete only if the head is still at this sequence (`stale_head` on
     /// mismatch).
-    expected_head_seq: Option<u64>,
+    expected_head_seq: Option<String>,
 }
 
 #[cfg_attr(
@@ -236,7 +236,7 @@ pub(super) async fn namespace_status(
         description = "Marks a namespace as deleted.",
         params(
             ("namespace" = String, Path, description = "Namespace id"),
-            ("expected_head_seq" = Option<u64>, Query, description = "Delete only if the namespace head is still at this sequence")
+            ("expected_head_seq" = Option<String>, Query, description = "Delete only if the namespace head is still at this sequence")
         ),
         responses(
             (status = 200, description = "Namespace deleted", body = loonfs_api::DeleteNamespaceResponse),
@@ -259,7 +259,11 @@ pub(super) async fn delete_namespace(
     let namespace_id = namespace.into_id()?;
     let query = query.into_params()?;
     let options = DeleteNamespaceOptions {
-        expected_head_seq: query.expected_head_seq.map(ChangeSeq),
+        expected_head_seq: query
+            .expected_head_seq
+            .as_deref()
+            .map(parse_expected_head_seq)
+            .transpose()?,
     };
     let response = state
         .writer
@@ -268,6 +272,16 @@ pub(super) async fn delete_namespace(
         .await
         .map_err(|error| ApiResponseError::core_for_namespace(&namespace_id, error))?;
     Ok(Json(response))
+}
+
+fn parse_expected_head_seq(value: &str) -> Result<ChangeSeq, ApiResponseError> {
+    value.parse::<u64>().map(ChangeSeq).map_err(|error| {
+        ApiResponseError::new(
+            StatusCode::BAD_REQUEST,
+            ErrorCode::InvalidRequest,
+            &format!("invalid expected_head_seq `{value}`: {error}"),
+        )
+    })
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -1,7 +1,7 @@
 //! The `query/v0` plane: derived-index reads.
 
 use super::handlers_uploads::current_unix_ms;
-use super::{authorize, AppJson, AppState, NamespaceIdPath};
+use super::{authorize, AppJson, AppState, NamespaceIdPath, OptionalAppJson};
 use crate::http::error::{status_for_core_error_code, ApiResponseError};
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -277,7 +277,7 @@ pub(super) async fn disable_grep_index(
         summary = "Collect grep-index garbage",
         description = "Runs one explicit garbage-collection pass over only this namespace's grep-owned extension keyspace. A tombstoned or absent namespace has aged extension state reaped; no grep garbage collection runs implicitly. `max_objects` bounds the reads the pass spends and returns a `next_cursor` when keys remain; resuming re-reads liveness and the grep root, so a cursor only skips enumeration. Requires this deployment to maintain the grep index.",
         params(("namespace" = String, Path, description = "Namespace id")),
-        request_body = GrepGcRequest,
+        request_body = Option<GrepGcRequest>,
         responses(
             (status = 200, description = "Namespace grep garbage collection completed", body = GrepGcResponse),
             (status = 400, description = "Invalid budget or cursor", body = ApiError),
@@ -292,10 +292,11 @@ pub(super) async fn gc_grep_index(
     State(state): State<AppState>,
     namespace: NamespaceIdPath,
     headers: HeaderMap,
-    AppJson(request): AppJson<GrepGcRequest>,
+    OptionalAppJson(request): OptionalAppJson<GrepGcRequest>,
 ) -> Result<Json<GrepGcResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace.into_id()?;
+    let request = request.unwrap_or_default();
     let report = state
         .grep_worker
         .as_ref()

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -36,13 +36,14 @@ use std::path::Path;
 
 const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "aborted_at_ms",
+    "absolute_path",
     "active_acquired_at_ms",
     "active_deletion_seq",
     "active_writer",
     "active_writer_epoch",
     "actual_attributes_revision_no",
     "actual_head_seq",
-    "actual_revision",
+    "actual_revision_no",
     "advance_retention",
     "after_seq",
     "allow_scan",
@@ -85,11 +86,10 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "expected_attributes_revision_no",
     "expected_head_seq",
     "expected_inode_id",
-    "expected_revision",
     "expected_revision_no",
     "expires_at_ms",
     "fenced_epoch",
-    "from_name",
+    "from_display_name",
     "from_parent_inode_id",
     "grace_window",
     "grace_window_ms",
@@ -135,7 +135,7 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "storage_checksum",
     "target_namespace_id",
     "target_seq",
-    "to_name",
+    "to_display_name",
     "to_parent_inode_id",
     "ttl_ms",
     "unrecognized_key",
@@ -1707,6 +1707,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         let body: serde_json::Value =
             serde_json::from_str(&body).unwrap_or_else(|_| panic!("json body, got: {body}"));
         assert_eq!(body["code"], code);
+        body
     };
 
     // A query value that fails its field type: enveloped invalid_request.
@@ -1716,7 +1717,13 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         .set("authorization", "Bearer test-token")
         .call()
         .expect_err("malformed after_seq should answer 400");
-    expect_enveloped(error, 400, "invalid_request");
+    let body = expect_enveloped(error, 400, "invalid_request");
+    assert!(
+        body["message"]
+            .as_str()
+            .is_some_and(|message| message.starts_with("invalid after_seq `abc`:")),
+        "{body}"
+    );
 
     // The same malformed query without credentials: 401 wins.
     let error = raw_agent()
@@ -1724,6 +1731,23 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         .call()
         .expect_err("unauthorized should answer 401");
     expect_enveloped(error, 401, "unauthorized");
+
+    // Optional numeric query fields use the same hand-parse policy and name
+    // themselves in the rejection rather than leaking framework wording.
+    let error = raw_agent()
+        .delete(&format!(
+            "http://{addr}/v0/namespaces/demo?expected_head_seq=abc"
+        ))
+        .set("authorization", "Bearer test-token")
+        .call()
+        .expect_err("malformed expected_head_seq should answer 400");
+    let body = expect_enveloped(error, 400, "invalid_request");
+    assert!(
+        body["message"]
+            .as_str()
+            .is_some_and(|message| message.starts_with("invalid expected_head_seq `abc`:")),
+        "{body}"
+    );
 
     // A missing required query parameter: enveloped invalid_request.
     let error = raw_agent()
@@ -2568,6 +2592,10 @@ async fn shutdown_keeps_readiness_reachable_until_an_active_request_finishes() {
     assert!(
         readiness.contains("\"code\":\"shutting_down\""),
         "readiness names the shutdown: {readiness}"
+    );
+    assert!(
+        readiness.contains("retry-after: 1\r\n"),
+        "readiness tells callers when to retry: {readiness}"
     );
     assert!(
         !slow.is_finished(),

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -216,7 +216,7 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
             &router,
             Method::POST,
             &format!("/v0/admin/namespaces/{namespace_id}/grep/index/gc"),
-            Some(b"{}".to_vec()),
+            None,
         )
         .await,
     )

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -381,6 +381,7 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         .list_file_revisions_page(&target, None, None)
         .await
         .expect("path revisions");
+    assert_eq!(revisions.absolute_path, target.absolute_path().clone());
     assert_eq!(revisions.inode_id, entry.inode_id);
     assert_eq!(revisions.revisions.len(), 2);
     assert_eq!(
@@ -416,6 +417,7 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         .list_file_revisions_page(&moved, None, None)
         .await
         .expect("moved-path revisions");
+    assert_eq!(moved_revisions.absolute_path, moved.absolute_path().clone());
     assert_eq!(moved_revisions.inode_id, entry.inode_id);
     assert_eq!(moved_revisions.revisions.len(), 2);
 

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -248,10 +248,10 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
             inode_id: InodeId(2),
             inode_kind: InodeKind::File,
             parent_inode_id: InodeId(1),
-            name,
+            display_name,
             revision_no: Some(RevisionNo(1)),
             content_ref: Some(created_ref),
-        } if name.as_str() == "uploaded.txt" && *created_ref == content_ref
+        } if display_name.as_str() == "uploaded.txt" && *created_ref == content_ref
     ));
 
     let empty = harness

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -13,13 +13,13 @@ use crate::{
 };
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
-    encode_cursor, CapabilityDocument, EffectiveLimit, FileRevision, FileRevisionsPageCursor, Page,
-    PaginationPolicy, FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART,
-    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_CONTENT_TOKENS,
-    LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS, LIMIT_COMMIT_MAX_MESSAGE_BYTES,
-    LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_GC_MIN_GRACE_WINDOW_MS, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
-    PROTOCOL_VERSION,
+    encode_cursor, AbsolutePath, CapabilityDocument, EffectiveLimit, FileRevision,
+    FileRevisionsPageCursor, Page, PaginationPolicy, FEATURE_ATTRIBUTES,
+    FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
+    FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
+    LIMIT_COMMIT_MAX_CONTENT_TOKENS, LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS,
+    LIMIT_COMMIT_MAX_MESSAGE_BYTES, LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_GC_MIN_GRACE_WINDOW_MS,
+    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 use loonfs_core::cache::{
     MetadataTableCache, StoredMetadataBlockCache, WalTailProjectionCache,
@@ -307,6 +307,7 @@ pub(super) fn default_page_limit() -> EffectiveLimit {
 
 pub(super) fn file_revisions_page_response(
     namespace_id: NamespaceId,
+    absolute_path: AbsolutePath,
     head_seq: ChangeSeq,
     page: Page<FileRevision, FileRevisionsPageCursor>,
     fallback_inode_id: Option<InodeId>,
@@ -328,6 +329,7 @@ pub(super) fn file_revisions_page_response(
         .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
     Ok(ListFileRevisionsResponse {
         namespace_id,
+        absolute_path,
         inode_id,
         head_seq,
         revisions: page.items,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -355,10 +355,12 @@ impl FsReader {
         absolute_path: &str,
         request: PageRequest<FileRevisionsPageCursor>,
     ) -> Result<ListFileRevisionsResponse> {
+        let absolute_path = AbsolutePath::parse(absolute_path)
+            .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
         let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
         let fallback_inode_id = request.cursor.as_ref().map(|cursor| cursor.inode_id);
         let page = engine
-            .list_file_revisions_page(absolute_path, request, &read_context)
+            .list_file_revisions_page(absolute_path.as_str(), request, &read_context)
             .await?;
         self.core
             .inner
@@ -366,6 +368,7 @@ impl FsReader {
             .record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
+            absolute_path,
             read_context.head.seq,
             page,
             fallback_inode_id,

--- a/crates/loonfs/tests/it/pagination.rs
+++ b/crates/loonfs/tests/it/pagination.rs
@@ -116,6 +116,7 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
         },
     ))
     .expect("first revision page");
+    assert_eq!(first.absolute_path.as_str(), "/doc.txt");
     assert_eq!(
         first
             .revisions
@@ -136,6 +137,7 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
         },
     ))
     .expect("second revision page");
+    assert_eq!(second.absolute_path.as_str(), "/doc.txt");
     assert_eq!(
         second
             .revisions
@@ -326,6 +328,7 @@ fn revisions_cursor_resumes_after_later_writes() {
         },
     ))
     .expect("first revisions page");
+    assert_eq!(first.absolute_path.as_str(), "/docs/report.txt");
     assert_eq!(
         first
             .revisions
@@ -360,6 +363,7 @@ fn revisions_cursor_resumes_after_later_writes() {
         },
     ))
     .expect("second revisions page resumes after head drift");
+    assert_eq!(second.absolute_path.as_str(), "/docs/report.txt");
     assert_eq!(
         second
             .revisions

--- a/crates/loonfs/tests/it/undelete.rs
+++ b/crates/loonfs/tests/it/undelete.rs
@@ -481,10 +481,10 @@ fn change_feed_reports_the_deletion_generation_an_undelete_takes() {
                 }
                 loonfs::FilesystemChange::Undeleted {
                     inode_id: undeleted_inode_id,
-                    name,
+                    display_name,
                     ..
                 } if *undeleted_inode_id == inode_id => {
-                    undeleted = Some(name.as_str().to_owned());
+                    undeleted = Some(display_name.as_str().to_owned());
                 }
                 _ => {}
             }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -223,7 +223,7 @@ The codes that populate it:
 | Code | Detail fields |
 | --- | --- |
 | `writer_fenced` | `fenced_epoch`, `active_writer_epoch`, plus `active_writer` and `active_acquired_at_ms` when the head recorded a writer block. Writer ids are process labels, so two runs on one machine can share one; the acquisition stamp is what tells them apart |
-| `stale_revision` | `inode_id`, `expected_revision`, `actual_revision` (absent when the inode has no current revision) |
+| `stale_revision` | `inode_id`, `expected_revision_no`, `actual_revision_no` (absent when the inode has no current revision) |
 | `stale_attributes` | `inode_id`, `expected_attributes_revision_no` (absent when the caller stated no expectation), `actual_attributes_revision_no` |
 | `commit_id_reuse_conflict` | `commit_id`, plus `committed_seq` and `committed_fingerprint` when the conflict was decided against a durable commit receipt — the sequence that `commit_id` already landed at, and the semantic identity of what landed there (section 5.1). Both come from the receipt, so both are present or neither is; both are absent when nothing has committed under the id yet and two live requests are claiming it at once |
 | `rebootstrap_required` | `after_seq`, `retention_floor_seq` |
@@ -288,6 +288,8 @@ caller or operator action. `checkpoint_unavailable`, `maintenance_required`,
 and `index_lagging` remain 503 status groupings but require maintenance before
 an unchanged request can succeed; `commit_outcome_unknown` and
 `deadline_exceeded` require reconciliation before retrying a mutation.
+Responses carrying any of those three immediately retryable codes include
+`Retry-After: 1`.
 
 Precondition failures surface as `409` resource-state conflicts
 (`stale_revision`, `stale_head`, `commit_id_reuse_conflict`) rather than
@@ -634,6 +636,7 @@ A representative v0 binding is shown below.
 | Apply a commit | `POST /v0/namespaces/{ns}/commits` |
 | Begin or prepare upload | `POST /v0/namespaces/{ns}/uploads` |
 | Upload full staged content | `PUT /v0/namespaces/{ns}/uploads/{upload_id}/content` |
+| Sign staged upload parts | `POST /v0/namespaces/{ns}/uploads/{upload_id}/parts` |
 | Complete staged upload | `POST /v0/namespaces/{ns}/uploads/{upload_id}/complete` |
 | Read an upload session | `GET /v0/namespaces/{ns}/uploads/{upload_id}` (a completed session answers with a freshly minted `validated_content_token`) |
 | Abort an upload session | `POST /v0/namespaces/{ns}/uploads/{upload_id}/abort` (terminal and repeatable; a completed session is refused) |
@@ -648,7 +651,7 @@ A representative v0 binding is shown below.
 | Read the grep index's lifecycle | `GET /v0/admin/namespaces/{ns}/grep/index` (feature `admin.grep.index`; one grep root read, no side effects) |
 | Enable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/enable` (feature `admin.grep.index`; CAS-publishes the independent grep root into checkpointed backfill and nudges the deployment's maintenance runner; idempotent) |
 | Disable the grep index | `POST /v0/admin/namespaces/{ns}/grep/index/disable` (feature `admin.grep.index`; CAS-publishes the grep root as disabled; grep-owned garbage collection later reclaims unreferenced segments; idempotent) |
-| Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (feature `admin.grep.index`; one explicit pass over only that namespace's grep extension; `max_objects` bounds the reads it spends and defaults to 1024 when omitted, returning a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
+| Collect grep-index garbage | `POST /v0/admin/namespaces/{ns}/grep/index/gc` (feature `admin.grep.index`; one explicit pass over only that namespace's grep extension; the body may be absent for the default request; `max_objects` bounds the reads it spends and defaults to 1024 when omitted, returning a `next_cursor` when keys remain; also reaps aged state for an absent or tombstoned namespace) |
 | Probe the store contract | `POST /v0/admin/store/probe` (the one admin route whose subject is the store rather than a namespace; body carries no options today and `{}` is the request; see below) |
 | Scrape metrics | `GET /metrics` (Prometheus text exposition; authorized, unlike the liveness routes — see below) |
 
@@ -813,15 +816,16 @@ Routes under `/v0/admin/` belong to the `admin/v0` profile and routes under
 `/v0/namespaces/{ns}/query/` to `query/v0`; everything else shown belongs to
 `core/v0`.
 
-Every GC response carries `next_reclamation_at_ms`, which is the soonest
-time still ahead of the pass at which something it retained becomes
-reclaimable: an open upload session's lease plus the grace window, an
-aborted session's grace, or a completed session's derived
-content-reclamation grace. A scheduler reads it to decide when to run the
-namespace again rather than tracking upload deadlines itself. It describes
-only what this pass examined — a pass that stopped on `next_cursor` saw part
-of the keyspace, and candidates that age out on their object timestamps
-carry no time here — so `null` is not a claim that nothing is owed.
+When a GC pass sees a future reclamation deadline, its response includes
+`next_reclamation_at_ms`, the soonest time still ahead of the pass at which
+something it retained becomes reclaimable: an open upload session's lease
+plus the grace window, an aborted session's grace, or a completed session's
+derived content-reclamation grace. A scheduler reads it to decide when to
+run the namespace again rather than tracking upload deadlines itself. It
+describes only what this pass examined — a pass that stopped on `next_cursor`
+saw part of the keyspace, and candidates that age out on their object
+timestamps carry no time here — so its absence is not a claim that nothing
+is owed.
 
 GC responses carry `next_cursor` only when more candidate enumeration remains.
 The token is opaque, tolerant of additive fields when decoded, and valid only
@@ -892,12 +896,12 @@ content nothing published — an abandoned upload, a completed session whose
 commit never arrived. An operator who deletes a large tree and watches the
 bucket should expect it to stay the size it is.
 
-Nothing has to be scheduled for the second horizon by hand. Every pass
-reports `next_reclamation_at_ms`, the soonest instant ahead of it at which
-something it kept becomes reclaimable, and the runtime's collection job
-hands that straight back as the earliest it will run the namespace again.
-A namespace that is being written to therefore reclaims its own staged
-content without a cron entry.
+Nothing has to be scheduled for the second horizon by hand. A pass that sees
+one reports `next_reclamation_at_ms`, the soonest instant ahead of it at
+which something it kept becomes reclaimable, and the runtime's collection
+job hands that straight back as the earliest it will run the namespace
+again. A namespace that is being written to therefore reclaims its own
+staged content without a cron entry.
 
 What that leaves is namespaces nobody is writing to. LoonFS has no operation
 that enumerates namespaces, so nothing can discover them: coverage is an
@@ -1268,6 +1272,7 @@ existed, could not be used, and needed an explicit repair.
 
 The examples below are representative, not exhaustive. Responses may gain
 fields within v0; clients must ignore JSON fields they do not recognize.
+Optional response fields are omitted when absent, never encoded as `null`.
 
 ### 6.1 `GET /v0/capabilities`
 
@@ -1381,10 +1386,9 @@ had attributes written reads as `{}` at revision 0. A read that did not
 include attributes omits the group, so an absent group never means "no
 attributes".
 
-The namespace root is nameless: its entry has `parent_inode_id: null` and
-omits `display_name` entirely. Every non-root entry carries a validated
-`display_name`; the empty string is not a spelling for the root or for any
-named path component.
+The namespace root is nameless: its entry omits both `parent_inode_id` and
+`display_name`. Every non-root entry carries a validated `display_name`; the
+empty string is not a spelling for the root or for any named path component.
 
 ### 6.5 `GET /filesystem/list`
 
@@ -1454,7 +1458,7 @@ An unrecognized cursor version is also rejected as `invalid_request`.
       "namespace_id": "demo",
       "absolute_path": "/docs/slides",
       "inode_id": 43,
-      "inode_kind": "directory",
+      "inode_kind": "dir",
       "head_seq": 418,
       "parent_inode_id": 7,
       "display_name": "slides"
@@ -1493,14 +1497,15 @@ client create such a file offers it.
 
 Revision listing returns newest revisions first and uses the same
 `limit` / `cursor` pattern as directory listing, resolving the current path
-to its current inode. Responses include
-`next_cursor` only when another page is available. Revision history is never
-pruned — paging to the end always reaches revision 1, regardless of how far
-the retention floor has advanced.
+to its current inode. The response echoes that requested path as
+`absolute_path`. Responses include `next_cursor` only when another page is
+available. Revision history is never pruned — paging to the end always
+reaches revision 1, regardless of how far the retention floor has advanced.
 
 ```json
 {
   "namespace_id": "demo",
+  "absolute_path": "/docs/report.txt",
   "inode_id": 42,
   "head_seq": 418,
   "revisions": [
@@ -2056,9 +2061,9 @@ presign writes either, no file it holds can be larger than it will proxy.
 
 ### 6.11 `GET /changes`
 
-Each change is one commit carrying its identity (`seq`,
-`commit_id`, observational `committed_at_ms`, writer provenance, optional
-`message`) and `events`: the semantic filesystem operations the commit
+Each change is one commit carrying its identity (`seq`, `commit_id`,
+observational `committed_at_ms`, optional `message`) and `events`: the
+semantic filesystem operations the commit
 applied, in the order it applied them. One request operation may apply
 several — a put creates each missing parent directory, a replacing move
 deletes the file it moves over, a copy carries the source's attributes onto
@@ -2099,11 +2104,11 @@ Event kinds:
 
 | Kind | Meaning | Fields |
 | --- | --- | --- |
-| `created` | A file or directory was created. | `inode_id`, `inode_kind`, `parent_inode_id`, `name`; file creations also carry `revision_no` and `content_ref`. |
+| `created` | A file or directory was created. | `inode_id`, `inode_kind`, `parent_inode_id`, `display_name`; file creations also carry `revision_no` and `content_ref`. |
 | `content_changed` | A file received a new current revision — a replacing put or a revision restore (one durable fact for both). | `inode_id`, `revision_no`, `content_ref`. |
-| `moved` | An entry moved to a new parent directory or name. | `inode_id`, `from_parent_inode_id`, `from_name`, `to_parent_inode_id`, `to_name`. |
+| `moved` | An entry moved to a new parent directory or name. | `inode_id`, `from_parent_inode_id`, `from_display_name`, `to_parent_inode_id`, `to_display_name`. |
 | `deleted` | A file or directory subtree was deleted. The enclosing change's `seq` is the `deleted_at_seq` an undelete passes. | `inode_id`, plus optional `deleted_direntry` containing `parent_inode_id`, `name_key`, and `display_name`. |
-| `undeleted` | A deleted inode was recovered and re-bound. | `inode_id`, `parent_inode_id`, `name`. |
+| `undeleted` | A deleted inode was recovered and re-bound. | `inode_id`, `parent_inode_id`, `display_name`. |
 | `attributes_changed` | An inode's attributes changed. `attributes` is the complete flat string map after the update, so a consumer projects it without reading anything back; an empty map is the cleared state. | `inode_id`, `attributes_revision_no`, `attributes`. |
 
 Events name inodes and their parent-directory bindings rather than full

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -15,7 +15,9 @@ a deployment exposes.
 
 Encoding conventions used by every durable and wire shape in this specification:
 field names and enum values are `snake_case`; fields holding typed identifiers
-are suffixed `_id`; tagged unions carry their discriminator in a `kind` field.
+are suffixed `_id`; tagged-union discriminators default to `kind`, but a union
+may use its domain word where that reads better. The current exceptions are
+`mode`, `completion`, `state`, `phase`, and `inode_kind`.
 
 Unknown fields are tolerated where a reader must accept what a newer writer
 added, and rejected where accepting one would lose information the sender

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -638,11 +638,17 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GrepGcRequest"
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GrepGcRequest"
+                  }
+                ]
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -1053,9 +1059,7 @@
             "description": "Delete only if the namespace head is still at this sequence",
             "required": false,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string"
             }
           }
         ],
@@ -1150,9 +1154,7 @@
             "description": "Return committed changes after this sequence",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 0
+              "type": "string"
             }
           },
           {
@@ -2982,7 +2984,7 @@
           {
             "type": "object",
             "title": "AuthoritativePathEntryDirectory",
-            "description": "A directory, which has no revision payload in v0.",
+            "description": "A directory, which has no revision payload in v0.\n\nThe entry tag reuses [`InodeKind`]'s wire vocabulary.",
             "required": [
               "inode_kind"
             ],
@@ -2990,7 +2992,7 @@
               "inode_kind": {
                 "type": "string",
                 "enum": [
-                  "directory"
+                  "dir"
                 ]
               }
             }
@@ -4056,7 +4058,7 @@
               }
             ]
           },
-          "actual_revision": {
+          "actual_revision_no": {
             "oneOf": [
               {
                 "type": "null"
@@ -4129,7 +4131,7 @@
               }
             ]
           },
-          "expected_revision": {
+          "expected_revision_no": {
             "oneOf": [
               {
                 "type": "null"
@@ -4240,7 +4242,7 @@
               "inode_id",
               "inode_kind",
               "parent_inode_id",
-              "name",
+              "display_name",
               "kind"
             ],
             "properties": {
@@ -4255,6 +4257,10 @@
                   }
                 ]
               },
+              "display_name": {
+                "$ref": "#/components/schemas/DisplayName",
+                "description": "User-facing spelling of the new entry."
+              },
               "inode_id": {
                 "$ref": "#/components/schemas/InodeId",
                 "description": "Newly allocated namespace-scoped inode identity."
@@ -4268,10 +4274,6 @@
                 "enum": [
                   "created"
                 ]
-              },
-              "name": {
-                "$ref": "#/components/schemas/DisplayName",
-                "description": "User-facing spelling of the new entry."
               },
               "parent_inode_id": {
                 "$ref": "#/components/schemas/InodeId",
@@ -4328,13 +4330,13 @@
             "required": [
               "inode_id",
               "from_parent_inode_id",
-              "from_name",
+              "from_display_name",
               "to_parent_inode_id",
-              "to_name",
+              "to_display_name",
               "kind"
             ],
             "properties": {
-              "from_name": {
+              "from_display_name": {
                 "$ref": "#/components/schemas/DisplayName",
                 "description": "Spelling of the old binding."
               },
@@ -4352,7 +4354,7 @@
                   "moved"
                 ]
               },
-              "to_name": {
+              "to_display_name": {
                 "$ref": "#/components/schemas/DisplayName",
                 "description": "Spelling of the new binding."
               },
@@ -4401,10 +4403,14 @@
             "required": [
               "inode_id",
               "parent_inode_id",
-              "name",
+              "display_name",
               "kind"
             ],
             "properties": {
+              "display_name": {
+                "$ref": "#/components/schemas/DisplayName",
+                "description": "Spelling of the recovered binding."
+              },
               "inode_id": {
                 "$ref": "#/components/schemas/InodeId",
                 "description": "Recovered inode."
@@ -4414,10 +4420,6 @@
                 "enum": [
                   "undeleted"
                 ]
-              },
-              "name": {
-                "$ref": "#/components/schemas/DisplayName",
-                "description": "Spelling of the recovered binding."
               },
               "parent_inode_id": {
                 "$ref": "#/components/schemas/InodeId",
@@ -4875,7 +4877,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "The soonest instant still ahead of this pass at which something it\nretained becomes reclaimable: an open session's lease plus the grace\nwindow, an aborted session's grace, or a completed session's derived\ncontent-reclamation grace. A scheduler reads this to decide when to\ncome back, so a namespace needs no other side channel to have its\nreclamation happen.\n\nIt reports what this pass saw and nothing more. A pass that stopped\non `next_cursor` examined only part of the keyspace, and candidates\nthat age out under a plain grace window on their object timestamps\ncarry no deadline here at all, so `None` is never a claim that\nnothing is owed.\n\nAlways serialized, `null` included, unlike `next_cursor` beside it:\na cursor's presence is what says the enumeration is unfinished,\nwhile this is an answer every pass has — and one whose absence\notherwise makes the response's shape depend on what happened to be\nin the namespace.",
+            "description": "The soonest instant still ahead of this pass at which something it\nretained becomes reclaimable: an open session's lease plus the grace\nwindow, an aborted session's grace, or a completed session's derived\ncontent-reclamation grace. A scheduler reads this to decide when to\ncome back, so a namespace needs no other side channel to have its\nreclamation happen.\n\nIt reports what this pass saw and nothing more. A pass that stopped\non `next_cursor` examined only part of the keyspace, and candidates\nthat age out under a plain grace window on their object timestamps\ncarry no deadline here at all, so absence is never a claim that\nnothing is owed.",
             "minimum": 0
           },
           "released_expired_checkpoints": {
@@ -5276,11 +5278,16 @@
         "description": "Response for listing file revisions.",
         "required": [
           "namespace_id",
+          "absolute_path",
           "inode_id",
           "head_seq",
           "revisions"
         ],
         "properties": {
+          "absolute_path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute file path requested by the caller."
+          },
           "head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Namespace head sequence used for the read."


### PR DESCRIPTION
Use the same field names and enum values for the same concepts across API responses. Change-feed events now use `display_name`, `from_display_name`, and `to_display_name`; revision error details use the `_revision_no` suffix; and authoritative path entries serialize directories as `dir`, matching `InodeKind`. File revision listings also echo the requested `absolute_path`, while root entries and other optional response fields omit values that are absent instead of serializing them as `null`.

Apply retry behavior consistently by returning `Retry-After` for every error that is retryable without operator action, including `server_busy`, `commit_queue_full`, and `shutting_down`. Parse `after_seq` and `expected_head_seq` through the shared query-validation path so invalid values identify the field that failed. Allow the admin GC endpoint to use its default request when the body is absent, and document the upload-parts binding alongside the other representative routes.

Update the API and format specifications, generated OpenAPI document, client and CLI handling, reference model, fixtures, and tests to use the revised wire shapes. Add coverage for matching inode-kind values, omitted optional fields, retry headers, empty GC requests, revision-list paths, and sequence query validation.