### PR TITLE
docs(api): publish semantic query parameter schemas

### DIFF
--- a/crates/loonfs-api/tests/golden_formats.rs
+++ b/crates/loonfs-api/tests/golden_formats.rs
@@ -95,63 +95,6 @@ fn read_golden(name: &str) -> Vec<u8> {
     })
 }
 
-fn assert_json_has_no_retired_public_field(value: &serde_json::Value, name: &str) {
-    match value {
-        serde_json::Value::Object(object) => {
-            for retired in [
-                "absolute_path",
-                "root_inode_id",
-                "deleted_at_seq",
-                "validated_content_token",
-            ] {
-                assert!(
-                    !object.contains_key(retired),
-                    "golden JSON `{name}` carries retired public field `{retired}`"
-                );
-            }
-            for nested in object.values() {
-                assert_json_has_no_retired_public_field(nested, name);
-            }
-        }
-        serde_json::Value::Array(values) => {
-            for nested in values {
-                assert_json_has_no_retired_public_field(nested, name);
-            }
-        }
-        _ => {}
-    }
-}
-
-#[test]
-fn json_goldens_do_not_pin_retired_public_field_names() {
-    let directory = golden_path("");
-    for entry in std::fs::read_dir(directory).expect("read golden directory") {
-        let entry = entry.expect("read golden directory entry");
-        let path = entry.path();
-        let bytes = std::fs::read(&path)
-            .unwrap_or_else(|error| panic!("read `{}`: {error}", path.display()));
-        for retired in ["ValidatedContentToken", "validated_content_token"] {
-            assert!(
-                !bytes
-                    .windows(retired.len())
-                    .any(|window| window == retired.as_bytes()),
-                "golden fixture `{}` carries retired public name `{retired}`",
-                path.display()
-            );
-        }
-        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
-            continue;
-        }
-        let name = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .expect("golden JSON filename");
-        let value: serde_json::Value = serde_json::from_slice(&bytes)
-            .unwrap_or_else(|error| panic!("parse `{name}`: {error}"));
-        assert_json_has_no_retired_public_field(&value, name);
-    }
-}
-
 fn unzstd(bytes: &[u8]) -> Vec<u8> {
     zstd::stream::decode_all(bytes).expect("decompress envelope")
 }

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -109,6 +109,62 @@ pub(super) struct ChangesQuery {
     limit: Option<String>,
 }
 
