### PR TITLE
chore(release): prepare v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,7 +1368,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loonfs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ciborium",
  "crc32c",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "clap",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "futures",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-grep"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-model"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "loonfs-api",
  "serde",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-objectstore"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-sim"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "loonfs-test-support"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,9 @@ serde_bytes = "0.11"
 serde_json = { version = "1", features = ["raw_value"] }
 sha2 = "0.10"
 hmac = "0.12"
-# Published workspace crates need a registry version as well as a local path.
-# Keep these versions in lockstep with `workspace.package.version`.
+# Cargo requires published dependencies to include a registry version even
+# when they also have a local path. These versions must match
+# `workspace.package.version`.
 loonfs = { path = "crates/loonfs", version = "0.2.1" }
 loonfs-api = { path = "crates/loonfs-api", version = "0.2.1" }
 loonfs-client = { path = "crates/loonfs-client", version = "0.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 rust-version = "1.85"
 description = "Spec-locked object-store-backed file service"
@@ -67,12 +67,12 @@ sha2 = "0.10"
 hmac = "0.12"
 # Published workspace crates need a registry version as well as a local path.
 # Keep these versions in lockstep with `workspace.package.version`.
-loonfs = { path = "crates/loonfs", version = "0.2.0" }
-loonfs-api = { path = "crates/loonfs-api", version = "0.2.0" }
-loonfs-client = { path = "crates/loonfs-client", version = "0.2.0" }
-loonfs-core = { path = "crates/loonfs-core", version = "0.2.0" }
-loonfs-grep = { path = "crates/loonfs-grep", version = "0.2.0" }
-loonfs-objectstore = { path = "crates/loonfs-objectstore", version = "0.2.0" }
+loonfs = { path = "crates/loonfs", version = "0.2.1" }
+loonfs-api = { path = "crates/loonfs-api", version = "0.2.1" }
+loonfs-client = { path = "crates/loonfs-client", version = "0.2.1" }
+loonfs-core = { path = "crates/loonfs-core", version = "0.2.1" }
+loonfs-grep = { path = "crates/loonfs-grep", version = "0.2.1" }
+loonfs-objectstore = { path = "crates/loonfs-objectstore", version = "0.2.1" }
 # foyer reports its internal counters through this registry trait and does not
 # re-export it, so a host that wants to read them names the crate itself. The
 # version must stay the one foyer resolves, or the trait this workspace

--- a/crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml
@@ -4,5 +4,5 @@ description: The LoonFS server, one active process behind the v0 HTTP API.
 type: application
 # Both track the workspace version. The chart ships with the server it runs,
 # so a chart version names the server version it defaults to.
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"

--- a/crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: loonfs-server
 description: The LoonFS server, one active process behind the v0 HTTP API.
 type: application
-# Both track the workspace version. The chart ships with the server it runs,
-# so a chart version names the server version it defaults to.
+# Keep both values equal to `workspace.package.version`. `version` identifies
+# the chart package, and `appVersion` identifies the LoonFS server version.
 version: 0.2.1
 appVersion: "0.2.1"

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "identifier": "Apache-2.0"
     },
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "paths": {
     "/health": {


### PR DESCRIPTION
Prepare LoonFS 0.2.1 by updating `workspace.package.version` and the registry versions declared for each published workspace crate. Refresh `Cargo.lock` so all workspace packages record the new version.

Update the Helm chart `version` and `appVersion` fields and the version reported by the generated OpenAPI document. This is a release metadata change only; it does not change runtime behavior or API shapes.

Validate the updated metadata with locked Cargo metadata resolution and the server’s OpenAPI tests.