### PR TITLE
refactor(api): flatten the path entry attributes projection

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -147,7 +147,7 @@ pub use secret::SecretString;
 // Curated root re-exports of the common v0 HTTP surface. v0 HTTP shapes live
 // in `v0`; add here only what most consumers touch.
 pub use v0::{
-    AdvanceRetentionResponse, ApiError, AuthoritativeAttributes, AuthoritativeFileBytes,
+    AdvanceRetentionResponse, ApiError, AttributesProjection, AuthoritativeFileBytes,
     AuthoritativePathEntry, AuthoritativePathEntryKind, CheckpointOwnerSummary, CheckpointSummary,
     CommitRequest, CommitResponse, CreateCheckpointRequest, CreateCheckpointResponse,
     CreateNamespaceRequest, DeleteDirectoryBehavior, DeleteNamespaceResponse, DestinationBehavior,

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -37,7 +37,7 @@ pub use operations::{
     WalFlushStepOutcome,
 };
 pub use reads::{
-    AuthoritativeAttributes, AuthoritativeFileBytes, AuthoritativePathEntry,
+    AttributesProjection, AuthoritativeFileBytes, AuthoritativePathEntry,
     AuthoritativePathEntryKind, ListPathEntriesResponse, ListTrashResponse, TrashEntry,
 };
 pub use search::{

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -13,7 +13,11 @@ use serde::{Deserialize, Serialize};
 /// This is the result shape for stat/list style reads. The entry kind carries
 /// the file-only revision and content summary, so a directory cannot carry a
 /// partial file payload. Attributes are likewise projected as one value or
-/// omitted as one value.
+/// omitted as one value, while serializing as prefixed sibling fields.
+/// The attribute revision is read independently — clients feed it to
+/// `expected_attributes_revision_no` on the next write without touching the
+/// values — so this is a prefixed-sibling projection rather than a value
+/// consumed as one nested unit.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AuthoritativePathEntry {
@@ -40,8 +44,8 @@ pub struct AuthoritativePathEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<DisplayName>,
     /// The inode's attribute projection, when requested.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub attributes: Option<AuthoritativeAttributes>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<AttributesProjection>,
 }
 
 impl AuthoritativePathEntry {
@@ -135,21 +139,21 @@ impl AuthoritativePathEntryKind {
     }
 }
 
-/// One inode's complete projected attribute state.
+/// One inode's structurally complete attribute projection.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct AuthoritativeAttributes {
+pub struct AttributesProjection {
     /// The attribute revision this projection represents.
-    pub revision_no: AttributeRevisionNo,
+    pub attributes_revision_no: AttributeRevisionNo,
     /// Actor responsible for the latest attribute update. This is `None` for
     /// the initial empty state at revision 0.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub updated_by: Option<ActorRef>,
+    pub attributes_updated_by: Option<ActorRef>,
     /// Time of the latest attribute update, in Unix milliseconds. This is
     /// `None` for the initial empty state at revision 0.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub updated_at_ms: Option<u64>,
-    /// The complete attribute map at `revision_no`.
+    pub attributes_updated_at_ms: Option<u64>,
+    /// The complete attribute map at `attributes_revision_no`.
     ///
     /// An inode that has never had attributes written is at revision 0 with
     /// an empty map.
@@ -331,27 +335,89 @@ mod tests {
         );
     }
 
-    /// An unprojected entry omits attributes; a projected one carries the
-    /// map and revision together, and an empty map is a projected answer.
     #[test]
-    fn attributes_serialize_as_one_optional_projection() {
+    fn requested_attributes_serialize_as_flat_prefixed_siblings() {
+        let mut projected = entry("/docs", Some(InodeId(1)), Some("docs"));
+        projected.attributes = Some(AttributesProjection {
+            attributes_revision_no: crate::AttributeRevisionNo(7),
+            attributes_updated_by: Some(ActorRef::loonfs_system()),
+            attributes_updated_at_ms: Some(1_752_624_000_000),
+            attributes: crate::Attributes::new(std::collections::BTreeMap::from([(
+                crate::AttributeKey::parse("owner").expect("attribute key"),
+                crate::AttributeValue::parse("finance").expect("attribute value"),
+            )]))
+            .expect("attributes"),
+        });
+
+        let projected_json = serde_json::to_value(&projected).expect("serialize projected entry");
+        assert_eq!(projected_json["attributes_revision_no"], 7);
+        assert_eq!(
+            projected_json["attributes"],
+            serde_json::json!({ "owner": "finance" })
+        );
+        assert_eq!(
+            projected_json["attributes_updated_by"],
+            serde_json::json!({ "kind": "system", "id": "loonfs" })
+        );
+        assert_eq!(
+            projected_json["attributes_updated_at_ms"],
+            1_752_624_000_000_u64
+        );
+
+        let decoded: AuthoritativePathEntry =
+            serde_json::from_value(projected_json).expect("decode projected entry");
+        let projection = decoded.attributes.expect("projected attributes");
+        assert_eq!(
+            projection.attributes_revision_no,
+            crate::AttributeRevisionNo(7)
+        );
+    }
+
+    #[test]
+    fn unrequested_attributes_omit_both_wire_keys() {
         let unprojected = entry("/docs", Some(InodeId(1)), Some("docs"));
         let unprojected_json =
             serde_json::to_value(&unprojected).expect("serialize unprojected entry");
         assert!(unprojected_json.get("attributes").is_none());
+        assert!(unprojected_json.get("attributes_revision_no").is_none());
 
-        let mut projected = unprojected;
-        projected.attributes = Some(AuthoritativeAttributes {
-            revision_no: crate::AttributeRevisionNo(0),
-            updated_by: None,
-            updated_at_ms: None,
+        let decoded: AuthoritativePathEntry =
+            serde_json::from_value(unprojected_json).expect("decode unprojected entry");
+        assert!(decoded.attributes.is_none());
+    }
+
+    #[test]
+    fn never_written_attributes_serialize_as_revision_zero_and_empty_map() {
+        let mut projected = entry("/docs", Some(InodeId(1)), Some("docs"));
+        projected.attributes = Some(AttributesProjection {
+            attributes_revision_no: crate::AttributeRevisionNo(0),
+            attributes_updated_by: None,
+            attributes_updated_at_ms: None,
             attributes: crate::Attributes::default(),
         });
         let projected_json = serde_json::to_value(&projected).expect("serialize projected entry");
-        assert_eq!(
-            projected_json["attributes"],
-            serde_json::json!({ "revision_no": 0, "attributes": {} })
-        );
+        assert_eq!(projected_json["attributes_revision_no"], 0);
+        assert_eq!(projected_json["attributes"], serde_json::json!({}));
+        assert!(projected_json.get("attributes_updated_by").is_none());
+        assert!(projected_json.get("attributes_updated_at_ms").is_none());
+    }
+
+    #[test]
+    fn serialized_entries_never_nest_attributes_inside_attributes() {
+        let mut projected = entry("/docs", Some(InodeId(1)), Some("docs"));
+        projected.attributes = Some(AttributesProjection {
+            attributes_revision_no: crate::AttributeRevisionNo(1),
+            attributes_updated_by: None,
+            attributes_updated_at_ms: None,
+            attributes: crate::Attributes::new(std::collections::BTreeMap::from([(
+                crate::AttributeKey::parse("owner").expect("attribute key"),
+                crate::AttributeValue::parse("finance").expect("attribute value"),
+            )]))
+            .expect("attributes"),
+        });
+
+        let projected_json = serde_json::to_value(projected).expect("serialize projected entry");
+        assert!(projected_json.pointer("/attributes/attributes").is_none());
     }
 }
 

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -793,13 +793,13 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             // is. An inode holding no attributes prints nothing extra: the
             // header already answered the question that was asked.
             if let Some(attributes) = &entry.attributes {
-                if let Some(updated_by) = &attributes.updated_by {
+                if let Some(updated_by) = &attributes.attributes_updated_by {
                     lines.push(format!(
                         "attributes_updated_by: {}",
                         render_actor(updated_by)
                     ));
                 }
-                if let Some(updated_at_ms) = attributes.updated_at_ms {
+                if let Some(updated_at_ms) = attributes.attributes_updated_at_ms {
                     lines.push(format!(
                         "attributes_updated: {}",
                         format_utc_ms(updated_at_ms)
@@ -1002,7 +1002,7 @@ mod tests {
     use crate::profiles::ProfileSummary;
     use insta::{assert_json_snapshot, assert_snapshot};
     use loonfs_api::{
-        AbsolutePath, AuthoritativeAttributes, AuthoritativePathEntry, AuthoritativePathEntryKind,
+        AbsolutePath, AttributesProjection, AuthoritativePathEntry, AuthoritativePathEntryKind,
         ChangeSeq, DisplayName, InodeId, NamespaceId,
     };
 
@@ -1049,10 +1049,10 @@ mod tests {
     /// can be read off the last line.
     fn stat_with_attribute(value: AttributeValue) -> CommandOutput {
         let mut entry = path_entry("/docs", Some("docs"));
-        entry.attributes = Some(AuthoritativeAttributes {
-            revision_no: loonfs_api::AttributeRevisionNo(1),
-            updated_by: Some(loonfs_api::ActorRef::loonfs_system()),
-            updated_at_ms: Some(1_752_624_000_000),
+        entry.attributes = Some(AttributesProjection {
+            attributes_revision_no: loonfs_api::AttributeRevisionNo(1),
+            attributes_updated_by: Some(loonfs_api::ActorRef::loonfs_system()),
+            attributes_updated_at_ms: Some(1_752_624_000_000),
             attributes: loonfs_api::Attributes::new(std::collections::BTreeMap::from([(
                 loonfs_api::AttributeKey::parse("note").expect("attribute key"),
                 value,
@@ -1111,16 +1111,15 @@ mod tests {
     /// JSON output needs no escaping of its own: serde emits an escaped
     /// string, and the value round-trips through a decode unchanged.
     #[test]
-    fn json_stat_carries_attribute_values_verbatim() {
+    fn json_stat_flattens_the_attribute_projection_and_preserves_values() {
         let newline =
             stat_with_attribute(AttributeValue::parse("first\nsecond").expect("attribute value"));
         let json: serde_json::Value =
             serde_json::from_str(&json_success(&newline).expect("JSON stat should render"))
                 .expect("rendered stat is JSON");
-        assert_eq!(
-            json["data"]["attributes"]["attributes"]["note"],
-            "first\nsecond"
-        );
+        assert_eq!(json["data"]["attributes"]["note"], "first\nsecond");
+        assert_eq!(json["data"]["attributes_revision_no"], 1);
+        assert!(json.pointer("/data/attributes/attributes").is_none());
     }
 
     #[test]

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -4531,13 +4531,10 @@ fn annotate_writes_and_removes_attributes_in_both_modes() {
         let bare_json = harness.run(&["--json", "stat", "--profile", profile, "/docs/file.txt"]);
         assert_success(&bare_json);
         let bare_entry = json_data(&bare_json);
-        assert_eq!(
-            bare_entry["attributes"]["attributes"],
-            serde_json::json!({})
-        );
-        assert_eq!(bare_entry["attributes"]["revision_no"], 0);
-        assert!(bare_entry["attributes"]["updated_by"].is_null());
-        assert!(bare_entry["attributes"]["updated_at_ms"].is_null());
+        assert_eq!(bare_entry["attributes"], serde_json::json!({}));
+        assert_eq!(bare_entry["attributes_revision_no"], 0);
+        assert!(bare_entry.get("attributes_updated_by").is_none());
+        assert!(bare_entry.get("attributes_updated_at_ms").is_none());
 
         let annotated = harness.run(&[
             "--json",
@@ -4576,15 +4573,15 @@ fn annotate_writes_and_removes_attributes_in_both_modes() {
             harness.run(&["--json", "stat", "--profile", profile, "/docs/file.txt"]);
         assert_success(&with_list_json);
         assert_eq!(
-            json_data(&with_list_json)["attributes"]["attributes"]["tags"],
+            json_data(&with_list_json)["attributes"]["tags"],
             serde_json::json!("red,blue")
         );
         assert_eq!(
-            json_data(&with_list_json)["attributes"]["updated_by"],
+            json_data(&with_list_json)["attributes_updated_by"],
             serde_json::json!({ "kind": "service", "id": "loonfs-cli" })
         );
         assert!(
-            json_data(&with_list_json)["attributes"]["updated_at_ms"]
+            json_data(&with_list_json)["attributes_updated_at_ms"]
                 .as_u64()
                 .expect("attribute update time")
                 > 0
@@ -4601,10 +4598,11 @@ fn annotate_writes_and_removes_attributes_in_both_modes() {
         let removed = harness.run(&["--json", "stat", "--profile", profile, "/docs/file.txt"]);
         assert_success(&removed);
         let entry = json_data(&removed);
-        assert!(entry["attributes"]["attributes"]["owner"].is_null());
-        assert_eq!(entry["attributes"]["attributes"]["note"], "has=equals");
+        assert!(entry["attributes"]["owner"].is_null());
+        assert_eq!(entry["attributes"]["note"], "has=equals");
         // Three effective updates, three revisions.
-        assert_eq!(entry["attributes"]["revision_no"], 3);
+        assert_eq!(entry["attributes_revision_no"], 3);
+        assert!(entry.pointer("/attributes/attributes").is_none());
 
         // Attributes belong to the inode, so a directory takes them too.
         assert_success(&harness.run(&[

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -21,7 +21,7 @@ use crate::storage::content::{content_object_key_for_ref, read_durable_content_b
 use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainLoadRequest};
 use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::{
-    AbsolutePath, AuthoritativeAttributes, AuthoritativeFileBytes, AuthoritativePathEntry,
+    AbsolutePath, AttributesProjection, AuthoritativeFileBytes, AuthoritativePathEntry,
     AuthoritativePathEntryKind, ChangeSeq, ContentRef, ContentStoreId, DirectoryPageCursor,
     DisplayName, FileRevision, FileRevisionsPageCursor, InodeId, InodeKind, ManifestId,
     NamespaceId, Page, PageRequest, RevisionNo, TrashEntry, TrashPageCursor,
@@ -801,10 +801,10 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             AttributeProjection::Include => {
                 let (revision_no, attributes, updated_by, updated_at_ms) =
                     session.attributes_of_visible(resolved.inode_id).await?;
-                Some(AuthoritativeAttributes {
-                    revision_no,
-                    updated_by,
-                    updated_at_ms,
+                Some(AttributesProjection {
+                    attributes_revision_no: revision_no,
+                    attributes_updated_by: updated_by,
+                    attributes_updated_at_ms: updated_at_ms,
                     attributes,
                 })
             }
@@ -1031,7 +1031,7 @@ mod tests {
             annotated
                 .attributes
                 .as_ref()
-                .map(|projection| projection.revision_no),
+                .map(|projection| projection.attributes_revision_no),
             Some(AttributeRevisionNo(1))
         );
         assert_eq!(
@@ -1048,9 +1048,12 @@ mod tests {
             .await
             .expect("stat bare");
         assert_eq!(
-            bare.attributes
-                .as_ref()
-                .map(|projection| (projection.revision_no, projection.attributes.len())),
+            bare.attributes.as_ref().map(|projection| {
+                (
+                    projection.attributes_revision_no,
+                    projection.attributes.len(),
+                )
+            }),
             Some((AttributeRevisionNo(0), 0))
         );
 

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -127,7 +127,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         loonfs_api::InodeKind,
         loonfs_api::AuthoritativePathEntry,
         loonfs_api::AuthoritativePathEntryKind,
-        loonfs_api::AuthoritativeAttributes,
+        loonfs_api::AttributesProjection,
         loonfs_api::ListPathEntriesResponse,
         BeginUploadRequest,
         BeginUploadResponse,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -50,6 +50,8 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "allow_stale",
     "attributes_changed",
     "attributes_revision_no",
+    "attributes_updated_at_ms",
+    "attributes_updated_by",
     "bearer_auth",
     "begin_put",
     "budget_exhausted",

--- a/crates/loonfs-server/tests/it/http_attributes.rs
+++ b/crates/loonfs-server/tests/it/http_attributes.rs
@@ -72,19 +72,24 @@ fn get_status(harness: &crate::common::TestServer, query: &str) -> u16 {
     }
 }
 
-/// The grouped attribute projection is either present in full or absent.
+/// The required attribute projection siblings are either both present or absent.
 fn assert_projection(entry: &serde_json::Value, projected: bool) {
     assert_eq!(
         entry.get("attributes").is_some(),
         projected,
         "wrong `attributes` projection: {entry}"
     );
+    assert_eq!(
+        entry.get("attributes_revision_no").is_some(),
+        projected,
+        "wrong `attributes_revision_no` projection: {entry}"
+    );
 }
 
-/// Stat projects attributes by default and drops the group on request;
+/// Stat projects attributes by default and drops the siblings on request;
 /// listing does the opposite.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn http_reads_project_the_grouped_attributes_value() {
+async fn http_reads_project_flat_attribute_siblings_together() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
         temp_dir.path().join("store"),
@@ -98,13 +103,14 @@ async fn http_reads_project_the_grouped_attributes_value() {
     // bare one carries the cleared state at revision 0 rather than nothing.
     let annotated = get_json(&harness, "/filesystem/stat?path=%2Fdocs%2Freport.txt");
     assert_projection(&annotated, true);
-    assert_eq!(annotated["attributes"]["attributes"]["owner"], "platform");
-    assert_eq!(annotated["attributes"]["revision_no"], 1);
+    assert_eq!(annotated["attributes"]["owner"], "platform");
+    assert_eq!(annotated["attributes_revision_no"], 1);
+    assert!(annotated.pointer("/attributes/attributes").is_none());
 
     let bare = get_json(&harness, "/filesystem/stat?path=%2Fdocs%2Fnotes.txt");
     assert_projection(&bare, true);
-    assert_eq!(bare["attributes"]["attributes"], serde_json::json!({}));
-    assert_eq!(bare["attributes"]["revision_no"], 0);
+    assert_eq!(bare["attributes"], serde_json::json!({}));
+    assert_eq!(bare["attributes_revision_no"], 0);
 
     let opted_out = get_json(
         &harness,
@@ -130,14 +136,15 @@ async fn http_reads_project_the_grouped_attributes_value() {
         assert_projection(entry, true);
         match entry["absolute_path"].as_str().expect("path") {
             "/docs/report.txt" => {
-                assert_eq!(entry["attributes"]["attributes"]["owner"], "platform");
-                assert_eq!(entry["attributes"]["revision_no"], 1);
+                assert_eq!(entry["attributes"]["owner"], "platform");
+                assert_eq!(entry["attributes_revision_no"], 1);
             }
             _ => {
-                assert_eq!(entry["attributes"]["attributes"], serde_json::json!({}));
-                assert_eq!(entry["attributes"]["revision_no"], 0);
+                assert_eq!(entry["attributes"], serde_json::json!({}));
+                assert_eq!(entry["attributes_revision_no"], 0);
             }
         }
+        assert!(entry.pointer("/attributes/attributes").is_none());
     }
 }
 
@@ -229,7 +236,7 @@ async fn the_client_round_trips_the_read_options() {
     assert_eq!(
         stat.attributes
             .as_ref()
-            .map(|projection| projection.revision_no),
+            .map(|projection| projection.attributes_revision_no),
         Some(AttributeRevisionNo(1))
     );
 

--- a/crates/loonfs-server/tests/it/http_attribution.rs
+++ b/crates/loonfs-server/tests/it/http_attribution.rs
@@ -62,8 +62,8 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
     assert_eq!(root.created_by, ActorRef::loonfs_system());
     assert!(root.created_at_ms > 0);
     let root_attributes = root.attributes.expect("root attributes");
-    assert_eq!(root_attributes.updated_by, None);
-    assert_eq!(root_attributes.updated_at_ms, None);
+    assert_eq!(root_attributes.attributes_updated_by, None);
+    assert_eq!(root_attributes.attributes_updated_at_ms, None);
 
     let creator = actor("creator");
     let create = harness
@@ -182,8 +182,8 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
     assert_eq!(after_move.kind, before_move.kind);
 
     let bare_attributes = after_move.attributes.expect("synthetic attributes");
-    assert_eq!(bare_attributes.updated_by, None);
-    assert_eq!(bare_attributes.updated_at_ms, None);
+    assert_eq!(bare_attributes.attributes_updated_by, None);
+    assert_eq!(bare_attributes.attributes_updated_at_ms, None);
     let updater = actor("updater");
     let update = harness
         .client
@@ -204,8 +204,11 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
         .expect("stat attributes")
         .attributes
         .expect("attributes projection");
-    assert_eq!(updated.updated_by, Some(updater));
-    assert_eq!(updated.updated_at_ms, Some(update_change.committed_at_ms));
+    assert_eq!(updated.attributes_updated_by, Some(updater));
+    assert_eq!(
+        updated.attributes_updated_at_ms,
+        Some(update_change.committed_at_ms)
+    );
 
     let deleter = actor("deleter");
     let delete = harness

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -234,6 +234,49 @@ fn openapi_reuses_the_one_checksum_and_upload_claim_shapes() {
 }
 
 #[test]
+fn openapi_flattens_the_path_entry_attribute_projection() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let schemas = spec
+        .pointer("/components/schemas")
+        .and_then(Value::as_object)
+        .expect("openapi schemas object");
+    assert!(!schemas.contains_key("AuthoritativeAttributes"));
+
+    let projection = schemas
+        .get("AttributesProjection")
+        .expect("AttributesProjection schema");
+    let projection_properties = projection
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("attribute projection properties");
+    assert!(projection_properties.contains_key("attributes_revision_no"));
+    assert!(projection_properties.contains_key("attributes"));
+    let required = required_fields(projection);
+    assert!(required.contains("attributes_revision_no"));
+    assert!(required.contains("attributes"));
+
+    let path_entry = schemas
+        .get("AuthoritativePathEntry")
+        .expect("AuthoritativePathEntry schema");
+    let flattened_projection_ref = path_entry
+        .get("allOf")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|schema| schema.get("oneOf").and_then(Value::as_array))
+        .flatten()
+        .filter_map(|schema| schema.get("$ref").and_then(Value::as_str))
+        .any(|reference| reference == "#/components/schemas/AttributesProjection");
+    assert!(
+        flattened_projection_ref,
+        "path entries must flatten AttributesProjection at the top level"
+    );
+}
+
+#[test]
 fn openapi_documents_delete_path_behavior() {
     let spec: Value = serde_json::from_str(
         &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -87,7 +87,7 @@ pub use loonfs_api::v0::{
 };
 pub use loonfs_api::{
     ActorId, ActorKind, ActorRef, AdvanceRetentionResponse, AttributeKey, AttributeRevisionNo,
-    AttributeValue, Attributes, AuthoritativeAttributes, AuthoritativeFileBytes,
+    AttributeValue, Attributes, AttributesProjection, AuthoritativeFileBytes,
     AuthoritativePathEntry, AuthoritativePathEntryKind, CapabilityDocument, ChangeSeq,
     CheckpointId, CheckpointOwnerSummary, CheckpointSummary, ChecksumAlgorithm, CommitId,
     ContentId, ContentRef, ContentRefKind, CreateCheckpointRequest, CreateCheckpointResponse,

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -141,7 +141,7 @@ fn a_write_is_visible_to_the_next_stat() {
         entry
             .attributes
             .as_ref()
-            .map(|projection| projection.revision_no),
+            .map(|projection| projection.attributes_revision_no),
         Some(AttributeRevisionNo(1))
     );
     assert_eq!(
@@ -168,10 +168,12 @@ fn a_write_is_visible_to_the_next_stat() {
         .stat_path_blocking(&namespace_id, "/docs/report.txt")
         .expect("stat cleared");
     assert_eq!(
-        cleared
-            .attributes
-            .as_ref()
-            .map(|projection| (projection.revision_no, projection.attributes.len())),
+        cleared.attributes.as_ref().map(|projection| {
+            (
+                projection.attributes_revision_no,
+                projection.attributes.len(),
+            )
+        }),
         Some((AttributeRevisionNo(2), 0))
     );
 }
@@ -239,7 +241,7 @@ fn read_options_project_grouped_attributes_or_none() {
         let projection = entry.attributes.as_ref().expect("projected attributes");
         match entry.absolute_path.as_str() {
             "/docs/report.txt" => {
-                assert_eq!(projection.revision_no, AttributeRevisionNo(1));
+                assert_eq!(projection.attributes_revision_no, AttributeRevisionNo(1));
                 assert_eq!(
                     projection.attributes.get(&attribute_key("owner")).cloned(),
                     Some(attribute_text("platform"))
@@ -248,7 +250,7 @@ fn read_options_project_grouped_attributes_or_none() {
             // An inode nobody annotated projects the cleared state, not an
             // absent one.
             _ => {
-                assert_eq!(projection.revision_no, AttributeRevisionNo(0));
+                assert_eq!(projection.attributes_revision_no, AttributeRevisionNo(0));
                 assert_eq!(projection.attributes.len(), 0);
             }
         }

--- a/crates/loonfs/tests/it/attribution_rows.rs
+++ b/crates/loonfs/tests/it/attribution_rows.rs
@@ -115,7 +115,7 @@ fn embedded_reads_project_commit_attribution_without_rewriting_inode_creation() 
             .attributes
             .as_ref()
             .expect("copied attributes")
-            .updated_by,
+            .attributes_updated_by,
         Some(copier.clone()),
         "copy restates inherited attributes under the copy commit"
     );
@@ -124,7 +124,7 @@ fn embedded_reads_project_commit_attribution_without_rewriting_inode_creation() 
             .expect("stat source after copy")
             .attributes
             .expect("source attributes")
-            .updated_by,
+            .attributes_updated_by,
         Some(source_attribute_editor),
         "the source keeps its own attribute attribution"
     );
@@ -158,8 +158,8 @@ fn attributes_root_forks_and_trash_report_their_row_attribution() {
     let root = fs.stat_path_blocking(&source_id, "/").expect("stat root");
     assert_eq!(root.created_by, ActorRef::loonfs_system());
     let root_attributes = root.attributes.expect("root attributes projection");
-    assert_eq!(root_attributes.updated_by, None);
-    assert_eq!(root_attributes.updated_at_ms, None);
+    assert_eq!(root_attributes.attributes_updated_by, None);
+    assert_eq!(root_attributes.attributes_updated_at_ms, None);
 
     let creator = actor("file-owner");
     fs.put_file_bytes_blocking(
@@ -184,8 +184,8 @@ fn attributes_root_forks_and_trash_report_their_row_attribution() {
         .expect("stat attributed attributes")
         .attributes
         .expect("attributes projection");
-    assert_eq!(projected.updated_by, Some(updater));
-    assert!(projected.updated_at_ms.is_some());
+    assert_eq!(projected.attributes_updated_by, Some(updater));
+    assert!(projected.attributes_updated_at_ms.is_some());
 
     let later_updater = actor("metadata-reviewer");
     block_on(fs.writer.update_attributes(
@@ -202,9 +202,9 @@ fn attributes_root_forks_and_trash_report_their_row_attribution() {
         .expect("stat later attributes")
         .attributes
         .expect("later attributes projection");
-    assert_eq!(later_projection.revision_no.0, 2);
-    assert_eq!(later_projection.updated_by, Some(later_updater));
-    assert!(later_projection.updated_at_ms.is_some());
+    assert_eq!(later_projection.attributes_revision_no.0, 2);
+    assert_eq!(later_projection.attributes_updated_by, Some(later_updater));
+    assert!(later_projection.attributes_updated_at_ms.is_some());
     let source_before_fork = fs
         .stat_path_blocking(&source_id, "/report.txt")
         .expect("stat source before fork");

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -460,7 +460,7 @@ Responses expose attribution through these fields:
 - `created_by` and `created_at_ms` come from the commit that created an inode.
 - `revision_actor` identifies the actor for the current file revision. Each
   revision-history entry also has an `actor`. Directories have neither field.
-- `attributes.updated_by` identifies who last changed the stored attributes.
+- `attributes_updated_by` identifies who last changed the stored attributes.
   The initial empty attributes at revision 0 have no updater.
 - `deleted_by` identifies the actor for an active trash entry.
 
@@ -1345,12 +1345,10 @@ the durable naming rules (`format.md`, "Durable naming conventions").
     "checksum": { "algorithm": "sha256", "value": "42d..." }
   },
   "committed_at_ms": 1752624000000,
-  "attributes": {
-    "revision_no": 3,
-    "updated_by": { "kind": "user", "id": "metadata-editor" },
-    "updated_at_ms": 1752623500000,
-    "attributes": { "owner": "platform" }
-  }
+  "attributes_revision_no": 3,
+  "attributes_updated_by": { "kind": "user", "id": "metadata-editor" },
+  "attributes_updated_at_ms": 1752623500000,
+  "attributes": { "owner": "platform" }
 }
 ```
 
@@ -1360,19 +1358,22 @@ current revision row. These stamps are observational — sequences are the
 order, and no validity rule reads them. Directories have creation time but no
 modified time in v0; rename and move change neither attribution nor time.
 
-`include_attributes` selects whether the entry carries the inode's grouped
-attribute projection. It accepts `true` or `false`; anything else is `invalid_request`. Stat
+`include_attributes` selects whether the entry carries the inode's attribute
+projection. It accepts `true` or `false`; anything else is `invalid_request`. Stat
 defaults to `true`, because a stat answers for one path and a map is capped
 at 64 KiB.
 
-The `attributes` value is present or absent as one group. When present, it
-carries `revision_no`, the complete `attributes` map, and `updated_by` plus
-`updated_at_ms` when a persisted attributes revision exists. An empty map is a
-real projected answer at its current revision, and an inode that has never
-had attributes written reads as `{}` at revision 0 with no `updated_by` or
-`updated_at_ms`. A read that did not
-include attributes omits the group, so an absent group never means "no
-attributes".
+The projection serializes as prefixed siblings. `attributes_revision_no` and
+the complete `attributes` map are present together or absent together;
+`attributes_updated_by` and `attributes_updated_at_ms` are also present when a
+persisted attributes revision exists. The revision number is read
+independently — clients feed it to `expected_attributes_revision_no` on the
+next write without touching the values — which is the prefixed-sibling case,
+not the consumed-as-a-unit case used by the entry-kind enum. An empty map is a
+real projected answer at its current revision, and an inode that has never had
+attributes written reads as `{}` at revision 0 with no updater or update time.
+A read that did not include attributes omits all four siblings, so an absent
+projection never means "no attributes".
 
 The namespace root is nameless: its entry omits both `parent_inode_id` and
 `display_name`. Every non-root entry carries a validated `display_name`; the
@@ -1393,11 +1394,11 @@ request path remains the authority for what is being listed. Responses
 include `next_cursor` only when another page is available.
 
 `include_attributes` works exactly as it does on stat, and obeys the same
-both-or-neither projection rule, but it defaults to `false`. That default is
-what bounds a listing: a page holds up to `pagination.max_limit` entries and
-each attribute map may be 64 KiB, and no request declares a byte budget, so a
-listing carries attributes only when the caller asks and sizes its pages for
-what comes back.
+required-siblings-together projection rule, but it defaults to `false`. That
+default is what bounds a listing: a page holds up to `pagination.max_limit`
+entries and each attribute map may be 64 KiB, and no request declares a byte
+budget, so a listing carries attributes only when the caller asks and sizes
+its pages for what comes back.
 
 A cursor is an opaque ordering resume, not a snapshot pin. Every cursor in the API
 — directory listing, revision listing, grep, and the change feed alike —

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2928,23 +2928,23 @@
           "type": "string"
         }
       },
-      "AuthoritativeAttributes": {
+      "AttributesProjection": {
         "type": "object",
-        "description": "One inode's complete projected attribute state.",
+        "description": "One inode's structurally complete attribute projection.",
         "required": [
-          "revision_no",
+          "attributes_revision_no",
           "attributes"
         ],
         "properties": {
           "attributes": {
             "$ref": "#/components/schemas/Attributes",
-            "description": "The complete attribute map at `revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
+            "description": "The complete attribute map at `attributes_revision_no`.\n\nAn inode that has never had attributes written is at revision 0 with\nan empty map."
           },
-          "revision_no": {
+          "attributes_revision_no": {
             "$ref": "#/components/schemas/AttributeRevisionNo",
             "description": "The attribute revision this projection represents."
           },
-          "updated_at_ms": {
+          "attributes_updated_at_ms": {
             "type": [
               "integer",
               "null"
@@ -2953,7 +2953,7 @@
             "description": "Time of the latest attribute update, in Unix milliseconds. This is\n`None` for the initial empty state at revision 0.",
             "minimum": 0
           },
-          "updated_by": {
+          "attributes_updated_by": {
             "oneOf": [
               {
                 "type": "null"
@@ -2973,6 +2973,17 @@
             "description": "File-or-directory classification and its kind-specific payload."
           },
           {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AttributesProjection",
+                "description": "The inode's attribute projection, when requested."
+              }
+            ]
+          },
+          {
             "type": "object",
             "required": [
               "namespace_id",
@@ -2986,17 +2997,6 @@
               "absolute_path": {
                 "$ref": "#/components/schemas/AbsolutePath",
                 "description": "Absolute path as rendered from stored display names."
-              },
-              "attributes": {
-                "oneOf": [
-                  {
-                    "type": "null"
-                  },
-                  {
-                    "$ref": "#/components/schemas/AuthoritativeAttributes",
-                    "description": "The inode's attribute projection, when requested."
-                  }
-                ]
               },
               "created_at_ms": {
                 "type": "integer",
@@ -3045,7 +3045,7 @@
             }
           }
         ],
-        "description": "Authoritative metadata for one visible path.\n\nThis is the result shape for stat/list style reads. The entry kind carries\nthe file-only revision and content summary, so a directory cannot carry a\npartial file payload. Attributes are likewise projected as one value or\nomitted as one value."
+        "description": "Authoritative metadata for one visible path.\n\nThis is the result shape for stat/list style reads. The entry kind carries\nthe file-only revision and content summary, so a directory cannot carry a\npartial file payload. Attributes are likewise projected as one value or\nomitted as one value, while serializing as prefixed sibling fields.\nThe attribute revision is read independently — clients feed it to\n`expected_attributes_revision_no` on the next write without touching the\nvalues — so this is a prefixed-sibling projection rather than a value\nconsumed as one nested unit."
       },
       "AuthoritativePathEntryKind": {
         "oneOf": [


### PR DESCRIPTION
Path reads now return attribute data as fields on the path entry: `attributes_revision_no`, `attributes`, `attributes_updated_by`, and `attributes_updated_at_ms`. This avoids nesting the attribute map inside another `attributes` object and gives each related field a clear name.

The attribute revision and map are still included or omitted together. When attributes are requested for an inode that has never had any, the response contains revision 0 and an empty map. When attributes are not requested, all attribute fields are omitted. The update actor and time are included only after an attribute change has been recorded.

This updates the Rust API types, server responses, clients, CLI output, OpenAPI schema, documentation, and tests. It only changes the response shape; stored data is unchanged.