+/// Schema-only override for the shared page-limit query contract.
+#[cfg(feature = "openapi")]
+pub(super) struct OpenApiPageLimit;
+
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for OpenApiPageLimit {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::Object::builder()
+            .schema_type(utoipa::openapi::schema::Type::Integer)
+            .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+                utoipa::openapi::KnownFormat::Int32,
+            )))
+            .minimum(Some(1u32))
+            .maximum(Some(loonfs_api::DEFAULT_MAX_PAGE_LIMIT))
+            .default(Some(serde_json::json!(loonfs_api::DEFAULT_PAGE_LIMIT)))
+            .into()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for OpenApiPageLimit {}
+
+/// Schema-only override for an optional boolean that defaults to true.
+#[cfg(feature = "openapi")]
+pub(super) struct OpenApiDefaultTrueBoolean;
+
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for OpenApiDefaultTrueBoolean {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::Object::builder()
+            .schema_type(utoipa::openapi::schema::Type::Boolean)
+            .default(Some(serde_json::json!(true)))
+            .into()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for OpenApiDefaultTrueBoolean {}
+
+/// Schema-only override for an optional boolean that defaults to false.
+#[cfg(feature = "openapi")]
+pub(super) struct OpenApiDefaultFalseBoolean;
+
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for OpenApiDefaultFalseBoolean {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::Object::builder()
+            .schema_type(utoipa::openapi::schema::Type::Boolean)
+            .default(Some(serde_json::json!(false)))
+            .into()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for OpenApiDefaultFalseBoolean {}
+
 #[cfg_attr(
     feature = "openapi",
     utoipa::path(
@@ -120,9 +176,9 @@ pub(super) struct ChangesQuery {
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute filesystem path"),
-            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("limit" = inline(Option<OpenApiPageLimit>), Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque directory-list page cursor"),
-            ("include_attributes" = Option<String>, Query, description = "Project each entry's attribute map and revision (`true` or `false`). Defaults to `false`: a page holds many entries and each map may be 64 KiB, so a listing does not carry them unless asked.")
+            ("include_attributes" = inline(Option<OpenApiDefaultFalseBoolean>), Query, description = "Project each entry's attribute map and revision (`true` or `false`). Defaults to `false`: a page holds many entries and each map may be 64 KiB, so a listing does not carry them unless asked.")
         ),
         responses(
             (status = 200, description = "Directory listing page", body = loonfs_api::ListPathEntriesResponse),
@@ -177,7 +233,7 @@ pub(super) async fn list_path_entries(
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute filesystem path"),
-            ("include_attributes" = Option<String>, Query, description = "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`: a stat answers for one path and a map is capped at 64 KiB.")
+            ("include_attributes" = inline(Option<OpenApiDefaultTrueBoolean>), Query, description = "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`: a stat answers for one path and a map is capped at 64 KiB.")
         ),
         responses(
             (status = 200, description = "Authoritative path entry", body = loonfs_api::AuthoritativePathEntry),
@@ -222,7 +278,7 @@ pub(super) async fn stat_path(
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute file path"),
-            ("revision_no" = Option<String>, Query, description = "Optional prior revision number")
+            ("revision_no" = Option<RevisionNo>, Query, description = "Optional prior revision number")
         ),
         responses(
             (status = 200, description = "File bytes", body = Vec<u8>, content_type = "application/octet-stream"),
@@ -283,7 +339,7 @@ pub(super) async fn get_file_bytes(
         description = "Returns the namespace's recoverable deletions, oldest deletion first. Entries never age out at the retention floor; each carries the inode id and deletion sequence undelete needs, plus the deleted name when the delete recorded one.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
-            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("limit" = inline(Option<OpenApiPageLimit>), Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque trash page cursor")
         ),
         responses(
@@ -329,7 +385,7 @@ pub(super) async fn list_trash(
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("path" = String, Query, description = "Absolute file path"),
-            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("limit" = inline(Option<OpenApiPageLimit>), Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque file-revisions page cursor")
         ),
         responses(
@@ -494,8 +550,8 @@ pub(super) async fn apply_commit(
         description = "Returns committed changes from the write-ahead log. Callers can use this feed to keep another projection synchronized with WAL history.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
-            ("after_seq" = String, Query, description = "Return committed changes after this sequence"),
-            ("limit" = Option<String>, Query, description = "Maximum page size")
+            ("after_seq" = loonfs_api::ChangeSeq, Query, description = "Return committed changes after this sequence"),
+            ("limit" = inline(Option<OpenApiPageLimit>), Query, description = "Maximum page size")
         ),
         responses(
             (status = 200, description = "Committed changes", body = ChangesResponse),

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -44,7 +44,7 @@ pub(super) struct StatInodeQuery {
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("inode_id" = InodeId, Path, description = "Inode id"),
-            ("include_attributes" = Option<String>, Query, description = "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`.")
+            ("include_attributes" = inline(Option<super::handlers_filesystem::OpenApiDefaultTrueBoolean>), Query, description = "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`: a stat answers for one path and a map is capped at 64 KiB.")
         ),
         responses(
             (status = 200, description = "Authoritative current inode entry", body = loonfs_api::AuthoritativePathEntry),
@@ -90,7 +90,7 @@ pub(super) async fn stat_inode(
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("inode_id" = InodeId, Path, description = "File inode id"),
-            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("limit" = inline(Option<super::handlers_filesystem::OpenApiPageLimit>), Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque file-revisions page cursor")
         ),
         responses(

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -211,7 +211,7 @@ pub(super) async fn create_namespace(
         path = "/v0/namespaces/{namespace_id}",
         tag = "namespaces",
         summary = "Get namespace status",
-        description = "Returns the current head, manifest, checkpoint, WAL tail, and retention state for a namespace.",
+        description = "Returns the current head, manifest, WAL tail, and retention state for a namespace.",
         params(("namespace_id" = String, Path, description = "Namespace id")),
         responses(
             (status = 200, description = "Namespace status", body = loonfs_api::NamespaceStatusResponse),
@@ -248,7 +248,7 @@ pub(super) async fn namespace_status(
         description = "Marks a namespace as deleted.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
-            ("expected_head_seq" = Option<String>, Query, description = "Delete only if the namespace head is still at this sequence")
+            ("expected_head_seq" = Option<ChangeSeq>, Query, description = "Delete only if the namespace head is still at this sequence")
         ),
         responses(
             (status = 200, description = "Namespace deleted", body = loonfs_api::DeleteNamespaceResponse),
@@ -379,7 +379,7 @@ pub(super) async fn create_checkpoint(
         description = "Lists one page of active checkpoints in checkpoint-id order. Expired checkpoints remain visible until collection releases them. Released checkpoints are omitted. The cursor resumes a live listing and does not create a snapshot.",
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
-            ("limit" = Option<String>, Query, description = "Maximum page size"),
+            ("limit" = inline(Option<super::handlers_filesystem::OpenApiPageLimit>), Query, description = "Maximum page size"),
             ("cursor" = Option<String>, Query, description = "Opaque checkpoint-list page cursor")
         ),
         responses(

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -220,6 +220,219 @@ fn openapi_documents_current_server_paths() {
 }
 
 #[test]
+fn openapi_operation_ids_are_the_frozen_public_registry() {
+    const REGISTRY_MESSAGE: &str = "the operationId registry is a frozen public contract; record any deliberate rename in crates/loonfs-server/tests/it/openapi.rs::openapi_operation_ids_are_the_frozen_public_registry";
+
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let paths = spec
+        .get("paths")
+        .and_then(Value::as_object)
+        .expect("openapi paths object");
+    let mut operation_ids = paths
+        .values()
+        .filter_map(Value::as_object)
+        .flat_map(|path_item| {
+            ["get", "post", "put", "delete", "patch"]
+                .into_iter()
+                .filter_map(|method| path_item.get(method))
+        })
+        .map(|operation| {
+            operation
+                .get("operationId")
+                .and_then(Value::as_str)
+                .expect("OpenAPI operation has an operationId")
+        })
+        .collect::<Vec<_>>();
+    let unique_operation_ids = operation_ids.iter().copied().collect::<BTreeSet<_>>();
+    assert_eq!(
+        unique_operation_ids.len(),
+        operation_ids.len(),
+        "duplicate operationIds found; {REGISTRY_MESSAGE}"
+    );
+
+    operation_ids.sort_unstable();
+    assert_eq!(
+        operation_ids,
+        [
+            "abort_upload",
+            "apply_commit",
+            "begin_download",
+            "begin_download_by_inode",
+            "begin_upload",
+            "capabilities",
+            "complete_upload",
+            "create_checkpoint",
+            "create_namespace",
+            "delete_namespace",
+            "disable_grep_index",
+            "enable_grep_index",
+            "fork_namespace",
+            "gc_grep_index",
+            "get_file_bytes",
+            "get_file_revision_bytes_by_inode",
+            "grep",
+            "grep_index_status",
+            "health",
+            "list_changes",
+            "list_checkpoints",
+            "list_file_revisions",
+            "list_file_revisions_by_inode",
+            "list_path_entries",
+            "list_trash",
+            "maintenance_step",
+            "namespace_status",
+            "probe_store",
+            "read_upload_status",
+            "readiness",
+            "release_checkpoint",
+            "serve_metrics",
+            "sign_upload_parts",
+            "stat_inode",
+            "stat_path",
+            "upload_content",
+        ],
+        "operationIds changed; {REGISTRY_MESSAGE}"
+    );
+}
+
+#[test]
+fn openapi_query_parameters_publish_the_runtime_grammar() {
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
+    )
+    .expect("parse openapi json");
+    let paths = spec
+        .get("paths")
+        .and_then(Value::as_object)
+        .expect("openapi paths object");
+
+    for (path, method) in [
+        ("/v0/namespaces/{namespace_id}/filesystem/list", "get"),
+        ("/v0/namespaces/{namespace_id}/filesystem/revisions", "get"),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
+            "get",
+        ),
+        ("/v0/namespaces/{namespace_id}/filesystem/trash", "get"),
+        ("/v0/admin/namespaces/{namespace_id}/checkpoints", "get"),
+        ("/v0/namespaces/{namespace_id}/changes", "get"),
+    ] {
+        let parameter = query_parameter(paths, path, method, "limit");
+        assert_eq!(parameter.get("required"), Some(&Value::Bool(false)));
+        let schema = parameter.get("schema").expect("limit schema");
+        assert_eq!(schema.get("type").and_then(Value::as_str), Some("integer"));
+        assert_eq!(schema.get("format").and_then(Value::as_str), Some("int32"));
+        assert_eq!(schema.get("minimum").and_then(Value::as_u64), Some(1));
+        assert_eq!(schema.get("maximum").and_then(Value::as_u64), Some(1000));
+        assert_eq!(schema.get("default").and_then(Value::as_u64), Some(1000));
+    }
+
+    for (path, default) in [
+        ("/v0/namespaces/{namespace_id}/filesystem/stat", true),
+        ("/v0/namespaces/{namespace_id}/filesystem/list", false),
+        ("/v0/namespaces/{namespace_id}/inodes/{inode_id}", true),
+    ] {
+        let parameter = query_parameter(paths, path, "get", "include_attributes");
+        assert_eq!(parameter.get("required"), Some(&Value::Bool(false)));
+        let schema = parameter.get("schema").expect("include_attributes schema");
+        assert_eq!(schema.get("type").and_then(Value::as_str), Some("boolean"));
+        assert_eq!(
+            schema.get("default").and_then(Value::as_bool),
+            Some(default)
+        );
+    }
+
+    for (path, method, parameter_name, schema_name, required) in [
+        (
+            "/v0/namespaces/{namespace_id}/changes",
+            "get",
+            "after_seq",
+            "ChangeSeq",
+            true,
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/filesystem/content",
+            "get",
+            "revision_no",
+            "RevisionNo",
+            false,
+        ),
+        (
+            "/v0/namespaces/{namespace_id}",
+            "delete",
+            "expected_head_seq",
+            "ChangeSeq",
+            false,
+        ),
+    ] {
+        let parameter = query_parameter(paths, path, method, parameter_name);
+        assert_eq!(parameter.get("required"), Some(&Value::Bool(required)));
+        let expected_ref = format!("#/components/schemas/{schema_name}");
+        assert_eq!(
+            parameter.pointer("/schema/$ref").and_then(Value::as_str),
+            Some(expected_ref.as_str())
+        );
+    }
+
+    for (path, method, parameter_name) in [
+        (
+            "/v0/namespaces/{namespace_id}/filesystem/list",
+            "get",
+            "path",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/filesystem/stat",
+            "get",
+            "path",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/filesystem/content",
+            "get",
+            "path",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/filesystem/revisions",
+            "get",
+            "path",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/filesystem/list",
+            "get",
+            "cursor",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/filesystem/revisions",
+            "get",
+            "cursor",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/inodes/{inode_id}/revisions",
+            "get",
+            "cursor",
+        ),
+        (
+            "/v0/namespaces/{namespace_id}/filesystem/trash",
+            "get",
+            "cursor",
+        ),
+        (
+            "/v0/admin/namespaces/{namespace_id}/checkpoints",
+            "get",
+            "cursor",
+        ),
+    ] {
+        let parameter = query_parameter(paths, path, method, parameter_name);
+        assert_eq!(
+            parameter.pointer("/schema/type").and_then(Value::as_str),
+            Some("string")
+        );
+    }
+}
+
+#[test]
 fn openapi_names_tagged_one_of_alternatives() {
     let spec: Value = serde_json::from_str(
         &std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json"),
@@ -597,6 +810,28 @@ fn assert_query_params(
             "missing query parameter `{name}` for `{method} {path}`"
         );
     }
+}
+
+fn query_parameter<'a>(
+    paths: &'a serde_json::Map<String, Value>,
+    path: &str,
+    method: &str,
+    parameter_name: &str,
+) -> &'a Value {
+    paths
+        .get(path)
+        .and_then(|path_item| path_item.get(method))
+        .and_then(|operation| operation.get("parameters"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .find(|parameter| {
+            parameter.get("in").and_then(Value::as_str) == Some("query")
+                && parameter.get("name").and_then(Value::as_str) == Some(parameter_name)
+        })
+        .unwrap_or_else(|| {
+            panic!("missing query parameter `{parameter_name}` for `{method} {path}`")
+        })
 }
 
 fn assert_path_parameter_schema(

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -135,7 +135,11 @@
             "description": "Maximum page size",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
             }
           },
           {
@@ -985,7 +989,7 @@
           "namespaces"
         ],
         "summary": "Get namespace status",
-        "description": "Returns the current head, manifest, checkpoint, WAL tail, and retention state for a namespace.",
+        "description": "Returns the current head, manifest, WAL tail, and retention state for a namespace.",
         "operationId": "namespace_status",
         "parameters": [
           {
@@ -1077,7 +1081,7 @@
             "description": "Delete only if the namespace head is still at this sequence",
             "required": false,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ChangeSeq"
             }
           }
         ],
@@ -1172,7 +1176,7 @@
             "description": "Return committed changes after this sequence",
             "required": true,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/ChangeSeq"
             }
           },
           {
@@ -1181,7 +1185,11 @@
             "description": "Maximum page size",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
             }
           }
         ],
@@ -1381,7 +1389,7 @@
             "description": "Optional prior revision number",
             "required": false,
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/RevisionNo"
             }
           }
         ],
@@ -1593,7 +1601,11 @@
             "description": "Maximum page size",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
             }
           },
           {
@@ -1611,7 +1623,8 @@
             "description": "Project each entry's attribute map and revision (`true` or `false`). Defaults to `false`: a page holds many entries and each map may be 64 KiB, so a listing does not carry them unless asked.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "boolean",
+              "default": false
             }
           }
         ],
@@ -1705,7 +1718,11 @@
             "description": "Maximum page size",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
             }
           },
           {
@@ -1808,7 +1825,8 @@
             "description": "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`: a stat answers for one path and a map is capped at 64 KiB.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -1893,7 +1911,11 @@
             "description": "Maximum page size",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
             }
           },
           {
@@ -2079,10 +2101,11 @@
           {
             "name": "include_attributes",
             "in": "query",
-            "description": "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`.",
+            "description": "Project the inode's attribute map and revision (`true` or `false`). Defaults to `true`: a stat answers for one path and a map is capped at 64 KiB.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -2176,7 +2199,11 @@
             "description": "Maximum page size",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int32",
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1
             }
           },
           {


### PR DESCRIPTION
This updates the OpenAPI document so query parameters use the same types and limits the server already enforces. Pagination limits are documented as integers from 1 to 1000, `include_attributes` is documented as a boolean with the correct default for each route, and sequence and revision parameters reference their existing schemas. Request handling does not change; the improved schema makes the API documentation and generated clients more accurate.

The change also adds a test for duplicate or unexpected operation IDs, removes a golden-file test that incorrectly treated valid durable fields as retired, and corrects two inaccurate endpoint descriptions. The generated OpenAPI document is updated to match.