### PR TITLE
chore(release): script the prep and tap bump, write the runbook

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,13 +72,9 @@ The script uses the release checksums to update the formula in the tap checkout
 (`../homebrew-tap` by default). Review the printed diff, then commit and push
 the tap change as `chore: update to vX.Y.Z`.
 
-## 5. Update the site
+## 5. Update the website
 
-In `loonfs_www`, re-vendor the spec the site renders and open a PR:
-
-```sh
-npm run sync:openapi
-```
+Update the API reference website through its private release process.
 
 ## 6. Verify the release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing LoonFS
 
-One release ships, under one version:
+Each release uses one version for these artifacts:
 
 - four CLI archives and their `SHA256SUMS` on the GitHub release
 - the server image `ghcr.io/loonfs/loonfs-server:vX.Y.Z` (linux/amd64 and linux/arm64)
@@ -9,48 +9,47 @@ One release ships, under one version:
 - the Homebrew formula `loonfs/tap/loonfs`
 - the API reference on [loonfs.com](https://loonfs.com)
 
-The GitHub release is the trigger. Publishing it runs
-`.github/workflows/release-loonfs.yml`, which refuses a tag that disagrees
-with the workspace or chart version, then builds and publishes everything
-above except crates.io, the tap, and the site — those are the manual steps
-that follow.
+Publishing a GitHub release starts `.github/workflows/release-loonfs.yml`.
+The workflow verifies that the tag matches the workspace and chart versions,
+then builds and publishes the CLI archives, server image, and Helm chart.
+Publishing crates, updating the Homebrew tap, and updating the website are
+manual steps.
 
 ## 1. Prepare the version
 
-From a branch cut off a clean, green main:
+Start from a clean branch based on `main` after CI passes:
 
 ```sh
 scripts/prepare-release.sh --version X.Y.Z
 ```
 
-The script rewrites every file that names the version — `Cargo.toml`
-(`workspace.package.version` and the pinned registry versions of the
-published crates), the server chart, and the regenerated OpenAPI spec —
-refreshes `Cargo.lock`, and then verifies the checkout with the same checks
-the release workflow runs against the tag, including the spec-lock test.
+The script updates `workspace.package.version` and the pinned registry
+versions in `Cargo.toml`, updates the server chart, regenerates the OpenAPI
+specification, and refreshes `Cargo.lock`. It then runs the version checks and
+OpenAPI specification test that the release workflow runs for the tag.
 
-Commit the result as `chore(release): prepare vX.Y.Z`, open a PR, and merge
-it. CI on the PR is the real gate; the script only catches drift early.
+Commit the result as `chore(release): prepare vX.Y.Z` and open a PR. Merge it
+only after the normal PR checks pass.
 
 ## 2. Publish the GitHub release
 
-Draft the notes first: a few curated highlights up top, then the generated
-PR list for the long tail:
+Write the release notes before publishing. Start with a short summary of the
+important changes, followed by the generated PR list:
 
 ```sh
 gh api repos/loonfs/loonfs/releases/generate-notes -f tag_name=vX.Y.Z --jq .body
 ```
 
-Then create the release on the merged main. Creating it publishes it, and
-publishing is what starts the workflow:
+Create the release from the updated `main` branch. This command publishes the
+release and starts the release workflow:
 
 ```sh
 gh release create vX.Y.Z --target main --title "LoonFS vX.Y.Z" --notes-file notes.md
 ```
 
-Watch the run with `gh run watch`, then confirm the release page carries the
-four archives, `SHA256SUMS`, and `ARTIFACTS.txt`. `ARTIFACTS.txt` records
-the image and chart digests the release published.
+Watch the workflow with `gh run watch`. After it completes, confirm that the
+release contains the four archives, `SHA256SUMS`, and `ARTIFACTS.txt`. The
+`ARTIFACTS.txt` file contains the published image and chart digests.
 
 ## 3. Publish the crates
 
@@ -69,9 +68,9 @@ is: `loonfs-api`, `loonfs-objectstore`, `loonfs-client`, `loonfs-core`,
 scripts/bump-homebrew-tap.sh --version X.Y.Z
 ```
 
-The script rewrites the formula in the tap checkout (`../homebrew-tap` by
-default) from the release's published checksums. Review the diff it prints,
-then commit and push in the tap as `chore: update to vX.Y.Z`.
+The script uses the release checksums to update the formula in the tap checkout
+(`../homebrew-tap` by default). Review the printed diff, then commit and push
+the tap change as `chore: update to vX.Y.Z`.
 
 ## 5. Update the site
 
@@ -81,10 +80,11 @@ In `loonfs_www`, re-vendor the spec the site renders and open a PR:
 npm run sync:openapi
 ```
 
-## 6. Prove the release
+## 6. Verify the release
 
-- `curl -fsSL https://install.loonfs.com | sh` installs a binary that
-  reports `X.Y.Z` — the installer resolves the latest release on its own.
-- `brew install loonfs/tap/loonfs` (or `brew upgrade loonfs`) lands `X.Y.Z`.
-- `docker pull ghcr.io/loonfs/loonfs-server:vX.Y.Z` resolves to the digest
-  `ARTIFACTS.txt` records.
+- `curl -fsSL https://install.loonfs.com | sh` installs a binary that reports
+  `X.Y.Z`. The installer selects the latest release automatically.
+- `brew install loonfs/tap/loonfs` (or `brew upgrade loonfs`) installs
+  `X.Y.Z`.
+- `docker pull ghcr.io/loonfs/loonfs-server:vX.Y.Z` downloads the digest
+  recorded in `ARTIFACTS.txt`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,90 @@
+# Releasing LoonFS
+
+One release ships, under one version:
+
+- four CLI archives and their `SHA256SUMS` on the GitHub release
+- the server image `ghcr.io/loonfs/loonfs-server:vX.Y.Z` (linux/amd64 and linux/arm64)
+- the Helm chart at `oci://ghcr.io/loonfs/charts/loonfs-server`
+- the published workspace crates on crates.io
+- the Homebrew formula `loonfs/tap/loonfs`
+- the API reference on [loonfs.com](https://loonfs.com)
+
+The GitHub release is the trigger. Publishing it runs
+`.github/workflows/release-loonfs.yml`, which refuses a tag that disagrees
+with the workspace or chart version, then builds and publishes everything
+above except crates.io, the tap, and the site — those are the manual steps
+that follow.
+
+## 1. Prepare the version
+
+From a branch cut off a clean, green main:
+
+```sh
+scripts/prepare-release.sh --version X.Y.Z
+```
+
+The script rewrites every file that names the version — `Cargo.toml`
+(`workspace.package.version` and the pinned registry versions of the
+published crates), the server chart, and the regenerated OpenAPI spec —
+refreshes `Cargo.lock`, and then verifies the checkout with the same checks
+the release workflow runs against the tag, including the spec-lock test.
+
+Commit the result as `chore(release): prepare vX.Y.Z`, open a PR, and merge
+it. CI on the PR is the real gate; the script only catches drift early.
+
+## 2. Publish the GitHub release
+
+Draft the notes first: a few curated highlights up top, then the generated
+PR list for the long tail:
+
+```sh
+gh api repos/loonfs/loonfs/releases/generate-notes -f tag_name=vX.Y.Z --jq .body
+```
+
+Then create the release on the merged main. Creating it publishes it, and
+publishing is what starts the workflow:
+
+```sh
+gh release create vX.Y.Z --target main --title "LoonFS vX.Y.Z" --notes-file notes.md
+```
+
+Watch the run with `gh run watch`, then confirm the release page carries the
+four archives, `SHA256SUMS`, and `ARTIFACTS.txt`. `ARTIFACTS.txt` records
+the image and chart digests the release published.
+
+## 3. Publish the crates
+
+```sh
+cargo publish --workspace
+```
+
+Cargo publishes the publishable crates in dependency order and skips the
+`publish = false` ones. If publishing one crate at a time instead, the order
+is: `loonfs-api`, `loonfs-objectstore`, `loonfs-client`, `loonfs-core`,
+`loonfs`, `loonfs-grep`, `loonfs-cli`.
+
+## 4. Update the Homebrew tap
+
+```sh
+scripts/bump-homebrew-tap.sh --version X.Y.Z
+```
+
+The script rewrites the formula in the tap checkout (`../homebrew-tap` by
+default) from the release's published checksums. Review the diff it prints,
+then commit and push in the tap as `chore: update to vX.Y.Z`.
+
+## 5. Update the site
+
+In `loonfs_www`, re-vendor the spec the site renders and open a PR:
+
+```sh
+npm run sync:openapi
+```
+
+## 6. Prove the release
+
+- `curl -fsSL https://install.loonfs.com | sh` installs a binary that
+  reports `X.Y.Z` — the installer resolves the latest release on its own.
+- `brew install loonfs/tap/loonfs` (or `brew upgrade loonfs`) lands `X.Y.Z`.
+- `docker pull ghcr.io/loonfs/loonfs-server:vX.Y.Z` resolves to the digest
+  `ARTIFACTS.txt` records.

--- a/scripts/bump-homebrew-tap.sh
+++ b/scripts/bump-homebrew-tap.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: bump-homebrew-tap.sh --version <version> [--tap-dir <path>]
+
+Points the loonfs formula in the Homebrew tap at an already-published
+GitHub release: downloads the release's SHA256SUMS, rewrites the two
+macOS URLs, their checksums, and the explicit Intel version, and leaves
+the tap checkout for you to review, commit, and push.
+
+The tap checkout defaults to ../homebrew-tap next to this repository.
+EOF
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+version=""
+tap_dir=""
+sums_tmp=""
+
+cleanup() {
+    if [ -n "$sums_tmp" ] && [ -f "$sums_tmp" ]; then
+        rm -f "$sums_tmp"
+    fi
+}
+
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version)
+            [ "$#" -ge 2 ] || die "--version requires a value"
+            version="$2"
+            shift 2
+            ;;
+        --tap-dir)
+            [ "$#" -ge 2 ] || die "--tap-dir requires a value"
+            tap_dir="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+if [ -z "$version" ]; then
+    usage >&2
+    exit 1
+fi
+
+version="${version#v}"
+case "$version" in
+    [0-9]*.[0-9]*.[0-9]*) ;;
+    *) die "version must look like X.Y.Z, got: $version" ;;
+esac
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+if [ -z "$tap_dir" ]; then
+    tap_dir="$repo_root/../homebrew-tap"
+fi
+[ -d "$tap_dir" ] || die "no tap checkout at $tap_dir"
+tap_dir=$(CDPATH= cd -- "$tap_dir" && pwd)
+formula="$tap_dir/Formula/loonfs.rb"
+[ -f "$formula" ] || die "no formula at $formula"
+
+command -v gh >/dev/null || die "gh is required to read the release checksums"
+
+if [ -n "$(git -C "$tap_dir" status --porcelain)" ]; then
+    die "the tap checkout at $tap_dir has local changes"
+fi
+
+sums_tmp=$(mktemp "${TMPDIR:-/tmp}/loonfs-sha256sums.XXXXXX")
+gh release download "v$version" --repo loonfs/loonfs \
+    --pattern SHA256SUMS --output "$sums_tmp" --clobber
+
+arm_sha=$(awk '$2 == "loonfs-aarch64-apple-darwin.tar.gz" { print $1 }' "$sums_tmp")
+intel_sha=$(awk '$2 == "loonfs-x86_64-apple-darwin.tar.gz" { print $1 }' "$sums_tmp")
+echo "$arm_sha" | grep -Eq '^[0-9a-f]{64}$' \
+    || die "release v$version lists no checksum for the aarch64 macOS archive"
+echo "$intel_sha" | grep -Eq '^[0-9a-f]{64}$' \
+    || die "release v$version lists no checksum for the x86_64 macOS archive"
+
+# The formula names each archive once, with its checksum on the next
+# sha256 line, and pins the Intel version explicitly. Rewrite exactly
+# those lines and leave the rest of the formula alone.
+awk -v version="$version" -v arm_sha="$arm_sha" -v intel_sha="$intel_sha" '
+    function indent_of(line) {
+        match(line, /^ */)
+        return substr(line, 1, RLENGTH)
+    }
+    /url ".*loonfs-aarch64-apple-darwin\.tar\.gz"/ {
+        print indent_of($0) "url \"https://github.com/loonfs/loonfs/releases/download/v" version "/loonfs-aarch64-apple-darwin.tar.gz\""
+        pending = arm_sha
+        next
+    }
+    /url ".*loonfs-x86_64-apple-darwin\.tar\.gz"/ {
+        print indent_of($0) "url \"https://github.com/loonfs/loonfs/releases/download/v" version "/loonfs-x86_64-apple-darwin.tar.gz\""
+        pending = intel_sha
+        next
+    }
+    /^ *sha256 "/ && pending != "" {
+        print indent_of($0) "sha256 \"" pending "\""
+        pending = ""
+        next
+    }
+    /^ *version "/ {
+        print indent_of($0) "version \"" version "\""
+        next
+    }
+    { print }
+' "$formula" > "$formula.tmp"
+mv "$formula.tmp" "$formula"
+
+[ "$(grep -c "download/v$version/" "$formula")" -eq 2 ] \
+    || die "the rewritten formula does not name two v$version archives"
+grep -q "$arm_sha" "$formula" && grep -q "$intel_sha" "$formula" \
+    || die "the rewritten formula is missing a release checksum"
+if command -v ruby >/dev/null; then
+    ruby -c "$formula" >/dev/null || die "the rewritten formula is not valid Ruby"
+fi
+
+echo
+git -C "$tap_dir" --no-pager diff
+echo
+echo "next, in $tap_dir:"
+echo "  git add Formula/loonfs.rb"
+echo "  git commit -m \"chore: update to v$version\""
+echo "  git push"

