### PR TITLE
refactor(api): normalize path, namespace, and deletion names

### DIFF
--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -229,11 +229,11 @@ fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFing
         },
         FilesystemOperation::Undelete {
             inode_id,
-            deleted_at_seq,
+            deletion_seq,
             path,
         } => OperationFingerprintInput::Undelete {
             inode_id: *inode_id,
-            deleted_at_seq: *deleted_at_seq,
+            deleted_at_seq: *deletion_seq,
             absolute_path: path.as_ref().map(|path| path.as_str()),
         },
         FilesystemOperation::UpdateAttributes {
@@ -688,7 +688,7 @@ mod tests {
             None,
             &[FilesystemOperation::Undelete {
                 inode_id: InodeId(42),
-                deleted_at_seq: ChangeSeq(17),
+                deletion_seq: ChangeSeq(17),
                 path: Some(AbsolutePath::parse("/docs/report.txt").expect("path")),
             }],
         )
@@ -720,7 +720,7 @@ mod tests {
             None,
             &[FilesystemOperation::Undelete {
                 inode_id: InodeId(42),
-                deleted_at_seq: ChangeSeq(17),
+                deletion_seq: ChangeSeq(17),
                 path: None,
             }],
         )

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -86,7 +86,7 @@ pub enum FilesystemChange {
     },
     /// A file or directory subtree was deleted. The enclosing change's
     /// `committed_seq` is the deletion generation an undelete request passes
-    /// as `deleted_at_seq`.
+    /// as `deletion_seq`.
     #[cfg_attr(feature = "openapi", schema(title = "FilesystemChangeDeleted"))]
     Deleted {
         /// Inode at the root of the deleted subtree.

--- a/crates/loonfs-api/src/v0/commits.rs
+++ b/crates/loonfs-api/src/v0/commits.rs
@@ -84,9 +84,8 @@ pub enum FilesystemChange {
         /// Spelling of the new binding.
         to_display_name: DisplayName,
     },
-    /// A file or directory subtree was deleted. The enclosing change's
-    /// `committed_seq` is the deletion generation an undelete request passes
-    /// as `deletion_seq`.
+    /// A file or directory subtree was deleted. Use the enclosing change's
+    /// `committed_seq` as `deletion_seq` when restoring it.
     #[cfg_attr(feature = "openapi", schema(title = "FilesystemChangeDeleted"))]
     Deleted {
         /// Inode at the root of the deleted subtree.

--- a/crates/loonfs-api/src/v0/downloads.rs
+++ b/crates/loonfs-api/src/v0/downloads.rs
@@ -63,7 +63,7 @@ pub struct BeginDownloadResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
     /// Absolute path as rendered from stored display names.
-    pub absolute_path: AbsolutePath,
+    pub path: AbsolutePath,
     /// Revision the capability reads, resolved from the request.
     pub revision_no: RevisionNo,
     /// Identity, byte length, and checksum evidence for the object the
@@ -113,7 +113,7 @@ mod tests {
     fn a_download_grant_exposes_only_presigned_access() {
         let response = BeginDownloadResponse {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            absolute_path: absolute_path(),
+            path: absolute_path(),
             revision_no: RevisionNo(7),
             content_ref: ContentRef::blob_v1(ContentId::generate(), b"hello"),
             access: ObjectTransferAccess::PresignedUrl {

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -278,7 +278,7 @@ pub enum FilesystemOperation {
         behavior: DestinationBehavior,
     },
     /// Recover a deleted file or subtree: revoke the deletion of
-    /// `inode_id` recorded at `deleted_at_seq` (both reported by the
+    /// `inode_id` recorded at `deletion_seq` (both reported by the
     /// delete and by the change feed) and re-bind it. Answers
     /// `not_deleted` when that generation is not the live one, so a stale
     /// request never cancels a later delete.
@@ -287,7 +287,7 @@ pub enum FilesystemOperation {
         /// Deleted inode to make reachable again.
         inode_id: InodeId,
         /// Observed deletion sequence, which prevents cancelling a newer tombstone generation.
-        deleted_at_seq: ChangeSeq,
+        deletion_seq: ChangeSeq,
         /// Optional destination for the restored inode.
         ///
         /// When absent, the inode is rebound to the parent and name recorded by the
@@ -411,7 +411,7 @@ pub struct ListFileRevisionsResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
     /// Absolute file path requested by the caller.
-    pub absolute_path: AbsolutePath,
+    pub path: AbsolutePath,
     /// File inode whose revisions were returned.
     pub inode_id: InodeId,
     /// Namespace head sequence used for the read.
@@ -1358,13 +1358,13 @@ mod tests {
             (
                 FilesystemOperation::Undelete {
                     inode_id: InodeId(7),
-                    deleted_at_seq: ChangeSeq(8),
+                    deletion_seq: ChangeSeq(8),
                     path: Some(path("/docs/restored")),
                 },
                 serde_json::json!({
                     "kind": "undelete",
                     "inode_id": 7,
-                    "deleted_at_seq": 8,
+                    "deletion_seq": 8,
                     "path": "/docs/restored"
                 }),
             ),
@@ -1426,7 +1426,7 @@ mod tests {
             serde_json::json!({
                 "kind": "undelete",
                 "inode_id": 7,
-                "deleted_at_seq": 8,
+                "deletion_seq": 8,
                 "path": "relative"
             }),
             serde_json::json!({

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -277,11 +277,10 @@ pub enum FilesystemOperation {
         #[serde(default)]
         behavior: DestinationBehavior,
     },
-    /// Recover a deleted file or subtree: revoke the deletion of
-    /// `inode_id` recorded at `deletion_seq` (both reported by the
-    /// delete and by the change feed) and re-bind it. Answers
-    /// `not_deleted` when that generation is not the live one, so a stale
-    /// request never cancels a later delete.
+    /// Restore a deleted file or subtree.
+    ///
+    /// `inode_id` and `deletion_seq` identify one exact deletion. A stale
+    /// sequence returns `not_deleted` and cannot undo a later deletion.
     #[cfg_attr(feature = "openapi", schema(title = "FsOpUndelete"))]
     Undelete {
         /// Deleted inode to make reachable again.

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -24,7 +24,7 @@ pub struct AuthoritativePathEntry {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
     /// Absolute path as rendered from stored display names.
-    pub absolute_path: AbsolutePath,
+    pub path: AbsolutePath,
     /// Stable inode identity for this item.
     pub inode_id: InodeId,
     /// Actor that created this inode, as supplied by the application.
@@ -171,7 +171,7 @@ pub struct ListPathEntriesResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
     /// Absolute path of the listed directory.
-    pub absolute_path: AbsolutePath,
+    pub path: AbsolutePath,
     /// Namespace head sequence this listing was read from.
     pub head_seq: ChangeSeq,
     /// Directory entries for this page.
@@ -205,7 +205,7 @@ mod tests {
     ) -> AuthoritativePathEntry {
         AuthoritativePathEntry {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            absolute_path: AbsolutePath::parse(path).expect("absolute path"),
+            path: AbsolutePath::parse(path).expect("absolute path"),
             inode_id: InodeId(if parent_inode_id.is_some() { 2 } else { 1 }),
             created_by: ActorRef::loonfs_system(),
             created_at_ms: 1_752_624_000_000,
@@ -224,7 +224,7 @@ mod tests {
             serde_json::to_value(&named).expect("serialize named entry"),
             serde_json::json!({
                 "namespace_id": "demo",
-                "absolute_path": "/docs",
+                "path": "/docs",
                 "inode_id": 2,
                 "created_by": { "kind": "system", "id": "loonfs" },
                 "created_at_ms": 1_752_624_000_000_u64,
@@ -237,7 +237,7 @@ mod tests {
 
         let response = ListPathEntriesResponse {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            absolute_path: AbsolutePath::parse("/").expect("absolute path"),
+            path: AbsolutePath::parse("/").expect("absolute path"),
             head_seq: ChangeSeq(3),
             entries: vec![named],
             next_cursor: None,
@@ -246,11 +246,11 @@ mod tests {
             serde_json::to_value(response).expect("serialize listing"),
             serde_json::json!({
                 "namespace_id": "demo",
-                "absolute_path": "/",
+                "path": "/",
                 "head_seq": 3,
                 "entries": [{
                     "namespace_id": "demo",
-                    "absolute_path": "/docs",
+                    "path": "/docs",
                     "inode_id": 2,
                     "created_by": { "kind": "system", "id": "loonfs" },
                     "created_at_ms": 1_752_624_000_000_u64,
@@ -279,7 +279,7 @@ mod tests {
             serde_json::to_value(file).expect("serialize file entry"),
             serde_json::json!({
                 "namespace_id": "demo",
-                "absolute_path": "/report.txt",
+                "path": "/report.txt",
                 "inode_id": 2,
                 "created_by": { "kind": "system", "id": "loonfs" },
                 "created_at_ms": 1_752_624_000_000_u64,
@@ -419,6 +419,50 @@ mod tests {
         let projected_json = serde_json::to_value(projected).expect("serialize projected entry");
         assert!(projected_json.pointer("/attributes/attributes").is_none());
     }
+
+    #[test]
+    fn trash_handle_copies_directly_into_an_undelete_operation() {
+        let trash = TrashEntry {
+            inode_id: InodeId(42),
+            deletion_seq: ChangeSeq(417),
+            deleted_at_ms: 1_752_625_000_000,
+            deleted_by: ActorRef::loonfs_system(),
+            parent_inode_id: Some(InodeId(7)),
+            name_key: Some(NameKey::parse("report.txt").expect("name key")),
+            display_name: Some(DisplayName::parse("Report.txt").expect("display name")),
+        };
+        let trash_json = serde_json::to_value(trash).expect("serialize trash entry");
+        assert_eq!(trash_json["inode_id"], serde_json::json!(42));
+        assert_eq!(trash_json["deletion_seq"], serde_json::json!(417));
+        assert!(trash_json.get("root_inode_id").is_none());
+        assert!(trash_json.get("deleted_at_seq").is_none());
+
+        let operation_json = serde_json::json!({
+            "kind": "undelete",
+            "inode_id": trash_json["inode_id"].clone(),
+            "deletion_seq": trash_json["deletion_seq"].clone()
+        });
+        let operation: crate::v0::FilesystemOperation =
+            serde_json::from_value(operation_json).expect("decode copied trash handle");
+        assert!(matches!(
+            operation,
+            crate::v0::FilesystemOperation::Undelete {
+                inode_id: InodeId(42),
+                deletion_seq: ChangeSeq(417),
+                path: None,
+            }
+        ));
+
+        assert!(
+            serde_json::from_value::<crate::v0::FilesystemOperation>(serde_json::json!({
+                "kind": "undelete",
+                "inode_id": 42,
+                "deleted_at_seq": 417
+            }))
+            .is_err(),
+            "the retired deletion handle must not decode"
+        );
+    }
 }
 
 /// One recoverable deletion: an active subtree tombstone plus the identity
@@ -428,10 +472,10 @@ mod tests {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct TrashEntry {
-    /// Root inode the deletion hid; half of the recovery handle.
-    pub root_inode_id: InodeId,
+    /// Inode the deletion hid; half of the recovery handle.
+    pub inode_id: InodeId,
     /// Commit sequence of the deletion; the other half of the handle.
-    pub deleted_at_seq: ChangeSeq,
+    pub deletion_seq: ChangeSeq,
     /// Time of the deletion, in Unix milliseconds.
     pub deleted_at_ms: u64,
     /// Actor responsible for the deletion.

--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -465,16 +465,16 @@ mod tests {
     }
 }
 
-/// One recoverable deletion: an active subtree tombstone plus the identity
-/// of the binding it deleted, when the delete recorded one. Entries with no
-/// recorded name predate the enriched tombstone rows; their inode and
-/// sequence still form a complete `undelete` handle.
+/// One deletion that can still be restored.
+///
+/// `inode_id` and `deletion_seq` are sufficient to restore it. The original
+/// parent and name are included when they were recorded.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct TrashEntry {
-    /// Inode the deletion hid; half of the recovery handle.
+    /// Inode hidden by the deletion.
     pub inode_id: InodeId,
-    /// Commit sequence of the deletion; the other half of the handle.
+    /// Commit sequence that identifies this deletion.
     pub deletion_seq: ChangeSeq,
     /// Time of the deletion, in Unix milliseconds.
     pub deleted_at_ms: u64,

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -75,7 +75,7 @@ impl GrepRequest {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GrepMatch {
     /// The file's absolute path, derived at the snapshot.
-    pub absolute_path: AbsolutePath,
+    pub path: AbsolutePath,
     /// Durable identity of the matched file.
     pub inode_id: InodeId,
     /// The matched revision (the newest visible one at the snapshot).
@@ -278,7 +278,7 @@ mod tests {
         );
 
         let found = GrepMatch {
-            absolute_path: AbsolutePath::parse("/docs/a.txt").expect("match path"),
+            path: AbsolutePath::parse("/docs/a.txt").expect("match path"),
             inode_id: InodeId(2),
             revision_no: RevisionNo(3),
             line_number: 4,
@@ -289,7 +289,7 @@ mod tests {
         assert_eq!(
             serde_json::to_value(found).expect("serialize grep match"),
             serde_json::json!({
-                "absolute_path": "/docs/a.txt",
+                "path": "/docs/a.txt",
                 "inode_id": 2,
                 "revision_no": 3,
                 "line_number": 4,

--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -95,6 +95,49 @@ fn read_golden(name: &str) -> Vec<u8> {
     })
 }
 
+fn assert_json_has_no_retired_public_field(value: &serde_json::Value, name: &str) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for retired in ["absolute_path", "root_inode_id", "deleted_at_seq"] {
+                assert!(
+                    !object.contains_key(retired),
+                    "golden JSON `{name}` carries retired public field `{retired}`"
+                );
+            }
+            for nested in object.values() {
+                assert_json_has_no_retired_public_field(nested, name);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for nested in values {
+                assert_json_has_no_retired_public_field(nested, name);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn json_goldens_do_not_pin_retired_public_field_names() {
+    let directory = golden_path("");
+    for entry in std::fs::read_dir(directory).expect("read golden directory") {
+        let entry = entry.expect("read golden directory entry");
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("golden JSON filename");
+        let value: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(&path).unwrap_or_else(|error| panic!("read `{name}`: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("parse `{name}`: {error}"));
+        assert_json_has_no_retired_public_field(&value, name);
+    }
+}
+
 fn unzstd(bytes: &[u8]) -> Vec<u8> {
     zstd::stream::decode_all(bytes).expect("decompress envelope")
 }

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -232,10 +232,9 @@ History and recovery
     Recover a deleted file or directory; --inode and --deletion-seq come from
     `loonfs trash` or the `rm` output and name one exact deletion, so a
     stale command cannot cancel a later delete. Omit <path> to restore in
-    place — the entry re-binds under the parent and name its deletion
-    recorded, which lands correctly even if the enclosing directories were
-    renamed since. Pass <path> to recover somewhere else, or when the
-    deletion recorded no binding
+    place under the parent and name recorded with the deletion. This still
+    works if an enclosing directory was renamed. Pass <path> to restore it
+    somewhere else, or when the deletion did not record a binding
 
   loonfs changes [--after <seq>] [--limit <n>]
     List committed changes after a sequence number, from the start of

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -227,9 +227,9 @@ History and recovery
     List recoverable deletions: what was deleted, when, and the exact
     `loonfs undelete` command that recovers each one
 
-  loonfs undelete [<path>] --inode <id> --deleted-at <seq>
+  loonfs undelete [<path>] --inode <id> --deletion-seq <seq>
                   [--actor-kind <kind> --actor-id <id>]
-    Recover a deleted file or directory; --inode and --deleted-at come from
+    Recover a deleted file or directory; --inode and --deletion-seq come from
     `loonfs trash` or the `rm` output and name one exact deletion, so a
     stale command cannot cancel a later delete. Omit <path> to restore in
     place — the entry re-binds under the parent and name its deletion

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -713,7 +713,7 @@ pub(crate) struct FilesystemUndeleteArgs {
     /// `rm` and the change feed. Scopes recovery to that exact deletion,
     /// so a stale command cannot cancel a later delete.
     #[arg(long)]
-    pub deleted_at: u64,
+    pub deletion_seq: u64,
     /// Annotation recorded on the commit and shown by `loonfs changes`. Part
     /// of the commit's identity: resubmitting the same --commit-id with a
     /// different message is a commit id conflict.

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -766,14 +766,14 @@ impl EmbeddedBackend {
         namespace: &NamespaceId,
         path: Option<&AbsolutePath>,
         inode_id: InodeId,
-        deleted_at_seq: ChangeSeq,
+        deletion_seq: ChangeSeq,
         options: &UndeleteOptions,
     ) -> Result<CommitResponse, BackendError> {
         self.publish_with_maintenance_recovery(namespace, || {
             self.writer.undelete(
                 namespace,
                 inode_id,
-                deleted_at_seq,
+                deletion_seq,
                 path.map(|path| path.as_str()),
                 options.clone(),
             )

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -772,7 +772,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Recovers a deleted file or subtree; `inode_id` and `deleted_at_seq`
+    /// Recovers a deleted file or subtree; `inode_id` and `deletion_seq`
     /// are the identity and committed sequence the delete reported. An
     /// absent `path` restores in place, under the parent and name the
     /// deletion recorded.
@@ -781,19 +781,19 @@ impl ResolvedTarget {
         namespace: &NamespaceId,
         path: Option<&AbsolutePath>,
         inode_id: InodeId,
-        deleted_at_seq: ChangeSeq,
+        deletion_seq: ChangeSeq,
         options: &UndeleteOptions,
     ) -> Result<CommitResponse, BackendError> {
         match self {
             Self::Embedded(target) => {
                 target
                     .backend
-                    .undelete(namespace, path, inode_id, deleted_at_seq, options)
+                    .undelete(namespace, path, inode_id, deletion_seq, options)
                     .await
             }
             Self::Remote(target) => Ok(target
                 .client
-                .undelete(namespace, inode_id, deleted_at_seq, path, options)
+                .undelete(namespace, inode_id, deletion_seq, path, options)
                 .await?),
         }
     }

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -772,10 +772,8 @@ impl ResolvedTarget {
         }
     }
 
-    /// Recovers a deleted file or subtree; `inode_id` and `deletion_seq`
-    /// are the identity and committed sequence the delete reported. An
-    /// absent `path` restores in place, under the parent and name the
-    /// deletion recorded.
+    /// Restores the deletion identified by `inode_id` and `deletion_seq`.
+    /// When `path` is absent, the original parent and name are used.
     pub(crate) async fn undelete(
         &self,
         namespace: &NamespaceId,

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -292,7 +292,7 @@ impl UndeleteHint {
         &self,
         recorded_binding: bool,
         inode_id: InodeId,
-        deleted_at: ChangeSeq,
+        deletion_seq: ChangeSeq,
     ) -> String {
         // The placeholder is deliberately left unquoted: pasted unedited, a
         // shell rejects it instead of recovering the entry to a file
@@ -303,8 +303,8 @@ impl UndeleteHint {
             format!("{PATH_PLACEHOLDER} ")
         };
         format!(
-            "loonfs undelete {destination}--inode {inode_id} --deleted-at {}{}",
-            deleted_at.0, self.context_flags
+            "loonfs undelete {destination}--inode {inode_id} --deletion-seq {}{}",
+            deletion_seq.0, self.context_flags
         )
     }
 }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -65,7 +65,7 @@ fn commit_options(
 
 struct FollowedPathEntryPages {
     namespace_id: NamespaceId,
-    absolute_path: AbsolutePath,
+    path: AbsolutePath,
     head_seq: ChangeSeq,
     head_drift: Option<ListingHeadDrift>,
     next_cursor: Option<String>,
@@ -96,7 +96,7 @@ async fn follow_path_entry_pages(
             .map_err(|error| context.fail(kind, error))?;
         let ListPathEntriesResponse {
             namespace_id,
-            absolute_path,
+            path: absolute_path,
             head_seq,
             entries,
             next_cursor,
@@ -110,7 +110,7 @@ async fn follow_path_entry_pages(
         if filled || !follow || cursor.is_none() {
             return Ok(FollowedPathEntryPages {
                 namespace_id,
-                absolute_path,
+                path: absolute_path,
                 head_seq: heads
                     .last()
                     .expect("a listing observes the page it just received"),
@@ -197,7 +197,7 @@ pub(crate) async fn run_filesystem_ls(
         mode: Some(context.mode),
         data: CommandData::PathEntries {
             namespace_id: followed.namespace_id,
-            absolute_path: followed.absolute_path,
+            path: followed.path,
             head_seq: followed.head_seq,
             head_drift: followed.head_drift,
             entries,
@@ -732,8 +732,8 @@ pub(crate) async fn run_filesystem_trash(
         .map(|entry| {
             hint.command(
                 entry.display_name.is_some(),
-                entry.root_inode_id,
-                entry.deleted_at_seq,
+                entry.inode_id,
+                entry.deletion_seq,
             )
         })
         .collect();
@@ -1218,7 +1218,7 @@ pub(crate) async fn run_filesystem_undelete(
             &context.namespace,
             spec.as_ref().map(|spec| spec.absolute_path()),
             loonfs_api::InodeId(args.inode),
-            loonfs_api::ChangeSeq(args.deleted_at),
+            loonfs_api::ChangeSeq(args.deletion_seq),
             &loonfs_client::UndeleteOptions {
                 commit: commit_options(&context.actor, commit_id, args.message.clone()),
             },

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -175,7 +175,7 @@ pub(crate) enum CommandData {
     Trash(TrashListing),
     PathEntries {
         namespace_id: NamespaceId,
-        absolute_path: AbsolutePath,
+        path: AbsolutePath,
         /// Namespace head the final page was read from.
         head_seq: ChangeSeq,
         /// Heads observed when this invocation crossed namespace states.
@@ -320,7 +320,7 @@ mod tests {
     fn path_entries(head_drift: Option<ListingHeadDrift>) -> CommandData {
         CommandData::PathEntries {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            absolute_path: AbsolutePath::parse("/docs").expect("absolute path"),
+            path: AbsolutePath::parse("/docs").expect("absolute path"),
             head_seq: ChangeSeq(8),
             head_drift,
             entries: Vec::new(),

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -595,8 +595,8 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                     format_utc_ms(entry.deleted_at_ms),
                     render_actor(&entry.deleted_by),
                     name,
-                    entry.root_inode_id,
-                    entry.deleted_at_seq.0,
+                    entry.inode_id,
+                    entry.deletion_seq.0,
                 ));
             }
             if response.entries.is_empty() {
@@ -739,12 +739,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         } => {
             let mut lines: Vec<String> = matches
                 .iter()
-                .map(|found| {
-                    format!(
-                        "{}:{}:{}",
-                        found.absolute_path, found.line_number, found.line
-                    )
-                })
+                .map(|found| format!("{}:{}:{}", found.path, found.line_number, found.line))
                 .collect();
             if *truncated {
                 lines.push(format!(
@@ -763,7 +758,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             lines.join("\n")
         }
         CommandData::PathEntry(entry) => {
-            let mut lines = vec![format!("path: {}", entry.absolute_path)];
+            let mut lines = vec![format!("path: {}", entry.path)];
             if let Some(display_name) = &entry.display_name {
                 lines.push(format!("name: {display_name}"));
             }
@@ -954,7 +949,7 @@ pub(crate) fn human_path_entry(entry: &loonfs_api::AuthoritativePathEntry) -> St
         size,
         format_utc_ms(entry.created_at_ms),
         render_actor(&entry.created_by),
-        entry.absolute_path
+        entry.path
     )
 }
 
@@ -1009,7 +1004,7 @@ mod tests {
     fn path_entry(path: &str, display_name: Option<&str>) -> AuthoritativePathEntry {
         AuthoritativePathEntry {
             namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-            absolute_path: AbsolutePath::parse(path).expect("absolute path"),
+            path: AbsolutePath::parse(path).expect("absolute path"),
             inode_id: InodeId(if display_name.is_some() { 2 } else { 1 }),
             created_by: loonfs_api::ActorRef::loonfs_system(),
             created_at_ms: 1_752_624_000_000,

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -1664,7 +1664,7 @@ fn every_mutating_command_records_its_message() {
     let inode_id = json_data(&removed)["inode_id"]
         .as_u64()
         .expect("rm reports the deleted inode id");
-    let deleted_at = json_data(&removed)["committed_seq"]
+    let deletion_seq = json_data(&removed)["committed_seq"]
         .as_u64()
         .expect("rm reports the committed seq");
     assert_success(&harness.run(&[
@@ -1672,8 +1672,8 @@ fn every_mutating_command_records_its_message() {
         "/dir/moved.txt",
         "--inode",
         &inode_id.to_string(),
-        "--deleted-at",
-        &deleted_at.to_string(),
+        "--deletion-seq",
+        &deletion_seq.to_string(),
         "-m",
         "undelete message",
     ]));
@@ -1795,14 +1795,14 @@ fn trash_lists_recoverable_deletions_with_their_handles() {
     assert!(table.contains("loonfs undelete "), "{table}");
 
     // Recovering through the listed handle empties that entry out of trash.
-    let inode = report["root_inode_id"].as_u64().expect("inode");
-    let seq = report["deleted_at_seq"].as_u64().expect("seq");
+    let inode = report["inode_id"].as_u64().expect("inode");
+    let seq = report["deletion_seq"].as_u64().expect("seq");
     assert_success(&harness.run(&[
         "undelete",
         "/docs/Quarterly Report.PDF",
         "--inode",
         &inode.to_string(),
-        "--deleted-at",
+        "--deletion-seq",
         &seq.to_string(),
     ]));
     let after = harness.run(&["--json", "trash"]);
@@ -1848,10 +1848,10 @@ fn recovery_hints_name_their_namespace_and_quote_the_path() {
     let removed = harness.run(&["rm", "/docs/Quarterly Report.PDF"]);
     assert_success(&removed);
     let entry = json_data(&harness.run(&["--json", "trash"]))["entries"][0].clone();
-    let deleted_at = entry["deleted_at_seq"].as_u64().expect("the deletion seq");
+    let deletion_seq = entry["deletion_seq"].as_u64().expect("the deletion seq");
     assert_eq!(
         hinted_recovery_command(&removed),
-        format!("loonfs undelete --inode {inode} --deleted-at {deleted_at} --namespace demo")
+        format!("loonfs undelete --inode {inode} --deletion-seq {deletion_seq} --namespace demo")
     );
 
     // The trash table offers the same command for the same deletion. Neither
@@ -1861,7 +1861,7 @@ fn recovery_hints_name_their_namespace_and_quote_the_path() {
     assert_success(&listed);
     assert_eq!(
         trash_recovery_command(&listed, "Quarterly Report.PDF"),
-        format!("loonfs undelete --inode {inode} --deleted-at {deleted_at} --namespace demo")
+        format!("loonfs undelete --inode {inode} --deletion-seq {deletion_seq} --namespace demo")
     );
 
     // Pasting the hint into a shell recovers the file, which is the whole
@@ -3478,12 +3478,25 @@ fn rm_reports_the_inode_and_undelete_recovers_it() {
     let inode_id = json_data(&removed)["inode_id"]
         .as_u64()
         .expect("rm reports the deleted inode id");
-    let deleted_at = json_data(&removed)["committed_seq"]
+    let deletion_seq = json_data(&removed)["committed_seq"]
         .as_u64()
         .expect("rm reports the deletion sequence");
     let gone = harness.run(&["--json", "revisions", "/docs/report.txt"]);
     assert_failure(&gone);
     assert_eq!(json_error(&gone)["code"], "path_not_found");
+
+    let retired_flag = harness.run(&[
+        "undelete",
+        "/docs/report.txt",
+        "--inode",
+        &inode_id.to_string(),
+        "--deleted-at",
+        &deletion_seq.to_string(),
+    ]);
+    assert_failure(&retired_flag);
+    let retired_flag_error = stderr_string(&retired_flag);
+    assert!(retired_flag_error.contains("--deleted-at"));
+    assert!(retired_flag_error.contains("--deletion-seq"));
 
     // Undelete brings back identity, content, and revision history.
     let recovered = harness.run(&[
@@ -3492,8 +3505,8 @@ fn rm_reports_the_inode_and_undelete_recovers_it() {
         "/docs/report.txt",
         "--inode",
         &inode_id.to_string(),
-        "--deleted-at",
-        &deleted_at.to_string(),
+        "--deletion-seq",
+        &deletion_seq.to_string(),
     ]);
     assert_success(&recovered);
     assert_eq!(json_data(&recovered)["target"], "demo:/docs/report.txt");
@@ -3517,8 +3530,8 @@ fn rm_reports_the_inode_and_undelete_recovers_it() {
         "/docs/report-copy.txt",
         "--inode",
         &inode_id.to_string(),
-        "--deleted-at",
-        &deleted_at.to_string(),
+        "--deletion-seq",
+        &deletion_seq.to_string(),
     ]);
     assert_failure(&again);
     assert_eq!(json_error(&again)["code"], "not_deleted");
@@ -3555,10 +3568,10 @@ fn an_undelete_without_a_path_restores_in_place() {
     let trash = harness.run(&["--json", "trash"]);
     assert_success(&trash);
     let entry = json_data(&trash)["entries"][0].clone();
-    let inode_id = entry["root_inode_id"]
+    let inode_id = entry["inode_id"]
         .as_u64()
         .expect("trash reports the deleted inode id");
-    let deleted_at = entry["deleted_at_seq"]
+    let deletion_seq = entry["deletion_seq"]
         .as_u64()
         .expect("trash reports the deletion sequence");
 
@@ -3570,8 +3583,8 @@ fn an_undelete_without_a_path_restores_in_place() {
         "undelete",
         "--inode",
         &inode_id.to_string(),
-        "--deleted-at",
-        &deleted_at.to_string(),
+        "--deletion-seq",
+        &deletion_seq.to_string(),
     ]);
     assert_success(&recovered);
     assert_eq!(json_data(&recovered)["target"], "demo:(restored in place)");
@@ -3600,8 +3613,8 @@ fn an_undelete_without_a_path_restores_in_place() {
         "undelete",
         "--inode",
         &inode_id.to_string(),
-        "--deleted-at",
-        &deleted_at.to_string(),
+        "--deletion-seq",
+        &deletion_seq.to_string(),
     ]);
     assert_failure(&stale);
     assert_eq!(json_error(&stale)["code"], "not_deleted");
@@ -3635,7 +3648,7 @@ fn remote_undelete_recovers_through_http() {
     let inode_id = json_data(&removed)["inode_id"]
         .as_u64()
         .expect("rm reports the deleted inode id");
-    let deleted_at = json_data(&removed)["committed_seq"]
+    let deletion_seq = json_data(&removed)["committed_seq"]
         .as_u64()
         .expect("rm reports the deletion sequence");
 
@@ -3647,7 +3660,7 @@ fn remote_undelete_recovers_through_http() {
         trash_recovery_command(&listed, "wire.txt"),
         format!(
             "loonfs undelete --inode {inode_id} \
-             --deleted-at {deleted_at} --namespace demo"
+             --deletion-seq {deletion_seq} --namespace demo"
         )
     );
 
@@ -3657,8 +3670,8 @@ fn remote_undelete_recovers_through_http() {
         "/wire.txt",
         "--inode",
         &inode_id.to_string(),
-        "--deleted-at",
-        &deleted_at.to_string(),
+        "--deletion-seq",
+        &deletion_seq.to_string(),
     ]);
     assert_success(&recovered);
     let cat = harness.run(&["cat", "/wire.txt"]);
@@ -4888,7 +4901,7 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     assert_success(&first);
     let first_data = json_data(&first);
     assert_eq!(first_data["namespace_id"], "demo");
-    assert_eq!(first_data["absolute_path"], "/listing");
+    assert_eq!(first_data["path"], "/listing");
     assert!(first_data["head_seq"].is_u64());
     assert!(first_data.get("head_drift").is_none());
     let first_entries = first_data["entries"].as_array().expect("first page");
@@ -4916,7 +4929,7 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     assert_success(&all_json);
     let all_json_data = json_data(&all_json);
     assert_eq!(all_json_data["namespace_id"], "demo");
-    assert_eq!(all_json_data["absolute_path"], "/listing");
+    assert_eq!(all_json_data["path"], "/listing");
     assert!(all_json_data["head_seq"].is_u64());
     assert!(all_json_data.get("head_drift").is_none());
     assert_eq!(
@@ -4943,7 +4956,7 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
         .all(|entry| entry.get("data").is_none()));
     let actual_paths = jsonl_entries
         .iter()
-        .map(|entry| entry["absolute_path"].as_str().expect("entry path"))
+        .map(|entry| entry["path"].as_str().expect("entry path"))
         .collect::<Vec<_>>();
     let expected_paths = (0..=loonfs_api::DEFAULT_PAGE_LIMIT)
         .map(|index| format!("/listing/f{index:04}.txt"))
@@ -4956,10 +4969,10 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     let second_entries = second_data["entries"].as_array().expect("second page");
     assert_eq!(second_entries.len(), 1);
     assert_eq!(
-        first_entries.last().expect("last first-page entry")["absolute_path"],
+        first_entries.last().expect("last first-page entry")["path"],
         "/listing/f0999.txt"
     );
-    assert_eq!(second_entries[0]["absolute_path"], "/listing/f1000.txt");
+    assert_eq!(second_entries[0]["path"], "/listing/f1000.txt");
 }
 
 /// A two-page wire fixture makes the otherwise racy between-page commit
@@ -4972,14 +4985,14 @@ fn ls_surfaces_head_drift_from_paged_responses() {
     let (server_url, server) = json_response_server(vec![
         serde_json::json!({
             "namespace_id": "demo",
-            "absolute_path": "/docs",
+            "path": "/docs",
             "head_seq": 5,
             "entries": [],
             "next_cursor": "resume-after-first-page",
         }),
         serde_json::json!({
             "namespace_id": "demo",
-            "absolute_path": "/docs",
+            "path": "/docs",
             "head_seq": 8,
             "entries": [],
         }),
@@ -4990,7 +5003,7 @@ fn ls_surfaces_head_drift_from_paged_responses() {
     assert!(json.stderr.is_empty());
     let data = json_data(&json);
     assert_eq!(data["namespace_id"], "demo");
-    assert_eq!(data["absolute_path"], "/docs");
+    assert_eq!(data["path"], "/docs");
     assert_eq!(data["head_seq"], 8);
     assert_eq!(
         data["head_drift"],
@@ -5004,14 +5017,14 @@ fn ls_surfaces_head_drift_from_paged_responses() {
     let (server_url, server) = json_response_server(vec![
         serde_json::json!({
             "namespace_id": "demo",
-            "absolute_path": "/docs",
+            "path": "/docs",
             "head_seq": 11,
             "entries": [],
             "next_cursor": "resume-after-first-page",
         }),
         serde_json::json!({
             "namespace_id": "demo",
-            "absolute_path": "/docs",
+            "path": "/docs",
             "head_seq": 12,
             "entries": [],
         }),
@@ -5039,7 +5052,7 @@ fn recursive_get_surfaces_drift_across_directory_listings() {
     let (server_url, server) = json_response_server(vec![
         serde_json::json!({
             "namespace_id": "demo",
-            "absolute_path": "/docs",
+            "path": "/docs",
             "inode_id": 2,
             "created_by": { "kind": "system", "id": "loonfs" },
             "created_at_ms": 1_752_624_000_000_u64,
@@ -5050,11 +5063,11 @@ fn recursive_get_surfaces_drift_across_directory_listings() {
         }),
         serde_json::json!({
             "namespace_id": "demo",
-            "absolute_path": "/docs",
+            "path": "/docs",
             "head_seq": 20,
             "entries": [{
                 "namespace_id": "demo",
-                "absolute_path": "/docs/sub",
+                "path": "/docs/sub",
                 "inode_id": 3,
                 "created_by": { "kind": "system", "id": "loonfs" },
                 "created_at_ms": 1_752_624_000_000_u64,
@@ -5066,7 +5079,7 @@ fn recursive_get_surfaces_drift_across_directory_listings() {
         }),
         serde_json::json!({
             "namespace_id": "demo",
-            "absolute_path": "/docs/sub",
+            "path": "/docs/sub",
             "head_seq": 21,
             "entries": [],
         }),
@@ -5139,7 +5152,7 @@ fn ls_limit_bounds_the_whole_listing_and_rejects_all() {
     let second_entries = second_data["entries"].as_array().expect("json array");
     assert_eq!(second_entries.len(), 2);
     assert_ne!(
-        second_entries[0]["absolute_path"], first_entries[0]["absolute_path"],
+        second_entries[0]["path"], first_entries[0]["path"],
         "the cursor resumes after the entries already printed"
     );
 

--- a/crates/loonfs-client/src/download_tests.rs
+++ b/crates/loonfs-client/src/download_tests.rs
@@ -112,7 +112,7 @@ async fn a_capability_failure_is_not_reported_as_no_direct_download() {
 fn grant(content_ref: ContentRef, url: &str) -> BeginDownloadResponse {
     BeginDownloadResponse {
         namespace_id: NamespaceId::parse("demo").expect("namespace id"),
-        absolute_path: AbsolutePath::parse("/big.bin").expect("absolute path"),
+        path: AbsolutePath::parse("/big.bin").expect("absolute path"),
         revision_no: RevisionNo(1),
         content_ref,
         access: ObjectTransferAccess::PresignedUrl {

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -628,7 +628,7 @@ impl Client {
             .await?;
         let mut envelope = ListPathEntriesResponse {
             namespace_id: first_page.namespace_id,
-            absolute_path: first_page.absolute_path,
+            path: first_page.path,
             head_seq: first_page.head_seq,
             entries: first_page.entries,
             next_cursor: None,
@@ -803,7 +803,7 @@ impl Client {
         if start_offset > download.content_ref.size_bytes {
             return Err(ClientError::Http(format!(
                 "cannot resume a download of `{}` at offset {start_offset} of {} bytes",
-                download.absolute_path, download.content_ref.size_bytes
+                download.path, download.content_ref.size_bytes
             )));
         }
         let mut request = WireRequest::presigned(reqwest::Method::GET, url);
@@ -817,7 +817,7 @@ impl Client {
         Ok(DirectDownloadStream {
             body,
             expected: download.content_ref.clone(),
-            path: download.absolute_path.clone(),
+            path: download.path.clone(),
             digest: StreamingChecksum::for_algorithm(download.content_ref.checksum.algorithm),
             // The counter measures the whole object, not this response, so
             // the length check at the end lands where it always did.
@@ -853,7 +853,7 @@ impl Client {
         W: tokio::io::AsyncWrite + Unpin,
     {
         use tokio::io::AsyncWriteExt as _;
-        let path = &download.absolute_path;
+        let path = &download.path;
         let mut download = self.open_direct_download(download).await?;
         let mut size_bytes = 0u64;
         while let Some(chunk) = download.next_chunk().await? {
@@ -2413,7 +2413,7 @@ impl Client {
         &self,
         namespace: &NamespaceId,
         inode_id: InodeId,
-        deleted_at_seq: ChangeSeq,
+        deletion_seq: ChangeSeq,
         path: Option<&AbsolutePath>,
         options: &UndeleteOptions,
     ) -> Result<ApiCommitResponse> {
@@ -2433,7 +2433,7 @@ impl Client {
                     options.commit.message.clone(),
                     FilesystemOperation::Undelete {
                         inode_id,
-                        deleted_at_seq,
+                        deletion_seq,
                         path: path.cloned(),
                     },
                 ),

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -2406,9 +2406,7 @@ impl Client {
         Ok(response)
     }
 
-    /// Recovers a deleted file or subtree: clears the tombstone rooted at
-    /// `inode_id` (the id the delete reported) and re-binds it at the spec's
-    /// path.
+    /// Restores a deleted file or subtree, optionally at a new path.
     pub async fn undelete(
         &self,
         namespace: &NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -243,7 +243,7 @@ async fn undelete<S: ObjectStore + ?Sized>(
         commit_id,
         FilesystemOperation::Undelete {
             inode_id,
-            deleted_at_seq,
+            deletion_seq: deleted_at_seq,
             path: Some(AbsolutePath::parse(absolute_path).expect("path")),
         },
         context,
@@ -328,8 +328,8 @@ fn trash_by_walking_every_tombstone(state: &MetadataState, head_seq: ChangeSeq) 
                 }
             };
             Some(TrashEntry {
-                root_inode_id,
-                deleted_at_seq: active.generation.seq,
+                inode_id: root_inode_id,
+                deletion_seq: active.generation.seq,
                 deleted_at_ms: active.deleted_at_ms,
                 deleted_by: active.actor,
                 parent_inode_id: deleted_direntry
@@ -349,7 +349,7 @@ fn trash_by_walking_every_tombstone(state: &MetadataState, head_seq: ChangeSeq) 
 /// normalized away and pinned separately by
 /// `the_listing_is_ordered_oldest_deletion_first`.
 fn sorted_by_generation(mut entries: Vec<TrashEntry>) -> Vec<TrashEntry> {
-    entries.sort_by_key(|entry| (entry.deleted_at_seq, entry.root_inode_id));
+    entries.sort_by_key(|entry| (entry.deletion_seq, entry.inode_id));
     entries
 }
 
@@ -522,8 +522,8 @@ async fn the_listing_is_ordered_oldest_deletion_first() {
     assert!(
         entries
             .windows(2)
-            .all(|pair| (pair[0].deleted_at_seq, pair[0].root_inode_id)
-                < (pair[1].deleted_at_seq, pair[1].root_inode_id)),
+            .all(|pair| (pair[0].deletion_seq, pair[0].inode_id)
+                < (pair[1].deletion_seq, pair[1].inode_id)),
         "entries must ascend by (deleted_at_seq, root_inode_id): {entries:?}"
     );
 }
@@ -572,7 +572,7 @@ async fn trash_pages_resume_after_the_generation_the_cursor_names() {
         .expect("five deletions do not fit one page of two");
     assert_eq!(
         (cursor.last_deleted_at_seq, cursor.last_root_inode_id),
-        (first.items[1].deleted_at_seq, first.items[1].root_inode_id),
+        (first.items[1].deletion_seq, first.items[1].inode_id),
         "the cursor names the generation the page ended on"
     );
 
@@ -677,8 +677,8 @@ async fn a_deletion_far_below_the_retention_floor_still_lists_and_still_undelete
         1,
         "a deletion below the floor stays listed: {entries:?}"
     );
-    assert_eq!(entries[0].root_inode_id, deleted_inode_id);
-    assert_eq!(entries[0].deleted_at_seq, deleted.committed_seq);
+    assert_eq!(entries[0].inode_id, deleted_inode_id);
+    assert_eq!(entries[0].deletion_seq, deleted.committed_seq);
 
     undelete(
         &store,
@@ -795,7 +795,7 @@ async fn nested_deletions_each_keep_their_own_entry() {
     assert_eq!(
         nested
             .iter()
-            .map(|entry| entry.root_inode_id)
+            .map(|entry| entry.inode_id)
             .collect::<Vec<_>>(),
         vec![child_inode_id, parent_inode_id],
         "a deletion inside an already-deleted subtree keeps its own entry"
@@ -813,10 +813,7 @@ async fn nested_deletions_each_keep_their_own_entry() {
     .await;
     let after = trash_entries(&store, &namespace_id, 10).await;
     assert_eq!(
-        after
-            .iter()
-            .map(|entry| entry.root_inode_id)
-            .collect::<Vec<_>>(),
+        after.iter().map(|entry| entry.inode_id).collect::<Vec<_>>(),
         vec![child_inode_id],
         "recovering the parent leaves the child's own deletion listed"
     );
@@ -862,13 +859,13 @@ async fn a_deletion_committed_after_the_last_manifest_lists_immediately() {
     let entries = trash_entries(&store, &namespace_id, 10).await;
     assert_eq!(entries.len(), 2, "{entries:?}");
     assert_eq!(
-        entries[1].deleted_at_seq, fresh.committed_seq,
+        entries[1].deletion_seq, fresh.committed_seq,
         "the unflushed deletion lists last, in deletion order"
     );
 
     // An undelete in the tail hides a deletion the manifest still lists.
-    let durable_inode_id = entries[0].root_inode_id;
-    let durable_seq = entries[0].deleted_at_seq;
+    let durable_inode_id = entries[0].inode_id;
+    let durable_seq = entries[0].deletion_seq;
     undelete(
         &store,
         &namespace_id,
@@ -885,5 +882,5 @@ async fn a_deletion_committed_after_the_last_manifest_lists_immediately() {
         1,
         "an unflushed undelete must hide the durable row it cancels: {entries:?}"
     );
-    assert_eq!(entries[0].deleted_at_seq, fresh.committed_seq);
+    assert_eq!(entries[0].deletion_seq, fresh.committed_seq);
 }

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -431,7 +431,7 @@ async fn undelete_newest_deletion<S: ObjectStore + ?Sized>(
         namespace_id,
         FilesystemOperation::Undelete {
             inode_id: root_inode_id,
-            deleted_at_seq,
+            deletion_seq: deleted_at_seq,
             path: None,
         },
         context,

--- a/crates/loonfs-core/src/commit/ops.rs
+++ b/crates/loonfs-core/src/commit/ops.rs
@@ -108,7 +108,7 @@ pub(crate) enum CommitOp {
         root_inode_id: InodeId,
     },
     /// Recover a deleted file or subtree: revoke the deletion recorded at
-    /// `deleted_at_seq` (the delete's committed sequence, reported by the
+    /// `deletion_seq` (the delete's committed sequence, reported by the
     /// delete and by the change feed) and re-bind the inode under a visible
     /// parent directory. Scoping recovery to the observed generation keeps
     /// a stale request from cancelling a later deletion of the same inode.
@@ -117,7 +117,7 @@ pub(crate) enum CommitOp {
         inode_id: InodeId,
         /// Observed deletion sequence, which prevents cancelling a newer
         /// tombstone generation.
-        deleted_at_seq: ChangeSeq,
+        deletion_seq: ChangeSeq,
         /// Visible directory that will own the recovered binding.
         parent_inode_id: InodeId,
         /// Recovered child spelling, whose derived key must be absent.

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -276,14 +276,14 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
             }
             CommitOp::Undelete {
                 inode_id,
-                deleted_at_seq,
+                deletion_seq,
                 parent_inode_id,
                 display_name,
             } => {
                 let active = validate_undelete_target(
                     metadata_state,
                     *inode_id,
-                    *deleted_at_seq,
+                    *deletion_seq,
                     committed_seq,
                 )
                 .await?;

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -357,7 +357,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             AuthoritativePathEntryKind::File { content_ref, .. } => content_ref.clone(),
             AuthoritativePathEntryKind::Directory {} => {
                 return Err(CoreError::ExpectedFile {
-                    path: entry.absolute_path.to_string(),
+                    path: entry.path.to_string(),
                     kind: InodeKind::Directory,
                 });
             }
@@ -395,7 +395,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             } => (*revision_no, content_ref.clone()),
             AuthoritativePathEntryKind::Directory {} => {
                 return Err(CoreError::ExpectedFile {
-                    path: entry.absolute_path.to_string(),
+                    path: entry.path.to_string(),
                     kind: InodeKind::Directory,
                 });
             }
@@ -410,7 +410,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let object_key = content_object_key_for_ref(&self.content_store_id, &content_ref)?;
 
         Ok(DirectDownloadTarget {
-            absolute_path: entry.absolute_path,
+            absolute_path: entry.path,
             revision_no,
             content_ref,
             object_key,
@@ -427,7 +427,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .await?;
         if matches!(entry.kind, AuthoritativePathEntryKind::Directory {}) {
             return Err(CoreError::ExpectedFile {
-                path: entry.absolute_path.to_string(),
+                path: entry.path.to_string(),
                 kind: InodeKind::Directory,
             });
         }
@@ -489,8 +489,8 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         let entries = deletions
             .into_iter()
             .map(|deletion| TrashEntry {
-                root_inode_id: deletion.root_inode_id,
-                deleted_at_seq: deletion.deleted_at_seq,
+                inode_id: deletion.root_inode_id,
+                deletion_seq: deletion.deleted_at_seq,
                 deleted_at_ms: deletion.deleted_at_ms,
                 deleted_by: deletion.deleted_by,
                 parent_inode_id: deletion
@@ -592,7 +592,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .await?;
         if matches!(entry.kind, AuthoritativePathEntryKind::Directory {}) {
             return Err(CoreError::ExpectedFile {
-                path: entry.absolute_path.to_string(),
+                path: entry.path.to_string(),
                 kind: InodeKind::Directory,
             });
         }
@@ -829,7 +829,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .transpose()?;
         Ok(AuthoritativePathEntry {
             namespace_id: self.namespace_id.clone(),
-            absolute_path,
+            path: absolute_path,
             inode_id: resolved.inode_id,
             created_by: resolved.created_by.clone(),
             created_at_ms: resolved.created_at_ms,

--- a/crates/loonfs-core/src/path/write/plan_create.rs
+++ b/crates/loonfs-core/src/path/write/plan_create.rs
@@ -76,7 +76,7 @@ pub(super) async fn plan_publish_create_directory<S: ObjectStore + ?Sized>(
 
 pub(super) async fn plan_publish_undelete<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
-    deleted_at_seq: ChangeSeq,
+    deletion_seq: ChangeSeq,
     absolute_path: Option<&AbsolutePath>,
     view: &PublishPathPlanningView<'_, '_, '_, S>,
 ) -> Result<PlannedOperation> {
@@ -114,7 +114,7 @@ pub(super) async fn plan_publish_undelete<S: ObjectStore + ?Sized>(
         None => {
             let Some(deletion) = view
                 .metadata_state
-                .recoverable_deletion(deleted_at_seq, inode_id)
+                .recoverable_deletion(deletion_seq, inode_id)
                 .await?
             else {
                 return Err(CommitValidationError::UndeleteTargetNotDeleted { inode_id }.into());
@@ -136,7 +136,7 @@ pub(super) async fn plan_publish_undelete<S: ObjectStore + ?Sized>(
     Ok(PlannedOperation::new(
         vec![ApiCommitOp::Undelete {
             inode_id,
-            deleted_at_seq,
+            deletion_seq,
             parent_inode_id,
             display_name: display_name.clone(),
         }],

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -154,9 +154,9 @@ async fn plan_operation<S: ObjectStore + ?Sized>(
         } => plan_publish_restore_revision(path, *source_revision_no, view).await,
         FilesystemOperation::Undelete {
             inode_id,
-            deleted_at_seq,
+            deletion_seq,
             path,
-        } => plan_publish_undelete(*inode_id, *deleted_at_seq, path.as_ref(), view).await,
+        } => plan_publish_undelete(*inode_id, *deletion_seq, path.as_ref(), view).await,
         FilesystemOperation::UpdateAttributes {
             path,
             set,

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -1082,7 +1082,7 @@ mod tests {
     fn test_entry() -> AuthoritativePathEntry {
         AuthoritativePathEntry {
             namespace_id: loonfs_api::NamespaceId::parse("demo").expect("namespace id"),
-            absolute_path: loonfs_api::AbsolutePath::parse("/file.bin").expect("absolute path"),
+            path: loonfs_api::AbsolutePath::parse("/file.bin").expect("absolute path"),
             inode_id: loonfs_api::InodeId(1),
             created_by: loonfs_api::ActorRef::loonfs_system(),
             created_at_ms: 1,

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -1013,7 +1013,7 @@ async fn a_delete_keeps_attributes_and_an_undelete_gives_them_back() {
         "undelete",
         FilesystemOperation::Undelete {
             inode_id: file_inode,
-            deleted_at_seq: deleted.committed_seq,
+            deletion_seq: deleted.committed_seq,
             path: None,
         },
         &context,

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -223,8 +223,7 @@ async fn list_file_revisions_for_inode<S: ObjectStore + ?Sized>(
         if cursor.is_none() {
             return Ok(loonfs_api::ListFileRevisionsResponse {
                 namespace_id: namespace_id.clone(),
-                absolute_path: loonfs_api::AbsolutePath::parse(absolute_path)
-                    .expect("valid test path"),
+                path: loonfs_api::AbsolutePath::parse(absolute_path).expect("valid test path"),
                 inode_id,
                 head_seq: context.head.seq,
                 revisions,
@@ -542,7 +541,7 @@ async fn query_driven_stat_uses_exact_name_key_for_dash_containing_siblings() {
         .expect("materialized stat");
 
     assert_eq!(actual, expected);
-    assert_eq!(actual.absolute_path.as_str(), "/docs/report");
+    assert_eq!(actual.path.as_str(), "/docs/report");
     assert_eq!(actual.size_bytes(), Some(5));
 }
 
@@ -1637,7 +1636,7 @@ async fn resolve_path_uses_nfc_casefold_folding() {
     let resolved = resolve_path(&store, &namespace_id("demo"), lookup_path)
         .await
         .expect("resolve path");
-    assert_eq!(resolved.absolute_path.as_str(), stored_path);
+    assert_eq!(resolved.path.as_str(), stored_path);
     assert_eq!(named_entry(&resolved), "Cafe\u{0301}.txt");
 }
 
@@ -1725,7 +1724,7 @@ async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data()
         .expect("list root");
     let root_names: Vec<&str> = root_entries
         .iter()
-        .map(|entry| entry.absolute_path.as_str())
+        .map(|entry| entry.path.as_str())
         .collect();
     assert!(
         root_names.contains(&"/live"),
@@ -1741,7 +1740,7 @@ async fn tombstoned_children_stay_unlisted_and_live_entries_keep_revision_data()
         .expect("list live dir");
     assert_eq!(live_entries.len(), 1, "one live child");
     let kept = &live_entries[0];
-    assert_eq!(kept.absolute_path.as_str(), "/live/kept.txt");
+    assert_eq!(kept.path.as_str(), "/live/kept.txt");
     assert_eq!(
         kept.size_bytes(),
         Some(b"alive".len() as u64),

--- a/crates/loonfs-core/tests/it/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/it/visibility_equivalence.rs
@@ -170,7 +170,7 @@ impl VisibilityHarness {
     ) -> Result<CommitResponse, CoreError> {
         self.publish_operation(FilesystemOperation::Undelete {
             inode_id,
-            deleted_at_seq,
+            deletion_seq: deleted_at_seq,
             path: Some(AbsolutePath::parse(path).expect("valid path")),
         })
         .await

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -850,7 +850,7 @@ impl GrepService {
                     continue;
                 }
                 if let Some(scope) = &scope {
-                    if !path_within_scope(&path, &scope.absolute_path) {
+                    if !path_within_scope(&path, &scope.path) {
                         rejected_frontier = Some(inode_id);
                         continue;
                     }
@@ -921,7 +921,7 @@ impl GrepService {
                     }
                     resume_cursor = Some((inode_id, found.byte_offset));
                     matches.push(GrepMatch {
-                        absolute_path: candidate.path.clone(),
+                        path: candidate.path.clone(),
                         inode_id,
                         revision_no: candidate.revision_no,
                         line_number: found.line_number,
@@ -993,7 +993,7 @@ async fn scan_candidate_inodes(
             inodes.insert(entry.inode_id);
             return Ok(inodes);
         }
-        Some(entry) => entry.absolute_path.clone(),
+        Some(entry) => entry.path.clone(),
         None => AbsolutePath::root(),
     };
     let mut directories = vec![root];
@@ -1007,7 +1007,7 @@ async fn scan_candidate_inodes(
                 .await?;
             for entry in page.items {
                 match entry.inode_kind() {
-                    InodeKind::Directory => directories.push(entry.absolute_path),
+                    InodeKind::Directory => directories.push(entry.path),
                     InodeKind::File => {
                         inodes.insert(entry.inode_id);
                     }

--- a/crates/loonfs-grep/tests/it/grams_index.rs
+++ b/crates/loonfs-grep/tests/it/grams_index.rs
@@ -161,7 +161,7 @@ async fn grep_worker_builds_the_gram_index_once_enabled() {
         .await
         .expect("grep after steps");
     assert_eq!(response.matches.len(), 1);
-    assert_eq!(response.matches[0].absolute_path, "/alpha.txt");
+    assert_eq!(response.matches[0].path, "/alpha.txt");
 
     // New commits are visible immediately through the exhaustive tail, and
     // a later step absorbs them into the index.
@@ -272,7 +272,7 @@ async fn a_publish_below_the_wal_threshold_does_not_schedule_grep_work() {
         .await
         .expect("stale grep after explicit worker catch-up");
     assert_eq!(response.matches.len(), 1);
-    assert_eq!(response.matches[0].absolute_path, "/delta.txt");
+    assert_eq!(response.matches[0].path, "/delta.txt");
 
     writer.shutdown().await.expect("writer shutdown");
 }
@@ -583,7 +583,7 @@ async fn collect_grep_paths(
             response
                 .matches
                 .into_iter()
-                .map(|found| found.absolute_path.to_string()),
+                .map(|found| found.path.to_string()),
         );
         let Some(cursor) = response.next_cursor else {
             return paths;
@@ -640,7 +640,7 @@ async fn grep_answers_identically_across_tiered_folds() {
         let mut matched: Vec<String> = response
             .matches
             .iter()
-            .map(|found| found.absolute_path.to_string())
+            .map(|found| found.path.to_string())
             .collect();
         matched.sort();
         assert_eq!(
@@ -838,7 +838,7 @@ async fn a_failed_candidate_read_surfaces_in_traversal_order() {
         .await
         .expect("a page that fills before the failed candidate must succeed");
     assert_eq!(response.matches.len(), 1);
-    assert_eq!(response.matches[0].absolute_path, "/alpha.txt");
+    assert_eq!(response.matches[0].path, "/alpha.txt");
     assert_eq!(response.matches[0].line, "needle one");
     let cursor = response
         .next_cursor
@@ -944,7 +944,7 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
         .await
         .expect("first page");
     assert_eq!(page_one.matches.len(), 1);
-    assert_eq!(page_one.matches[0].absolute_path, "/alpha.txt");
+    assert_eq!(page_one.matches[0].path, "/alpha.txt");
     let cursor_token = page_one
         .next_cursor
         .clone()
@@ -967,7 +967,7 @@ async fn an_oversized_tail_candidate_is_skipped_without_a_content_read() {
         .await
         .expect("second page");
     assert_eq!(page_two.matches.len(), 1);
-    assert_eq!(page_two.matches[0].absolute_path, "/charlie.txt");
+    assert_eq!(page_two.matches[0].path, "/charlie.txt");
     assert!(page_two.next_cursor.is_none());
     assert!(
         cursor.last_inode_id < page_two.matches[0].inode_id,

--- a/crates/loonfs-grep/tests/it/grep_service_differential.rs
+++ b/crates/loonfs-grep/tests/it/grep_service_differential.rs
@@ -283,7 +283,7 @@ async fn planless_scan_returns_exact_materialized_and_wal_boundary_revisions_onc
     let paths = response
         .matches
         .iter()
-        .map(|found| found.absolute_path.as_str())
+        .map(|found| found.path.as_str())
         .collect::<Vec<_>>();
     assert_eq!(paths.len(), 2);
     assert_eq!(
@@ -350,7 +350,7 @@ async fn planless_scan_deduplicates_an_inode_revised_across_materialization() {
     scan.allow_scan = true;
     let response = harness.success("overlapping inode sources", &scan).await;
     assert_eq!(response.matches.len(), 1);
-    assert_eq!(response.matches[0].absolute_path, "/overlap.txt");
+    assert_eq!(response.matches[0].path, "/overlap.txt");
     assert_eq!(response.matches[0].revision_no.0, 2);
     assert_eq!(response.matches[0].line, "x WAL revision");
 
@@ -485,7 +485,7 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
     assert!(indexed.built_through_seq < indexed.head_seq);
     assert!(indexed.tail_scanned);
     assert_eq!(indexed.matches.len(), 1);
-    assert_eq!(indexed.matches[0].absolute_path, "/docs/indexed.txt");
+    assert_eq!(indexed.matches[0].path, "/docs/indexed.txt");
     assert_eq!(indexed.matches[0].line_number, 1);
     assert_eq!(indexed.matches[0].byte_offset, 0);
     assert_eq!(indexed.matches[0].line, "indexed-needle");
@@ -498,7 +498,7 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
     assert_eq!(tail.matches.len(), 1);
     assert!(tail.tail_scanned);
     assert!(tail.built_through_seq < tail.head_seq);
-    assert_eq!(tail.matches[0].absolute_path, "/tail/tail-hit.txt");
+    assert_eq!(tail.matches[0].path, "/tail/tail-hit.txt");
 
     let mut scan_off = request("ab");
     harness
@@ -525,7 +525,7 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
             scanned
                 .matches
                 .iter()
-                .map(|found| found.absolute_path.as_str().to_owned()),
+                .map(|found| found.path.as_str().to_owned()),
         );
         let Some(cursor) = scanned.next_cursor else {
             break;
@@ -545,13 +545,13 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
     case_folded.case_insensitive = true;
     let case_folded = harness.success("case folding", &case_folded).await;
     assert_eq!(case_folded.matches.len(), 1);
-    assert_eq!(case_folded.matches[0].absolute_path, "/docs/case.txt");
+    assert_eq!(case_folded.matches[0].path, "/docs/case.txt");
 
     let visible = harness
         .success("deleted and moved visibility", &request("visibility-token"))
         .await;
     assert_eq!(visible.matches.len(), 1);
-    assert_eq!(visible.matches[0].absolute_path, "/archive/moved.txt");
+    assert_eq!(visible.matches[0].path, "/archive/moved.txt");
 
     let mut binary = request("ry");
     binary.allow_scan = true;
@@ -580,11 +580,11 @@ async fn grep_service_pins_query_semantics_response_shapes_and_budgets() {
         assert!(page.tail_scanned);
         assert!(page.matches.len() <= 17);
         for found in &page.matches {
-            assert!(found.absolute_path.starts_with("/budget/candidate-"));
+            assert!(found.path.starts_with("/budget/candidate-"));
             assert_eq!(found.line_number, 1);
             assert_eq!(found.byte_offset, 0);
             assert_eq!(found.line, "budget-needle without the final letter");
-            assert!(matched_paths.insert(found.absolute_path.clone()));
+            assert!(matched_paths.insert(found.path.clone()));
         }
         let Some(cursor) = page.next_cursor else {
             break;

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -681,7 +681,7 @@ fn matched_paths(response: &GrepResponse) -> Vec<String> {
     response
         .matches
         .iter()
-        .map(|found| found.absolute_path.as_str().to_owned())
+        .map(|found| found.path.as_str().to_owned())
         .collect()
 }
 
@@ -1246,10 +1246,7 @@ async fn planless_scan_covers_wal_revisions_at_or_below_index_watermark() {
         1,
         "scan must cover the WAL-only revision"
     );
-    assert_eq!(
-        response.matches[0].absolute_path.as_str(),
-        "/only-in-wal.txt"
-    );
+    assert_eq!(response.matches[0].path.as_str(), "/only-in-wal.txt");
 
     writer.shutdown().await.expect("shutdown");
 }
@@ -1378,7 +1375,7 @@ async fn grep_worker_pins_fold_tail_and_pagination_results() {
     assert!(shared.built_through_seq < shared.head_seq);
     assert!(shared.next_cursor.is_none());
     for found in &shared.matches {
-        assert!(found.absolute_path.starts_with("/docs/file-"));
+        assert!(found.path.starts_with("/docs/file-"));
         assert!(matches!(found.line_number, 1 | 2));
         assert_eq!(
             found.byte_offset,
@@ -1392,7 +1389,7 @@ async fn grep_worker_pins_fold_tail_and_pagination_results() {
         .await
         .expect("tail query");
     assert_eq!(tail.matches.len(), 1);
-    assert_eq!(tail.matches[0].absolute_path, "/tail.txt");
+    assert_eq!(tail.matches[0].path, "/tail.txt");
     assert_eq!(tail.matches[0].line_number, 1);
     assert_eq!(tail.matches[0].byte_offset, 0);
     assert_eq!(tail.matches[0].line, "tail-only needle");
@@ -1423,7 +1420,7 @@ async fn grep_worker_pins_fold_tail_and_pagination_results() {
         assert_eq!(page.namespace_id, namespace_id);
         assert_eq!(page.matches.len(), 1);
         let found = &page.matches[0];
-        assert!(found_matches.insert((found.absolute_path.clone(), found.line_number)));
+        assert!(found_matches.insert((found.path.clone(), found.line_number)));
         let Some(cursor) = page.next_cursor else {
             break;
         };
@@ -1520,7 +1517,7 @@ async fn fork_of_grep_enabled_namespace_starts_unmaterialized_without_manifest_s
         .await
         .expect("source query after fork");
     assert_eq!(source_response.matches.len(), 1);
-    assert_eq!(source_response.matches[0].absolute_path, "/source.txt");
+    assert_eq!(source_response.matches[0].path, "/source.txt");
     writer.shutdown().await.expect("shutdown");
 }
 
@@ -1717,7 +1714,7 @@ async fn a_publication_in_flight_keeps_its_candidate_through_a_collection_pass()
         .await
         .expect("query follows the published pointer");
     assert_eq!(response.matches.len(), 1);
-    assert_eq!(response.matches[0].absolute_path, "/needle.txt");
+    assert_eq!(response.matches[0].path, "/needle.txt");
 
     // And the retention above was the grace window, not an inert pass: past
     // it, the superseded manifest goes and the published one stays.

--- a/crates/loonfs-server/docs/actor-attribution.md
+++ b/crates/loonfs-server/docs/actor-attribution.md
@@ -33,5 +33,9 @@ Key each change by `(namespace_id, committed_seq)`. Identify files and
 directories by `inode_id`, because paths can change. Store `commit_id` for
 correlation only; it is unique only while its receipt remains in LoonFS.
 
+For a `deleted` event, the enclosing `committed_seq` is the `deletion_seq`
+used with the event's `inode_id` by trash and undelete. The event does not
+duplicate the sequence inside its payload.
+
 If LoonFS returns `rebootstrap_required`, a checkpoint can rebuild the current
 filesystem state, but it cannot recover activity history that was discarded.

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -63,14 +63,14 @@ fn parse_namespace_id(value: String) -> Result<NamespaceId, ApiResponseError> {
     NamespaceId::parse(&value).map_err(ApiResponseError::invalid_namespace_id)
 }
 
-/// The decoded `namespace` path segment, deserialized by name so routes with
+/// The decoded `namespace_id` path segment, deserialized by name so routes with
 /// additional path parameters can share the extractor.
 #[derive(Debug, serde::Deserialize)]
 struct NamespaceSegment {
-    namespace: String,
+    namespace_id: String,
 }
 
-/// Extractor for the `{namespace}` path segment of namespace-scoped routes.
+/// Extractor for the `{namespace_id}` path segment of namespace-scoped routes.
 ///
 /// The segment is parsed into a [`NamespaceId`] at extraction time, but the
 /// outcome is surfaced through [`NamespaceIdPath::into_id`] inside the
@@ -96,7 +96,9 @@ where
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         match AxumPath::<NamespaceSegment>::from_request_parts(parts, state).await {
-            Ok(AxumPath(NamespaceSegment { namespace })) => Ok(Self(parse_namespace_id(namespace))),
+            Ok(AxumPath(NamespaceSegment { namespace_id })) => {
+                Ok(Self(parse_namespace_id(namespace_id)))
+            }
             Err(rejection) => Ok(Self(Err(invalid_path_params(&rejection)))),
         }
     }

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -63,21 +63,16 @@ fn parse_namespace_id(value: String) -> Result<NamespaceId, ApiResponseError> {
     NamespaceId::parse(&value).map_err(ApiResponseError::invalid_namespace_id)
 }
 
-/// The decoded `namespace_id` path segment, deserialized by name so routes with
-/// additional path parameters can share the extractor.
+/// The `namespace_id` path segment shared by namespace-scoped routes.
 #[derive(Debug, serde::Deserialize)]
 struct NamespaceSegment {
     namespace_id: String,
 }
 
-/// Extractor for the `{namespace_id}` path segment of namespace-scoped routes.
+/// Parses the `{namespace_id}` path segment.
 ///
-/// The segment is parsed into a [`NamespaceId`] at extraction time, but the
-/// outcome is surfaced through [`NamespaceIdPath::into_id`] inside the
-/// handler body rather than as an extractor rejection: every handler
-/// authorizes before validating the namespace id, and rejecting during
-/// extraction would let a malformed id short-circuit `authorize` and turn
-/// today's 401 into a 400 for unauthorized requests.
+/// The handler reads the result after authorization. This keeps malformed
+/// namespace ids from changing an unauthorized response from 401 to 400.
 pub(super) struct NamespaceIdPath(Result<NamespaceId, ApiResponseError>);
 
 impl NamespaceIdPath {

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -32,11 +32,11 @@ const DIRECT_GET_URL_TTL: Duration = Duration::from_secs(15 * 60);
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/namespaces/{namespace}/filesystem/downloads",
+        path = "/v0/namespaces/{namespace_id}/filesystem/downloads",
         tag = "filesystem",
         summary = "Begin download",
         description = "Authorizes one direct read of a file's content object and returns a short-lived presigned GET capability, the resolved revision, and the content reference the client checks the arriving bytes against. `Range` is outside the signature, so one grant serves ranged, resumed, and parallel reads. Deployments that cannot presign answer 501 `not_supported`; the proxied `GET /filesystem/content` route stays available and is capped by `download.max_content_bytes`.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body = BeginDownloadRequest,
         responses(
             (status = 200, description = "Download authorized", body = BeginDownloadResponse),
@@ -65,10 +65,10 @@ const DIRECT_GET_URL_TTL: Duration = Duration::from_secs(15 * 60);
 /// come here at all, which is the entire point.
 pub(super) async fn begin_download(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     AppJson(request): AppJson<BeginDownloadRequest>,
 ) -> Result<Json<BeginDownloadResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     // A store either authorizes direct transfers or it does not, and one
     // that does can always sign a read — so this asks for the bundle, not
     // for a direction within it.
@@ -102,7 +102,7 @@ pub(super) async fn begin_download(
 
     Ok(Json(BeginDownloadResponse {
         namespace_id,
-        absolute_path: target.absolute_path,
+        path: target.absolute_path,
         revision_no: target.revision_no,
         content_ref: target.content_ref,
         access: ObjectTransferAccess::PresignedUrl {

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -100,12 +100,12 @@ pub(super) struct ChangesQuery {
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/namespaces/{namespace}/filesystem/list",
+        path = "/v0/namespaces/{namespace_id}/filesystem/list",
         tag = "filesystem",
         summary = "List directory",
         description = "Lists a directory at the current namespace head.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute filesystem path"),
             ("limit" = Option<String>, Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque directory-list page cursor"),
@@ -123,12 +123,12 @@ pub(super) struct ChangesQuery {
 )]
 pub(super) async fn list_path_entries(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
     query: AppQuery<ListPathPageQuery>,
 ) -> Result<Json<loonfs_api::ListPathEntriesResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
     let path = query.path;
     // An absent parameter leaves the option type's own default in place, so
@@ -157,12 +157,12 @@ pub(super) async fn list_path_entries(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/namespaces/{namespace}/filesystem/stat",
+        path = "/v0/namespaces/{namespace_id}/filesystem/stat",
         tag = "filesystem",
         summary = "Stat path",
         description = "Returns the current metadata for a path, including inode identity, kind, display name, file content metadata, and the inode's attributes.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute filesystem path"),
             ("include_attributes" = Option<String>, Query, description = "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`: a stat answers for one path and a map is capped at 64 KiB.")
         ),
@@ -178,12 +178,12 @@ pub(super) async fn list_path_entries(
 )]
 pub(super) async fn stat_path(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
     query: AppQuery<PathQuery>,
 ) -> Result<Json<loonfs_api::AuthoritativePathEntry>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
     let path = query.path;
     let mut options = StatPathOptions::default();
@@ -202,12 +202,12 @@ pub(super) async fn stat_path(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/namespaces/{namespace}/filesystem/content",
+        path = "/v0/namespaces/{namespace_id}/filesystem/content",
         tag = "filesystem",
         summary = "Read file",
         description = "Returns file bytes for the current revision at a path, or for a specific retained revision when `revision_no` is provided.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute file path"),
             ("revision_no" = Option<String>, Query, description = "Optional prior revision number")
         ),
@@ -224,12 +224,12 @@ pub(super) async fn stat_path(
 )]
 pub(super) async fn get_file_bytes(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
     query: AppQuery<ContentQuery>,
 ) -> Result<Response, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
     // Content reads buffer the whole file, so the permit must follow those
     // bytes through the response body rather than ending with this handler.
@@ -273,12 +273,12 @@ pub(super) async fn get_file_bytes(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/namespaces/{namespace}/filesystem/trash",
+        path = "/v0/namespaces/{namespace_id}/filesystem/trash",
         tag = "filesystem",
         summary = "List recoverable deletions",
         description = "Returns the namespace's recoverable deletions, oldest deletion first. Entries never age out at the retention floor; each carries the inode id and deletion sequence undelete needs, plus the deleted name when the delete recorded one.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("limit" = Option<String>, Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque trash page cursor")
         ),
@@ -293,12 +293,12 @@ pub(super) async fn get_file_bytes(
 )]
 pub(super) async fn list_trash(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
     query: AppQuery<PageQuery>,
 ) -> Result<Json<ListTrashResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
     let response = state
         .reader
@@ -318,12 +318,12 @@ pub(super) async fn list_trash(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/namespaces/{namespace}/filesystem/revisions",
+        path = "/v0/namespaces/{namespace_id}/filesystem/revisions",
         tag = "filesystem",
         summary = "List file revisions",
         description = "Resolves the current path to a file inode and returns revisions for that file. If the file could be renamed, use the inode revision API for stable identity.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute file path"),
             ("limit" = Option<String>, Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque file-revisions page cursor")
@@ -340,12 +340,12 @@ pub(super) async fn list_trash(
 )]
 pub(super) async fn list_file_revisions(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
     query: AppQuery<PathPageQuery>,
 ) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
     let path = query.path;
     let response = state
@@ -367,11 +367,11 @@ pub(super) async fn list_file_revisions(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/namespaces/{namespace}/commits",
+        path = "/v0/namespaces/{namespace_id}/commits",
         tag = "filesystem",
         summary = "Apply a commit",
         description = "Applies one commit: an ordered, non-empty list of path operations that commit together as one logical commit, under one commit id that makes retries idempotent. A single-operation call is the one-element case. The first operation that fails aborts the whole request, and a request carrying more than one operation names that operation's position in `details.operation_index`.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body = ApiCommitRequest,
         responses(
             (status = 200, description = "Commit applied", body = ApiCommitResponse),
@@ -388,10 +388,10 @@ pub(super) async fn list_file_revisions(
 /// The server stores the actor from the request; the shared token does not verify it.
 pub(super) async fn apply_commit(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     AppJson(request): AppJson<ApiCommitRequest>,
 ) -> Result<Json<ApiCommitResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let ApiCommitRequest {
         commit_id,
         actor,
@@ -484,12 +484,12 @@ pub(super) async fn apply_commit(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/namespaces/{namespace}/changes",
+        path = "/v0/namespaces/{namespace_id}/changes",
         tag = "filesystem",
         summary = "List changes after a sequence",
         description = "Returns committed changes from the write-ahead log. Callers can use this feed to keep another projection synchronized with WAL history.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("after_seq" = String, Query, description = "Return committed changes after this sequence"),
             ("limit" = Option<String>, Query, description = "Maximum page size")
         ),
@@ -505,12 +505,12 @@ pub(super) async fn apply_commit(
 )]
 pub(super) async fn list_changes(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
     query: AppQuery<ChangesQuery>,
 ) -> Result<Json<ChangesResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
     let after_seq = parse_after_seq(&query.after_seq)?;
     let limit = resolve_page_limit(query.limit)?;

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -196,11 +196,11 @@ pub(super) async fn create_namespace(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/namespaces/{namespace}",
+        path = "/v0/namespaces/{namespace_id}",
         tag = "namespaces",
         summary = "Get namespace status",
         description = "Returns the current head, manifest, checkpoint, WAL tail, and retention state for a namespace.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Namespace status", body = loonfs_api::NamespaceStatusResponse),
             (status = 400, description = "Invalid namespace id", body = ApiError),
@@ -213,11 +213,11 @@ pub(super) async fn create_namespace(
 )]
 pub(super) async fn namespace_status(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<loonfs_api::NamespaceStatusResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let status = state
         .admin
         .namespace_status(&namespace_id)
@@ -230,12 +230,12 @@ pub(super) async fn namespace_status(
     feature = "openapi",
     utoipa::path(
         delete,
-        path = "/v0/namespaces/{namespace}",
+        path = "/v0/namespaces/{namespace_id}",
         tag = "namespaces",
         summary = "Delete namespace",
         description = "Marks a namespace as deleted.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("expected_head_seq" = Option<String>, Query, description = "Delete only if the namespace head is still at this sequence")
         ),
         responses(
@@ -251,12 +251,12 @@ pub(super) async fn namespace_status(
 )]
 pub(super) async fn delete_namespace(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     query: AppQuery<DeleteNamespaceQuery>,
     headers: HeaderMap,
 ) -> Result<Json<loonfs_api::DeleteNamespaceResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
     let options = DeleteNamespaceOptions {
         expected_head_seq: query
@@ -288,11 +288,11 @@ fn parse_expected_head_seq(value: &str) -> Result<ChangeSeq, ApiResponseError> {
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/namespaces/{namespace}/forks",
+        path = "/v0/namespaces/{namespace_id}/forks",
         tag = "namespaces",
         summary = "Fork namespace",
         description = "Creates a new namespace as a fork from the source namespace's current durable view.",
-        params(("namespace" = String, Path, description = "Source namespace id")),
+        params(("namespace_id" = String, Path, description = "Source namespace id")),
         request_body = ForkNamespaceRequest,
         responses(
             (status = 200, description = "Namespace forked", body = loonfs_api::NamespaceSummary),
@@ -307,10 +307,10 @@ fn parse_expected_head_seq(value: &str) -> Result<ChangeSeq, ApiResponseError> {
 )]
 pub(super) async fn fork_namespace(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     AppJson(request): AppJson<ForkNamespaceRequest>,
 ) -> Result<Json<loonfs_api::NamespaceSummary>, ApiResponseError> {
-    let source_namespace_id = namespace.into_id()?;
+    let source_namespace_id = namespace_id_path.into_id()?;
     let summary = state
         .writer
         .fork_namespace(&source_namespace_id, &request.new_namespace_id)
@@ -323,11 +323,11 @@ pub(super) async fn fork_namespace(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/admin/namespaces/{namespace}/checkpoints",
+        path = "/v0/admin/namespaces/{namespace_id}/checkpoints",
         tag = "admin",
         summary = "Create checkpoint",
         description = "Creates a named, user-owned checkpoint record pinning the current namespace view. Every call mints a new record under a new id; the name is a label, not a key. The record is a garbage-collection root until it is released, so routine maintenance should flush the WAL instead. This is a maintenance/admin operation, not a file mutation.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body(content = CreateCheckpointRequest, description = "Checkpoint name and optional lifetime"),
         responses(
             (status = 200, description = "Checkpoint created", body = CreateCheckpointResponse),
@@ -342,10 +342,10 @@ pub(super) async fn fork_namespace(
 )]
 pub(super) async fn create_checkpoint(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     AppJson(request): AppJson<CreateCheckpointRequest>,
 ) -> Result<Json<CreateCheckpointResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let response = state
         .admin
         .create_checkpoint(
@@ -361,11 +361,11 @@ pub(super) async fn create_checkpoint(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/admin/namespaces/{namespace}/checkpoints",
+        path = "/v0/admin/namespaces/{namespace_id}/checkpoints",
         tag = "admin",
         summary = "List checkpoints",
         description = "Lists every active checkpoint record on the namespace, oldest first. Each record is a garbage-collection root, and its id is what the release endpoint takes; because a checkpoint name is a label rather than a key, this is the only way to find a pin whose creation response is gone. An expired record that no collection pass has released yet is still active and is listed, with its expiry in the entry — the operator is looking for roots, and a record that still pins its basis is one. Released records are absent: a release is what stops a record pinning anything.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Active checkpoint records", body = ListCheckpointsResponse),
             (status = 400, description = "Invalid namespace id", body = ApiError),
@@ -377,11 +377,11 @@ pub(super) async fn create_checkpoint(
 )]
 pub(super) async fn list_checkpoints(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<ListCheckpointsResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let response = state
         .admin
         .list_checkpoints(&namespace_id)
@@ -394,12 +394,12 @@ pub(super) async fn list_checkpoints(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release",
+        path = "/v0/admin/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release",
         tag = "admin",
         summary = "Release checkpoint",
         description = "Releases a user-owned checkpoint pin by id. Idempotent: releasing an already-released or reaped record succeeds. The record is reaped by a later garbage-collection pass; its pinned data becomes collectable only on the pass after that.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("checkpoint_id" = String, Path, description = "Checkpoint id")
         ),
         responses(
@@ -413,12 +413,12 @@ pub(super) async fn list_checkpoints(
 )]
 pub(super) async fn release_checkpoint(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     path: AppPath<CheckpointPathParams>,
     headers: HeaderMap,
 ) -> Result<Json<ReleaseCheckpointResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let CheckpointPathParams { checkpoint_id } = path.into_params()?;
     let checkpoint_id = parse_checkpoint_id(&checkpoint_id)?;
     let response = state
@@ -448,11 +448,11 @@ fn parse_checkpoint_id(value: &str) -> Result<CheckpointId, ApiResponseError> {
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/admin/namespaces/{namespace}/maintenance/step",
+        path = "/v0/admin/namespaces/{namespace_id}/maintenance/step",
         tag = "admin",
         summary = "Run maintenance step",
         description = "Runs one bounded maintenance step. The body selects the actions by naming them: `metadata` folds the WAL tail once it reaches the threshold and merges one bounded reorganization unit, `advance_retention: true` advances the retention floor, and `gc` runs one bounded garbage-collection pass. Selected actions run in that order, each reports separately, and an absent report means the body did not select that action. A body that selects nothing is rejected. Nothing surrenders replay history or sweeps objects unless the body asked for it. A deleted namespace accepts a step that selects `gc` alone, which is how its reclaimable state is collected; any other selection is refused. Step-driven GC defaults to 1024 candidates and returns its cursor for a later step rather than looping internally. Losing the root race is an outcome, not an error.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body(content = MaintenanceStepRequest, description = "The actions this step selects"),
         responses(
             (status = 200, description = "Maintenance step completed", body = MaintenanceStepResponse),
@@ -465,10 +465,10 @@ fn parse_checkpoint_id(value: &str) -> Result<CheckpointId, ApiResponseError> {
 )]
 pub(super) async fn maintenance_step(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     OptionalAppJson(request): OptionalAppJson<MaintenanceStepRequest>,
 ) -> Result<Json<MaintenanceStepResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let plan = loonfs::MaintenancePlan::from_request(request.unwrap_or_default())
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     let result = state

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -19,11 +19,11 @@ use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError, NamespaceRea
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/namespaces/{namespace}/query/grep",
+        path = "/v0/namespaces/{namespace_id}/query/grep",
         tag = "query",
         summary = "Content search",
         description = "Searches file content with a regular expression, accelerated by the namespace's grep index. Matches are verified against the real pattern and returned in ascending `(inode_id, byte_offset)` order; revisions committed after the index watermark are scanned exhaustively unless `allow_stale` skips them. Requires this deployment to serve grep and the namespace to carry a materialized steady-state grep root.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body = GrepRequest,
         responses(
             (status = 200, description = "One page of matches", body = GrepResponse),
@@ -41,10 +41,10 @@ use loonfs_grep::{GrepDisableOutcome, GrepEnableOutcome, GrepError, NamespaceRea
 )]
 pub(super) async fn grep(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     AppJson(request): AppJson<GrepRequest>,
 ) -> Result<Json<GrepResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     // First touch: on a deployment that maintains this index, a search is
     // also the hint that someone cares about this namespace again — after a
     // restart, nothing else has said so.
@@ -98,11 +98,11 @@ pub(super) async fn grep_index_not_maintained(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/admin/namespaces/{namespace}/grep/index/enable",
+        path = "/v0/admin/namespaces/{namespace_id}/grep/index/enable",
         tag = "admin",
         summary = "Enable the grep index",
         description = "Enables the namespace's grep root and asks this deployment's maintenance runner for the backfill's first step. The response reports the durable lifecycle it published or found: a fresh enable is `backfilling` with the sequence its checkpoint captured, while an already-enabled namespace answers with whichever phase it is in. Idempotent. Requires this deployment to maintain the grep index.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Grep root enabled or already enabled", body = EnableGrepIndexResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
@@ -117,11 +117,11 @@ pub(super) async fn grep_index_not_maintained(
 )]
 pub(super) async fn enable_grep_index(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<EnableGrepIndexResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let outcome = state
         .grep_worker
         .as_ref()
@@ -160,11 +160,11 @@ pub(super) async fn enable_grep_index(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/admin/namespaces/{namespace}/grep/index",
+        path = "/v0/admin/namespaces/{namespace_id}/grep/index",
         tag = "admin",
         summary = "Read the grep index's lifecycle",
         description = "Reports where the namespace's grep index is: `disabled`, `backfilling` with the sequence it walks toward and how far the walk got, or `steady` with the watermark it has built through. One grep root read, no side effects. A namespace that never enabled the index reads as `disabled`. Requires this deployment to maintain the grep index.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "The index's lifecycle and bookkeeping", body = GrepIndexStatusResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
@@ -177,11 +177,11 @@ pub(super) async fn enable_grep_index(
 )]
 pub(super) async fn grep_index_status(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<GrepIndexStatusResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let root = state
         .grep_worker
         .as_ref()
@@ -211,11 +211,11 @@ pub(super) async fn grep_index_status(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/admin/namespaces/{namespace}/grep/index/disable",
+        path = "/v0/admin/namespaces/{namespace_id}/grep/index/disable",
         tag = "admin",
         summary = "Disable the grep index",
         description = "Disables the namespace's grep root and clears its segment references with one durable compare-and-swap; index maintenance stops on its own once a step reads the disabled root. Explicit grep garbage collection later reclaims the segments. Idempotent. Requires this deployment to maintain the grep index.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Grep root disabled or already disabled", body = DisableGrepIndexResponse),
             (status = 401, description = "Unauthorized", body = ApiError),
@@ -230,11 +230,11 @@ pub(super) async fn grep_index_status(
 )]
 pub(super) async fn disable_grep_index(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
 ) -> Result<Json<DisableGrepIndexResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     // Disabling is one durable compare-and-swap and nothing else. A step
     // already running loses its own publication race to this one and
     // retries; the retry reads a disabled root, concludes there is nothing
@@ -272,11 +272,11 @@ pub(super) async fn disable_grep_index(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/admin/namespaces/{namespace}/grep/index/gc",
+        path = "/v0/admin/namespaces/{namespace_id}/grep/index/gc",
         tag = "admin",
         summary = "Collect grep-index garbage",
         description = "Runs one explicit garbage-collection pass over only this namespace's grep-owned extension keyspace. A tombstoned or absent namespace has aged extension state reaped; no grep garbage collection runs implicitly. `max_objects` bounds the reads the pass spends and returns a `next_cursor` when keys remain; resuming re-reads liveness and the grep root, so a cursor only skips enumeration. Requires this deployment to maintain the grep index.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body = Option<GrepGcRequest>,
         responses(
             (status = 200, description = "Namespace grep garbage collection completed", body = GrepGcResponse),
@@ -290,12 +290,12 @@ pub(super) async fn disable_grep_index(
 )]
 pub(super) async fn gc_grep_index(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
     OptionalAppJson(request): OptionalAppJson<GrepGcRequest>,
 ) -> Result<Json<GrepGcResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let request = request.unwrap_or_default();
     let report = state
         .grep_worker

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -95,11 +95,11 @@ pub(super) struct UploadPathParams {
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/namespaces/{namespace}/uploads",
+        path = "/v0/namespaces/{namespace_id}/uploads",
         tag = "uploads",
         summary = "Begin upload",
         description = "Starts an upload session for content that may later be attached to a file. Service-proxied uploads send bytes through the server; direct-put uploads return object-store presigned credentials.",
-        params(("namespace" = String, Path, description = "Namespace id")),
+        params(("namespace_id" = String, Path, description = "Namespace id")),
         request_body = BeginUploadRequest,
         responses(
             (status = 200, description = "Upload session started", body = BeginUploadResponse),
@@ -114,10 +114,10 @@ pub(super) struct UploadPathParams {
 )]
 pub(super) async fn begin_upload(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     AppJson(request): AppJson<BeginUploadRequest>,
 ) -> Result<Json<BeginUploadResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     // Decoding the body settled which transport this is and that it carries
     // that transport's fields and no other's, so there is nothing left here
     // to check before dispatching on it.
@@ -270,12 +270,12 @@ async fn begin_direct_multipart_upload(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/namespaces/{namespace}/uploads/{upload_id}/parts",
+        path = "/v0/namespaces/{namespace_id}/uploads/{upload_id}/parts",
         tag = "uploads",
         summary = "Sign multipart parts",
         description = "Returns one short-lived, checksum-bound upload capability per requested part of an open direct_multipart session. Asking again for a part is how a client retries it.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
         ),
         request_body = SignUploadPartsRequest,
@@ -293,11 +293,11 @@ async fn begin_direct_multipart_upload(
 )]
 pub(super) async fn sign_upload_parts(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
     AppJson(request): AppJson<SignUploadPartsRequest>,
 ) -> Result<Json<SignUploadPartsResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let Some(issuer) = state
@@ -491,12 +491,12 @@ pub(super) fn current_unix_ms() -> Result<u64, ApiResponseError> {
     feature = "openapi",
     utoipa::path(
         put,
-        path = "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+        path = "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content",
         tag = "uploads",
         summary = "Upload content",
         description = "Uploads bytes into a service-proxied upload session and returns the content reference for the stored object.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
         ),
         request_body(content = Vec<u8>, content_type = "application/octet-stream"),
@@ -527,11 +527,11 @@ pub(super) fn current_unix_ms() -> Result<u64, ApiResponseError> {
 /// storage error.
 pub(super) async fn upload_content(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
     body: UploadBodyStream,
 ) -> Result<Json<UploadContentResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let (stream, outcome) = body.into_stream();
@@ -551,12 +551,12 @@ pub(super) async fn upload_content(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
+        path = "/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
         tag = "uploads",
         summary = "Complete upload",
         description = "Completes an upload session once the caller confirms the expected content reference. The response may include a short-lived validation token for a following file write.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
         ),
         request_body = CompleteUploadRequest,
@@ -573,11 +573,11 @@ pub(super) async fn upload_content(
 )]
 pub(super) async fn complete_upload(
     State(state): State<AppState>,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
     AppJson(request): AppJson<CompleteUploadRequest>,
 ) -> Result<Json<CompleteUploadResponse>, ApiResponseError> {
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let completed = state
@@ -596,12 +596,12 @@ pub(super) async fn complete_upload(
     feature = "openapi",
     utoipa::path(
         get,
-        path = "/v0/namespaces/{namespace}/uploads/{upload_id}",
+        path = "/v0/namespaces/{namespace_id}/uploads/{upload_id}",
         tag = "uploads",
         summary = "Read upload session",
         description = "Reads one upload session. A completed session answers with a freshly minted validation token for its content, so a client that lost a commit response can commit again without re-uploading anything.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
         ),
         responses(
@@ -617,14 +617,14 @@ pub(super) async fn complete_upload(
 pub(super) async fn read_upload_status(
     State(state): State<AppState>,
     headers: HeaderMap,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
 ) -> Result<Json<UploadStatusResponse>, ApiResponseError> {
     // A completed session answers with a freshly minted content-validation
     // token, which is a capability to commit that content. Authorization
     // runs before the id is even parsed, as everywhere else.
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let (mut response, receipt) = state
@@ -647,12 +647,12 @@ pub(super) async fn read_upload_status(
     feature = "openapi",
     utoipa::path(
         post,
-        path = "/v0/namespaces/{namespace}/uploads/{upload_id}/abort",
+        path = "/v0/namespaces/{namespace_id}/uploads/{upload_id}/abort",
         tag = "uploads",
         summary = "Abort upload",
         description = "Ends an upload session without selecting content and deletes the object it was writing. Repeating it succeeds; a session that already completed cannot be aborted.",
         params(
-            ("namespace" = String, Path, description = "Namespace id"),
+            ("namespace_id" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
         ),
         responses(
@@ -669,11 +669,11 @@ pub(super) async fn read_upload_status(
 pub(super) async fn abort_upload(
     State(state): State<AppState>,
     headers: HeaderMap,
-    namespace: NamespaceIdPath,
+    namespace_id_path: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
 ) -> Result<Json<AbortUploadResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
-    let namespace_id = namespace.into_id()?;
+    let namespace_id = namespace_id_path.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
     let response = state

--- a/crates/loonfs-server/src/http/metrics/tests.rs
+++ b/crates/loonfs-server/src/http/metrics/tests.rs
@@ -171,8 +171,8 @@ fn a_scrape_reports_positive_process_resident_bytes() {
 #[test]
 fn route_labels_intern_once_and_refuse_to_grow_without_bound() {
     let mut routes = RouteLabels::default();
-    let first = routes.intern("/v0/namespaces/{namespace}/commits");
-    let again = routes.intern("/v0/namespaces/{namespace}/commits");
+    let first = routes.intern("/v0/namespaces/{namespace_id}/commits");
+    let again = routes.intern("/v0/namespaces/{namespace_id}/commits");
     assert_eq!(first, again);
     assert_eq!(first.as_ptr(), again.as_ptr());
 

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -93,11 +93,11 @@ macro_rules! request_completion_event {
 
 // Membership is limited to streamed content and operator work that is long by design.
 const DEADLINE_EXEMPT_ROUTES: &[&str] = &[
-    "/v0/namespaces/{namespace}/filesystem/content",
-    "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
-    "/v0/admin/namespaces/{namespace}/maintenance/step",
+    "/v0/namespaces/{namespace_id}/filesystem/content",
+    "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content",
+    "/v0/admin/namespaces/{namespace_id}/maintenance/step",
     "/v0/admin/store/probe",
-    "/v0/admin/namespaces/{namespace}/grep/index/gc",
+    "/v0/admin/namespaces/{namespace_id}/grep/index/gc",
 ];
 
 /// Assigns each request a correlation id: every response carries it as the
@@ -223,17 +223,20 @@ fn router(state: AppState) -> Router {
         .route("/v0/capabilities", get(handlers_namespace::capabilities))
         .route("/v0/namespaces", post(create_namespace))
         .route(
-            "/v0/namespaces/{namespace}",
+            "/v0/namespaces/{namespace_id}",
             get(namespace_status).delete(delete_namespace),
         )
-        .route("/v0/namespaces/{namespace}/forks", post(fork_namespace))
+        .route("/v0/namespaces/{namespace_id}/forks", post(fork_namespace))
         .route(
-            "/v0/namespaces/{namespace}/filesystem/list",
+            "/v0/namespaces/{namespace_id}/filesystem/list",
             get(list_path_entries),
         )
-        .route("/v0/namespaces/{namespace}/filesystem/stat", get(stat_path))
         .route(
-            "/v0/namespaces/{namespace}/filesystem/content",
+            "/v0/namespaces/{namespace_id}/filesystem/stat",
+            get(stat_path),
+        )
+        .route(
+            "/v0/namespaces/{namespace_id}/filesystem/content",
             get(get_file_bytes),
         )
         // The read this deployment authorizes rather than performs. It sits
@@ -242,41 +245,41 @@ fn router(state: AppState) -> Router {
         // `not_supported` where no issuer does, exactly as the direct
         // upload modes do on `POST .../uploads`.
         .route(
-            "/v0/namespaces/{namespace}/filesystem/downloads",
+            "/v0/namespaces/{namespace_id}/filesystem/downloads",
             post(begin_download),
         )
-        .route("/v0/namespaces/{namespace}/query/grep", grep_route)
+        .route("/v0/namespaces/{namespace_id}/query/grep", grep_route)
         .route(
-            "/v0/admin/namespaces/{namespace}/grep/index",
+            "/v0/admin/namespaces/{namespace_id}/grep/index",
             grep_status_route,
         )
         .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/enable",
+            "/v0/admin/namespaces/{namespace_id}/grep/index/enable",
             enable_grep_route,
         )
         .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/disable",
+            "/v0/admin/namespaces/{namespace_id}/grep/index/disable",
             disable_grep_route,
         )
         .route(
-            "/v0/admin/namespaces/{namespace}/grep/index/gc",
+            "/v0/admin/namespaces/{namespace_id}/grep/index/gc",
             grep_gc_route,
         )
         .route(
-            "/v0/namespaces/{namespace}/filesystem/revisions",
+            "/v0/namespaces/{namespace_id}/filesystem/revisions",
             get(list_file_revisions),
         )
         .route(
-            "/v0/namespaces/{namespace}/filesystem/trash",
+            "/v0/namespaces/{namespace_id}/filesystem/trash",
             get(list_trash),
         )
         // A commit that reaches the deadline may still land. The publisher
         // owns an accepted candidate, as after a client disconnect, and the
         // commit receipt makes retry safe.
-        .route("/v0/namespaces/{namespace}/commits", post(apply_commit))
-        .route("/v0/namespaces/{namespace}/uploads", post(begin_upload))
+        .route("/v0/namespaces/{namespace_id}/commits", post(apply_commit))
+        .route("/v0/namespaces/{namespace_id}/uploads", post(begin_upload))
         .route(
-            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+            "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content",
             // No body-limit layer: the upload route never buffers its
             // body, so a framework limit measured against a buffered read
             // would never fire. `UploadBodyStream` counts the bytes as it
@@ -284,32 +287,32 @@ fn router(state: AppState) -> Router {
             put(upload_content),
         )
         .route(
-            "/v0/namespaces/{namespace}/uploads/{upload_id}/parts",
+            "/v0/namespaces/{namespace_id}/uploads/{upload_id}/parts",
             post(sign_upload_parts),
         )
         .route(
-            "/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
+            "/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
             post(complete_upload),
         )
         .route(
-            "/v0/namespaces/{namespace}/uploads/{upload_id}/abort",
+            "/v0/namespaces/{namespace_id}/uploads/{upload_id}/abort",
             post(abort_upload),
         )
         .route(
-            "/v0/namespaces/{namespace}/uploads/{upload_id}",
+            "/v0/namespaces/{namespace_id}/uploads/{upload_id}",
             get(read_upload_status),
         )
-        .route("/v0/namespaces/{namespace}/changes", get(list_changes))
+        .route("/v0/namespaces/{namespace_id}/changes", get(list_changes))
         .route(
-            "/v0/admin/namespaces/{namespace}/checkpoints",
+            "/v0/admin/namespaces/{namespace_id}/checkpoints",
             post(create_checkpoint).get(list_checkpoints),
         )
         .route(
-            "/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release",
+            "/v0/admin/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release",
             post(release_checkpoint),
         )
         .route(
-            "/v0/admin/namespaces/{namespace}/maintenance/step",
+            "/v0/admin/namespaces/{namespace_id}/maintenance/step",
             post(maintenance_step),
         )
         // The one admin route whose subject is the store rather than a

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -36,7 +36,6 @@ use std::path::Path;
 
 const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "aborted_at_ms",
-    "absolute_path",
     "active_acquired_at_ms",
     "active_deletion_seq",
     "active_writer",
@@ -80,7 +79,7 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "cursor_inode_id",
     "degraded_retention",
     "degraded_roots",
-    "deleted_at_seq",
+    "deletion_seq",
     "deleted_by",
     "deleted_direntry",
     "destination_exists",
@@ -523,7 +522,7 @@ async fn every_deadline_exemption_names_a_served_route() {
 
     for route in super::DEADLINE_EXEMPT_ROUTES {
         let uri = route
-            .replace("{namespace}", "deadline-exempt")
+            .replace("{namespace_id}", "deadline-exempt")
             .replace("{upload_id}", "upl_deadline_exempt");
         let response = router
             .clone()
@@ -1330,7 +1329,7 @@ async fn runtime_created_state_is_readable_through_http() {
         .stat_path(&target, &Default::default())
         .await
         .expect("stat file");
-    assert_eq!(stat.absolute_path, "/notes/hello.txt");
+    assert_eq!(stat.path, "/notes/hello.txt");
     assert_eq!(stat.size_bytes(), Some(18));
     let bytes = harness
         .client
@@ -3352,7 +3351,7 @@ mod direct_download {
             .begin_download(&target, None)
             .await
             .expect("download grant");
-        assert_eq!(grant.absolute_path.as_str(), "/big.bin");
+        assert_eq!(grant.path.as_str(), "/big.bin");
         assert_eq!(grant.content_ref.size_bytes, payload.len() as u64);
 
         let mut received = Vec::new();

--- a/crates/loonfs-server/tests/it/grep_modes.rs
+++ b/crates/loonfs-server/tests/it/grep_modes.rs
@@ -180,7 +180,7 @@ async fn serving_and_maintaining_enables_queries_nudges_and_disables_per_namespa
     // exhaustive tail and nudges the index at the same time.
     let response = grep(&router, &namespace_id, "automatic needle").await;
     assert_eq!(response.matches.len(), 1);
-    assert_eq!(response.matches[0].absolute_path, "/note.txt");
+    assert_eq!(response.matches[0].path, "/note.txt");
     settle(&server).await;
     assert_eq!(watermark(&store, &namespace_id).await, ChangeSeq(1));
     let caught_up = grep(&router, &namespace_id, "automatic needle").await;

--- a/crates/loonfs-server/tests/it/http_attributes.rs
+++ b/crates/loonfs-server/tests/it/http_attributes.rs
@@ -134,7 +134,7 @@ async fn http_reads_project_flat_attribute_siblings_together() {
     assert_eq!(entries.len(), 2);
     for entry in entries {
         assert_projection(entry, true);
-        match entry["absolute_path"].as_str().expect("path") {
+        match entry["path"].as_str().expect("path") {
             "/docs/report.txt" => {
                 assert_eq!(entry["attributes"]["owner"], "platform");
                 assert_eq!(entry["attributes_revision_no"], 1);

--- a/crates/loonfs-server/tests/it/http_attribution.rs
+++ b/crates/loonfs-server/tests/it/http_attribution.rs
@@ -224,7 +224,7 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
         .expect("list trash");
     assert_eq!(trash.entries.len(), 1);
     let deleted = &trash.entries[0];
-    assert_eq!(deleted.deleted_at_seq, delete.committed_seq);
+    assert_eq!(deleted.deletion_seq, delete.committed_seq);
     assert_eq!(deleted.deleted_at_ms, delete_change.committed_at_ms);
     assert_eq!(deleted.deleted_by, deleter);
 
@@ -233,8 +233,8 @@ async fn http_rows_project_the_commit_that_created_each_retained_fact() {
         .client
         .undelete(
             &namespace,
-            deleted.root_inode_id,
-            deleted.deleted_at_seq,
+            deleted.inode_id,
+            deleted.deletion_seq,
             None,
             &UndeleteOptions::new(undelete_actor.clone()),
         )

--- a/crates/loonfs-server/tests/it/http_metrics.rs
+++ b/crates/loonfs-server/tests/it/http_metrics.rs
@@ -76,7 +76,7 @@ async fn a_scrape_reports_requests_object_store_calls_and_cache_metrics() {
     // Labels render in sorted order, so a scrape of the same readings is
     // byte-stable however the instrument was registered.
     let status_route = "loonfs_server_requests_total{method=\"GET\",\
-                        route=\"/v0/namespaces/{namespace}\",status_class=\"2xx\"}";
+                        route=\"/v0/namespaces/{namespace_id}\",status_class=\"2xx\"}";
     assert_eq!(series(&first, status_route), 1.0);
     assert_eq!(
         series(
@@ -92,7 +92,7 @@ async fn a_scrape_reports_requests_object_store_calls_and_cache_metrics() {
     assert!(
         series(
             &first,
-            "loonfs_server_request_seconds_count{route=\"/v0/namespaces/{namespace}\"}"
+            "loonfs_server_request_seconds_count{route=\"/v0/namespaces/{namespace_id}\"}"
         ) >= 1.0
     );
 

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -409,7 +409,7 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         .list_file_revisions_page(&target, None, None)
         .await
         .expect("path revisions");
-    assert_eq!(revisions.absolute_path, target.absolute_path().clone());
+    assert_eq!(revisions.path, target.absolute_path().clone());
     assert_eq!(revisions.inode_id, entry.inode_id);
     assert_eq!(revisions.revisions.len(), 2);
     assert_eq!(
@@ -448,7 +448,7 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         .list_file_revisions_page(&moved, None, None)
         .await
         .expect("moved-path revisions");
-    assert_eq!(moved_revisions.absolute_path, moved.absolute_path().clone());
+    assert_eq!(moved_revisions.path, moved.absolute_path().clone());
     assert_eq!(moved_revisions.inode_id, entry.inode_id);
     assert_eq!(moved_revisions.revisions.len(), 2);
 

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -35,38 +35,44 @@ fn openapi_documents_current_server_paths() {
         ("/metrics", "get"),
         ("/v0/capabilities", "get"),
         ("/v0/namespaces", "post"),
-        ("/v0/namespaces/{namespace}", "get"),
-        ("/v0/namespaces/{namespace}", "delete"),
-        ("/v0/namespaces/{namespace}/forks", "post"),
-        ("/v0/namespaces/{namespace}/filesystem/list", "get"),
-        ("/v0/namespaces/{namespace}/filesystem/stat", "get"),
-        ("/v0/namespaces/{namespace}/filesystem/content", "get"),
-        ("/v0/namespaces/{namespace}/filesystem/downloads", "post"),
-        ("/v0/namespaces/{namespace}/filesystem/revisions", "get"),
-        ("/v0/namespaces/{namespace}/commits", "post"),
-        ("/v0/namespaces/{namespace}/uploads", "post"),
+        ("/v0/namespaces/{namespace_id}", "get"),
+        ("/v0/namespaces/{namespace_id}", "delete"),
+        ("/v0/namespaces/{namespace_id}/forks", "post"),
+        ("/v0/namespaces/{namespace_id}/filesystem/list", "get"),
+        ("/v0/namespaces/{namespace_id}/filesystem/stat", "get"),
+        ("/v0/namespaces/{namespace_id}/filesystem/content", "get"),
+        ("/v0/namespaces/{namespace_id}/filesystem/downloads", "post"),
+        ("/v0/namespaces/{namespace_id}/filesystem/revisions", "get"),
+        ("/v0/namespaces/{namespace_id}/commits", "post"),
+        ("/v0/namespaces/{namespace_id}/uploads", "post"),
         (
-            "/v0/namespaces/{namespace}/uploads/{upload_id}/content",
+            "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content",
             "put",
         ),
         (
-            "/v0/namespaces/{namespace}/uploads/{upload_id}/complete",
+            "/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
             "post",
         ),
-        ("/v0/namespaces/{namespace}/changes", "get"),
-        ("/v0/admin/namespaces/{namespace}/checkpoints", "post"),
-        ("/v0/admin/namespaces/{namespace}/checkpoints", "get"),
+        ("/v0/namespaces/{namespace_id}/changes", "get"),
+        ("/v0/admin/namespaces/{namespace_id}/checkpoints", "post"),
+        ("/v0/admin/namespaces/{namespace_id}/checkpoints", "get"),
         (
-            "/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release",
+            "/v0/admin/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release",
             "post",
         ),
-        ("/v0/admin/namespaces/{namespace}/maintenance/step", "post"),
-        ("/v0/admin/namespaces/{namespace}/grep/index/enable", "post"),
         (
-            "/v0/admin/namespaces/{namespace}/grep/index/disable",
+            "/v0/admin/namespaces/{namespace_id}/maintenance/step",
             "post",
         ),
-        ("/v0/admin/namespaces/{namespace}/grep/index/gc", "post"),
+        (
+            "/v0/admin/namespaces/{namespace_id}/grep/index/enable",
+            "post",
+        ),
+        (
+            "/v0/admin/namespaces/{namespace_id}/grep/index/disable",
+            "post",
+        ),
+        ("/v0/admin/namespaces/{namespace_id}/grep/index/gc", "post"),
         ("/v0/admin/store/probe", "post"),
     ] {
         assert_path_method(paths, path, method);
@@ -75,16 +81,48 @@ fn openapi_documents_current_server_paths() {
     assert!(!paths.contains_key("/openapi.json"));
     assert_query_params(
         paths,
-        "/v0/namespaces/{namespace}/filesystem/list",
+        "/v0/namespaces/{namespace_id}/filesystem/list",
         "get",
         &["path", "limit", "cursor"],
     );
     assert_query_params(
         paths,
-        "/v0/namespaces/{namespace}/changes",
+        "/v0/namespaces/{namespace_id}/changes",
         "get",
         &["after_seq", "limit"],
     );
+
+    let mut namespace_scoped_operations = 0;
+    for (path, path_item) in paths {
+        if !path.contains("/namespaces/{") {
+            continue;
+        }
+        assert!(
+            path.contains("{namespace_id}"),
+            "namespace-scoped OpenAPI path uses the retired parameter name: `{path}`"
+        );
+        assert!(!path.contains("{namespace}"));
+        for method in ["get", "post", "put", "delete", "patch"] {
+            let Some(operation) = path_item.get(method) else {
+                continue;
+            };
+            namespace_scoped_operations += 1;
+            let path_parameter_names = operation
+                .get("parameters")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter(|parameter| parameter.get("in").and_then(Value::as_str) == Some("path"))
+                .filter_map(|parameter| parameter.get("name").and_then(Value::as_str))
+                .collect::<BTreeSet<_>>();
+            assert!(
+                path_parameter_names.contains("namespace_id"),
+                "`{method} {path}` does not declare `namespace_id` as a path parameter"
+            );
+            assert!(!path_parameter_names.contains("namespace"));
+        }
+    }
+    assert_eq!(namespace_scoped_operations, 26);
 }
 
 #[test]
@@ -181,6 +219,9 @@ fn openapi_reuses_the_one_checksum_and_upload_claim_shapes() {
         "whole_file_sha256",
         "DirectPutContentClaim",
         "DirectMultipartContentClaim",
+        "absolute_path",
+        "root_inode_id",
+        "deleted_at_seq",
     ] {
         assert!(
             !raw.contains(dead_name),
@@ -226,6 +267,12 @@ fn openapi_reuses_the_one_checksum_and_upload_claim_shapes() {
     assert!(!required.contains("multipart"));
 
     for properties in values_named(&spec, "properties").filter_map(Value::as_object) {
+        for retired_name in ["absolute_path", "root_inode_id", "deleted_at_seq"] {
+            assert!(
+                !properties.contains_key(retired_name),
+                "retired public field `{retired_name}` remains in an OpenAPI schema"
+            );
+        }
         assert!(
             !properties.contains_key("crc64nvme"),
             "crc64nvme must be an algorithm value, never a raw public field"

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -329,7 +329,7 @@ pub(super) fn file_revisions_page_response(
         .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
     Ok(ListFileRevisionsResponse {
         namespace_id,
-        absolute_path,
+        path: absolute_path,
         inode_id,
         head_seq,
         revisions: page.items,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -148,7 +148,7 @@ impl FsReader {
         let next_cursor = page.next_cursor;
         let response = ListPathEntriesResponse {
             namespace_id: namespace_id.clone(),
-            absolute_path: listed_path,
+            path: listed_path,
             head_seq,
             entries: page.items,
             next_cursor: None,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -650,7 +650,7 @@ impl FsWriter {
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
-        deleted_at_seq: ChangeSeq,
+        deletion_seq: ChangeSeq,
         absolute_path: Option<&str>,
         options: UndeleteOptions,
     ) -> Result<CommitResponse> {
@@ -671,7 +671,7 @@ impl FsWriter {
                 options.commit.message.clone(),
                 FilesystemOperation::Undelete {
                     inode_id,
-                    deleted_at_seq,
+                    deletion_seq,
                     path,
                 },
             ),

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -643,9 +643,7 @@ impl FsWriter {
         .await
     }
 
-    /// Recovers a deleted file or subtree: clears the tombstone rooted at
-    /// `inode_id` and binds it at `absolute_path`. The inode id is the one
-    /// the delete reported (also visible in the change feed).
+    /// Restores a deleted file or subtree, optionally at a new path.
     pub async fn undelete(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/tests/it/attributes.rs
+++ b/crates/loonfs/tests/it/attributes.rs
@@ -239,7 +239,7 @@ fn read_options_project_grouped_attributes_or_none() {
     assert_eq!(projected.entries.len(), 2);
     for entry in &projected.entries {
         let projection = entry.attributes.as_ref().expect("projected attributes");
-        match entry.absolute_path.as_str() {
+        match entry.path.as_str() {
             "/docs/report.txt" => {
                 assert_eq!(projection.attributes_revision_no, AttributeRevisionNo(1));
                 assert_eq!(

--- a/crates/loonfs/tests/it/attribution_rows.rs
+++ b/crates/loonfs/tests/it/attribution_rows.rs
@@ -250,7 +250,7 @@ fn attributes_root_forks_and_trash_report_their_row_attribution() {
     .expect("list trash before checkpoint");
     assert_eq!(trash.entries.len(), 1);
     assert_eq!(trash.entries[0].deleted_by, deleter);
-    assert_eq!(trash.entries[0].deleted_at_seq, deletion.committed_seq);
+    assert_eq!(trash.entries[0].deletion_seq, deletion.committed_seq);
 
     fs.create_checkpoint_blocking(&source_id)
         .expect("checkpoint deletion rows");
@@ -275,5 +275,5 @@ fn attributes_root_forks_and_trash_report_their_row_attribution() {
     .expect("list trash after checkpoint, retention, and restart");
     assert_eq!(trash.entries.len(), 1);
     assert_eq!(trash.entries[0].deleted_by, deleter);
-    assert_eq!(trash.entries[0].deleted_at_seq, deletion.committed_seq);
+    assert_eq!(trash.entries[0].deletion_seq, deletion.committed_seq);
 }

--- a/crates/loonfs/tests/it/bulk_file_reads.rs
+++ b/crates/loonfs/tests/it/bulk_file_reads.rs
@@ -53,7 +53,7 @@ async fn listed_files(
         for entry in entries {
             match entry.kind {
                 loonfs::AuthoritativePathEntryKind::Directory {} => {
-                    directories.push(entry.absolute_path.as_str().to_owned());
+                    directories.push(entry.path.as_str().to_owned());
                 }
                 loonfs::AuthoritativePathEntryKind::File {
                     revision_no,
@@ -64,7 +64,7 @@ async fn listed_files(
                     found.insert(
                         entry.inode_id,
                         ListedFile {
-                            absolute_path: entry.absolute_path.as_str().to_owned(),
+                            absolute_path: entry.path.as_str().to_owned(),
                             revision_no,
                             size_bytes,
                             content_ref,

--- a/crates/loonfs/tests/it/cache_seeding.rs
+++ b/crates/loonfs/tests/it/cache_seeding.rs
@@ -198,7 +198,7 @@ fn runtime_cache_observes_head_advanced_by_another_runtime() {
     let stat = reader
         .stat_path_blocking(&namespace_id, "/docs/new")
         .expect("reader should observe external head advance");
-    assert_eq!(stat.absolute_path, "/docs/new");
+    assert_eq!(stat.path, "/docs/new");
     assert_eq!(stat.head_seq, ChangeSeq(2));
     assert!(raw_store.wal_get_count() > 0);
 }
@@ -484,10 +484,10 @@ async fn concurrent_materialized_stat_and_list_share_async_store() {
     let stat = stat.expect("stat file");
     let list = list.expect("list docs");
 
-    assert_eq!(stat.absolute_path, "/docs/file.txt");
+    assert_eq!(stat.path, "/docs/file.txt");
     assert_eq!(stat.size_bytes(), Some(4));
     assert_eq!(list.len(), 1);
-    assert_eq!(list[0].absolute_path, "/docs/file.txt");
+    assert_eq!(list[0].path, "/docs/file.txt");
 
     let stats = fs.runtime_cache_stats();
     assert_eq!(stats.latest_metadata_view_reads, 2);
@@ -664,7 +664,7 @@ fn root_stat_and_list_work_immediately_after_namespace_create() {
     let root = fs
         .stat_path_blocking(&namespace_id, "/")
         .expect("stat root after create");
-    assert_eq!(root.absolute_path, "/");
+    assert_eq!(root.path, "/");
     assert_eq!(root.inode_id, InodeId(1));
     assert_eq!(root.inode_kind(), InodeKind::Directory);
     assert_eq!(root.head_seq, ChangeSeq(0));

--- a/crates/loonfs/tests/it/pagination.rs
+++ b/crates/loonfs/tests/it/pagination.rs
@@ -124,7 +124,7 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
         },
     ))
     .expect("first revision page");
-    assert_eq!(first.absolute_path.as_str(), "/doc.txt");
+    assert_eq!(first.path.as_str(), "/doc.txt");
     assert_eq!(
         first
             .revisions
@@ -145,7 +145,7 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
         },
     ))
     .expect("second revision page");
-    assert_eq!(second.absolute_path.as_str(), "/doc.txt");
+    assert_eq!(second.path.as_str(), "/doc.txt");
     assert_eq!(
         second
             .revisions
@@ -336,7 +336,7 @@ fn revisions_cursor_resumes_after_later_writes() {
         },
     ))
     .expect("first revisions page");
-    assert_eq!(first.absolute_path.as_str(), "/docs/report.txt");
+    assert_eq!(first.path.as_str(), "/docs/report.txt");
     assert_eq!(
         first
             .revisions
@@ -371,7 +371,7 @@ fn revisions_cursor_resumes_after_later_writes() {
         },
     ))
     .expect("second revisions page resumes after head drift");
-    assert_eq!(second.absolute_path.as_str(), "/docs/report.txt");
+    assert_eq!(second.path.as_str(), "/docs/report.txt");
     assert_eq!(
         second
             .revisions

--- a/crates/loonfs/tests/it/runtime_config.rs
+++ b/crates/loonfs/tests/it/runtime_config.rs
@@ -86,14 +86,14 @@ fn filesystem_operations_match_core_semantics() {
     let stat = fs
         .stat_path_blocking(&namespace_id, "/docs/hello.txt")
         .expect("stat file");
-    assert_eq!(stat.absolute_path, "/docs/hello.txt");
+    assert_eq!(stat.path, "/docs/hello.txt");
     assert_eq!(stat.size_bytes(), Some(5));
 
     let entries = fs
         .list_path_blocking(&namespace_id, "/docs")
         .expect("list docs");
     assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].absolute_path, "/docs/hello.txt");
+    assert_eq!(entries[0].path, "/docs/hello.txt");
 
     let read = fs
         .get_file_bytes_blocking(&namespace_id, "/docs/hello.txt")
@@ -170,7 +170,7 @@ async fn async_runtime_methods_are_the_engine_boundary() {
     .await
     .expect("async stat");
 
-    assert_eq!(async_stat.absolute_path, "/docs/hello.txt");
+    assert_eq!(async_stat.path, "/docs/hello.txt");
     assert_eq!(async_stat.size_bytes(), Some(5));
 }
 

--- a/crates/loonfs/tests/it/streamed_read.rs
+++ b/crates/loonfs/tests/it/streamed_read.rs
@@ -94,7 +94,7 @@ async fn a_streamed_read_holds_one_chunk_of_its_file() {
         .await
         .expect("open stream");
     assert_eq!(stream.size_bytes(), PAYLOAD_BYTES as u64);
-    assert_eq!(stream.entry().absolute_path.as_str(), PATH);
+    assert_eq!(stream.entry().path.as_str(), PATH);
 
     let mut read = Vec::with_capacity(PAYLOAD_BYTES);
     let mut chunks = 0u64;

--- a/crates/loonfs/tests/it/undelete.rs
+++ b/crates/loonfs/tests/it/undelete.rs
@@ -523,7 +523,7 @@ fn change_feed_reports_the_deletion_generation_an_undelete_takes() {
         }
     }
     // The `Deleted` event's enclosing sequence is the deletion generation an
-    // undelete passes as `deleted_at_seq`, so a feed projection can drive a
+    // undelete passes as `deletion_seq`, so a feed projection can drive a
     // recovery without guessing at "newest".
     assert_eq!(deleted_seq, Some(deletion));
     assert_eq!(undeleted.as_deref(), Some("report.txt"));
@@ -611,7 +611,7 @@ fn undelete_rejects_deletions_from_the_same_commit() {
                     },
                     FilesystemOperation::Undelete {
                         inode_id: entry.inode_id,
-                        deleted_at_seq: guessed_seq,
+                        deletion_seq: guessed_seq,
                         path: Some(
                             parse_mutation_path("/resurrected.txt").expect("valid mutation path"),
                         ),

--- a/crates/loonfs/tests/it/undelete.rs
+++ b/crates/loonfs/tests/it/undelete.rs
@@ -522,9 +522,7 @@ fn change_feed_reports_the_deletion_generation_an_undelete_takes() {
             }
         }
     }
-    // The `Deleted` event's enclosing sequence is the deletion generation an
-    // undelete passes as `deletion_seq`, so a feed projection can drive a
-    // recovery without guessing at "newest".
+    // The change sequence can be copied directly into an undelete request.
     assert_eq!(deleted_seq, Some(deletion));
     assert_eq!(undeleted.as_deref(), Some("report.txt"));
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -26,7 +26,7 @@ within a plane is expressed as **named features** (section 2).
 | --- | --- | --- | --- |
 | `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, the change feed, namespace status by id, `GET /v0/capabilities`, and the standard error contract. Namespace `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
 | `admin/v0` | Maintenance plane | Create and release checkpoints; run one-shot maintenance steps that select any of metadata upkeep (WAL flush plus reorganization), retention-floor advancement, and garbage collection. Maintenance triggers for derived indexes arrive as features in this plane: grep-index administration is the `admin.grep.index` **feature**. | Optional |
-| `query/v0` | Query plane | Content search over derived indexes (`POST /v0/namespaces/{namespace}/query/grep`). Grep-index search is the `query.grep` **feature** within this profile; using it also requires a materialized steady-state grep root for the namespace. | Optional |
+| `query/v0` | Query plane | Content search over derived indexes (`POST /v0/namespaces/{namespace_id}/query/grep`). Grep-index search is the `query.grep` **feature** within this profile; using it also requires a materialized steady-state grep root for the namespace. | Optional |
 | `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. Clients must tolerate unknown error codes, so authorization errors can land with this plane without breaking anyone. |
 
 Notes:
@@ -409,7 +409,7 @@ silently merge. Those checks are evaluated where their operation runs, which
 is what lets a later operation depend on an earlier one. Callers add their
 own cross-request guards on the operation itself where staleness matters:
 `expected_revision_no` on a replacing put, `expected_inode_id` on a delete,
-`deleted_at_seq` on an undelete, and `expected_head_seq` on a namespace
+`deletion_seq` on an undelete, and `expected_head_seq` on a namespace
 delete. A guard is evaluated against the state its own operation sees, which
 includes what earlier operations in the same request did.
 
@@ -1327,7 +1327,7 @@ the durable naming rules (`format.md`, "Durable naming conventions").
 ```json
 {
   "namespace_id": "demo",
-  "absolute_path": "/docs/report.txt",
+  "path": "/docs/report.txt",
   "inode_id": 42,
   "created_by": { "kind": "user", "id": "usr_8f3c" },
   "created_at_ms": 1752623000000,
@@ -1422,12 +1422,12 @@ An unrecognized cursor version is also rejected as `invalid_request`.
 ```json
 {
   "namespace_id": "demo",
-  "absolute_path": "/docs",
+  "path": "/docs",
   "head_seq": 418,
   "entries": [
     {
       "namespace_id": "demo",
-      "absolute_path": "/docs/report.txt",
+      "path": "/docs/report.txt",
       "inode_id": 42,
       "created_by": { "kind": "user", "id": "usr_8f3c" },
       "created_at_ms": 1752623000000,
@@ -1448,7 +1448,7 @@ An unrecognized cursor version is also rejected as `invalid_request`.
     },
     {
       "namespace_id": "demo",
-      "absolute_path": "/docs/slides",
+      "path": "/docs/slides",
       "inode_id": 43,
       "created_by": { "kind": "user", "id": "usr_8f3c" },
       "created_at_ms": 1752623000000,
@@ -1465,7 +1465,7 @@ An unrecognized cursor version is also rejected as `invalid_request`.
 ### 6.6 `GET /filesystem/trash`
 
 Lists the namespace's recoverable deletions, oldest deletion first — ascending
-by `(deleted_at_seq, root_inode_id)` — paged with the standard `limit`/`cursor`
+by `(deletion_seq, inode_id)` — paged with the standard `limit`/`cursor`
 pattern (the cursor is an ordering resume like every other). The listing is a
 range scan over the derived active-deletions family (format spec, section
 2.5), so a page costs the page rather than the namespace's deletion history.
@@ -1485,8 +1485,8 @@ leaves the inner one listed.
   "head_seq": 418,
   "entries": [
     {
-      "root_inode_id": 42,
-      "deleted_at_seq": 417,
+      "inode_id": 42,
+      "deletion_seq": 417,
       "deleted_at_ms": 1752625000000,
       "deleted_by": { "kind": "user", "id": "usr_8f3c" },
       "parent_inode_id": 7,
@@ -1510,15 +1510,15 @@ client create such a file offers it.
 
 Revision listing returns newest revisions first and uses the same
 `limit` / `cursor` pattern as directory listing, resolving the current path
-to its current inode. The response echoes that requested path as
-`absolute_path`. Responses include `next_cursor` only when another page is
+to its current inode. The response echoes that requested path as `path`.
+Responses include `next_cursor` only when another page is
 available. Revision history is never pruned — paging to the end always
 reaches revision 1, regardless of how far the retention floor has advanced.
 
 ```json
 {
   "namespace_id": "demo",
-  "absolute_path": "/docs/report.txt",
+  "path": "/docs/report.txt",
   "inode_id": 42,
   "head_seq": 418,
   "revisions": [
@@ -1696,7 +1696,7 @@ deletion's committed sequence.
     {
       "kind": "undelete",
       "inode_id": 42,
-      "deleted_at_seq": 17,
+      "deletion_seq": 17,
       "path": "/docs/report.txt"
     }
   ]
@@ -1715,7 +1715,7 @@ would: the parent must not be deleted, and the name must be free, each
 answering its usual code otherwise.
 
 Only the root of a deletion can be undeleted, and only the exact deletion
-generation named by `deleted_at_seq` — anything else answers `not_deleted`
+generation named by `deletion_seq` — anything else answers `not_deleted`
 with the requested and active generations in the details, so a stale
 recovery request can never cancel a later deletion.
 
@@ -2021,7 +2021,7 @@ checks the arriving bytes against:
 ```json
 {
   "namespace_id": "demo",
-  "absolute_path": "/docs/report.txt",
+  "path": "/docs/report.txt",
   "revision_no": 3,
   "content_ref": {
     "kind": "blob_v1",
@@ -2114,7 +2114,7 @@ Event kinds:
 | `created` | A file or directory was created. | `inode_id`, `inode_kind`, `parent_inode_id`, `display_name`; file creations also carry `revision_no` and `content_ref`. |
 | `content_changed` | A file received a new current revision — a replacing put or a revision restore (one durable fact for both). | `inode_id`, `revision_no`, `content_ref`. |
 | `moved` | An entry moved to a new parent directory or name. | `inode_id`, `from_parent_inode_id`, `from_display_name`, `to_parent_inode_id`, `to_display_name`. |
-| `deleted` | A file or directory subtree was deleted. The enclosing change's `committed_seq` is the `deleted_at_seq` an undelete passes. | `inode_id`, plus optional `deleted_direntry` containing `parent_inode_id`, `name_key`, and `display_name`. |
+| `deleted` | A file or directory subtree was deleted. The enclosing change's `committed_seq` **is** the `deletion_seq` used by trash and undelete; the event does not duplicate it. | `inode_id`, plus optional `deleted_direntry` containing `parent_inode_id`, `name_key`, and `display_name`. |
 | `undeleted` | A deleted inode was recovered and re-bound. | `inode_id`, `parent_inode_id`, `display_name`. |
 | `attributes_changed` | An inode's attributes changed. `attributes` is the complete flat string map after the update, so a consumer projects it without reading anything back; an empty map is the cleared state. | `inode_id`, `attributes_revision_no`, `attributes`. |
 
@@ -2180,7 +2180,7 @@ Representative response:
   "tail_scanned": true,
   "matches": [
     {
-      "absolute_path": "/src/search.rs",
+      "path": "/src/search.rs",
       "inode_id": 42,
       "revision_no": 3,
       "line_number": 17,
@@ -2254,7 +2254,7 @@ Metric names are `loonfs_<subsystem>_<metric>`, covering the object-store
 calls the process made, the maintenance steps it settled, the publications
 it batched, what garbage collection reclaimed, and the requests this
 server served. Label values come from closed vocabularies only: a request
-is labeled by the route template it matched (`/v0/namespaces/{namespace}`),
+is labeled by the route template it matched (`/v0/namespaces/{namespace_id}`),
 never by its own path, so no namespace, upload, commit, or checkpoint id
 ever appears in a label. Values are per process and reset when it
 restarts, which is the ordinary contract for a counter a scraper reads.

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2114,7 +2114,7 @@ Event kinds:
 | `created` | A file or directory was created. | `inode_id`, `inode_kind`, `parent_inode_id`, `display_name`; file creations also carry `revision_no` and `content_ref`. |
 | `content_changed` | A file received a new current revision — a replacing put or a revision restore (one durable fact for both). | `inode_id`, `revision_no`, `content_ref`. |
 | `moved` | An entry moved to a new parent directory or name. | `inode_id`, `from_parent_inode_id`, `from_display_name`, `to_parent_inode_id`, `to_display_name`. |
-| `deleted` | A file or directory subtree was deleted. The enclosing change's `committed_seq` **is** the `deletion_seq` used by trash and undelete; the event does not duplicate it. | `inode_id`, plus optional `deleted_direntry` containing `parent_inode_id`, `name_key`, and `display_name`. |
+| `deleted` | A file or directory subtree was deleted. Use the enclosing `committed_seq` as `deletion_seq` when restoring it. | `inode_id`, plus optional `deleted_direntry` containing `parent_inode_id`, `name_key`, and `display_name`. |
 | `undeleted` | A deleted inode was recovered and re-bound. | `inode_id`, `parent_inode_id`, `display_name`. |
 | `attributes_changed` | An inode's attributes changed. `attributes` is the complete flat string map after the update, so a consumer projects it without reading anything back; an empty map is the cleared state. | `inode_id`, `attributes_revision_no`, `attributes`. |
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -734,8 +734,9 @@ fields does not decode.
 Which deletions are recoverable *right now* is a separate question from the
 event history that decides it, and it has its own family. Materialization
 derives an `active-deletions` row from every tombstone event: a `set` adds a
-`listed` row keyed by `(deleted_at_seq, root_inode_id)` — the exact handle
-`undelete` takes — carrying the deletion's wall-clock stamp and a copy of
+`listed` row keyed durably by `(deleted_at_seq, root_inode_id)`. The API projects
+that pair as `(deletion_seq, inode_id)`, the exact handle `undelete` takes. The
+row carries the deletion's wall-clock stamp and a copy of
 its `deleted_direntry`, and a `revoke` adds a `removed` row repeating its
 target's key. The two rows for one deletion sort together with `removed` first, so an
 ascending scan sees a removal before the row it removes and reorganization
@@ -1404,9 +1405,9 @@ The first standard lower-level mutation set includes:
 - `replace_file(inode_id, base_revision_no, content_ref)`
 - `rename(inode_id, new_parent_inode_id, new_display_name)`
 - `delete_file(inode_id)`
-- `delete_subtree(root_inode_id)`
+- `delete_subtree(inode_id)`
 - `restore_revision(inode_id, source_revision_no, base_revision_no)`
-- `undelete(inode_id, deleted_at_seq, parent_inode_id, display_name)`
+- `undelete(inode_id, deletion_seq, parent_inode_id, display_name)`
 - `update_attributes(inode_id, base_attributes_revision_no, attributes_revision_no, attributes)`
 
 The path-oriented filesystem surface may compile higher-level operations into
@@ -2506,7 +2507,7 @@ authorization can arrive without a format break:
 1. Authorization state is control-plane state. ACL or share changes never
    advance namespace `seq` and never appear in the change feed.
 2. An access grant targets durable identity — a whole namespace or a subtree
-   identified by `(namespace_id, root_inode_id)` — never path text. Paths are
+   identified by `(namespace_id, inode_id)` — never path text. Paths are
    presentation; inode-rooted identity is durable.
 
 ## 8. Optional commit metadata, resource properties, and timestamps

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -731,19 +731,15 @@ the generation as `tombstone_seq` and `tombstone_delta_index` beside
 independent optional `parent_inode_id`, `name_key`, and `display_name`
 fields does not decode.
 
-Which deletions are recoverable *right now* is a separate question from the
-event history that decides it, and it has its own family. Materialization
-derives an `active-deletions` row from every tombstone event: a `set` adds a
-`listed` row keyed durably by `(deleted_at_seq, root_inode_id)`. The API projects
-that pair as `(deletion_seq, inode_id)`, the exact handle `undelete` takes. The
-row carries the deletion's wall-clock stamp and a copy of
-its `deleted_direntry`, and a `revoke` adds a `removed` row repeating its
-target's key. The two rows for one deletion sort together with `removed` first, so an
-ascending scan sees a removal before the row it removes and reorganization
-drops the pair. Reading the recoverable set is therefore a range scan in
-deletion order, not a walk over every deletion the namespace ever recorded.
-Because the family is derived, the tombstone rows stay authoritative: a
-disagreement between the two is corruption of the derived family.
+The `active-deletions` family tracks which deletions can still be restored. A
+`set` tombstone adds a `listed` row keyed by `(deleted_at_seq, root_inode_id)`.
+The API exposes that pair as `(deletion_seq, inode_id)`. The row also stores
+the deletion time and `deleted_direntry`. A `revoke` tombstone adds a
+`removed` row with the same key. The two rows sort together with `removed`
+first, so reorganization can discard both.
+
+The recoverable set is read as a range scan in deletion order. Tombstone rows
+remain authoritative because this family is derived from them.
 
 A namespace head has exactly two recorded states: `active` (the default; an
 absent field reads as active) and terminal `deleted`. There is no

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -111,7 +111,7 @@
         ]
       }
     },
-    "/v0/admin/namespaces/{namespace}/checkpoints": {
+    "/v0/admin/namespaces/{namespace_id}/checkpoints": {
       "get": {
         "tags": [
           "admin"
@@ -121,7 +121,7 @@
         "operationId": "list_checkpoints",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -185,7 +185,7 @@
         "operationId": "create_checkpoint",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -272,7 +272,7 @@
         }
       }
     },
-    "/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release": {
+    "/v0/admin/namespaces/{namespace_id}/checkpoints/{checkpoint_id}/release": {
       "post": {
         "tags": [
           "admin"
@@ -282,7 +282,7 @@
         "operationId": "release_checkpoint",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -347,7 +347,7 @@
         }
       }
     },
-    "/v0/admin/namespaces/{namespace}/grep/index": {
+    "/v0/admin/namespaces/{namespace_id}/grep/index": {
       "get": {
         "tags": [
           "admin"
@@ -357,7 +357,7 @@
         "operationId": "grep_index_status",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -423,7 +423,7 @@
         }
       }
     },
-    "/v0/admin/namespaces/{namespace}/grep/index/disable": {
+    "/v0/admin/namespaces/{namespace_id}/grep/index/disable": {
       "post": {
         "tags": [
           "admin"
@@ -433,7 +433,7 @@
         "operationId": "disable_grep_index",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -519,7 +519,7 @@
         }
       }
     },
-    "/v0/admin/namespaces/{namespace}/grep/index/enable": {
+    "/v0/admin/namespaces/{namespace_id}/grep/index/enable": {
       "post": {
         "tags": [
           "admin"
@@ -529,7 +529,7 @@
         "operationId": "enable_grep_index",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -615,7 +615,7 @@
         }
       }
     },
-    "/v0/admin/namespaces/{namespace}/grep/index/gc": {
+    "/v0/admin/namespaces/{namespace_id}/grep/index/gc": {
       "post": {
         "tags": [
           "admin"
@@ -625,7 +625,7 @@
         "operationId": "gc_grep_index",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -714,7 +714,7 @@
         }
       }
     },
-    "/v0/admin/namespaces/{namespace}/maintenance/step": {
+    "/v0/admin/namespaces/{namespace_id}/maintenance/step": {
       "post": {
         "tags": [
           "admin"
@@ -724,7 +724,7 @@
         "operationId": "maintenance_step",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -961,7 +961,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}": {
+    "/v0/namespaces/{namespace_id}": {
       "get": {
         "tags": [
           "namespaces"
@@ -971,7 +971,7 @@
         "operationId": "namespace_status",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1045,7 +1045,7 @@
         "operationId": "delete_namespace",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1130,7 +1130,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/changes": {
+    "/v0/namespaces/{namespace_id}/changes": {
       "get": {
         "tags": [
           "filesystem"
@@ -1140,7 +1140,7 @@
         "operationId": "list_changes",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1224,7 +1224,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/commits": {
+    "/v0/namespaces/{namespace_id}/commits": {
       "post": {
         "tags": [
           "filesystem"
@@ -1234,7 +1234,7 @@
         "operationId": "apply_commit",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1330,7 +1330,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/filesystem/content": {
+    "/v0/namespaces/{namespace_id}/filesystem/content": {
       "get": {
         "tags": [
           "filesystem"
@@ -1340,7 +1340,7 @@
         "operationId": "get_file_bytes",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1446,7 +1446,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/filesystem/downloads": {
+    "/v0/namespaces/{namespace_id}/filesystem/downloads": {
       "post": {
         "tags": [
           "filesystem"
@@ -1456,7 +1456,7 @@
         "operationId": "begin_download",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1542,7 +1542,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/filesystem/list": {
+    "/v0/namespaces/{namespace_id}/filesystem/list": {
       "get": {
         "tags": [
           "filesystem"
@@ -1552,7 +1552,7 @@
         "operationId": "list_path_entries",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1654,7 +1654,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/filesystem/revisions": {
+    "/v0/namespaces/{namespace_id}/filesystem/revisions": {
       "get": {
         "tags": [
           "filesystem"
@@ -1664,7 +1664,7 @@
         "operationId": "list_file_revisions",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1757,7 +1757,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/filesystem/stat": {
+    "/v0/namespaces/{namespace_id}/filesystem/stat": {
       "get": {
         "tags": [
           "filesystem"
@@ -1767,7 +1767,7 @@
         "operationId": "stat_path",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1851,7 +1851,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/filesystem/trash": {
+    "/v0/namespaces/{namespace_id}/filesystem/trash": {
       "get": {
         "tags": [
           "filesystem"
@@ -1861,7 +1861,7 @@
         "operationId": "list_trash",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -1935,7 +1935,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/forks": {
+    "/v0/namespaces/{namespace_id}/forks": {
       "post": {
         "tags": [
           "namespaces"
@@ -1945,7 +1945,7 @@
         "operationId": "fork_namespace",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Source namespace id",
             "required": true,
@@ -2031,7 +2031,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/query/grep": {
+    "/v0/namespaces/{namespace_id}/query/grep": {
       "post": {
         "tags": [
           "query"
@@ -2041,7 +2041,7 @@
         "operationId": "grep",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -2157,7 +2157,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/uploads": {
+    "/v0/namespaces/{namespace_id}/uploads": {
       "post": {
         "tags": [
           "uploads"
@@ -2167,7 +2167,7 @@
         "operationId": "begin_upload",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -2253,7 +2253,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/uploads/{upload_id}": {
+    "/v0/namespaces/{namespace_id}/uploads/{upload_id}": {
       "get": {
         "tags": [
           "uploads"
@@ -2263,7 +2263,7 @@
         "operationId": "read_upload_status",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -2338,7 +2338,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/uploads/{upload_id}/abort": {
+    "/v0/namespaces/{namespace_id}/uploads/{upload_id}/abort": {
       "post": {
         "tags": [
           "uploads"
@@ -2348,7 +2348,7 @@
         "operationId": "abort_upload",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -2433,7 +2433,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/uploads/{upload_id}/complete": {
+    "/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete": {
       "post": {
         "tags": [
           "uploads"
@@ -2443,7 +2443,7 @@
         "operationId": "complete_upload",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -2538,7 +2538,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/uploads/{upload_id}/content": {
+    "/v0/namespaces/{namespace_id}/uploads/{upload_id}/content": {
       "put": {
         "tags": [
           "uploads"
@@ -2548,7 +2548,7 @@
         "operationId": "upload_content",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -2665,7 +2665,7 @@
         }
       }
     },
-    "/v0/namespaces/{namespace}/uploads/{upload_id}/parts": {
+    "/v0/namespaces/{namespace_id}/uploads/{upload_id}/parts": {
       "post": {
         "tags": [
           "uploads"
@@ -2675,7 +2675,7 @@
         "operationId": "sign_upload_parts",
         "parameters": [
           {
-            "name": "namespace",
+            "name": "namespace_id",
             "in": "path",
             "description": "Namespace id",
             "required": true,
@@ -2987,17 +2987,13 @@
             "type": "object",
             "required": [
               "namespace_id",
-              "absolute_path",
+              "path",
               "inode_id",
               "created_by",
               "created_at_ms",
               "head_seq"
             ],
             "properties": {
-              "absolute_path": {
-                "$ref": "#/components/schemas/AbsolutePath",
-                "description": "Absolute path as rendered from stored display names."
-              },
               "created_at_ms": {
                 "type": "integer",
                 "format": "int64",
@@ -3041,6 +3037,10 @@
                     "description": "Parent directory inode, or `None` for the root."
                   }
                 ]
+              },
+              "path": {
+                "$ref": "#/components/schemas/AbsolutePath",
+                "description": "Absolute path as rendered from stored display names."
               }
             }
           }
@@ -3143,16 +3143,12 @@
         "description": "A short-lived capability to read one file's content object, plus\neverything the reader needs to check what arrives.\n\nThe raw object key is deliberately not here, exactly as it is not in a\n`direct_put` grant: a client learns a URL that expires, not an address it\ncan revisit.\n\nThe grant names one immutable content object, so it does not go stale\nwhen the path moves on. A commit that replaces the file writes a new\nobject and leaves this one alone; what the capability reads is what the\nrequested revision held when the grant was issued, and the reference\nsays which bytes those are.",
         "required": [
           "namespace_id",
-          "absolute_path",
+          "path",
           "revision_no",
           "content_ref",
           "access"
         ],
         "properties": {
-          "absolute_path": {
-            "$ref": "#/components/schemas/AbsolutePath",
-            "description": "Absolute path as rendered from stored display names."
-          },
           "access": {
             "$ref": "#/components/schemas/ObjectTransferAccess",
             "description": "Short-lived read capability the client uses without learning the raw object key."
@@ -3164,6 +3160,10 @@
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Namespace that was read."
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path as rendered from stored display names."
           },
           "revision_no": {
             "$ref": "#/components/schemas/RevisionNo",
@@ -4433,7 +4433,7 @@
           {
             "type": "object",
             "title": "FilesystemChangeDeleted",
-            "description": "A file or directory subtree was deleted. The enclosing change's\n`committed_seq` is the deletion generation an undelete request passes\nas `deleted_at_seq`.",
+            "description": "A file or directory subtree was deleted. The enclosing change's\n`committed_seq` is the deletion generation an undelete request passes\nas `deletion_seq`.",
             "required": [
               "inode_id",
               "kind"
@@ -4694,14 +4694,14 @@
           {
             "type": "object",
             "title": "FsOpUndelete",
-            "description": "Recover a deleted file or subtree: revoke the deletion of\n`inode_id` recorded at `deleted_at_seq` (both reported by the\ndelete and by the change feed) and re-bind it. Answers\n`not_deleted` when that generation is not the live one, so a stale\nrequest never cancels a later delete.",
+            "description": "Recover a deleted file or subtree: revoke the deletion of\n`inode_id` recorded at `deletion_seq` (both reported by the\ndelete and by the change feed) and re-bind it. Answers\n`not_deleted` when that generation is not the live one, so a stale\nrequest never cancels a later delete.",
             "required": [
               "inode_id",
-              "deleted_at_seq",
+              "deletion_seq",
               "kind"
             ],
             "properties": {
-              "deleted_at_seq": {
+              "deletion_seq": {
                 "$ref": "#/components/schemas/ChangeSeq",
                 "description": "Observed deletion sequence, which prevents cancelling a newer tombstone generation."
               },
@@ -5167,7 +5167,7 @@
         "type": "object",
         "description": "One line-oriented match.",
         "required": [
-          "absolute_path",
+          "path",
           "inode_id",
           "revision_no",
           "line_number",
@@ -5175,10 +5175,6 @@
           "line"
         ],
         "properties": {
-          "absolute_path": {
-            "$ref": "#/components/schemas/AbsolutePath",
-            "description": "The file's absolute path, derived at the snapshot."
-          },
           "byte_offset": {
             "type": "integer",
             "format": "int64",
@@ -5202,6 +5198,10 @@
           "line_truncated": {
             "type": "boolean",
             "description": "True when `line` was truncated."
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "The file's absolute path, derived at the snapshot."
           },
           "revision_no": {
             "$ref": "#/components/schemas/RevisionNo",
@@ -5345,16 +5345,12 @@
         "description": "Response for listing file revisions.",
         "required": [
           "namespace_id",
-          "absolute_path",
+          "path",
           "inode_id",
           "head_seq",
           "revisions"
         ],
         "properties": {
-          "absolute_path": {
-            "$ref": "#/components/schemas/AbsolutePath",
-            "description": "Absolute file path requested by the caller."
-          },
           "head_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
             "description": "Namespace head sequence used for the read."
@@ -5374,6 +5370,10 @@
             ],
             "description": "Opaque cursor for the next page, if more revisions are available."
           },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute file path requested by the caller."
+          },
           "revisions": {
             "type": "array",
             "items": {
@@ -5388,15 +5388,11 @@
         "description": "One directory listing and the namespace head it was answered at.\n\nThe envelope names the listing target and head so an empty directory\nstill tells the caller which state it observed, and so the response can\ngrow without reshaping `entries`.",
         "required": [
           "namespace_id",
-          "absolute_path",
+          "path",
           "head_seq",
           "entries"
         ],
         "properties": {
-          "absolute_path": {
-            "$ref": "#/components/schemas/AbsolutePath",
-            "description": "Absolute path of the listed directory."
-          },
           "entries": {
             "type": "array",
             "items": {
@@ -5418,6 +5414,10 @@
               "null"
             ],
             "description": "Cursor for the next page, if more entries remain."
+          },
+          "path": {
+            "$ref": "#/components/schemas/AbsolutePath",
+            "description": "Absolute path of the listed directory."
           }
         }
       },
@@ -6028,8 +6028,8 @@
         "type": "object",
         "description": "One recoverable deletion: an active subtree tombstone plus the identity\nof the binding it deleted, when the delete recorded one. Entries with no\nrecorded name predate the enriched tombstone rows; their inode and\nsequence still form a complete `undelete` handle.",
         "required": [
-          "root_inode_id",
-          "deleted_at_seq",
+          "inode_id",
+          "deletion_seq",
           "deleted_at_ms",
           "deleted_by"
         ],
@@ -6040,13 +6040,13 @@
             "description": "Time of the deletion, in Unix milliseconds.",
             "minimum": 0
           },
-          "deleted_at_seq": {
-            "$ref": "#/components/schemas/ChangeSeq",
-            "description": "Commit sequence of the deletion; the other half of the handle."
-          },
           "deleted_by": {
             "$ref": "#/components/schemas/ActorRef",
             "description": "Actor responsible for the deletion."
+          },
+          "deletion_seq": {
+            "$ref": "#/components/schemas/ChangeSeq",
+            "description": "Commit sequence of the deletion; the other half of the handle."
           },
           "display_name": {
             "oneOf": [
@@ -6058,6 +6058,10 @@
                 "description": "User-facing spelling of the deleted binding, when recorded."
               }
             ]
+          },
+          "inode_id": {
+            "$ref": "#/components/schemas/InodeId",
+            "description": "Inode the deletion hid; half of the recovery handle."
           },
           "name_key": {
             "oneOf": [
@@ -6080,10 +6084,6 @@
                 "description": "Directory that held the deleted binding, when recorded."
               }
             ]
-          },
-          "root_inode_id": {
-            "$ref": "#/components/schemas/InodeId",
-            "description": "Root inode the deletion hid; half of the recovery handle."
           }
         }
       },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -4433,7 +4433,7 @@
           {
             "type": "object",
             "title": "FilesystemChangeDeleted",
-            "description": "A file or directory subtree was deleted. The enclosing change's\n`committed_seq` is the deletion generation an undelete request passes\nas `deletion_seq`.",
+            "description": "A file or directory subtree was deleted. Use the enclosing change's\n`committed_seq` as `deletion_seq` when restoring it.",
             "required": [
               "inode_id",
               "kind"
@@ -4694,7 +4694,7 @@
           {
             "type": "object",
             "title": "FsOpUndelete",
-            "description": "Recover a deleted file or subtree: revoke the deletion of\n`inode_id` recorded at `deletion_seq` (both reported by the\ndelete and by the change feed) and re-bind it. Answers\n`not_deleted` when that generation is not the live one, so a stale\nrequest never cancels a later delete.",
+            "description": "Restore a deleted file or subtree.\n\n`inode_id` and `deletion_seq` identify one exact deletion. A stale\nsequence returns `not_deleted` and cannot undo a later deletion.",
             "required": [
               "inode_id",
               "deletion_seq",
@@ -6026,7 +6026,7 @@
       },
       "TrashEntry": {
         "type": "object",
-        "description": "One recoverable deletion: an active subtree tombstone plus the identity\nof the binding it deleted, when the delete recorded one. Entries with no\nrecorded name predate the enriched tombstone rows; their inode and\nsequence still form a complete `undelete` handle.",
+        "description": "One deletion that can still be restored.\n\n`inode_id` and `deletion_seq` are sufficient to restore it. The original\nparent and name are included when they were recorded.",
         "required": [
           "inode_id",
           "deletion_seq",
@@ -6046,7 +6046,7 @@
           },
           "deletion_seq": {
             "$ref": "#/components/schemas/ChangeSeq",
-            "description": "Commit sequence of the deletion; the other half of the handle."
+            "description": "Commit sequence that identifies this deletion."
           },
           "display_name": {
             "oneOf": [
@@ -6061,7 +6061,7 @@
           },
           "inode_id": {
             "$ref": "#/components/schemas/InodeId",
-            "description": "Inode the deletion hid; half of the recovery handle."
+            "description": "Inode hidden by the deletion."
           },
           "name_key": {
             "oneOf": [


### PR DESCRIPTION
Standardizes public API names around `path`, `namespace_id`, `inode_id`, and `deletion_seq`. Route parameter names now use `namespace_id`, path responses use `path`, and trash entries provide the same `inode_id` and `deletion_seq` pair accepted by undelete. A deleted change-feed event uses its enclosing `committed_seq` as the deletion sequence.

The changes apply across the API types, server, clients, CLI, OpenAPI schema, documentation, and tests. Durable records and canonical commit encoding are unchanged, so stored data and commit fingerprints are unaffected.