### PR TITLE
refactor(api): let the session drive upload completion

### DIFF
--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -45,9 +45,10 @@ pub use search::{
     GrepIndexLifecycle, GrepIndexStatusResponse, GrepMatch, GrepRequest, GrepResponse,
 };
 pub use uploads::{
-    AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest,
-    CompleteUploadResponse, CompletedUploadPart, ContentToken, DirectMultipartUpload,
-    DirectMultipartUploadOptions, DirectPutUpload, ObjectTransferAccess, SignUploadPartsRequest,
-    SignUploadPartsResponse, SignedUploadPart, UploadContentClaim, UploadContentResponse,
-    UploadMode, UploadPartChecksumClaim, UploadSessionStatus, UploadStatusResponse,
+    AbortUploadResponse, BeginUploadRequest, BeginUploadResponse,
+    CompleteKnownContentUploadRequest, CompleteMultipartUploadRequest, CompleteUploadResponse,
+    CompletedUploadPart, ContentToken, DirectMultipartUpload, DirectMultipartUploadOptions,
+    DirectPutUpload, ObjectTransferAccess, SignUploadPartsRequest, SignUploadPartsResponse,
+    SignedUploadPart, UploadContentClaim, UploadContentResponse, UploadMode,
+    UploadPartChecksumClaim, UploadSessionStatus, UploadStatusResponse,
 };

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -320,30 +320,21 @@ pub struct UploadContentResponse {
     pub content_ref: ContentRef,
 }
 
-/// Request to complete a service-proxied or `direct_put` upload.
-///
-/// The durable session already owns the content reference and selects this
-/// schema, so the caller has nothing to repeat.
+/// Empty request used when the upload session already contains the content
+/// reference.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
 pub struct CompleteKnownContentUploadRequest {}
 
-/// Request to complete a `direct_multipart` upload.
-///
-/// The durable session selects this schema and owns the content object's
-/// identity. The caller supplies only what became known while uploading the
-/// parts.
+/// Information required to complete a `direct_multipart` upload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
 pub struct CompleteMultipartUploadRequest {
-    /// The assembled object's length and checksum, which completion verifies
-    /// against the provider's own reading of the object.
+    /// Expected length and checksum of the assembled object.
     pub content: UploadContentClaim,
-    /// Every part the client uploaded, in ascending part order. The server
-    /// holds no part records of its own, so this list is what it assembles the
-    /// object from.
+    /// Uploaded parts in ascending part order.
     pub parts: Vec<CompletedUploadPart>,
 }
 
@@ -474,8 +465,7 @@ mod tests {
         }
     }
 
