### PR TITLE
feat(api): paginate checkpoint listing

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -521,16 +521,19 @@ pub struct CheckpointSummary {
     pub manifest_id: ManifestId,
 }
 
-/// Every active checkpoint record a namespace currently carries.
+/// One bounded page of active checkpoint records a namespace currently carries.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListCheckpointsResponse {
     /// Namespace the records belong to.
     pub namespace_id: NamespaceId,
-    /// Active records, oldest first. Released records are absent because a
+    /// Active records in ascending checkpoint-id order. Released records are absent because a
     /// release is what stops a record pinning anything; a released record
     /// that garbage collection has not yet deleted is not reported either.
     pub checkpoints: Vec<CheckpointSummary>,
+    /// Opaque cursor for the next page, omitted when this key enumeration is complete.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 /// How one WAL flush satisfied its goal.

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -521,17 +521,16 @@ pub struct CheckpointSummary {
     pub manifest_id: ManifestId,
 }
 
-/// One bounded page of active checkpoint records a namespace currently carries.
+/// One page of active checkpoint records.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListCheckpointsResponse {
     /// Namespace the records belong to.
     pub namespace_id: NamespaceId,
-    /// Active records in ascending checkpoint-id order. Released records are absent because a
-    /// release is what stops a record pinning anything; a released record
-    /// that garbage collection has not yet deleted is not reported either.
+    /// Active records in ascending checkpoint-id order. Released records are
+    /// omitted even if garbage collection has not deleted them yet.
     pub checkpoints: Vec<CheckpointSummary>,
-    /// Opaque cursor for the next page, omitted when this key enumeration is complete.
+    /// Opaque cursor for the next page.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -286,14 +286,10 @@ Maintenance
     expires the pin, and an omitted TTL holds it until release
 
   loonfs admin checkpoint-list [--limit <n>] [--cursor <cursor>]
-    List the namespace's active checkpoint pins in checkpoint-id order: when
-    each was taken, when it expires, the sequence it pins, its label or fork
-    target, and the id `checkpoint-release` takes. By default the command
-    follows bounded pages to completion; --limit or --cursor requests one
-    page and prints next_cursor when more keys remain. A name is a label
-    rather than a key, so this is how a pin is found again once its id has
-    been lost; a pin whose expiry has passed is still listed until collection
-    releases it
+    List active checkpoint pins in checkpoint-id order. By default the
+    command follows every page. Use --limit or --cursor to request one page;
+    next_cursor is printed when another page is available. Expired pins stay
+    visible until collection releases them
 
   loonfs admin checkpoint-release <checkpoint-id>
     Release a checkpoint pin

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -285,12 +285,15 @@ Maintenance
     Pin the namespace's current state under a named checkpoint; --ttl-ms
     expires the pin, and an omitted TTL holds it until release
 
