### PR TITLE
feat(api): read inodes by identity

### DIFF
--- a/crates/loonfs-api/src/error.rs
+++ b/crates/loonfs-api/src/error.rs
@@ -140,6 +140,7 @@ error_codes! {
     NamespaceExists => "namespace_exists",
     ContentNotPrepared => "content_not_prepared",
     PathNotFound => "path_not_found",
+    InodeNotFound => "inode_not_found",
     RevisionNotFound => "revision_not_found",
     PathConflict => "path_conflict",
     DirectoryNotEmpty => "directory_not_empty",
@@ -188,6 +189,7 @@ impl ErrorCode {
             ErrorCode::NotSupported => ErrorKind::NotSupported,
             ErrorCode::NamespaceNotFound
             | ErrorCode::PathNotFound
+            | ErrorCode::InodeNotFound
             | ErrorCode::RevisionNotFound
             | ErrorCode::UploadNotFound
             | ErrorCode::RouteNotFound => ErrorKind::NotFound,
@@ -251,6 +253,7 @@ impl ErrorCode {
             | ErrorCode::NamespaceExists
             | ErrorCode::ContentNotPrepared
             | ErrorCode::PathNotFound
+            | ErrorCode::InodeNotFound
             | ErrorCode::RevisionNotFound
             | ErrorCode::PathConflict
             | ErrorCode::DirectoryNotEmpty

--- a/crates/loonfs-api/src/v0/downloads.rs
+++ b/crates/loonfs-api/src/v0/downloads.rs
@@ -8,7 +8,7 @@
 //! send this method to this URL with these headers, before this instant.
 
 use super::ObjectTransferAccess;
-use crate::{AbsolutePath, ContentRef, NamespaceId, RevisionNo};
+use crate::{AbsolutePath, ContentRef, InodeId, NamespaceId, RevisionNo};
 use serde::{Deserialize, Serialize};
 
 /// What a client names when it asks to read a file directly.
@@ -75,9 +75,37 @@ pub struct BeginDownloadResponse {
     pub access: ObjectTransferAccess,
 }
 
+/// Strict empty body for a download already addressed by route identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
+pub struct BeginDownloadByInodeRequest {}
+
+/// A short-lived capability to read one inode revision's content object.
+///
+/// Historical inode identity is deliberately path-free: the inode may have
+/// moved since the revision was written or may have no current binding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct BeginDownloadByInodeResponse {
+    /// Namespace that was read.
+    pub namespace_id: NamespaceId,
+    /// File inode whose revision is authorized.
+    pub inode_id: InodeId,
+    /// Revision the capability reads.
+    pub revision_no: RevisionNo,
+    /// Identity, byte length, and checksum evidence for the authorized object.
+    pub content_ref: ContentRef,
+    /// Short-lived read capability the client uses without learning the raw object key.
+    pub access: ObjectTransferAccess,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{BeginDownloadRequest, BeginDownloadResponse};
+    use super::{
+        BeginDownloadByInodeRequest, BeginDownloadByInodeResponse, BeginDownloadRequest,
+        BeginDownloadResponse,
+    };
     use crate::v0::ObjectTransferAccess;
     use crate::{AbsolutePath, ContentId, ContentRef, NamespaceId, RevisionNo};
     use std::collections::BTreeMap;
@@ -127,5 +155,29 @@ mod tests {
         let json = serde_json::to_string(&response).expect("serialize response");
         assert!(json.contains(r#""kind":"presigned_url""#));
         assert!(!json.contains("object_key"));
+    }
+
+    #[test]
+    fn an_inode_download_request_is_strictly_empty_and_its_grant_is_path_free() {
+        let request: BeginDownloadByInodeRequest =
+            serde_json::from_str("{}").expect("decode empty request");
+        assert_eq!(request, BeginDownloadByInodeRequest {});
+        assert!(serde_json::from_str::<BeginDownloadByInodeRequest>(r#"{"path":"/old"}"#).is_err());
+
+        let response = BeginDownloadByInodeResponse {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            inode_id: crate::InodeId(42),
+            revision_no: RevisionNo(7),
+            content_ref: ContentRef::blob_v1(ContentId::generate(), b"hello"),
+            access: ObjectTransferAccess::PresignedUrl {
+                method: "GET".to_owned(),
+                url: "https://bucket.example/object?X-Amz-Signature=abc".to_owned(),
+                headers: BTreeMap::new(),
+                expires_at_ms: 1,
+            },
+        };
+        let json = serde_json::to_value(response).expect("serialize response");
+        assert_eq!(json["inode_id"], 42);
+        assert!(json.get("path").is_none());
     }
 }

--- a/crates/loonfs-api/src/v0/downloads.rs
+++ b/crates/loonfs-api/src/v0/downloads.rs
@@ -75,28 +75,25 @@ pub struct BeginDownloadResponse {
     pub access: ObjectTransferAccess,
 }
 
-/// Strict empty body for a download already addressed by route identity.
+/// Empty request for an inode-addressed download.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
 pub struct BeginDownloadByInodeRequest {}
 
-/// A short-lived capability to read one inode revision's content object.
-///
-/// Historical inode identity is deliberately path-free: the inode may have
-/// moved since the revision was written or may have no current binding.
+/// A short-lived capability to read one inode revision.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct BeginDownloadByInodeResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
-    /// File inode whose revision is authorized.
+    /// File inode being read.
     pub inode_id: InodeId,
-    /// Revision the capability reads.
+    /// Revision being read.
     pub revision_no: RevisionNo,
-    /// Identity, byte length, and checksum evidence for the authorized object.
+    /// Content identity, size, and checksum.
     pub content_ref: ContentRef,
-    /// Short-lived read capability the client uses without learning the raw object key.
+    /// Short-lived provider access without the raw object key.
     pub access: ObjectTransferAccess,
 }
 

--- a/crates/loonfs-api/src/v0/mod.rs
+++ b/crates/loonfs-api/src/v0/mod.rs
@@ -23,7 +23,10 @@ mod search;
 mod uploads;
 
 pub use commits::{ChangesResponse, CommitResponse, CommittedChange, FilesystemChange};
-pub use downloads::{BeginDownloadRequest, BeginDownloadResponse};
+pub use downloads::{
+    BeginDownloadByInodeRequest, BeginDownloadByInodeResponse, BeginDownloadRequest,
+    BeginDownloadResponse,
+};
 pub use operations::{
     AdvanceRetentionResponse, ApiError, CheckpointOwnerSummary, CheckpointSummary, CommitRequest,
     CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -409,8 +409,6 @@ pub struct FileRevision {
 pub struct ListFileRevisionsResponse {
     /// Namespace that was read.
     pub namespace_id: NamespaceId,
-    /// Absolute file path requested by the caller.
-    pub path: AbsolutePath,
     /// File inode whose revisions were returned.
     pub inode_id: InodeId,
     /// Namespace head sequence used for the read.

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -56,8 +56,8 @@ pub(crate) enum Command {
     Current(CurrentArgs),
     /// List a directory.
     Ls(FilesystemLsArgs),
-    /// Describe one path (kind, size, revision, content digest, attributes).
-    Stat(FilesystemPathArgs),
+    /// Describe one visible path or inode (kind, size, revision, content digest, attributes).
+    Stat(FilesystemStatArgs),
     /// Write and remove attributes on a file or directory.
     Annotate(FilesystemAnnotateArgs),
     /// Print a file's content to stdout.
@@ -444,10 +444,15 @@ pub(crate) struct FilesystemLsArgs {
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct FilesystemPathArgs {
+pub(crate) struct FilesystemStatArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
-    pub path: String,
+    /// Absolute path to describe. Omit when using `--inode`.
+    #[arg(required_unless_present = "inode", conflicts_with = "inode")]
+    pub path: Option<String>,
+    /// Currently visible inode to describe by stable identity.
+    #[arg(long, value_name = "INODE_ID")]
+    pub inode: Option<u64>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -447,10 +447,10 @@ pub(crate) struct FilesystemLsArgs {
 pub(crate) struct FilesystemStatArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
-    /// Absolute path to describe. Omit when using `--inode`.
+    /// Absolute path to describe.
     #[arg(required_unless_present = "inode", conflicts_with = "inode")]
     pub path: Option<String>,
-    /// Currently visible inode to describe by stable identity.
+    /// Visible inode to describe instead of a path.
     #[arg(long, value_name = "INODE_ID")]
     pub inode: Option<u64>,
 }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -240,6 +240,18 @@ impl EmbeddedBackend {
             .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
     }
 
+    pub(super) async fn stat_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        options: &StatPathOptions,
+    ) -> Result<AuthoritativePathEntry, BackendError> {
+        self.reader
+            .stat_inode(namespace_id, inode_id, options.clone())
+            .await
+            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+    }
+
     pub(super) async fn get_file_bytes(
         &self,
         spec: &NamespacePath,

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -353,7 +353,7 @@ impl ResolvedTarget {
             .await
     }
 
-    /// Describes one currently visible inode, attributes included.
+    /// Describes one visible inode, including its attributes.
     pub(crate) async fn stat_inode(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -353,6 +353,26 @@ impl ResolvedTarget {
             .await
     }
 
+    /// Describes one currently visible inode, attributes included.
+    pub(crate) async fn stat_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+    ) -> Result<AuthoritativePathEntry, BackendError> {
+        match self {
+            Self::Embedded(target) => {
+                target
+                    .backend
+                    .stat_inode(namespace_id, inode_id, &StatPathOptions::default())
+                    .await
+            }
+            Self::Remote(target) => Ok(target
+                .client
+                .stat_inode(namespace_id, inode_id, &StatPathOptions::default())
+                .await?),
+        }
+    }
+
     /// Describes a single path entry without its attributes: the shape a
     /// command that only needs the kind or the inode id asks for, so it pays
     /// neither the extra lookup nor the extra bytes over the wire.

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -14,8 +14,8 @@ use super::partial::{self, PartialDownload, PartialMeta};
 use super::recursive;
 use crate::args::{
     CommandKind, FilesystemAnnotateArgs, FilesystemCatArgs, FilesystemGetArgs, FilesystemGrepArgs,
-    FilesystemLsArgs, FilesystemMkdirArgs, FilesystemPathArgs, FilesystemPutArgs,
-    FilesystemRestoreArgs, FilesystemRevisionsArgs, FilesystemRmArgs, FilesystemTransferArgs,
+    FilesystemLsArgs, FilesystemMkdirArgs, FilesystemPutArgs, FilesystemRestoreArgs,
+    FilesystemRevisionsArgs, FilesystemRmArgs, FilesystemStatArgs, FilesystemTransferArgs,
     FilesystemUndeleteArgs, RuntimeBehavior, TrashArgs,
 };
 use crate::backend::FileDownload;
@@ -209,17 +209,28 @@ pub(crate) async fn run_filesystem_ls(
 pub(crate) async fn run_filesystem_stat(
     kind: CommandKind,
     config_path: &Path,
-    args: FilesystemPathArgs,
+    args: FilesystemStatArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
-    let allow_root = true;
-    let spec = namespace_path(&context.namespace, &args.path, allow_root)
-        .map_err(|error| context.fail(kind, error))?;
-    let entry = context
-        .target
-        .stat_path(&spec)
-        .await
-        .map_err(|error| context.fail(kind, error))?;
+    let entry = match args.inode {
+        Some(inode_id) => {
+            context
+                .target
+                .stat_inode(&context.namespace, InodeId(inode_id))
+                .await
+        }
+        None => {
+            let path = args
+                .path
+                .as_deref()
+                .expect("clap requires either path or --inode");
+            let allow_root = true;
+            let spec = namespace_path(&context.namespace, path, allow_root)
+                .map_err(|error| context.fail(kind, error))?;
+            context.target.stat_path(&spec).await
+        }
+    }
+    .map_err(|error| context.fail(kind, error))?;
 
     Ok(CommandOutput {
         kind,

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -3259,6 +3259,114 @@ fn embedded_and_remote_profiles_emit_the_same_error_codes() {
 }
 
 #[test]
+fn stat_inode_has_embedded_and_remote_parity_and_tracks_renames() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("embedded");
+    let remote_server =
+        harness.start_external_server(harness.write_server_config("remote", "stat-inode-parity"));
+    assert_success(&harness.run(&[
+        "--json",
+        "profile",
+        "create",
+        "remote",
+        "--mode",
+        "remote",
+        "--server-url",
+        &remote_server.server_url,
+        "--auth-token",
+        "test-token",
+    ]));
+    let payload = harness.temp_dir.path().join("inode-stat.txt");
+    fs::write(&payload, b"inode stat").expect("write payload");
+
+    for profile in ["embedded", "remote"] {
+        assert_success(&harness.run(&["namespace", "create", "--profile", profile, "demo"]));
+        assert_success(&harness.run(&[
+            "put",
+            "--profile",
+            profile,
+            "--namespace",
+            "demo",
+            payload.to_str().expect("utf-8 path"),
+            "/before.txt",
+        ]));
+        let by_path = harness.run(&[
+            "--json",
+            "stat",
+            "--profile",
+            profile,
+            "--namespace",
+            "demo",
+            "/before.txt",
+        ]);
+        assert_success(&by_path);
+        let inode_id = json_data(&by_path)["inode_id"]
+            .as_u64()
+            .expect("stat reports inode id");
+        let by_inode = harness.run(&[
+            "--json",
+            "stat",
+            "--profile",
+            profile,
+            "--namespace",
+            "demo",
+            "--inode",
+            &inode_id.to_string(),
+        ]);
+        assert_success(&by_inode);
+        assert_eq!(json_data(&by_inode), json_data(&by_path));
+
+        assert_success(&harness.run(&[
+            "mv",
+            "--profile",
+            profile,
+            "--namespace",
+            "demo",
+            "/before.txt",
+            "/after.txt",
+        ]));
+        let renamed = harness.run(&[
+            "--json",
+            "stat",
+            "--profile",
+            profile,
+            "--namespace",
+            "demo",
+            "--inode",
+            &inode_id.to_string(),
+        ]);
+        assert_success(&renamed);
+        assert_eq!(json_data(&renamed)["inode_id"], inode_id);
+        assert_eq!(json_data(&renamed)["path"], "/after.txt");
+
+        let missing = harness.run(&[
+            "--json",
+            "stat",
+            "--profile",
+            profile,
+            "--namespace",
+            "demo",
+            "--inode",
+            &u64::MAX.to_string(),
+        ]);
+        assert_failure(&missing);
+        assert_eq!(json_error(&missing)["code"], "inode_not_found");
+    }
+
+    let neither = harness.run(&["stat", "--profile", "embedded"]);
+    assert_failure(&neither);
+    let both = harness.run(&[
+        "stat",
+        "--profile",
+        "embedded",
+        "/after.txt",
+        "--inode",
+        "2",
+    ]);
+    assert_failure(&both);
+}
+
+#[test]
 fn filesystem_requires_default_namespace_when_omitted() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -23,14 +23,15 @@ use bytes::Bytes;
 use futures::StreamExt as _;
 use loonfs_api::{
     v0::{
-        AbortUploadResponse, BeginDownloadRequest, BeginDownloadResponse, BeginUploadRequest,
-        BeginUploadResponse, ChangesResponse, CommitResponse as ApiCommitResponse,
-        CompleteKnownContentUploadRequest, CompleteMultipartUploadRequest, CompleteUploadResponse,
-        CompletedUploadPart, ContentToken, DirectMultipartUploadOptions, DisableGrepIndexResponse,
-        EnableGrepIndexResponse, GrepGcRequest, GrepGcResponse, GrepIndexStatusResponse,
-        ObjectTransferAccess, SignUploadPartsRequest, SignUploadPartsResponse, SignedUploadPart,
-        StoreProbeRequest, StoreProbeResponse, UploadContentClaim, UploadContentResponse,
-        UploadPartChecksumClaim, UploadStatusResponse,
+        AbortUploadResponse, BeginDownloadByInodeRequest, BeginDownloadByInodeResponse,
+        BeginDownloadRequest, BeginDownloadResponse, BeginUploadRequest, BeginUploadResponse,
+        ChangesResponse, CommitResponse as ApiCommitResponse, CompleteKnownContentUploadRequest,
+        CompleteMultipartUploadRequest, CompleteUploadResponse, CompletedUploadPart, ContentToken,
+        DirectMultipartUploadOptions, DisableGrepIndexResponse, EnableGrepIndexResponse,
+        GrepGcRequest, GrepGcResponse, GrepIndexStatusResponse, ObjectTransferAccess,
+        SignUploadPartsRequest, SignUploadPartsResponse, SignedUploadPart, StoreProbeRequest,
+        StoreProbeResponse, UploadContentClaim, UploadContentResponse, UploadPartChecksumClaim,
+        UploadStatusResponse,
     },
     AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId, Checksum,
     ChecksumAlgorithm, CommitId, CommitRequest, ContentEvidence, ContentRef,
@@ -137,7 +138,7 @@ pub struct Client {
 pub struct DirectDownloadStream {
     body: payload::PayloadStream,
     expected: ContentRef,
-    path: AbsolutePath,
+    target: String,
     /// The checksum the complete object must produce, folded so far. The
     /// grant's reference names it, so an object nobody hashed for us — a
     /// provider-assembled multipart, or a direct transfer described only by
@@ -177,7 +178,7 @@ impl DirectDownloadStream {
                 "a download of `{}` resumed at offset {} was given {} bytes of what it \
                  skipped; verification covers the whole object, so all of them are needed \
                  first",
-                self.path, self.resumed_from, self.prefix_folded
+                self.target, self.resumed_from, self.prefix_folded
             )));
         }
         if self.finished {
@@ -190,7 +191,7 @@ impl DirectDownloadStream {
                     self.finished = true;
                     return Err(ClientError::Protocol(format!(
                         "direct download of `{}` sent more than the {} bytes the grant named",
-                        self.path, self.expected.size_bytes
+                        self.target, self.expected.size_bytes
                     )));
                 }
                 self.digest.update(&chunk);
@@ -200,7 +201,7 @@ impl DirectDownloadStream {
                 self.finished = true;
                 Err(ClientError::Io(format!(
                     "read of `{}` failed: {error}",
-                    self.path
+                    self.target
                 )))
             }
             None => {
@@ -208,7 +209,7 @@ impl DirectDownloadStream {
                 if self.size_bytes != self.expected.size_bytes {
                     return Err(ClientError::Protocol(format!(
                         "direct download of `{}` ended after {} bytes, not the {} the grant named",
-                        self.path, self.size_bytes, self.expected.size_bytes
+                        self.target, self.size_bytes, self.expected.size_bytes
                     )));
                 }
                 let expected = &self.expected.checksum;
@@ -222,7 +223,7 @@ impl DirectDownloadStream {
                 if observed != *expected {
                     return Err(ClientError::Protocol(format!(
                         "direct download of `{}` produced {}:{}, not the {}:{} the grant named",
-                        self.path,
+                        self.target,
                         observed.algorithm,
                         observed.value,
                         expected.algorithm,
@@ -694,6 +695,27 @@ impl Client {
         self.request_json::<(), _>(self.get(&url), None).await
     }
 
+    /// Stats one currently visible inode, projecting what `options` asks for.
+    pub async fn stat_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        options: &StatPathOptions,
+    ) -> Result<AuthoritativePathEntry> {
+        let mut url = format!(
+            "{}/v0/namespaces/{namespace_id}/inodes/{inode_id}",
+            self.base_url
+        );
+        let mut has_query = false;
+        append_query_param(
+            &mut url,
+            &mut has_query,
+            "include_attributes",
+            &options.include_attributes.to_string(),
+        );
+        self.request_json::<(), _>(self.get(&url), None).await
+    }
+
     /// Reads the file's current contents into memory.
     pub async fn get_file_bytes(&self, spec: &NamespacePath) -> Result<Vec<u8>> {
         let url = format!(
@@ -717,6 +739,20 @@ impl Client {
             spec.namespace().as_str(),
             urlencoding::encode(spec.absolute_path().as_str()),
             revision_no.0
+        );
+        self.request_bytes(&url).await
+    }
+
+    /// Reads and verifies one retained file revision by inode identity.
+    pub async fn get_file_revision_bytes_by_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>> {
+        let url = format!(
+            "{}/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
+            self.base_url
         );
         self.request_bytes(&url).await
     }
@@ -766,6 +802,25 @@ impl Client {
             .await
     }
 
+    /// Asks for one short-lived capability to read a retained inode revision
+    /// straight from the store.
+    pub async fn begin_download_by_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<BeginDownloadByInodeResponse> {
+        let url = format!(
+            "{}/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads",
+            self.base_url
+        );
+        self.request_json::<_, BeginDownloadByInodeResponse>(
+            self.post(&url),
+            Some(&BeginDownloadByInodeRequest {}),
+        )
+        .await
+    }
+
     /// Opens the response body authorized by a download grant as a bounded,
     /// verified stream.
     pub async fn open_direct_download(
@@ -789,21 +844,63 @@ impl Client {
         download: &BeginDownloadResponse,
         start_offset: u64,
     ) -> Result<DirectDownloadStream> {
+        self.open_direct_download_target(
+            &download.access,
+            &download.content_ref,
+            download.path.to_string(),
+            start_offset,
+        )
+        .await
+    }
+
+    /// Opens an inode-addressed download grant as a bounded, verified stream.
+    pub async fn open_direct_download_by_inode(
+        &self,
+        download: &BeginDownloadByInodeResponse,
+    ) -> Result<DirectDownloadStream> {
+        self.open_direct_download_by_inode_at(download, 0).await
+    }
+
+    /// Opens an inode-addressed download grant from `start_offset`.
+    pub async fn open_direct_download_by_inode_at(
+        &self,
+        download: &BeginDownloadByInodeResponse,
+        start_offset: u64,
+    ) -> Result<DirectDownloadStream> {
+        self.open_direct_download_target(
+            &download.access,
+            &download.content_ref,
+            format!(
+                "inode {} revision {}",
+                download.inode_id, download.revision_no
+            ),
+            start_offset,
+        )
+        .await
+    }
+
+    async fn open_direct_download_target(
+        &self,
+        access: &ObjectTransferAccess,
+        content_ref: &ContentRef,
+        target: String,
+        start_offset: u64,
+    ) -> Result<DirectDownloadStream> {
         let ObjectTransferAccess::PresignedUrl {
             method,
             url,
             headers,
             ..
-        } = &download.access;
+        } = access;
         if method != "GET" {
             return Err(ClientError::Protocol(format!(
                 "unsupported presigned download method `{method}`"
             )));
         }
-        if start_offset > download.content_ref.size_bytes {
+        if start_offset > content_ref.size_bytes {
             return Err(ClientError::Http(format!(
-                "cannot resume a download of `{}` at offset {start_offset} of {} bytes",
-                download.path, download.content_ref.size_bytes
+                "cannot resume a download of `{target}` at offset {start_offset} of {} bytes",
+                content_ref.size_bytes
             )));
         }
         let mut request = WireRequest::presigned(reqwest::Method::GET, url);
@@ -816,9 +913,9 @@ impl Client {
         let body = self.call_for_response_stream(&request).await?;
         Ok(DirectDownloadStream {
             body,
-            expected: download.content_ref.clone(),
-            path: download.path.clone(),
-            digest: StreamingChecksum::for_algorithm(download.content_ref.checksum.algorithm),
+            expected: content_ref.clone(),
+            target,
+            digest: StreamingChecksum::for_algorithm(content_ref.checksum.algorithm),
             // The counter measures the whole object, not this response, so
             // the length check at the end lands where it always did.
             size_bytes: start_offset,
@@ -882,6 +979,24 @@ impl Client {
             urlencoding::encode(spec.absolute_path().as_str())
         );
         let mut has_query = true;
+        append_optional_pagination_query(&mut url, &mut has_query, limit, cursor);
+        self.request_json::<(), ListFileRevisionsResponse>(self.get(&url), None)
+            .await
+    }
+
+    /// Returns one path-free page of retained revisions for a file inode.
+    pub async fn list_file_revisions_by_inode_page(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListFileRevisionsResponse> {
+        let mut url = format!(
+            "{}/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
+            self.base_url
+        );
+        let mut has_query = false;
         append_optional_pagination_query(&mut url, &mut has_query, limit, cursor);
         self.request_json::<(), ListFileRevisionsResponse>(self.get(&url), None)
             .await

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -695,7 +695,7 @@ impl Client {
         self.request_json::<(), _>(self.get(&url), None).await
     }
 
-    /// Stats one currently visible inode, projecting what `options` asks for.
+    /// Returns the current entry for a visible inode.
     pub async fn stat_inode(
         &self,
         namespace_id: &NamespaceId,
@@ -802,8 +802,7 @@ impl Client {
             .await
     }
 
-    /// Asks for one short-lived capability to read a retained inode revision
-    /// straight from the store.
+    /// Requests direct access to one retained inode revision.
     pub async fn begin_download_by_inode(
         &self,
         namespace_id: &NamespaceId,
@@ -853,7 +852,7 @@ impl Client {
         .await
     }
 
-    /// Opens an inode-addressed download grant as a bounded, verified stream.
+    /// Opens an inode download as a bounded, verified stream.
     pub async fn open_direct_download_by_inode(
         &self,
         download: &BeginDownloadByInodeResponse,
@@ -861,7 +860,7 @@ impl Client {
         self.open_direct_download_by_inode_at(download, 0).await
     }
 
-    /// Opens an inode-addressed download grant from `start_offset`.
+    /// Opens an inode download from `start_offset`.
     pub async fn open_direct_download_by_inode_at(
         &self,
         download: &BeginDownloadByInodeResponse,
@@ -984,7 +983,7 @@ impl Client {
             .await
     }
 
-    /// Returns one path-free page of retained revisions for a file inode.
+    /// Returns one page of retained revisions for a file inode.
     pub async fn list_file_revisions_by_inode_page(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -283,8 +283,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
-    /// Resolves one inode revision to the object key needed for a direct
-    /// download. This reads retained identity metadata only and transfers no
+    /// Resolves one inode revision for a direct download without reading its
     /// content bytes.
     pub async fn direct_download_target_by_inode(
         &self,
@@ -297,8 +296,7 @@ impl<S: ObjectStore> NamespaceEngine<S> {
             .await
     }
 
-    /// Stats one currently visible inode against the pinned runtime read
-    /// context.
+    /// Returns the current entry for a visible inode.
     pub async fn stat_inode(
         &self,
         inode_id: InodeId,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -11,7 +11,8 @@ use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::namespace::{bootstrap, fork, BootstrapNamespaceError};
 use crate::options::{BootstrapOptions, DeleteNamespaceOptions};
 use crate::path::read::{
-    load_metadata_view, CurrentFileState, DirectDownloadTarget, LoadedMetadataView, ReadLoadContext,
+    load_metadata_view, CurrentFileState, DirectDownloadByInodeTarget, DirectDownloadTarget,
+    LoadedMetadataView, ReadLoadContext,
 };
 use crate::protocol::{
     BeginDirectMultipartUploadTargetResponse, BeginDirectPutUploadTargetResponse, CompletedUpload,
@@ -279,6 +280,33 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     ) -> Result<DirectDownloadTarget> {
         let view = self.load_read_view(context).await?;
         view.direct_download_target(path.as_ref(), revision_no)
+            .await
+    }
+
+    /// Resolves one inode revision to the object key needed for a direct
+    /// download. This reads retained identity metadata only and transfers no
+    /// content bytes.
+    pub async fn direct_download_target_by_inode(
+        &self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+        context: &RuntimeReadContext,
+    ) -> Result<DirectDownloadByInodeTarget> {
+        let view = self.load_read_view(context).await?;
+        view.direct_download_target_by_inode(inode_id, revision_no)
+            .await
+    }
+
+    /// Stats one currently visible inode against the pinned runtime read
+    /// context.
+    pub async fn stat_inode(
+        &self,
+        inode_id: InodeId,
+        options: StatPathOptions,
+        context: &RuntimeReadContext,
+    ) -> Result<AuthoritativePathEntry> {
+        let view = self.load_read_view(context).await?;
+        view.stat_inode(inode_id, options.include_attributes.into())
             .await
     }
 

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -75,6 +75,8 @@ pub enum CoreError {
     InvalidUploadId(#[from] GeneratedIdValidationError),
     #[error("path not found `{0}`")]
     PathNotFound(String),
+    #[error("inode not found `{0}`")]
+    InodeNotFound(InodeId),
     #[error("revision `{revision_no}` not found for inode `{inode_id}`")]
     RevisionNotFound {
         inode_id: InodeId,
@@ -388,6 +390,7 @@ impl CoreError {
             | CoreError::ResumePrefixIncomplete { .. }
             | CoreError::NonDirectoryPathComponent(_) => ErrorCode::InvalidRequest,
             CoreError::PathNotFound(_) => ErrorCode::PathNotFound,
+            CoreError::InodeNotFound(_) => ErrorCode::InodeNotFound,
             CoreError::RevisionNotFound { .. } => ErrorCode::RevisionNotFound,
             CoreError::ContentTooLarge { .. } => ErrorCode::ContentTooLarge,
             CoreError::NamespaceExists { .. } => ErrorCode::NamespaceExists,

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -182,7 +182,9 @@ pub use error::{
 pub use gc::{delete_if_aged, gc_namespace, AgedSweep, GcConfig, PassBudget};
 pub use namespace::BootstrapNamespaceError;
 pub use options::{BootstrapOptions, DeleteNamespaceOptions};
-pub use path::read::{CurrentFileState, DirectDownloadTarget, MAX_RESOLVE_CURRENT_FILES};
+pub use path::read::{
+    CurrentFileState, DirectDownloadByInodeTarget, DirectDownloadTarget, MAX_RESOLVE_CURRENT_FILES,
+};
 // The streaming read `loonfs`'s reader handle returns, and the chunk size it
 // reads in.
 pub use storage::content::{FileContentStream, CONTENT_READ_CHUNK_BYTES};

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -321,7 +321,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
         let inode = self
             .inode_at_seq(inode_id)
             .await?
-            .ok_or_else(|| CoreError::PathNotFound(inode_id.to_string()))?;
+            .ok_or(CoreError::InodeNotFound(inode_id))?;
         if inode.inode_kind != InodeKind::File {
             return Err(CoreError::ExpectedFile {
                 path: inode_id.to_string(),

--- a/crates/loonfs-core/src/path/read/current_files.rs
+++ b/crates/loonfs-core/src/path/read/current_files.rs
@@ -107,9 +107,7 @@ async fn resolve_one<S: ObjectStore + ?Sized>(
     })
 }
 
-/// Resolves one currently visible inode through the child-keyed binding
-/// index, returning the same canonical identity projection a path walk
-/// produces. No directory listing is involved.
+/// Resolves a visible inode and its current path through parent bindings.
 pub(super) async fn resolve_visible_inode<S: ObjectStore + ?Sized>(
     session: &mut MetadataViewSession<'_, '_, S>,
     ancestor_paths: &mut HashMap<InodeId, AbsolutePath>,

--- a/crates/loonfs-core/src/path/read/current_files.rs
+++ b/crates/loonfs-core/src/path/read/current_files.rs
@@ -8,7 +8,7 @@
 
 use super::materialized_view::LoadedMetadataView;
 use crate::error::{CoreError, Result};
-use crate::metadata::MetadataViewSession;
+use crate::metadata::{MetadataViewSession, ResolvedVisiblePath};
 use loonfs_api::{AbsolutePath, InodeId, InodeKind, RevisionNo, ROOT_INODE_ID};
 use loonfs_objectstore::ObjectStore;
 use std::collections::{HashMap, HashSet};
@@ -81,13 +81,10 @@ async fn resolve_one<S: ObjectStore + ?Sized>(
     ancestor_paths: &mut HashMap<InodeId, AbsolutePath>,
     inode_id: InodeId,
 ) -> Result<CurrentFileState> {
-    let Some(inode) = session.visible_inode(inode_id).await? else {
+    let Some(resolved) = resolve_visible_inode(session, ancestor_paths, inode_id).await? else {
         return Ok(missing(inode_id));
     };
-    let Some(current_path) = current_path(session, ancestor_paths, inode_id).await? else {
-        return Ok(missing(inode_id));
-    };
-    let current_revision_no = if inode.inode_kind == InodeKind::File {
+    let current_revision_no = if resolved.inode_kind == InodeKind::File {
         session
             .latest_revision_head_of_visible(inode_id)
             .await?
@@ -99,8 +96,52 @@ async fn resolve_one<S: ObjectStore + ?Sized>(
         inode_id,
         visible: true,
         current_revision_no,
-        current_path: Some(current_path),
+        current_path: Some(
+            AbsolutePath::parse(&resolved.absolute_path).map_err(|error| {
+                CoreError::NamespaceCorrupt(format!(
+                    "resolved inode `{inode_id}` to invalid path `{}`: {error}",
+                    resolved.absolute_path
+                ))
+            })?,
+        ),
     })
+}
+
+/// Resolves one currently visible inode through the child-keyed binding
+/// index, returning the same canonical identity projection a path walk
+/// produces. No directory listing is involved.
+pub(super) async fn resolve_visible_inode<S: ObjectStore + ?Sized>(
+    session: &mut MetadataViewSession<'_, '_, S>,
+    ancestor_paths: &mut HashMap<InodeId, AbsolutePath>,
+    inode_id: InodeId,
+) -> Result<Option<ResolvedVisiblePath>> {
+    let Some(inode) = session.visible_inode(inode_id).await? else {
+        return Ok(None);
+    };
+    let Some(current_path) = current_path(session, ancestor_paths, inode_id).await? else {
+        return Ok(None);
+    };
+    let current_binding = if inode_id == ROOT_INODE_ID {
+        None
+    } else {
+        let Some(binding) = session.current_parent_binding_for_child(inode_id).await? else {
+            return Ok(None);
+        };
+        Some(binding)
+    };
+    Ok(Some(ResolvedVisiblePath {
+        absolute_path: current_path.to_string(),
+        inode_id,
+        inode_kind: inode.inode_kind,
+        created_by: inode.created_by,
+        created_at_ms: inode.created_at_ms,
+        parent_inode_id: current_binding
+            .as_ref()
+            .map(|binding| binding.parent_inode_id),
+        display_name: current_binding
+            .map(|binding| binding.display_name.to_string())
+            .unwrap_or_default(),
+    }))
 }
 
 fn missing(inode_id: InodeId) -> CurrentFileState {

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -173,20 +173,16 @@ pub struct DirectDownloadTarget {
     pub object_key: String,
 }
 
-/// Where one inode revision's bytes live for direct-download authorization.
-///
-/// Unlike [`DirectDownloadTarget`], this identity-addressed target carries no
-/// path because a retained revision remains readable after its inode moves or
-/// loses its current binding.
+/// Content information needed to authorize an inode download.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectDownloadByInodeTarget {
-    /// File inode that owns the revision.
+    /// File inode that owns this revision.
     pub inode_id: InodeId,
-    /// Revision this target reads.
+    /// Revision being read.
     pub revision_no: RevisionNo,
-    /// Identity, byte length, and checksum evidence for those bytes.
+    /// Content identity, size, and checksum.
     pub content_ref: ContentRef,
-    /// Logical unscoped object key an issuer signs a read of.
+    /// Object key used to sign the read.
     pub object_key: String,
 }
 
@@ -346,9 +342,8 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .await
     }
 
-    /// Resolves a currently visible inode to the canonical entry returned by
-    /// path stat, using the child-keyed binding index rather than a directory
-    /// listing scan.
+    /// Returns the current entry for a visible inode without listing a
+    /// directory.
     pub(crate) async fn stat_inode(
         &self,
         inode_id: InodeId,
@@ -453,8 +448,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         })
     }
 
-    /// Resolves one retained inode revision to the object a direct read would
-    /// fetch. Current visibility and path are intentionally irrelevant.
+    /// Resolves retained inode content without requiring a current path.
     pub(crate) async fn direct_download_target_by_inode(
         &self,
         inode_id: InodeId,

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -1,6 +1,7 @@
 //! [`LoadedMetadataView`]: a verified, seq-pinned view of one namespace
 //! that answers core reads.
 
+use super::current_files::resolve_visible_inode;
 use super::listing::{invalid_cursor, validate_cursor_head, validate_directory_cursor};
 use crate::checkpoint::{
     head_from_manifest, load_basis_metadata_tables, MetadataTableCache, VerifiedMetadataTables,
@@ -27,6 +28,7 @@ use loonfs_api::{
     NamespaceId, Page, PageRequest, RevisionNo, TrashEntry, TrashPageCursor,
 };
 use loonfs_objectstore::ObjectStore;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::Instrument;
 
@@ -164,6 +166,23 @@ pub struct DirectDownloadTarget {
     /// Absolute path as rendered from stored display names.
     pub absolute_path: AbsolutePath,
     /// Revision this target reads, resolved from the request.
+    pub revision_no: RevisionNo,
+    /// Identity, byte length, and checksum evidence for those bytes.
+    pub content_ref: ContentRef,
+    /// Logical unscoped object key an issuer signs a read of.
+    pub object_key: String,
+}
+
+/// Where one inode revision's bytes live for direct-download authorization.
+///
+/// Unlike [`DirectDownloadTarget`], this identity-addressed target carries no
+/// path because a retained revision remains readable after its inode moves or
+/// loses its current binding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectDownloadByInodeTarget {
+    /// File inode that owns the revision.
+    pub inode_id: InodeId,
+    /// Revision this target reads.
     pub revision_no: RevisionNo,
     /// Identity, byte length, and checksum evidence for those bytes.
     pub content_ref: ContentRef,
@@ -327,6 +346,23 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .await
     }
 
+    /// Resolves a currently visible inode to the canonical entry returned by
+    /// path stat, using the child-keyed binding index rather than a directory
+    /// listing scan.
+    pub(crate) async fn stat_inode(
+        &self,
+        inode_id: InodeId,
+        attributes: AttributeProjection,
+    ) -> Result<AuthoritativePathEntry> {
+        let mut session = self.metadata_view().session();
+        let mut ancestor_paths = HashMap::new();
+        let resolved = resolve_visible_inode(&mut session, &mut ancestor_paths, inode_id)
+            .await?
+            .ok_or(CoreError::InodeNotFound(inode_id))?;
+        self.build_authoritative_path_entry_with_session(&mut session, &resolved, attributes)
+            .await
+    }
+
     pub(crate) async fn read_file_bytes(
         &self,
         store: &S,
@@ -413,6 +449,23 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             absolute_path: entry.path,
             revision_no,
             content_ref,
+            object_key,
+        })
+    }
+
+    /// Resolves one retained inode revision to the object a direct read would
+    /// fetch. Current visibility and path are intentionally irrelevant.
+    pub(crate) async fn direct_download_target_by_inode(
+        &self,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<DirectDownloadByInodeTarget> {
+        let revision = self.revision_for_inode(inode_id, revision_no).await?;
+        let object_key = content_object_key_for_ref(&self.content_store_id, &revision.content_ref)?;
+        Ok(DirectDownloadByInodeTarget {
+            inode_id,
+            revision_no: revision.revision_no,
+            content_ref: revision.content_ref,
             object_key,
         })
     }
@@ -521,7 +574,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .metadata_view()
             .inode_at_seq(inode_id)
             .await?
-            .ok_or_else(|| CoreError::PathNotFound(inode_id.to_string()))?;
+            .ok_or(CoreError::InodeNotFound(inode_id))?;
         if inode.inode_kind != InodeKind::File {
             return Err(CoreError::ExpectedFile {
                 path: inode_id.to_string(),

--- a/crates/loonfs-core/src/path/read/mod.rs
+++ b/crates/loonfs-core/src/path/read/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use current_files::{ensure_resolve_batch_within_cap, resolve_current_
 pub use current_files::{CurrentFileState, MAX_RESOLVE_CURRENT_FILES};
 #[cfg(test)]
 pub(crate) use materialized_view::AttributeProjection;
-pub use materialized_view::DirectDownloadTarget;
 pub(crate) use materialized_view::{
     ensure_within_read_limit, load_metadata_view, LoadedMetadataView, ReadLoadContext,
 };
+pub use materialized_view::{DirectDownloadByInodeTarget, DirectDownloadTarget};

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -200,7 +200,7 @@ async fn list_file_revisions<S: ObjectStore + ?Sized>(
 async fn list_file_revisions_for_inode<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
-    absolute_path: &str,
+    _absolute_path: &str,
     inode_id: InodeId,
 ) -> Result<loonfs_api::ListFileRevisionsResponse, CoreError> {
     let context = read_context(store, namespace_id).await;
@@ -223,7 +223,6 @@ async fn list_file_revisions_for_inode<S: ObjectStore + ?Sized>(
         if cursor.is_none() {
             return Ok(loonfs_api::ListFileRevisionsResponse {
                 namespace_id: namespace_id.clone(),
-                path: loonfs_api::AbsolutePath::parse(absolute_path).expect("valid test path"),
                 inode_id,
                 head_seq: context.head.seq,
                 revisions,

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -101,7 +101,7 @@ pub(super) async fn begin_download(
         path = "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads",
         tag = "inodes",
         summary = "Begin download by inode",
-        description = "Authorizes a direct read of one retained inode revision. The strict body is `{}` and the response is path-free because historical identity does not imply a current binding.",
+        description = "Authorizes a direct read of one retained inode revision. The request body is `{}` and the response does not include a path.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("inode_id" = InodeId, Path, description = "File inode id"),
@@ -120,7 +120,7 @@ pub(super) async fn begin_download(
         )
     )
 )]
-/// Issues one short-lived read capability for a retained inode revision.
+/// Authorizes a direct read of one retained inode revision.
 pub(super) async fn begin_download_by_inode(
     State(state): State<AppState>,
     namespace_id_path: NamespaceIdPath,

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -7,17 +7,21 @@
 //! advertised together.
 
 use super::error::ApiResponseError;
+use super::handlers_inodes::InodeRevisionPathParams;
 use super::handlers_uploads::{presign_issuer_error, presign_time};
-use super::{AppJson, AppState, NamespaceIdPath};
+use super::{AppJson, AppPath, AppState, NamespaceIdPath};
 use axum::extract::State;
 use axum::Json;
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
 use loonfs_api::{
-    v0::{BeginDownloadRequest, BeginDownloadResponse, ObjectTransferAccess},
-    FEATURE_DOWNLOADS_DIRECT_GET,
+    v0::{
+        BeginDownloadByInodeRequest, BeginDownloadByInodeResponse, BeginDownloadRequest,
+        BeginDownloadResponse, ObjectTransferAccess,
+    },
+    InodeId, RevisionNo, FEATURE_DOWNLOADS_DIRECT_GET,
 };
-use loonfs_objectstore::presign::PresignedGetRequest;
+use loonfs_objectstore::presign::{DirectGetIssuer, PresignedGetRequest};
 use std::time::Duration;
 
 /// Lifetime of one read capability, the same window a whole-object write
@@ -72,44 +76,109 @@ pub(super) async fn begin_download(
     // A store either authorizes direct transfers or it does not, and one
     // that does can always sign a read — so this asks for the bundle, not
     // for a direction within it.
-    let Some(issuer) = state
-        .direct_transfers
-        .as_ref()
-        .map(|transfers| &transfers.get)
-    else {
-        return Err(ApiResponseError::not_supported(
-            FEATURE_DOWNLOADS_DIRECT_GET,
-            "direct_get requires an object store that can presign object reads; \
-             this deployment's endpoint cannot, so every read is proxied and \
-             bounded by `download.max_content_bytes`",
-        ));
-    };
+    let issuer = direct_get_issuer(&state)?;
 
     let target = state
         .reader
         .direct_download_target(&namespace_id, request.path.as_str(), request.revision_no)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    let signed = issuer
-        .presign_get(
-            PresignedGetRequest {
-                object_key: &target.object_key,
-                expires_in: DIRECT_GET_URL_TTL,
-            },
-            presign_time(),
-        )
-        .map_err(presign_issuer_error)?;
+    let access = presigned_access(issuer, &target.object_key)?;
 
     Ok(Json(BeginDownloadResponse {
         namespace_id,
         path: target.absolute_path,
         revision_no: target.revision_no,
         content_ref: target.content_ref,
-        access: ObjectTransferAccess::PresignedUrl {
-            method: signed.method,
-            url: signed.url,
-            headers: signed.headers,
-            expires_at_ms: signed.expires_at_ms,
-        },
+        access,
     }))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        post,
+        path = "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads",
+        tag = "inodes",
+        summary = "Begin download by inode",
+        description = "Authorizes a direct read of one retained inode revision. The strict body is `{}` and the response is path-free because historical identity does not imply a current binding.",
+        params(
+            ("namespace_id" = String, Path, description = "Namespace id"),
+            ("inode_id" = InodeId, Path, description = "File inode id"),
+            ("revision_no" = RevisionNo, Path, description = "Revision number")
+        ),
+        request_body = BeginDownloadByInodeRequest,
+        responses(
+            (status = 200, description = "Download authorized", body = BeginDownloadByInodeResponse),
+            (status = 400, description = "Invalid inode id, revision number, or request body", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace, inode, or revision not found", body = ApiError),
+            (status = 409, description = "Inode is not a file", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            (status = 501, description = "Direct download is unsupported", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
+        )
+    )
+)]
+/// Issues one short-lived read capability for a retained inode revision.
+pub(super) async fn begin_download_by_inode(
+    State(state): State<AppState>,
+    namespace_id_path: NamespaceIdPath,
+    path: AppPath<InodeRevisionPathParams>,
+    AppJson(_request): AppJson<BeginDownloadByInodeRequest>,
+) -> Result<Json<BeginDownloadByInodeResponse>, ApiResponseError> {
+    let namespace_id = namespace_id_path.into_id()?;
+    let path = path.into_params()?;
+    let inode_id = InodeId(path.inode_id);
+    let revision_no = RevisionNo(path.revision_no);
+    let issuer = direct_get_issuer(&state)?;
+    let target = state
+        .reader
+        .direct_download_target_by_inode(&namespace_id, inode_id, revision_no)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    let access = presigned_access(issuer, &target.object_key)?;
+    Ok(Json(BeginDownloadByInodeResponse {
+        namespace_id,
+        inode_id: target.inode_id,
+        revision_no: target.revision_no,
+        content_ref: target.content_ref,
+        access,
+    }))
+}
+
+fn direct_get_issuer(state: &AppState) -> Result<&dyn DirectGetIssuer, ApiResponseError> {
+    state
+        .direct_transfers
+        .as_ref()
+        .map(|transfers| transfers.get.as_ref())
+        .ok_or_else(|| {
+            ApiResponseError::not_supported(
+                FEATURE_DOWNLOADS_DIRECT_GET,
+                "direct_get requires an object store that can presign object reads; \
+                 this deployment's endpoint cannot, so every read is proxied and \
+                 bounded by `download.max_content_bytes`",
+            )
+        })
+}
+
+fn presigned_access(
+    issuer: &dyn DirectGetIssuer,
+    object_key: &str,
+) -> Result<ObjectTransferAccess, ApiResponseError> {
+    let signed = issuer
+        .presign_get(
+            PresignedGetRequest {
+                object_key,
+                expires_in: DIRECT_GET_URL_TTL,
+            },
+            presign_time(),
+        )
+        .map_err(presign_issuer_error)?;
+    Ok(ObjectTransferAccess::PresignedUrl {
+        method: signed.method,
+        url: signed.url,
+        headers: signed.headers,
+        expires_at_ms: signed.expires_at_ms,
+    })
 }

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -62,8 +62,8 @@ pub(super) struct ListPathPageQuery {
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct PageQuery {
-    limit: Option<String>,
-    cursor: Option<String>,
+    pub(super) limit: Option<String>,
+    pub(super) cursor: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -80,6 +80,19 @@ pub(super) struct ContentQuery {
 struct DownloadBodyStream {
     bytes: Option<bytes::Bytes>,
     _permit: OwnedSemaphorePermit,
+}
+
+pub(super) fn buffered_download_response(bytes: Vec<u8>, permit: OwnedSemaphorePermit) -> Response {
+    let body = Body::from_stream(DownloadBodyStream {
+        bytes: Some(bytes.into()),
+        _permit: permit,
+    });
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
+        body,
+    )
+        .into_response()
 }
 
 impl Stream for DownloadBodyStream {
@@ -257,16 +270,7 @@ pub(super) async fn get_file_bytes(
         None => state.reader.get_file_bytes(&namespace_id, &path).await,
     }
     .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    let body = Body::from_stream(DownloadBodyStream {
-        bytes: Some(file.bytes.into()),
-        _permit: permit,
-    });
-    Ok((
-        StatusCode::OK,
-        [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
-        body,
-    )
-        .into_response())
+    Ok(buffered_download_response(file.bytes, permit))
 }
 
 #[cfg_attr(
@@ -539,7 +543,7 @@ fn parse_after_seq(value: &str) -> Result<loonfs_api::ChangeSeq, ApiResponseErro
         })
 }
 
-fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {
+pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {
     match value {
         "true" => Ok(true),
         "false" => Ok(false),
@@ -600,7 +604,7 @@ fn decode_optional_cursor<C: loonfs_api::PageCursor>(
         .map_err(page_cursor_response_error)
 }
 
-fn decode_file_revisions_page_cursor(
+pub(super) fn decode_file_revisions_page_cursor(
     cursor: Option<String>,
 ) -> Result<Option<FileRevisionsPageCursor>, ApiResponseError> {
     cursor

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -1,0 +1,185 @@
+//! Inode-addressed read handlers: current stat and retained revision reads.
+
+use super::error::ApiResponseError;
+use super::handlers_filesystem::{
+    buffered_download_response, decode_file_revisions_page_cursor, parse_include_attributes,
+    resolve_page_limit, PageQuery,
+};
+use super::{authorize, AppPath, AppQuery, AppState, NamespaceIdPath};
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::Response;
+use axum::Json;
+use loonfs::StatPathOptions;
+#[cfg(feature = "openapi")]
+use loonfs_api::ApiError;
+use loonfs_api::{
+    FileRevisionsPageCursor, InodeId, ListFileRevisionsResponse, PageRequest, RevisionNo,
+};
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct InodePathParams {
+    pub(super) inode_id: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct InodeRevisionPathParams {
+    pub(super) inode_id: u64,
+    pub(super) revision_no: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct StatInodeQuery {
+    include_attributes: Option<String>,
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace_id}/inodes/{inode_id}",
+        tag = "inodes",
+        summary = "Stat inode",
+        description = "Returns the canonical current entry for a visible inode, including its current path. Unknown and currently invisible inodes answer `inode_not_found`.",
+        params(
+            ("namespace_id" = String, Path, description = "Namespace id"),
+            ("inode_id" = InodeId, Path, description = "Inode id"),
+            ("include_attributes" = Option<String>, Query, description = "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`.")
+        ),
+        responses(
+            (status = 200, description = "Authoritative current inode entry", body = loonfs_api::AuthoritativePathEntry),
+            (status = 400, description = "Invalid inode id or include_attributes", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or visible inode not found", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
+        )
+    )
+)]
+pub(super) async fn stat_inode(
+    State(state): State<AppState>,
+    namespace_id_path: NamespaceIdPath,
+    path: AppPath<InodePathParams>,
+    headers: HeaderMap,
+    query: AppQuery<StatInodeQuery>,
+) -> Result<Json<loonfs_api::AuthoritativePathEntry>, ApiResponseError> {
+    authorize(state.config.auth_policy(), &headers)?;
+    let namespace_id = namespace_id_path.into_id()?;
+    let inode_id = InodeId(path.into_params()?.inode_id);
+    let query = query.into_params()?;
+    let mut options = StatPathOptions::default();
+    if let Some(value) = query.include_attributes.as_deref() {
+        options.include_attributes = parse_include_attributes(value)?;
+    }
+    let entry = state
+        .reader
+        .stat_inode(&namespace_id, inode_id, options)
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    Ok(Json(entry))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
+        tag = "inodes",
+        summary = "List file revisions by inode",
+        description = "Returns retained revisions for a file inode without requiring a current path or binding. The response is path-free.",
+        params(
+            ("namespace_id" = String, Path, description = "Namespace id"),
+            ("inode_id" = InodeId, Path, description = "File inode id"),
+            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("cursor" = Option<String>, Query, description = "Opaque file-revisions page cursor")
+        ),
+        responses(
+            (status = 200, description = "File revisions", body = ListFileRevisionsResponse),
+            (status = 400, description = "Invalid inode id, limit, or cursor", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace or inode not found", body = ApiError),
+            (status = 409, description = "Inode is not a file", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            crate::http::openapi::DeadlineExceededResponses
+        )
+    )
+)]
+pub(super) async fn list_file_revisions_by_inode(
+    State(state): State<AppState>,
+    namespace_id_path: NamespaceIdPath,
+    path: AppPath<InodePathParams>,
+    headers: HeaderMap,
+    query: AppQuery<PageQuery>,
+) -> Result<Json<ListFileRevisionsResponse>, ApiResponseError> {
+    authorize(state.config.auth_policy(), &headers)?;
+    let namespace_id = namespace_id_path.into_id()?;
+    let inode_id = InodeId(path.into_params()?.inode_id);
+    let query = query.into_params()?;
+    let response = state
+        .reader
+        .list_file_revisions_by_inode_page(
+            &namespace_id,
+            inode_id,
+            PageRequest::<FileRevisionsPageCursor> {
+                limit: resolve_page_limit(query.limit)?,
+                cursor: decode_file_revisions_page_cursor(query.cursor)?,
+            },
+        )
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    Ok(Json(response))
+}
+
+#[cfg_attr(
+    feature = "openapi",
+    utoipa::path(
+        get,
+        path = "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
+        tag = "inodes",
+        summary = "Read file revision by inode",
+        description = "Reads and verifies one retained file revision directly by `(inode_id, revision_no)`, without resolving a current path.",
+        params(
+            ("namespace_id" = String, Path, description = "Namespace id"),
+            ("inode_id" = InodeId, Path, description = "File inode id"),
+            ("revision_no" = RevisionNo, Path, description = "Revision number")
+        ),
+        responses(
+            (status = 200, description = "Revision bytes", body = Vec<u8>, content_type = "application/octet-stream"),
+            (status = 400, description = "Invalid inode id or revision number", body = ApiError),
+            (status = 401, description = "Unauthorized", body = ApiError),
+            (status = 404, description = "Namespace, inode, or revision not found", body = ApiError),
+            (status = 409, description = "Inode is not a file", body = ApiError),
+            (status = 410, description = "Namespace deleted", body = ApiError),
+            (status = 413, description = "Content exceeds the advertised `download.max_content_bytes` limit", body = ApiError),
+            (status = 503, description = "The server is at its concurrent content-read limit; retry shortly", body = ApiError)
+        )
+    )
+)]
+pub(super) async fn get_file_revision_bytes_by_inode(
+    State(state): State<AppState>,
+    namespace_id_path: NamespaceIdPath,
+    path: AppPath<InodeRevisionPathParams>,
+    headers: HeaderMap,
+) -> Result<Response, ApiResponseError> {
+    authorize(state.config.auth_policy(), &headers)?;
+    let namespace_id = namespace_id_path.into_id()?;
+    let path = path.into_params()?;
+    let permit = state
+        .download_permits
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| {
+            state.metrics.download_rejected_as_busy();
+            super::server_busy_error("proxied content reads")
+        })?;
+    let bytes = state
+        .reader
+        .get_file_revision_bytes_by_inode(
+            &namespace_id,
+            InodeId(path.inode_id),
+            RevisionNo(path.revision_no),
+        )
+        .await
+        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    Ok(buffered_download_response(bytes, permit))
+}

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -1,4 +1,4 @@
-//! Inode-addressed read handlers: current stat and retained revision reads.
+//! HTTP reads addressed by inode id.
 
 use super::error::ApiResponseError;
 use super::handlers_filesystem::{
@@ -86,7 +86,7 @@ pub(super) async fn stat_inode(
         path = "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
         tag = "inodes",
         summary = "List file revisions by inode",
-        description = "Returns retained revisions for a file inode without requiring a current path or binding. The response is path-free.",
+        description = "Returns retained revisions for a file inode without requiring a current path.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("inode_id" = InodeId, Path, description = "File inode id"),
@@ -137,7 +137,7 @@ pub(super) async fn list_file_revisions_by_inode(
         path = "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
         tag = "inodes",
         summary = "Read file revision by inode",
-        description = "Reads and verifies one retained file revision directly by `(inode_id, revision_no)`, without resolving a current path.",
+        description = "Reads and verifies one retained file revision by inode id and revision number.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("inode_id" = InodeId, Path, description = "File inode id"),

--- a/crates/loonfs-server/src/http/mod.rs
+++ b/crates/loonfs-server/src/http/mod.rs
@@ -8,6 +8,7 @@ mod error;
 mod extractors;
 mod handlers_downloads;
 mod handlers_filesystem;
+mod handlers_inodes;
 mod handlers_namespace;
 mod handlers_query;
 mod handlers_store;
@@ -32,10 +33,13 @@ use self::extractors::{
     authorize, server_busy_error, AppJson, AppPath, AppQuery, NamespaceIdPath, OptionalAppJson,
     UploadBodyBytes, UploadBodyStream,
 };
-use self::handlers_downloads::begin_download;
+use self::handlers_downloads::{begin_download, begin_download_by_inode};
 use self::handlers_filesystem::{
     apply_commit, get_file_bytes, list_changes, list_file_revisions, list_path_entries, list_trash,
     stat_path,
+};
+use self::handlers_inodes::{
+    get_file_revision_bytes_by_inode, list_file_revisions_by_inode, stat_inode,
 };
 use self::handlers_namespace::{
     create_checkpoint, create_namespace, delete_namespace, fork_namespace, list_checkpoints,
@@ -268,6 +272,22 @@ fn router(state: AppState) -> Router {
         .route(
             "/v0/namespaces/{namespace_id}/filesystem/revisions",
             get(list_file_revisions),
+        )
+        .route(
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}",
+            get(stat_inode),
+        )
+        .route(
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
+            get(list_file_revisions_by_inode),
+        )
+        .route(
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
+            get(get_file_revision_bytes_by_inode),
+        )
+        .route(
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads",
+            post(begin_download_by_inode),
         )
         .route(
             "/v0/namespaces/{namespace_id}/filesystem/trash",

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -9,8 +9,9 @@
 use loonfs_api::ChangeSeq;
 use loonfs_api::{
     v0::{
-        BeginDownloadRequest, BeginDownloadResponse, BeginUploadRequest, BeginUploadResponse,
-        ChangesResponse, CommitResponse as ApiCommitResponse, CompleteKnownContentUploadRequest,
+        BeginDownloadByInodeRequest, BeginDownloadByInodeResponse, BeginDownloadRequest,
+        BeginDownloadResponse, BeginUploadRequest, BeginUploadResponse, ChangesResponse,
+        CommitResponse as ApiCommitResponse, CompleteKnownContentUploadRequest,
         CompleteMultipartUploadRequest, CompleteUploadResponse, ContentToken, DirectPutUpload,
         ObjectTransferAccess, UploadContentResponse,
     },
@@ -79,6 +80,10 @@ impl utoipa::ToSchema for CompleteUploadRequestSchema {
         crate::http::handlers_filesystem::get_file_bytes,
         crate::http::handlers_downloads::begin_download,
         crate::http::handlers_filesystem::list_file_revisions,
+        crate::http::handlers_inodes::stat_inode,
+        crate::http::handlers_inodes::list_file_revisions_by_inode,
+        crate::http::handlers_inodes::get_file_revision_bytes_by_inode,
+        crate::http::handlers_downloads::begin_download_by_inode,
         crate::http::handlers_filesystem::list_trash,
         crate::http::handlers_filesystem::apply_commit,
         crate::http::handlers_uploads::begin_upload,
@@ -172,6 +177,8 @@ impl utoipa::ToSchema for CompleteUploadRequestSchema {
         loonfs_api::v0::CompletedUploadPart,
         BeginDownloadRequest,
         BeginDownloadResponse,
+        BeginDownloadByInodeRequest,
+        BeginDownloadByInodeResponse,
         ObjectTransferAccess,
         ContentToken,
         ApiCommitResponse,
@@ -204,6 +211,7 @@ impl utoipa::ToSchema for CompleteUploadRequestSchema {
         (name = "capabilities", description = "Capability discovery"),
         (name = "namespaces", description = "Namespace lifecycle and status"),
         (name = "filesystem", description = "Path-oriented filesystem APIs"),
+        (name = "inodes", description = "Identity-oriented inode read APIs"),
         (name = "uploads", description = "Upload session APIs"),
         (name = "admin", description = "Administrative maintenance APIs"),
         (name = "query", description = "Derived-index query APIs")

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -2387,6 +2387,12 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
         "download-busy-seed-01",
     )
     .await;
+    let inode_id = seed_writer
+        .reader()
+        .stat_path(&namespace_id("demo"), "/note.txt", Default::default())
+        .await
+        .expect("stat seeded file")
+        .inode_id;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.max_concurrent_downloads = 1;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -2424,10 +2430,22 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
         "server_busy",
         Some("the server is at its concurrency limit for proxied content reads; retry shortly"),
     );
+    assert_api_error(
+        client
+            .get_file_revision_bytes_by_inode(
+                &namespace_id("demo"),
+                inode_id,
+                loonfs_api::RevisionNo(1),
+            )
+            .await,
+        503,
+        "server_busy",
+        Some("the server is at its concurrency limit for proxied content reads; retry shortly"),
+    );
     assert!(state
         .metrics
         .render(None, 0, 0)
-        .contains("loonfs_server_busy_rejections_total{kind=\"download\"} 1\n"));
+        .contains("loonfs_server_busy_rejections_total{kind=\"download\"} 2\n"));
 
     drop(held);
     let client = Client::new(client_config).expect("valid client config");
@@ -2437,6 +2455,17 @@ async fn http_content_reads_answer_server_busy_at_the_concurrency_cap() {
         .await
         .expect("a freed slot admits the read");
     assert_eq!(bytes, b"bounded");
+    assert_eq!(
+        client
+            .get_file_revision_bytes_by_inode(
+                &namespace_id("demo"),
+                inode_id,
+                loonfs_api::RevisionNo(1),
+            )
+            .await
+            .expect("a freed slot admits the inode read"),
+        b"bounded"
+    );
 
     server.abort();
 }
@@ -2520,6 +2549,18 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
         "download-limit-seed-02",
     )
     .await;
+    let big_inode_id = seed_writer
+        .reader()
+        .stat_path(&namespace_id("demo"), "/big.bin", Default::default())
+        .await
+        .expect("stat big file")
+        .inode_id;
+    let small_inode_id = seed_writer
+        .reader()
+        .stat_path(&namespace_id("demo"), "/small.bin", Default::default())
+        .await
+        .expect("stat small file")
+        .inode_id;
     let mut config = test_config(temp_dir.path(), "server-writer");
     config.max_download_bytes = 16;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -2547,12 +2588,36 @@ async fn http_content_read_over_the_download_limit_answers_content_too_large() {
         "content_too_large",
         None,
     );
+    assert_api_error(
+        client
+            .get_file_revision_bytes_by_inode(
+                &namespace_id("demo"),
+                big_inode_id,
+                loonfs_api::RevisionNo(1),
+            )
+            .await,
+        413,
+        "content_too_large",
+        None,
+    );
     // Content inside the limit still reads through the same route.
     let bytes = client
         .get_file_bytes(&NamespacePath::parse("demo", "/small.bin").expect("target"))
         .await
         .expect("small content fits under the limit");
     assert_eq!(bytes.len(), 8);
+    assert_eq!(
+        client
+            .get_file_revision_bytes_by_inode(
+                &namespace_id("demo"),
+                small_inode_id,
+                loonfs_api::RevisionNo(1),
+            )
+            .await
+            .expect("small inode content fits under the limit")
+            .len(),
+        8
+    );
 
     server.abort();
 }
@@ -3342,6 +3407,10 @@ mod direct_download {
             .put_file_bytes(&target, &payload, &replace_file_options())
             .await
             .expect("seed the oversized file");
+        let entry = client
+            .stat_path(&target, &Default::default())
+            .await
+            .expect("stat seeded file");
 
         // The wall the audit found: this deployment let the file exist and
         // will not proxy it back.
@@ -3358,6 +3427,7 @@ mod direct_download {
             .expect("download grant");
         assert_eq!(grant.path.as_str(), "/big.bin");
         assert_eq!(grant.content_ref.size_bytes, payload.len() as u64);
+        assert_eq!(Some(&grant.content_ref), entry.content_ref());
 
         let mut received = Vec::new();
         let written = client
@@ -3366,6 +3436,29 @@ mod direct_download {
             .expect("stream the granted object");
         assert_eq!(written, payload.len() as u64);
         assert_eq!(received, payload);
+
+        client
+            .delete_path(
+                &target,
+                &DeleteOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("delete current binding");
+        let inode_grant = client
+            .begin_download_by_inode(&namespace, entry.inode_id, RevisionNo(1))
+            .await
+            .expect("grant retained inode revision");
+        assert_eq!(inode_grant.inode_id, entry.inode_id);
+        assert_eq!(inode_grant.content_ref, grant.content_ref);
+        let mut stream = client
+            .open_direct_download_by_inode(&inode_grant)
+            .await
+            .expect("open inode grant");
+        let mut inode_received = Vec::new();
+        while let Some(chunk) = stream.next_chunk().await.expect("read inode grant") {
+            inode_received.extend_from_slice(&chunk);
+        }
+        assert_eq!(inode_received, payload);
     }
 
     /// A grant names one immutable object, so a commit that replaces the
@@ -3451,6 +3544,28 @@ mod direct_download {
                 ..
             } => {
                 assert_eq!(*status, 501);
+                assert_eq!(code, ErrorCode::NotSupported.as_str());
+                assert_eq!(feature.as_deref(), Some(FEATURE_DOWNLOADS_DIRECT_GET));
+            }
+            other => panic!("expected a typed not_supported, got {other:?}"),
+        }
+        let inode_id = client
+            .stat_path(&target, &Default::default())
+            .await
+            .expect("stat proxied file")
+            .inode_id;
+        let inode_error = client
+            .begin_download_by_inode(&namespace, inode_id, RevisionNo(1))
+            .await
+            .expect_err("the inode route honors the same provider gate");
+        match inode_error {
+            ClientError::Api {
+                status,
+                code,
+                feature,
+                ..
+            } => {
+                assert_eq!(status, 501);
                 assert_eq!(code, ErrorCode::NotSupported.as_str());
                 assert_eq!(feature.as_deref(), Some(FEATURE_DOWNLOADS_DIRECT_GET));
             }

--- a/crates/loonfs-server/tests/it/http_inodes.rs
+++ b/crates/loonfs-server/tests/it/http_inodes.rs
@@ -1,4 +1,4 @@
-//! HTTP inode-addressed stat, revision history, and content reads.
+//! HTTP stat, revision history, and content reads by inode id.
 
 use crate::common::http_split_support::{replace_file_options, test_config};
 use crate::common::start_server;

--- a/crates/loonfs-server/tests/it/http_inodes.rs
+++ b/crates/loonfs-server/tests/it/http_inodes.rs
@@ -1,0 +1,290 @@
+//! HTTP inode-addressed stat, revision history, and content reads.
+
+use crate::common::http_split_support::{replace_file_options, test_config};
+use crate::common::start_server;
+use loonfs_api::{ApiError, ErrorCode, InodeId, RevisionNo};
+use loonfs_client::{
+    ClientError, CreateDirectoryOptions, DeleteOptions, MoveOptions, NamespacePath, PutFileOptions,
+};
+use loonfs_test_support::http::raw_agent;
+use loonfs_test_support::ids::namespace_id;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn assert_api_code<T: std::fmt::Debug>(
+    result: Result<T, ClientError>,
+    expected_status: u16,
+    code: ErrorCode,
+) {
+    match result.expect_err("request should fail") {
+        ClientError::Api {
+            status,
+            code: actual,
+            ..
+        } => {
+            assert_eq!(status, expected_status);
+            assert_eq!(actual, code.as_str());
+            assert_ne!(actual, ErrorCode::PathNotFound.as_str());
+        }
+        other => unreachable!("expected API error, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_stat_inode_tracks_renames_and_revision_reads_survive_deletion() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "http-inode-rename",
+        "http-inode-rename",
+    ))
+    .await;
+    let namespace = namespace_id("demo");
+    let actor = loonfs_test_support::test_actor();
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let before = NamespacePath::parse("demo", "/before.txt").expect("before path");
+    let after = NamespacePath::parse("demo", "/after.txt").expect("after path");
+    harness
+        .client
+        .put_file_bytes(&before, b"one", &PutFileOptions::new(actor.clone()))
+        .await
+        .expect("put revision one");
+    harness
+        .client
+        .put_file_bytes(&before, b"two", &replace_file_options())
+        .await
+        .expect("put revision two");
+
+    let by_path = harness
+        .client
+        .stat_path(&before, &Default::default())
+        .await
+        .expect("stat path");
+    let inode_id = by_path.inode_id;
+    assert_eq!(
+        harness
+            .client
+            .stat_inode(&namespace, inode_id, &Default::default())
+            .await
+            .expect("stat inode before rename"),
+        by_path
+    );
+    assert_eq!(
+        harness
+            .client
+            .get_file_revision_bytes_by_inode(&namespace, inode_id, RevisionNo(1))
+            .await
+            .expect("read inode revision before rename"),
+        b"one"
+    );
+
+    harness
+        .client
+        .move_path(&before, &after, &MoveOptions::new(actor.clone()))
+        .await
+        .expect("rename file");
+    let renamed = harness
+        .client
+        .stat_inode(&namespace, inode_id, &Default::default())
+        .await
+        .expect("stat inode after rename");
+    assert_eq!(renamed.inode_id, inode_id);
+    assert_eq!(renamed.path.as_str(), "/after.txt");
+    assert_eq!(
+        renamed,
+        harness
+            .client
+            .stat_path(&after, &Default::default())
+            .await
+            .expect("stat renamed path")
+    );
+    let revisions = harness
+        .client
+        .list_file_revisions_by_inode_page(&namespace, inode_id, Some(1), None)
+        .await
+        .expect("first inode revision page");
+    assert_eq!(revisions.inode_id, inode_id);
+    assert_eq!(revisions.revisions.len(), 1);
+    assert!(revisions.next_cursor.is_some());
+
+    let raw: Value = serde_json::from_reader(
+        raw_agent()
+            .get(&format!(
+                "{}/v0/namespaces/{namespace}/inodes/{inode_id}/revisions",
+                harness.server_url
+            ))
+            .set("authorization", "Bearer test-token")
+            .call()
+            .expect("raw revision listing")
+            .into_reader(),
+    )
+    .expect("decode raw revision listing");
+    assert!(raw.get("path").is_none());
+
+    harness
+        .client
+        .delete_path(&after, &DeleteOptions::new(actor))
+        .await
+        .expect("delete file");
+    assert_api_code(
+        harness
+            .client
+            .stat_inode(&namespace, inode_id, &Default::default())
+            .await,
+        404,
+        ErrorCode::InodeNotFound,
+    );
+    assert_eq!(
+        harness
+            .client
+            .get_file_revision_bytes_by_inode(&namespace, inode_id, RevisionNo(2))
+            .await
+            .expect("read retained deleted revision"),
+        b"two"
+    );
+    assert_eq!(
+        harness
+            .client
+            .list_file_revisions_by_inode_page(&namespace, inode_id, None, None)
+            .await
+            .expect("list retained deleted revisions")
+            .revisions
+            .len(),
+        2
+    );
+
+    harness.server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_inode_read_errors_use_identity_codes_and_root_is_nameless() {
+    let temp_dir = tempdir().expect("tempdir");
+    let harness = start_server(test_config(
+        temp_dir.path().join("store"),
+        "http-inode-errors",
+        "http-inode-errors",
+    ))
+    .await;
+    let namespace = namespace_id("demo");
+    let actor = loonfs_test_support::test_actor();
+    harness
+        .client
+        .create_namespace(&namespace)
+        .await
+        .expect("create namespace");
+    let root = harness
+        .client
+        .stat_inode(&namespace, InodeId(1), &Default::default())
+        .await
+        .expect("stat root inode");
+    assert_eq!(root.path.as_str(), "/");
+    assert_eq!(root.parent_inode_id, None);
+    assert_eq!(root.display_name, None);
+
+    let directory = NamespacePath::parse("demo", "/docs").expect("directory path");
+    harness
+        .client
+        .create_directory(&directory, &CreateDirectoryOptions::new(actor.clone()))
+        .await
+        .expect("create directory");
+    let directory_id = harness
+        .client
+        .stat_path(&directory, &Default::default())
+        .await
+        .expect("stat directory")
+        .inode_id;
+    assert_api_code(
+        harness
+            .client
+            .list_file_revisions_by_inode_page(&namespace, directory_id, None, None)
+            .await,
+        409,
+        ErrorCode::PathConflict,
+    );
+    for result in [
+        harness
+            .client
+            .stat_inode(&namespace, InodeId(u64::MAX), &Default::default())
+            .await
+            .map(|_| ()),
+        harness
+            .client
+            .get_file_revision_bytes_by_inode(&namespace, InodeId(u64::MAX), RevisionNo(1))
+            .await
+            .map(|_| ()),
+    ] {
+        assert_api_code(result, 404, ErrorCode::InodeNotFound);
+    }
+
+    let file = NamespacePath::parse("demo", "/file.txt").expect("file path");
+    harness
+        .client
+        .put_file_bytes(&file, b"body", &PutFileOptions::new(actor))
+        .await
+        .expect("put file");
+    let file_id = harness
+        .client
+        .stat_path(&file, &Default::default())
+        .await
+        .expect("stat file")
+        .inode_id;
+    assert_api_code(
+        harness
+            .client
+            .get_file_revision_bytes_by_inode(&namespace, file_id, RevisionNo(999))
+            .await,
+        404,
+        ErrorCode::RevisionNotFound,
+    );
+
+    let deleted_namespace = namespace_id("deleted");
+    harness
+        .client
+        .create_namespace(&deleted_namespace)
+        .await
+        .expect("create deleted namespace");
+    harness
+        .client
+        .delete_namespace(&deleted_namespace, None)
+        .await
+        .expect("delete namespace");
+    assert_api_code(
+        harness
+            .client
+            .stat_inode(&deleted_namespace, InodeId(1), &Default::default())
+            .await,
+        410,
+        ErrorCode::NamespaceDeleted,
+    );
+
+    let strict_body = raw_agent()
+        .post(&format!(
+            "{}/v0/namespaces/{namespace}/inodes/{file_id}/revisions/1/downloads",
+            harness.server_url
+        ))
+        .set("authorization", "Bearer test-token")
+        .send_json(serde_json::json!({ "path": "/file.txt" }))
+        .expect_err("inode download body rejects fields");
+    let ureq::Error::Status(status, response) = strict_body else {
+        unreachable!("expected status response")
+    };
+    assert_eq!(status, 400);
+    let error: ApiError =
+        serde_json::from_reader(response.into_reader()).expect("decode strict-body error");
+    assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
+
+    assert_api_code(
+        harness
+            .client
+            .begin_download_by_inode(&namespace, file_id, RevisionNo(1))
+            .await,
+        501,
+        ErrorCode::NotSupported,
+    );
+
+    harness.server.abort();
+}

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -537,7 +537,6 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         .list_file_revisions_page(&target, None, None)
         .await
         .expect("path revisions");
-    assert_eq!(revisions.path, target.absolute_path().clone());
     assert_eq!(revisions.inode_id, entry.inode_id);
     assert_eq!(revisions.revisions.len(), 2);
     assert_eq!(
@@ -576,7 +575,6 @@ async fn http_revision_routes_list_read_and_restore_by_path() {
         .list_file_revisions_page(&moved, None, None)
         .await
         .expect("moved-path revisions");
-    assert_eq!(moved_revisions.path, moved.absolute_path().clone());
     assert_eq!(moved_revisions.inode_id, entry.inode_id);
     assert_eq!(moved_revisions.revisions.len(), 2);
 

--- a/crates/loonfs-server/tests/it/main.rs
+++ b/crates/loonfs-server/tests/it/main.rs
@@ -11,6 +11,7 @@ mod http_attributes;
 mod http_attribution;
 mod http_auth;
 mod http_commits;
+mod http_inodes;
 mod http_limits;
 mod http_metrics;
 mod http_pagination;

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -43,6 +43,19 @@ fn openapi_documents_current_server_paths() {
         ("/v0/namespaces/{namespace_id}/filesystem/content", "get"),
         ("/v0/namespaces/{namespace_id}/filesystem/downloads", "post"),
         ("/v0/namespaces/{namespace_id}/filesystem/revisions", "get"),
+        ("/v0/namespaces/{namespace_id}/inodes/{inode_id}", "get"),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
+            "get",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
+            "get",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads",
+            "post",
+        ),
         ("/v0/namespaces/{namespace_id}/commits", "post"),
         ("/v0/namespaces/{namespace_id}/uploads", "post"),
         (
@@ -128,7 +141,82 @@ fn openapi_documents_current_server_paths() {
             assert!(!path_parameter_names.contains("namespace"));
         }
     }
-    assert_eq!(namespace_scoped_operations, 26);
+    assert_eq!(namespace_scoped_operations, 30);
+
+    for (path, method, parameter, schema_name) in [
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}",
+            "get",
+            "inode_id",
+            "InodeId",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
+            "get",
+            "inode_id",
+            "InodeId",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
+            "get",
+            "inode_id",
+            "InodeId",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
+            "get",
+            "revision_no",
+            "RevisionNo",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads",
+            "post",
+            "inode_id",
+            "InodeId",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads",
+            "post",
+            "revision_no",
+            "RevisionNo",
+        ),
+    ] {
+        assert_path_parameter_schema(paths, path, method, parameter, schema_name);
+    }
+
+    for (path, method, operation_id) in [
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}",
+            "get",
+            "stat_inode",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
+            "get",
+            "list_file_revisions_by_inode",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content",
+            "get",
+            "get_file_revision_bytes_by_inode",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads",
+            "post",
+            "begin_download_by_inode",
+        ),
+    ] {
+        let actual = paths
+            .get(path)
+            .and_then(|path_item| path_item.get(method))
+            .and_then(|operation| operation.get("operationId"))
+            .and_then(Value::as_str);
+        assert_eq!(
+            actual,
+            Some(operation_id),
+            "unexpected operation id for `{method} {path}`"
+        );
+    }
 }
 
 #[test]
@@ -509,4 +597,35 @@ fn assert_query_params(
             "missing query parameter `{name}` for `{method} {path}`"
         );
     }
+}
+
+fn assert_path_parameter_schema(
+    paths: &serde_json::Map<String, Value>,
+    path: &str,
+    method: &str,
+    parameter_name: &str,
+    schema_name: &str,
+) {
+    let operation = paths
+        .get(path)
+        .and_then(|path_item| path_item.get(method))
+        .unwrap_or_else(|| panic!("missing OpenAPI operation `{method} {path}`"));
+    let parameter = operation
+        .get("parameters")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .find(|parameter| {
+            parameter.get("in").and_then(Value::as_str) == Some("path")
+                && parameter.get("name").and_then(Value::as_str) == Some(parameter_name)
+        })
+        .unwrap_or_else(|| {
+            panic!("missing path parameter `{parameter_name}` for `{method} {path}`")
+        });
+    let expected_ref = format!("#/components/schemas/{schema_name}");
+    assert_eq!(
+        parameter.pointer("/schema/$ref").and_then(Value::as_str),
+        Some(expected_ref.as_str()),
+        "path parameter `{parameter_name}` for `{method} {path}` does not use `{schema_name}`",
+    );
 }

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -13,13 +13,13 @@ use crate::{
 };
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
-    encode_cursor, AbsolutePath, CapabilityDocument, EffectiveLimit, FileRevision,
-    FileRevisionsPageCursor, Page, PaginationPolicy, FEATURE_ATTRIBUTES,
-    FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
-    FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
-    LIMIT_COMMIT_MAX_CONTENT_TOKENS, LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS,
-    LIMIT_COMMIT_MAX_MESSAGE_BYTES, LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_GC_MIN_GRACE_WINDOW_MS,
-    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
+    encode_cursor, CapabilityDocument, EffectiveLimit, FileRevision, FileRevisionsPageCursor, Page,
+    PaginationPolicy, FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_NAMESPACES_CREATE,
+    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART,
+    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_CONTENT_TOKENS,
+    LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS, LIMIT_COMMIT_MAX_MESSAGE_BYTES,
+    LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_GC_MIN_GRACE_WINDOW_MS, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
+    PROTOCOL_VERSION,
 };
 use loonfs_core::cache::{
     MetadataTableCache, StoredMetadataBlockCache, WalTailProjectionCache,
@@ -307,7 +307,6 @@ pub(super) fn default_page_limit() -> EffectiveLimit {
 
 pub(super) fn file_revisions_page_response(
     namespace_id: NamespaceId,
-    absolute_path: AbsolutePath,
     head_seq: ChangeSeq,
     page: Page<FileRevision, FileRevisionsPageCursor>,
     fallback_inode_id: Option<InodeId>,
@@ -329,7 +328,6 @@ pub(super) fn file_revisions_page_response(
         .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
     Ok(ListFileRevisionsResponse {
         namespace_id,
-        path: absolute_path,
         inode_id,
         head_seq,
         revisions: page.items,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -53,8 +53,7 @@ impl FsReader {
         Ok(entry)
     }
 
-    /// Resolves a currently visible inode to its canonical entry at the
-    /// current head, projecting what `options` asks for.
+    /// Returns the current entry for a visible inode.
     #[tracing::instrument(
         level = "debug",
         name = "loonfs.stat_inode",
@@ -277,9 +276,8 @@ impl FsReader {
         Ok(target)
     }
 
-    /// Resolves one retained inode revision to the content object a direct
-    /// read would fetch. The answer is path-free and does not require the
-    /// inode to be currently visible.
+    /// Resolves retained inode content for a direct download without
+    /// requiring a current path.
     pub async fn direct_download_target_by_inode(
         &self,
         namespace_id: &NamespaceId,
@@ -425,9 +423,7 @@ impl FsReader {
         )?)
     }
 
-    /// Lists one page of a file inode's retained revision history. The
-    /// response is path-free because the inode may have moved or been
-    /// deleted since those revisions were written.
+    /// Lists one page of retained revisions for a file inode.
     pub async fn list_file_revisions_by_inode_page(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -3,7 +3,7 @@
 //! own data from the filesystem walks.
 
 use super::core::{default_page_limit, file_revisions_page_response};
-use crate::downloads::DirectDownloadTarget;
+use crate::downloads::{DirectDownloadByInodeTarget, DirectDownloadTarget};
 use crate::FsReader;
 use crate::Result;
 use crate::{
@@ -45,6 +45,38 @@ impl FsReader {
         let entry = engine
             .resolve_path(absolute_path, options, &read_context)
             .await?;
+        tracing::Span::current().record("cache_path", crate::trace::CACHE_MATERIALIZED_TABLES);
+        self.core
+            .inner
+            .cache_stats
+            .record_latest_metadata_view_read();
+        Ok(entry)
+    }
+
+    /// Resolves a currently visible inode to its canonical entry at the
+    /// current head, projecting what `options` asks for.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.stat_inode",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "stat_inode",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            cache_path = tracing::field::Empty,
+        )
+    )]
+    pub async fn stat_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        options: StatPathOptions,
+    ) -> Result<AuthoritativePathEntry> {
+        let span = tracing::Span::current();
+        self.core.record_trace_context(&span);
+        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let entry = engine.stat_inode(inode_id, options, &read_context).await?;
         tracing::Span::current().record("cache_path", crate::trace::CACHE_MATERIALIZED_TABLES);
         self.core
             .inner
@@ -245,6 +277,26 @@ impl FsReader {
         Ok(target)
     }
 
+    /// Resolves one retained inode revision to the content object a direct
+    /// read would fetch. The answer is path-free and does not require the
+    /// inode to be currently visible.
+    pub async fn direct_download_target_by_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<DirectDownloadByInodeTarget> {
+        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let target = engine
+            .direct_download_target_by_inode(inode_id, revision_no, &read_context)
+            .await?;
+        self.core
+            .inner
+            .cache_stats
+            .record_latest_metadata_view_read();
+        Ok(target)
+    }
+
     /// Reads one page of the files visible in the state a checkpoint pins,
     /// in ascending inode-id order.
     ///
@@ -367,10 +419,34 @@ impl FsReader {
             .record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
-            absolute_path,
             read_context.head.seq,
             page,
             fallback_inode_id,
+        )?)
+    }
+
+    /// Lists one page of a file inode's retained revision history. The
+    /// response is path-free because the inode may have moved or been
+    /// deleted since those revisions were written.
+    pub async fn list_file_revisions_by_inode_page(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> Result<ListFileRevisionsResponse> {
+        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let page = engine
+            .list_file_revisions_for_inode_page(inode_id, request, &read_context)
+            .await?;
+        self.core
+            .inner
+            .cache_stats
+            .record_latest_metadata_view_read();
+        Ok(file_revisions_page_response(
+            namespace_id.clone(),
+            read_context.head.seq,
+            page,
+            Some(inode_id),
         )?)
     }
 
@@ -395,6 +471,30 @@ impl FsReader {
             .cache_stats
             .record_latest_metadata_view_read();
         Ok(read)
+    }
+
+    /// Reads and verifies one retained file revision by inode identity.
+    /// Current visibility and path are not required.
+    pub async fn get_file_revision_bytes_by_inode(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        revision_no: RevisionNo,
+    ) -> Result<Vec<u8>> {
+        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let bytes = engine
+            .read_file_revision_for_inode(
+                inode_id,
+                revision_no,
+                &read_context,
+                self.core.inner.config.max_read_content_bytes,
+            )
+            .await?;
+        self.core
+            .inner
+            .cache_stats
+            .record_latest_metadata_view_read();
+        Ok(bytes)
     }
 
     /// Reads the ordered change feed after the `after_seq` cursor.

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -167,7 +167,7 @@ pub mod uploads {
 /// Direct-download target type used by servers to create a presigned
 /// object-read URL. Most embedded applications do not need this module.
 pub mod downloads {
-    pub use loonfs_core::DirectDownloadTarget;
+    pub use loonfs_core::{DirectDownloadByInodeTarget, DirectDownloadTarget};
 }
 
 /// Typed loaders for inspecting durable namespace control objects.

--- a/crates/loonfs/tests/it/inode_reads.rs
+++ b/crates/loonfs/tests/it/inode_reads.rs
@@ -1,0 +1,258 @@
+//! Inode-addressed current metadata and retained revision reads.
+
+use crate::common::{open_runtime_async, store};
+use loonfs::{
+    CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions, ErrorCode, FsReader, InodeId,
+    MoveOptions, PageRequest, PaginationPolicy, PutFileOptions, RevisionNo, StatPathOptions,
+};
+use loonfs_test_support::ids::namespace_id;
+use tempfile::tempdir;
+
+fn page_request() -> PageRequest<loonfs::FileRevisionsPageCursor> {
+    PageRequest {
+        limit: PaginationPolicy::default()
+            .resolve_limit(None)
+            .expect("default page limit"),
+        cursor: None,
+    }
+}
+
+#[tokio::test]
+async fn stat_inode_tracks_a_rename_and_retained_revisions_keep_the_same_identity() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "inode-rename-test").await;
+    let namespace_id = namespace_id("demo");
+    let actor = loonfs_test_support::test_actor();
+    fs.writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    fs.writer
+        .put_file_bytes(
+            &namespace_id,
+            "/before.txt",
+            b"one",
+            PutFileOptions::new(actor.clone()),
+        )
+        .await
+        .expect("put first revision");
+    fs.writer
+        .put_file_bytes(
+            &namespace_id,
+            "/before.txt",
+            b"two",
+            PutFileOptions {
+                behavior: loonfs::DestinationBehavior::Replace,
+                ..PutFileOptions::new(actor.clone())
+            },
+        )
+        .await
+        .expect("put second revision");
+
+    let path_entry = fs
+        .reader
+        .stat_path(&namespace_id, "/before.txt", StatPathOptions::default())
+        .await
+        .expect("stat path before rename");
+    let inode_id = path_entry.inode_id;
+    let inode_entry = fs
+        .reader
+        .stat_inode(&namespace_id, inode_id, StatPathOptions::default())
+        .await
+        .expect("stat inode before rename");
+    assert_eq!(inode_entry, path_entry);
+    assert_eq!(
+        fs.reader
+            .get_file_revision_bytes_by_inode(&namespace_id, inode_id, RevisionNo(1))
+            .await
+            .expect("read revision before rename"),
+        b"one"
+    );
+
+    fs.writer
+        .move_path(
+            &namespace_id,
+            "/before.txt",
+            "/after.txt",
+            MoveOptions::new(actor.clone()),
+        )
+        .await
+        .expect("rename file");
+    let after = fs
+        .reader
+        .stat_inode(&namespace_id, inode_id, StatPathOptions::default())
+        .await
+        .expect("stat inode after rename");
+    assert_eq!(after.inode_id, inode_id);
+    assert_eq!(after.path.as_str(), "/after.txt");
+    assert_eq!(
+        after,
+        fs.reader
+            .stat_path(&namespace_id, "/after.txt", StatPathOptions::default())
+            .await
+            .expect("stat renamed path")
+    );
+    let revisions = fs
+        .reader
+        .list_file_revisions_by_inode_page(&namespace_id, inode_id, page_request())
+        .await
+        .expect("list revisions after rename");
+    assert_eq!(revisions.inode_id, inode_id);
+    assert_eq!(revisions.revisions.len(), 2);
+    assert_eq!(
+        fs.reader
+            .get_file_revision_bytes_by_inode(&namespace_id, inode_id, RevisionNo(1))
+            .await
+            .expect("read revision after rename"),
+        b"one"
+    );
+
+    fs.writer
+        .delete_path(&namespace_id, "/after.txt", DeleteOptions::new(actor))
+        .await
+        .expect("delete file");
+    let hidden = fs
+        .reader
+        .stat_inode(&namespace_id, inode_id, StatPathOptions::default())
+        .await
+        .expect_err("deleted inode is not current");
+    assert_eq!(hidden.code(), ErrorCode::InodeNotFound);
+    assert_eq!(
+        fs.reader
+            .get_file_revision_bytes_by_inode(&namespace_id, inode_id, RevisionNo(2))
+            .await
+            .expect("read retained deleted revision"),
+        b"two"
+    );
+    assert_eq!(
+        fs.reader
+            .list_file_revisions_by_inode_page(&namespace_id, inode_id, page_request())
+            .await
+            .expect("list retained deleted revisions")
+            .revisions
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn stat_inode_preserves_the_nameless_root_and_revision_error_conventions() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = open_runtime_async(store(temp_dir.path()), "inode-error-test").await;
+    let namespace_id = namespace_id("demo");
+    let actor = loonfs_test_support::test_actor();
+    fs.writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+
+    let root = fs
+        .reader
+        .stat_inode(&namespace_id, InodeId(1), StatPathOptions::default())
+        .await
+        .expect("stat root inode");
+    assert_eq!(root.path.as_str(), "/");
+    assert_eq!(root.parent_inode_id, None);
+    assert_eq!(root.display_name, None);
+    assert_eq!(
+        root,
+        fs.reader
+            .stat_path(&namespace_id, "/", StatPathOptions::default())
+            .await
+            .expect("stat root path")
+    );
+
+    fs.writer
+        .create_directory(&namespace_id, "/docs", CreateDirectoryOptions::new(actor))
+        .await
+        .expect("create directory");
+    let directory = fs
+        .reader
+        .stat_path(&namespace_id, "/docs", StatPathOptions::default())
+        .await
+        .expect("stat directory");
+    let directory_error = fs
+        .reader
+        .list_file_revisions_by_inode_page(&namespace_id, directory.inode_id, page_request())
+        .await
+        .expect_err("directory has no file revisions");
+    assert_eq!(directory_error.code(), ErrorCode::PathConflict);
+
+    for error in [
+        fs.reader
+            .stat_inode(&namespace_id, InodeId(u64::MAX), StatPathOptions::default())
+            .await
+            .expect_err("unknown inode stat"),
+        fs.reader
+            .get_file_revision_bytes_by_inode(&namespace_id, InodeId(u64::MAX), RevisionNo(1))
+            .await
+            .expect_err("unknown inode content"),
+    ] {
+        assert_eq!(error.code(), ErrorCode::InodeNotFound);
+        assert_ne!(error.code(), ErrorCode::PathNotFound);
+    }
+}
+
+#[tokio::test]
+async fn stat_inode_and_stat_path_have_the_same_point_lookup_request_count() {
+    use loonfs_test_support::stores::{KeyPredicate, RecordingStore};
+    use std::sync::Arc;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let recorded = Arc::new(RecordingStore::new(
+        loonfs_objectstore::local_fs_store::LocalFsStore::new(temp_dir.path())
+            .expect("local store"),
+        KeyPredicate::any(),
+    ));
+    let shared: loonfs::SharedObjectStore = recorded.clone();
+    let fs = open_runtime_async(shared.clone(), "inode-accounting-writer").await;
+    let namespace_id = namespace_id("demo");
+    fs.writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    fs.writer
+        .put_file_bytes(
+            &namespace_id,
+            "/file.txt",
+            b"body",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("put file");
+    let inode_id = fs
+        .reader
+        .stat_path(&namespace_id, "/file.txt", StatPathOptions::default())
+        .await
+        .expect("discover inode")
+        .inode_id;
+    drop(fs);
+    let _ = recorded.take_gets();
+
+    let path_reader = FsReader::builder_with_store(shared.clone())
+        .build()
+        .await
+        .expect("build path reader");
+    path_reader
+        .stat_path(&namespace_id, "/file.txt", StatPathOptions::default())
+        .await
+        .expect("cold path stat");
+    let path_gets = recorded.take_gets();
+    drop(path_reader);
+
+    let inode_reader = FsReader::builder_with_store(shared)
+        .build()
+        .await
+        .expect("build inode reader");
+    inode_reader
+        .stat_inode(&namespace_id, inode_id, StatPathOptions::default())
+        .await
+        .expect("cold inode stat");
+    let inode_gets = recorded.take_gets();
+
+    assert_eq!(
+        inode_gets.len(),
+        path_gets.len(),
+        "identity stat must remain a point lookup: path={path_gets:#?}, inode={inode_gets:#?}"
+    );
+}

--- a/crates/loonfs/tests/it/inode_reads.rs
+++ b/crates/loonfs/tests/it/inode_reads.rs
@@ -1,4 +1,4 @@
-//! Inode-addressed current metadata and retained revision reads.
+//! Current metadata and revision reads by inode id.
 
 use crate::common::{open_runtime_async, store};
 use loonfs::{

--- a/crates/loonfs/tests/it/main.rs
+++ b/crates/loonfs/tests/it/main.rs
@@ -17,6 +17,7 @@ mod content_request_accounting;
 mod direct_put;
 mod handles;
 mod immutable_view_inputs;
+mod inode_reads;
 mod invalidation;
 mod maintenance;
 mod metrics_instruments;

--- a/crates/loonfs/tests/it/pagination.rs
+++ b/crates/loonfs/tests/it/pagination.rs
@@ -124,7 +124,6 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
         },
     ))
     .expect("first revision page");
-    assert_eq!(first.path.as_str(), "/doc.txt");
     assert_eq!(
         first
             .revisions
@@ -145,7 +144,6 @@ fn file_revision_pages_merge_manifest_and_wal_tail_newest_first() {
         },
     ))
     .expect("second revision page");
-    assert_eq!(second.path.as_str(), "/doc.txt");
     assert_eq!(
         second
             .revisions
@@ -336,7 +334,6 @@ fn revisions_cursor_resumes_after_later_writes() {
         },
     ))
     .expect("first revisions page");
-    assert_eq!(first.path.as_str(), "/docs/report.txt");
     assert_eq!(
         first
             .revisions
@@ -371,7 +368,6 @@ fn revisions_cursor_resumes_after_later_writes() {
         },
     ))
     .expect("second revisions page resumes after head drift");
-    assert_eq!(second.path.as_str(), "/docs/report.txt");
     assert_eq!(
         second
             .revisions

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -251,7 +251,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `namespace_not_found` | 404 | The namespace has no head, so it does not exist. |
 | `namespace_deleted` | 410 | The namespace's head records the terminal deleted state. The id is permanently retired, so a create or fork against it fails here rather than as a conflict. |
 | `path_not_found` | 404 | No visible entry at the path. |
-| `inode_not_found` | 404 | No currently visible inode for an inode-addressed current-state read, or no retained inode row for an identity-addressed history read. |
+| `inode_not_found` | 404 | The requested visible or retained inode does not exist. |
 | `revision_not_found` | 404 | The file has no such revision. |
 | `upload_not_found` | 404 | No upload session with this id, or one that was aborted: an aborted session will never select content, so it reports the absence that its deletion will. |
 | `namespace_exists` | 409 | The create or fork target already exists: another namespace holds the id. |
@@ -1387,14 +1387,10 @@ The namespace root is nameless: its entry omits both `parent_inode_id` and
 `display_name`. Every non-root entry carries a validated `display_name`; the
 empty string is not a spelling for the root or for any named path component.
 
-The inode form returns this exact entry shape, including the inode's current
-`path`. It resolves identity through the child-keyed current-binding index;
-it never searches directory listings. A rename therefore changes `path`,
-`parent_inode_id`, and `display_name` as applicable while preserving
-`inode_id`, creation attribution, attributes, and file revision metadata.
-An unknown or not-currently-visible inode answers `inode_not_found`. The root
-inode answers `/` under the same nameless-root rule. `include_attributes`
-has the same syntax and default as path stat.
+The inode route returns the same entry shape, including the current `path`.
+Renaming an entry changes its path and name but not its inode id or metadata.
+An unknown or hidden inode returns `inode_not_found`. The root inode returns
+`/`. `include_attributes` behaves the same as it does for path stat.
 
 ### 6.5 `GET /filesystem/list`
 
@@ -1525,21 +1521,16 @@ end of the road: the download transport in section 6.10 reads the same bytes
 without the server holding them, and every deployment that could have let a
 client create such a file offers it.
 
-Revision listing returns newest revisions first and uses the standard
-`limit` / `cursor` pattern. The path route resolves the current path to its
-current inode; the inode route addresses that inode directly. The response is
-path-free for both forms: a path is not historical identity, and an inode may
-move while a cursor is held. Responses include `next_cursor` only when another
-page is available. Revision history is never pruned — paging to the end always
-reaches revision 1, regardless of how far the retention floor has advanced.
+Revision listings return newest revisions first and use the standard
+`limit`/`cursor` pattern. The path route resolves the current inode first; the
+inode route addresses it directly. Both return the same path-free response.
+`next_cursor` is included only when another page is available. Revision
+history is not pruned, so paging to the end reaches revision 1.
 
-`GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/content`
-likewise resolves the pair directly and verifies the selected `ContentRef`;
-it never re-enters through a current path. A deleted file remains listable and
-readable by inode while its retained rows exist. A directory inode follows the
-existing not-a-file convention (`path_conflict`), an unknown inode answers
-`inode_not_found`, and a missing revision under a valid file inode answers
-`revision_not_found`. Inode routes never answer `path_not_found`.
+The inode content route reads and verifies a revision without resolving a
+current path. Deleted files remain readable while their revision rows are
+retained. A directory returns `path_conflict`, an unknown inode returns
+`inode_not_found`, and an unknown revision returns `revision_not_found`.
 
 ```json
 {
@@ -2062,10 +2053,9 @@ checks the arriving bytes against:
 }
 ```
 
-The identity-addressed form is
+The inode form is
 `POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads`.
-Its body is strictly `{}`. Its response deliberately does not invent a path
-for a historical or unbound revision:
+Its body is `{}` and its response does not include a path:
 
 ```json
 {
@@ -2087,10 +2077,9 @@ for a historical or unbound revision:
 }
 ```
 
-Both grant routes use the same proven-provider gate and access shape. The
-inode form resolves the retained `(inode_id, revision_no)` pair directly, so
-it remains available after rename or deletion exactly when the proxied inode
-revision read does.
+Both download routes use the same provider support check and access format.
+The inode route remains available after a rename or deletion while the
+revision is retained.
 
 Four properties follow from the shape, and clients may rely on all of them.
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -24,7 +24,7 @@ within a plane is expressed as **named features** (section 2).
 
 | Profile | Plane | Ops | Status |
 | --- | --- | --- | --- |
-| `core/v0` | Data plane | Path reads and mutations (stat, list, content, revisions, path operations), staged uploads, the change feed, namespace status by id, `GET /v0/capabilities`, and the standard error contract. Namespace `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
+| `core/v0` | Data plane | Path and inode reads (stat, list, content, revisions), path mutations, staged uploads, the change feed, namespace status by id, `GET /v0/capabilities`, and the standard error contract. Namespace `create`, `fork`, and `delete` are **features** within this profile. | **Mandatory** for any conforming deployment |
 | `admin/v0` | Maintenance plane | Create and release checkpoints; run one-shot maintenance steps that select any of metadata upkeep (WAL flush plus reorganization), retention-floor advancement, and garbage collection. Maintenance triggers for derived indexes arrive as features in this plane: grep-index administration is the `admin.grep.index` **feature**. | Optional |
 | `query/v0` | Query plane | Content search over derived indexes (`POST /v0/namespaces/{namespace_id}/query/grep`). Grep-index search is the `query.grep` **feature** within this profile; using it also requires a materialized steady-state grep root for the namespace. | Optional |
 | `acl/v0` | Authorization plane | — | **Reserved name only.** Do not specify ops yet. Clients must tolerate unknown error codes, so authorization errors can land with this plane without breaking anyone. |
@@ -130,7 +130,7 @@ Registered limit keys:
 | `pagination.max_limit` | Largest accepted page size for paged requests. A `limit` greater than this value is rejected with 400 `invalid_request`. |
 | `upload.max_content_bytes` | Largest request body accepted for service-proxied upload content (`PUT .../uploads/{upload_id}/content`). Clients may use `direct_put` for larger content only when `core.uploads.direct_put` is advertised; otherwise they must stay within this limit. |
 | `upload.direct_put_max_content_bytes` | Largest object this deployment's provider accepts in one presigned `direct_put` request. Unrelated to `upload.max_content_bytes`, which bounds what the service buffers on a client's behalf; this one is the provider's own single-request ceiling and is typically far larger. A claim above it answers `content_too_large` at begin, rather than being signed into a write the provider would refuse. Advertised only alongside `core.uploads.direct_put`. |
-| `download.max_content_bytes` | Largest file content a service-proxied read (`GET .../filesystem/content`, inode revision content) will buffer and return in one response. Over-limit reads answer `content_too_large`; v0 has no proxied streaming or range reads. A file past this limit is read through a download grant (`POST .../filesystem/downloads`) when `core.downloads.direct_get` is advertised — which it is on exactly the deployments that could have let a client create such a file. |
+| `download.max_content_bytes` | Largest file content a service-proxied read (`GET .../filesystem/content` or `GET .../inodes/{inode_id}/revisions/{revision_no}/content`) will buffer and return in one response. Over-limit reads answer `content_too_large`; v0 has no proxied streaming or range reads. A file past this limit is read through the corresponding path or inode download grant when `core.downloads.direct_get` is advertised — which it is on exactly the deployments that could have let a client create such a file. |
 | `upload.max_concurrent` | How many service-proxied upload bodies the deployment buffers at once; requests past the cap answer `server_busy`. |
 | `download.max_concurrent` | How many service-proxied content reads the deployment materializes at once; requests past the cap answer `server_busy`. |
 | `commit.max_operations` | Most path operations one commit may carry. A longer list answers `invalid_request` before planning, on every transport. |
@@ -159,7 +159,7 @@ hoc.
 | `core.uploads.direct_put` | Starting presigned `direct_put` upload sessions (`POST /v0/namespaces/{ns}/uploads`). | The server returns a short-lived presigned PUT capability for the exact content object. The key is present only when the deployment's provider can sign a write that binds a whole-object checksum and a create-only precondition, on an endpoint the live conformance suite has run against. Independent of `core.uploads.direct_multipart`: a provider may offer this and no multipart API at all. Raw object keys and caller-managed object-store writes are not part of this feature. |
 | `core.uploads.direct_put.checksum.<algorithm>` | Nothing on its own; it names the whole-object checksum a `direct_put` claim must carry. | Exactly one is advertised, alongside `core.uploads.direct_put`, and only ever `true`. Registered algorithms are `sha256`, `crc64nvme`, and `crc32c`, matching the `checksum.algorithm` spellings. Providers do not agree on what they can bind into a presigned write, so the deployment names it and the client folds that digest while staging; a claim in any other algorithm answers `invalid_request` at begin. |
 | `core.uploads.direct_multipart` | Starting presigned `direct_multipart` upload sessions (`POST /v0/namespaces/{ns}/uploads`) and signing their parts (`POST /v0/namespaces/{ns}/uploads/{upload_id}/parts`). | The server opens the provider's multipart upload and returns one short-lived, checksum-bound capability per part. It needs an S3-style multipart API on top of the signing the other keys need, so a provider without one advertises this key alone as absent. |
-| `core.downloads.direct_get` | Taking download grants (`POST /v0/namespaces/{ns}/filesystem/downloads`). | The server returns a short-lived presigned GET capability for the content object behind one path and revision. Any deployment that offers a direct write advertises this too, because one that lets a client create an object larger than `download.max_content_bytes` must be able to hand that object back. Raw object keys are not part of this feature. |
+| `core.downloads.direct_get` | Taking path or inode download grants (`POST /v0/namespaces/{ns}/filesystem/downloads` and `POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads`). | The server returns a short-lived presigned GET capability for the selected content object. Any deployment that offers a direct write advertises this too, because one that lets a client create an object larger than `download.max_content_bytes` must be able to hand that object back. Raw object keys are not part of this feature. |
 | `query.grep` | Content search (`POST /v0/namespaces/{ns}/query/grep`). | The serving half of a data-dependent capability: the request also requires a materialized steady-state grep root, and a namespace without one answers `not_supported` whatever this key advertises. |
 
 `admin/v0`'s only feature key is `admin.grep.index`; the rest of that plane
@@ -251,6 +251,7 @@ The full registry (`ErrorCode` in `loonfs-api`):
 | `namespace_not_found` | 404 | The namespace has no head, so it does not exist. |
 | `namespace_deleted` | 410 | The namespace's head records the terminal deleted state. The id is permanently retired, so a create or fork against it fails here rather than as a conflict. |
 | `path_not_found` | 404 | No visible entry at the path. |
+| `inode_not_found` | 404 | No currently visible inode for an inode-addressed current-state read, or no retained inode row for an identity-addressed history read. |
 | `revision_not_found` | 404 | The file has no such revision. |
 | `upload_not_found` | 404 | No upload session with this id, or one that was aborted: an aborted session will never select content, so it reports the absence that its deletion will. |
 | `namespace_exists` | 409 | The create or fork target already exists: another namespace holds the id. |
@@ -659,11 +660,15 @@ A representative v0 binding is shown below.
 | Create a namespace | `POST /v0/namespaces` |
 | Read one namespace's status | `GET /v0/namespaces/{ns}` |
 | Stat a path | `GET /v0/namespaces/{ns}/filesystem/stat?path=/docs/report.txt&include_attributes=false` (the parameter is optional and defaults to `true`) |
+| Stat an inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}?include_attributes=false` (the parameter is optional and defaults to `true`) |
 | List a path | `GET /v0/namespaces/{ns}/filesystem/list?path=/docs&limit=100&cursor=...&include_attributes=true` (the parameter is optional and defaults to `false`) |
 | List file revisions by path | `GET /v0/namespaces/{ns}/filesystem/revisions?path=/docs/report.txt&limit=100&cursor=...` |
+| List file revisions by inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions?limit=100&cursor=...` |
 | Read file content | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt` |
 | Read prior file content by path | `GET /v0/namespaces/{ns}/filesystem/content?path=/docs/report.txt&revision_no=3` |
+| Read prior file content by inode | `GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/content` |
 | Take a download grant for one file | `POST /v0/namespaces/{ns}/filesystem/downloads` |
+| Take a download grant by inode | `POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads` with strict empty body `{}` |
 | List recoverable deletions | `GET /v0/namespaces/{ns}/filesystem/trash?limit=100&cursor=...` |
 | Apply a commit | `POST /v0/namespaces/{ns}/commits` |
 | Begin or prepare upload | `POST /v0/namespaces/{ns}/uploads` |
@@ -1322,7 +1327,7 @@ its queue in admission order — requests admitted before the delete publish fir
 after it fail with `namespace_deleted`, and nothing is rejected for a delete
 that ends up failing its precondition.
 
-### 6.4 `GET /filesystem/stat`
+### 6.4 `GET /filesystem/stat` and `GET /inodes/{inode_id}`
 
 The response is one authoritative path entry. Enum values are snake_case per
 the durable naming rules (`format.md`, "Durable naming conventions").
@@ -1381,6 +1386,15 @@ projection never means "no attributes".
 The namespace root is nameless: its entry omits both `parent_inode_id` and
 `display_name`. Every non-root entry carries a validated `display_name`; the
 empty string is not a spelling for the root or for any named path component.
+
+The inode form returns this exact entry shape, including the inode's current
+`path`. It resolves identity through the child-keyed current-binding index;
+it never searches directory listings. A rename therefore changes `path`,
+`parent_inode_id`, and `display_name` as applicable while preserving
+`inode_id`, creation attribution, attributes, and file revision metadata.
+An unknown or not-currently-visible inode answers `inode_not_found`. The root
+inode answers `/` under the same nameless-root rule. `include_attributes`
+has the same syntax and default as path stat.
 
 ### 6.5 `GET /filesystem/list`
 
@@ -1511,17 +1525,25 @@ end of the road: the download transport in section 6.10 reads the same bytes
 without the server holding them, and every deployment that could have let a
 client create such a file offers it.
 
-Revision listing returns newest revisions first and uses the same
-`limit` / `cursor` pattern as directory listing, resolving the current path
-to its current inode. The response echoes that requested path as `path`.
-Responses include `next_cursor` only when another page is
-available. Revision history is never pruned — paging to the end always
+Revision listing returns newest revisions first and uses the standard
+`limit` / `cursor` pattern. The path route resolves the current path to its
+current inode; the inode route addresses that inode directly. The response is
+path-free for both forms: a path is not historical identity, and an inode may
+move while a cursor is held. Responses include `next_cursor` only when another
+page is available. Revision history is never pruned — paging to the end always
 reaches revision 1, regardless of how far the retention floor has advanced.
+
+`GET /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/content`
+likewise resolves the pair directly and verifies the selected `ContentRef`;
+it never re-enters through a current path. A deleted file remains listable and
+readable by inode while its retained rows exist. A directory inode follows the
+existing not-a-file convention (`path_conflict`), an unknown inode answers
+`inode_not_found`, and a missing revision under a valid file inode answers
+`revision_not_found`. Inode routes never answer `path_not_found`.
 
 ```json
 {
   "namespace_id": "demo",
-  "path": "/docs/report.txt",
   "inode_id": 42,
   "head_seq": 418,
   "revisions": [
@@ -2039,6 +2061,36 @@ checks the arriving bytes against:
   }
 }
 ```
+
+The identity-addressed form is
+`POST /v0/namespaces/{ns}/inodes/{inode_id}/revisions/{revision_no}/downloads`.
+Its body is strictly `{}`. Its response deliberately does not invent a path
+for a historical or unbound revision:
+
+```json
+{
+  "namespace_id": "demo",
+  "inode_id": 42,
+  "revision_no": 3,
+  "content_ref": {
+    "kind": "blob_v1",
+    "content_id": "con_9f2a6c0e4b7d4a90b13f0d8c5e6a2b41",
+    "size_bytes": 314572800,
+    "checksum": { "algorithm": "sha256", "value": "42d..." }
+  },
+  "access": {
+    "kind": "presigned_url",
+    "method": "GET",
+    "url": "https://bucket.s3.us-east-1.amazonaws.com/...&X-Amz-Signature=...",
+    "expires_at_ms": 1780000000000
+  }
+}
+```
+
+Both grant routes use the same proven-provider gate and access shape. The
+inode form resolves the retained `(inode_id, revision_no)` pair directly, so
+it remains available after rename or deletion exactly when the proxied inode
+revision read does.
 
 Four properties follow from the shape, and clients may rely on all of them.
 

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2049,6 +2049,463 @@
         }
       }
     },
+    "/v0/namespaces/{namespace_id}/inodes/{inode_id}": {
+      "get": {
+        "tags": [
+          "inodes"
+        ],
+        "summary": "Stat inode",
+        "description": "Returns the canonical current entry for a visible inode, including its current path. Unknown and currently invisible inodes answer `inode_not_found`.",
+        "operationId": "stat_inode",
+        "parameters": [
+          {
+            "name": "namespace_id",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "inode_id",
+            "in": "path",
+            "description": "Inode id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/InodeId"
+            }
+          },
+          {
+            "name": "include_attributes",
+            "in": "query",
+            "description": "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authoritative current inode entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthoritativePathEntry"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid inode id or include_attributes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or visible inode not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions": {
+      "get": {
+        "tags": [
+          "inodes"
+        ],
+        "summary": "List file revisions by inode",
+        "description": "Returns retained revisions for a file inode without requiring a current path or binding. The response is path-free.",
+        "operationId": "list_file_revisions_by_inode",
+        "parameters": [
+          {
+            "name": "namespace_id",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "inode_id",
+            "in": "path",
+            "description": "File inode id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/InodeId"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum page size",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque file-revisions page cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File revisions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFileRevisionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid inode id, limit, or cursor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace or inode not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "409": {
+            "description": "Inode is not a file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/content": {
+      "get": {
+        "tags": [
+          "inodes"
+        ],
+        "summary": "Read file revision by inode",
+        "description": "Reads and verifies one retained file revision directly by `(inode_id, revision_no)`, without resolving a current path.",
+        "operationId": "get_file_revision_bytes_by_inode",
+        "parameters": [
+          {
+            "name": "namespace_id",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "inode_id",
+            "in": "path",
+            "description": "File inode id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/InodeId"
+            }
+          },
+          {
+            "name": "revision_no",
+            "in": "path",
+            "description": "Revision number",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RevisionNo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revision bytes",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid inode id or revision number",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace, inode, or revision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Inode is not a file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Content exceeds the advertised `download.max_content_bytes` limit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The server is at its concurrent content-read limit; retry shortly",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions/{revision_no}/downloads": {
+      "post": {
+        "tags": [
+          "inodes"
+        ],
+        "summary": "Begin download by inode",
+        "description": "Authorizes a direct read of one retained inode revision. The strict body is `{}` and the response is path-free because historical identity does not imply a current binding.",
+        "operationId": "begin_download_by_inode",
+        "parameters": [
+          {
+            "name": "namespace_id",
+            "in": "path",
+            "description": "Namespace id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "inode_id",
+            "in": "path",
+            "description": "File inode id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/InodeId"
+            }
+          },
+          {
+            "name": "revision_no",
+            "in": "path",
+            "description": "Revision number",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RevisionNo"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeginDownloadByInodeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Download authorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeginDownloadByInodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid inode id, revision number, or request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Namespace, inode, or revision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "408": {
+            "$ref": "#/components/responses/DeadlineExceededResponse"
+          },
+          "409": {
+            "description": "Inode is not a file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Namespace deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Direct download is unsupported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v0/namespaces/{namespace_id}/query/grep": {
       "post": {
         "tags": [
@@ -3131,6 +3588,44 @@
           }
         ],
         "description": "Kind-specific metadata for an authoritative path entry."
+      },
+      "BeginDownloadByInodeRequest": {
+        "type": "object",
+        "description": "Strict empty body for a download already addressed by route identity.",
+        "additionalProperties": false
+      },
+      "BeginDownloadByInodeResponse": {
+        "type": "object",
+        "description": "A short-lived capability to read one inode revision's content object.\n\nHistorical inode identity is deliberately path-free: the inode may have\nmoved since the revision was written or may have no current binding.",
+        "required": [
+          "namespace_id",
+          "inode_id",
+          "revision_no",
+          "content_ref",
+          "access"
+        ],
+        "properties": {
+          "access": {
+            "$ref": "#/components/schemas/ObjectTransferAccess",
+            "description": "Short-lived read capability the client uses without learning the raw object key."
+          },
+          "content_ref": {
+            "$ref": "#/components/schemas/ContentRef",
+            "description": "Identity, byte length, and checksum evidence for the authorized object."
+          },
+          "inode_id": {
+            "$ref": "#/components/schemas/InodeId",
+            "description": "File inode whose revision is authorized."
+          },
+          "namespace_id": {
+            "$ref": "#/components/schemas/NamespaceId",
+            "description": "Namespace that was read."
+          },
+          "revision_no": {
+            "$ref": "#/components/schemas/RevisionNo",
+            "description": "Revision the capability reads."
+          }
+        }
       },
       "BeginDownloadRequest": {
         "type": "object",
@@ -5391,7 +5886,6 @@
         "description": "Response for listing file revisions.",
         "required": [
           "namespace_id",
-          "path",
           "inode_id",
           "head_seq",
           "revisions"
@@ -5415,10 +5909,6 @@
               "null"
             ],
             "description": "Opaque cursor for the next page, if more revisions are available."
-          },
-          "path": {
-            "$ref": "#/components/schemas/AbsolutePath",
-            "description": "Absolute file path requested by the caller."
           },
           "revisions": {
             "type": "array",
@@ -6490,6 +6980,10 @@
     {
       "name": "filesystem",
       "description": "Path-oriented filesystem APIs"
+    },
+    {
+      "name": "inodes",
+      "description": "Identity-oriented inode read APIs"
     },
     {
       "name": "uploads",

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -2149,7 +2149,7 @@
           "inodes"
         ],
         "summary": "List file revisions by inode",
-        "description": "Returns retained revisions for a file inode without requiring a current path or binding. The response is path-free.",
+        "description": "Returns retained revisions for a file inode without requiring a current path.",
         "operationId": "list_file_revisions_by_inode",
         "parameters": [
           {
@@ -2262,7 +2262,7 @@
           "inodes"
         ],
         "summary": "Read file revision by inode",
-        "description": "Reads and verifies one retained file revision directly by `(inode_id, revision_no)`, without resolving a current path.",
+        "description": "Reads and verifies one retained file revision by inode id and revision number.",
         "operationId": "get_file_revision_bytes_by_inode",
         "parameters": [
           {
@@ -2388,7 +2388,7 @@
           "inodes"
         ],
         "summary": "Begin download by inode",
-        "description": "Authorizes a direct read of one retained inode revision. The strict body is `{}` and the response is path-free because historical identity does not imply a current binding.",
+        "description": "Authorizes a direct read of one retained inode revision. The request body is `{}` and the response does not include a path.",
         "operationId": "begin_download_by_inode",
         "parameters": [
           {
@@ -3591,12 +3591,12 @@
       },
       "BeginDownloadByInodeRequest": {
         "type": "object",
-        "description": "Strict empty body for a download already addressed by route identity.",
+        "description": "Empty request for an inode-addressed download.",
         "additionalProperties": false
       },
       "BeginDownloadByInodeResponse": {
         "type": "object",
-        "description": "A short-lived capability to read one inode revision's content object.\n\nHistorical inode identity is deliberately path-free: the inode may have\nmoved since the revision was written or may have no current binding.",
+        "description": "A short-lived capability to read one inode revision.",
         "required": [
           "namespace_id",
           "inode_id",
@@ -3607,15 +3607,15 @@
         "properties": {
           "access": {
             "$ref": "#/components/schemas/ObjectTransferAccess",
-            "description": "Short-lived read capability the client uses without learning the raw object key."
+            "description": "Short-lived provider access without the raw object key."
           },
           "content_ref": {
             "$ref": "#/components/schemas/ContentRef",
-            "description": "Identity, byte length, and checksum evidence for the authorized object."
+            "description": "Content identity, size, and checksum."
           },
           "inode_id": {
             "$ref": "#/components/schemas/InodeId",
-            "description": "File inode whose revision is authorized."
+            "description": "File inode being read."
           },
           "namespace_id": {
             "$ref": "#/components/schemas/NamespaceId",
@@ -3623,7 +3623,7 @@
           },
           "revision_no": {
             "$ref": "#/components/schemas/RevisionNo",
-            "description": "Revision the capability reads."
+            "description": "Revision being read."
           }
         }
       },


### PR DESCRIPTION
Adds reads addressed by stable inode id. Callers can stat a visible inode, list its revisions, read a retained revision, or request a direct-download grant without first resolving a path. Stat responses include the current path, while revision and download responses are path-free because an inode may have moved or been deleted.

The new routes use `inode_not_found` for missing identities and preserve the existing file and revision errors. The runtime, client, CLI, OpenAPI schema, documentation, and tests cover the new operations. `loonfs stat --inode <id>` exposes current inode lookup from the CLI.