### PR TITLE
docs: specify actor attribution and the partner contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ loonfs use {namespace_id}
 ## Server deployment
 
 See [Self-hosting LoonFS](crates/loonfs-server/docs/self-hosting.md) for the
-complete deployment guide.
+complete deployment guide. Applications that submit changes on behalf of
+users should also read the [actor attribution partner guide](crates/loonfs-server/docs/actor-attribution.md).
 
 ## Documentation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,6 +36,14 @@ only after the normal PR checks pass.
 Write the release notes before publishing. Start with a short summary of the
 important changes, followed by the generated PR list:
 
+The next release must include this breaking-change entry:
+
+### Breaking changes
+
+- Every mutating request now requires `actor`. Durable formats changed in
+  place, with regenerated golden fixtures. Existing pre-release namespaces
+  must be recreated, not migrated.
+
 ```sh
 gh api repos/loonfs/loonfs/releases/generate-notes -f tag_name=vX.Y.Z --jq .body
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,14 +36,6 @@ only after the normal PR checks pass.
 Write the release notes before publishing. Start with a short summary of the
 important changes, followed by the generated PR list:
 
-The next release must include this breaking-change entry:
-
-### Breaking changes
-
-- Every mutating request now requires `actor`. Durable formats changed in
-  place, with regenerated golden fixtures. Existing pre-release namespaces
-  must be recreated, not migrated.
-
 ```sh
 gh api repos/loonfs/loonfs/releases/generate-notes -f tag_name=vX.Y.Z --jq .body
 ```

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -171,14 +171,20 @@ Reading
     exceeds the scan budget
 
 Writing
-  loonfs put <local-path|-> [remote-path] [-r] [--force] [--expected-revision <n>]
+  Every writing command accepts --actor-kind <user|service|system> together
+  with --actor-id <stable-id>. Flags override LOONFS_ACTOR_KIND and
+  LOONFS_ACTOR_ID, then the profile actor. Without any of them,
+  service/loonfs-cli identifies the tool, not the human running it.
+
+  loonfs put <local-path|-> [remote-path] [-r] [--force]
+             [--expected-revision <n>] [--actor-kind <kind> --actor-id <id>]
     Upload a local file, standard input when the local path is `-`, or with
     -r the directory tree rooted at the local path; --force replaces an
     existing destination, and --expected-revision replaces only while the
     file is still at that revision, so a raced write fails instead of
     stacking on it
 
-  loonfs mkdir <path> [-p]
+  loonfs mkdir <path> [-p] [--actor-kind <kind> --actor-id <id>]
     Create a directory; -p creates missing parents as well and succeeds when
     the directory is already there
 
@@ -186,6 +192,7 @@ Writing
                          [--attributes-json '<update>']
                          [--expected-inode-id <n>]
                          [--expected-attributes-revision <n>]
+                         [--actor-kind <kind> --actor-id <id>]
     Write and remove attributes on a file or directory. --set takes
     key=value and splits on the first `=`, --remove takes a key, and both
     repeat. A list value needs --attributes-json, which takes the whole
@@ -194,15 +201,17 @@ Writing
     refuse the update when the path has been rebound or the attributes have
     moved on
 
-  loonfs rm <path> [-r]
+  loonfs rm <path> [-r] [--actor-kind <kind> --actor-id <id>]
     Delete a file, or with -r a directory and everything under it as one
     commit; the output carries the handle `loonfs undelete` needs
 
   loonfs mv <source> <dest> [--force]
+            [--actor-kind <kind> --actor-id <id>]
     Move or rename a path, a directory included, in one commit; --force
     replaces an existing destination
 
   loonfs cp <source> <dest> [-r] [--force]
+            [--actor-kind <kind> --actor-id <id>]
     Copy a file, or with -r the directory tree rooted at the source;
     --force replaces an existing destination
 
@@ -211,6 +220,7 @@ History and recovery
     List a file's revision history newest first, one page at a time
 
   loonfs restore <path> --revision <n>
+                 [--actor-kind <kind> --actor-id <id>]
     Write a prior revision's content as the file's next revision
 
   loonfs trash [--limit <n>] [--cursor <cursor>]
@@ -218,6 +228,7 @@ History and recovery
     `loonfs undelete` command that recovers each one
 
   loonfs undelete [<path>] --inode <id> --deleted-at <seq>
+                  [--actor-kind <kind> --actor-id <id>]
     Recover a deleted file or directory; --inode and --deleted-at come from
     `loonfs trash` or the `rm` output and name one exact deletion, so a
     stale command cannot cancel a later delete. Omit <path> to restore in
@@ -359,6 +370,11 @@ Profile options
                                        certificate authorities to trust for
                                        an https server url
 
+  Mutation actor:
+    --actor-kind <user|service|system> optional, requires --actor-id
+    --actor-id <stable-id>             optional, requires --actor-kind
+    The default service/loonfs-cli identifies the tool, not the human.
+
 Update options
   Used by:
     loonfs profile update <name>
@@ -402,6 +418,10 @@ Update options
     --server-url <url>
     --auth-token <token>
     --ca-cert-path <path>
+
+  Mutation actor updates:
+    --actor-kind <user|service|system> requires --actor-id
+    --actor-id <stable-id>             requires --actor-kind
 
 Interrupted transfers
   A transfer killed part way is picked up by rerunning the same command.

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -347,6 +347,7 @@ pub(crate) struct TargetSelectorArgs {
 #[derive(Debug, Args, Clone)]
 pub(crate) struct ActorSelectorArgs {
     /// Actor kind for this mutation. Must be used with `--actor-id`.
+    /// Takes priority over the environment and profile values.
     #[arg(long, value_enum)]
     pub actor_kind: Option<ActorKindArg>,
     /// Actor ID for this mutation. Must be used with `--actor-kind`.

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -347,7 +347,7 @@ pub(crate) struct TargetSelectorArgs {
 #[derive(Debug, Args, Clone)]
 pub(crate) struct ActorSelectorArgs {
     /// Actor kind for this mutation. Must be used with `--actor-id`.
-    /// Takes priority over the environment and profile values.
+    /// Overrides actor values from the environment or profile.
     #[arg(long, value_enum)]
     pub actor_kind: Option<ActorKindArg>,
     /// Actor ID for this mutation. Must be used with `--actor-kind`.

--- a/crates/loonfs-server/README.md
+++ b/crates/loonfs-server/README.md
@@ -65,6 +65,9 @@ Read [docs/self-hosting.md](docs/self-hosting.md) for the topology, the
 minimal config, the probes, logging, the local cache, upgrades, and what a
 one-writer deployment does not do.
 
+Read [docs/actor-attribution.md](docs/actor-attribution.md) when an application
+submits filesystem changes on behalf of its users.
+
 Every release publishes the Helm chart as
 `oci://ghcr.io/loonfs/charts/loonfs-server`, at the same version as the
 server it runs. [`deploy/helm/loonfs-server`](deploy/helm/loonfs-server) is