-  loonfs admin checkpoint-list
-    List the namespace's active checkpoint pins, oldest first: when each was
-    taken, when it expires, the sequence it pins, its label or fork target,
-    and the id `checkpoint-release` takes. A name is a label rather than a
-    key, so this is how a pin is found again once its id has been lost; a
-    pin whose expiry has passed is still listed until collection releases it
+  loonfs admin checkpoint-list [--limit <n>] [--cursor <cursor>]
+    List the namespace's active checkpoint pins in checkpoint-id order: when
+    each was taken, when it expires, the sequence it pins, its label or fork
+    target, and the id `checkpoint-release` takes. By default the command
+    follows bounded pages to completion; --limit or --cursor requests one
+    page and prints next_cursor when more keys remain. A name is a label
+    rather than a key, so this is how a pin is found again once its id has
+    been lost; a pin whose expiry has passed is still listed until collection
+    releases it
 
   loonfs admin checkpoint-release <checkpoint-id>
     Release a checkpoint pin

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -754,10 +754,10 @@ pub(crate) struct ChangesArgs {
 pub(crate) enum AdminCommand {
     /// Pin the namespace's current state under a named checkpoint.
     Checkpoint(AdminCheckpointArgs),
-    /// List the namespace's active checkpoint pins, oldest first. A
+    /// List the namespace's active checkpoint pins in checkpoint-id order. A
     /// checkpoint name is a label, not a key, so this is how a pin is found
     /// again when its id has been lost.
-    CheckpointList(AdminNamespaceArgs),
+    CheckpointList(AdminCheckpointListArgs),
     /// Release a checkpoint pin.
     CheckpointRelease(AdminCheckpointReleaseArgs),
     /// Flush the WAL tail into a durable segment.
@@ -885,6 +885,18 @@ pub(crate) struct AdminCheckpointArgs {
     /// now. Omitted means the pin holds until explicitly released.
     #[arg(long)]
     pub ttl_ms: Option<u64>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct AdminCheckpointListArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    /// Maximum checkpoints to return. Supplying this requests one page.
+    #[arg(long)]
+    pub limit: Option<u32>,
+    /// Resume cursor from a previous page. Supplying this requests one page.
+    #[arg(long)]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -754,9 +754,7 @@ pub(crate) struct ChangesArgs {
 pub(crate) enum AdminCommand {
     /// Pin the namespace's current state under a named checkpoint.
     Checkpoint(AdminCheckpointArgs),
-    /// List the namespace's active checkpoint pins in checkpoint-id order. A
-    /// checkpoint name is a label, not a key, so this is how a pin is found
-    /// again when its id has been lost.
+    /// List active checkpoint pins in checkpoint-id order.
     CheckpointList(AdminCheckpointListArgs),
     /// Release a checkpoint pin.
     CheckpointRelease(AdminCheckpointReleaseArgs),

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -8,13 +8,13 @@ use crate::backend_error::{
 };
 use crate::render::write_stderr_warning;
 use loonfs::{
-    ByteStream, ChangesResponse, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
-    CreateNamespaceOptions, DeleteNamespaceOptions, DeleteNamespaceResponse, DeleteOptions,
-    FileContentStream, FsAdmin, FsReader, FsWriter, ListChangesOptions, ListPathEntriesOptions,
-    MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenancePlan,
-    MaintenanceStepConclusion, MoveOptions, PutFileOptions, ReadFileStreamOptions,
-    RestoreRevisionOptions, RuntimeError, SharedObjectStore, StatPathOptions, UndeleteOptions,
-    UpdateAttributesOptions,
+    ByteStream, ChangesResponse, CheckpointPageCursor, CopyOptions, CreateCheckpointOptions,
+    CreateDirectoryOptions, CreateNamespaceOptions, DeleteNamespaceOptions,
+    DeleteNamespaceResponse, DeleteOptions, FileContentStream, FsAdmin, FsReader, FsWriter,
+    ListChangesOptions, ListPathEntriesOptions, MaintenanceHandle, MaintenanceJob,
+    MaintenanceJobId, MaintenancePlan, MaintenanceStepConclusion, MoveOptions, PutFileOptions,
+    ReadFileStreamOptions, RestoreRevisionOptions, RuntimeError, SharedObjectStore,
+    StatPathOptions, UndeleteOptions, UpdateAttributesOptions,
 };
 use loonfs_api::{
     v0::{
@@ -797,12 +797,28 @@ impl EmbeddedBackend {
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
-    pub(super) async fn list_checkpoints(
+    pub(super) async fn list_checkpoints_page(
         &self,
         namespace_id: &NamespaceId,
+        limit: Option<u32>,
+        cursor: Option<&str>,
     ) -> Result<ListCheckpointsResponse, BackendError> {
+        let request = loonfs_api::PageRequest {
+            limit: resolve_cli_page_limit(limit)?,
+            cursor: cursor
+                .map(|cursor| {
+                    loonfs_api::decode_namespace_cursor::<CheckpointPageCursor>(
+                        cursor,
+                        namespace_id,
+                    )
+                })
+                .transpose()
+                .map_err(|error| {
+                    BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
+                })?,
+        };
         self.admin
-            .list_checkpoints(namespace_id)
+            .list_checkpoints_page(namespace_id, request)
             .await
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -819,14 +819,24 @@ impl ResolvedTarget {
         }
     }
 
-    /// Lists the namespace's active checkpoint pins, oldest first.
-    pub(crate) async fn list_checkpoints(
+    /// Lists one page of the namespace's active checkpoint pins.
+    pub(crate) async fn list_checkpoints_page(
         &self,
         namespace_id: &NamespaceId,
+        limit: Option<u32>,
+        cursor: Option<&str>,
     ) -> Result<ListCheckpointsResponse, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.list_checkpoints(namespace_id).await,
-            Self::Remote(target) => Ok(target.client.list_checkpoints(namespace_id).await?),
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .list_checkpoints_page(namespace_id, limit, cursor)
+                    .await
+            }
+            Self::Remote(target) => Ok(target
+                .client
+                .list_checkpoints_page(namespace_id, limit, cursor)
+                .await?),
         }
     }
 

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -4,9 +4,10 @@
 use super::context::{fail, fail_for, resolve_command_context};
 use super::output::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
 use crate::args::{
-    AdminCheckpointArgs, AdminCheckpointReleaseArgs, AdminCommand, AdminGcArgs,
-    AdminIndexEnableArgs, AdminIndexGcArgs, AdminNamespaceArgs, AdminRunArgs, AdminStepArgs,
-    AdminStoreProbeArgs, ChangesArgs, CommandKind, MaintenanceJobArg, RuntimeBehavior,
+    AdminCheckpointArgs, AdminCheckpointListArgs, AdminCheckpointReleaseArgs, AdminCommand,
+    AdminGcArgs, AdminIndexEnableArgs, AdminIndexGcArgs, AdminNamespaceArgs, AdminRunArgs,
+    AdminStepArgs, AdminStoreProbeArgs, ChangesArgs, CommandKind, MaintenanceJobArg,
+    RuntimeBehavior,
 };
 use crate::backend::{MaintenanceKeyProgress, StepBudget};
 use crate::render::{format_utc_ms, write_stderr_progress};
@@ -263,14 +264,26 @@ async fn run_admin_checkpoint(
 async fn run_admin_checkpoint_list(
     kind: CommandKind,
     config_path: &Path,
-    args: AdminNamespaceArgs,
+    args: AdminCheckpointListArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
-    let response = context
+    let single_page = args.limit.is_some() || args.cursor.is_some();
+    let mut response = context
         .target
-        .list_checkpoints(&context.namespace)
+        .list_checkpoints_page(&context.namespace, args.limit, args.cursor.as_deref())
         .await
         .map_err(|error| context.fail(kind, error))?;
+    if !single_page {
+        while let Some(cursor) = response.next_cursor.take() {
+            let page = context
+                .target
+                .list_checkpoints_page(&context.namespace, None, Some(&cursor))
+                .await
+                .map_err(|error| context.fail(kind, error))?;
+            response.checkpoints.extend(page.checkpoints);
+            response.next_cursor = page.next_cursor;
+        }
+    }
 
     Ok(CommandOutput {
         kind,

--- a/crates/loonfs-cli/src/render.rs
+++ b/crates/loonfs-cli/src/render.rs
@@ -480,6 +480,9 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             if response.checkpoints.is_empty() {
                 lines.push("(none)".to_owned());
             }
+            if let Some(cursor) = &response.next_cursor {
+                lines.push(format!("next_cursor: {cursor}"));
+            }
             lines.join("\n")
         }
         CommandData::CheckpointReleased(response) => {

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -5344,9 +5344,7 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         assert_eq!(listed_ids, expected_ids);
         assert!(listed_data.get("next_cursor").is_none());
 
-        // Supplying a page control requests exactly one page. The opaque
-        // cursor is printed in both renderings, and resuming yields the
-        // second id in the same durable-id order as the default aggregate.
+        // A page limit returns one page and a cursor that resumes at the next id.
         let first_page = harness.run(&[
             "--json",
             "admin",

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -5325,7 +5325,7 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         let listed_data = json_data(&listed);
         assert_eq!(listed_data["kind"], "checkpoints_listed");
         assert_eq!(listed_data["namespace_id"], "demo");
-        let mut listed_ids = listed_data["checkpoints"]
+        let listed_ids = listed_data["checkpoints"]
             .as_array()
             .expect("json array")
             .iter()
@@ -5339,10 +5339,68 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
                     .to_owned()
             })
             .collect::<Vec<_>>();
-        listed_ids.sort();
         let mut expected_ids = vec![checkpoint_id.clone(), second_checkpoint_id.clone()];
         expected_ids.sort();
         assert_eq!(listed_ids, expected_ids);
+        assert!(listed_data.get("next_cursor").is_none());
+
+        // Supplying a page control requests exactly one page. The opaque
+        // cursor is printed in both renderings, and resuming yields the
+        // second id in the same durable-id order as the default aggregate.
+        let first_page = harness.run(&[
+            "--json",
+            "admin",
+            "checkpoint-list",
+            "--profile",
+            profile,
+            "--limit",
+            "1",
+        ]);
+        assert_success(&first_page);
+        let first_page_data = json_data(&first_page);
+        assert_eq!(
+            first_page_data["checkpoints"]
+                .as_array()
+                .expect("json array")
+                .len(),
+            1
+        );
+        assert_eq!(
+            first_page_data["checkpoints"][0]["checkpoint_id"],
+            expected_ids[0].as_str()
+        );
+        let cursor = first_page_data["next_cursor"]
+            .as_str()
+            .expect("partial page cursor")
+            .to_owned();
+
+        let resumed_page = harness.run(&[
+            "--json",
+            "admin",
+            "checkpoint-list",
+            "--profile",
+            profile,
+            "--cursor",
+            &cursor,
+        ]);
+        assert_success(&resumed_page);
+        let resumed_page_data = json_data(&resumed_page);
+        assert_eq!(
+            resumed_page_data["checkpoints"][0]["checkpoint_id"],
+            expected_ids[1].as_str()
+        );
+        assert!(resumed_page_data.get("next_cursor").is_none());
+
+        let first_page_human = harness.run(&[
+            "admin",
+            "checkpoint-list",
+            "--profile",
+            profile,
+            "--limit",
+            "1",
+        ]);
+        assert_success(&first_page_human);
+        assert!(stdout_string(&first_page_human).contains("next_cursor:"));
 
         // The human rendering is the same table in both modes, and it names
         // the id the release command takes.

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -1226,21 +1226,48 @@ impl Client {
         self.request_json(self.post(&url), Some(request)).await
     }
 
-    /// Lists the namespace's active checkpoint records, oldest first (admin
-    /// plane).
+    /// Lists every active checkpoint record by following bounded pages
+    /// (admin plane).
     ///
     /// A checkpoint name is a label rather than a key, so this is how a pin
     /// is found again once its creation response is gone. An expired record
     /// that no collection pass has released yet is still listed, with its
     /// expiry in the entry.
-    pub async fn list_checkpoints(
+    pub async fn list_checkpoints_all(
         &self,
         namespace_id: &NamespaceId,
+    ) -> Result<ListCheckpointsResponse> {
+        let first_page = self.list_checkpoints_page(namespace_id, None, None).await?;
+        let mut response = ListCheckpointsResponse {
+            namespace_id: first_page.namespace_id,
+            checkpoints: first_page.checkpoints,
+            next_cursor: None,
+        };
+        let mut next_cursor = first_page.next_cursor;
+        while let Some(cursor) = next_cursor {
+            let page = self
+                .list_checkpoints_page(namespace_id, None, Some(&cursor))
+                .await?;
+            response.checkpoints.extend(page.checkpoints);
+            next_cursor = page.next_cursor;
+        }
+        Ok(response)
+    }
+
+    /// Lists one bounded page of active checkpoint records (admin plane).
+    pub async fn list_checkpoints_page(
+        &self,
+        namespace_id: &NamespaceId,
+        limit: Option<u32>,
+        cursor: Option<&str>,
     ) -> Result<ListCheckpointsResponse> {
         let url = format!(
             "{}/v0/admin/namespaces/{namespace_id}/checkpoints",
             self.base_url
         );
+        let mut url = url;
+        let mut has_query = false;
+        append_optional_pagination_query(&mut url, &mut has_query, limit, cursor);
         self.request_json::<(), ListCheckpointsResponse>(self.get(&url), None)
             .await
     }

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -16,11 +16,66 @@ use crate::error::{CoreError, Result};
 use crate::namespace::control::read_head_object;
 use futures::StreamExt;
 use loonfs_api::wire::control::{CheckpointOwner, CheckpointRecordLifecycle};
-use loonfs_api::{CheckpointOwnerSummary, CheckpointSummary, ListCheckpointsResponse, NamespaceId};
+use loonfs_api::{
+    CheckpointOwnerSummary, CheckpointSummary, NamespaceCursor, NamespaceId, Page, PageCursor,
+    PageRequest,
+};
 use loonfs_objectstore::keys::checkpoint_prefix;
 use loonfs_objectstore::ObjectStore;
+use serde::{Deserialize, Serialize};
 
-/// Lists every active checkpoint record under `namespace_id`, oldest first.
+/// Opaque checkpoint-inventory position returned by one runtime page.
+///
+/// Cursor payloads are short-lived API tokens, not durable objects. Serde's
+/// default unknown-field handling keeps decoding tolerant of additive fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointPageCursor {
+    namespace_id: NamespaceId,
+    last_key: String,
+}
+
+impl PageCursor for CheckpointPageCursor {
+    const KIND: &'static str = "checkpoint_inventory";
+}
+
+impl NamespaceCursor for CheckpointPageCursor {
+    fn namespace_id(&self) -> &NamespaceId {
+        &self.namespace_id
+    }
+
+    fn last_key(&self) -> Option<&str> {
+        Some(&self.last_key)
+    }
+
+    fn key_prefix(&self) -> String {
+        checkpoint_prefix(&self.namespace_id)
+    }
+}
+
+impl CheckpointPageCursor {
+    fn after(namespace_id: &NamespaceId, last_key: String) -> Self {
+        Self {
+            namespace_id: namespace_id.clone(),
+            last_key,
+        }
+    }
+
+    fn validate_for(&self, namespace_id: &NamespaceId) -> Result<()> {
+        if &self.namespace_id != namespace_id {
+            return Err(CoreError::InvalidCursor(
+                "cursor belongs to a different namespace".to_owned(),
+            ));
+        }
+        if !self.last_key.starts_with(&checkpoint_prefix(namespace_id)) {
+            return Err(CoreError::InvalidCursor(
+                "cursor names a key outside the checkpoint inventory".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Lists one page of active checkpoint records in ascending checkpoint-id order.
 ///
 /// An expired record that no collection pass has released yet is reported,
 /// with its expiry in the answer. It is still active, it still roots its
@@ -38,19 +93,36 @@ use loonfs_objectstore::ObjectStore;
 /// namespace still answers: its records outlive the tombstone until garbage
 /// collection reaps them, and that is exactly the state an operator is
 /// looking into.
-pub(crate) async fn list_checkpoints<S: ObjectStore + ?Sized>(
+pub(crate) async fn list_checkpoints_page<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-) -> Result<ListCheckpointsResponse> {
+    request: PageRequest<CheckpointPageCursor>,
+) -> Result<Page<CheckpointSummary, CheckpointPageCursor>> {
     read_head_object(store, namespace_id)
         .await
         .map_err(CoreError::load_head)?;
 
+    if let Some(cursor) = &request.cursor {
+        cursor.validate_for(namespace_id)?;
+    }
+
     let prefix = checkpoint_prefix(namespace_id);
-    let mut keys = store.list_prefix_stream(&prefix);
-    let mut checkpoints = Vec::new();
-    while let Some(item) = keys.next().await {
+    let start_after = request
+        .cursor
+        .as_ref()
+        .map(|cursor| cursor.last_key.as_str());
+    let keys = store
+        .list_prefix_from_stream(&prefix, start_after)
+        .peekable();
+    futures::pin_mut!(keys);
+    let mut checkpoints = Vec::with_capacity(request.limit.as_usize());
+    let mut last_inspected_key = None;
+    while checkpoints.len() < request.limit.as_usize() {
+        let Some(item) = keys.next().await else {
+            break;
+        };
         let key = item.map_err(|error| CoreError::store(&prefix, &error))?;
+        last_inspected_key = Some(key.clone());
         // Gone between the listing and the read: reaped underneath this
         // call, which is the same answer as never having been there.
         let loaded = match load_checkpoint_record_at_key(store, &key).await {
@@ -78,18 +150,72 @@ pub(crate) async fn list_checkpoints<S: ObjectStore + ?Sized>(
             manifest_id: record.manifest_id,
         });
     }
-    // Oldest first, and the id breaks ties, so two records minted in one
-    // millisecond still list in one order across calls.
-    checkpoints.sort_by(|left, right| {
-        left.created_at_ms.cmp(&right.created_at_ms).then_with(|| {
-            left.checkpoint_id
-                .as_str()
-                .cmp(right.checkpoint_id.as_str())
-        })
+    let has_more = if checkpoints.len() == request.limit.as_usize() {
+        match keys.as_mut().peek().await {
+            Some(Ok(_)) => true,
+            Some(Err(_)) => {
+                let error = keys
+                    .next()
+                    .await
+                    .expect("a peeked listing item should still be present")
+                    .expect_err("the peeked listing item should still be an error");
+                return Err(CoreError::store(&prefix, &error));
+            }
+            None => false,
+        }
+    } else {
+        false
+    };
+    let next_cursor = has_more.then(|| {
+        CheckpointPageCursor::after(
+            namespace_id,
+            last_inspected_key.expect("a full page should inspect at least one key"),
+        )
     });
 
-    Ok(ListCheckpointsResponse {
-        namespace_id: namespace_id.clone(),
-        checkpoints,
+    Ok(Page {
+        items: checkpoints,
+        next_cursor,
     })
+}
+
+#[cfg(test)]
+mod cursor_tests {
+    use super::*;
+    use loonfs_api::{decode_namespace_cursor, encode_cursor, DirectoryPageCursor, NameKey};
+
+    #[test]
+    fn cursor_decode_tolerates_additive_fields() {
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let token = loonfs_api::wire::hex::hex_encode_bytes(
+            &serde_json::to_vec(&serde_json::json!({
+                "v": 1,
+                "kind": "checkpoint_inventory",
+                "namespace_id": "demo",
+                "last_key": "namespaces/demo/checkpoints/chk_00000000000000000000000000000001.json",
+                "future_field": {"ignored": true}
+            }))
+            .expect("encode cursor"),
+        );
+
+        let cursor = decode_namespace_cursor::<CheckpointPageCursor>(&token, &namespace_id)
+            .expect("decode cursor with additive field");
+        assert_eq!(
+            cursor.last_key(),
+            Some("namespaces/demo/checkpoints/chk_00000000000000000000000000000001.json")
+        );
+    }
+
+    #[test]
+    fn cursor_is_operation_bound() {
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let directory = DirectoryPageCursor {
+            head_seq: loonfs_api::ChangeSeq(1),
+            directory_inode_id: loonfs_api::InodeId(1),
+            last_name_key: NameKey::parse("entry").expect("name key"),
+        };
+        let token = encode_cursor(&directory).expect("encode directory cursor");
+
+        assert!(decode_namespace_cursor::<CheckpointPageCursor>(&token, &namespace_id).is_err());
+    }
 }

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -24,10 +24,7 @@ use loonfs_objectstore::keys::checkpoint_prefix;
 use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
 
-/// Opaque checkpoint-inventory position returned by one runtime page.
-///
-/// Cursor payloads are short-lived API tokens, not durable objects. Serde's
-/// default unknown-field handling keeps decoding tolerant of additive fields.
+/// Resume position for a checkpoint listing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CheckpointPageCursor {
     namespace_id: NamespaceId,
@@ -75,24 +72,12 @@ impl CheckpointPageCursor {
     }
 }
 
-/// Lists one page of active checkpoint records in ascending checkpoint-id order.
+/// Lists active checkpoints in ascending checkpoint-id order.
 ///
-/// An expired record that no collection pass has released yet is reported,
-/// with its expiry in the answer. It is still active, it still roots its
-/// basis, and reads still serve from it (`files.rs`) — filtering it out
-/// would hide a live root from the one operation whose job is to find live
-/// roots. The expiry instant is what says the record is on its way out.
-///
-/// Fork-owned records are reported beside user pins for the same reason:
-/// they root a basis too. The owner in each entry is what says which ones
-/// `release_checkpoint` will act on.
-///
-/// The head is read first so a namespace that does not exist answers
-/// `namespace_not_found` rather than "no checkpoints" — an inventory that
-/// cannot tell those apart is not an inventory. A terminally deleted
-/// namespace still answers: its records outlive the tombstone until garbage
-/// collection reaps them, and that is exactly the state an operator is
-/// looking into.
+/// Expired checkpoints remain active until collection releases them, so they
+/// are included. Released checkpoints are omitted. Fork-owned records are
+/// included because they also pin data. The namespace head is read first so
+/// a missing namespace does not look like an empty checkpoint list.
 pub(crate) async fn list_checkpoints_page<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -123,8 +108,7 @@ pub(crate) async fn list_checkpoints_page<S: ObjectStore + ?Sized>(
         };
         let key = item.map_err(|error| CoreError::store(&prefix, &error))?;
         last_inspected_key = Some(key.clone());
-        // Gone between the listing and the read: reaped underneath this
-        // call, which is the same answer as never having been there.
+        // Skip records deleted after the key listing was read.
         let loaded = match load_checkpoint_record_at_key(store, &key).await {
             Ok(loaded) => loaded,
             Err(ControlObjectLoadError::MissingObject { .. }) => continue,

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -57,6 +57,7 @@ pub use self::cache::{
 };
 pub use self::error::{ManifestLoadError, ManifestLoadFailureClass};
 pub use self::files::{CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor};
+pub use self::list::CheckpointPageCursor;
 pub use self::reorganize::{
     FrozenBasePolicy, MetadataCompactionView, MetadataReorganizeOutcome, MetadataReorganizeReport,
 };
@@ -74,7 +75,7 @@ pub(crate) use self::compaction_lease::{claim_compaction_prefix, CompactionPrefi
 pub(crate) use self::create::create_checkpoint;
 pub(crate) use self::files::list_checkpoint_files_page;
 pub(crate) use self::flush::flush_wal;
-pub(crate) use self::list::list_checkpoints;
+pub(crate) use self::list::list_checkpoints_page;
 pub(crate) use self::load::{
     head_from_manifest, load_basis_metadata_tables, load_namespace_manifest_envelope,
     load_namespace_manifest_envelope_if_present, load_verified_manifest_tables,

--- a/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cas_recovery.rs
@@ -106,11 +106,12 @@ impl ObjectStore for ManifestSwapOnCasConflictStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -216,11 +217,12 @@ impl ObjectStore for FloorRaiseOnCasConflictStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -267,11 +269,12 @@ impl ObjectStore for StaleHeadOnceStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -350,11 +353,12 @@ impl ObjectStore for RootCasTransportAfterApplyStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -437,11 +441,12 @@ impl ObjectStore for RootCasTransportAfterCompetingRootStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/tests/inventory.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inventory.rs
@@ -6,9 +6,41 @@
 //! release removes them from the answer, and a passed expiry does not.
 
 use super::*;
-use crate::checkpoint::list::list_checkpoints;
+use crate::checkpoint::list::list_checkpoints_page;
 use loonfs_api::wire::control::CheckpointOwner;
-use loonfs_api::{CheckpointOwnerSummary, ErrorCode};
+use loonfs_api::{
+    CheckpointOwnerSummary, EffectiveLimit, ErrorCode, ListCheckpointsResponse, NamespaceCursor,
+    PageRequest, PaginationPolicy,
+};
+
+fn page_limit(limit: u32) -> EffectiveLimit {
+    PaginationPolicy::default()
+        .resolve_limit(Some(limit))
+        .expect("test page limit")
+}
+
+async fn list_all_checkpoints<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+) -> crate::error::Result<ListCheckpointsResponse> {
+    let limit = page_limit(2);
+    let mut checkpoints = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page =
+            list_checkpoints_page(store, namespace_id, PageRequest { limit, cursor }).await?;
+        checkpoints.extend(page.items);
+        let Some(next_cursor) = page.next_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+    Ok(ListCheckpointsResponse {
+        namespace_id: namespace_id.clone(),
+        checkpoints,
+        next_cursor: None,
+    })
+}
 
 async fn pin_named<S: ObjectStore + ?Sized>(
     store: &S,
@@ -47,7 +79,7 @@ async fn two_pins_under_one_label_list_as_two_records() {
     let second = pin_named(&store, &namespace_id, "nightly", None, &context).await;
     assert_ne!(first, second, "each call mints its own record");
 
-    let listed = list_checkpoints(&store, &namespace_id)
+    let listed = list_all_checkpoints(&store, &namespace_id)
         .await
         .expect("list checkpoints");
     assert_eq!(listed.namespace_id, namespace_id);
@@ -73,7 +105,7 @@ async fn two_pins_under_one_label_list_as_two_records() {
     super::super::release::release_checkpoint(&store, &namespace_id, &first, &context)
         .await
         .expect("release checkpoint");
-    let after_release = list_checkpoints(&store, &namespace_id)
+    let after_release = list_all_checkpoints(&store, &namespace_id)
         .await
         .expect("list checkpoints");
     assert_eq!(after_release.checkpoints.len(), 1);
@@ -104,7 +136,7 @@ async fn an_expired_record_is_listed_with_its_expiry_until_it_is_released() {
     )
     .await;
 
-    let listed = list_checkpoints(&store, &namespace_id)
+    let listed = list_all_checkpoints(&store, &namespace_id)
         .await
         .expect("list checkpoints");
     assert_eq!(listed.checkpoints.len(), 1);
@@ -120,8 +152,315 @@ async fn a_namespace_that_does_not_exist_is_not_a_namespace_without_checkpoints(
     let store = LocalFsStore::new(temp_dir.path()).expect("store");
     let namespace_id = NamespaceId::parse("absent").expect("namespace id");
 
-    let error = list_checkpoints(&store, &namespace_id)
+    let error = list_all_checkpoints(&store, &namespace_id)
         .await
         .expect_err("listing an absent namespace fails");
     assert_eq!(error.code(), ErrorCode::NamespaceNotFound);
+}
+
+#[tokio::test]
+async fn pages_concatenate_to_every_checkpoint_once_in_id_order() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+
+    let mut expected = Vec::new();
+    for index in 0..7 {
+        expected.push(
+            pin_named(
+                &store,
+                &namespace_id,
+                &format!("pin-{index}"),
+                None,
+                &context,
+            )
+            .await,
+        );
+    }
+    expected.sort();
+
+    let mut actual = Vec::new();
+    let mut cursor = None;
+    let mut page_count = 0;
+    loop {
+        let page = list_checkpoints_page(
+            &store,
+            &namespace_id,
+            PageRequest {
+                limit: page_limit(2),
+                cursor,
+            },
+        )
+        .await
+        .expect("list checkpoint page");
+        page_count += 1;
+        actual.extend(
+            page.items
+                .into_iter()
+                .map(|checkpoint| checkpoint.checkpoint_id),
+        );
+        let Some(next_cursor) = page.next_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+
+    assert!(page_count > 1);
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn released_runs_advance_the_last_inspected_key_cursor() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&store, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+
+    let mut ids = Vec::new();
+    for index in 0..8 {
+        ids.push(
+            pin_named(
+                &store,
+                &namespace_id,
+                &format!("pin-{index}"),
+                None,
+                &context,
+            )
+            .await,
+        );
+    }
+    ids.sort();
+    for checkpoint_id in &ids[1..6] {
+        super::super::release::release_checkpoint(&store, &namespace_id, checkpoint_id, &context)
+            .await
+            .expect("release checkpoint in filtered run");
+    }
+
+    let first = list_checkpoints_page(
+        &store,
+        &namespace_id,
+        PageRequest {
+            limit: page_limit(1),
+            cursor: None,
+        },
+    )
+    .await
+    .expect("first page");
+    assert_eq!(first.items[0].checkpoint_id, ids[0]);
+
+    let second = list_checkpoints_page(
+        &store,
+        &namespace_id,
+        PageRequest {
+            limit: page_limit(1),
+            cursor: first.next_cursor,
+        },
+    )
+    .await
+    .expect("second page across released run");
+    assert_eq!(second.items[0].checkpoint_id, ids[6]);
+    assert_eq!(
+        second
+            .next_cursor
+            .as_ref()
+            .and_then(NamespaceCursor::last_key),
+        Some(loonfs_objectstore::keys::checkpoint_record(&namespace_id, &ids[6]).as_str())
+    );
+
+    let third = list_checkpoints_page(
+        &store,
+        &namespace_id,
+        PageRequest {
+            limit: page_limit(1),
+            cursor: second.next_cursor,
+        },
+    )
+    .await
+    .expect("third page");
+    assert_eq!(third.items[0].checkpoint_id, ids[7]);
+    assert!(third.next_cursor.is_none());
+}
+
+#[derive(Debug)]
+struct DeleteOnCheckpointLoadStore<S> {
+    inner: S,
+    target: String,
+    deleted: std::sync::atomic::AtomicBool,
+}
+
+#[async_trait]
+impl<S: ObjectStore> ObjectStore for DeleteOnCheckpointLoadStore<S> {
+    async fn head(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<ObjectMetadata>, ObjectStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn get_with_metadata(
+        &self,
+        key: &str,
+    ) -> std::result::Result<Option<ObjectBody>, ObjectStoreError> {
+        if key == self.target && !self.deleted.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            self.inner.delete(key).await?;
+        }
+        self.inner.get_with_metadata(key).await
+    }
+
+    async fn get(
+        &self,
+        key: &str,
+        range: Option<ByteRange>,
+    ) -> std::result::Result<Option<Bytes>, ObjectStoreError> {
+        self.inner.get(key, range).await
+    }
+
+    async fn put(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        mode: PutMode,
+    ) -> std::result::Result<ObjectMetadata, ObjectStoreError> {
+        self.inner.put(key, bytes, mode).await
+    }
+
+    async fn delete(&self, key: &str) -> std::result::Result<(), ObjectStoreError> {
+        self.inner.delete(key).await
+    }
+
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, std::result::Result<String, ObjectStoreError>> {
+        self.inner.list_prefix_from_stream(prefix, start_after)
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_deleted_between_listing_and_load_is_skipped() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&inner, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+
+    let mut ids = Vec::new();
+    for index in 0..3 {
+        ids.push(
+            pin_named(
+                &inner,
+                &namespace_id,
+                &format!("pin-{index}"),
+                None,
+                &context,
+            )
+            .await,
+        );
+    }
+    ids.sort();
+    let deleted = ids[1].clone();
+    let store = DeleteOnCheckpointLoadStore {
+        inner,
+        target: loonfs_objectstore::keys::checkpoint_record(&namespace_id, &deleted),
+        deleted: std::sync::atomic::AtomicBool::new(false),
+    };
+
+    let listed = list_all_checkpoints(&store, &namespace_id)
+        .await
+        .expect("list across concurrent reap");
+    let listed_ids = listed
+        .checkpoints
+        .into_iter()
+        .map(|checkpoint| checkpoint.checkpoint_id)
+        .collect::<Vec<_>>();
+    assert_eq!(listed_ids, vec![ids[0].clone(), ids[2].clone()]);
+}
+
+#[tokio::test]
+async fn first_page_loads_only_the_records_needed_to_fill_it() {
+    let temp_dir = tempdir().expect("tempdir");
+    let inner = LocalFsStore::new(temp_dir.path()).expect("store");
+    let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+    let context = test_context();
+    bootstrap_namespace(&inner, &namespace_id, &context, false)
+        .await
+        .expect("bootstrap namespace");
+    for index in 0..20 {
+        pin_named(
+            &inner,
+            &namespace_id,
+            &format!("pin-{index}"),
+            None,
+            &context,
+        )
+        .await;
+    }
+    let prefix = loonfs_objectstore::keys::checkpoint_prefix(&namespace_id);
+    let store = CountingStore::new(inner, KeyPredicate::prefix(prefix));
+
+    let page = list_checkpoints_page(
+        &store,
+        &namespace_id,
+        PageRequest {
+            limit: page_limit(2),
+            cursor: None,
+        },
+    )
+    .await
+    .expect("first checkpoint page");
+
+    assert_eq!(page.items.len(), 2);
+    assert!(page.next_cursor.is_some());
+    let counts = store.snapshot();
+    assert_eq!(counts.lists, 1);
+    assert_eq!(counts.gets_with_metadata, 2);
+}
+
+#[tokio::test]
+async fn checkpoint_cursor_is_bound_to_its_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store = LocalFsStore::new(temp_dir.path()).expect("store");
+    let source = NamespaceId::parse("source").expect("namespace id");
+    let target = NamespaceId::parse("target").expect("namespace id");
+    let context = test_context();
+    for namespace_id in [&source, &target] {
+        bootstrap_namespace(&store, namespace_id, &context, false)
+            .await
+            .expect("bootstrap namespace");
+    }
+    for index in 0..2 {
+        pin_named(&store, &source, &format!("pin-{index}"), None, &context).await;
+    }
+    let source_page = list_checkpoints_page(
+        &store,
+        &source,
+        PageRequest {
+            limit: page_limit(1),
+            cursor: None,
+        },
+    )
+    .await
+    .expect("source page");
+
+    let error = list_checkpoints_page(
+        &store,
+        &target,
+        PageRequest {
+            limit: page_limit(1),
+            cursor: source_page.next_cursor,
+        },
+    )
+    .await
+    .expect_err("foreign cursor should fail");
+    assert_eq!(error.code(), ErrorCode::InvalidRequest);
 }

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -764,11 +764,12 @@ impl ObjectStore for ConflictOnManifestCreateStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/tests/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/retention.rs
@@ -92,11 +92,12 @@ impl ObjectStore for ManifestChecksumMismatchOnceStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -1661,11 +1661,12 @@ impl ObjectStore for ReadRecorderStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -2081,11 +2082,12 @@ impl ObjectStore for CancelAfterReadsStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -3247,11 +3249,12 @@ impl ObjectStore for FlushDuringFinalizationStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -3556,11 +3559,12 @@ impl ObjectStore for CancelAtTheFirstPublicationStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -2,7 +2,7 @@
 //! uploads, checkpoints, and maintenance.
 
 use crate::cache::{MetadataTableCache, WalTailProjectionCache};
-use crate::checkpoint::{CheckpointFilesPage, CheckpointFilesPageCursor};
+use crate::checkpoint::{CheckpointFilesPage, CheckpointFilesPageCursor, CheckpointPageCursor};
 use crate::commit_engine::CommitCandidate;
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
@@ -33,8 +33,8 @@ use loonfs_api::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq,
     CheckpointId, ContentRef, CreateCheckpointResponse, DeleteNamespaceResponse,
     DirectoryPageCursor, FileRevision, FileRevisionsPageCursor, FlushWalResponse, InodeId,
-    ListCheckpointsResponse, NamespaceId, NamespaceSummary, Page, PageRequest,
-    ReleaseCheckpointResponse, RevisionNo, TrashEntry, TrashPageCursor, UploadId,
+    NamespaceId, NamespaceSummary, Page, PageRequest, ReleaseCheckpointResponse, RevisionNo,
+    TrashEntry, TrashPageCursor, UploadId,
 };
 use loonfs_objectstore::{ByteStream, ObjectStore};
 use std::num::NonZeroU64;
@@ -781,12 +781,15 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Lists active checkpoint records from oldest to newest.
+    /// Lists one page of active checkpoint records in ascending id order.
     ///
     /// This method does not release expired records. A record remains active and
     /// appears in the result until garbage collection processes it.
-    pub async fn list_checkpoints(&self) -> Result<ListCheckpointsResponse> {
-        crate::checkpoint::list_checkpoints(&self.store, &self.namespace_id).await
+    pub async fn list_checkpoints_page(
+        &self,
+        request: PageRequest<CheckpointPageCursor>,
+    ) -> Result<Page<loonfs_api::CheckpointSummary, CheckpointPageCursor>> {
+        crate::checkpoint::list_checkpoints_page(&self.store, &self.namespace_id, request).await
     }
 
     /// Releases a user-owned checkpoint by id.

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -781,10 +781,8 @@ impl<S: ObjectStore> NamespaceEngine<S> {
         .await
     }
 
-    /// Lists one page of active checkpoint records in ascending id order.
-    ///
-    /// This method does not release expired records. A record remains active and
-    /// appears in the result until garbage collection processes it.
+    /// Lists one page of active checkpoints in ascending id order. Expired
+    /// records remain visible until garbage collection releases them.
     pub async fn list_checkpoints_page(
         &self,
         request: PageRequest<CheckpointPageCursor>,

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -250,12 +250,13 @@ impl ObjectStore for IncompleteGcAccountingStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         self.lists.fetch_add(1, Ordering::SeqCst);
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -160,9 +160,9 @@ pub mod publish {
 // `MetadataReorganizeReport` remains public because
 // `NamespaceEngine::reorganize_metadata` returns it.
 pub use checkpoint::{
-    CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, FrozenBasePolicy,
-    MetadataCompactionCancellation, MetadataCompactionJobOutcome, MetadataCompactionSpec,
-    MetadataCompactionView, MetadataFamilyGroup, MetadataReorganizeOutcome,
+    CheckpointFile, CheckpointFilesPage, CheckpointFilesPageCursor, CheckpointPageCursor,
+    FrozenBasePolicy, MetadataCompactionCancellation, MetadataCompactionJobOutcome,
+    MetadataCompactionSpec, MetadataCompactionView, MetadataFamilyGroup, MetadataReorganizeOutcome,
     MetadataReorganizeReport,
 };
 pub use context::MutationContext;

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -587,11 +587,12 @@ mod tests {
             self.inner.delete(key).await
         }
 
-        fn list_prefix_stream(
+        fn list_prefix_from_stream(
             &self,
             prefix: &str,
+            start_after: Option<&str>,
         ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
+            self.inner.list_prefix_from_stream(prefix, start_after)
         }
     }
 
@@ -704,11 +705,12 @@ mod tests {
             self.inner.delete(key).await
         }
 
-        fn list_prefix_stream(
+        fn list_prefix_from_stream(
             &self,
             prefix: &str,
+            start_after: Option<&str>,
         ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
+            self.inner.list_prefix_from_stream(prefix, start_after)
         }
     }
 }

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -187,11 +187,12 @@ impl ObjectStore for StaleHeadGetStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -314,11 +315,12 @@ impl ObjectStore for StaleHeadAfterWalWriteStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -106,11 +106,12 @@ impl ObjectStore for ContentStoreAccessLimitStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-core/tests/it/common/mod.rs
+++ b/crates/loonfs-core/tests/it/common/mod.rs
@@ -468,11 +468,12 @@ pub(crate) mod commit_split_support {
             self.inner.delete(key).await
         }
 
-        fn list_prefix_stream(
+        fn list_prefix_from_stream(
             &self,
             prefix: &str,
+            start_after: Option<&str>,
         ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
+            self.inner.list_prefix_from_stream(prefix, start_after)
         }
     }
 

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -1159,11 +1159,12 @@ impl ObjectStore for ReleasePinAfterHeadStore {
         self.inner.list_prefix(prefix).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> futures::stream::BoxStream<'static, Result<String, loonfs_objectstore::ObjectStoreError>>
     {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -300,7 +300,7 @@ async fn enable_releases_its_checkpoint_when_root_reload_fails_before_publicatio
 
     let checkpoints = host
         .admin
-        .list_checkpoints(&namespace_id)
+        .list_checkpoints_all(&namespace_id)
         .await
         .expect("list checkpoints after failed enable");
     assert!(

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -137,8 +137,15 @@ impl ObjectStore for AzureAbsStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
-        self.inner.list_prefix_stream(prefix)
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
+        // Azure exposes continuation markers but no key offset. The
+        // provider adapter therefore walks marker pages from the prefix
+        // start and filters keys through `start_after` locally.
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -142,9 +142,8 @@ impl ObjectStore for AzureAbsStore {
         prefix: &str,
         start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String>> {
-        // Azure exposes continuation markers but no key offset. The
-        // provider adapter therefore walks marker pages from the prefix
-        // start and filters keys through `start_after` locally.
+        // Azure has no native start-after key, so the provider adapter filters
+        // results while following its normal continuation pages.
         self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -279,10 +279,8 @@ impl ObjectStore for GcpGcsStore {
         prefix: &str,
         start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String>> {
-        // GCS's JSON `startOffset` is inclusive. Whichever native listing
-        // transport the upstream adapter selects, `ProviderObjectStore`
-        // filters the exact match so this public operation remains
-        // strictly-after.
+        // GCS offsets are inclusive. The provider adapter removes the offset
+        // key so this method remains strictly after it.
         self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -274,8 +274,16 @@ impl ObjectStore for GcpGcsStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
-        self.inner.list_prefix_stream(prefix)
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
+        // GCS's JSON `startOffset` is inclusive. Whichever native listing
+        // transport the upstream adapter selects, `ProviderObjectStore`
+        // filters the exact match so this public operation remains
+        // strictly-after.
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-objectstore/src/local_fs_store.rs
+++ b/crates/loonfs-objectstore/src/local_fs_store.rs
@@ -511,31 +511,44 @@ impl ObjectStore for LocalFsStore {
         self.delete_object(&self.scoped(key)?).await
     }
 
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
         let scoped = match scope_list_prefix(self.key_prefix.as_deref(), prefix) {
             Ok(scoped) => scoped,
+            Err(err) => return stream::once(async { Err(err) }).boxed(),
+        };
+        let scoped_start_after = match start_after
+            .map(|key| scope_object_key(self.key_prefix.as_deref(), key))
+            .transpose()
+        {
+            Ok(start_after) => start_after,
             Err(err) => return stream::once(async { Err(err) }).boxed(),
         };
         let root = self.root.clone();
         let key_prefix = self.key_prefix.clone();
         Box::pin(
-            stream::once(async move { list_prefix_for_root(root, scoped).await })
-                .flat_map(|result| match result {
-                    Ok(keys) => stream::iter(keys.into_iter().map(Ok)).boxed(),
-                    Err(err) => stream::once(async { Err(err) }).boxed(),
-                })
-                .filter_map(move |result| {
-                    let key_prefix = key_prefix.clone();
-                    async move {
-                        match result {
-                            Ok(key) => match key_prefix.as_deref() {
-                                Some(prefix) => unscope_listed_key(Some(prefix), &key).map(Ok),
-                                None => Some(Ok(key)),
-                            },
-                            Err(err) => Some(Err(err)),
-                        }
+            stream::once(async move {
+                list_prefix_for_root(root, scoped, scoped_start_after.as_deref()).await
+            })
+            .flat_map(|result| match result {
+                Ok(keys) => stream::iter(keys.into_iter().map(Ok)).boxed(),
+                Err(err) => stream::once(async { Err(err) }).boxed(),
+            })
+            .filter_map(move |result| {
+                let key_prefix = key_prefix.clone();
+                async move {
+                    match result {
+                        Ok(key) => match key_prefix.as_deref() {
+                            Some(prefix) => unscope_listed_key(Some(prefix), &key).map(Ok),
+                            None => Some(Ok(key)),
+                        },
+                        Err(err) => Some(Err(err)),
                     }
-                }),
+                }
+            }),
         )
     }
 }
@@ -554,7 +567,11 @@ fn require_atomic_rename_replace() -> Result<()> {
     ))
 }
 
-async fn list_prefix_for_root(root: PathBuf, prefix: String) -> Result<Vec<String>> {
+async fn list_prefix_for_root(
+    root: PathBuf,
+    prefix: String,
+    start_after: Option<&str>,
+) -> Result<Vec<String>> {
     validate_segments(&prefix, true)?;
 
     if !fs::try_exists(&root)
@@ -565,7 +582,9 @@ async fn list_prefix_for_root(root: PathBuf, prefix: String) -> Result<Vec<Strin
     }
 
     let mut keys = collect_keys(&prefix, root).await?;
-    keys.retain(|key| key.starts_with(&prefix));
+    keys.retain(|key| {
+        key.starts_with(&prefix) && start_after.is_none_or(|start_after| key.as_str() > start_after)
+    });
     keys.sort();
     Ok(keys)
 }

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -475,13 +475,17 @@ where
         result
     }
 
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
         // Streamed listings (WAL replay, GC) must not be invisible in the
         // metrics. The wrapper records one sample when the stream is
         // dropped — finished or abandoned — carrying the item count and
         // the first error's class.
         Box::pin(RecordedListStream {
-            inner: self.inner.list_prefix_stream(prefix),
+            inner: self.inner.list_prefix_from_stream(prefix, start_after),
             recorder: Arc::clone(&self.recorder),
             store_kind: self.store_kind.clone(),
             key_class: classify_key(prefix),

--- a/crates/loonfs-objectstore/src/object_store.rs
+++ b/crates/loonfs-objectstore/src/object_store.rs
@@ -405,7 +405,21 @@ pub trait ObjectStore: Send + Sync + Debug {
     /// Streams keys under `prefix` in ascending lexicographic order.
     ///
     /// Invalid prefixes and listing failures arrive as stream items.
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>>;
+    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
+        self.list_prefix_from_stream(prefix, None)
+    }
+
+    /// Streams keys under `prefix` strictly after `start_after` in ascending
+    /// lexicographic order.
+    ///
+    /// `start_after` is a durable key rather than a provider continuation
+    /// token. Invalid prefixes, invalid resume keys, and listing failures
+    /// arrive as stream items.
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>>;
 
     /// Collects and sorts every key under `prefix`.
     ///
@@ -526,6 +540,14 @@ impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
         self.as_ref().list_prefix_stream(prefix)
     }
 
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
+        self.as_ref().list_prefix_from_stream(prefix, start_after)
+    }
+
     async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>> {
         self.as_ref().list_prefix(prefix).await
     }
@@ -614,6 +636,14 @@ impl<T: ObjectStore + ?Sized> ObjectStore for &T {
         (*self).list_prefix_stream(prefix)
     }
 
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
+        (*self).list_prefix_from_stream(prefix, start_after)
+    }
+
     async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>> {
         (*self).list_prefix(prefix).await
     }
@@ -653,6 +683,7 @@ mod tests {
     #[derive(Debug)]
     struct ListOverrideStore {
         override_reached: Arc<AtomicBool>,
+        resume_reached: Arc<AtomicBool>,
     }
 
     #[async_trait]
@@ -679,8 +710,13 @@ mod tests {
             Ok(())
         }
 
-        fn list_prefix_stream(&self, _prefix: &str) -> BoxStream<'static, Result<String>> {
-            Box::pin(stream::empty())
+        fn list_prefix_from_stream(
+            &self,
+            _prefix: &str,
+            _start_after: Option<&str>,
+        ) -> BoxStream<'static, Result<String>> {
+            self.resume_reached.store(true, Ordering::SeqCst);
+            Box::pin(stream::iter([Ok("resumed".to_owned())]))
         }
 
         async fn list_prefix(&self, _prefix: &str) -> Result<Vec<String>> {
@@ -694,6 +730,7 @@ mod tests {
         let override_reached = Arc::new(AtomicBool::new(false));
         let store: Arc<dyn ObjectStore> = Arc::new(ListOverrideStore {
             override_reached: Arc::clone(&override_reached),
+            resume_reached: Arc::new(AtomicBool::new(false)),
         });
 
         let keys = <Arc<dyn ObjectStore> as ObjectStore>::list_prefix(&store, "prefix/")
@@ -702,5 +739,40 @@ mod tests {
 
         assert_eq!(keys, vec!["overridden"]);
         assert!(override_reached.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn arc_and_reference_stores_forward_start_after_listing() {
+        let arc_reached = Arc::new(AtomicBool::new(false));
+        let store: Arc<dyn ObjectStore> = Arc::new(ListOverrideStore {
+            override_reached: Arc::new(AtomicBool::new(false)),
+            resume_reached: Arc::clone(&arc_reached),
+        });
+        let arc_keys = <Arc<dyn ObjectStore> as ObjectStore>::list_prefix_from_stream(
+            &store,
+            "prefix/",
+            Some("prefix/key"),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Arc resume should succeed");
+        assert_eq!(arc_keys, vec!["resumed"]);
+        assert!(arc_reached.load(Ordering::SeqCst));
+
+        let reference_reached = Arc::new(AtomicBool::new(false));
+        let concrete = ListOverrideStore {
+            override_reached: Arc::new(AtomicBool::new(false)),
+            resume_reached: Arc::clone(&reference_reached),
+        };
+        let reference_keys = <&ListOverrideStore as ObjectStore>::list_prefix_from_stream(
+            &&concrete,
+            "prefix/",
+            Some("prefix/key"),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("reference resume should succeed");
+        assert_eq!(reference_keys, vec!["resumed"]);
+        assert!(reference_reached.load(Ordering::SeqCst));
     }
 }

--- a/crates/loonfs-objectstore/src/probe.rs
+++ b/crates/loonfs-objectstore/src/probe.rs
@@ -900,8 +900,12 @@ mod tests {
             self.inner.delete(key).await
         }
 
-        fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
-            self.inner.list_prefix_stream(prefix)
+        fn list_prefix_from_stream(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+        ) -> BoxStream<'static, StoreResult<String>> {
+            self.inner.list_prefix_from_stream(prefix, start_after)
         }
     }
 
@@ -983,8 +987,12 @@ mod tests {
             self.inner.delete(key).await
         }
 
-        fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
-            self.inner.list_prefix_stream(prefix)
+        fn list_prefix_from_stream(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+        ) -> BoxStream<'static, StoreResult<String>> {
+            self.inner.list_prefix_from_stream(prefix, start_after)
         }
     }
 
@@ -1030,8 +1038,12 @@ mod tests {
             self.inner.delete(key).await
         }
 
-        fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
-            self.inner.list_prefix_stream(prefix)
+        fn list_prefix_from_stream(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+        ) -> BoxStream<'static, StoreResult<String>> {
+            self.inner.list_prefix_from_stream(prefix, start_after)
         }
     }
 
@@ -1068,8 +1080,12 @@ mod tests {
             self.inner.delete(key).await
         }
 
-        fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, StoreResult<String>> {
-            self.inner.list_prefix_stream(prefix)
+        fn list_prefix_from_stream(
+            &self,
+            prefix: &str,
+            start_after: Option<&str>,
+        ) -> BoxStream<'static, StoreResult<String>> {
+            self.inner.list_prefix_from_stream(prefix, start_after)
         }
     }
 

--- a/crates/loonfs-objectstore/src/provider_object_store.rs
+++ b/crates/loonfs-objectstore/src/provider_object_store.rs
@@ -948,25 +948,48 @@ impl ObjectStore for ProviderObjectStore {
         }
     }
 
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
         let prefix_path = match self.list_path(prefix) {
             Ok(prefix_path) => prefix_path,
             Err(err) => return stream::once(async { Err(err) }).boxed(),
         };
+        let offset = match start_after.map(|key| self.to_path(key)).transpose() {
+            Ok(offset) => offset,
+            Err(err) => return stream::once(async { Err(err) }).boxed(),
+        };
         let key_prefix = self.key_prefix.clone();
         let listed_prefix = prefix.to_owned();
-        self.inner
-            .list(prefix_path.as_ref())
+        let start_after = start_after.map(str::to_owned);
+        let listed = match offset.as_ref() {
+            Some(offset) => self.inner.list_with_offset(prefix_path.as_ref(), offset),
+            None => self.inner.list(prefix_path.as_ref()),
+        };
+        listed
             .filter_map(move |result| {
                 let key_prefix = key_prefix.clone();
                 let listed_prefix = listed_prefix.clone();
+                let start_after = start_after.clone();
                 async move {
                     match result {
                         Ok(meta) => {
                             let key = meta.location.as_ref();
-                            match key_prefix.as_deref() {
+                            let key = match key_prefix.as_deref() {
                                 Some(prefix) => unscope_listed_key(Some(prefix), key).map(Ok),
                                 None => Some(Ok(key.to_owned())),
+                            };
+                            match key {
+                                Some(Ok(key))
+                                    if start_after
+                                        .as_deref()
+                                        .is_some_and(|start_after| key.as_str() <= start_after) =>
+                                {
+                                    None
+                                }
+                                other => other,
                             }
                         }
                         Err(err) => Some(Err(map_provider_error(&listed_prefix, err))),

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -479,8 +479,12 @@ impl ObjectStore for S3CompatibleStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
-        self.inner.list_prefix_stream(prefix)
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
+++ b/crates/loonfs-objectstore/tests/it/metrics_instrumented_object_store.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream};
+use futures::TryStreamExt;
 use loonfs_api::ManifestObjectId;
 use loonfs_objectstore::keys::{
     checkpoint_record, metadata_manifest_object, metadata_table, wal_head, wal_segment,
@@ -194,6 +195,33 @@ async fn records_list_count() {
     assert_eq!(sample.result, ObjectStoreResultClass::Ok);
     assert_eq!(sample.item_count, Some(2));
     assert_eq!(sample.range_class, Some(RangeClass::Prefix));
+}
+
+#[tokio::test]
+async fn instrumented_store_forwards_start_after_listing() {
+    let temp_dir = tempdir().expect("tempdir");
+    let recorder = Arc::new(VecObjectStoreMetricsRecorder::default());
+    let store = instrumented_object_store(temp_dir.path(), recorder.clone());
+    let prefix = "namespaces/ns-1/checkpoints/";
+    let first = format!("{prefix}chk_00000000000000000000000000000001.json");
+    let second = format!("{prefix}chk_00000000000000000000000000000002.json");
+    for key in [&first, &second] {
+        store
+            .put_overwrite(key, bytes(b"checkpoint"))
+            .await
+            .expect("put checkpoint");
+    }
+
+    let keys = store
+        .list_prefix_from_stream(prefix, Some(&first))
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("resume instrumented listing");
+
+    assert_eq!(keys, vec![second]);
+    let sample = recorder.samples().pop().expect("streamed list sample");
+    assert_eq!(sample.operation, ObjectStoreOperation::ListPrefixStream);
+    assert_eq!(sample.item_count, Some(1));
 }
 
 #[tokio::test]
@@ -420,9 +448,10 @@ impl ObjectStore for DelegatingWriteStore {
         Ok(())
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         _prefix: &str,
+        _start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         Box::pin(stream::empty())
     }

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -6,7 +6,7 @@ use crate::provider_env::{
     GCP_GCS_REQUIRED_VARS,
 };
 use bytes::Bytes;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use loonfs_api::{Checksum, ContentId, ManifestObjectId};
 use loonfs_objectstore::abs::{AzureAbsStore, AzureAbsStoreConfig};
 use loonfs_objectstore::gcs::{GcpGcsStore, GcpGcsStoreConfig};
@@ -102,6 +102,7 @@ async fn local_fs_passes_the_store_contract_probe() {
     let temp_dir = test_dir("contract-probe");
     let store = LocalFsStore::new(temp_dir.path()).expect("create local object store");
     assert_store_contract_probe_passes(&store, false).await;
+    assert_start_after_contract(&store).await;
 }
 
 #[tokio::test]
@@ -325,7 +326,60 @@ async fn azure_abs_streamed_write_round_trips() {
 /// production and for this sweep in one edit, or not at all.
 async fn assert_provider_conformance(store: &dyn ObjectStore, direct_put_proven: bool) {
     assert_store_contract_probe_passes(store, direct_put_proven).await;
+    assert_start_after_contract(store).await;
     assert_rejects_invalid_keys_consistently(store).await;
+}
+
+/// Pins the provider-independent resume contract: the public offset is a
+/// durable key, results are sorted, and the named key is never repeated.
+async fn assert_start_after_contract(store: &dyn ObjectStore) {
+    let run_id = loonfs_api::generated_id("list");
+    let prefix = format!("start-after/{run_id}/");
+    let keys = [
+        format!("{prefix}a"),
+        format!("{prefix}b"),
+        format!("{prefix}c"),
+    ];
+    for key in &keys {
+        store
+            .put_overwrite(key, Bytes::from_static(b"listed"))
+            .await
+            .expect("write start-after fixture");
+    }
+
+    let all = store
+        .list_prefix_from_stream(&prefix, None)
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("list from prefix start");
+    assert_eq!(all, keys);
+
+    let after_exact = store
+        .list_prefix_from_stream(&prefix, Some(&keys[0]))
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("list after exact key");
+    assert_eq!(after_exact, keys[1..]);
+
+    let between = format!("{prefix}bb");
+    let after_gap = store
+        .list_prefix_from_stream(&prefix, Some(&between))
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("list after absent key");
+    assert_eq!(after_gap, keys[2..]);
+
+    let after_end = format!("{prefix}z");
+    let complete = store
+        .list_prefix_from_stream(&prefix, Some(&after_end))
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("list after prefix end");
+    assert!(complete.is_empty());
+
+    for key in &keys {
+        store.delete(key).await.expect("delete start-after fixture");
+    }
 }
 
 /// Requires every probe check to pass, and prints the whole report when one
@@ -463,6 +517,13 @@ async fn assert_rejects_invalid_keys_consistently(store: &dyn ObjectStore) {
         );
         assert_invalid_key(key, store.delete(key).await);
         assert_invalid_key(key, store.list_prefix(key).await);
+        assert_invalid_key(
+            key,
+            store
+                .list_prefix_from_stream("valid/", Some(key))
+                .try_collect::<Vec<_>>()
+                .await,
+        );
     }
 }
 

--- a/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
+++ b/crates/loonfs-objectstore/tests/it/objectstore_conformance.rs
@@ -330,8 +330,7 @@ async fn assert_provider_conformance(store: &dyn ObjectStore, direct_put_proven:
     assert_rejects_invalid_keys_consistently(store).await;
 }
 
-/// Pins the provider-independent resume contract: the public offset is a
-/// durable key, results are sorted, and the named key is never repeated.
+/// Checks that every provider resumes after the given key in sorted order.
 async fn assert_start_after_contract(store: &dyn ObjectStore) {
     let run_id = loonfs_api::generated_id("list");
     let prefix = format!("start-after/{run_id}/");

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -561,7 +561,7 @@ fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
     })
 }
 
-fn resolve_page_limit(
+pub(super) fn resolve_page_limit(
     limit: Option<String>,
 ) -> Result<loonfs_api::EffectiveLimit, ApiResponseError> {
     let requested = limit.as_deref().map(parse_page_limit).transpose()?;

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -2,24 +2,26 @@
 //! handlers.
 
 use super::error::ApiResponseError;
+use super::handlers_filesystem::resolve_page_limit;
 use super::{authorize, AppJson, AppPath, AppQuery, AppState, NamespaceIdPath, OptionalAppJson};
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
-use loonfs::{CreateNamespaceOptions, DeleteNamespaceOptions};
+use loonfs::{CheckpointPageCursor, CreateNamespaceOptions, DeleteNamespaceOptions};
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::ChangeSeq;
 use loonfs_api::{
-    CapabilityDocument, CheckpointId, CreateCheckpointRequest, CreateCheckpointResponse,
-    CreateNamespaceRequest, ErrorCode, ForkNamespaceRequest, ListCheckpointsResponse,
-    MaintenanceStepRequest, MaintenanceStepResponse, PaginationPolicy, ReleaseCheckpointResponse,
-    FEATURE_ADMIN_GREP_INDEX, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_QUERY_GREP,
-    FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_DOWNLOAD_MAX_CONCURRENT,
-    LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX,
-    LIMIT_QUERY_GREP_SCAN_BUDGET_FILES, LIMIT_QUERY_GREP_TAIL_BUDGET_FILES,
-    LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES, LIMIT_UPLOAD_MAX_CONCURRENT,
-    LIMIT_UPLOAD_MAX_CONTENT_BYTES, PROFILE_QUERY_V0, UPLOADS_DIRECT_PUT_CHECKSUM_FEATURES,
+    decode_namespace_cursor, CapabilityDocument, CheckpointId, CreateCheckpointRequest,
+    CreateCheckpointResponse, CreateNamespaceRequest, ErrorCode, ForkNamespaceRequest,
+    ListCheckpointsResponse, MaintenanceStepRequest, MaintenanceStepResponse, PageRequest,
+    PaginationPolicy, ReleaseCheckpointResponse, FEATURE_ADMIN_GREP_INDEX,
+    FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_QUERY_GREP, FEATURE_UPLOADS_DIRECT_MULTIPART,
+    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_DOWNLOAD_MAX_CONCURRENT, LIMIT_DOWNLOAD_MAX_CONTENT_BYTES,
+    LIMIT_QUERY_GREP_DEFAULT, LIMIT_QUERY_GREP_MAX, LIMIT_QUERY_GREP_SCAN_BUDGET_FILES,
+    LIMIT_QUERY_GREP_TAIL_BUDGET_FILES, LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES,
+    LIMIT_UPLOAD_MAX_CONCURRENT, LIMIT_UPLOAD_MAX_CONTENT_BYTES, PROFILE_QUERY_V0,
+    UPLOADS_DIRECT_PUT_CHECKSUM_FEATURES,
 };
 
 /// Advertises a feature, or removes the key: an absent key and an
@@ -37,6 +39,12 @@ pub(super) struct DeleteNamespaceQuery {
     /// Delete only if the head is still at this sequence (`stale_head` on
     /// mismatch).
     expected_head_seq: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct CheckpointPageQuery {
+    limit: Option<String>,
+    cursor: Option<String>,
 }
 
 #[cfg_attr(
@@ -364,11 +372,15 @@ pub(super) async fn create_checkpoint(
         path = "/v0/admin/namespaces/{namespace_id}/checkpoints",
         tag = "admin",
         summary = "List checkpoints",
-        description = "Lists every active checkpoint record on the namespace, oldest first. Each record is a garbage-collection root, and its id is what the release endpoint takes; because a checkpoint name is a label rather than a key, this is the only way to find a pin whose creation response is gone. An expired record that no collection pass has released yet is still active and is listed, with its expiry in the entry — the operator is looking for roots, and a record that still pins its basis is one. Released records are absent: a release is what stops a record pinning anything.",
-        params(("namespace_id" = String, Path, description = "Namespace id")),
+        description = "Lists one bounded page of active checkpoint records in ascending checkpoint-id order. Each record is a garbage-collection root, and its id is what the release endpoint takes; because a checkpoint name is a label rather than a key, this is the only way to find a pin whose creation response is gone. An expired record that no collection pass has released yet is still active and is listed, with its expiry in the entry. Released records are absent. Pagination is a live key-order resume, not a snapshot.",
+        params(
+            ("namespace_id" = String, Path, description = "Namespace id"),
+            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("cursor" = Option<String>, Query, description = "Opaque checkpoint-list page cursor")
+        ),
         responses(
             (status = 200, description = "Active checkpoint records", body = ListCheckpointsResponse),
-            (status = 400, description = "Invalid namespace id", body = ApiError),
+            (status = 400, description = "Invalid namespace id, limit, or cursor", body = ApiError),
             (status = 401, description = "Unauthorized", body = ApiError),
             (status = 404, description = "Namespace not found", body = ApiError),
             crate::http::openapi::DeadlineExceededResponses
@@ -379,12 +391,32 @@ pub(super) async fn list_checkpoints(
     State(state): State<AppState>,
     namespace_id_path: NamespaceIdPath,
     headers: HeaderMap,
+    query: AppQuery<CheckpointPageQuery>,
 ) -> Result<Json<ListCheckpointsResponse>, ApiResponseError> {
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
+    let query = query.into_params()?;
+    let cursor = query
+        .cursor
+        .as_deref()
+        .map(|cursor| decode_namespace_cursor::<CheckpointPageCursor>(cursor, &namespace_id))
+        .transpose()
+        .map_err(|error| {
+            ApiResponseError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                &error.to_string(),
+            )
+        })?;
     let response = state
         .admin
-        .list_checkpoints(&namespace_id)
+        .list_checkpoints_page(
+            &namespace_id,
+            PageRequest {
+                limit: resolve_page_limit(query.limit)?,
+                cursor,
+            },
+        )
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -372,7 +372,7 @@ pub(super) async fn create_checkpoint(
         path = "/v0/admin/namespaces/{namespace_id}/checkpoints",
         tag = "admin",
         summary = "List checkpoints",
-        description = "Lists one bounded page of active checkpoint records in ascending checkpoint-id order. Each record is a garbage-collection root, and its id is what the release endpoint takes; because a checkpoint name is a label rather than a key, this is the only way to find a pin whose creation response is gone. An expired record that no collection pass has released yet is still active and is listed, with its expiry in the entry. Released records are absent. Pagination is a live key-order resume, not a snapshot.",
+        description = "Lists one page of active checkpoints in checkpoint-id order. Expired checkpoints remain visible until collection releases them. Released checkpoints are omitted. The cursor resumes a live listing and does not create a snapshot.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("limit" = Option<String>, Query, description = "Maximum page size"),

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -394,11 +394,12 @@ impl ObjectStore for StaleHeadOnceStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 
@@ -1695,7 +1696,7 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
         // The checkpoint inventory names this deployment's garbage-collection
         // roots, so it answers behind the same token as everything else.
         assert_api_error(
-            client.list_checkpoints(&namespace_id("demo")).await,
+            client.list_checkpoints_all(&namespace_id("demo")).await,
             401,
             "unauthorized",
             Some("missing or invalid bearer token"),
@@ -3308,11 +3309,12 @@ mod direct_download {
             self.inner.delete(key).await
         }
 
-        fn list_prefix_stream(
+        fn list_prefix_from_stream(
             &self,
             prefix: &str,
+            start_after: Option<&str>,
         ) -> futures::stream::BoxStream<'static, Result<String, ObjectStoreError>> {
-            self.inner.list_prefix_stream(prefix)
+            self.inner.list_prefix_from_stream(prefix, start_after)
         }
     }
 

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -3,8 +3,9 @@
 use crate::common::http_split_support::*;
 use crate::common::start_server;
 use loonfs_api::{
-    v0::FilesystemChange, ApiError, ChangeSeq, CommitId, DestinationBehavior,
-    ListPathEntriesResponse, RevisionNo,
+    v0::FilesystemChange, ApiError, ChangeSeq, CommitId, CreateCheckpointRequest,
+    DestinationBehavior, ListCheckpointsResponse, ListPathEntriesResponse, RevisionNo,
+    DEFAULT_MAX_PAGE_LIMIT,
 };
 use loonfs_client::{
     ClientError, CreateDirectoryOptions, MoveOptions, NamespacePath, PutFileOptions,
@@ -26,6 +27,133 @@ fn entry_names(response: &ListPathEntriesResponse) -> Vec<&str> {
                 .as_str()
         })
         .collect()
+}
+
+fn assert_invalid_request<T: std::fmt::Debug>(result: Result<T, ClientError>) {
+    match result.expect_err("request should be rejected") {
+        ClientError::Api { status, code, .. } => {
+            assert_eq!(status, 400);
+            assert_eq!(code, "invalid_request");
+        }
+        other => unreachable!("expected invalid_request API error, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_paginates_checkpoint_inventory_and_rejects_invalid_requests() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "loonfs-server-test",
+        "http-checkpoint-pagination",
+    ))
+    .await;
+    let demo = namespace_id("demo");
+    let other = namespace_id("other");
+    for namespace_id in [&demo, &other] {
+        harness
+            .client
+            .create_namespace(namespace_id)
+            .await
+            .expect("create namespace");
+    }
+
+    let mut expected_ids = Vec::new();
+    for index in 0..5 {
+        expected_ids.push(
+            harness
+                .client
+                .create_checkpoint(
+                    &demo,
+                    &CreateCheckpointRequest {
+                        name: format!("pin-{index}"),
+                        ttl_ms: None,
+                    },
+                )
+                .await
+                .expect("create checkpoint")
+                .checkpoint_id,
+        );
+    }
+    expected_ids.sort();
+
+    let mut actual_ids = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = harness
+            .client
+            .list_checkpoints_page(&demo, Some(2), cursor.as_deref())
+            .await
+            .expect("list checkpoint page");
+        actual_ids.extend(
+            page.checkpoints
+                .into_iter()
+                .map(|checkpoint| checkpoint.checkpoint_id),
+        );
+        let Some(next_cursor) = page.next_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+    assert_eq!(actual_ids, expected_ids);
+
+    let all = harness
+        .client
+        .list_checkpoints_all(&demo)
+        .await
+        .expect("aggregate checkpoint pages");
+    assert_eq!(
+        all.checkpoints
+            .into_iter()
+            .map(|checkpoint| checkpoint.checkpoint_id)
+            .collect::<Vec<_>>(),
+        expected_ids
+    );
+    assert!(all.next_cursor.is_none());
+
+    let first = harness
+        .client
+        .list_checkpoints_page(&demo, Some(1), None)
+        .await
+        .expect("first checkpoint page");
+    let foreign_cursor = first.next_cursor.expect("checkpoint cursor");
+    assert_invalid_request(
+        harness
+            .client
+            .list_checkpoints_page(&other, Some(1), Some(&foreign_cursor))
+            .await,
+    );
+    assert_invalid_request(
+        harness
+            .client
+            .list_checkpoints_page(&demo, Some(1), Some("not-a-cursor"))
+            .await,
+    );
+    assert_invalid_request(
+        harness
+            .client
+            .list_checkpoints_page(&demo, Some(0), None)
+            .await,
+    );
+    assert_invalid_request(
+        harness
+            .client
+            .list_checkpoints_page(&demo, Some(DEFAULT_MAX_PAGE_LIMIT + 1), None)
+            .await,
+    );
+
+    let raw: ListCheckpointsResponse = get_json(
+        &format!(
+            "{}/v0/admin/namespaces/demo/checkpoints?limit=1",
+            harness.server_url
+        ),
+        "test-token",
+    )
+    .expect("raw checkpoint page");
+    assert_eq!(raw.checkpoints.len(), 1);
+    assert!(raw.next_cursor.is_some());
+
+    harness.server.abort();
 }
 
 fn get_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> Result<T, ApiError> {

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -91,6 +91,12 @@ fn openapi_documents_current_server_paths() {
         "get",
         &["after_seq", "limit"],
     );
+    assert_query_params(
+        paths,
+        "/v0/admin/namespaces/{namespace_id}/checkpoints",
+        "get",
+        &["limit", "cursor"],
+    );
 
     let mut namespace_scoped_operations = 0;
     for (path, path_item) in paths {

--- a/crates/loonfs-sim/src/fault_store.rs
+++ b/crates/loonfs-sim/src/fault_store.rs
@@ -512,9 +512,10 @@ where
         .await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         let op = self.next_object_op(ObjectOperationKind::ListPrefix, prefix);
         let scheduled = self.scheduled_fault(&op);
@@ -543,7 +544,7 @@ where
             };
 
         Box::pin(TracedListStream {
-            inner: self.inner.list_prefix_stream(prefix),
+            inner: self.inner.list_prefix_from_stream(prefix, start_after),
             trace: self.trace.clone(),
             op: Some(op),
             operation,

--- a/crates/loonfs-test-support/src/stores/blocking_store.rs
+++ b/crates/loonfs-test-support/src/stores/blocking_store.rs
@@ -290,13 +290,14 @@ impl<S: ObjectStore> ObjectStore for BlockingStore<S> {
         result
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         let selected = self.matches(&OperationContext::new(prefix, OperationKind::List));
         let gate = Arc::clone(&self.gate);
-        let inner = self.inner.list_prefix_stream(prefix);
+        let inner = self.inner.list_prefix_from_stream(prefix, start_after);
         if !selected {
             return inner;
         }

--- a/crates/loonfs-test-support/src/stores/buffer_watch_store.rs
+++ b/crates/loonfs-test-support/src/stores/buffer_watch_store.rs
@@ -205,10 +205,11 @@ impl<S: ObjectStore> ObjectStore for BufferWatchStore<S> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-test-support/src/stores/concurrency_watch_store.rs
+++ b/crates/loonfs-test-support/src/stores/concurrency_watch_store.rs
@@ -152,10 +152,11 @@ impl<S: ObjectStore> ObjectStore for ConcurrencyWatchStore<S> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-test-support/src/stores/counting_store.rs
+++ b/crates/loonfs-test-support/src/stores/counting_store.rs
@@ -304,13 +304,14 @@ impl<S: ObjectStore> ObjectStore for CountingStore<S> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         if self.matches(prefix) {
             self.counters.lists.fetch_add(1, Ordering::SeqCst);
         }
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-test-support/src/stores/fail_store.rs
+++ b/crates/loonfs-test-support/src/stores/fail_store.rs
@@ -319,9 +319,10 @@ impl<S: ObjectStore> ObjectStore for FailStore<S> {
         }
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         if self.should_fail(&OperationContext::new(prefix, OperationKind::List)) {
             return Box::pin(stream::once({
@@ -329,6 +330,6 @@ impl<S: ObjectStore> ObjectStore for FailStore<S> {
                 async move { Err(error) }
             }));
         }
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-test-support/src/stores/metadata_map_store.rs
+++ b/crates/loonfs-test-support/src/stores/metadata_map_store.rs
@@ -154,10 +154,11 @@ impl<S: ObjectStore> ObjectStore for MetadataMapStore<S> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-test-support/src/stores/mod.rs
+++ b/crates/loonfs-test-support/src/stores/mod.rs
@@ -21,3 +21,67 @@ pub use metadata_map_store::MetadataMapStore;
 pub use multipart_store::{MultipartChecksumEnforcement, MultipartStore};
 pub use operation::{OperationClass, OperationContext, OperationKind};
 pub use recording_store::{RecordedGet, RecordedOperation, RecordingStore};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use futures::TryStreamExt;
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
+    use loonfs_objectstore::ObjectStore;
+
+    #[tokio::test]
+    async fn wrappers_preserve_the_start_after_contract() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("local store");
+        let store = MultipartStore::new(store);
+        let store = MetadataMapStore::new(store, KeyPredicate::any(), |metadata| metadata);
+        let store = FailStore::new(
+            store,
+            KeyPredicate::any(),
+            OperationClass::List,
+            InjectedError::Transport("unused".to_owned()),
+        );
+        let store = BlockingStore::new(store, KeyPredicate::any(), OperationClass::List);
+        let store = BufferWatchStore::new(store, KeyPredicate::any());
+        let store = ConcurrencyWatchStore::new(store, KeyPredicate::any());
+        let store = CountingStore::new(store, KeyPredicate::any());
+        let store = RecordingStore::new(store, KeyPredicate::any());
+
+        let prefix = "contract/start-after/";
+        let keys = [
+            format!("{prefix}a"),
+            format!("{prefix}c"),
+            format!("{prefix}e"),
+        ];
+        for key in &keys {
+            store
+                .put_overwrite(key, Bytes::from_static(b"fixture"))
+                .await
+                .expect("write fixture");
+        }
+
+        let exact = store
+            .list_prefix_from_stream(prefix, Some(&keys[0]))
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("list after exact key");
+        assert_eq!(exact, keys[1..]);
+
+        let absent = format!("{prefix}d");
+        let gap = store
+            .list_prefix_from_stream(prefix, Some(&absent))
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("list after absent key");
+        assert_eq!(gap, keys[2..]);
+
+        let past_end = format!("{prefix}z");
+        let complete = store
+            .list_prefix_from_stream(prefix, Some(&past_end))
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("list after end");
+        assert!(complete.is_empty());
+    }
+}

--- a/crates/loonfs-test-support/src/stores/multipart_store.rs
+++ b/crates/loonfs-test-support/src/stores/multipart_store.rs
@@ -231,7 +231,11 @@ impl<S: ObjectStore> ObjectStore for MultipartStore<S> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(&self, prefix: &str) -> BoxStream<'static, Result<String>> {
-        self.inner.list_prefix_stream(prefix)
+    fn list_prefix_from_stream(
+        &self,
+        prefix: &str,
+        start_after: Option<&str>,
+    ) -> BoxStream<'static, Result<String>> {
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs-test-support/src/stores/recording_store.rs
+++ b/crates/loonfs-test-support/src/stores/recording_store.rs
@@ -227,13 +227,14 @@ impl<S: ObjectStore> ObjectStore for RecordingStore<S> {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
         self.record(RecordedOperation::List {
             prefix: prefix.to_owned(),
         });
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -610,16 +610,7 @@ impl FsAdmin {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    /// Lists every active checkpoint record by aggregating bounded pages.
-    ///
-    /// This is how a pin is found again when the creation response is gone:
-    /// every call to [`Self::create_checkpoint`] mints its own record under
-    /// its own id, so a label identifies nothing, and a record nobody can
-    /// name is a garbage-collection root nobody can release. A record whose
-    /// expiry has passed but which no collection pass has released yet is
-    /// still active and still listed, with its expiry in the answer.
-    ///
-    /// A read: it releases nothing and reaps nothing.
+    /// Lists every active checkpoint by following bounded pages.
     pub async fn list_checkpoints_all(
         &self,
         namespace_id: &NamespaceId,
@@ -650,10 +641,8 @@ impl FsAdmin {
         Ok(response)
     }
 
-    /// Lists one bounded page of active checkpoint records in ascending id order.
-    ///
-    /// The cursor is an opaque live-list resume position, not a snapshot pin.
-    /// Released, reaped, or concurrently deleted records are skipped.
+    /// Lists one page of active checkpoints in ascending id order. The cursor
+    /// resumes a live listing and does not create a snapshot.
     pub async fn list_checkpoints_page(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -9,13 +9,16 @@ use crate::maintenance_runner::CompactionStart;
 use crate::FsAdmin;
 use crate::NamespaceStatusResponse;
 use crate::{
-    AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
-    ErrorCode, FlushWalOutcome, FlushWalResponse, ListCheckpointsResponse, MaintenancePlan,
-    MaintenanceStepResponse, MetadataMaintenanceOptions, MetadataMaintenanceResponse, NamespaceId,
-    ReleaseCheckpointResponse, ReorganizeStepOutcome, SharedObjectStore, WalFlushStepOutcome,
+    AdvanceRetentionResponse, CheckpointId, CoreError, CreateCheckpointOptions,
+    CreateCheckpointResponse, ErrorCode, FlushWalOutcome, FlushWalResponse,
+    ListCheckpointsResponse, MaintenancePlan, MaintenanceStepResponse, MetadataMaintenanceOptions,
+    MetadataMaintenanceResponse, NamespaceId, ReleaseCheckpointResponse, ReorganizeStepOutcome,
+    SharedObjectStore, WalFlushStepOutcome,
 };
 use crate::{ChangeSeq, Result, RuntimeError};
+use loonfs_api::{encode_cursor, PageRequest};
 use loonfs_core::cache::{load_namespace_fold_basis, load_namespace_head_summary};
+use loonfs_core::CheckpointPageCursor;
 use tokio::time::Instant;
 
 #[cfg(test)]
@@ -607,7 +610,7 @@ impl FsAdmin {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    /// Lists every active checkpoint record on a namespace, oldest first.
+    /// Lists every active checkpoint record by aggregating bounded pages.
     ///
     /// This is how a pin is found again when the creation response is gone:
     /// every call to [`Self::create_checkpoint`] mints its own record under
@@ -617,14 +620,75 @@ impl FsAdmin {
     /// still active and still listed, with its expiry in the answer.
     ///
     /// A read: it releases nothing and reaps nothing.
-    pub async fn list_checkpoints(
+    pub async fn list_checkpoints_all(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<ListCheckpointsResponse> {
-        self.engine(namespace_id)
-            .list_checkpoints()
+        let limit = super::core::default_page_limit();
+        let (mut response, mut next_cursor) = self
+            .list_checkpoints_page_typed(
+                namespace_id,
+                PageRequest {
+                    limit,
+                    cursor: None,
+                },
+            )
+            .await?;
+        while let Some(cursor) = next_cursor {
+            let (page, page_next_cursor) = self
+                .list_checkpoints_page_typed(
+                    namespace_id,
+                    PageRequest {
+                        limit,
+                        cursor: Some(cursor),
+                    },
+                )
+                .await?;
+            response.checkpoints.extend(page.checkpoints);
+            next_cursor = page_next_cursor;
+        }
+        Ok(response)
+    }
+
+    /// Lists one bounded page of active checkpoint records in ascending id order.
+    ///
+    /// The cursor is an opaque live-list resume position, not a snapshot pin.
+    /// Released, reaped, or concurrently deleted records are skipped.
+    pub async fn list_checkpoints_page(
+        &self,
+        namespace_id: &NamespaceId,
+        request: PageRequest<CheckpointPageCursor>,
+    ) -> Result<ListCheckpointsResponse> {
+        let (mut response, next_cursor) = self
+            .list_checkpoints_page_typed(namespace_id, request)
+            .await?;
+        response.next_cursor = next_cursor
+            .as_ref()
+            .map(encode_cursor)
+            .transpose()
+            .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+        Ok(response)
+    }
+
+    async fn list_checkpoints_page_typed(
+        &self,
+        namespace_id: &NamespaceId,
+        request: PageRequest<CheckpointPageCursor>,
+    ) -> Result<(ListCheckpointsResponse, Option<CheckpointPageCursor>)> {
+        let page = self
+            .engine(namespace_id)
+            .list_checkpoints_page(request)
             .await
-            .map_err(RuntimeError::from)
+            .map_err(RuntimeError::from)?;
+        let next_cursor = page.next_cursor;
+        Ok((
+            ListCheckpointsResponse {
+                namespace_id: namespace_id.clone(),
+                checkpoints: page.items,
+                next_cursor: None,
+            },
+            next_cursor,
+        ))
     }
 
     /// Releases a user-owned checkpoint by id. Idempotent.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -114,10 +114,10 @@ pub use loonfs_core::limits::{
 pub use loonfs_core::time::current_time_ms;
 pub use loonfs_core::{
     delete_if_aged, AgedSweep, BootstrapNamespaceError, CheckpointFile, CheckpointFilesPage,
-    CheckpointFilesPageCursor, CurrentFileState, DeleteNamespaceOptions, Error as CoreError,
-    ErrorCode, ErrorKind, FileContentStream, GcConfig, MetadataCompactionJobOutcome,
-    MetadataViewError, PassBudget, StoreFailureClass, WriterFence, CONTENT_READ_CHUNK_BYTES,
-    MAX_RESOLVE_CURRENT_FILES,
+    CheckpointFilesPageCursor, CheckpointPageCursor, CurrentFileState, DeleteNamespaceOptions,
+    Error as CoreError, ErrorCode, ErrorKind, FileContentStream, GcConfig,
+    MetadataCompactionJobOutcome, MetadataViewError, PassBudget, StoreFailureClass, WriterFence,
+    CONTENT_READ_CHUNK_BYTES, MAX_RESOLVE_CURRENT_FILES,
 };
 pub use publisher::PublishObserver;
 

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -169,11 +169,12 @@ impl ObjectStore for PanicHeadCasStore {
         self.inner.delete(key).await
     }
 
-    fn list_prefix_stream(
+    fn list_prefix_from_stream(
         &self,
         prefix: &str,
+        start_after: Option<&str>,
     ) -> BoxStream<'static, Result<String, ObjectStoreError>> {
-        self.inner.list_prefix_stream(prefix)
+        self.inner.list_prefix_from_stream(prefix, start_after)
     }
 }
 

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -756,7 +756,7 @@ fn tombstoned_namespace_keeps_checkpoint_inventory_and_user_release_available() 
         .expect("create user checkpoint");
 
     let before_delete =
-        block_on(fs.admin.list_checkpoints(&source)).expect("list checkpoints before deletion");
+        block_on(fs.admin.list_checkpoints_all(&source)).expect("list checkpoints before deletion");
     let fork_checkpoint = before_delete
         .checkpoints
         .iter()
@@ -787,8 +787,8 @@ fn tombstoned_namespace_keeps_checkpoint_inventory_and_user_release_available() 
             .build(),
     )
     .expect("build post-delete admin");
-    let listed =
-        block_on(admin.list_checkpoints(&source)).expect("list checkpoints on deleted namespace");
+    let listed = block_on(admin.list_checkpoints_all(&source))
+        .expect("list checkpoints on deleted namespace");
     assert_eq!(listed.checkpoints.len(), 2);
     assert!(listed
         .checkpoints

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -676,7 +676,7 @@ A representative v0 binding is shown below.
 | Fork a namespace | `POST /v0/namespaces/{source_ns}/forks` |
 | Delete a namespace | `DELETE /v0/namespaces/{ns}?expected_head_seq=418` (feature `core.namespaces.delete`; the precondition is optional) |
 | Create a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoints` (body carries the required `name` and optional `ttl_ms`; every call mints a new user-owned record under a new id, and that record is a GC root until it is released) |
-| List checkpoints | `GET /v0/admin/namespaces/{ns}/checkpoints` (every active record, oldest first, with the id the release route takes; see below) |
+| List checkpoints | `GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` (one bounded page of active records in ascending checkpoint-id order, with the id the release route takes; see below) |
 | Release a checkpoint | `POST /v0/admin/namespaces/{ns}/checkpoints/{checkpoint_id}/release` (idempotent and one-way; fork-owned records are rejected) |
 | Run a maintenance step | `POST /v0/admin/namespaces/{ns}/maintenance/step` (the one maintenance entry point; see below) |
 | Content search | `POST /v0/namespaces/{ns}/query/grep` (feature `query.grep`; requires a materialized steady-state grep root) |
@@ -792,14 +792,33 @@ creation response is where that id comes from, so losing it — or never
 seeing it — would otherwise leave a garbage-collection root nobody can name.
 The listing is the way back to it.
 
-`GET /v0/admin/namespaces/{ns}/checkpoints` returns every active record on
-the namespace, oldest first, each carrying its `checkpoint_id`, `owner`,
+`GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` returns one
+bounded page of active records in ascending `checkpoint_id` order, which is
+the durable checkpoint-record key order. Efficient oldest-first listing
+would require a durable creation-time index that this inventory endpoint
+does not justify. Each entry carries its `checkpoint_id`, `owner`,
 `created_at_ms`, `expires_at_ms` (absent when the pin holds until released),
 `checkpoint_seq`, and `manifest_id` — the same identity the create response
 returned. `owner` is tagged: `user` carries the label the creator recorded,
 and `fork` carries the `target_namespace_id` whose existence keeps that
 lease standing. Only a `user` record is released by id; a `fork` record goes
-when its target namespace does.
+when its target namespace does. `limit` uses the advertised
+`pagination.default` and `pagination.max` limits; zero and over-limit values
+answer `invalid_request`. `next_cursor` is absent once the enumerated
+checkpoint keyspace is complete.
+
+The cursor is opaque, URL-safe, namespace-bound, and operation-bound. It
+encodes the last checkpoint-record key the page inspected, not the last
+active checkpoint it returned: released records and records reaped between
+listing and loading are skipped while still advancing the resume position.
+Resumption is strictly after that key, so a run of filtered records cannot
+stall a caller. Clients must only round-trip cursor strings returned by this
+endpoint; their encoding is internal and may change between builds.
+
+Checkpoint pagination is a live listing, not a snapshot. A record released
+or reaped between key listing and record loading is skipped; a checkpoint
+created before the cursor position is not returned by a later page, while
+one created after it can appear. Listing creates no snapshot pin.
 
 Released records are absent, because a release is what stops a record
 pinning anything. A record whose `expires_at_ms` has passed is still

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -792,33 +792,18 @@ creation response is where that id comes from, so losing it — or never
 seeing it — would otherwise leave a garbage-collection root nobody can name.
 The listing is the way back to it.
 
-`GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` returns one
-bounded page of active records in ascending `checkpoint_id` order, which is
-the durable checkpoint-record key order. Efficient oldest-first listing
-would require a durable creation-time index that this inventory endpoint
-does not justify. Each entry carries its `checkpoint_id`, `owner`,
-`created_at_ms`, `expires_at_ms` (absent when the pin holds until released),
-`checkpoint_seq`, and `manifest_id` — the same identity the create response
-returned. `owner` is tagged: `user` carries the label the creator recorded,
-and `fork` carries the `target_namespace_id` whose existence keeps that
-lease standing. Only a `user` record is released by id; a `fork` record goes
-when its target namespace does. `limit` uses the advertised
-`pagination.default` and `pagination.max` limits; zero and over-limit values
-answer `invalid_request`. `next_cursor` is absent once the enumerated
-checkpoint keyspace is complete.
+`GET /v0/admin/namespaces/{ns}/checkpoints?limit=100&cursor=...` returns active
+checkpoints in ascending `checkpoint_id` order. Each entry includes its id,
+owner, creation and expiration times, checkpoint sequence, and manifest id.
+User checkpoints can be released by id. Fork checkpoints remain until their
+target namespace is deleted.
 
-The cursor is opaque, URL-safe, namespace-bound, and operation-bound. It
-encodes the last checkpoint-record key the page inspected, not the last
-active checkpoint it returned: released records and records reaped between
-listing and loading are skipped while still advancing the resume position.
-Resumption is strictly after that key, so a run of filtered records cannot
-stall a caller. Clients must only round-trip cursor strings returned by this
-endpoint; their encoding is internal and may change between builds.
+`limit` follows the advertised pagination limits. `next_cursor` is omitted
+after the final page. Cursors are opaque and tied to this namespace and
+operation; clients should only return them unchanged.
 
-Checkpoint pagination is a live listing, not a snapshot. A record released
-or reaped between key listing and record loading is skipped; a checkpoint
-created before the cursor position is not returned by a later page, while
-one created after it can appear. Listing creates no snapshot pin.
+This is a live listing, not a snapshot. Checkpoints created, released, or
+collected while a client is paging can affect later pages.
 
 Released records are absent, because a release is what stops a record
 pinning anything. A record whose `expires_at_ms` has passed is still

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -117,7 +117,7 @@
           "admin"
         ],
         "summary": "List checkpoints",
-        "description": "Lists one bounded page of active checkpoint records in ascending checkpoint-id order. Each record is a garbage-collection root, and its id is what the release endpoint takes; because a checkpoint name is a label rather than a key, this is the only way to find a pin whose creation response is gone. An expired record that no collection pass has released yet is still active and is listed, with its expiry in the entry. Released records are absent. Pagination is a live key-order resume, not a snapshot.",
+        "description": "Lists one page of active checkpoints in checkpoint-id order. Expired checkpoints remain visible until collection releases them. Released checkpoints are omitted. The cursor resumes a live listing and does not create a snapshot.",
         "operationId": "list_checkpoints",
         "parameters": [
           {
@@ -5360,7 +5360,7 @@
       },
       "ListCheckpointsResponse": {
         "type": "object",
-        "description": "One bounded page of active checkpoint records a namespace currently carries.",
+        "description": "One page of active checkpoint records.",
         "required": [
           "namespace_id",
           "checkpoints"
@@ -5371,7 +5371,7 @@
             "items": {
               "$ref": "#/components/schemas/CheckpointSummary"
             },
-            "description": "Active records in ascending checkpoint-id order. Released records are absent because a\nrelease is what stops a record pinning anything; a released record\nthat garbage collection has not yet deleted is not reported either."
+            "description": "Active records in ascending checkpoint-id order. Released records are\nomitted even if garbage collection has not deleted them yet."
           },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
@@ -5382,7 +5382,7 @@
               "string",
               "null"
             ],
-            "description": "Opaque cursor for the next page, omitted when this key enumeration is complete."
+            "description": "Opaque cursor for the next page."
           }
         }
       },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -117,7 +117,7 @@
           "admin"
         ],
         "summary": "List checkpoints",
-        "description": "Lists every active checkpoint record on the namespace, oldest first. Each record is a garbage-collection root, and its id is what the release endpoint takes; because a checkpoint name is a label rather than a key, this is the only way to find a pin whose creation response is gone. An expired record that no collection pass has released yet is still active and is listed, with its expiry in the entry — the operator is looking for roots, and a record that still pins its basis is one. Released records are absent: a release is what stops a record pinning anything.",
+        "description": "Lists one bounded page of active checkpoint records in ascending checkpoint-id order. Each record is a garbage-collection root, and its id is what the release endpoint takes; because a checkpoint name is a label rather than a key, this is the only way to find a pin whose creation response is gone. An expired record that no collection pass has released yet is still active and is listed, with its expiry in the entry. Released records are absent. Pagination is a live key-order resume, not a snapshot.",
         "operationId": "list_checkpoints",
         "parameters": [
           {
@@ -125,6 +125,24 @@
             "in": "path",
             "description": "Namespace id",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque checkpoint-list page cursor",
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -142,7 +160,7 @@
             }
           },
           "400": {
-            "description": "Invalid namespace id",
+            "description": "Invalid namespace id, limit, or cursor",
             "content": {
               "application/json": {
                 "schema": {
@@ -5342,7 +5360,7 @@
       },
       "ListCheckpointsResponse": {
         "type": "object",
-        "description": "Every active checkpoint record a namespace currently carries.",
+        "description": "One bounded page of active checkpoint records a namespace currently carries.",
         "required": [
           "namespace_id",
           "checkpoints"
@@ -5353,11 +5371,18 @@
             "items": {
               "$ref": "#/components/schemas/CheckpointSummary"
             },
-            "description": "Active records, oldest first. Released records are absent because a\nrelease is what stops a record pinning anything; a released record\nthat garbage collection has not yet deleted is not reported either."
+            "description": "Active records in ascending checkpoint-id order. Released records are absent because a\nrelease is what stops a record pinning anything; a released record\nthat garbage collection has not yet deleted is not reported either."
           },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
             "description": "Namespace the records belong to."
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque cursor for the next page, omitted when this key enumeration is complete."
           }
         }
       },


### PR DESCRIPTION
Adds bounded pagination to checkpoint listing. Checkpoints are returned in ascending checkpoint-id order with an opaque cursor for the next page. Released or concurrently collected records are skipped, while expired records remain visible until collection releases them. The cursor resumes a live listing and does not create a snapshot.

The runtime and client expose both single-page and aggregate methods. The CLI follows all pages by default and accepts `--limit` and `--cursor` for one-page requests. Object-store implementations now support listing strictly after a key so later pages can resume consistently across local storage, S3-compatible stores, GCS, and Azure.