### PR TITLE
fix(api): name committed sequences consistently and document ID formats

### DIFF
--- a/crates/loonfs-api/src/attributes.rs
+++ b/crates/loonfs-api/src/attributes.rs
@@ -46,7 +46,8 @@ string_id! {
     /// attempt to write a reserved key is rejected.
     AttributeKey,
     error = AttributeKeyValidationError,
-    validate = validate_attribute_key
+    validate = validate_attribute_key,
+    schema(example = "owner")
 }
 
 impl AttributeKey {
@@ -100,7 +101,8 @@ string_id! {
     /// operation deletes an attribute.
     AttributeValue,
     error = AttributeValueValidationError,
-    validate = validate_attribute_value
+    validate = validate_attribute_value,
+    schema(example = "platform")
 }
 
 fn validate_attribute_value(value: &str) -> Result<(), AttributeValueValidationError> {

--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -395,7 +395,7 @@ where
         Err(error) => return Err(error),
     };
     let Some(committed) = page.changes.into_iter().find(|change| {
-        change.seq == receipt.committed_seq && &change.commit_id == attempt.commit_id
+        change.committed_seq == receipt.committed_seq && &change.commit_id == attempt.commit_id
     }) else {
         return Err(conflict);
     };
@@ -418,7 +418,7 @@ where
     Ok(crate::v0::CommitResponse {
         namespace_id: attempt.namespace_id.clone(),
         commit_id: committed.commit_id,
-        committed_seq: committed.seq,
+        committed_seq: committed.committed_seq,
     })
 }
 