--- a/crates/loonfs-server/deploy/helm/loonfs-server/README.md
+++ b/crates/loonfs-server/deploy/helm/loonfs-server/README.md
@@ -23,6 +23,8 @@ helm install loonfs-server crates/loonfs-server/deploy/helm/loonfs-server \
 
 [`docs/self-hosting.md`](../../../docs/self-hosting.md) covers the server
 itself: the config fields, the probes, the logging, and the upgrade rule.
+[`docs/actor-attribution.md`](../../../docs/actor-attribution.md) covers the
+trusted-backend contract for applications that submit user mutations.
 This file covers the chart.
 
 ## Topology

--- a/crates/loonfs-server/docs/actor-attribution.md
+++ b/crates/loonfs-server/docs/actor-attribution.md
@@ -1,0 +1,37 @@
+# Actor attribution
+
+Every mutation includes an actor, such as
+`{ "kind": "user", "id": "usr_8f3c" }`.
+
+Your backend authenticates and authorizes the request. LoonFS records the
+actor exactly as sent; it does not verify the identity or manage profiles. Use
+a stable internal ID, not an email address or display name.
+
+- `user`: a known person caused the change. Use this even when a backend or
+  worker carries out the change for that person.
+- `service`: your application, integration, or background job caused the
+  change without acting for a specific user.
+- `system`: platform-level work changed filesystem data.
+
+Use the actor and event fields for attribution. Do not infer the actor from a
+commit message or error message.
+
+## Security
+
+The LoonFS bearer token identifies your backend, not the actor. Never expose it
+to browser code. The browser should call your backend, and your backend should
+call LoonFS after checking access.
+
+## Permanent history
+
+LoonFS may discard change history below a namespace's retention floor. If you
+need permanent history, copy the change feed to your own store before the floor
+advances. Process changes in sequence order, and save the feed cursor only
+after the change is durable.
+
+Key each change by `(namespace_id, committed_seq)`. Identify files and
+directories by `inode_id`, because paths can change. Store `commit_id` for
+correlation only; it is unique only while its receipt remains in LoonFS.
+
+If LoonFS returns `rebootstrap_required`, a checkpoint can rebuild the current
+filesystem state, but it cannot recover activity history that was discarded.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -20,6 +20,25 @@
 //!     .background_work(loonfs::FsBackgroundWork::Enabled)
 //!     .build()
 //!     .await?;