--- a/scripts/bump-homebrew-tap.sh
+++ b/scripts/bump-homebrew-tap.sh
@@ -6,10 +6,10 @@ usage() {
     cat <<'EOF'
 Usage: bump-homebrew-tap.sh --version <version> [--tap-dir <path>]
 
-Points the loonfs formula in the Homebrew tap at an already-published
-GitHub release: downloads the release's SHA256SUMS, rewrites the two
-macOS URLs, their checksums, and the explicit Intel version, and leaves
-the tap checkout for you to review, commit, and push.
+Updates the LoonFS formula in the Homebrew tap for an existing GitHub
+release. The script downloads SHA256SUMS and updates the two macOS URLs,
+their checksums, and the explicit Intel version. It does not commit or
+push the changes.
 
 The tap checkout defaults to ../homebrew-tap next to this repository.
 EOF
@@ -93,9 +93,8 @@ echo "$arm_sha" | grep -Eq '^[0-9a-f]{64}$' \
 echo "$intel_sha" | grep -Eq '^[0-9a-f]{64}$' \
     || die "release v$version lists no checksum for the x86_64 macOS archive"
 
-# The formula names each archive once, with its checksum on the next
-# sha256 line, and pins the Intel version explicitly. Rewrite exactly
-# those lines and leave the rest of the formula alone.
+# Each archive URL is followed by its sha256 value. The Intel block also has
+# an explicit version. Update only these values.
 awk -v version="$version" -v arm_sha="$arm_sha" -v intel_sha="$intel_sha" '
     function indent_of(line) {
         match(line, /^ */)

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -6,9 +6,9 @@ usage() {
     cat <<'EOF'
 Usage: prepare-release.sh --version <version>
 
-Rewrites every file that names the workspace version, regenerates the
-OpenAPI spec, and refreshes Cargo.lock, then verifies the checkout the
-same way the release workflow will verify the tag:
+Updates the workspace version references, regenerates the OpenAPI
+specification, and refreshes Cargo.lock. It then runs the version and
+OpenAPI checks used by the release workflow:
 
   Cargo.toml               workspace.package.version and the pinned
                            versions of the published workspace crates
@@ -16,8 +16,8 @@ same way the release workflow will verify the tag:
   docs/specs/openapi.json  regenerated from the server
   Cargo.lock               refreshed by the regeneration build
 
-Run it on a branch cut from a clean, green main, commit the result as
-"chore(release): prepare v<version>", and follow RELEASING.md from there.
+Run it on a clean branch based on main after CI passes. Commit the result
+as "chore(release): prepare v<version>", then follow RELEASING.md.
 EOF
 }
 
@@ -79,8 +79,8 @@ current=$(awk '
 
 echo "bumping $current -> $version"
 
-# workspace.package.version, then the pinned registry versions of the
-# published workspace crates. RELEASING.md explains why both exist.
+# Update the workspace version and the pinned registry versions of the
+# published workspace crates. RELEASING.md explains why both are required.
 sed "/^\[workspace\.package\]$/,/^\[/ s/^version = \"$current\"\$/version = \"$version\"/
      s/\(^loonfs[a-z-]* = { path = \"crates\/[a-z-]*\", version = \"\)$current\(\" }\)\$/\1$version\2/" \
     Cargo.toml > Cargo.toml.tmp
@@ -96,11 +96,11 @@ sed "s/^version: .*\$/version: $version/
     "$chart" > "$chart.tmp"
 mv "$chart.tmp" "$chart"
 
-# The spec carries the version, so regenerate it rather than editing it.
-# This build also refreshes Cargo.lock for the bumped workspace crates.
+# Regenerate the specification because it includes the release version.
+# Cargo also refreshes Cargo.lock while building the OpenAPI generator.
 cargo run -p loonfs-server --features openapi --bin loonfs-openapi -- "$spec"
 
-# The same checks the release workflow's prepare job runs against the tag.
+# Run the version checks used by the release workflow.
 resolved=$(cargo pkgid -p loonfs-cli | sed 's/.*#//')
 [ "$resolved" = "$version" ] \
     || die "cargo resolves loonfs-cli to $resolved, expected $version"
@@ -115,7 +115,7 @@ app_version=$(sed -n 's/^appVersion: *//p' "$chart" | tr -d '"')
 grep -q "\"version\": \"$version\"" "$spec" \
     || die "regenerated spec does not carry version $version"
 
-# The spec-lock test, exactly as CI runs it.
+# Run the OpenAPI specification test with the same options used in CI.
 cargo test -p loonfs-server --features openapi --locked openapi
 
 echo

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+Usage: prepare-release.sh --version <version>
+
+Rewrites every file that names the workspace version, regenerates the
+OpenAPI spec, and refreshes Cargo.lock, then verifies the checkout the
+same way the release workflow will verify the tag:
+
+  Cargo.toml               workspace.package.version and the pinned
+                           versions of the published workspace crates
+  Chart.yaml               version and appVersion of the server chart
+  docs/specs/openapi.json  regenerated from the server
+  Cargo.lock               refreshed by the regeneration build
+
+Run it on a branch cut from a clean, green main, commit the result as
+"chore(release): prepare v<version>", and follow RELEASING.md from there.
+EOF
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+version=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version)
+            [ "$#" -ge 2 ] || die "--version requires a value"
+            version="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+if [ -z "$version" ]; then
+    usage >&2
+    exit 1
+fi
+
+case "$version" in
+    [0-9]*.[0-9]*.[0-9]*) ;;
+    *) die "version must look like X.Y.Z, got: $version" ;;
+esac
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+cd "$repo_root"
+
+chart="crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml"
+spec="docs/specs/openapi.json"
+
+git diff --quiet && git diff --cached --quiet \
+    || die "the working tree has changes; prepare a release from a clean checkout"
+
+if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+    die "tag v$version already exists"
+fi
+
+current=$(awk '
+    /^\[workspace\.package\]$/ { in_section = 1; next }
+    /^\[/ { in_section = 0 }
+    in_section && /^version = / { gsub(/"/, ""); print $3; exit }
+' Cargo.toml)
+[ -n "$current" ] || die "could not read workspace.package.version from Cargo.toml"
+[ "$current" != "$version" ] || die "the workspace is already at $version"
+
+echo "bumping $current -> $version"
+
+# workspace.package.version, then the pinned registry versions of the
+# published workspace crates. RELEASING.md explains why both exist.
+sed "/^\[workspace\.package\]$/,/^\[/ s/^version = \"$current\"\$/version = \"$version\"/
+     s/\(^loonfs[a-z-]* = { path = \"crates\/[a-z-]*\", version = \"\)$current\(\" }\)\$/\1$version\2/" \
+    Cargo.toml > Cargo.toml.tmp
+mv Cargo.toml.tmp Cargo.toml
+
+bumped=$(grep -c "version = \"$version\"" Cargo.toml) || true
+if [ "$bumped" -ne 7 ]; then
+    die "expected 7 versions in Cargo.toml to read $version (workspace.package plus 6 pinned crates), found $bumped"
+fi
+
+sed "s/^version: .*\$/version: $version/
+     s/^appVersion: .*\$/appVersion: \"$version\"/" \
+    "$chart" > "$chart.tmp"
+mv "$chart.tmp" "$chart"
+
+# The spec carries the version, so regenerate it rather than editing it.
+# This build also refreshes Cargo.lock for the bumped workspace crates.
+cargo run -p loonfs-server --features openapi --bin loonfs-openapi -- "$spec"
+
+# The same checks the release workflow's prepare job runs against the tag.
+resolved=$(cargo pkgid -p loonfs-cli | sed 's/.*#//')
+[ "$resolved" = "$version" ] \
+    || die "cargo resolves loonfs-cli to $resolved, expected $version"
+
+chart_version=$(sed -n 's/^version: *//p' "$chart" | tr -d '"')
+app_version=$(sed -n 's/^appVersion: *//p' "$chart" | tr -d '"')
+[ "$chart_version" = "$version" ] \
+    || die "chart version is $chart_version, expected $version"
+[ "$app_version" = "$version" ] \
+    || die "chart appVersion is $app_version, expected $version"
+
+grep -q "\"version\": \"$version\"" "$spec" \
+    || die "regenerated spec does not carry version $version"
+
+# The spec-lock test, exactly as CI runs it.
+cargo test -p loonfs-server --features openapi --locked openapi
+
+echo
+echo "prepared v$version:"
+git status --short
+echo
+echo "next: commit as \"chore(release): prepare v$version\" and follow RELEASING.md"


### PR DESCRIPTION
Add `scripts/prepare-release.sh` to update the workspace and published crate versions, update the Helm chart version, regenerate the OpenAPI specification, and refresh `Cargo.lock`. The script requires a clean checkout, rejects an existing release tag or unchanged version, verifies that the updated files agree, and runs the OpenAPI specification test used by the release workflow.

Add `scripts/bump-homebrew-tap.sh` to update the Homebrew formula after a GitHub release is published. It downloads the release checksums, updates the macOS archive URLs and checksums, updates the explicit Intel version, validates the result when Ruby is available, and prints the diff and follow-up commands without committing or pushing changes.

Add `RELEASING.md` with the complete release process: prepare and review the version change, publish the GitHub release, publish the crates, update Homebrew and the website, and verify the published artifacts. The guide identifies which steps are automated by the release workflow and which steps must be completed manually.