@@ -1044,7 +1044,7 @@ mod tests {
             through_seq: committed_seq,
             next_after_seq: None,
             changes: vec![crate::v0::CommittedChange {
-                seq: committed_seq,
+                committed_seq,
                 commit_id: commit_id.clone(),
                 committed_at_ms: 1,
                 message: None,

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -73,6 +73,10 @@ validation_error!(
 ///   server-generated shape `xyz_<32 lowercase hex>` and adds a
 ///   `generate()` constructor.
 ///
+/// Either form may end with `schema(...)` metadata. Its optional `pattern`
+/// and `example` are added to the OpenAPI string schema when that feature is
+/// enabled.
+///
 /// Type-specific constructors that the macro cannot express (for example
 /// `CommitId::generate` or `NameKey::for_display_name`) live in a separate
 /// `impl` block next to the invocation.
@@ -82,11 +86,16 @@ macro_rules! string_id {
         $name:ident,
         error = $error:ty,
         validate = $validate:expr
+        $(, schema($($schema:tt)+))?
+        $(,)?
     ) => {
         $(#[$meta])*
         #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
         #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-        #[cfg_attr(feature = "openapi", schema(value_type = String))]
+        #[cfg_attr(
+            feature = "openapi",
+            schema(value_type = String $(, $($schema)+)?)
+        )]
         pub struct $name(String);
 
         impl $name {
@@ -168,12 +177,15 @@ macro_rules! string_id {
         $(#[$meta:meta])*
         $name:ident,
         prefix = $prefix:literal
+        $(, schema($($schema:tt)+))?
+        $(,)?
     ) => {
         string_id! {
             $(#[$meta])*
             $name,
             error = GeneratedIdValidationError,
             validate = |value: &str| validate_generated_id($prefix, value)
+            $(, schema($($schema)+))?
         }
 
         impl $name {
@@ -428,10 +440,19 @@ string_id! {
     /// Durable id for one namespace.
     ///
     /// A namespace is one filesystem history. This id is not a display name and
-    /// should not be reused after destruction.
+    /// should not be reused after destruction. Its serialized form is 1 to 128
+    /// lowercase ASCII letters, digits, dots, underscores, or hyphens, starting
+    /// with a letter or digit; the `loonfs-` prefix is reserved for system use.
     NamespaceId,
     error = NamespaceIdValidationError,
-    validate = validate_namespace_id
+    validate = validate_namespace_id,
+    schema(
+        // The `loonfs-` reservation stays in the description: a lookahead
+        // would state it, but portable pattern dialects (RE2, most SDK
+        // generators) reject lookaheads, so the pattern is the grammar only.
+        pattern = r"^[a-z0-9][a-z0-9._-]{0,127}$",
+        example = "demo"
+    )
 }
 
 string_id! {
@@ -445,10 +466,17 @@ string_id! {
 string_id! {
     /// Client-supplied idempotency key for one logical commit.
     ///
-    /// Reuse the same `CommitId` when retrying the same request.
+    /// Reuse the same `CommitId` when retrying the same request. The accepted
+    /// grammar is 1 to 128 lowercase ASCII letters, digits, dots, underscores,
+    /// or hyphens, starting with a letter or digit. [`CommitId::generate`] mints
+    /// `c_<32 lowercase hex>`, but callers may supply any value in that grammar.
     CommitId,
     error = CommitIdValidationError,
-    validate = validate_commit_id
+    validate = validate_commit_id,
+    schema(
+        pattern = r"^[a-z0-9][a-z0-9._-]{0,127}$",
+        example = "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0"
+    )
 }
 
 impl CommitId {
@@ -463,13 +491,21 @@ string_id! {
     ///
     /// A checkpoint is a durable bookmark to a namespace manifest version.
     CheckpointId,
-    prefix = "chk"
+    prefix = "chk",
+    schema(
+        pattern = r"^chk_[0-9a-f]{32}$",
+        example = "chk_00000000000000000000000000000002"
+    )
 }
 
 string_id! {
     /// Durable id for one upload session.
     UploadId,
-    prefix = "upl"
+    prefix = "upl",
+    schema(
+        pattern = r"^upl_[0-9a-f]{32}$",
+        example = "upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c"
+    )
 }
 
 string_id! {
@@ -482,7 +518,11 @@ string_id! {
     /// rides [`crate::ContentRef`] beside it.
     ContentId,
     error = GeneratedIdValidationError,
-    validate = |value: &str| validate_generated_id("con", value)
+    validate = |value: &str| validate_generated_id("con", value),
+    schema(
+        pattern = r"^con_[0-9a-f]{32}$",
+        example = "con_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41"
+    )
 }
 
 impl ContentId {
@@ -611,7 +651,8 @@ string_id! {
     /// `DisplayName`.
     NameKey,
     error = NameKeyValidationError,
-    validate = validate_name_key
+    validate = validate_name_key,
+    schema(example = "report.txt")
 }
 
 impl NameKey {

--- a/crates/loonfs-api/src/path.rs
+++ b/crates/loonfs-api/src/path.rs
@@ -27,7 +27,8 @@ string_id! {
     /// User-facing spelling of one path component.
     DisplayName,
     error = PathError,
-    validate = validate_display_name
+    validate = validate_display_name,
+    schema(example = "report.txt")
 }
 
 /// Maximum stored display-name length in UTF-8 bytes: the 255-byte
@@ -271,12 +272,17 @@ impl fmt::Display for AbsolutePath {
 
 #[cfg(feature = "openapi")]
 impl utoipa::PartialSchema for AbsolutePath {
+    #[allow(
+        deprecated,
+        reason = "the published schema uses the requested singular example field"
+    )]
     fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
         utoipa::openapi::schema::Object::builder()
             .schema_type(utoipa::openapi::schema::Type::String)
             .description(Some(
                 "Validated complete absolute namespace path, serialized as a plain string.",
             ))
+            .example(Some(serde_json::json!("/docs/report.txt")))
             .into()
     }
 }

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -85,8 +85,8 @@ pub enum FilesystemChange {
         to_display_name: DisplayName,
     },
     /// A file or directory subtree was deleted. The enclosing change's
-    /// `seq` is the deletion generation an undelete request passes as
-    /// `deleted_at_seq`.
+    /// `committed_seq` is the deletion generation an undelete request passes
+    /// as `deleted_at_seq`.
     #[cfg_attr(feature = "openapi", schema(title = "FilesystemChangeDeleted"))]
     Deleted {
         /// Inode at the root of the deleted subtree.
@@ -128,11 +128,11 @@ pub enum FilesystemChange {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CommittedChange {
     /// Namespace sequence for this logical commit.
-    pub seq: ChangeSeq,
+    pub committed_seq: ChangeSeq,
     /// Client idempotency key for this logical commit.
     pub commit_id: CommitId,
     /// Wall-clock stamp of the commit, in Unix milliseconds.
-    /// Observational: `seq` is the order.
+    /// Observational: `committed_seq` is the order.
     pub committed_at_ms: u64,
     /// Caller annotation, omitted when absent and carrying no filesystem semantics.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -562,7 +562,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             for change in &response.changes {
                 lines.push(format!(
                     "{}\t{}\t{}\t{}",
-                    change.seq.0,
+                    change.committed_seq.0,
                     format_utc_ms(change.committed_at_ms),
                     event_summary(&change.events),
                     change.message.as_deref().unwrap_or("-")

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -5127,8 +5127,8 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert!(changes_data["next_after_seq"].is_null());
         let listed = changes_data["changes"].as_array().expect("json array");
         assert_eq!(listed.len(), 2);
-        assert_eq!(listed[0]["seq"], 1);
-        assert_eq!(listed[1]["seq"], 2);
+        assert_eq!(listed[0]["committed_seq"], 1);
+        assert_eq!(listed[1]["committed_seq"], 2);
         assert!(listed[0]["commit_id"]
             .as_str()
             .expect("json string")
@@ -5145,7 +5145,7 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
             paged_data["changes"].as_array().expect("json array").len(),
             1
         );
-        assert_eq!(paged_data["changes"][0]["seq"], 1);
+        assert_eq!(paged_data["changes"][0]["committed_seq"], 1);
         assert_eq!(paged_data["next_after_seq"], 1);
 
         let resumed = harness.run(&["--json", "changes", "--profile", profile, "--after", "1"]);
@@ -5159,7 +5159,7 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
                 .len(),
             1
         );
-        assert_eq!(resumed_data["changes"][0]["seq"], 2);
+        assert_eq!(resumed_data["changes"][0]["committed_seq"], 2);
 
         let checkpoint = harness.run(&[
             "--json",

--- a/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/manifest_round_trips.rs
@@ -315,7 +315,7 @@ async fn maintenance_and_status_do_not_make_orphan_wal_visible() {
 
     assert_eq!(changes.through_seq, ChangeSeq(2));
     assert_eq!(changes.changes.len(), 1);
-    assert_eq!(changes.changes[0].seq, ChangeSeq(2));
+    assert_eq!(changes.changes[0].committed_seq, ChangeSeq(2));
 }
 
 #[tokio::test]

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -73,7 +73,7 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
             if record.seq > after_seq {
                 let seq = record.seq;
                 changes.push(CommittedChange {
-                    seq,
+                    committed_seq: seq,
                     commit_id: record.commit_id.clone(),
                     committed_at_ms: record.committed_at_ms,
                     message: record.message.clone(),

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -1093,7 +1093,7 @@ async fn a_copy_to_a_vacant_destination_inherits_the_sources_attributes() {
         .expect("read the change feed")
         .changes
         .into_iter()
-        .find(|change| change.seq == response.committed_seq)
+        .find(|change| change.committed_seq == response.committed_seq)
         .expect("the copy's commit")
         .events
         .iter()

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -475,7 +475,7 @@ async fn fork_namespace_reuses_content_store_and_isolates_metadata() {
         .await
         .expect("clone changes");
     assert_eq!(clone_changes.changes.len(), 1);
-    assert_eq!(clone_changes.changes[0].seq, ChangeSeq(2));
+    assert_eq!(clone_changes.changes[0].committed_seq, ChangeSeq(2));
 
     // The target's own first flush inherits the source's tables by
     // reference and adds only its own delta run.

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -455,15 +455,18 @@ async fn tail_revisions(reads: &NamespaceReads<'_>, resume: ChangeFeedResume) ->
             .list_changes_after(after_seq, TAIL_FEED_PAGE_COMMITS)
             .await?;
         for change in &feed.changes {
-            let start_event_index = resume.start_event_index(change.seq).map_err(|_| {
-                CoreError::Internal("grep event cursor does not fit in memory".to_owned())
-            })?;
+            let start_event_index =
+                resume
+                    .start_event_index(change.committed_seq)
+                    .map_err(|_| {
+                        CoreError::Internal("grep event cursor does not fit in memory".to_owned())
+                    })?;
             if start_event_index > change.events.len() {
                 let next_event_index = resume.next_event_index();
                 return Err(GrepError::CorruptIndex {
                     message: format!(
                         "grep event cursor `{next_event_index}` exceeds commit `{}` length `{}`",
-                        change.seq,
+                        change.committed_seq,
                         change.events.len()
                     ),
                 });

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -863,15 +863,17 @@ async fn collect_incremental_unit(
     let mut planned_content_bytes = 0u64;
     let mut examined_files = 0usize;
     'changes: for change in feed.changes {
-        let start_event_index = resume.start_event_index(change.seq).map_err(|_| {
-            CoreError::Internal("grep event cursor does not fit in memory".to_owned())
-        })?;
+        let start_event_index = resume
+            .start_event_index(change.committed_seq)
+            .map_err(|_| {
+                CoreError::Internal("grep event cursor does not fit in memory".to_owned())
+            })?;
         if start_event_index > change.events.len() {
             return Err(GrepError::CorruptIndex {
                 message: format!(
                     "grep event cursor `{}` exceeds commit `{}` length `{}`",
                     resume.next_event_index(),
-                    change.seq,
+                    change.committed_seq,
                     change.events.len()
                 ),
             });
@@ -885,8 +887,8 @@ async fn collect_incremental_unit(
                     > policy.max_content_bytes_per_step.get();
             if examined_files >= policy.max_files_per_step.get() || would_exceed_content_budget {
                 if event_index > 0 {
-                    collected_through_seq = change.seq;
-                    run_seq = change.seq;
+                    collected_through_seq = change.committed_seq;
+                    run_seq = change.committed_seq;
                     collected_next_event_index = u32::try_from(event_index).map_err(|_| {
                         CoreError::Internal("grep event cursor overflow".to_owned())
                     })?;
@@ -907,8 +909,8 @@ async fn collect_incremental_unit(
             if examined_files >= policy.max_files_per_step.get()
                 || planned_content_bytes >= policy.max_content_bytes_per_step.get()
             {
-                collected_through_seq = change.seq;
-                run_seq = change.seq;
+                collected_through_seq = change.committed_seq;
+                run_seq = change.committed_seq;
                 let next_event_index = event_index
                     .checked_add(1)
                     .ok_or_else(|| CoreError::Internal("grep event cursor overflow".to_owned()))?;
@@ -922,8 +924,8 @@ async fn collect_incremental_unit(
                 break 'changes;
             }
         }
-        collected_through_seq = change.seq;
-        run_seq = change.seq;
+        collected_through_seq = change.committed_seq;
+        run_seq = change.committed_seq;
         collected_next_event_index = 0;
     }
     if collected_through_seq == built_through_seq && collected_next_event_index == next_event_index

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -115,7 +115,6 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         loonfs_api::v0::DirectMultipartContentClaim,
         loonfs_api::v0::DirectMultipartUploadOptions,
         loonfs_api::NamespaceId,
-        loonfs_api::ContentStoreId,
         loonfs_api::CommitId,
         InodeId,
         RevisionNo,

--- a/crates/loonfs-server/tests/it/http_commits.rs
+++ b/crates/loonfs-server/tests/it/http_commits.rs
@@ -44,7 +44,7 @@ fn change_identity(change: &CommittedChange) -> (ChangeSeq, String, Option<Strin
         }
     }
     (
-        change.seq,
+        change.committed_seq,
         change.commit_id.to_string(),
         change.message.clone(),
         events.to_string(),

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -335,7 +335,7 @@ async fn http_restore_revision_appends_new_head_and_reports_change() {
         second_page
             .changes
             .iter()
-            .map(|change| change.seq)
+            .map(|change| change.committed_seq)
             .collect::<Vec<_>>(),
         vec![ChangeSeq(3)]
     );

--- a/crates/loonfs-server/tests/it/http_retry.rs
+++ b/crates/loonfs-server/tests/it/http_retry.rs
@@ -283,7 +283,7 @@ async fn http_put_conflict_stands_when_only_the_message_changed() {
     let committed = changes
         .changes
         .iter()
-        .find(|change| change.seq == first.committed_seq)
+        .find(|change| change.committed_seq == first.committed_seq)
         .expect("the committed change is on the feed");
     assert_eq!(
         committed.message.as_deref(),

--- a/crates/loonfs-server/tests/it/http_smoke.rs
+++ b/crates/loonfs-server/tests/it/http_smoke.rs
@@ -439,7 +439,7 @@ async fn http_namespace_fork_shares_content_and_diverges() {
         .await
         .expect("clone changes");
     assert_eq!(clone_changes.changes.len(), 1);
-    assert_eq!(clone_changes.changes[0].seq, ChangeSeq(2));
+    assert_eq!(clone_changes.changes[0].committed_seq, ChangeSeq(2));
 
     harness.server.abort();
 }

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -235,7 +235,7 @@ async fn http_upload_commit_and_change_feed_are_idempotent() {
     assert_eq!(changes.through_seq, commit.committed_seq);
     assert_eq!(changes.changes.len(), 1);
     let change = &changes.changes[0];
-    assert_eq!(change.seq, commit.committed_seq);
+    assert_eq!(change.committed_seq, commit.committed_seq);
     assert_eq!(change.commit_id, commit.commit_id);
     assert_eq!(change.commit_id, put_request.commit_id);
     assert_eq!(change.message.as_deref(), Some("upload over http"));

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -149,6 +149,30 @@ fn openapi_names_tagged_one_of_alternatives() {
 }
 
 #[test]
+fn openapi_documents_string_id_contracts_without_dead_schemas() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let schemas = spec
+        .get("components")
+        .and_then(|components| components.get("schemas"))
+        .and_then(Value::as_object)
+        .expect("openapi schemas object");
+    let content_id = schemas.get("ContentId").expect("ContentId schema");
+
+    assert_eq!(
+        content_id.get("pattern").and_then(Value::as_str),
+        Some(r"^con_[0-9a-f]{32}$")
+    );
+    assert_eq!(
+        content_id.get("example").and_then(Value::as_str),
+        Some("con_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41")
+    );
+    assert!(!schemas.contains_key("ContentStoreId"));
+}
+
+#[test]
 fn openapi_documents_delete_path_behavior() {
     let spec: Value = serde_json::from_str(
         &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),

--- a/crates/loonfs/tests/it/commit_retry.rs
+++ b/crates/loonfs/tests/it/commit_retry.rs
@@ -61,7 +61,7 @@ async fn feed_message(
         .expect("list changes");
     page.changes
         .into_iter()
-        .find(|change| change.seq == seq)
+        .find(|change| change.committed_seq == seq)
         .expect("the committed change is on the feed")
         .message
 }

--- a/crates/loonfs/tests/it/undelete.rs
+++ b/crates/loonfs/tests/it/undelete.rs
@@ -477,7 +477,7 @@ fn change_feed_reports_the_deletion_generation_an_undelete_takes() {
                     inode_id: deleted_inode_id,
                     ..
                 } if *deleted_inode_id == inode_id => {
-                    deleted_seq = Some(change.seq);
+                    deleted_seq = Some(change.committed_seq);
                 }
                 loonfs::FilesystemChange::Undeleted {
                     inode_id: undeleted_inode_id,

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2061,7 +2061,7 @@ presign writes either, no file it holds can be larger than it will proxy.
 
 ### 6.11 `GET /changes`
 
-Each change is one commit carrying its identity (`seq`, `commit_id`,
+Each change is one commit carrying its identity (`committed_seq`, `commit_id`,
 observational `committed_at_ms`, optional `message`) and `events`: the
 semantic filesystem operations the commit
 applied, in the order it applied them. One request operation may apply
@@ -2077,7 +2077,7 @@ more than three events. The events stay in request order.
   "through_seq": 419,
   "changes": [
     {
-      "seq": 419,
+      "committed_seq": 419,
       "commit_id": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
       "committed_at_ms": 1752624000000,
       "message": "replace report bytes",
@@ -2107,7 +2107,7 @@ Event kinds:
 | `created` | A file or directory was created. | `inode_id`, `inode_kind`, `parent_inode_id`, `display_name`; file creations also carry `revision_no` and `content_ref`. |
 | `content_changed` | A file received a new current revision — a replacing put or a revision restore (one durable fact for both). | `inode_id`, `revision_no`, `content_ref`. |
 | `moved` | An entry moved to a new parent directory or name. | `inode_id`, `from_parent_inode_id`, `from_display_name`, `to_parent_inode_id`, `to_display_name`. |
-| `deleted` | A file or directory subtree was deleted. The enclosing change's `seq` is the `deleted_at_seq` an undelete passes. | `inode_id`, plus optional `deleted_direntry` containing `parent_inode_id`, `name_key`, and `display_name`. |
+| `deleted` | A file or directory subtree was deleted. The enclosing change's `committed_seq` is the `deleted_at_seq` an undelete passes. | `inode_id`, plus optional `deleted_direntry` containing `parent_inode_id`, `name_key`, and `display_name`. |
 | `undeleted` | A deleted inode was recovered and re-bound. | `inode_id`, `parent_inode_id`, `display_name`. |
 | `attributes_changed` | An inode's attributes changed. `attributes` is the complete flat string map after the update, so a consumer projects it without reading anything back; an empty map is the cleared state. | `inode_id`, `attributes_revision_no`, `attributes`. |
 
@@ -2117,8 +2117,8 @@ binding projection from this feed. Clients must ignore unknown event kinds
 and unknown fields.
 
 If `limit` truncates the page before the namespace head, the response includes
-`next_after_seq` set to the last returned change seq. The client resumes with
-`after_seq={next_after_seq}`.
+`next_after_seq` set to the last returned change's `committed_seq`. The client
+resumes with `after_seq={next_after_seq}`.
 
 ### 6.12 `POST /forks`
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2810,7 +2810,8 @@
       },
       "AbsolutePath": {
         "type": "string",
-        "description": "Validated complete absolute namespace path, serialized as a plain string."
+        "description": "Validated complete absolute namespace path, serialized as a plain string.",
+        "example": "/docs/report.txt"
       },
       "AdvanceRetentionResponse": {
         "type": "object",
@@ -2870,7 +2871,8 @@
       },
       "AttributeKey": {
         "type": "string",
-        "description": "Validated name of one inode attribute.\n\nA key is 1 to 128 UTF-8 bytes and carries no Unicode control\ncharacter, which is also what rejects NUL. Keys are compared exactly:\nnothing case-folds or normalizes them, so two spellings that differ in\nany byte name two different attributes.\n\nThe `loonfs.` prefix is reserved for system-owned attributes. This\ntype accepts a reserved key, because a durable row has to be able to\ncarry a system attribute. The write operation is where a caller's\nattempt to write a reserved key is rejected."
+        "description": "Validated name of one inode attribute.\n\nA key is 1 to 128 UTF-8 bytes and carries no Unicode control\ncharacter, which is also what rejects NUL. Keys are compared exactly:\nnothing case-folds or normalizes them, so two spellings that differ in\nany byte name two different attributes.\n\nThe `loonfs.` prefix is reserved for system-owned attributes. This\ntype accepts a reserved key, because a durable row has to be able to\ncarry a system attribute. The write operation is where a caller's\nattempt to write a reserved key is rejected.",
+        "example": "owner"
       },
       "AttributeRevisionNo": {
         "type": "integer",
@@ -2880,7 +2882,8 @@
       },
       "AttributeValue": {
         "type": "string",
-        "description": "One validated attribute value.\n\nA value is at most [`MAX_ATTRIBUTE_VALUE_BYTES`] UTF-8 bytes. It is\notherwise free text: control characters and the empty string are legal.\nEmpty is a stored value, not a tombstone; only an explicit remove\noperation deletes an attribute."
+        "description": "One validated attribute value.\n\nA value is at most [`MAX_ATTRIBUTE_VALUE_BYTES`] UTF-8 bytes. It is\notherwise free text: control characters and the empty string are legal.\nEmpty is a stored value, not a tombstone; only an explicit remove\noperation deletes an attribute.",
+        "example": "platform"
       },
       "Attributes": {
         "type": "object",
@@ -3353,7 +3356,9 @@
       },
       "CheckpointId": {
         "type": "string",
-        "description": "Durable checkpoint identifier.\n\nA checkpoint is a durable bookmark to a namespace manifest version."
+        "description": "Durable checkpoint identifier.\n\nA checkpoint is a durable bookmark to a namespace manifest version.",
+        "example": "chk_00000000000000000000000000000002",
+        "pattern": "^chk_[0-9a-f]{32}$"
       },
       "CheckpointOwnerSummary": {
         "oneOf": [
@@ -3457,7 +3462,9 @@
       },
       "CommitId": {
         "type": "string",
-        "description": "Client-supplied idempotency key for one logical commit.\n\nReuse the same `CommitId` when retrying the same request."
+        "description": "Client-supplied idempotency key for one logical commit.\n\nReuse the same `CommitId` when retrying the same request. The accepted\ngrammar is 1 to 128 lowercase ASCII letters, digits, dots, underscores,\nor hyphens, starting with a letter or digit. [`CommitId::generate`] mints\n`c_<32 lowercase hex>`, but callers may supply any value in that grammar.",
+        "example": "c_f3a9c2d4b6e8417a90c5d2f8e1b7a6c0",
+        "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
       },
       "CommitRequest": {
         "type": "object",
@@ -3522,7 +3529,7 @@
         "type": "object",
         "description": "One committed change in namespace order.",
         "required": [
-          "seq",
+          "committed_seq",
           "commit_id",
           "committed_at_ms",
           "events"
@@ -3535,8 +3542,12 @@
           "committed_at_ms": {
             "type": "integer",
             "format": "int64",
-            "description": "Wall-clock stamp of the commit, in Unix milliseconds.\nObservational: `seq` is the order.",
+            "description": "Wall-clock stamp of the commit, in Unix milliseconds.\nObservational: `committed_seq` is the order.",
             "minimum": 0
+          },
+          "committed_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Namespace sequence for this logical commit."
           },
           "events": {
             "type": "array",
@@ -3551,10 +3562,6 @@
               "null"
             ],
             "description": "Caller annotation, omitted when absent and carrying no filesystem semantics."
-          },
-          "seq": {
-            "$ref": "#/components/schemas/ChangeSeq",
-            "description": "Namespace sequence for this logical commit."
           }
         }
       },
@@ -3671,7 +3678,9 @@
       },
       "ContentId": {
         "type": "string",
-        "description": "Durable identity of one immutable content object.\n\nThe body is 128 fully random bits, with no time component: content\nobject keys shard on the id's leading characters, and a clock-derived\nprefix would put every upload in one window into one shard. The id\nnames *which object*, never what it contains — integrity evidence\nrides [`crate::ContentRef`] beside it."
+        "description": "Durable identity of one immutable content object.\n\nThe body is 128 fully random bits, with no time component: content\nobject keys shard on the id's leading characters, and a clock-derived\nprefix would put every upload in one window into one shard. The id\nnames *which object*, never what it contains — integrity evidence\nrides [`crate::ContentRef`] beside it.",
+        "example": "con_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41",
+        "pattern": "^con_[0-9a-f]{32}$"
       },
       "ContentRef": {
         "type": "object",
@@ -3710,10 +3719,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "ContentStoreId": {
-        "type": "string",
-        "description": "Durable id for an immutable content store.\n\nContent stores own file bytes. Namespaces point at content stores."
       },
       "CreateCheckpointRequest": {
         "type": "object",
@@ -3969,7 +3974,8 @@
       },
       "DisplayName": {
         "type": "string",
-        "description": "User-facing spelling of one path component."
+        "description": "User-facing spelling of one path component.",
+        "example": "report.txt"
       },
       "EnableGrepIndexResponse": {
         "type": "object",
@@ -4367,7 +4373,7 @@
           {
             "type": "object",
             "title": "FilesystemChangeDeleted",
-            "description": "A file or directory subtree was deleted. The enclosing change's\n`seq` is the deletion generation an undelete request passes as\n`deleted_at_seq`.",
+            "description": "A file or directory subtree was deleted. The enclosing change's\n`committed_seq` is the deletion generation an undelete request passes\nas `deleted_at_seq`.",
             "required": [
               "inode_id",
               "kind"
@@ -4744,7 +4750,8 @@
                 },
                 "propertyNames": {
                   "type": "string",
-                  "description": "Validated name of one inode attribute.\n\nA key is 1 to 128 UTF-8 bytes and carries no Unicode control\ncharacter, which is also what rejects NUL. Keys are compared exactly:\nnothing case-folds or normalizes them, so two spellings that differ in\nany byte name two different attributes.\n\nThe `loonfs.` prefix is reserved for system-owned attributes. This\ntype accepts a reserved key, because a durable row has to be able to\ncarry a system attribute. The write operation is where a caller's\nattempt to write a reserved key is rejected."
+                  "description": "Validated name of one inode attribute.\n\nA key is 1 to 128 UTF-8 bytes and carries no Unicode control\ncharacter, which is also what rejects NUL. Keys are compared exactly:\nnothing case-folds or normalizes them, so two spellings that differ in\nany byte name two different attributes.\n\nThe `loonfs.` prefix is reserved for system-owned attributes. This\ntype accepts a reserved key, because a durable row has to be able to\ncarry a system attribute. The write operation is where a caller's\nattempt to write a reserved key is rejected.",
+                  "example": "owner"
                 }
               }
             }
@@ -5513,11 +5520,14 @@
       },
       "NameKey": {
         "type": "string",
-        "description": "Name-policy-derived directory entry key.\n\nUse this for exact name preconditions. Keep user-facing spelling in\n`DisplayName`."
+        "description": "Name-policy-derived directory entry key.\n\nUse this for exact name preconditions. Keep user-facing spelling in\n`DisplayName`.",
+        "example": "report.txt"
       },
       "NamespaceId": {
         "type": "string",
-        "description": "Durable id for one namespace.\n\nA namespace is one filesystem history. This id is not a display name and\nshould not be reused after destruction."
+        "description": "Durable id for one namespace.\n\nA namespace is one filesystem history. This id is not a display name and\nshould not be reused after destruction. Its serialized form is 1 to 128\nlowercase ASCII letters, digits, dots, underscores, or hyphens, starting\nwith a letter or digit; the `loonfs-` prefix is reserved for system use.",
+        "example": "demo",
+        "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
       },
       "NamespaceStatusResponse": {
         "type": "object",
@@ -6056,7 +6066,9 @@
       },
       "UploadId": {
         "type": "string",
-        "description": "Durable id for one upload session."
+        "description": "Durable id for one upload session.",
+        "example": "upl_4d8f2c91a7b34e0f9c6d1a2b3e5f708c",
+        "pattern": "^upl_[0-9a-f]{32}$"
       },
       "UploadPartChecksumClaim": {
         "type": "object",


### PR DESCRIPTION
Rename the sequence field on each change-feed entry from `seq` to `committed_seq`, matching the commit response and distinguishing the committed change from paging fields such as `after_seq`, `through_seq`, and `next_after_seq`. Apply the new name across the public API, core change processing, grep indexing, client and CLI output, tests, and documentation.

Expose validation rules and useful examples for public string identifiers in the OpenAPI schema. Generated content, checkpoint, and upload IDs now include their required prefix and lowercase hexadecimal pattern. Namespace and commit IDs include their shared character and length rules, while paths, display names, name keys, attribute keys, and attribute values include representative examples without claiming stricter validation than the implementation provides.

Remove the unused `ContentStoreId` OpenAPI component and regenerate the checked-in specification. Add coverage that verifies identifier patterns and examples reach the generated schema and that unused components do not return.