+//! let namespace_id = loonfs::NamespaceId::parse("demo").expect("valid namespace id");
+//! writer
+//!     .create_namespace(&namespace_id, loonfs::CreateNamespaceOptions::default())
+//!     .await?;
+//! let commit = loonfs::CommitOptions::new(loonfs::ActorRef::service(
+//!     loonfs::ActorId::parse("document-worker").expect("valid actor id"),
+//! ));
+//! writer
+//!     .put_file_bytes(
+//!         &namespace_id,
+//!         "/report.txt",
+//!         b"report",
+//!         loonfs::PutFileOptions {
+//!             behavior: loonfs::DestinationBehavior::Replace,
+//!             commit,
+//!             expected_revision_no: None,
+//!         },
+//!     )
+//!     .await?;
 //! # Ok(()) }
 //! ```
 //!

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -420,6 +420,43 @@ the requested cursor is older than the retention floor, the caller must
 re-bootstrap instead of expecting older incremental history to remain
 available.
 
+### Actor attribution
+
+The actor is the application-asserted identity of who caused a mutation.
+LoonFS records one actor on each logical commit and copies that reference onto
+the retained facts that the commit creates.
+
+The shared bearer token proves that a request came from the credential holder.
+It does not prove that the named actor initiated the action. Keep LoonFS behind
+a trusted backend. That backend must authenticate its user, authorize the
+namespace and operation, and then assert the actor.
+
+Use stable opaque actor ids such as usr_8f3c. Do not use email addresses or
+display names because profile changes and deletions never rewrite filesystem
+history.
+
+Actor kind and actor id are part of the semantic commit fingerprint. Reusing a
+`commit_id` with a different actor id or kind fails with
+`commit_id_reuse_conflict`. The observational commit timestamp is not part of
+the fingerprint, so a retry at a later time keeps the same identity.
+
+Attribution fields in v0 responses have these meanings:
+
+- `created_by` is the actor on the commit that created the inode.
+- `created_at_ms` is the observational wall-clock stamp on the commit that
+  created the inode.
+- `revision_actor` is the actor on the commit that created the current file
+  revision; directories do not carry this field.
+- A revision's `actor` is the actor on the commit that created that revision.
+- `attributes.updated_by` is the actor on the commit that created the current
+  persisted attributes revision; synthetic revision 0 has no updater.
+- A trash entry's `deleted_by` is the actor on the commit that created its
+  active deletion generation.
+
+The CLI uses `service/loonfs-cli` when no actor is supplied by flags,
+environment, or profile. This actor identifies the tool, not the human running
+it.
+
 ### 5.2 Commit responses and safe retry
 
 Every commit returns the same response envelope: the `namespace_id` that changed, the
@@ -1565,9 +1602,9 @@ reaches revision 1, regardless of how far the retention floor has advanced.
 
 ### 6.8 `POST /commits`
 
