### PR TITLE
refactor(api): tag maintenance step outcomes as outcomes

### DIFF
--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -916,7 +916,7 @@ pub struct MetadataMaintenanceRequest {
 /// What the WAL-flush part of a maintenance step did.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum WalFlushStepOutcome {
     /// The tail was below the threshold, so there was nothing to fold.
     NotNeeded,
@@ -946,7 +946,7 @@ pub enum WalFlushStepOutcome {
 /// consumes are engine policy, not a wire contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum ReorganizeStepOutcome {
     /// No family group had enough delta runs to merge.
     NotNeeded,
@@ -1553,6 +1553,22 @@ mod tests {
         let gc: GcResponse =
             serde_json::from_value(gc_json).expect("decode gc response without optional fields");
         assert_eq!(gc.next_reclamation_at_ms, None);
+    }
+
+    #[test]
+    fn maintenance_step_outcomes_use_the_outcome_tag() {
+        assert_eq!(
+            serde_json::to_value(WalFlushStepOutcome::Flushed {
+                manifest_head_seq: ChangeSeq(9),
+            })
+            .expect("serialize WAL flush outcome"),
+            serde_json::json!({"outcome": "flushed", "manifest_head_seq": 9})
+        );
+        assert_eq!(
+            serde_json::to_value(ReorganizeStepOutcome::UnitPublished)
+                .expect("serialize reorganize outcome"),
+            serde_json::json!({"outcome": "unit_published"})
+        );
     }
 
     /// The maintenance bodies are optional selectors and overrides all the

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -5551,7 +5551,10 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         let flush_data = json_data(&flush);
         assert_eq!(flush_data["kind"], "maintenance_stepped");
         assert_eq!(flush_data["namespace_id"], "demo");
-        assert_eq!(flush_data["metadata"]["reorganize"]["kind"], "not_needed");
+        assert_eq!(
+            flush_data["metadata"]["reorganize"]["outcome"],
+            "not_needed"
+        );
         assert!(flush_data["metadata"]["wal_flush"].is_object());
         assert!(flush_data.get("retention").is_none());
         assert!(flush_data.get("gc").is_none());
@@ -5598,8 +5601,8 @@ fn admin_and_changes_commands_report_the_same_shapes_in_both_modes() {
         let step_data = json_data(&step);
         assert_eq!(step_data["kind"], "maintenance_stepped");
         assert_eq!(step_data["namespace_id"], "demo");
-        assert_eq!(step_data["metadata"]["wal_flush"]["kind"], "not_needed");
-        assert_eq!(step_data["metadata"]["reorganize"]["kind"], "not_needed");
+        assert_eq!(step_data["metadata"]["wal_flush"]["outcome"], "not_needed");
+        assert_eq!(step_data["metadata"]["reorganize"]["outcome"], "not_needed");
         // A step without `--retention` never advances the floor, and says
         // nothing about it: the floor is `status_before`'s to report.
         assert!(step_data.get("retention").is_none());

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -749,7 +749,7 @@ or retain.
 Four reorganize outcomes describe work the step did not do itself. A family
 group that has outgrown one step is rebuilt by a background streaming
 compaction, and the step publishes nothing in that case: the job publishes
-once, when it finishes. `reorganize.kind` says what became of that job.
+once, when it finishes. `reorganize.outcome` says what became of that job.
 
 `compaction_started` means this step started one. `compaction_at_capacity`
 means this step's job claimed the namespace but is waiting for a process

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -6274,10 +6274,10 @@
           {
             "type": "object",
             "required": [
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "not_needed"
@@ -6288,10 +6288,10 @@
           {
             "type": "object",
             "required": [
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "unit_published"
@@ -6302,10 +6302,10 @@
           {
             "type": "object",
             "required": [
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "compaction_started"
@@ -6316,10 +6316,10 @@
           {
             "type": "object",
             "required": [
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "compaction_running"
@@ -6330,10 +6330,10 @@
           {
             "type": "object",
             "required": [
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "compaction_at_capacity"
@@ -6344,10 +6344,10 @@
           {
             "type": "object",
             "required": [
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "compaction_required"
@@ -6358,10 +6358,10 @@
           {
             "type": "object",
             "required": [
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "superseded"
@@ -6832,10 +6832,10 @@
             "type": "object",
             "description": "The tail was below the threshold, so there was nothing to fold.",
             "required": [
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "not_needed"
@@ -6848,18 +6848,18 @@
             "description": "The step flushed the WAL tail and advanced the metadata root.",
             "required": [
               "manifest_head_seq",
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "manifest_head_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Sequence covered by the published manifest."
+              },
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "flushed"
                 ]
-              },
-              "manifest_head_seq": {
-                "$ref": "#/components/schemas/ChangeSeq",
-                "description": "Sequence covered by the published manifest."
               }
             }
           },
@@ -6869,7 +6869,7 @@
             "required": [
               "attempted_seq",
               "current_manifest_id",
-              "kind"
+              "outcome"
             ],
             "properties": {
               "attempted_seq": {
@@ -6880,7 +6880,7 @@
                 "$ref": "#/components/schemas/ManifestId",
                 "description": "Manifest the root currently references."
               },
-              "kind": {
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "superseded"
@@ -6893,18 +6893,18 @@
             "description": "A concurrent head update won the race.",
             "required": [
               "observed_head_seq",
-              "kind"
+              "outcome"
             ],
             "properties": {
-              "kind": {
+              "observed_head_seq": {
+                "$ref": "#/components/schemas/ChangeSeq",
+                "description": "Head sequence observed before the advance attempt."
+              },
+              "outcome": {
                 "type": "string",
                 "enum": [
                   "race_lost"
                 ]
-              },
-              "observed_head_seq": {
-                "$ref": "#/components/schemas/ChangeSeq",
-                "description": "Head sequence observed before the advance attempt."
               }
             }
           }


### PR DESCRIPTION
Maintenance step results now use `outcome` as the discriminator for WAL flush and metadata reorganization results. For example, a successful WAL flush is returned as `{"outcome":"flushed","manifest_head_seq":9}`.

This change is limited to maintenance action results. Structural variants and durable formats continue to use `kind`. The API documentation, generated OpenAPI document, and CLI tests are updated to match.