-    /// Each completion body is strict even though the stored session, rather
-    /// than a request tag, chooses which one the server decodes.
+    /// Completion request fields must match the stored upload mode.
     #[test]
     fn completion_request_shapes_reject_fields_the_session_did_not_select() {
         assert_eq!(

--- a/crates/loonfs-api/src/v0/uploads.rs
+++ b/crates/loonfs-api/src/v0/uploads.rs
@@ -320,51 +320,31 @@ pub struct UploadContentResponse {
     pub content_ref: ContentRef,
 }
 
-/// Request to complete an upload.
+/// Request to complete a service-proxied or `direct_put` upload.
 ///
-/// A service-proxied or `direct_put` session receives its content reference
-/// before the upload and returns that reference at completion. A
-/// `direct_multipart` session instead provides the completed parts and a
-/// claim describing the assembled object.
+/// The durable session already owns the content reference and selects this
+/// schema, so the caller has nothing to repeat.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
+pub struct CompleteKnownContentUploadRequest {}
+
+/// Request to complete a `direct_multipart` upload.
 ///
-/// The variants share no fields, so fields from one completion type are
-/// rejected when used with the other type. The server also checks that the
-/// completion type matches the transport stored in the upload session.
+/// The durable session selects this schema and owns the content object's
+/// identity. The caller supplies only what became known while uploading the
+/// parts.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(tag = "completion", rename_all = "snake_case", deny_unknown_fields)]
-pub enum CompleteUploadRequest {
-    /// Completes a session the server named a content object for: the
-    /// caller names it back and the server proves the object matches.
-    #[cfg_attr(feature = "openapi", schema(title = "CompleteUploadContentRef"))]
-    ContentRef {
-        /// Content identity the caller expects the session to have settled
-        /// on.
-        content_ref: ContentRef,
-    },
-    /// Completes a `direct_multipart` session with what it uploaded.
-    #[cfg_attr(feature = "openapi", schema(title = "CompleteUploadMultipart"))]
-    Multipart {
-        /// The assembled object's length and checksum, which completion
-        /// verifies against the provider's own reading of the object.
-        content: UploadContentClaim,
-        /// Every part the client uploaded, in ascending part order. The
-        /// server holds no part records of its own, so this list is what it
-        /// assembles the object from.
-        parts: Vec<CompletedUploadPart>,
-    },
-}
-
-impl CompleteUploadRequest {
-    /// Completes a session that already knows its content reference.
-    pub fn for_content_ref(content_ref: ContentRef) -> Self {
-        Self::ContentRef { content_ref }
-    }
-
-    /// Completes a `direct_multipart` session with what it assembled.
-    pub fn for_multipart(content: UploadContentClaim, parts: Vec<CompletedUploadPart>) -> Self {
-        Self::Multipart { content, parts }
-    }
+#[serde(deny_unknown_fields)]
+pub struct CompleteMultipartUploadRequest {
+    /// The assembled object's length and checksum, which completion verifies
+    /// against the provider's own reading of the object.
+    pub content: UploadContentClaim,
+    /// Every part the client uploaded, in ascending part order. The server
+    /// holds no part records of its own, so this list is what it assembles the
+    /// object from.
+    pub parts: Vec<CompletedUploadPart>,
 }
 
 /// Response after an upload session is completed.
@@ -448,9 +428,10 @@ pub struct AbortUploadResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, CompleteUploadResponse,
-        ContentToken, DirectMultipartUpload, DirectPutUpload, ObjectTransferAccess,
-        UploadContentClaim, UploadMode, UploadSessionStatus,
+        BeginUploadRequest, BeginUploadResponse, CompleteKnownContentUploadRequest,
+        CompleteMultipartUploadRequest, CompleteUploadResponse, ContentToken,
+        DirectMultipartUpload, DirectPutUpload, ObjectTransferAccess, UploadContentClaim,
+        UploadMode, UploadSessionStatus,
     };
     use crate::{Checksum, ChecksumAlgorithm, ContentId, ContentRef, NamespaceId, UploadId};
     use std::collections::BTreeMap;
@@ -493,21 +474,46 @@ mod tests {
         }
     }
 
-    /// A completion carries one shape's fields under that shape's tag.
+    /// Each completion body is strict even though the stored session, rather
+    /// than a request tag, chooses which one the server decodes.
     #[test]
-    fn a_completion_mixing_its_two_shapes_does_not_decode() {
+    fn completion_request_shapes_reject_fields_the_session_did_not_select() {
+        assert_eq!(
+            serde_json::from_str::<CompleteKnownContentUploadRequest>("{}")
+                .expect("decode known-content completion"),
+            CompleteKnownContentUploadRequest {}
+        );
+        assert_eq!(
+            serde_json::to_string(&CompleteKnownContentUploadRequest {})
+                .expect("encode known-content completion"),
+            "{}"
+        );
         for body in [
-            r#"{"completion":"multipart","content":{"size_bytes":5,"checksum":{"algorithm":"crc64nvme","value":"0123456789abcdef"}},"parts":[],"content_ref":{"kind":"blob_v1","content_id":"con_0123456789abcdef0123456789abcdef","size_bytes":5,"checksum":{"algorithm":"sha256","value":"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"}}}"#,
-            // Neither multipart-completion field stands without the other.
-            r#"{"completion":"multipart","content":{"size_bytes":5,"checksum":{"algorithm":"crc64nvme","value":"0123456789abcdef"}}}"#,
-            r#"{"completion":"multipart","parts":[]}"#,
             r#"{"completion":"content_ref"}"#,
+            r#"{"content_ref":{"kind":"blob_v1","content_id":"con_0123456789abcdef0123456789abcdef","size_bytes":5,"checksum":{"algorithm":"sha256","value":"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"}}}"#,
+            r#"{"content":{"size_bytes":5,"checksum":{"algorithm":"crc64nvme","value":"0123456789abcdef"}},"parts":[]}"#,
         ] {
             assert!(
-                serde_json::from_str::<CompleteUploadRequest>(body).is_err(),
-                "decoded a completion that mixes shapes: {body}"
+                serde_json::from_str::<CompleteKnownContentUploadRequest>(body).is_err(),
+                "decoded a known-content completion carrying fields: {body}"
             );
         }
+
+        let missing_parts = r#"{"content":{"size_bytes":5,"checksum":{"algorithm":"crc64nvme","value":"0123456789abcdef"}}}"#;
+        let error = serde_json::from_str::<CompleteMultipartUploadRequest>(missing_parts)
+            .expect_err("multipart parts are required");
+        assert!(error.to_string().contains("missing field `parts`"));
+
+        let multipart = CompleteMultipartUploadRequest {
+            content: UploadContentClaim {
+                size_bytes: 5,
+                checksum: Checksum::crc64nvme(b"hello"),
+            },
+            parts: Vec::new(),
+        };
+        let encoded = serde_json::to_string(&multipart).expect("encode multipart completion");
+        assert!(!encoded.contains("completion"));
+        assert!(!encoded.contains("content_ref"));
     }
 
     #[test]

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -25,12 +25,12 @@ use loonfs_api::{
     v0::{
         AbortUploadResponse, BeginDownloadRequest, BeginDownloadResponse, BeginUploadRequest,
         BeginUploadResponse, ChangesResponse, CommitResponse as ApiCommitResponse,
-        CompleteUploadRequest, CompleteUploadResponse, CompletedUploadPart, ContentToken,
-        DirectMultipartUploadOptions, DisableGrepIndexResponse, EnableGrepIndexResponse,
-        GrepGcRequest, GrepGcResponse, GrepIndexStatusResponse, ObjectTransferAccess,
-        SignUploadPartsRequest, SignUploadPartsResponse, SignedUploadPart, StoreProbeRequest,
-        StoreProbeResponse, UploadContentClaim, UploadContentResponse, UploadPartChecksumClaim,
-        UploadStatusResponse,
+        CompleteKnownContentUploadRequest, CompleteMultipartUploadRequest, CompleteUploadResponse,
+        CompletedUploadPart, ContentToken, DirectMultipartUploadOptions, DisableGrepIndexResponse,
+        EnableGrepIndexResponse, GrepGcRequest, GrepGcResponse, GrepIndexStatusResponse,
+        ObjectTransferAccess, SignUploadPartsRequest, SignUploadPartsResponse, SignedUploadPart,
+        StoreProbeRequest, StoreProbeResponse, UploadContentClaim, UploadContentResponse,
+        UploadPartChecksumClaim, UploadStatusResponse,
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId, Checksum,
     ChecksumAlgorithm, CommitId, CommitRequest, ContentEvidence, ContentRef,
@@ -1159,18 +1159,35 @@ impl Client {
             .await
     }
 
-    /// Completes an upload session after verifying the uploaded content.
+    /// Completes a service-proxied or direct-PUT upload session.
     pub async fn complete_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
-        request: &CompleteUploadRequest,
     ) -> Result<CompleteUploadResponse> {
         let url = format!(
             "{}/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
             self.base_url
         );
         // The durable completed-session record replays an identical completion without new effect.
+        self.request_json::<_, CompleteUploadResponse>(
+            self.post(&url),
+            Some(&CompleteKnownContentUploadRequest {}),
+        )
+        .await
+    }
+
+    /// Completes a direct-multipart upload session.
+    pub async fn complete_multipart_upload(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        request: &CompleteMultipartUploadRequest,
+    ) -> Result<CompleteUploadResponse> {
+        let url = format!(
+            "{}/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
+            self.base_url
+        );
         self.request_json::<_, CompleteUploadResponse>(self.post(&url), Some(request))
             .await
     }
@@ -1671,13 +1688,7 @@ impl Client {
             let _ = self.abort_upload(namespace_id, &upload_id).await;
             return Err(error);
         }
-        let response = self
-            .complete_upload(
-                namespace_id,
-                &upload_id,
-                &CompleteUploadRequest::for_content_ref(direct_put.content_ref),
-            )
-            .await?;
+        let response = self.complete_upload(namespace_id, &upload_id).await?;
         Ok(Self::staged_from_completion(response))
     }
 
@@ -1763,16 +1774,16 @@ impl Client {
         }
 
         let response = self
-            .complete_upload(
+            .complete_multipart_upload(
                 namespace_id,
                 &upload_id,
-                &CompleteUploadRequest::for_multipart(
-                    UploadContentClaim {
+                &CompleteMultipartUploadRequest {
+                    content: UploadContentClaim {
                         size_bytes: uploaded.size_bytes,
                         checksum: uploaded.checksum,
                     },
-                    uploaded.parts,
-                ),
+                    parts: uploaded.parts,
+                },
             )
             .await?;
         Ok(Self::staged_from_completion(response))
@@ -1953,11 +1964,9 @@ impl Client {
         let upload = self
             .begin_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await?;
-        let staged = self
-            .upload_content(namespace_id, upload.upload_id(), bytes)
+        self.upload_content(namespace_id, upload.upload_id(), bytes)
             .await?;
-        self.complete_staged(namespace_id, upload.upload_id(), staged)
-            .await
+        self.complete_staged(namespace_id, upload.upload_id()).await
     }
 
     /// Stages a streamed payload through the server, which hashes it as it
@@ -1976,30 +1985,19 @@ impl Client {
         let staged = self
             .upload_streamed_content(namespace_id, upload.upload_id(), source)
             .await;
-        let staged = match staged {
-            Ok(staged) => staged,
-            Err(error) => {
-                let _ = self.abort_upload(namespace_id, upload.upload_id()).await;
-                return Err(error);
-            }
-        };
-        self.complete_staged(namespace_id, upload.upload_id(), staged)
-            .await
+        if let Err(error) = staged {
+            let _ = self.abort_upload(namespace_id, upload.upload_id()).await;
+            return Err(error);
+        }
+        self.complete_staged(namespace_id, upload.upload_id()).await
     }
 
     async fn complete_staged(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
-        staged: UploadContentResponse,
     ) -> Result<StagedContent> {
-        let response = self
-            .complete_upload(
-                namespace_id,
-                upload_id,
-                &CompleteUploadRequest::for_content_ref(staged.content_ref),
-            )
-            .await?;
+        let response = self.complete_upload(namespace_id, upload_id).await?;
         Ok(Self::staged_from_completion(response))
     }
 
@@ -2898,11 +2896,7 @@ mod tests {
         let client = retry_policy_client();
 
         let actual = client
-            .complete_upload(
-                &namespace_id,
-                &upload_id,
-                &CompleteUploadRequest::for_content_ref(content_ref),
-            )
+            .complete_upload(&namespace_id, &upload_id)
             .await
             .expect("completed-session replay should retry");
         assert_eq!(actual, response);

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -15,7 +15,7 @@ use crate::path::read::{
 };
 use crate::protocol::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
-    MultipartPartTargets,
+    MultipartPartTargets, ResolvedUploadCompletion,
 };
 use crate::storage::content::FileContentStream;
 use crate::storage::content_admission::{CompletedUploadReceipt, PreparedContent};
@@ -23,8 +23,9 @@ use crate::time::current_time_ms;
 use loonfs_api::options::{ListPathEntriesOptions, StatPathOptions};
 use loonfs_api::v0::{
     AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, ChangesResponse, CommitResponse,
-    CompleteUploadRequest, CompleteUploadResponse, DirectMultipartUploadOptions,
-    UploadContentClaim, UploadContentResponse, UploadPartChecksumClaim, UploadStatusResponse,
+    CompleteMultipartUploadRequest, CompleteUploadResponse, DirectMultipartUploadOptions,
+    UploadContentClaim, UploadContentResponse, UploadMode, UploadPartChecksumClaim,
+    UploadStatusResponse,
 };
 use loonfs_api::wire::control::{CheckpointOwner, HeadState, NamespaceState};
 use loonfs_api::EffectiveLimit;
@@ -560,14 +561,19 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Completes an upload session when the expected content ref matches.
-    pub async fn complete_upload(
+    /// Completes a service-proxied or direct-PUT upload session.
+    pub async fn complete_upload(&self, upload_id: &UploadId) -> Result<CompleteUploadResponse> {
+        Ok(self.complete_upload_prepared(upload_id).await?.response)
+    }
+
+    /// Completes a direct-multipart upload session.
+    pub async fn complete_multipart_upload(
         &self,
         upload_id: &UploadId,
-        request: &CompleteUploadRequest,
+        request: &CompleteMultipartUploadRequest,
     ) -> Result<CompleteUploadResponse> {
         Ok(self
-            .complete_upload_prepared(upload_id, request)
+            .complete_multipart_upload_prepared(upload_id, request)
             .await?
             .response)
     }
@@ -576,17 +582,35 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     ///
     /// Service-proxied completion performs no content-blob I/O. Direct-put
     /// completion performs one content-blob HEAD and no content-blob GET.
-    pub async fn complete_upload_prepared(
+    pub async fn complete_upload_prepared(&self, upload_id: &UploadId) -> Result<CompletedUpload> {
+        self.complete_upload_prepared_inner(upload_id, ResolvedUploadCompletion::KnownContent)
+            .await
+    }
+
+    /// Completes a multipart upload and returns proof for later publication.
+    pub async fn complete_multipart_upload_prepared(
         &self,
         upload_id: &UploadId,
-        request: &CompleteUploadRequest,
+        request: &CompleteMultipartUploadRequest,
+    ) -> Result<CompletedUpload> {
+        self.complete_upload_prepared_inner(
+            upload_id,
+            ResolvedUploadCompletion::Multipart(request.clone()),
+        )
+        .await
+    }
+
+    async fn complete_upload_prepared_inner(
+        &self,
+        upload_id: &UploadId,
+        completion: ResolvedUploadCompletion,
     ) -> Result<CompletedUpload> {
         let catalog = crate::namespace::catalog::load_namespace_catalog_entry(
             &self.store,
             &self.namespace_id,
         )
         .await?;
-        self.complete_upload_prepared_with_catalog(&catalog, upload_id, request)
+        self.complete_upload_prepared_with_catalog(&catalog, upload_id, completion)
             .await
     }
 
@@ -596,7 +620,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         &self,
         catalog: &VerifiedNamespaceCatalogEntry,
         upload_id: &UploadId,
-        request: &CompleteUploadRequest,
+        completion: ResolvedUploadCompletion,
     ) -> Result<CompletedUpload> {
         let catalog = self.own_catalog(catalog)?;
         crate::protocol::complete_upload(
@@ -604,7 +628,33 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             &self.namespace_id,
             catalog.content_store_id(),
             upload_id,
-            request,
+            completion,
+            &self.mutation_context()?,
+        )
+        .await
+    }
+
+    /// Completes an upload after its durable mode selects a request decoder.
+    ///
+    /// Server integrations use this to decode raw request bytes without a
+    /// second upload-session read. A resolver failure is classified as an
+    /// invalid upload request.
+    pub async fn complete_upload_prepared_with_catalog_for_mode<F>(
+        &self,
+        catalog: &VerifiedNamespaceCatalogEntry,
+        upload_id: &UploadId,
+        resolve: F,
+    ) -> Result<CompletedUpload>
+    where
+        F: FnOnce(UploadMode) -> std::result::Result<ResolvedUploadCompletion, String>,
+    {
+        let catalog = self.own_catalog(catalog)?;
+        crate::protocol::complete_upload_for_mode(
+            &self.store,
+            &self.namespace_id,
+            catalog.content_store_id(),
+            upload_id,
+            resolve,
             &self.mutation_context()?,
         )
         .await

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -797,22 +797,12 @@ async fn complete_staged_upload<S: ObjectStore + ?Sized>(
         crate::namespace::catalog::load_namespace_content_store_id(store, namespace_id)
             .await
             .expect("content store id");
-    let session = read_upload_session(store, namespace_id, upload_id)
-        .await
-        .expect("open session");
-    let content_ref = match session.transport {
-        UploadSessionTransport::ServiceProxied {
-            staging: ProxiedStaging::Staged(content_ref),
-        } => Some(content_ref),
-        _ => None,
-    }
-    .expect("a staged session carries the reference it wrote");
     crate::protocol::complete_upload(
         store,
         namespace_id,
         &content_store_id,
         upload_id,
-        &loonfs_api::v0::CompleteUploadRequest::for_content_ref(content_ref),
+        crate::protocol::ResolvedUploadCompletion::KnownContent,
         context,
     )
     .await
@@ -869,7 +859,7 @@ async fn upload_completion_wins_before_gc_abort_and_the_session_is_retained() {
             &namespace_id,
             &content_store_id,
             &upload_id,
-            &loonfs_api::v0::CompleteUploadRequest::for_content_ref(content_ref.clone()),
+            crate::protocol::ResolvedUploadCompletion::KnownContent,
             &aged,
         )
         .await;
@@ -908,13 +898,12 @@ async fn gc_abort_wins_before_completion_and_completion_reports_not_found() {
     let content_key =
         loonfs_objectstore::keys::content_blob(&content_store_id, &content_ref.content_id);
     let store = blocking_control_cas_store(store, BlockingControlCasTarget::UploadCompleted);
-    let request = loonfs_api::v0::CompleteUploadRequest::for_content_ref(content_ref.clone());
     let completion = crate::protocol::complete_upload(
         &store,
         &namespace_id,
         &content_store_id,
         &upload_id,
-        &request,
+        crate::protocol::ResolvedUploadCompletion::KnownContent,
         &aged,
     );
     let abort = async {
@@ -975,7 +964,7 @@ async fn complete_upload_for_gc<S: ObjectStore + ?Sized>(
         namespace_id,
         &content_store_id,
         begin.upload_id(),
-        &loonfs_api::v0::CompleteUploadRequest::for_content_ref(staged.content_ref.clone()),
+        crate::protocol::ResolvedUploadCompletion::KnownContent,
         context,
     )
     .await

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -170,6 +170,7 @@ pub use engine::RuntimeReadContext;
 pub use protocol::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse,
     DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget, MultipartPartTargets,
+    ResolvedUploadCompletion,
 };
 // The builder pair is reachable through `NamespaceEngine::builder()` and its
 // `build()`, so both stay public even though no caller names them directly.

--- a/crates/loonfs-core/src/protocol/mod.rs
+++ b/crates/loonfs-core/src/protocol/mod.rs
@@ -35,11 +35,12 @@ pub(crate) use self::publish_view::{load_publish_metadata_view, PublishTailProje
 pub use self::publish_view::{PublishTailOptions, PublishTailWeight};
 pub(crate) use self::uploads::{
     abort_upload, begin_direct_multipart_upload_target, begin_direct_put_upload_target,
-    begin_upload, complete_upload, direct_multipart_part_targets, read_upload_status,
-    stage_owned_bytes, stage_owned_stream, upload_content, upload_streamed_content,
-    AbandonedUpload,
+    begin_upload, complete_upload, complete_upload_for_mode, direct_multipart_part_targets,
+    read_upload_status, stage_owned_bytes, stage_owned_stream, upload_content,
+    upload_streamed_content, AbandonedUpload,
 };
 pub use self::uploads::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
     DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget, MultipartPartTargets,
+    ResolvedUploadCompletion,
 };

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -87,19 +87,13 @@ pub struct BeginDirectMultipartUploadTargetResponse {
     pub target: DirectMultipartUploadTarget,
 }
 
-/// A completion body after the durable session selected and decoded its wire
-/// schema.
-///
-/// This is an integration value, not a wire shape. HTTP callers send either
-/// `{}` or [`CompleteMultipartUploadRequest`], and the stored upload mode
-/// decides which one becomes this value.
+/// Completion data after the request has been decoded for the stored upload
+/// mode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolvedUploadCompletion {
-    /// A service-proxied or direct-PUT session already owns every content
-    /// fact completion needs.
+    /// The session already contains all required content information.
     KnownContent,
-    /// A multipart session learned its whole-object claim and part list while
-    /// uploading.
+    /// Multipart content information supplied at completion.
     Multipart(CompleteMultipartUploadRequest),
 }
 
@@ -882,12 +876,8 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
     .await
 }
 
-/// Completes an upload after using its durable transport to resolve the
-/// caller's request shape.
-///
-/// The resolver runs after the session read and terminal-abort check, and
-/// before any provider access or durable write. Keeping that decision inside
-/// the existing session read preserves the completion accounting contract.
+/// Loads the session, decodes completion data for its mode, and completes the
+/// upload. Decoding happens before provider access or durable writes.
 pub(crate) async fn complete_upload_for_mode<S, F>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -1401,20 +1391,13 @@ enum CompletionOutcome {
     Unusable(String),
 }
 
-/// The verification plan derived from the upload transport and completion
-/// request.
-///
-/// Building the plan performs no provider calls or durable writes. Each
-/// variant contains all data needed for the verification step.
+/// Information needed to verify an upload before completion.
 enum CompletionPlan<'a> {
-    /// A proxied session, which wrote and checked its own bytes: what it
-    /// recorded staging is the evidence.
+    /// Content previously staged through the server.
     Proxied { staged: Option<&'a ContentRef> },
-    /// A direct-put session, whose bytes went past this server: the object
-    /// that came to rest has to be read back against the promise.
+    /// Directly uploaded content that must be checked at the provider.
     DirectPut { promised: &'a ContentRef },
-    /// A direct-multipart session: the provider still has to assemble the
-    /// object from the parts the client uploaded, and then be proven right.
+    /// Parts the provider must assemble and verify.
     DirectMultipart {
         requested: ContentRef,
         provider_upload_id: &'a str,
@@ -1424,8 +1407,7 @@ enum CompletionPlan<'a> {
 }
 
 impl CompletionPlan<'_> {
-    /// The content a repeated completion must agree with when the request
-    /// still contributes content facts.
+    /// Content a repeated multipart completion must match.
     fn expected_completed_content(&self) -> Option<&ContentRef> {
         match self {
             Self::Proxied { .. } | Self::DirectPut { .. } => None,

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -32,7 +32,7 @@ use crate::storage::content_admission::{
 };
 use bytes::Bytes;
 use loonfs_api::v0::{
-    AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest,
+    AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, CompleteMultipartUploadRequest,
     CompleteUploadResponse, CompletedUploadPart, DirectMultipartUploadOptions, UploadContentClaim,
     UploadContentResponse, UploadMode, UploadPartChecksumClaim, UploadSessionStatus,
     UploadStatusResponse,
@@ -85,6 +85,22 @@ pub struct BeginDirectMultipartUploadTargetResponse {
     pub namespace_id: NamespaceId,
     pub upload_id: UploadId,
     pub target: DirectMultipartUploadTarget,
+}
+
+/// A completion body after the durable session selected and decoded its wire
+/// schema.
+///
+/// This is an integration value, not a wire shape. HTTP callers send either
+/// `{}` or [`CompleteMultipartUploadRequest`], and the stored upload mode
+/// decides which one becomes this value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedUploadCompletion {
+    /// A service-proxied or direct-PUT session already owns every content
+    /// fact completion needs.
+    KnownContent,
+    /// A multipart session learned its whole-object claim and part list while
+    /// uploading.
+    Multipart(CompleteMultipartUploadRequest),
 }
 
 /// One part a server integration is about to sign.
@@ -350,6 +366,11 @@ fn multipart_parts(
     parts: &[CompletedUploadPart],
     checksum_algorithm: ChecksumAlgorithm,
 ) -> Result<Vec<MultipartPart>> {
+    if parts.is_empty() {
+        return Err(CoreError::InvalidUploadContent(
+            "completion must include at least one uploaded part".to_owned(),
+        ));
+    }
     let mut previous = 0;
     parts
         .iter()
@@ -847,9 +868,38 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     content_store_id: &ContentStoreId,
     upload_id: &UploadId,
-    request: &CompleteUploadRequest,
+    completion: ResolvedUploadCompletion,
     context: &MutationContext,
 ) -> Result<CompletedUpload> {
+    complete_upload_for_mode(
+        store,
+        namespace_id,
+        content_store_id,
+        upload_id,
+        |_| Ok(completion),
+        context,
+    )
+    .await
+}
+
+/// Completes an upload after using its durable transport to resolve the
+/// caller's request shape.
+///
+/// The resolver runs after the session read and terminal-abort check, and
+/// before any provider access or durable write. Keeping that decision inside
+/// the existing session read preserves the completion accounting contract.
+pub(crate) async fn complete_upload_for_mode<S, F>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    content_store_id: &ContentStoreId,
+    upload_id: &UploadId,
+    resolve: F,
+    context: &MutationContext,
+) -> Result<CompletedUpload>
+where
+    S: ObjectStore + ?Sized,
+    F: FnOnce(UploadMode) -> std::result::Result<ResolvedUploadCompletion, String>,
+{
     let now_ms = context.now_ms;
     let loaded = read_upload_session_state(store, namespace_id, upload_id).await?;
     // An aborted session answers the same absence its physical deletion
@@ -859,13 +909,15 @@ pub(crate) async fn complete_upload<S: ObjectStore + ?Sized>(
             upload_id: upload_id.clone(),
         });
     }
-    let plan = completion_plan(&loaded, request)?;
+    let completion =
+        resolve(upload_mode(&loaded.transport)).map_err(CoreError::InvalidUploadContent)?;
+    let plan = completion_plan(&loaded, &completion)?;
     if let Some(completed) = completed_outcome(
         &loaded.state,
         namespace_id,
         content_store_id,
         upload_id,
-        Some(plan.requested()),
+        plan.expected_completed_content(),
         now_ms,
     )? {
         return Ok(completed);
@@ -1357,16 +1409,10 @@ enum CompletionOutcome {
 enum CompletionPlan<'a> {
     /// A proxied session, which wrote and checked its own bytes: what it
     /// recorded staging is the evidence.
-    Proxied {
-        requested: ContentRef,
-        staged: Option<&'a ContentRef>,
-    },
+    Proxied { staged: Option<&'a ContentRef> },
     /// A direct-put session, whose bytes went past this server: the object
     /// that came to rest has to be read back against the promise.
-    DirectPut {
-        requested: ContentRef,
-        promised: &'a ContentRef,
-    },
+    DirectPut { promised: &'a ContentRef },
     /// A direct-multipart session: the provider still has to assemble the
     /// object from the parts the client uploaded, and then be proven right.
     DirectMultipart {
@@ -1378,13 +1424,21 @@ enum CompletionPlan<'a> {
 }
 
 impl CompletionPlan<'_> {
-    /// The reference this completion is about.
-    fn requested(&self) -> &ContentRef {
+    /// The content a repeated completion must agree with when the request
+    /// still contributes content facts.
+    fn expected_completed_content(&self) -> Option<&ContentRef> {
         match self {
-            Self::Proxied { requested, .. }
-            | Self::DirectPut { requested, .. }
-            | Self::DirectMultipart { requested, .. } => requested,
+            Self::Proxied { .. } | Self::DirectPut { .. } => None,
+            Self::DirectMultipart { requested, .. } => Some(requested),
         }
+    }
+}
+
+fn upload_mode(transport: &UploadSessionTransport) -> UploadMode {
+    match transport {
+        UploadSessionTransport::ServiceProxied { .. } => UploadMode::ServiceProxied,
+        UploadSessionTransport::DirectPut { .. } => UploadMode::DirectPut,
+        UploadSessionTransport::DirectMultipart { .. } => UploadMode::DirectMultipart,
     }
 }
 
@@ -1397,14 +1451,13 @@ impl CompletionPlan<'_> {
 /// valid.
 fn completion_plan<'a>(
     session: &'a UploadSessionState,
-    request: &'a CompleteUploadRequest,
+    completion: &'a ResolvedUploadCompletion,
 ) -> Result<CompletionPlan<'a>> {
-    match (&session.transport, request) {
+    match (&session.transport, completion) {
         (
             UploadSessionTransport::ServiceProxied { staging },
-            CompleteUploadRequest::ContentRef { content_ref },
+            ResolvedUploadCompletion::KnownContent,
         ) => Ok(CompletionPlan::Proxied {
-            requested: content_ref.clone(),
             staged: match staging {
                 ProxiedStaging::Staged(content_ref) => Some(content_ref),
                 ProxiedStaging::Idle | ProxiedStaging::Claimed { .. } => None,
@@ -1412,9 +1465,8 @@ fn completion_plan<'a>(
         }),
         (
             UploadSessionTransport::DirectPut { promised_content },
-            CompleteUploadRequest::ContentRef { content_ref },
+            ResolvedUploadCompletion::KnownContent,
         ) => Ok(CompletionPlan::DirectPut {
-            requested: content_ref.clone(),
             promised: promised_content,
         }),
         (
@@ -1423,7 +1475,7 @@ fn completion_plan<'a>(
                 checksum_algorithm,
                 ..
             },
-            CompleteUploadRequest::Multipart { content, parts },
+            ResolvedUploadCompletion::Multipart(CompleteMultipartUploadRequest { content, parts }),
         ) => Ok(CompletionPlan::DirectMultipart {
             requested: direct_multipart_content_ref(
                 session.content_id.clone(),
@@ -1437,18 +1489,16 @@ fn completion_plan<'a>(
         (
             UploadSessionTransport::ServiceProxied { .. }
             | UploadSessionTransport::DirectPut { .. },
-            CompleteUploadRequest::Multipart { .. },
+            ResolvedUploadCompletion::Multipart(_),
         ) => Err(CoreError::InvalidUploadContent(format!(
             "{} completion carries no multipart claim",
             transport_name(&session.transport)
         ))),
         (
             UploadSessionTransport::DirectMultipart { .. },
-            CompleteUploadRequest::ContentRef { .. },
+            ResolvedUploadCompletion::KnownContent,
         ) => Err(CoreError::InvalidUploadContent(
-            "direct_multipart completion names no content ref: the server owns the identity \
-             and reports it back"
-                .to_owned(),
+            "direct_multipart completion requires a content claim and parts".to_owned(),
         )),
     }
 }
@@ -1466,26 +1516,13 @@ async fn completion_outcome<S: ObjectStore + ?Sized>(
     plan: CompletionPlan<'_>,
 ) -> Result<CompletionOutcome> {
     match plan {
-        CompletionPlan::Proxied { requested, staged } => {
+        CompletionPlan::Proxied { staged } => {
             let staged = staged.ok_or_else(|| {
                 CoreError::InvalidUploadContent("upload content has not been staged".to_owned())
             })?;
-            if staged != &requested {
-                return Err(CoreError::InvalidUploadContent(
-                    "completed content ref does not match staged content".to_owned(),
-                ));
-            }
             Ok(CompletionOutcome::Verified(staged.clone()))
         }
-        CompletionPlan::DirectPut {
-            requested,
-            promised,
-        } => {
-            if promised != &requested {
-                return Err(CoreError::InvalidUploadContent(
-                    "completed content ref does not match the direct_put target".to_owned(),
-                ));
-            }
+        CompletionPlan::DirectPut { promised } => {
             match verify_durable_content_checksum(store, content_store_id, promised).await {
                 Ok(()) => Ok(CompletionOutcome::Verified(promised.clone())),
                 Err(err) => Ok(CompletionOutcome::Unusable(content_failure_reason(err)?)),
@@ -1625,7 +1662,6 @@ mod tests {
         namespace_id: &NamespaceId,
         content_store_id: &ContentStoreId,
         upload_id: &UploadId,
-        content_ref: &ContentRef,
         context: &MutationContext,
     ) -> Result<CompletedUpload> {
         complete_upload(
@@ -1633,7 +1669,7 @@ mod tests {
             namespace_id,
             content_store_id,
             upload_id,
-            &CompleteUploadRequest::for_content_ref(content_ref.clone()),
+            ResolvedUploadCompletion::KnownContent,
             context,
         )
         .await
@@ -1718,7 +1754,7 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let setup = context(1_000);
-        let (namespace_id, content_store_id, upload_id, content_ref, content_key) =
+        let (namespace_id, content_store_id, upload_id, _content_ref, content_key) =
             staged_session(&store, &setup).await;
 
         abort_upload(
@@ -1737,7 +1773,6 @@ mod tests {
             &namespace_id,
             &content_store_id,
             &upload_id,
-            &content_ref,
             &context(3_000),
         )
         .await
@@ -1793,7 +1828,7 @@ mod tests {
             &namespace_id,
             &content_store_id,
             &begin.upload_id,
-            &CompleteUploadRequest::for_content_ref(begin.target.content_ref.clone()),
+            ResolvedUploadCompletion::KnownContent,
             &context(2_000),
         )
         .await
@@ -1819,7 +1854,7 @@ mod tests {
             &namespace_id,
             &content_store_id,
             &begin.upload_id,
-            &CompleteUploadRequest::for_content_ref(begin.target.content_ref),
+            ResolvedUploadCompletion::KnownContent,
             &context(3_000),
         )
         .await
@@ -1835,14 +1870,13 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let setup = context(1_000);
-        let (namespace_id, content_store_id, upload_id, content_ref, content_key) =
+        let (namespace_id, content_store_id, upload_id, _content_ref, content_key) =
             staged_session(&store, &setup).await;
         complete(
             &store,
             &namespace_id,
             &content_store_id,
             &upload_id,
-            &content_ref,
             &context(2_000),
         )
         .await
@@ -1903,14 +1937,13 @@ mod tests {
         let temp_dir = tempdir().expect("tempdir");
         let store = LocalFsStore::new(temp_dir.path()).expect("store");
         let setup = context(1_000);
-        let (namespace_id, content_store_id, upload_id, content_ref, _content_key) =
+        let (namespace_id, content_store_id, upload_id, _content_ref, _content_key) =
             staged_session(&store, &setup).await;
         complete(
             &store,
             &namespace_id,
             &content_store_id,
             &upload_id,
-            &content_ref,
             &context(2_000),
         )
         .await
@@ -1971,7 +2004,6 @@ mod tests {
             &namespace_id,
             &content_store_id,
             &upload_id,
-            &content_ref,
             &context(2_000),
         )
         .await
@@ -2040,7 +2072,6 @@ mod tests {
             &namespace_id,
             &content_store_id,
             &upload_id,
-            &content_ref,
             &context(completed_at_ms),
         )
         .await
@@ -2085,7 +2116,6 @@ mod tests {
             &namespace_id,
             &content_store_id,
             &upload_id,
-            &content_ref,
             &context(past),
         )
         .await

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -241,15 +241,12 @@ async fn valid_content_admission_skips_durable_content_validation() {
         .begin_upload(loonfs_api::v0::BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
-    let staged = engine
+    engine
         .upload_content(upload.upload_id(), b"admitted")
         .await
         .expect("stage content");
     let completed = engine
-        .complete_upload_prepared(
-            upload.upload_id(),
-            &loonfs_api::v0::CompleteUploadRequest::for_content_ref(staged.content_ref.clone()),
-        )
+        .complete_upload_prepared(upload.upload_id())
         .await
         .expect("complete upload");
     let content_ref = completed.response.content_ref.clone();
@@ -971,10 +968,7 @@ async fn a_re_minted_receipt_publishes_after_the_first_one_expired() {
         .await
         .expect("stage content");
     let completed = engine
-        .complete_upload_prepared(
-            upload.upload_id(),
-            &loonfs_api::v0::CompleteUploadRequest::for_content_ref(staged.content_ref.clone()),
-        )
+        .complete_upload_prepared(upload.upload_id())
         .await
         .expect("complete upload");
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -97,15 +97,12 @@ async fn reads_commits_and_change_feed_never_list() {
         .begin_upload(BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
-    let uploaded = engine
+    engine
         .upload_content(staged.upload_id(), b"uploaded\n")
         .await
         .expect("upload content");
     engine
-        .complete_upload(
-            staged.upload_id(),
-            &loonfs_api::v0::CompleteUploadRequest::for_content_ref(uploaded.content_ref),
-        )
+        .complete_upload(staged.upload_id())
         .await
         .expect("complete upload");
     put_file(
@@ -201,15 +198,12 @@ async fn maintenance_never_touches_the_wal_head() {
         .begin_upload(BeginUploadRequest::ServiceProxied {})
         .await
         .expect("second upload");
-    let uploaded = engine
+    engine
         .upload_content(staged.upload_id(), b"more\n")
         .await
         .expect("second upload content");
     engine
-        .complete_upload(
-            staged.upload_id(),
-            &loonfs_api::v0::CompleteUploadRequest::for_content_ref(uploaded.content_ref),
-        )
+        .complete_upload(staged.upload_id())
         .await
         .expect("second upload complete");
 

--- a/crates/loonfs-core/tests/it/upload_sessions.rs
+++ b/crates/loonfs-core/tests/it/upload_sessions.rs
@@ -6,13 +6,12 @@
 use crate::common::commit_split_support::*;
 use crate::common::namespace_engine;
 use bytes::Bytes;
-use loonfs_api::v0::UploadContentClaim;
+use loonfs_api::v0::{CompleteMultipartUploadRequest, UploadContentClaim};
 use loonfs_api::{
-    v0::CompleteUploadRequest,
     wire::control::{ControlObjectKind, UploadSessionState, UploadSessionTransport},
     ContentRef, DestinationBehavior, NamespaceId, UploadId,
 };
-use loonfs_api::{Checksum, ChecksumAlgorithm, ContentId};
+use loonfs_api::{Checksum, ChecksumAlgorithm};
 use loonfs_core::{
     BeginDirectPutUploadTargetResponse, Error as CoreError, ErrorCode, MutationContext,
 };
@@ -71,11 +70,10 @@ async fn complete_upload<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     upload_id: &UploadId,
-    request: &CompleteUploadRequest,
     context: &MutationContext,
 ) -> Result<loonfs_api::v0::CompleteUploadResponse, CoreError> {
     namespace_engine(store, namespace_id, context)
-        .complete_upload(upload_id, request)
+        .complete_upload(upload_id)
         .await
 }
 
@@ -267,57 +265,17 @@ async fn complete_upload_does_not_get_content_blob_after_staging() {
         .expect("upload content");
 
     store.reset();
-    let completed = complete_upload(
-        &store,
-        &namespace_id,
-        begin.upload_id(),
-        &CompleteUploadRequest::for_content_ref(uploaded.content_ref.clone()),
-        &context,
-    )
-    .await
-    .expect("complete upload");
+    let completed = complete_upload(&store, &namespace_id, begin.upload_id(), &context)
+        .await
+        .expect("complete upload");
     assert_eq!(completed.content_ref, uploaded.content_ref);
     assert_eq!(store.count(OperationClass::Read), 0);
 
     store.reset();
-    let completed_again = complete_upload(
-        &store,
-        &namespace_id,
-        begin.upload_id(),
-        &CompleteUploadRequest::for_content_ref(uploaded.content_ref),
-        &context,
-    )
-    .await
-    .expect("complete upload idempotently");
-    assert_eq!(completed_again.content_ref, completed.content_ref);
-    assert_eq!(store.count(OperationClass::Read), 0);
-
-    let mismatch_begin = begin_upload(&store, &namespace_id, &context)
+    let completed_again = complete_upload(&store, &namespace_id, begin.upload_id(), &context)
         .await
-        .expect("begin mismatch");
-    let mismatch_uploaded = upload_content(
-        &store,
-        &namespace_id,
-        mismatch_begin.upload_id(),
-        b"staged",
-        &context,
-    )
-    .await
-    .expect("upload mismatch content");
-    let wrong_ref = ContentRef::blob_v1(ContentId::generate(), b"different");
-    assert_ne!(wrong_ref, mismatch_uploaded.content_ref);
-
-    store.reset();
-    let mismatch = complete_upload(
-        &store,
-        &namespace_id,
-        mismatch_begin.upload_id(),
-        &CompleteUploadRequest::for_content_ref(wrong_ref),
-        &context,
-    )
-    .await
-    .expect_err("mismatched content ref");
-    assert_eq!(mismatch.code(), ErrorCode::InvalidRequest);
+        .expect("complete upload idempotently");
+    assert_eq!(completed_again.content_ref, completed.content_ref);
     assert_eq!(store.count(OperationClass::Read), 0);
 }
 
@@ -414,15 +372,9 @@ mod streamed_content {
         );
 
         // Completion is unchanged: it trusts what the server already checked.
-        let completed = complete_upload(
-            &store,
-            &namespace_id,
-            begin.upload_id(),
-            &CompleteUploadRequest::for_content_ref(staged.content_ref.clone()),
-            &context,
-        )
-        .await
-        .expect("complete a streamed upload");
+        let completed = complete_upload(&store, &namespace_id, begin.upload_id(), &context)
+            .await
+            .expect("complete a streamed upload");
         assert_eq!(completed.content_ref, staged.content_ref);
     }
 
@@ -703,8 +655,23 @@ mod direct_multipart {
     fn complete_request(
         session: &Session,
         parts: Vec<CompletedUploadPart>,
-    ) -> CompleteUploadRequest {
-        CompleteUploadRequest::for_multipart(session.claim.clone(), parts)
+    ) -> CompleteMultipartUploadRequest {
+        CompleteMultipartUploadRequest {
+            content: session.claim.clone(),
+            parts,
+        }
+    }
+
+    async fn complete_upload<S: ObjectStore + ?Sized>(
+        store: &S,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        request: &CompleteMultipartUploadRequest,
+        context: &MutationContext,
+    ) -> Result<loonfs_api::v0::CompleteUploadResponse, CoreError> {
+        namespace_engine(store, namespace_id, context)
+            .complete_multipart_upload(upload_id, request)
+            .await
     }
 
     /// The whole point of the transport: parts go straight to the provider,
@@ -756,6 +723,26 @@ mod direct_multipart {
             Bytes::from(session.payload.clone())
         );
         assert_eq!(store.open_uploads(), 0, "completion consumes the upload");
+    }
+
+    #[tokio::test]
+    async fn a_multipart_completion_rejects_an_empty_part_list() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = MultipartStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
+        let context = mutation_context();
+        let session = open_session(&store, &context).await;
+
+        let error = complete_upload(
+            &store,
+            &session.namespace_id,
+            &session.upload_id,
+            &complete_request(&session, Vec::new()),
+            &context,
+        )
+        .await
+        .expect_err("a multipart completion needs at least one part");
+        assert_eq!(error.code(), ErrorCode::InvalidRequest);
+        assert!(error.to_string().contains("at least one uploaded part"));
     }
 
     /// Re-uploading a part is how a client retries one. The last write wins
@@ -1124,62 +1111,5 @@ mod direct_multipart {
                 .expect_err("a part size no provider accepts is refused");
             assert_eq!(error.code(), ErrorCode::InvalidRequest);
         }
-    }
-
-    /// The two completion shapes are not interchangeable, and which one is
-    /// right depends on the durable record. That is the one thing decoding
-    /// a completion body cannot settle — the client's request is well
-    /// formed either way — so it is settled here, against the session.
-    #[tokio::test]
-    async fn each_mode_completes_with_the_shape_it_was_opened_for() {
-        let temp_dir = tempdir().expect("tempdir");
-        let store = MultipartStore::new(LocalFsStore::new(temp_dir.path()).expect("store"));
-        let context = mutation_context();
-        let session = open_session(&store, &context).await;
-
-        // A multipart session's client never learned an identity, so naming
-        // one back is a mistake worth reporting rather than a value worth
-        // checking.
-        let error = complete_upload(
-            &store,
-            &session.namespace_id,
-            &session.upload_id,
-            &CompleteUploadRequest::for_content_ref(ContentRef::blob_v1(
-                ContentId::generate(),
-                PART,
-            )),
-            &context,
-        )
-        .await
-        .expect_err("a multipart completion cannot name the identity");
-        assert_eq!(error.code(), ErrorCode::InvalidRequest);
-
-        // And the proxied direction: a session that was handed a reference
-        // has no assembly to claim.
-        let begin = begin_upload(&store, &session.namespace_id, &context)
-            .await
-            .expect("begin a proxied session");
-        upload_content(
-            &store,
-            &session.namespace_id,
-            begin.upload_id(),
-            PART,
-            &context,
-        )
-        .await
-        .expect("stage bytes");
-        let error = complete_upload(
-            &store,
-            &session.namespace_id,
-            begin.upload_id(),
-            &CompleteUploadRequest::for_multipart(
-                session.claim.clone(),
-                upload_every_part(&store, &session),
-            ),
-            &context,
-        )
-        .await
-        .expect_err("a proxied completion carries no multipart claim");
-        assert_eq!(error.code(), ErrorCode::InvalidRequest);
     }
 }

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -212,11 +212,7 @@ where
     }
 }
 
-/// An authorized JSON-sized request body whose schema is selected later.
-///
-/// Completion uses this extractor because its durable upload session chooses
-/// the body type. Authorization still runs before a byte is read, and body
-/// failures remain inside the API error envelope.
+/// An authorized request body decoded after the upload mode is loaded.
 pub(super) struct UploadBodyBytes(Bytes);
 
 impl UploadBodyBytes {

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -8,6 +8,7 @@ use axum::extract::{FromRequest, FromRequestParts, Path as AxumPath, Query};
 use axum::http::request::Parts;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
+use bytes::Bytes;
 use futures::StreamExt;
 use loonfs::{ByteStream, ErrorCode};
 use loonfs_api::NamespaceId;
@@ -208,6 +209,42 @@ where
         extract_json(req, state, json_body_too_large_error)
             .await
             .map(AppJson)
+    }
+}
+
+/// An authorized JSON-sized request body whose schema is selected later.
+///
+/// Completion uses this extractor because its durable upload session chooses
+/// the body type. Authorization still runs before a byte is read, and body
+/// failures remain inside the API error envelope.
+pub(super) struct UploadBodyBytes(Bytes);
+
+impl UploadBodyBytes {
+    pub(super) fn into_bytes(self) -> Bytes {
+        self.0
+    }
+}
+
+const MAX_UPLOAD_CONTROL_BODY_BYTES: usize = 1024 * 1024;
+
+impl FromRequest<AppState> for UploadBodyBytes {
+    type Rejection = ApiResponseError;
+
+    async fn from_request(
+        req: axum::extract::Request,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        authorize(state.config.auth_policy(), req.headers())?;
+        axum::body::to_bytes(req.into_body(), MAX_UPLOAD_CONTROL_BODY_BYTES)
+            .await
+            .map(Self)
+            .map_err(|error| {
+                ApiResponseError::new(
+                    StatusCode::BAD_REQUEST,
+                    ErrorCode::InvalidRequest,
+                    &format!("request body unreadable: {error}"),
+                )
+            })
     }
 }
 

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -559,14 +559,14 @@ pub(super) async fn upload_content(
         path = "/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
         tag = "uploads",
         summary = "Complete upload",
-        description = "Completes an upload session using the request schema selected by its durable mode. Service-proxied and direct-put sessions accept `{}`; direct-multipart sessions accept the content claim and completed parts. The response may include a short-lived content token for a following file write.",
+        description = "Completes an upload using the body required by its stored mode. Service-proxied and direct-put sessions accept `{}`. Direct-multipart sessions require the content claim and completed parts.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
         ),
         request_body(
             content = crate::http::openapi::CompleteUploadRequestSchema,
-            description = "The stored session mode selects which strict oneOf variant is accepted."
+            description = "The stored upload mode determines which body is accepted."
         ),
         responses(
             (status = 200, description = "Upload completed", body = CompleteUploadResponse),

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -2,7 +2,9 @@
 //! backing them.
 
 use super::error::ApiResponseError;
-use super::{authorize, AppJson, AppPath, AppState, NamespaceIdPath, UploadBodyStream};
+use super::{
+    authorize, AppJson, AppPath, AppState, NamespaceIdPath, UploadBodyBytes, UploadBodyStream,
+};
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
@@ -10,6 +12,7 @@ use loonfs::content_tokens::{
     mint_content_token, CompletedUploadReceipt, ContentToken, ContentTokenError,
 };
 use loonfs::publish::PreparedContent;
+use loonfs::uploads::ResolvedUploadCompletion;
 use loonfs::FsWriter;
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -17,11 +20,11 @@ use loonfs_api::ErrorCode;
 use loonfs_api::{
     direct_put_checksum_feature,
     v0::{
-        AbortUploadResponse, BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest,
-        CompleteUploadResponse, DirectMultipartUpload, DirectMultipartUploadOptions,
-        DirectPutUpload, ObjectTransferAccess, SignUploadPartsRequest, SignUploadPartsResponse,
-        SignedUploadPart, UploadContentClaim, UploadContentResponse, UploadSessionStatus,
-        UploadStatusResponse,
+        AbortUploadResponse, BeginUploadRequest, BeginUploadResponse,
+        CompleteKnownContentUploadRequest, CompleteMultipartUploadRequest, CompleteUploadResponse,
+        DirectMultipartUpload, DirectMultipartUploadOptions, DirectPutUpload, ObjectTransferAccess,
+        SignUploadPartsRequest, SignUploadPartsResponse, SignedUploadPart, UploadContentClaim,
+        UploadContentResponse, UploadMode, UploadSessionStatus, UploadStatusResponse,
     },
     ChecksumAlgorithm, ContentId, ContentRef, NamespaceId, UploadId,
     FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
@@ -556,12 +559,15 @@ pub(super) async fn upload_content(
         path = "/v0/namespaces/{namespace_id}/uploads/{upload_id}/complete",
         tag = "uploads",
         summary = "Complete upload",
-        description = "Completes an upload session once the caller confirms the expected content reference. The response may include a short-lived content token for a following file write.",
+        description = "Completes an upload session using the request schema selected by its durable mode. Service-proxied and direct-put sessions accept `{}`; direct-multipart sessions accept the content claim and completed parts. The response may include a short-lived content token for a following file write.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("upload_id" = String, Path, description = "Upload session id")
         ),
-        request_body = CompleteUploadRequest,
+        request_body(
+            content = crate::http::openapi::CompleteUploadRequestSchema,
+            description = "The stored session mode selects which strict oneOf variant is accepted."
+        ),
         responses(
             (status = 200, description = "Upload completed", body = CompleteUploadResponse),
             (status = 400, description = "Invalid completion request", body = ApiError),
@@ -577,20 +583,109 @@ pub(super) async fn complete_upload(
     State(state): State<AppState>,
     namespace_id_path: NamespaceIdPath,
     path: AppPath<UploadPathParams>,
-    AppJson(request): AppJson<CompleteUploadRequest>,
+    body: UploadBodyBytes,
 ) -> Result<Json<CompleteUploadResponse>, ApiResponseError> {
     let namespace_id = namespace_id_path.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
+    let body = body.into_bytes();
     let completed = state
         .writer
-        .complete_upload_prepared(&namespace_id, &upload_id, &request)
+        .complete_upload_prepared_for_mode(&namespace_id, &upload_id, |mode| {
+            decode_completion_body(mode, &body)
+        })
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     let mut response = completed.response;
     response.content_token = ContentTokenVerifier::new(state.config.content_token_secret())
         .mint_receipt(completed.receipt.as_ref())?;
     Ok(Json(response))
+}
+
+fn decode_completion_body(
+    mode: UploadMode,
+    body: &[u8],
+) -> std::result::Result<ResolvedUploadCompletion, String> {
+    let invalid = |error: serde_json::Error| {
+        format!(
+            "request body is not valid JSON for {} completion: {error}",
+            upload_mode_name(mode)
+        )
+    };
+    match mode {
+        UploadMode::ServiceProxied | UploadMode::DirectPut => {
+            serde_json::from_slice::<CompleteKnownContentUploadRequest>(body)
+                .map(|_| ResolvedUploadCompletion::KnownContent)
+                .map_err(invalid)
+        }
+        UploadMode::DirectMultipart => {
+            serde_json::from_slice::<CompleteMultipartUploadRequest>(body)
+                .map(ResolvedUploadCompletion::Multipart)
+                .map_err(invalid)
+        }
+    }
+}
+
+fn upload_mode_name(mode: UploadMode) -> &'static str {
+    match mode {
+        UploadMode::ServiceProxied => "service_proxied",
+        UploadMode::DirectPut => "direct_put",
+        UploadMode::DirectMultipart => "direct_multipart",
+    }
+}
+
+#[cfg(test)]
+mod completion_body_tests {
+    use super::*;
+
+    const CONTENT: &str =
+        r#"{"size_bytes":5,"checksum":{"algorithm":"crc64nvme","value":"0123456789abcdef"}}"#;
+
+    #[test]
+    fn stored_mode_selects_a_precise_completion_schema_error() {
+        let multipart_body = format!(r#"{{"content":{CONTENT},"parts":[]}}"#);
+        let direct_put_error =
+            decode_completion_body(UploadMode::DirectPut, multipart_body.as_bytes())
+                .expect_err("multipart fields do not belong to direct put");
+        assert_eq!(
+            direct_put_error,
+            "request body is not valid JSON for direct_put completion: unknown field `content`, \
+             there are no fields at line 1 column 10"
+        );
+
+        let multipart_error = decode_completion_body(UploadMode::DirectMultipart, b"{}")
+            .expect_err("multipart completion needs its claim and parts");
+        assert_eq!(
+            multipart_error,
+            "request body is not valid JSON for direct_multipart completion: missing field \
+             `content` at line 1 column 2"
+        );
+
+        let missing_parts = format!(r#"{{"content":{CONTENT}}}"#);
+        let missing_parts_error =
+            decode_completion_body(UploadMode::DirectMultipart, missing_parts.as_bytes())
+                .expect_err("multipart completion needs parts");
+        assert_eq!(
+            missing_parts_error,
+            "request body is not valid JSON for direct_multipart completion: missing field \
+             `parts` at line 1 column 92"
+        );
+    }
+
+    #[test]
+    fn retired_completion_fields_are_unknown_in_known_content_bodies() {
+        for (body, field) in [
+            (r#"{"completion":"content_ref"}"#, "completion"),
+            (r#"{"content_ref":{}}"#, "content_ref"),
+        ] {
+            let error = decode_completion_body(UploadMode::ServiceProxied, body.as_bytes())
+                .expect_err("retired completion field");
+            assert!(
+                error.contains(&format!("unknown field `{field}`")),
+                "wrong error for {field}: {error}"
+            );
+        }
+    }
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -30,7 +30,7 @@ pub use self::tls::TlsConfigError;
 use self::error::ApiResponseError;
 use self::extractors::{
     authorize, server_busy_error, AppJson, AppPath, AppQuery, NamespaceIdPath, OptionalAppJson,
-    UploadBodyStream,
+    UploadBodyBytes, UploadBodyStream,
 };
 use self::handlers_downloads::begin_download;
 use self::handlers_filesystem::{

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -10,9 +10,9 @@ use loonfs_api::ChangeSeq;
 use loonfs_api::{
     v0::{
         BeginDownloadRequest, BeginDownloadResponse, BeginUploadRequest, BeginUploadResponse,
-        ChangesResponse, CommitResponse as ApiCommitResponse, CompleteUploadRequest,
-        CompleteUploadResponse, ContentToken, DirectPutUpload, ObjectTransferAccess,
-        UploadContentResponse,
+        ChangesResponse, CommitResponse as ApiCommitResponse, CompleteKnownContentUploadRequest,
+        CompleteMultipartUploadRequest, CompleteUploadResponse, ContentToken, DirectPutUpload,
+        ObjectTransferAccess, UploadContentResponse,
     },
     AdvanceRetentionResponse, ApiError, CheckpointOwnerSummary, CheckpointSummary, CommitRequest,
     ContentRef, CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
@@ -29,6 +29,34 @@ pub fn openapi_document() -> utoipa::openapi::OpenApi {
 
 pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&openapi_document())
+}
+
+/// Manual completion request schema: the durable session mode, not a field in
+/// the body, selects one of the two strict wire objects.
+pub(super) struct CompleteUploadRequestSchema;
+
+impl utoipa::PartialSchema for CompleteUploadRequestSchema {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::OneOfBuilder::new()
+            .item(utoipa::openapi::Ref::from_schema_name(
+                "CompleteKnownContentUploadRequest",
+            ))
+            .item(utoipa::openapi::Ref::from_schema_name(
+                "CompleteMultipartUploadRequest",
+            ))
+            .description(Some(
+                "The stored upload session mode selects the accepted variant: service_proxied \
+                 and direct_put use the empty object; direct_multipart uses the content claim \
+                 and completed parts.",
+            ))
+            .into()
+    }
+}
+
+impl utoipa::ToSchema for CompleteUploadRequestSchema {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("CompleteUploadRequest")
+    }
 }
 
 #[derive(utoipa::OpenApi)]
@@ -132,7 +160,9 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
         BeginUploadRequest,
         BeginUploadResponse,
         UploadContentResponse,
-        CompleteUploadRequest,
+        CompleteUploadRequestSchema,
+        CompleteKnownContentUploadRequest,
+        CompleteMultipartUploadRequest,
         CompleteUploadResponse,
         DirectPutUpload,
         loonfs_api::v0::DirectMultipartUpload,

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -31,8 +31,7 @@ pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&openapi_document())
 }
 
-/// Manual completion request schema: the durable session mode, not a field in
-/// the body, selects one of the two strict wire objects.
+/// OpenAPI schema for the two upload completion bodies.
 pub(super) struct CompleteUploadRequestSchema;
 
 impl utoipa::PartialSchema for CompleteUploadRequestSchema {
@@ -45,9 +44,9 @@ impl utoipa::PartialSchema for CompleteUploadRequestSchema {
                 "CompleteMultipartUploadRequest",
             ))
             .description(Some(
-                "The stored upload session mode selects the accepted variant: service_proxied \
-                 and direct_put use the empty object; direct_multipart uses the content claim \
-                 and completed parts.",
+                "The stored upload mode determines the accepted body. Service-proxied and \
+                 direct-put sessions use an empty object. Direct-multipart sessions provide \
+                 the content claim and completed parts.",
             ))
             .into()
     }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -3004,6 +3004,7 @@ mod direct_download {
     use super::*;
     use crate::http::app_with_store_and_direct_transfers;
     use loonfs_api::{
+        v0::{CompleteMultipartUploadRequest, UploadContentClaim},
         Checksum, ChecksumAlgorithm, RevisionNo, FEATURE_DOWNLOADS_DIRECT_GET,
         FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
         FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_CRC32C, FEATURE_UPLOADS_DIRECT_PUT_CHECKSUM_SHA256,
@@ -3500,6 +3501,67 @@ mod direct_download {
             Some(&PROXY_CAP_BYTES),
             "the proxy cap stays advertised: it is what tells a client which reads need a grant"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_direct_put_session_rejects_multipart_completion_fields_precisely() {
+        let temp_dir = tempdir().expect("tempdir");
+        let issuer = LoopbackIssuer::at("http://object.invalid");
+        let transfers = DirectTransferIssuers::read_only(issuer.clone()).with_put(issuer);
+        let client = start(
+            temp_dir.path(),
+            "direct-put-completion-shape",
+            Some(transfers),
+        )
+        .await;
+        let namespace_id =
+            NamespaceId::parse("direct-put-completion-shape").expect("valid namespace id");
+        client
+            .create_namespace(&namespace_id)
+            .await
+            .expect("create namespace");
+        let begin = client
+            .begin_direct_put(
+                &namespace_id,
+                UploadContentClaim {
+                    size_bytes: 5,
+                    checksum: Checksum::sha256(b"hello"),
+                },
+            )
+            .await
+            .expect("begin direct put");
+
+        let error = client
+            .complete_multipart_upload(
+                &namespace_id,
+                begin.upload_id(),
+                &CompleteMultipartUploadRequest {
+                    content: UploadContentClaim {
+                        size_bytes: 5,
+                        checksum: Checksum::sha256(b"hello"),
+                    },
+                    parts: Vec::new(),
+                },
+            )
+            .await
+            .expect_err("multipart completion body does not belong to direct put");
+        match error {
+            ClientError::Api {
+                status,
+                code,
+                message,
+                ..
+            } => {
+                assert_eq!(status, 400);
+                assert_eq!(code, ErrorCode::InvalidRequest.as_str());
+                assert_eq!(
+                    message,
+                    "invalid upload content: request body is not valid JSON for direct_put \
+                     completion: unknown field `content`, there are no fields at line 1 column 10"
+                );
+            }
+            other => panic!("expected a typed invalid_request, got {other:?}"),
+        }
     }
 
     /// The GCS shape, end to end, with no GCS-specific code anywhere above

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -292,7 +292,7 @@ pub(crate) mod http_split_support {
     #![allow(dead_code)]
 
     use loonfs_api::{
-        v0::{BeginUploadRequest, CompleteUploadRequest, CompleteUploadResponse, ContentToken},
+        v0::{BeginUploadRequest, CompleteUploadResponse, ContentToken},
         CommitRequest, DestinationBehavior, NamespaceId,
     };
     use loonfs_client::{Client, PutFileOptions};
@@ -357,17 +357,16 @@ pub(crate) mod http_split_support {
             .begin_upload(namespace_id, &BeginUploadRequest::ServiceProxied {})
             .await
             .expect("begin upload");
-        let staged = client
+        client
             .upload_content(namespace_id, begin.upload_id(), file_bytes)
             .await
             .expect("upload content");
-        let complete_request = CompleteUploadRequest::for_content_ref(staged.content_ref);
         let complete = client
-            .complete_upload(namespace_id, begin.upload_id(), &complete_request)
+            .complete_upload(namespace_id, begin.upload_id())
             .await
             .expect("complete upload");
         let repeated = client
-            .complete_upload(namespace_id, begin.upload_id(), &complete_request)
+            .complete_upload(namespace_id, begin.upload_id())
             .await
             .expect("repeat complete upload");
         assert_eq!(repeated.namespace_id, complete.namespace_id);

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use loonfs_api::{
     v0::{
-        BeginUploadResponse, CompleteUploadRequest, DirectMultipartUpload,
+        BeginUploadResponse, CompleteMultipartUploadRequest, DirectMultipartUpload,
         DirectMultipartUploadOptions, DirectPutUpload, ObjectTransferAccess, UploadContentClaim,
         UploadPartChecksumClaim,
     },
@@ -199,11 +199,7 @@ async fn direct_put_round_trip(signed_write: SignedWriteHeaders, config: ServerC
 
     let complete = harness
         .client
-        .complete_upload(
-            &namespace_id,
-            begin.upload_id(),
-            &CompleteUploadRequest::for_content_ref(content_ref.clone()),
-        )
+        .complete_upload(&namespace_id, begin.upload_id())
         .await
         .expect("complete direct-put upload");
     assert_eq!(complete.content_ref, content_ref);
@@ -339,7 +335,6 @@ async fn assert_wrong_direct_put_bytes_rejected(
         .await
         .expect("begin wrong-bytes direct put");
     let direct_put = direct_put_of(&begin);
-    let content_ref = direct_put.content_ref.clone();
 
     expect_client_rejection(
         client
@@ -349,11 +344,7 @@ async fn assert_wrong_direct_put_bytes_rejected(
     );
     expect_client_rejection(
         client
-            .complete_upload(
-                namespace_id,
-                begin.upload_id(),
-                &CompleteUploadRequest::for_content_ref(content_ref),
-            )
+            .complete_upload(namespace_id, begin.upload_id())
             .await,
         "complete wrong-bytes direct put",
     );
@@ -406,7 +397,6 @@ async fn assert_direct_put_requires_its_signed_headers(
             .await
             .expect("begin meddled direct put");
         let direct_put = direct_put_of(&begin);
-        let content_ref = direct_put.content_ref.clone();
 
         expect_client_rejection(
             client
@@ -418,11 +408,7 @@ async fn assert_direct_put_requires_its_signed_headers(
         // find and hands out no token.
         expect_client_rejection(
             client
-                .complete_upload(
-                    namespace_id,
-                    begin.upload_id(),
-                    &CompleteUploadRequest::for_content_ref(content_ref),
-                )
+                .complete_upload(namespace_id, begin.upload_id())
                 .await,
             &format!("complete after {label}"),
         );
@@ -445,7 +431,6 @@ async fn assert_direct_put_is_no_replace(
         .await
         .expect("begin duplicate direct put");
     let direct_put = direct_put_of(&begin);
-    let content_ref = direct_put.content_ref.clone();
 
     client
         .upload_via_presigned_url(&direct_put.access, bytes)
@@ -459,11 +444,7 @@ async fn assert_direct_put_is_no_replace(
     );
 
     let complete = client
-        .complete_upload(
-            namespace_id,
-            begin.upload_id(),
-            &CompleteUploadRequest::for_content_ref(content_ref),
-        )
+        .complete_upload(namespace_id, begin.upload_id())
         .await
         .expect("complete first direct put");
     assert!(
@@ -768,9 +749,8 @@ async fn gcp_gcs_signed_capabilities_are_scoped_bounded_and_single_use() {
     harness.server.abort();
 }
 
-/// Completion reads the object back and judges it. A promise that does not
-/// describe what is actually stored fails, and a failed completion hands out
-/// no content token — so nothing unproven can reach a commit.
+/// Completion reads the object back against the durable promise before it
+/// hands out a content token, so nothing unproven can reach a commit.
 async fn assert_gcs_completion_judges_the_object_that_is_there(
     client: &Client,
     namespace_id: &NamespaceId,
@@ -790,37 +770,9 @@ async fn assert_gcs_completion_judges_the_object_that_is_there(
         .await
         .expect("upload the promised bytes");
 
-    // A ref claiming the wrong length, and one claiming the wrong digest,
-    // each describe an object that is not the one stored.
-    let wrong_size = loonfs_api::ContentRef {
-        size_bytes: content_ref.size_bytes + 1,
-        ..content_ref.clone()
-    };
-    let wrong_checksum = loonfs_api::ContentRef {
-        checksum: Checksum::crc32c(b"some other object entirely\n"),
-        ..content_ref.clone()
-    };
-    for (label, claimed) in [
-        ("wrong size", wrong_size),
-        ("wrong checksum", wrong_checksum),
-    ] {
-        let refused = client
-            .complete_upload(
-                namespace_id,
-                begin.upload_id(),
-                &CompleteUploadRequest::for_content_ref(claimed),
-            )
-            .await;
-        expect_client_rejection(refused, &format!("complete with a {label}"));
-    }
-
-    // The honest promise completes, against the very same stored object.
+    // The session completes against the promise it durably owns.
     let complete = client
-        .complete_upload(
-            namespace_id,
-            begin.upload_id(),
-            &CompleteUploadRequest::for_content_ref(content_ref.clone()),
-        )
+        .complete_upload(namespace_id, begin.upload_id())
         .await
         .expect("complete the honest promise");
     assert_eq!(complete.content_ref, content_ref);
@@ -1162,16 +1114,16 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
 
     // The claim rides with the completion, and the identity comes back with
     // the answer: the client never named the object it wrote.
-    let request = CompleteUploadRequest::for_multipart(
-        UploadContentClaim {
+    let request = CompleteMultipartUploadRequest {
+        content: UploadContentClaim {
             size_bytes: payload.len() as u64,
             checksum: whole_object.clone(),
         },
         parts,
-    );
+    };
     let complete = harness
         .client
-        .complete_upload(&namespace_id, &upload_id, &request)
+        .complete_multipart_upload(&namespace_id, &upload_id, &request)
         .await
         .expect("complete the multipart upload");
     let content_ref = complete.content_ref.clone();
@@ -1184,7 +1136,7 @@ async fn direct_multipart_round_trip(config: ServerConfig) {
     // used. Both reconcile from the durable session and the object.
     let replayed = harness
         .client
-        .complete_upload(&namespace_id, &upload_id, &request)
+        .complete_multipart_upload(&namespace_id, &upload_id, &request)
         .await
         .expect("a lost completion is answered, not failed");
     assert_eq!(replayed.content_ref, content_ref);

--- a/crates/loonfs-server/tests/it/direct_put_real_provider.rs
+++ b/crates/loonfs-server/tests/it/direct_put_real_provider.rs
@@ -749,8 +749,7 @@ async fn gcp_gcs_signed_capabilities_are_scoped_bounded_and_single_use() {
     harness.server.abort();
 }
 
-/// Completion reads the object back against the durable promise before it
-/// hands out a content token, so nothing unproven can reach a commit.
+/// Completion verifies the stored object before issuing a content token.
 async fn assert_gcs_completion_judges_the_object_that_is_there(
     client: &Client,
     namespace_id: &NamespaceId,
@@ -770,7 +769,7 @@ async fn assert_gcs_completion_judges_the_object_that_is_there(
         .await
         .expect("upload the promised bytes");
 
-    // The session completes against the promise it durably owns.
+    // Completion uses the content reference stored in the session.
     let complete = client
         .complete_upload(namespace_id, begin.upload_id())
         .await

--- a/crates/loonfs-server/tests/it/http_uploads.rs
+++ b/crates/loonfs-server/tests/it/http_uploads.rs
@@ -2,11 +2,10 @@
 
 use crate::common::http_split_support::*;
 use crate::common::start_server;
-use loonfs_api::ContentId;
 use loonfs_api::{
     v0::{
-        AbortUploadResponse, BeginUploadRequest, CompleteUploadRequest, FilesystemChange,
-        UploadSessionStatus, UploadStatusResponse,
+        AbortUploadResponse, BeginUploadRequest, FilesystemChange, UploadSessionStatus,
+        UploadStatusResponse,
     },
     AbsolutePath, ApiError, ChangeSeq, CommitId, CommitRequest, CommitResponse, ContentRef,
     DestinationBehavior, ErrorCode, FilesystemOperation, InodeId, InodeKind, RevisionNo,
@@ -106,6 +105,78 @@ async fn http_begin_upload_rejects_a_body_that_mixes_transports() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stored_proxied_mode_rejects_multipart_and_retired_completion_fields_precisely() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-completion-shape",
+    ))
+    .await;
+    let namespace = namespace_id("demo");
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let begin = harness
+        .client
+        .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
+        .await
+        .expect("begin upload");
+
+    let completion_url = format!(
+        "{}/v0/namespaces/{namespace}/uploads/{}/complete",
+        harness.server_url,
+        begin.upload_id()
+    );
+    for (body, wrong) in [
+        (
+            r#"{"content":{"size_bytes":5,"checksum":{"algorithm":"sha256","value":"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"}},"parts":[]}"#,
+            "unknown field `content`",
+        ),
+        (
+            r#"{"completion":"content_ref"}"#,
+            "unknown field `completion`",
+        ),
+        (r#"{"content_ref":{}}"#, "unknown field `content_ref`"),
+    ] {
+        let result = raw_agent()
+            .post(&completion_url)
+            .set("authorization", "Bearer test-token")
+            .set("content-type", "application/json")
+            .send_string(body);
+        let ureq::Error::Status(status, response) =
+            result.expect_err("wrong completion shape should fail")
+        else {
+            unreachable!("a rejected completion body returns an HTTP status");
+        };
+        assert_eq!(status, 400);
+        let error: ApiError =
+            serde_json::from_reader(response.into_reader()).expect("API error envelope");
+        assert_eq!(error.code, "invalid_request");
+        assert!(
+            error.message.contains(wrong),
+            "completion error should name `{wrong}` verbatim: {}",
+            error.message
+        );
+        assert!(error.message.contains("service_proxied completion"));
+    }
+
+    harness
+        .client
+        .upload_content(&namespace, begin.upload_id(), b"hello")
+        .await
+        .expect("stage content");
+    harness
+        .client
+        .complete_upload(&namespace, begin.upload_id())
+        .await
+        .expect("empty completion succeeds for proxied mode");
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn completion_content_token_passes_unchanged_into_http_commit() {
     let temp_dir = tempdir().expect("tempdir");
     let harness = start_server(test_config(
@@ -147,36 +218,6 @@ async fn completion_content_token_passes_unchanged_into_http_commit() {
     {
         Err(ClientError::Api { code, .. }) => assert_eq!(code, "upload_content_conflict"),
         other => unreachable!("expected upload_content_conflict, got {other:?}"),
-    }
-
-    let mismatch_upload = harness
-        .client
-        .begin_upload(&namespace, &BeginUploadRequest::ServiceProxied {})
-        .await
-        .expect("begin mismatch upload");
-    let staged = harness
-        .client
-        .upload_content(&namespace, mismatch_upload.upload_id(), file_bytes)
-        .await
-        .expect("stage mismatch upload content");
-    assert_ne!(
-        staged.content_ref,
-        ContentRef::blob_v1(ContentId::generate(), b"other bytes")
-    );
-    match harness
-        .client
-        .complete_upload(
-            &namespace,
-            mismatch_upload.upload_id(),
-            &CompleteUploadRequest::for_content_ref(ContentRef::blob_v1(
-                ContentId::generate(),
-                b"other bytes",
-            )),
-        )
-        .await
-    {
-        Err(ClientError::Api { code, .. }) => assert_eq!(code, "invalid_request"),
-        other => unreachable!("expected upload content rejection, got {other:?}"),
     }
 
     let completed = stage_uploaded_content(&harness.client, &namespace, file_bytes).await;
@@ -306,14 +347,7 @@ async fn http_upload_status_re_mints_and_abort_is_terminal() {
     // deletion will.
     let completion = harness
         .client
-        .complete_upload(
-            &namespace,
-            open.upload_id(),
-            &CompleteUploadRequest::for_content_ref(ContentRef::blob_v1(
-                ContentId::generate(),
-                b"never staged",
-            )),
-        )
+        .complete_upload(&namespace, open.upload_id())
         .await
         .expect_err("an aborted session cannot complete");
     assert_eq!(completion.code(), Some(ErrorCode::UploadNotFound));
@@ -452,18 +486,14 @@ async fn complete_upload_session(
         .begin_upload(namespace, &BeginUploadRequest::ServiceProxied {})
         .await
         .expect("begin upload");
-    let staged = harness
+    harness
         .client
         .upload_content(namespace, begin.upload_id(), bytes)
         .await
         .expect("upload content");
     let completed = harness
         .client
-        .complete_upload(
-            namespace,
-            begin.upload_id(),
-            &CompleteUploadRequest::for_content_ref(staged.content_ref),
-        )
+        .complete_upload(namespace, begin.upload_id())
         .await
         .expect("complete upload");
     (begin.upload_id().clone(), completed.content_ref)

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -259,15 +259,50 @@ fn openapi_reuses_the_one_checksum_and_upload_claim_shapes() {
         .and_then(|schema| schema.get("oneOf"))
         .and_then(Value::as_array)
         .expect("completion variants");
-    let multipart_completion = completion_variants
-        .iter()
-        .find(|schema| {
-            schema.get("title").and_then(Value::as_str) == Some("CompleteUploadMultipart")
-        })
-        .expect("multipart completion variant");
+    assert_eq!(
+        completion_variants,
+        &[
+            serde_json::json!({
+                "$ref": "#/components/schemas/CompleteKnownContentUploadRequest"
+            }),
+            serde_json::json!({
+                "$ref": "#/components/schemas/CompleteMultipartUploadRequest"
+            }),
+        ]
+    );
+    let completion_description = schemas["CompleteUploadRequest"]["description"]
+        .as_str()
+        .expect("completion schema description");
+    assert!(completion_description.contains("stored upload session mode selects"));
+
+    let known_completion = schemas
+        .get("CompleteKnownContentUploadRequest")
+        .expect("known-content completion schema");
+    assert!(known_completion
+        .get("properties")
+        .and_then(Value::as_object)
+        .is_none_or(serde_json::Map::is_empty));
+
+    let multipart_completion = schemas
+        .get("CompleteMultipartUploadRequest")
+        .expect("multipart completion schema");
     let required = required_fields(multipart_completion);
     assert!(required.contains("content"));
-    assert!(!required.contains("multipart"));
+    assert!(required.contains("parts"));
+
+    for request_schema in [known_completion, multipart_completion] {
+        let properties = request_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        for retired_name in ["completion", "content_ref"] {
+            assert!(
+                !properties.contains_key(retired_name),
+                "retired completion request field `{retired_name}` remains in OpenAPI"
+            );
+        }
+    }
 
     for properties in values_named(&spec, "properties").filter_map(Value::as_object) {
         for retired_name in [

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -180,7 +180,7 @@ impl FsWriter {
         .await
     }
 
-    /// Completes a multipart upload and returns proof for later publication.
+    /// Completes a multipart upload and returns its publication proof.
     pub async fn complete_multipart_upload_prepared(
         &self,
         namespace_id: &NamespaceId,
@@ -212,10 +212,7 @@ impl FsWriter {
         Ok(completed)
     }
 
-    /// Completes an upload after its durable mode selects a request decoder.
-    ///
-    /// Server integrations use this with an authorized raw-body extractor so
-    /// decoding does not require a separate upload-session read.
+    /// Completes an upload after decoding its request for the stored mode.
     pub async fn complete_upload_prepared_for_mode<F>(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -17,8 +17,9 @@ use crate::ByteStream;
 use crate::FsWriter;
 use crate::Result;
 use crate::{
-    BeginUploadRequest, BeginUploadResponse, CompleteUploadRequest, CompleteUploadResponse,
-    MaintenanceJobId, NamespaceId, UploadContentClaim, UploadContentResponse,
+    BeginUploadRequest, BeginUploadResponse, CompleteMultipartUploadRequest,
+    CompleteUploadResponse, MaintenanceJobId, NamespaceId, UploadContentClaim,
+    UploadContentResponse, UploadMode,
 };
 use loonfs_api::v0::{
     AbortUploadResponse, DirectMultipartUploadOptions, UploadPartChecksumClaim,
@@ -137,15 +138,27 @@ impl FsWriter {
             .await?)
     }
 
-    /// Completes an upload session when the expected content ref matches.
+    /// Completes a service-proxied or direct-PUT upload session.
     pub async fn complete_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
-        request: &CompleteUploadRequest,
     ) -> Result<CompleteUploadResponse> {
         Ok(self
-            .complete_upload_prepared(namespace_id, upload_id, request)
+            .complete_upload_prepared(namespace_id, upload_id)
+            .await?
+            .response)
+    }
+
+    /// Completes a direct-multipart upload session.
+    pub async fn complete_multipart_upload(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        request: &CompleteMultipartUploadRequest,
+    ) -> Result<CompleteUploadResponse> {
+        Ok(self
+            .complete_multipart_upload_prepared(namespace_id, upload_id, request)
             .await?
             .response)
     }
@@ -158,14 +171,68 @@ impl FsWriter {
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
-        request: &CompleteUploadRequest,
+    ) -> Result<CompletedUpload> {
+        self.complete_upload_prepared_inner(
+            namespace_id,
+            upload_id,
+            loonfs_core::ResolvedUploadCompletion::KnownContent,
+        )
+        .await
+    }
+
+    /// Completes a multipart upload and returns proof for later publication.
+    pub async fn complete_multipart_upload_prepared(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        request: &CompleteMultipartUploadRequest,
+    ) -> Result<CompletedUpload> {
+        self.complete_upload_prepared_inner(
+            namespace_id,
+            upload_id,
+            loonfs_core::ResolvedUploadCompletion::Multipart(request.clone()),
+        )
+        .await
+    }
+
+    async fn complete_upload_prepared_inner(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        completion: loonfs_core::ResolvedUploadCompletion,
     ) -> Result<CompletedUpload> {
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
         let completed = self
             .engine(namespace_id)
-            .complete_upload_prepared_with_catalog(&catalog, upload_id, request)
+            .complete_upload_prepared_with_catalog(&catalog, upload_id, completion)
+            .await?;
+        self.schedule_completed_upload_reclamation(namespace_id);
+        Ok(completed)
+    }
+
+    /// Completes an upload after its durable mode selects a request decoder.
+    ///
+    /// Server integrations use this with an authorized raw-body extractor so
+    /// decoding does not require a separate upload-session read.
+    pub async fn complete_upload_prepared_for_mode<F>(
+        &self,
+        namespace_id: &NamespaceId,
+        upload_id: &UploadId,
+        resolve: F,
+    ) -> Result<CompletedUpload>
+    where
+        F: FnOnce(
+            UploadMode,
+        ) -> std::result::Result<crate::uploads::ResolvedUploadCompletion, String>,
+    {
+        let catalog = self
+            .load_namespace_catalog_for_content_preparation(namespace_id)
+            .await?;
+        let completed = self
+            .engine(namespace_id)
+            .complete_upload_prepared_with_catalog_for_mode(&catalog, upload_id, resolve)
             .await?;
         self.schedule_completed_upload_reclamation(namespace_id);
         Ok(completed)

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -82,8 +82,9 @@ use thiserror::Error;
 
 pub use loonfs_api::v0::{
     BeginUploadRequest, BeginUploadResponse, ChangesResponse, CommitResponse, CommittedChange,
-    CompleteUploadRequest, CompleteUploadResponse, DirectPutUpload, FilesystemChange,
-    ObjectTransferAccess, UploadContentClaim, UploadContentResponse, UploadMode,
+    CompleteKnownContentUploadRequest, CompleteMultipartUploadRequest, CompleteUploadResponse,
+    DirectPutUpload, FilesystemChange, ObjectTransferAccess, UploadContentClaim,
+    UploadContentResponse, UploadMode,
 };
 pub use loonfs_api::{
     ActorId, ActorKind, ActorRef, AdvanceRetentionResponse, AttributeKey, AttributeRevisionNo,
@@ -159,7 +160,7 @@ pub mod uploads {
     pub use loonfs_core::{
         BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse,
         DirectMultipartUploadTarget, DirectPutUploadTarget, MultipartPartTarget,
-        MultipartPartTargets,
+        MultipartPartTargets, ResolvedUploadCompletion,
     };
 }
 

--- a/crates/loonfs/src/maintenance_runner/tests.rs
+++ b/crates/loonfs/src/maintenance_runner/tests.rs
@@ -6,9 +6,7 @@
 // The drain test injects a step panic to assert it is surfaced.
 
 use super::*;
-use crate::{
-    BeginUploadRequest, CompleteUploadRequest, CreateNamespaceOptions, FsWriter, SharedObjectStore,
-};
+use crate::{BeginUploadRequest, CreateNamespaceOptions, FsWriter, SharedObjectStore};
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::ids::{namespace_id, nonzero_usize};
 use std::collections::VecDeque;
@@ -893,16 +891,12 @@ async fn upload_paths_plant_the_collection_deadlines_they_create() {
         "an open session's lease schedules the pass that may abort it"
     );
 
-    let uploaded = writer
+    writer
         .upload_content(&namespace_id, begun.upload_id(), b"body")
         .await
         .expect("upload content");
     writer
-        .complete_upload(
-            &namespace_id,
-            begun.upload_id(),
-            &CompleteUploadRequest::for_content_ref(uploaded.content_ref),
-        )
+        .complete_upload(&namespace_id, begun.upload_id())
         .await
         .expect("complete upload");
     // The session's own lease comes due first, so it stays the next wake;

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -8,13 +8,13 @@ use loonfs::publish::CommitRequest;
 use loonfs::UploadContentClaim;
 use loonfs::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadRequest,
-    BeginUploadResponse, ChangeSeq, ChangesResponse, CommitResponse, CompleteUploadRequest,
-    CompleteUploadResponse, ContentRef, CopyOptions, CreateCheckpointOptions,
-    CreateCheckpointResponse, CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions,
-    DirectoryPageCursor, ErrorCode, FsAdmin, FsReader, FsWriter, FsWriterBuilder,
-    ListChangesOptions, MaintenancePlan, MaintenanceStepResponse, MetadataMaintenanceResponse,
-    MoveOptions, NamespaceId, NamespaceStatusResponse, PageRequest, PutFileOptions, RuntimeError,
-    SharedObjectStore, UploadContentResponse, UploadId,
+    BeginUploadResponse, ChangeSeq, ChangesResponse, CommitResponse, CompleteUploadResponse,
+    ContentRef, CopyOptions, CreateCheckpointOptions, CreateCheckpointResponse,
+    CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions, DirectoryPageCursor, ErrorCode,
+    FsAdmin, FsReader, FsWriter, FsWriterBuilder, ListChangesOptions, MaintenancePlan,
+    MaintenanceStepResponse, MetadataMaintenanceResponse, MoveOptions, NamespaceId,
+    NamespaceStatusResponse, PageRequest, PutFileOptions, RuntimeError, SharedObjectStore,
+    UploadContentResponse, UploadId,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::block_on::block_on;
@@ -311,7 +311,6 @@ pub(crate) trait RuntimeTestExt {
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
-        request: &CompleteUploadRequest,
     ) -> loonfs::Result<CompleteUploadResponse>;
     fn mutate_blocking(
         &self,
@@ -494,12 +493,8 @@ impl RuntimeTestExt for TestRuntime {
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
-        request: &CompleteUploadRequest,
     ) -> loonfs::Result<CompleteUploadResponse> {
-        block_on(
-            self.writer
-                .complete_upload(namespace_id, upload_id, request),
-        )
+        block_on(self.writer.complete_upload(namespace_id, upload_id))
     }
 
     fn mutate_blocking(

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -7,9 +7,9 @@ use loonfs::publish::{
     FilesystemOperation, PreparedContent,
 };
 use loonfs::{
-    BeginUploadRequest, CommitId, CompleteUploadRequest, CoreError, CreateDirectoryOptions,
-    CreateNamespaceOptions, DestinationBehavior, ErrorCode, FsWriter, NamespaceId, PutFileOptions,
-    RevisionNo, RuntimeError, SharedObjectStore,
+    BeginUploadRequest, CommitId, CoreError, CreateDirectoryOptions, CreateNamespaceOptions,
+    DestinationBehavior, ErrorCode, FsWriter, NamespaceId, PutFileOptions, RevisionNo,
+    RuntimeError, SharedObjectStore,
 };
 use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
 use loonfs_api::{ContentId, ContentStoreId};
@@ -494,7 +494,7 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
         .expect("begin upload");
     harness.recording.reset();
 
-    let staged = harness
+    harness
         .writer
         .upload_content(&harness.namespace_id, begin.upload_id(), bytes)
         .await
@@ -514,11 +514,7 @@ async fn proxied_upload_completion_proof_publishes_without_additional_content_io
 
     let completed = harness
         .writer
-        .complete_upload_prepared(
-            &harness.namespace_id,
-            begin.upload_id(),
-            &CompleteUploadRequest::for_content_ref(staged.content_ref),
-        )
+        .complete_upload_prepared(&harness.namespace_id, begin.upload_id())
         .await
         .expect("complete upload with proof");
     let prepared = completed.prepared;
@@ -568,11 +564,7 @@ async fn direct_put_completion_avoids_blob_get_and_prepared_publish_uses_no_cont
 
     let completed = harness
         .writer
-        .complete_upload_prepared(
-            &harness.namespace_id,
-            &begin.upload_id,
-            &CompleteUploadRequest::for_content_ref(content_ref.clone()),
-        )
+        .complete_upload_prepared(&harness.namespace_id, &begin.upload_id)
         .await
         .expect("complete direct put with proof");
     let prepared = completed.prepared;

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -7,9 +7,9 @@ use crate::common::*;
 use bytes::Bytes;
 use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
 use loonfs::{
-    BeginUploadRequest, ChangeSeq, CommitId, CompleteUploadRequest, CreateDirectoryOptions,
-    CreateNamespaceOptions, DestinationBehavior, ErrorCode, NamespaceId, PutFileOptions,
-    RuntimeCacheConfig, SharedObjectStore,
+    BeginUploadRequest, ChangeSeq, CommitId, CreateDirectoryOptions, CreateNamespaceOptions,
+    DestinationBehavior, ErrorCode, NamespaceId, PutFileOptions, RuntimeCacheConfig,
+    SharedObjectStore,
 };
 use loonfs_api::v0::{UploadContentClaim, UploadSessionStatus};
 use loonfs_api::Checksum;
@@ -82,12 +82,11 @@ fn upload_flow_is_available_from_runtime() {
         .expect("repeat upload content");
     assert_eq!(staged.content_ref, staged_again.content_ref);
 
-    let request = CompleteUploadRequest::for_content_ref(staged.content_ref);
     let completed = fs
-        .complete_upload_blocking(&namespace_id, begin.upload_id(), &request)
+        .complete_upload_blocking(&namespace_id, begin.upload_id())
         .expect("complete upload");
     let completed_again = fs
-        .complete_upload_blocking(&namespace_id, begin.upload_id(), &request)
+        .complete_upload_blocking(&namespace_id, begin.upload_id())
         .expect("repeat complete upload");
     assert_eq!(completed.content_ref, completed_again.content_ref);
 }
@@ -115,9 +114,8 @@ fn direct_put_upload_flow_validates_durable_object_on_complete() {
     block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
         .expect("write direct object");
 
-    let complete_request = CompleteUploadRequest::for_content_ref(content_ref.clone());
     let completed = fs
-        .complete_upload_blocking(&namespace_id, &begin.upload_id, &complete_request)
+        .complete_upload_blocking(&namespace_id, &begin.upload_id)
         .expect("complete direct put");
     assert_eq!(completed.content_ref, content_ref);
 
@@ -161,11 +159,7 @@ fn direct_put_completion_proves_upload_without_reading_content() {
 
     raw_store.reset();
     let completed = fs
-        .complete_upload_blocking(
-            &namespace_id,
-            &begin.upload_id,
-            &CompleteUploadRequest::for_content_ref(content_ref.clone()),
-        )
+        .complete_upload_blocking(&namespace_id, &begin.upload_id)
         .expect("complete direct put");
     assert_eq!(completed.content_ref, content_ref);
     assert_eq!(
@@ -190,18 +184,12 @@ fn direct_put_completion_rejects_a_mis_declared_size() {
         .expect("create namespace");
     let begin = block_on(fs.begin_direct_put_upload_target(&namespace_id, claim))
         .expect("begin direct put");
-    let content_ref = begin.target.content_ref.clone();
-
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
     block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
         .expect("write direct object");
 
     let error = fs
-        .complete_upload_blocking(
-            &namespace_id,
-            &begin.upload_id,
-            &CompleteUploadRequest::for_content_ref(content_ref),
-        )
+        .complete_upload_blocking(&namespace_id, &begin.upload_id)
         .expect_err("mis-declared size must fail completion");
     assert!(
         error.to_string().contains("content length mismatch"),
@@ -226,8 +214,6 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
     let begin =
         block_on(fs.begin_direct_put_upload_target(&namespace_id, direct_put_claim(promised)))
             .expect("begin direct put");
-    let content_ref = begin.target.content_ref.clone();
-
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
     block_on(
         direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(delivered)),
@@ -235,11 +221,7 @@ fn direct_put_completion_rejects_and_removes_bytes_that_do_not_match_the_claim()
     .expect("write mismatched direct object");
 
     let error = fs
-        .complete_upload_blocking(
-            &namespace_id,
-            &begin.upload_id,
-            &CompleteUploadRequest::for_content_ref(content_ref),
-        )
+        .complete_upload_blocking(&namespace_id, &begin.upload_id)
         .expect_err("mismatched bytes must fail completion");
     assert_eq!(
         error.code(),
@@ -275,7 +257,6 @@ fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
     let begin = block_on(fs.begin_direct_put_upload_target(&namespace_id, direct_put_claim(bytes)))
         .expect("begin direct put");
     let content_ref = begin.target.content_ref.clone();
-    let request = CompleteUploadRequest::for_content_ref(content_ref.clone());
 
     let direct_store = LocalFsStore::new(temp_dir.path()).expect("direct object-store handle");
     block_on(direct_store.put_if_absent(&begin.target.object_key, Bytes::copy_from_slice(bytes)))
@@ -283,7 +264,7 @@ fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
 
     raw_store.fail_next(1);
     let error = fs
-        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
+        .complete_upload_blocking(&namespace_id, &begin.upload_id)
         .expect_err("a verification that cannot run does not complete the upload");
     assert_eq!(error.code(), ErrorCode::ServerError);
     assert_eq!(raw_store.attempts(), 1, "the checksum head is what failed");
@@ -304,7 +285,7 @@ fn direct_put_completion_reports_a_failed_read_back_as_a_store_failure() {
     );
 
     let completed = fs
-        .complete_upload_blocking(&namespace_id, &begin.upload_id, &request)
+        .complete_upload_blocking(&namespace_id, &begin.upload_id)
         .expect("the retried completion verifies and completes");
     assert_eq!(completed.content_ref, content_ref);
 }
@@ -539,18 +520,13 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
                 .begin_upload(&namespace_id, BeginUploadRequest::ServiceProxied {})
                 .await
                 .expect("begin upload");
-            let staged = fs
-                .writer
+            fs.writer
                 .upload_content(&namespace_id, begin.upload_id(), bytes)
                 .await
                 .expect("upload content");
             let completed = fs
                 .writer
-                .complete_upload(
-                    &namespace_id,
-                    begin.upload_id(),
-                    &CompleteUploadRequest::for_content_ref(staged.content_ref),
-                )
+                .complete_upload(&namespace_id, begin.upload_id())
                 .await
                 .expect("complete upload");
             prepared_contents.push(

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1059,10 +1059,10 @@ A browser calling a presigned URL is talking to the provider, not to LoonFS,
 so cross-origin access is governed by the bucket's or container's own CORS
 configuration rather than by anything this API sets.
 
-After the client uploads bytes to the presigned URL, it calls complete with the
-`content_ref` returned when the session began. The server reads the stored
-object's size and checksum from the provider and compares them with that
-reference. A mismatch fails the completion and deletes the unpublished object.
+After the client uploads bytes to the presigned URL, it calls complete with
+`{}`. The server reads the content reference from the durable session, then
+reads the stored object's size and checksum from the provider and compares
+them. A mismatch fails the completion and deletes the unpublished object.
 If the provider metadata request fails, the server returns `server_error`
 without changing the object or session, so the client can retry. The server
 does not download the object during this check.
@@ -1126,7 +1126,6 @@ resulting content reference stores that complete-object checksum.
 
 ```json
 {
-  "completion": "multipart",
   "content": {
     "size_bytes": 17301504,
     "checksum": { "algorithm": "crc64nvme", "value": "<16 lowercase hex>" }
@@ -1141,8 +1140,8 @@ resulting content reference stores that complete-object checksum.
 
 The request lists every part once in ascending order. It does not include a
 content reference; the server returns the reference after completion.
-Service-proxied and direct-PUT completion requests instead send the content
-reference under `"completion": "content_ref"` and do not include parts.
+Service-proxied and direct-PUT completion requests are `{}` because their
+durable sessions already own every content fact completion needs.
 
 The server asks the provider to assemble the object, then reads its stored size
 and checksum and compares them with the completion request. This read is
@@ -1801,8 +1800,8 @@ The semantic rule is:
 
 - `PUT /content` stores the immutable whole-file object and records the staged
   `content_ref`;
-- `complete` finalizes the upload session only when the expected `content_ref`
-  exactly matches the service-computed staged ref; and
+- `complete` finalizes the upload session from the content facts frozen in the
+  durable session; and
 - the returned `content_ref` is then safe to reference from a commit. Remote
   servers may also return an opaque `content_token` that remote
   create/replace mutations carry back as their content-preparation proof.
@@ -1820,10 +1819,12 @@ only the fields for that mode:
 `direct_multipart` accepts an optional `multipart` object and otherwise uses
 the default part size.
 
-Completion requests use `completion` in the same way. Service-proxied and
-direct-PUT sessions use `content_ref`; multipart sessions use `content` and
-`parts`. Missing tags, mixed fields, and a completion shape that does not match
-the session fail with `invalid_request`.
+The stored session mode selects the completion request schema. Service-proxied
+and direct-PUT sessions accept only `{}`. Multipart sessions require `content`
+and `parts`. Both shapes reject unknown fields, so a multipart body sent to a
+direct-PUT session, `{}` sent to a multipart session, and the retired
+`completion` or echoed `content_ref` fields fail with `invalid_request` and a
+field-specific message.
 
 The begin-upload *response* is tagged the same way, in the same `mode`, and
 carries its transport's field and no other's: `service_proxied` carries
@@ -1836,9 +1837,8 @@ An upload session allocates its content object when it begins, so repeating
 object and is idempotent. Repeating it with different bytes is a conflict.
 Two *different* sessions carrying identical bytes get their own objects:
 content is never shared across uploads, so retry idempotency belongs to the
-session and nothing else. Completing an
-upload fails if no content was staged or if the expected `content_ref` differs
-from the staged one. Publication never downloads an arbitrary external ref to
+session and nothing else. Completing a service-proxied upload fails if no
+content was staged. Publication never downloads an arbitrary external ref to
 rescue a missing proof.
 
 A session is `open`, then `completed` or `aborted`, and both of those are
@@ -1971,14 +1971,7 @@ Representative content-upload response:
 Representative complete-upload request:
 
 ```json
-{
-  "content_ref": {
-    "kind": "blob_v1",
-    "content_id": "con_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41",
-    "size_bytes": 20591,
-    "checksum": { "algorithm": "sha256", "value": "7ab..." }
-  }
-}
+{}
 ```
 
 Representative complete-upload response:

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1059,10 +1059,10 @@ A browser calling a presigned URL is talking to the provider, not to LoonFS,
 so cross-origin access is governed by the bucket's or container's own CORS
 configuration rather than by anything this API sets.
 
-After the client uploads bytes to the presigned URL, it calls complete with
-`{}`. The server reads the content reference from the durable session, then
-reads the stored object's size and checksum from the provider and compares
-them. A mismatch fails the completion and deletes the unpublished object.
+After uploading to the presigned URL, the client completes the session with
+`{}`. The server loads the expected content reference from the session and
+compares it with the object's size and checksum at the provider. A mismatch
+fails completion and deletes the unpublished object.
 If the provider metadata request fails, the server returns `server_error`
 without changing the object or session, so the client can retry. The server
 does not download the object during this check.
@@ -1138,10 +1138,9 @@ resulting content reference stores that complete-object checksum.
 }
 ```
 
-The request lists every part once in ascending order. It does not include a
-content reference; the server returns the reference after completion.
-Service-proxied and direct-PUT completion requests are `{}` because their
-durable sessions already own every content fact completion needs.
+The request lists every part once in ascending order. The server returns the
+content reference after completion. Service-proxied and direct-PUT sessions
+use `{}` because the session already stores the required content information.
 
 The server asks the provider to assemble the object, then reads its stored size
 and checksum and compares them with the completion request. This read is
@@ -1819,12 +1818,9 @@ only the fields for that mode:
 `direct_multipart` accepts an optional `multipart` object and otherwise uses
 the default part size.
 
-The stored session mode selects the completion request schema. Service-proxied
-and direct-PUT sessions accept only `{}`. Multipart sessions require `content`
-and `parts`. Both shapes reject unknown fields, so a multipart body sent to a
-direct-PUT session, `{}` sent to a multipart session, and the retired
-`completion` or echoed `content_ref` fields fail with `invalid_request` and a
-field-specific message.
+The stored upload mode determines the completion body. Service-proxied and
+direct-PUT sessions accept only `{}`. Multipart sessions require `content` and
+`parts`. Unknown, missing, or mode-specific fields return `invalid_request`.
 
 The begin-upload *response* is tagged the same way, in the same `mode`, and
 carries its transport's field and no other's: `service_proxied` carries

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -17,7 +17,7 @@ Encoding conventions used by every durable and wire shape in this specification:
 field names and enum values are `snake_case`; fields holding typed identifiers
 are suffixed `_id`; tagged-union discriminators default to `kind`, but a union
 may use its domain word where that reads better. The current exceptions are
-`mode`, `completion`, `state`, `phase`, and `inode_kind`.
+`mode`, `state`, `phase`, and `inode_kind`.
 
 Unknown fields are tolerated where a reader must accept what a newer writer
 added, and rejected where accepting one would lose information the sender

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2439,7 +2439,7 @@
           "uploads"
         ],
         "summary": "Complete upload",
-        "description": "Completes an upload session once the caller confirms the expected content reference. The response may include a short-lived content token for a following file write.",
+        "description": "Completes an upload session using the request schema selected by its durable mode. Service-proxied and direct-put sessions accept `{}`; direct-multipart sessions accept the content claim and completed parts. The response may include a short-lived content token for a following file write.",
         "operationId": "complete_upload",
         "parameters": [
           {
@@ -2462,6 +2462,7 @@
           }
         ],
         "requestBody": {
+          "description": "The stored session mode selects which strict oneOf variant is accepted.",
           "content": {
             "application/json": {
               "schema": {
@@ -3664,60 +3665,43 @@
           }
         }
       },
+      "CompleteKnownContentUploadRequest": {
+        "type": "object",
+        "description": "Request to complete a service-proxied or `direct_put` upload.\n\nThe durable session already owns the content reference and selects this\nschema, so the caller has nothing to repeat.",
+        "additionalProperties": false
+      },
+      "CompleteMultipartUploadRequest": {
+        "type": "object",
+        "description": "Request to complete a `direct_multipart` upload.\n\nThe durable session selects this schema and owns the content object's\nidentity. The caller supplies only what became known while uploading the\nparts.",
+        "required": [
+          "content",
+          "parts"
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/UploadContentClaim",
+            "description": "The assembled object's length and checksum, which completion verifies\nagainst the provider's own reading of the object."
+          },
+          "parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompletedUploadPart"
+            },
+            "description": "Every part the client uploaded, in ascending part order. The server\nholds no part records of its own, so this list is what it assembles the\nobject from."
+          }
+        },
+        "additionalProperties": false
+      },
       "CompleteUploadRequest": {
         "oneOf": [
           {
-            "type": "object",
-            "title": "CompleteUploadContentRef",
-            "description": "Completes a session the server named a content object for: the\ncaller names it back and the server proves the object matches.",
-            "required": [
-              "content_ref",
-              "completion"
-            ],
-            "properties": {
-              "completion": {
-                "type": "string",
-                "enum": [
-                  "content_ref"
-                ]
-              },
-              "content_ref": {
-                "$ref": "#/components/schemas/ContentRef",
-                "description": "Content identity the caller expects the session to have settled\non."
-              }
-            }
+            "$ref": "#/components/schemas/CompleteKnownContentUploadRequest"
           },
           {
-            "type": "object",
-            "title": "CompleteUploadMultipart",
-            "description": "Completes a `direct_multipart` session with what it uploaded.",
-            "required": [
-              "content",
-              "parts",
-              "completion"
-            ],
-            "properties": {
-              "completion": {
-                "type": "string",
-                "enum": [
-                  "multipart"
-                ]
-              },
-              "content": {
-                "$ref": "#/components/schemas/UploadContentClaim",
-                "description": "The assembled object's length and checksum, which completion\nverifies against the provider's own reading of the object."
-              },
-              "parts": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/CompletedUploadPart"
-                },
-                "description": "Every part the client uploaded, in ascending part order. The\nserver holds no part records of its own, so this list is what it\nassembles the object from."
-              }
-            }
+            "$ref": "#/components/schemas/CompleteMultipartUploadRequest"
           }
         ],
-        "description": "Request to complete an upload.\n\nA service-proxied or `direct_put` session receives its content reference\nbefore the upload and returns that reference at completion. A\n`direct_multipart` session instead provides the completed parts and a\nclaim describing the assembled object.\n\nThe variants share no fields, so fields from one completion type are\nrejected when used with the other type. The server also checks that the\ncompletion type matches the transport stored in the upload session."
+        "description": "The stored upload session mode selects the accepted variant: service_proxied and direct_put use the empty object; direct_multipart uses the content claim and completed parts."
       },
       "CompleteUploadResponse": {
         "type": "object",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2439,7 +2439,7 @@
           "uploads"
         ],
         "summary": "Complete upload",
-        "description": "Completes an upload session using the request schema selected by its durable mode. Service-proxied and direct-put sessions accept `{}`; direct-multipart sessions accept the content claim and completed parts. The response may include a short-lived content token for a following file write.",
+        "description": "Completes an upload using the body required by its stored mode. Service-proxied and direct-put sessions accept `{}`. Direct-multipart sessions require the content claim and completed parts.",
         "operationId": "complete_upload",
         "parameters": [
           {
@@ -2462,7 +2462,7 @@
           }
         ],
         "requestBody": {
-          "description": "The stored session mode selects which strict oneOf variant is accepted.",
+          "description": "The stored upload mode determines which body is accepted.",
           "content": {
             "application/json": {
               "schema": {
@@ -3667,12 +3667,12 @@
       },
       "CompleteKnownContentUploadRequest": {
         "type": "object",
-        "description": "Request to complete a service-proxied or `direct_put` upload.\n\nThe durable session already owns the content reference and selects this\nschema, so the caller has nothing to repeat.",
+        "description": "Empty request used when the upload session already contains the content\nreference.",
         "additionalProperties": false
       },
       "CompleteMultipartUploadRequest": {
         "type": "object",
-        "description": "Request to complete a `direct_multipart` upload.\n\nThe durable session selects this schema and owns the content object's\nidentity. The caller supplies only what became known while uploading the\nparts.",
+        "description": "Information required to complete a `direct_multipart` upload.",
         "required": [
           "content",
           "parts"
@@ -3680,14 +3680,14 @@
         "properties": {
           "content": {
             "$ref": "#/components/schemas/UploadContentClaim",
-            "description": "The assembled object's length and checksum, which completion verifies\nagainst the provider's own reading of the object."
+            "description": "Expected length and checksum of the assembled object."
           },
           "parts": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CompletedUploadPart"
             },
-            "description": "Every part the client uploaded, in ascending part order. The server\nholds no part records of its own, so this list is what it assembles the\nobject from."
+            "description": "Uploaded parts in ascending part order."
           }
         },
         "additionalProperties": false
@@ -3701,7 +3701,7 @@
             "$ref": "#/components/schemas/CompleteMultipartUploadRequest"
           }
         ],
-        "description": "The stored upload session mode selects the accepted variant: service_proxied and direct_put use the empty object; direct_multipart uses the content claim and completed parts."
+        "description": "The stored upload mode determines the accepted body. Service-proxied and direct-put sessions use an empty object. Direct-multipart sessions provide the content claim and completed parts."
       },
       "CompleteUploadResponse": {
         "type": "object",


### PR DESCRIPTION
Simplifies upload completion by using the mode already stored in the upload session. Service-proxied and direct-put sessions complete with `{}`. Direct-multipart sessions provide only the completed content claim and part list. Clients no longer repeat a mode discriminator or content reference the server already has.

The server loads the session before decoding the body, then applies the strict request shape for that mode. OpenAPI documents the two accepted bodies as a `oneOf`. Existing content verification, completion retries, provider reconciliation, and content-token issuance remain unchanged.