-This is the binding for the commit model in section 5.1: one `commit_id`,
-an optional `message`, and `operations` — an ordered, non-empty array of
-path operations. An empty array is `invalid_request`.
+This is the binding for the commit model in section 5.1: one `commit_id`, one
+required `actor`, an optional `message`, and `operations` — an ordered,
+non-empty array of path operations. An empty array is `invalid_request`.
 
 The root path `/` is readable but never a mutation target. An operation that
 names it — as its own path, or as either end of a move or copy — is
@@ -2104,8 +2141,8 @@ presign writes either, no file it holds can be larger than it will proxy.
 ### 6.11 `GET /changes`
 
 Each change is one commit carrying its identity (`committed_seq`, `commit_id`,
-observational `committed_at_ms`, optional `message`) and `events`: the
-semantic filesystem operations the commit
+`actor`, observational `committed_at_ms`, optional `message`) and `events`:
+the semantic filesystem operations the commit
 applied, in the order it applied them. One request operation may apply
 several — a put creates each missing parent directory, a replacing move
 deletes the file it moves over, a copy carries the source's attributes onto

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -422,40 +422,25 @@ available.
 
 ### Actor attribution
 
-The actor is the application-asserted identity of who caused a mutation.
-LoonFS records one actor on each logical commit and copies that reference onto
-the retained facts that the commit creates.
-
-The shared bearer token proves that a request came from the credential holder.
-It does not prove that the named actor initiated the action. Keep LoonFS behind
-a trusted backend. That backend must authenticate its user, authorize the
-namespace and operation, and then assert the actor.
-
-Use stable opaque actor ids such as usr_8f3c. Do not use email addresses or
-display names because profile changes and deletions never rewrite filesystem
-history.
+Every commit includes an actor with a `kind` and `id`. The application chooses
+this value, and LoonFS stores it on the commit and the metadata created by that
+commit. LoonFS does not authenticate the actor. The application must
+authenticate the user and authorize the operation before sending the request.
+Use a stable internal ID, not an email address or display name.
 
 Actor kind and actor id are part of the semantic commit fingerprint. Reusing a
 `commit_id` with a different actor id or kind fails with
-`commit_id_reuse_conflict`. The observational commit timestamp is not part of
-the fingerprint, so a retry at a later time keeps the same identity.
+`commit_id_reuse_conflict`. The commit timestamp is not part of the
+fingerprint.
 
-Attribution fields in v0 responses have these meanings:
+Responses expose attribution through these fields:
 
-- `created_by` is the actor on the commit that created the inode.
-- `created_at_ms` is the observational wall-clock stamp on the commit that
-  created the inode.
-- `revision_actor` is the actor on the commit that created the current file
-  revision; directories do not carry this field.
-- A revision's `actor` is the actor on the commit that created that revision.
-- `attributes.updated_by` is the actor on the commit that created the current
-  persisted attributes revision; synthetic revision 0 has no updater.
-- A trash entry's `deleted_by` is the actor on the commit that created its
-  active deletion generation.
-
-The CLI uses `service/loonfs-cli` when no actor is supplied by flags,
-environment, or profile. This actor identifies the tool, not the human running
-it.
+- `created_by` and `created_at_ms` come from the commit that created an inode.
+- `revision_actor` identifies the actor for the current file revision. Each
+  revision-history entry also has an `actor`. Directories have neither field.
+- `attributes.updated_by` identifies who last changed the stored attributes.
+  The initial empty attributes at revision 0 have no updater.
+- `deleted_by` identifies the actor for an active trash entry.
 
 ### 5.2 Commit responses and safe retry
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1536,8 +1536,12 @@ deleter.
 LoonFS does not promise that every historical move or rename remains queryable
 forever. A partner that needs an all-time activity record must consume the
 change feed into its own store before the retention floor passes the commit.
-That store keys changes by `(namespace_id, commit_id)` and keys event targets
-by `inode_id`, not by path.
+That store keys changes by `(namespace_id, committed_seq)` and keys event
+targets by `inode_id`, not by path. `committed_seq` is never reused within a
+namespace. `commit_id` is not a unique key over all time: its uniqueness is
+enforced only while the commit's receipt is retained (the receipt horizon),
+so a caller-supplied id can legally recur after the retention floor passes
+its receipt. Sinks store `commit_id` as a correlation field, not as the key.
 
 The retention floor may advance only after the system has enough verified
 material to keep replay safe at or after that point: advancement derives its

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -567,11 +567,10 @@ The metadata rows store attribution as follows:
   initial empty state at revision 0 is not persisted and has neither value.
 - Directory bind and unbind rows store neither an actor nor a timestamp.
 
-Each timestamp comes from the commit that created or updated the corresponding
-metadata row. It is informational only. Renaming or moving an item does not
-change any timestamp, and directories do not have a modification time.
-Sequence numbers determine ordering. The format does not define a rename time
-or a directory modification time.
+Each timestamp comes from the commit that wrote the metadata row. Timestamps
+are informational; sequence numbers determine ordering. Renaming or moving an
+item does not change a timestamp, and directories do not have a modification
+time.
 
 ### 2.2 Inode kinds
 
@@ -997,14 +996,12 @@ in ascending row-key order (adjacent equal keys permitted); readers reject a
 segment whose rows are out of order as malformed. Readers load the referenced
 runs, then replay only the visible WAL chain after the manifest's `head_seq`.
 
-The WAL preserves ordered history even when multiple logical commits are
-stored in one segment. Each logical commit envelope records `commit_id`,
-`semantic_commit_fingerprint`, required `actor`, `committed_at_ms`, optional
-`message`, and normalized metadata deltas such as inode creation, direntry
-bind/unbind, file revision append, and subtree tombstone rows. The `actor`
-object contains `kind` (`user`, `service`, or `system`) and `id`, and it is
-recorded once per commit. Validation inputs and operation results are not
-persisted in the WAL. Checkpoints keep replay bounded as history grows.
+The WAL preserves commit order even when a segment contains several commits.
+Each commit stores `commit_id`, `semantic_commit_fingerprint`, `actor`,
+`committed_at_ms`, an optional `message`, and its metadata changes. The actor
+contains a `kind` and `id` and is stored once per commit, not once per change.
+Validation inputs and operation results are not stored. Checkpoints keep replay
+bounded as history grows.
 
 #### 2.9.1 Resolving the metadata basis
 
@@ -1399,10 +1396,6 @@ can prove its retry is the same request (API spec, section 5.2). Reference
 values are pinned by tests in `loonfs-api` (`commit_identity.rs`); those
 literals must never change within scheme `v1`.
 
-Actor references use stable opaque application-owned ids such as `usr_8f3c`.
-Do not use email addresses or display names because profile changes and
-deletions never rewrite filesystem history.
-
 ### 3.4 Server authority
 
 The server is authoritative for commit validation.
@@ -1526,22 +1519,16 @@ A namespace may advance a retention floor to say:
 Clients older than the retention floor must re-bootstrap from a fresh
 checkpoint instead of replaying from an obsolete cursor.
 
-#### 3.8.1 Attribution retention contract
+#### 3.8.1 Attribution and retention
 
-For every retained commit, LoonFS promises an attributed change-feed entry.
-LoonFS also promises attributed retained projections for the inode creator,
-each file revision actor, the current attribute updater, and the active
-deleter.
+Retained commits keep their actor in the change feed and in metadata for inode
+creation, file revisions, current attributes, and active deletions.
 
-LoonFS does not promise that every historical move or rename remains queryable
-forever. A partner that needs an all-time activity record must consume the
-change feed into its own store before the retention floor passes the commit.
-That store keys changes by `(namespace_id, committed_seq)` and keys event
-targets by `inode_id`, not by path. `committed_seq` is never reused within a
-namespace. `commit_id` is not a unique key over all time: its uniqueness is
-enforced only while the commit's receipt is retained (the receipt horizon),
-so a caller-supplied id can legally recur after the retention floor passes
-its receipt. Sinks store `commit_id` as a correlation field, not as the key.
+Moves and renames below the retention floor may no longer be available. A
+consumer that needs permanent history must copy the change feed before the
+floor advances. It keys changes by `(namespace_id, committed_seq)` and targets
+by `inode_id`, not by path. It may store `commit_id` for correlation, but not
+as a permanent key because the id may be reused after its receipt is removed.
 
 The retention floor may advance only after the system has enough verified
 material to keep replay safe at or after that point: advancement derives its

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -567,11 +567,11 @@ The metadata rows store attribution as follows:
   initial empty state at revision 0 is not persisted and has neither value.
 - Directory bind and unbind rows store neither an actor nor a timestamp.
 
-`created_at_ms` is the wall-clock time reported by the commit that created the
-inode. It is informational only. Renaming or moving an item does not change
-any timestamp, and directories do not have a modification time. Sequence
-numbers determine ordering. The format does not define a rename time or a
-directory modification time.
+Each timestamp comes from the commit that created or updated the corresponding
+metadata row. It is informational only. Renaming or moving an item does not
+change any timestamp, and directories do not have a modification time.
+Sequence numbers determine ordering. The format does not define a rename time
+or a directory modification time.
 
 ### 2.2 Inode kinds
 
@@ -998,11 +998,13 @@ segment whose rows are out of order as malformed. Readers load the referenced
 runs, then replay only the visible WAL chain after the manifest's `head_seq`.
 
 The WAL preserves ordered history even when multiple logical commits are
-stored in one segment. Each logical commit records the commit identity, required
-actor, optional message, and normalized metadata deltas such as inode creation, direntry
-bind/unbind, file revision append, and subtree tombstone rows. Validation
-inputs and operation results are not persisted in the WAL. Checkpoints keep
-replay bounded as history grows.
+stored in one segment. Each logical commit envelope records `commit_id`,
+`semantic_commit_fingerprint`, required `actor`, `committed_at_ms`, optional
+`message`, and normalized metadata deltas such as inode creation, direntry
+bind/unbind, file revision append, and subtree tombstone rows. The `actor`
+object contains `kind` (`user`, `service`, or `system`) and `id`, and it is
+recorded once per commit. Validation inputs and operation results are not
+persisted in the WAL. Checkpoints keep replay bounded as history grows.
 
 #### 2.9.1 Resolving the metadata basis
 
@@ -1397,6 +1399,10 @@ can prove its retry is the same request (API spec, section 5.2). Reference
 values are pinned by tests in `loonfs-api` (`commit_identity.rs`); those
 literals must never change within scheme `v1`.
 
+Actor references use stable opaque application-owned ids such as `usr_8f3c`.
+Do not use email addresses or display names because profile changes and
+deletions never rewrite filesystem history.
+
 ### 3.4 Server authority
 
 The server is authoritative for commit validation.
@@ -1519,6 +1525,19 @@ A namespace may advance a retention floor to say:
 
 Clients older than the retention floor must re-bootstrap from a fresh
 checkpoint instead of replaying from an obsolete cursor.
+
+#### 3.8.1 Attribution retention contract
+
+For every retained commit, LoonFS promises an attributed change-feed entry.
+LoonFS also promises attributed retained projections for the inode creator,
+each file revision actor, the current attribute updater, and the active
+deleter.
+
+LoonFS does not promise that every historical move or rename remains queryable
+forever. A partner that needs an all-time activity record must consume the
+change feed into its own store before the retention floor passes the commit.
+That store keys changes by `(namespace_id, commit_id)` and keys event targets
+by `inode_id`, not by path.
 
 The retention floor may advance only after the system has enough verified
 material to keep replay safe at or after that point: advancement derives its


### PR DESCRIPTION
Document how applications should supply and use commit actors. The API and format specifications now define the actor trust model, the meaning of each attribution field, timestamp behavior, and how retention affects attribution history.

Add a guide for application backends that authenticate and authorize users before sending a stable actor reference to LoonFS. It explains how to retain activity history outside LoonFS and warns against exposing the server token to browsers, using mutable profile data as actor IDs, or parsing free-form messages for attribution.
