### PR TITLE
feat(api): cap public ordinals at the safe integer range

### DIFF
--- a/crates/loonfs-api/src/attributes.rs
+++ b/crates/loonfs-api/src/attributes.rs
@@ -242,18 +242,15 @@ pub enum AttributesError {
 }
 
 numeric_id! {
-    /// Monotonically increasing attribute revision counter within one inode.
+    /// Revision number for an inode's attributes.
     ///
-    /// Every inode starts at revision 0 with an empty attribute map, and every
-    /// effective update — one that changes the map — advances the counter by
-    /// one. The counter is the optimistic-concurrency token for attribute
-    /// writes: a writer states the revision it expects, and the write fails
-    /// when the inode has moved past it. The counter is not an index into a
-    /// history. LoonFS keeps the current map and this number, and promises no
-    /// queryable record of earlier maps.
+    /// Every inode starts at revision 0 with an empty attribute map. The
+    /// revision increases only when an update changes the map. Clients can
+    /// provide the current revision to reject a write if another update
+    /// happened first. Earlier attribute maps cannot be queried.
     AttributeRevisionNo,
     public_ordinal,
-    schema_description = "Monotonically increasing attribute revision counter within one inode.\n\nEvery inode starts at revision 0 with an empty attribute map, and every\neffective update — one that changes the map — advances the counter by\none. The counter is the optimistic-concurrency token for attribute\nwrites: a writer states the revision it expects, and the write fails\nwhen the inode has moved past it. The counter is not an index into a\nhistory. LoonFS keeps the current map and this number, and promises no\nqueryable record of earlier maps."
+    schema_description = "Revision number for an inode's attributes. It starts at 0 and increases whenever the attribute map changes."
 }
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/attributes.rs
+++ b/crates/loonfs-api/src/attributes.rs
@@ -251,7 +251,9 @@ numeric_id! {
     /// when the inode has moved past it. The counter is not an index into a
     /// history. LoonFS keeps the current map and this number, and promises no
     /// queryable record of earlier maps.
-    AttributeRevisionNo
+    AttributeRevisionNo,
+    public_ordinal,
+    schema_description = "Monotonically increasing attribute revision counter within one inode.\n\nEvery inode starts at revision 0 with an empty attribute map, and every\neffective update — one that changes the map — advances the counter by\none. The counter is the optimistic-concurrency token for attribute\nwrites: a writer states the revision it expects, and the write fails\nwhen the inode has moved past it. The counter is not an index into a\nhistory. LoonFS keeps the current map and this number, and promises no\nqueryable record of earlier maps."
 }
 
 #[cfg(test)]

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -7,7 +7,7 @@ use crate::WriterEpoch;
 use crate::{
     ChangeSeq, CheckpointId, Checksum, ChecksumAlgorithm, CommitId, ContentId, ContentRef,
     ContentRefKind, ContentStoreId, InodeId, ManifestId, ManifestObjectId, MetadataCompactionId,
-    NamespaceId, UploadId, WalSegmentId, ROOT_INODE_ID,
+    NamespaceId, UploadId, WalSegmentId,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -619,7 +619,7 @@ impl HeadState {
             writer_epoch: WriterEpoch(0),
             writer: None,
             // Inode 1 is the root directory; inode 2 is the first assignable id.
-            next_inode_id: InodeId(ROOT_INODE_ID.0 + 1),
+            next_inode_id: crate::FIRST_ALLOCATABLE_INODE_ID,
             visible_wal_tip: None,
             recent_segments: Vec::new(),
             state: NamespaceState::Active,

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -214,6 +214,21 @@ macro_rules! numeric_id {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
         pub struct $name(pub u64);
 
+        impl $name {
+            /// Parses and validates an ordinal received at a non-serde boundary.
+            ///
+            /// Serde and this checked constructor guard external inputs. The
+            /// public tuple field and `From<u64>` remain available for trusted
+            /// internal construction, including already-checked advancement
+            /// and durable key formatting.
+            pub fn parse(value: u64) -> Result<Self, $crate::PublicOrdinalRangeError> {
+                if value > $crate::MAX_PUBLIC_INTEGER {
+                    return Err($crate::PublicOrdinalRangeError);
+                }
+                Ok(Self(value))
+            }
+        }
+
         #[cfg(feature = "openapi")]
         impl utoipa::PartialSchema for $name {
             fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
@@ -238,13 +253,7 @@ macro_rules! numeric_id {
                 D: serde::Deserializer<'de>,
             {
                 let value = <u64 as serde::Deserialize>::deserialize(deserializer)?;
-                if value > $crate::MAX_PUBLIC_INTEGER {
-                    return Err(serde::de::Error::custom(format_args!(
-                        "must be an integer from 0 through {}",
-                        $crate::MAX_PUBLIC_INTEGER
-                    )));
-                }
-                Ok(Self(value))
+                Self::parse(value).map_err(serde::de::Error::custom)
             }
         }
 
@@ -658,7 +667,10 @@ impl ManifestObjectId {
 pub fn manifest_object_id_manifest_id(object_id: &str) -> Option<ManifestId> {
     validate_position_suffix_id(object_id, ("manifest_id", "manifest id")).ok()?;
     let (position, _) = object_id.split_once('-')?;
-    position.parse().ok().map(ManifestId)
+    position
+        .parse()
+        .ok()
+        .and_then(|value| ManifestId::parse(value).ok())
 }
 
 string_id! {
@@ -697,7 +709,10 @@ impl WalSegmentId {
 pub fn wal_segment_id_start_seq(segment_id: &str) -> Option<ChangeSeq> {
     validate_position_suffix_id(segment_id, ("start_seq", "position")).ok()?;
     let (position, _) = segment_id.split_once('-')?;
-    position.parse().ok().map(ChangeSeq)
+    position
+        .parse()
+        .ok()
+        .and_then(|value| ChangeSeq::parse(value).ok())
 }
 
 string_id! {
@@ -725,6 +740,18 @@ impl NameKey {
 /// Largest integer a JSON client can represent exactly (2^53 - 1). No
 /// API-visible ordinal may durably advance beyond it.
 pub const MAX_PUBLIC_INTEGER: u64 = 9_007_199_254_740_991;
+
+/// An integer lies outside the exact range supported for public ordinals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PublicOrdinalRangeError;
+
+impl fmt::Display for PublicOrdinalRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "must be an integer from 0 through {MAX_PUBLIC_INTEGER}")
+    }
+}
+
+impl std::error::Error for PublicOrdinalRangeError {}
 
 /// Advances one API-visible ordinal without crossing [`MAX_PUBLIC_INTEGER`].
 pub fn next_public_ordinal(current: u64) -> Option<u64> {
@@ -832,6 +859,17 @@ mod tests {
     fn public_ordinal_deserialization_enforces_the_json_safe_integer_range() {
         macro_rules! assert_range {
             ($type:ty) => {{
+                let constructed =
+                    <$type>::parse(MAX_PUBLIC_INTEGER).expect("maximum public ordinal constructor");
+                assert_eq!(constructed.0, MAX_PUBLIC_INTEGER);
+
+                let construction_error = <$type>::parse(MAX_PUBLIC_INTEGER + 1)
+                    .expect_err("ordinal above the constructor's public range");
+                assert_eq!(
+                    construction_error.to_string(),
+                    "must be an integer from 0 through 9007199254740991"
+                );
+
                 let maximum = serde_json::from_str::<$type>(&MAX_PUBLIC_INTEGER.to_string())
                     .expect("maximum public ordinal");
                 assert_eq!(maximum.0, MAX_PUBLIC_INTEGER);
@@ -1100,6 +1138,10 @@ mod tests {
             Some(ChangeSeq(412))
         );
         assert_eq!(super::wal_segment_id_start_seq("not-a-segment-id"), None);
+        assert_eq!(
+            super::wal_segment_id_start_seq("00009007199254740992-9f2a6c0e4b7d4a90"),
+            None
+        );
     }
 
     #[test]
@@ -1110,6 +1152,10 @@ mod tests {
         );
         assert_eq!(
             super::manifest_object_id_manifest_id("not-a-manifest-object-id"),
+            None
+        );
+        assert_eq!(
+            super::manifest_object_id_manifest_id("00009007199254740992-9f2a6c0e4b7d4a90"),
             None
         );
     }

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -215,12 +215,12 @@ macro_rules! numeric_id {
         pub struct $name(pub u64);
 
         impl $name {
-            /// Parses and validates an ordinal received at a non-serde boundary.
+            /// Validates a numeric value before using it as an ordinal.
             ///
-            /// Serde and this checked constructor guard external inputs. The
-            /// public tuple field and `From<u64>` remain available for trusted
-            /// internal construction, including already-checked advancement
-            /// and durable key formatting.
+            /// Deserialization calls this method automatically. Code that
+            /// receives a raw integer through another interface must call it
+            /// explicitly. Direct tuple construction and `From<u64>` are for
+            /// values that have already been validated.
             pub fn parse(value: u64) -> Result<Self, $crate::PublicOrdinalRangeError> {
                 if value > $crate::MAX_PUBLIC_INTEGER {
                     return Err($crate::PublicOrdinalRangeError);
@@ -737,11 +737,13 @@ impl NameKey {
 // Numeric ids
 // ---------------------------------------------------------------------------
 
-/// Largest integer a JSON client can represent exactly (2^53 - 1). No
-/// API-visible ordinal may durably advance beyond it.
+/// Maximum value for an ordinal exposed through the API.
+///
+/// This is `2^53 - 1`, the largest integer JSON clients can represent
+/// without losing precision.
 pub const MAX_PUBLIC_INTEGER: u64 = 9_007_199_254_740_991;
 
-/// An integer lies outside the exact range supported for public ordinals.
+/// Returned when an ordinal exceeds [`MAX_PUBLIC_INTEGER`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PublicOrdinalRangeError;
 
@@ -753,7 +755,7 @@ impl fmt::Display for PublicOrdinalRangeError {
 
 impl std::error::Error for PublicOrdinalRangeError {}
 
-/// Advances one API-visible ordinal without crossing [`MAX_PUBLIC_INTEGER`].
+/// Returns the next ordinal, or `None` if the value is already at the limit.
 pub fn next_public_ordinal(current: u64) -> Option<u64> {
     current
         .checked_add(1)
@@ -770,42 +772,40 @@ numeric_id! {
 /// Inode 1 is always the root directory of a namespace.
 pub const ROOT_INODE_ID: InodeId = InodeId(1);
 
-/// First inode id available to a namespace allocator after reserving the root.
+/// First inode id available after the root inode.
 pub const FIRST_ALLOCATABLE_INODE_ID: InodeId = InodeId(ROOT_INODE_ID.0 + 1);
 
 numeric_id! {
-    /// Monotonically increasing file revision counter within one file inode.
+    /// Revision number for a file's content.
     RevisionNo,
     public_ordinal,
-    schema_description = "Monotonically increasing file revision counter within one file inode."
+    schema_description = "Revision number for a file's content. It increases whenever the content is replaced or restored."
 }
 
 numeric_id! {
-    /// Monotonically increasing namespace commit sequence number.
+    /// Sequence number assigned to a namespace commit.
     ///
-    /// This is the global visibility order for a namespace.
+    /// This number determines the order in which commits become visible.
     ChangeSeq,
     public_ordinal,
-    schema_description = "Monotonically increasing namespace commit sequence number.\n\nThis is the global visibility order for a namespace."
+    schema_description = "Sequence number assigned to a namespace commit. It determines the order in which commits become visible."
 }
 
 numeric_id! {
-    /// Monotonically increasing namespace manifest identity.
+    /// Version number for a namespace manifest.
     ///
-    /// This is the durable file-set version identity for namespace manifests.
-    /// Initial/fork manifests may be seeded from the current head sequence, but
-    /// later manifest ids can advance for checkpoint metadata, compaction, or
-    /// fork/index metadata without a new namespace commit.
+    /// The manifest version can increase when metadata changes, even if no
+    /// namespace commit is written.
     ManifestId,
     public_ordinal,
-    schema_description = "Monotonically increasing namespace manifest identity.\n\nThis is the durable file-set version identity for namespace manifests.\nInitial/fork manifests may be seeded from the current head sequence, but\nlater manifest ids can advance for checkpoint metadata, compaction, or\nfork/index metadata without a new namespace commit."
+    schema_description = "Version number for a namespace manifest. It can increase when metadata changes, even if no namespace commit is written."
 }
 
 numeric_id! {
-    /// Monotonically increasing writer epoch for namespace write fencing.
+    /// Counter used to reject writes from an older writer.
     WriterEpoch,
     public_ordinal,
-    schema_description = "Monotonically increasing writer epoch for namespace write fencing."
+    schema_description = "Counter used to reject writes from an older writer."
 }
 
 // ---------------------------------------------------------------------------
@@ -856,22 +856,22 @@ mod tests {
     }
 
     #[test]
-    fn public_ordinal_deserialization_enforces_the_json_safe_integer_range() {
+    fn public_ordinal_inputs_must_fit_the_json_safe_integer_range() {
         macro_rules! assert_range {
             ($type:ty) => {{
-                let constructed =
-                    <$type>::parse(MAX_PUBLIC_INTEGER).expect("maximum public ordinal constructor");
+                let constructed = <$type>::parse(MAX_PUBLIC_INTEGER)
+                    .expect("construct the maximum public ordinal");
                 assert_eq!(constructed.0, MAX_PUBLIC_INTEGER);
 
                 let construction_error = <$type>::parse(MAX_PUBLIC_INTEGER + 1)
-                    .expect_err("ordinal above the constructor's public range");
+                    .expect_err("reject a value above the public limit");
                 assert_eq!(
                     construction_error.to_string(),
                     "must be an integer from 0 through 9007199254740991"
                 );
 
                 let maximum = serde_json::from_str::<$type>(&MAX_PUBLIC_INTEGER.to_string())
-                    .expect("maximum public ordinal");
+                    .expect("deserialize the maximum public ordinal");
                 assert_eq!(maximum.0, MAX_PUBLIC_INTEGER);
 
                 let error = serde_json::from_str::<$type>(&(MAX_PUBLIC_INTEGER + 1).to_string())

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -206,6 +206,62 @@ macro_rules! string_id {
 macro_rules! numeric_id {
     (
         $(#[$meta:meta])*
+        $name:ident,
+        public_ordinal,
+        schema_description = $schema_description:literal
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+        pub struct $name(pub u64);
+
+        #[cfg(feature = "openapi")]
+        impl utoipa::PartialSchema for $name {
+            fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                utoipa::openapi::schema::Object::builder()
+                    .schema_type(utoipa::openapi::schema::Type::Integer)
+                    .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+                        utoipa::openapi::KnownFormat::Int64,
+                    )))
+                    .minimum(Some(0u64))
+                    .maximum(Some($crate::MAX_PUBLIC_INTEGER))
+                    .description(Some($schema_description))
+                    .into()
+            }
+        }
+
+        #[cfg(feature = "openapi")]
+        impl utoipa::ToSchema for $name {}
+
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = <u64 as serde::Deserialize>::deserialize(deserializer)?;
+                if value > $crate::MAX_PUBLIC_INTEGER {
+                    return Err(serde::de::Error::custom(format_args!(
+                        "must be an integer from 0 through {}",
+                        $crate::MAX_PUBLIC_INTEGER
+                    )));
+                }
+                Ok(Self(value))
+            }
+        }
+
+        impl From<u64> for $name {
+            fn from(value: u64) -> Self {
+                Self(value)
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+    };
+    (
+        $(#[$meta:meta])*
         $name:ident
     ) => {
         $(#[$meta])*
@@ -666,6 +722,17 @@ impl NameKey {
 // Numeric ids
 // ---------------------------------------------------------------------------
 
+/// Largest integer a JSON client can represent exactly (2^53 - 1). No
+/// API-visible ordinal may durably advance beyond it.
+pub const MAX_PUBLIC_INTEGER: u64 = 9_007_199_254_740_991;
+
+/// Advances one API-visible ordinal without crossing [`MAX_PUBLIC_INTEGER`].
+pub fn next_public_ordinal(current: u64) -> Option<u64> {
+    current
+        .checked_add(1)
+        .filter(|next| *next <= MAX_PUBLIC_INTEGER)
+}
+
 numeric_id! {
     /// Numeric identity of a file or directory within a namespace.
     ///
@@ -676,16 +743,23 @@ numeric_id! {
 /// Inode 1 is always the root directory of a namespace.
 pub const ROOT_INODE_ID: InodeId = InodeId(1);
 
+/// First inode id available to a namespace allocator after reserving the root.
+pub const FIRST_ALLOCATABLE_INODE_ID: InodeId = InodeId(ROOT_INODE_ID.0 + 1);
+
 numeric_id! {
     /// Monotonically increasing file revision counter within one file inode.
-    RevisionNo
+    RevisionNo,
+    public_ordinal,
+    schema_description = "Monotonically increasing file revision counter within one file inode."
 }
 
 numeric_id! {
     /// Monotonically increasing namespace commit sequence number.
     ///
     /// This is the global visibility order for a namespace.
-    ChangeSeq
+    ChangeSeq,
+    public_ordinal,
+    schema_description = "Monotonically increasing namespace commit sequence number.\n\nThis is the global visibility order for a namespace."
 }
 
 numeric_id! {
@@ -695,12 +769,16 @@ numeric_id! {
     /// Initial/fork manifests may be seeded from the current head sequence, but
     /// later manifest ids can advance for checkpoint metadata, compaction, or
     /// fork/index metadata without a new namespace commit.
-    ManifestId
+    ManifestId,
+    public_ordinal,
+    schema_description = "Monotonically increasing namespace manifest identity.\n\nThis is the durable file-set version identity for namespace manifests.\nInitial/fork manifests may be seeded from the current head sequence, but\nlater manifest ids can advance for checkpoint metadata, compaction, or\nfork/index metadata without a new namespace commit."
 }
 
 numeric_id! {
     /// Monotonically increasing writer epoch for namespace write fencing.
-    WriterEpoch
+    WriterEpoch,
+    public_ordinal,
+    schema_description = "Monotonically increasing writer epoch for namespace write fencing."
 }
 
 // ---------------------------------------------------------------------------
@@ -734,10 +812,53 @@ impl fmt::Display for InodeKind {
 #[cfg(test)]
 mod tests {
     use super::{
-        ChangeSeq, CheckpointId, CommitId, ContentId, ContentStoreId, ManifestId, ManifestObjectId,
-        MetadataTableId, NameKey, NamespaceId, UploadId, WalSegmentId,
+        next_public_ordinal, ChangeSeq, CheckpointId, CommitId, ContentId, ContentStoreId, InodeId,
+        ManifestId, ManifestObjectId, MetadataTableId, NameKey, NamespaceId, RevisionNo, UploadId,
+        WalSegmentId, WriterEpoch, MAX_PUBLIC_INTEGER,
     };
+    use crate::AttributeRevisionNo;
     use std::collections::BTreeSet;
+
+    #[test]
+    fn public_ordinal_advancement_accepts_the_maximum_and_rejects_the_next_value() {
+        assert_eq!(
+            next_public_ordinal(MAX_PUBLIC_INTEGER - 1),
+            Some(MAX_PUBLIC_INTEGER)
+        );
+        assert_eq!(next_public_ordinal(MAX_PUBLIC_INTEGER), None);
+    }
+
+    #[test]
+    fn public_ordinal_deserialization_enforces_the_json_safe_integer_range() {
+        macro_rules! assert_range {
+            ($type:ty) => {{
+                let maximum = serde_json::from_str::<$type>(&MAX_PUBLIC_INTEGER.to_string())
+                    .expect("maximum public ordinal");
+                assert_eq!(maximum.0, MAX_PUBLIC_INTEGER);
+
+                let error = serde_json::from_str::<$type>(&(MAX_PUBLIC_INTEGER + 1).to_string())
+                    .expect_err("ordinal above the public range");
+                assert!(
+                    error
+                        .to_string()
+                        .contains("must be an integer from 0 through 9007199254740991"),
+                    "unexpected range error: {error}"
+                );
+            }};
+        }
+
+        assert_range!(RevisionNo);
+        assert_range!(ChangeSeq);
+        assert_range!(AttributeRevisionNo);
+        assert_range!(ManifestId);
+        assert_range!(WriterEpoch);
+
+        assert_eq!(
+            serde_json::from_str::<InodeId>(&(MAX_PUBLIC_INTEGER + 1).to_string())
+                .expect("inode ids retain the full u64 range"),
+            InodeId(MAX_PUBLIC_INTEGER + 1)
+        );
+    }
 
     #[test]
     fn namespace_id_parse_accepts_allowed_grammar() {

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -125,12 +125,13 @@ pub use content::{
 pub use digest::sha256_digest;
 pub use error::{ErrorCode, ErrorKind};
 pub use ids::{
-    generated_id, manifest_object_id_manifest_id, wal_segment_id_start_seq, ChangeSeq,
-    CheckpointId, CommitId, CommitIdValidationError, ContentId, ContentStoreId,
+    generated_id, manifest_object_id_manifest_id, next_public_ordinal, wal_segment_id_start_seq,
+    ChangeSeq, CheckpointId, CommitId, CommitIdValidationError, ContentId, ContentStoreId,
     GeneratedIdValidationError, IndexSegmentId, InodeId, InodeKind, ManifestId, ManifestObjectId,
     MetadataCompactionId, MetadataTableId, NameKey, NameKeyValidationError, NamespaceId,
-    NamespaceIdValidationError, RevisionNo, UploadId, WalSegmentId, WriterEpoch, MAX_ID_BYTES,
-    MAX_NAME_KEY_BYTES, ROOT_INODE_ID,
+    NamespaceIdValidationError, RevisionNo, UploadId, WalSegmentId, WriterEpoch,
+    FIRST_ALLOCATABLE_INODE_ID, MAX_ID_BYTES, MAX_NAME_KEY_BYTES, MAX_PUBLIC_INTEGER,
+    ROOT_INODE_ID,
 };
 pub use name_policy::name_key_for_display_name;
 pub use pagination::{

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -129,8 +129,8 @@ pub use ids::{
     ChangeSeq, CheckpointId, CommitId, CommitIdValidationError, ContentId, ContentStoreId,
     GeneratedIdValidationError, IndexSegmentId, InodeId, InodeKind, ManifestId, ManifestObjectId,
     MetadataCompactionId, MetadataTableId, NameKey, NameKeyValidationError, NamespaceId,
-    NamespaceIdValidationError, RevisionNo, UploadId, WalSegmentId, WriterEpoch,
-    FIRST_ALLOCATABLE_INODE_ID, MAX_ID_BYTES, MAX_NAME_KEY_BYTES, MAX_PUBLIC_INTEGER,
+    NamespaceIdValidationError, PublicOrdinalRangeError, RevisionNo, UploadId, WalSegmentId,
+    WriterEpoch, FIRST_ALLOCATABLE_INODE_ID, MAX_ID_BYTES, MAX_NAME_KEY_BYTES, MAX_PUBLIC_INTEGER,
     ROOT_INODE_ID,
 };
 pub use name_policy::name_key_for_display_name;

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -1496,7 +1496,7 @@ mod tests {
     }
 
     #[test]
-    fn expected_revision_no_body_guard_enforces_the_public_integer_range() {
+    fn expected_revision_no_must_fit_the_public_integer_range() {
         let body = |expected_revision_no: u64| {
             serde_json::json!({
                 "commit_id": "bounded-revision-guard",
@@ -1512,7 +1512,7 @@ mod tests {
         };
 
         let request: CommitRequest = serde_json::from_value(body(crate::MAX_PUBLIC_INTEGER))
-            .expect("the exact public maximum decodes");
+            .expect("deserialize the maximum revision number");
         assert!(matches!(
             request.operations.as_slice(),
             [FilesystemOperation::PutFile {
@@ -1522,7 +1522,7 @@ mod tests {
         ));
 
         let error = serde_json::from_value::<CommitRequest>(body(crate::MAX_PUBLIC_INTEGER + 1))
-            .expect_err("a guard above the public range must not decode");
+            .expect_err("reject a revision number above the public limit");
         assert!(
             error
                 .to_string()

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -1495,6 +1495,42 @@ mod tests {
         }
     }
 
+    #[test]
+    fn expected_revision_no_body_guard_enforces_the_public_integer_range() {
+        let body = |expected_revision_no: u64| {
+            serde_json::json!({
+                "commit_id": "bounded-revision-guard",
+                "actor": crate::ActorRef::loonfs_system(),
+                "operations": [{
+                    "kind": "put_file",
+                    "path": "/docs/a.txt",
+                    "content_ref": sample_content_ref(),
+                    "behavior": "replace",
+                    "expected_revision_no": expected_revision_no
+                }]
+            })
+        };
+
+        let request: CommitRequest = serde_json::from_value(body(crate::MAX_PUBLIC_INTEGER))
+            .expect("the exact public maximum decodes");
+        assert!(matches!(
+            request.operations.as_slice(),
+            [FilesystemOperation::PutFile {
+                expected_revision_no: Some(RevisionNo(value)),
+                ..
+            }] if *value == crate::MAX_PUBLIC_INTEGER
+        ));
+
+        let error = serde_json::from_value::<CommitRequest>(body(crate::MAX_PUBLIC_INTEGER + 1))
+            .expect_err("a guard above the public range must not decode");
+        assert!(
+            error
+                .to_string()
+                .contains("must be an integer from 0 through 9007199254740991"),
+            "unexpected range error: {error}"
+        );
+    }
+
     /// The whole commit request tree is strict, not just its root: a typo one
     /// level down hides the same guards.
     #[test]

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -188,6 +188,7 @@ pub struct GrepIndexStatusResponse {
     #[serde(flatten)]
     pub lifecycle: GrepIndexLifecycle,
     /// Next logical run ordinal the index will allocate.
+    #[cfg_attr(feature = "openapi", schema(maximum = 9007199254740991_u64))]
     pub next_run_ordinal: u64,
     /// True while a partitioned segment reorganization is in progress.
     pub reorganize_pending: bool,

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -1,7 +1,7 @@
 //! `loonfs admin` commands: checkpoints, retention, GC, indexes, and the
 //! change feed.
 
-use super::context::{fail, fail_for, resolve_command_context};
+use super::context::{fail, fail_for, parse_public_ordinal_arg, resolve_command_context};
 use super::output::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
 use crate::args::{
     AdminCheckpointArgs, AdminCheckpointListArgs, AdminCheckpointReleaseArgs, AdminCommand,
@@ -532,7 +532,8 @@ pub(crate) async fn run_admin_changes(
     args: ChangesArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
-    let after_seq = ChangeSeq(args.after.unwrap_or(0));
+    let after_seq = parse_public_ordinal_arg("--after", args.after.unwrap_or(0), ChangeSeq::parse)
+        .map_err(|error| context.fail(kind, error))?;
     let response = context
         .target
         .list_changes(&context.namespace, after_seq, args.limit)

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -7,7 +7,9 @@ use crate::error::CliError;
 use crate::resolve::{
     load_cli_config, resolve_actor, resolve_namespace, resolve_target_profile_from_config,
 };
-use loonfs_api::{AbsolutePath, ActorRef, ChangeSeq, InodeId, NamespaceId};
+use loonfs_api::{
+    AbsolutePath, ActorRef, ChangeSeq, ErrorCode, InodeId, NamespaceId, PublicOrdinalRangeError,
+};
 use loonfs_client::NamespacePath;
 use std::path::{Path, PathBuf};
 
@@ -33,6 +35,20 @@ pub(crate) fn fail_for(
         Some(mode.to_owned()),
         error,
     )
+}
+
+/// Validates one numeric command argument before either backend sees it.
+pub(crate) fn parse_public_ordinal_arg<T>(
+    argument: &str,
+    value: u64,
+    constructor: impl FnOnce(u64) -> Result<T, PublicOrdinalRangeError>,
+) -> Result<T, CliError> {
+    constructor(value).map_err(|error| {
+        CliError::new(
+            ErrorCode::InvalidRequest.as_str(),
+            format!("invalid {argument} `{value}`: {error}"),
+        )
+    })
 }
 
 impl CommandContext {

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -37,7 +37,7 @@ pub(crate) fn fail_for(
     )
 }
 
-/// Validates one numeric command argument before either backend sees it.
+/// Validates an ordinal argument before dispatching the command.
 pub(crate) fn parse_public_ordinal_arg<T>(
     argument: &str,
     value: u64,

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -3,8 +3,8 @@
 
 use super::context::{
     default_remote_put_path, destination_path_for_get, destination_user_path, directory_intent,
-    fail, namespace_path, parse_user_path, render_target, resolve_command_context,
-    resolve_mutation_context, CommandContext, UndeleteHint,
+    fail, namespace_path, parse_public_ordinal_arg, parse_user_path, render_target,
+    resolve_command_context, resolve_mutation_context, CommandContext, UndeleteHint,
 };
 use super::output::{
     CommandData, CommandFailure, CommandOutput, ListingHeadDrift, ListingHeadObservation,
@@ -302,7 +302,16 @@ fn update_attributes_options(
         remove,
         commit: commit_options(actor, commit_id, args.message.clone()),
         expected_inode_id: args.expected_inode_id.map(InodeId),
-        expected_attributes_revision_no: args.expected_attributes_revision.map(AttributeRevisionNo),
+        expected_attributes_revision_no: args
+            .expected_attributes_revision
+            .map(|value| {
+                parse_public_ordinal_arg(
+                    "--expected-attributes-revision",
+                    value,
+                    AttributeRevisionNo::parse,
+                )
+            })
+            .transpose()?,
     })
 }
 
@@ -419,7 +428,11 @@ pub(crate) async fn run_filesystem_cat(
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
-    let revision_no = args.revision.map(RevisionNo);
+    let revision_no = args
+        .revision
+        .map(|value| parse_public_ordinal_arg("--revision", value, RevisionNo::parse))
+        .transpose()
+        .map_err(|error| context.fail(kind, error))?;
     let bytes = match revision_no {
         Some(revision_no) => {
             context
@@ -457,6 +470,11 @@ pub(crate) async fn run_filesystem_get(
 
     let allow_root = args.recursive;
     let spec = namespace_path(&context.namespace, &args.remote_path, allow_root)
+        .map_err(|error| context.fail(kind, error))?;
+    let revision_no = args
+        .revision
+        .map(|value| parse_public_ordinal_arg("--revision", value, RevisionNo::parse))
+        .transpose()
         .map_err(|error| context.fail(kind, error))?;
     let entry = context
         .target
@@ -510,7 +528,6 @@ pub(crate) async fn run_filesystem_get(
         ));
     }
 
-    let revision_no = args.revision.map(RevisionNo);
     if args.local_destination.as_deref() == Some("-") {
         // No progress and no resume: standard output is carrying the file,
         // and bytes already piped onward are somewhere this CLI cannot see.
@@ -1092,7 +1109,10 @@ fn put_file_options(
     actor: &ActorRef,
 ) -> Result<PutFileOptions, CliError> {
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())?;
-    let expected_revision_no = args.expected_revision.map(RevisionNo);
+    let expected_revision_no = args
+        .expected_revision
+        .map(|value| parse_public_ordinal_arg("--expected-revision", value, RevisionNo::parse))
+        .transpose()?;
     // The revision guard is a stronger replace statement, so it implies
     // --force rather than demanding both flags.
     let behavior = if args.force || expected_revision_no.is_some() {
@@ -1180,11 +1200,13 @@ pub(crate) async fn run_filesystem_restore(
         .map_err(|error| context.fail(kind, error))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
+    let revision_no = parse_public_ordinal_arg("--revision", args.revision, RevisionNo::parse)
+        .map_err(|error| context.fail(kind, error))?;
     let result = context
         .target
         .restore_file_revision(
             &spec,
-            RevisionNo(args.revision),
+            revision_no,
             &loonfs_client::RestoreRevisionOptions {
                 commit: commit_options(&context.actor, commit_id, args.message.clone()),
             },
@@ -1223,13 +1245,16 @@ pub(crate) async fn run_filesystem_undelete(
         .map_err(|error| context.fail(kind, error))?;
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
+    let deletion_seq =
+        parse_public_ordinal_arg("--deletion-seq", args.deletion_seq, ChangeSeq::parse)
+            .map_err(|error| context.fail(kind, error))?;
     let result = context
         .target
         .undelete(
             &context.namespace,
             spec.as_ref().map(|spec| spec.absolute_path()),
             loonfs_api::InodeId(args.inode),
-            loonfs_api::ChangeSeq(args.deletion_seq),
+            deletion_seq,
             &loonfs_client::UndeleteOptions {
                 commit: commit_options(&context.actor, commit_id, args.message.clone()),
             },

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -1,6 +1,6 @@
 //! `loonfs namespace` commands: create, fork, delete, use, and current.
 
-use super::context::{fail, fail_for};
+use super::context::{fail, fail_for, parse_public_ordinal_arg};
 use super::output::{CommandData, CommandFailure, CommandOutput};
 use crate::args::{
     CommandKind, CurrentArgs, NamespaceCommand, NamespaceCreateArgs, NamespaceDeleteArgs,
@@ -72,6 +72,13 @@ async fn run_namespace_delete(
     let mode = resolved.target.mode_str().to_owned();
     let namespace_id = parse_namespace_id(&args.namespace_id)
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+    let expected_head_seq = args
+        .expected_head_seq
+        .map(|value| {
+            parse_public_ordinal_arg("--expected-head-seq", value, loonfs_api::ChangeSeq::parse)
+        })
+        .transpose()
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     if !args.yes {
         // Without a terminal (or under --no-input / --json) there is no
@@ -110,10 +117,7 @@ async fn run_namespace_delete(
 
     let response = resolved
         .target
-        .delete_namespace(
-            &namespace_id,
-            args.expected_head_seq.map(loonfs_api::ChangeSeq),
-        )
+        .delete_namespace(&namespace_id, expected_head_seq)
         .await
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -3100,6 +3100,29 @@ fn embedded_namespace_commands_reject_invalid_namespace_ids() {
 }
 
 #[test]
+fn embedded_commands_reject_out_of_range_ordinal_arguments_at_the_cli_boundary() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+
+    let changes = harness.run(&[
+        "--json",
+        "changes",
+        "--profile",
+        "default",
+        "--namespace",
+        "demo",
+        "--after",
+        "9007199254740992",
+    ]);
+    assert_failure(&changes);
+    assert_eq!(json_error(&changes)["code"], "invalid_request");
+    assert!(json_error(&changes)["message"]
+        .as_str()
+        .expect("json string")
+        .contains("must be an integer from 0 through 9007199254740991"));
+}
+
+#[test]
 fn remote_namespace_commands_reject_invalid_namespace_ids_before_http() {
     let harness = Harness::new();
     let add_remote = harness.run(&[

--- a/crates/loonfs-cli/tests/cli.rs
+++ b/crates/loonfs-cli/tests/cli.rs
@@ -3100,7 +3100,7 @@ fn embedded_namespace_commands_reject_invalid_namespace_ids() {
 }
 
 #[test]
-fn embedded_commands_reject_out_of_range_ordinal_arguments_at_the_cli_boundary() {
+fn embedded_commands_reject_out_of_range_ordinal_arguments() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
 

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -31,8 +31,8 @@ use crate::wal::{load_validated_wal_chain, project_validated_wal_tail, WalChainL
 use loonfs_api::wire::control::{HeadState, NamespaceState};
 use loonfs_api::wire::manifest::{NamespaceManifestEnvelope, NamespaceManifestPayload};
 use loonfs_api::{
-    ChangeSeq, CommitId, FlushWalOutcome, FlushWalResponse, ManifestId, ManifestObjectId,
-    NamespaceId,
+    next_public_ordinal, ChangeSeq, CommitId, FlushWalOutcome, FlushWalResponse, ManifestId,
+    ManifestObjectId, NamespaceId, MAX_PUBLIC_INTEGER,
 };
 use loonfs_objectstore::ObjectStore;
 use tracing::Instrument;
@@ -311,11 +311,13 @@ fn ensure_reconstructed_head_matches(
 }
 
 pub(super) fn next_manifest_id_after(current: ManifestId) -> Result<ManifestId> {
-    current
-        .0
-        .checked_add(1)
+    next_public_ordinal(current.0)
         .map(ManifestId)
-        .ok_or_else(|| CoreError::Internal("manifest id overflow".to_owned()))
+        .ok_or_else(|| {
+            CoreError::Internal(format!(
+                "manifest id cannot advance beyond the public integer range 0 through {MAX_PUBLIC_INTEGER}"
+            ))
+        })
 }
 
 /// Refuses to initiate a root compare-and-swap once the publication budget
@@ -411,4 +413,25 @@ async fn build_namespace_manifest_for_projection<S: ObjectStore + ?Sized>(
             "failed to build namespace manifest envelope: {err}"
         ))
     })
+}
+
+#[cfg(test)]
+mod ordinal_tests {
+    use super::*;
+
+    #[test]
+    fn manifest_id_advancement_accepts_the_maximum_and_rejects_the_next_value() {
+        assert_eq!(
+            next_manifest_id_after(ManifestId(MAX_PUBLIC_INTEGER - 1))
+                .expect("advance to public maximum"),
+            ManifestId(MAX_PUBLIC_INTEGER)
+        );
+
+        let error = next_manifest_id_after(ManifestId(MAX_PUBLIC_INTEGER))
+            .expect_err("manifest id must not exceed the public maximum");
+        assert!(matches!(
+            error,
+            CoreError::Internal(message) if message.contains("public integer range")
+        ));
+    }
 }

--- a/crates/loonfs-core/src/checkpoint/flush.rs
+++ b/crates/loonfs-core/src/checkpoint/flush.rs
@@ -37,8 +37,9 @@ use loonfs_api::{
 use loonfs_objectstore::ObjectStore;
 use tracing::Instrument;
 
-/// The basis one flush attempt settled on: the manifest this attempt
-/// published, or the one already covering the head.
+/// Manifest that covers the head after a flush attempt.
+///
+/// This may be a newly published manifest or one that was already current.
 pub(super) struct FlushedBasis {
     pub(super) manifest_id: ManifestId,
     pub(super) manifest_object_id: ManifestObjectId,
@@ -314,9 +315,7 @@ pub(super) fn next_manifest_id_after(current: ManifestId) -> Result<ManifestId> 
     next_public_ordinal(current.0)
         .map(ManifestId)
         .ok_or_else(|| {
-            CoreError::Internal(format!(
-                "manifest id cannot advance beyond the public integer range 0 through {MAX_PUBLIC_INTEGER}"
-            ))
+            CoreError::Internal(format!("manifest id cannot exceed {MAX_PUBLIC_INTEGER}"))
         })
 }
 
@@ -431,7 +430,7 @@ mod ordinal_tests {
             .expect_err("manifest id must not exceed the public maximum");
         assert!(matches!(
             error,
-            CoreError::Internal(message) if message.contains("public integer range")
+            CoreError::Internal(message) if message.contains("cannot exceed")
         ));
     }
 }

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use loonfs_api::wire::control::{
     encode_control_object, ControlObjectKind, HeadState, HeadStateEnvelope, WalSegmentPointer,
 };
-use loonfs_api::ChangeSeq;
+use loonfs_api::{next_public_ordinal, ChangeSeq};
 use loonfs_objectstore::keys::wal_head;
 use loonfs_objectstore::ObjectStoreError;
 use loonfs_objectstore::{ObjectMetadata, ObjectStore};
@@ -66,11 +66,7 @@ pub(crate) fn prepare_commit_head_publish(
     }
 
     let expected_start_seq = ChangeSeq(
-        current_head
-            .seq
-            .0
-            .checked_add(1)
-            .ok_or(CommitHeadPublishError::SeqOverflow)?,
+        next_public_ordinal(current_head.seq.0).ok_or(CommitHeadPublishError::SeqOverflow)?,
     );
     if wal_payload.start_seq != expected_start_seq {
         return Err(CommitHeadPublishError::WalSegmentStartSeqMismatch {
@@ -332,6 +328,58 @@ mod tests {
             prepared.write.encoded_bytes,
             encode_control_object(&expected_envelope).expect("encoded head"),
         );
+    }
+
+    #[test]
+    fn head_publish_accepts_the_public_sequence_maximum() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let current_head = head(
+            namespace_id.clone(),
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER - 1),
+        );
+        let plan = plan(
+            namespace_id.clone(),
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER),
+        );
+        let wal = wal_segment(
+            namespace_id,
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER - 1),
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER),
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER),
+            1,
+        );
+
+        let prepared =
+            prepare_commit_head_publish(&current_head, &plan, &wal).expect("maximum sequence");
+        assert_eq!(
+            prepared.resulting_head.seq,
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER)
+        );
+    }
+
+    #[test]
+    fn head_publish_rejects_advancing_past_the_public_sequence_maximum() {
+        let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
+        let current_head = head(
+            namespace_id.clone(),
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER),
+        );
+        let plan = plan(
+            namespace_id.clone(),
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER),
+        );
+        let wal = wal_segment(
+            namespace_id,
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER),
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER),
+            ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER),
+            1,
+        );
+
+        assert!(matches!(
+            prepare_commit_head_publish(&current_head, &plan, &wal),
+            Err(CommitHeadPublishError::SeqOverflow)
+        ));
     }
 
     #[test]

--- a/crates/loonfs-core/src/commit/publish_error.rs
+++ b/crates/loonfs-core/src/commit/publish_error.rs
@@ -43,7 +43,9 @@ pub enum CommitHeadPublishError {
     /// before the compare-and-swap so it can never become durable.
     #[error("{0}")]
     HeadIdentityDrift(loonfs_api::wire::control::HeadIdentityDrift),
-    #[error("sequence counter overflow")]
+    #[error(
+        "sequence counter cannot advance beyond the public integer range 0 through 9007199254740991"
+    )]
     SeqOverflow,
     #[error("namespace head changed since the publish view was loaded")]
     StaleHead,

--- a/crates/loonfs-core/src/commit/publish_error.rs
+++ b/crates/loonfs-core/src/commit/publish_error.rs
@@ -43,9 +43,7 @@ pub enum CommitHeadPublishError {
     /// before the compare-and-swap so it can never become durable.
     #[error("{0}")]
     HeadIdentityDrift(loonfs_api::wire::control::HeadIdentityDrift),
-    #[error(
-        "sequence counter cannot advance beyond the public integer range 0 through 9007199254740991"
-    )]
+    #[error("sequence number cannot exceed 9007199254740991")]
     SeqOverflow,
     #[error("namespace head changed since the publish view was loaded")]
     StaleHead,

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -10,8 +10,8 @@ use super::view::PublishValidationView;
 use crate::error::CoreError;
 use crate::metadata::{BindingIdentity, InodeRecord, RevisionRecord, SubtreeTombstoneRecord};
 use loonfs_api::{
-    ActorRef, AttributeRevisionNo, Attributes, ChangeSeq, DisplayName, InodeId, InodeKind, NameKey,
-    RevisionNo,
+    next_public_ordinal, ActorRef, AttributeRevisionNo, Attributes, ChangeSeq, DisplayName,
+    InodeId, InodeKind, NameKey, RevisionNo,
 };
 use loonfs_objectstore::ObjectStore;
 
@@ -407,9 +407,7 @@ fn next_revision_no(
     base_revision_no: RevisionNo,
     overflow: impl FnOnce(InodeId, RevisionNo) -> CommitValidationError,
 ) -> Result<RevisionNo, CommitValidationError> {
-    base_revision_no
-        .0
-        .checked_add(1)
+    next_public_ordinal(base_revision_no.0)
         .map(RevisionNo)
         .ok_or_else(|| overflow(inode_id, base_revision_no))
 }
@@ -418,9 +416,7 @@ fn next_attributes_revision_no(
     inode_id: InodeId,
     base_attributes_revision_no: AttributeRevisionNo,
 ) -> Result<AttributeRevisionNo, CommitValidationError> {
-    base_attributes_revision_no
-        .0
-        .checked_add(1)
+    next_public_ordinal(base_attributes_revision_no.0)
         .map(AttributeRevisionNo)
         .ok_or(CommitValidationError::UpdateAttributesRevisionOverflow {
             inode_id,
@@ -887,4 +883,55 @@ async fn validate_rename_does_not_cycle<S: ObjectStore + ?Sized>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod ordinal_tests {
+    use super::*;
+    use loonfs_api::MAX_PUBLIC_INTEGER;
+
+    #[test]
+    fn revision_advancement_accepts_the_maximum_and_rejects_the_next_value() {
+        let at_maximum = next_revision_no(
+            InodeId(2),
+            RevisionNo(MAX_PUBLIC_INTEGER - 1),
+            |inode_id, base_revision_no| CommitValidationError::RestoreRevisionOverflow {
+                inode_id,
+                base_revision_no,
+            },
+        )
+        .expect("advance to public maximum");
+        assert_eq!(at_maximum, RevisionNo(MAX_PUBLIC_INTEGER));
+
+        assert!(matches!(
+            next_revision_no(
+                InodeId(2),
+                RevisionNo(MAX_PUBLIC_INTEGER),
+                |inode_id, base_revision_no| CommitValidationError::RestoreRevisionOverflow {
+                    inode_id,
+                    base_revision_no,
+                },
+            ),
+            Err(CommitValidationError::RestoreRevisionOverflow {
+                inode_id: InodeId(2),
+                base_revision_no: RevisionNo(MAX_PUBLIC_INTEGER),
+            })
+        ));
+    }
+
+    #[test]
+    fn attribute_revision_advancement_accepts_the_maximum_and_rejects_the_next_value() {
+        assert_eq!(
+            next_attributes_revision_no(InodeId(2), AttributeRevisionNo(MAX_PUBLIC_INTEGER - 1),)
+                .expect("advance to public maximum"),
+            AttributeRevisionNo(MAX_PUBLIC_INTEGER)
+        );
+        assert!(matches!(
+            next_attributes_revision_no(InodeId(2), AttributeRevisionNo(MAX_PUBLIC_INTEGER),),
+            Err(CommitValidationError::UpdateAttributesRevisionOverflow {
+                inode_id: InodeId(2),
+                base_attributes_revision_no: AttributeRevisionNo(MAX_PUBLIC_INTEGER),
+            })
+        ));
+    }
 }

--- a/crates/loonfs-core/src/commit/validate/plan_build.rs
+++ b/crates/loonfs-core/src/commit/validate/plan_build.rs
@@ -8,7 +8,7 @@ use super::view::PublishValidationView;
 use crate::error::CoreError;
 use crate::metadata::{MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
-use loonfs_api::ChangeSeq;
+use loonfs_api::{next_public_ordinal, ChangeSeq};
 use loonfs_objectstore::ObjectStore;
 
 pub(crate) async fn validate_commit_for_publish<S: ObjectStore + ?Sized>(
@@ -18,10 +18,7 @@ pub(crate) async fn validate_commit_for_publish<S: ObjectStore + ?Sized>(
     metadata_view: MetadataView<'_, '_, S>,
     accepted_rows: &MetadataState,
 ) -> Result<ValidatedCommitPlan, CoreError> {
-    let committed_seq = head
-        .seq
-        .0
-        .checked_add(1)
+    let committed_seq = next_public_ordinal(head.seq.0)
         .map(ChangeSeq)
         .ok_or(CommitValidationError::SeqOverflow)?;
     build_commit_plan(

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -19,6 +19,7 @@ use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
     AttributeKey, AttributeRevisionNo, AttributeValue, Attributes, ChangeSeq, CommitId, ContentId,
     ContentRef, DisplayName, InodeId, InodeKind, NameKey, NamespaceId, RevisionNo, WriterEpoch,
+    MAX_PUBLIC_INTEGER,
 };
 
 fn test_display_name(value: impl AsRef<str>) -> DisplayName {
@@ -836,7 +837,7 @@ async fn restore_revision_overflow_is_rejected() {
     deltas[2] = WalDelta::AppendFileRevision {
         delta_index: 2,
         inode_id: InodeId(2),
-        revision_no: RevisionNo(u64::MAX),
+        revision_no: RevisionNo(MAX_PUBLIC_INTEGER),
         content_ref: content_ref("content-max"),
     };
     let metadata_state = MetadataState::default()
@@ -864,8 +865,8 @@ async fn restore_revision_overflow_is_rejected() {
         writer_epoch: WriterEpoch(1),
         ops: planned(vec![CommitOp::RestoreRevision {
             inode_id: InodeId(2),
-            source_revision_no: RevisionNo(u64::MAX),
-            base_revision_no: RevisionNo(u64::MAX),
+            source_revision_no: RevisionNo(MAX_PUBLIC_INTEGER),
+            base_revision_no: RevisionNo(MAX_PUBLIC_INTEGER),
         }]),
         message: None,
     };
@@ -877,7 +878,7 @@ async fn restore_revision_overflow_is_rejected() {
         error,
         CommitValidationError::RestoreRevisionOverflow {
             inode_id: InodeId(2),
-            base_revision_no: RevisionNo(u64::MAX),
+            base_revision_no: RevisionNo(MAX_PUBLIC_INTEGER),
         }
     ));
 }

--- a/crates/loonfs-core/src/commit/validate_error.rs
+++ b/crates/loonfs-core/src/commit/validate_error.rs
@@ -226,14 +226,14 @@ pub enum CommitValidationError {
         active_seq: ChangeSeq,
     },
     #[error(
-        "revision counter overflow restoring inode `{inode_id}` at base revision `{base_revision_no}`"
+        "revision counter cannot advance beyond the public integer range 0 through 9007199254740991 restoring inode `{inode_id}` at base revision `{base_revision_no}`"
     )]
     RestoreRevisionOverflow {
         inode_id: InodeId,
         base_revision_no: RevisionNo,
     },
     #[error(
-        "revision counter overflow replacing inode `{inode_id}` at base revision `{base_revision_no}`"
+        "revision counter cannot advance beyond the public integer range 0 through 9007199254740991 replacing inode `{inode_id}` at base revision `{base_revision_no}`"
     )]
     ReplaceFileRevisionOverflow {
         inode_id: InodeId,
@@ -258,7 +258,7 @@ pub enum CommitValidationError {
         tombstone_seq: ChangeSeq,
     },
     #[error(
-        "attribute revision counter overflow updating inode `{inode_id}` at base revision `{base_attributes_revision_no}`"
+        "attribute revision counter cannot advance beyond the public integer range 0 through 9007199254740991 updating inode `{inode_id}` at base revision `{base_attributes_revision_no}`"
     )]
     UpdateAttributesRevisionOverflow {
         inode_id: InodeId,
@@ -271,7 +271,9 @@ pub enum CommitValidationError {
     },
     #[error("validated preview apply failed: {0}")]
     ValidatedPreviewApplyFailed(String),
-    #[error("sequence counter overflow")]
+    #[error(
+        "sequence counter cannot advance beyond the public integer range 0 through 9007199254740991"
+    )]
     SeqOverflow,
     #[error("next inode id counter overflow")]
     NextInodeOverflow,

--- a/crates/loonfs-core/src/commit/validate_error.rs
+++ b/crates/loonfs-core/src/commit/validate_error.rs
@@ -226,14 +226,14 @@ pub enum CommitValidationError {
         active_seq: ChangeSeq,
     },
     #[error(
-        "revision counter cannot advance beyond the public integer range 0 through 9007199254740991 restoring inode `{inode_id}` at base revision `{base_revision_no}`"
+        "cannot restore inode `{inode_id}` because revision `{base_revision_no}` is already at the maximum 9007199254740991"
     )]
     RestoreRevisionOverflow {
         inode_id: InodeId,
         base_revision_no: RevisionNo,
     },
     #[error(
-        "revision counter cannot advance beyond the public integer range 0 through 9007199254740991 replacing inode `{inode_id}` at base revision `{base_revision_no}`"
+        "cannot replace inode `{inode_id}` because revision `{base_revision_no}` is already at the maximum 9007199254740991"
     )]
     ReplaceFileRevisionOverflow {
         inode_id: InodeId,
@@ -258,7 +258,7 @@ pub enum CommitValidationError {
         tombstone_seq: ChangeSeq,
     },
     #[error(
-        "attribute revision counter cannot advance beyond the public integer range 0 through 9007199254740991 updating inode `{inode_id}` at base revision `{base_attributes_revision_no}`"
+        "cannot update attributes for inode `{inode_id}` because revision `{base_attributes_revision_no}` is already at the maximum 9007199254740991"
     )]
     UpdateAttributesRevisionOverflow {
         inode_id: InodeId,
@@ -271,9 +271,7 @@ pub enum CommitValidationError {
     },
     #[error("validated preview apply failed: {0}")]
     ValidatedPreviewApplyFailed(String),
-    #[error(
-        "sequence counter cannot advance beyond the public integer range 0 through 9007199254740991"
-    )]
+    #[error("sequence number cannot exceed 9007199254740991")]
     SeqOverflow,
     #[error("next inode id counter overflow")]
     NextInodeOverflow,

--- a/crates/loonfs-core/src/namespace/basis.rs
+++ b/crates/loonfs-core/src/namespace/basis.rs
@@ -20,8 +20,8 @@ use crate::namespace::control::{
     read_head_and_metadata_root_if_present, read_wal_floor_object, LoadedHeadObject,
 };
 use loonfs_api::wire::control::HeadState;
+use loonfs_api::NamespaceId;
 use loonfs_api::{manifest_object_id_manifest_id, ChangeSeq, ManifestId, ManifestObjectId};
-use loonfs_api::{NamespaceId, ROOT_INODE_ID};
 use loonfs_objectstore::ObjectStore;
 
 /// The materialized starting point every read and flush builds on.
@@ -156,7 +156,7 @@ pub(crate) fn metadata_basis_without_root(
 /// The genesis head fields a synthesized basis replays from: sequence zero,
 /// the genesis commit, and the root inode already reserved.
 pub(crate) fn genesis_next_inode_id() -> loonfs_api::InodeId {
-    loonfs_api::InodeId(ROOT_INODE_ID.0 + 1)
+    loonfs_api::FIRST_ALLOCATABLE_INODE_ID
 }
 
 /// The sequence a namespace's own history begins at: zero for a created

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -6,7 +6,7 @@ use crate::control_object::ControlObjectLoadError;
 use crate::control_update::{update_head, ControlUpdateError, HeadReplacement};
 use crate::error::StoreFailureClass;
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState, WriterBlock};
-use loonfs_api::{NamespaceId, WriterEpoch};
+use loonfs_api::{next_public_ordinal, NamespaceId, WriterEpoch};
 use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -22,7 +22,9 @@ pub enum WriterEpochAcquireError {
     NamespaceDeleted { namespace_id: NamespaceId },
     #[error("empty writer id")]
     EmptyWriterId,
-    #[error("writer epoch overflow from `{active}`")]
+    #[error(
+        "writer epoch cannot advance beyond the public integer range 0 through 9007199254740991 from `{active}`"
+    )]
     WriterEpochOverflow { active: WriterEpoch },
     #[error("failed to write head object `{object_key}` during writer epoch acquire: {message}")]
     HeadWrite {
@@ -86,9 +88,7 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
 }
 
 fn next_writer_epoch(active: WriterEpoch) -> Result<WriterEpoch, WriterEpochAcquireError> {
-    active
-        .0
-        .checked_add(1)
+    next_public_ordinal(active.0)
         .map(WriterEpoch)
         .ok_or(WriterEpochAcquireError::WriterEpochOverflow { active })
 }
@@ -182,7 +182,7 @@ mod tests {
         decode_control_object, encode_control_object, ControlObjectKind, HeadStateEnvelope,
         NamespaceState,
     };
-    use loonfs_api::{ChangeSeq, CommitId, NamespaceId};
+    use loonfs_api::{ChangeSeq, CommitId, NamespaceId, MAX_PUBLIC_INTEGER};
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::{
@@ -235,6 +235,21 @@ mod tests {
             .expect("head exists")
             .etag
             .expect("head etag")
+    }
+
+    #[test]
+    fn writer_epoch_advancement_accepts_the_maximum_and_rejects_the_next_value() {
+        assert_eq!(
+            next_writer_epoch(WriterEpoch(MAX_PUBLIC_INTEGER - 1))
+                .expect("advance to public maximum"),
+            WriterEpoch(MAX_PUBLIC_INTEGER)
+        );
+        assert!(matches!(
+            next_writer_epoch(WriterEpoch(MAX_PUBLIC_INTEGER)),
+            Err(WriterEpochAcquireError::WriterEpochOverflow {
+                active: WriterEpoch(MAX_PUBLIC_INTEGER),
+            })
+        ));
     }
 
     #[tokio::test]

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -23,7 +23,7 @@ pub enum WriterEpochAcquireError {
     #[error("empty writer id")]
     EmptyWriterId,
     #[error(
-        "writer epoch cannot advance beyond the public integer range 0 through 9007199254740991 from `{active}`"
+        "writer epoch `{active}` cannot be incremented because the maximum is 9007199254740991"
     )]
     WriterEpochOverflow { active: WriterEpoch },
     #[error("failed to write head object `{object_key}` during writer epoch acquire: {message}")]

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -72,7 +72,7 @@ pub(crate) async fn plan_commit_against_publish_view<S: ObjectStore + ?Sized>(
         .map(ChangeSeq)
         .ok_or_else(|| {
             CoreError::Internal(format!(
-                "namespace sequence cannot advance beyond the public integer range 0 through {MAX_PUBLIC_INTEGER}"
+                "namespace sequence cannot exceed {MAX_PUBLIC_INTEGER}"
             ))
         })?;
 

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -17,7 +17,7 @@ use crate::commit::{
 use crate::error::{CoreError, Result};
 use crate::metadata::{MetadataState, MetadataView};
 use loonfs_api::wire::control::HeadState;
-use loonfs_api::{ChangeSeq, NamespaceId};
+use loonfs_api::{next_public_ordinal, ChangeSeq, NamespaceId, MAX_PUBLIC_INTEGER};
 use loonfs_objectstore::ObjectStore;
 
 /// One mutation request compiled into a commit's operations.
@@ -68,12 +68,13 @@ pub(crate) async fn plan_commit_against_publish_view<S: ObjectStore + ?Sized>(
             "mutation request carries no operations".to_owned(),
         ));
     }
-    let committed_seq = head
-        .seq
-        .0
-        .checked_add(1)
+    let committed_seq = next_public_ordinal(head.seq.0)
         .map(ChangeSeq)
-        .ok_or_else(|| CoreError::Internal("namespace sequence overflow".to_owned()))?;
+        .ok_or_else(|| {
+            CoreError::Internal(format!(
+                "namespace sequence cannot advance beyond the public integer range 0 through {MAX_PUBLIC_INTEGER}"
+            ))
+        })?;
 
     let mut resolved = PublishValidationView::new(base_view, accepted_rows, committed_seq);
     let mut cursor = OpValidationCursor::new();

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -454,9 +454,8 @@ mod tests {
             .await
             .expect("list WAL before");
 
-        // The loaded metadata remains a valid read basis. Only the in-memory
-        // publish head is moved to exhaustion, which drives the same planning
-        // guard a real namespace at the limit reaches before any write.
+        // Change only the in-memory head so this exercises the sequence limit
+        // without modifying the stored metadata.
         view.head.seq = ChangeSeq(MAX_PUBLIC_INTEGER);
         let candidate = CommitCandidate::new(CommitRequest::single(
             CommitId::parse("past-sequence-limit").expect("commit id"),
@@ -481,7 +480,7 @@ mod tests {
             .as_ref()
             .expect_err("exhausted sequence must reject the commit");
         assert_eq!(error.code(), loonfs_api::ErrorCode::ServerError);
-        assert!(error.to_string().contains("public integer range"));
+        assert!(error.to_string().contains("cannot exceed"));
         assert!(matches!(result.effect, PublishViewEffect::Unchanged));
         assert_eq!(
             store

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -402,3 +402,101 @@ fn fail_outcomes_contingent_on_unpublished_batch(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::namespace::bootstrap::bootstrap_namespace;
+    use crate::namespace::writer_epoch::acquire_writer_epoch;
+    use crate::path::write::{CommitRequest, FilesystemOperation};
+    use crate::protocol::{load_publish_metadata_view, PublishTailOptions};
+    use crate::timing::StdMonotonicTimer;
+    use loonfs_api::{AbsolutePath, ChangeSeq, CommitId, MAX_PUBLIC_INTEGER};
+    use loonfs_objectstore::keys::{wal_head, wal_segment_prefix};
+    use loonfs_objectstore::local_fs_store::LocalFsStore;
+    use loonfs_objectstore::ObjectStore;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn sequence_exhaustion_writes_neither_wal_nor_head() {
+        let temp_dir = tempdir().expect("tempdir");
+        let store = LocalFsStore::new(temp_dir.path()).expect("store");
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let context = MutationContext {
+            writer_id: "writer".to_owned(),
+            now_ms: 1_000,
+        };
+        bootstrap_namespace(&store, &namespace_id, &context, false)
+            .await
+            .expect("bootstrap namespace");
+        let acquired_writer = acquire_writer_epoch(&store, &namespace_id, &context)
+            .await
+            .expect("acquire writer");
+        let (mut view, _projection) = load_publish_metadata_view(
+            &store,
+            None,
+            &namespace_id,
+            acquired_writer,
+            None,
+            &PublishTailOptions::default(),
+        )
+        .await
+        .expect("load publish view");
+
+        let head_key = wal_head(&namespace_id);
+        let head_before = store
+            .get(&head_key, None)
+            .await
+            .expect("read head")
+            .expect("head exists");
+        let wal_before = store
+            .list_prefix(&wal_segment_prefix(&namespace_id))
+            .await
+            .expect("list WAL before");
+
+        // The loaded metadata remains a valid read basis. Only the in-memory
+        // publish head is moved to exhaustion, which drives the same planning
+        // guard a real namespace at the limit reaches before any write.
+        view.head.seq = ChangeSeq(MAX_PUBLIC_INTEGER);
+        let candidate = CommitCandidate::new(CommitRequest::single(
+            CommitId::parse("past-sequence-limit").expect("commit id"),
+            loonfs_test_support::test_actor(),
+            None,
+            FilesystemOperation::CreateDirectory {
+                path: AbsolutePath::parse("/blocked").expect("path"),
+                parents: false,
+            },
+        ));
+        let result = publish_namespace_commits_batch_against_publish_view(
+            &store,
+            &namespace_id,
+            &[candidate],
+            &context,
+            &view,
+            &StdMonotonicTimer::default(),
+        )
+        .await;
+
+        let error = result.results[0]
+            .as_ref()
+            .expect_err("exhausted sequence must reject the commit");
+        assert_eq!(error.code(), loonfs_api::ErrorCode::ServerError);
+        assert!(error.to_string().contains("public integer range"));
+        assert!(matches!(result.effect, PublishViewEffect::Unchanged));
+        assert_eq!(
+            store
+                .get(&head_key, None)
+                .await
+                .expect("read head after")
+                .expect("head exists"),
+            head_before
+        );
+        assert_eq!(
+            store
+                .list_prefix(&wal_segment_prefix(&namespace_id))
+                .await
+                .expect("list WAL after"),
+            wal_before
+        );
+    }
+}

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -34,7 +34,9 @@ pub enum WalBuildError {
     },
     #[error("WAL codec error: {0}")]
     Codec(String),
-    #[error("sequence counter overflow")]
+    #[error(
+        "sequence calculation falls outside the public integer range 0 through 9007199254740991"
+    )]
     SeqOverflow,
 }
 
@@ -234,6 +236,8 @@ pub enum WalReplayError {
         object_key: String,
         required_seq: ChangeSeq,
     },
-    #[error("sequence counter overflow")]
+    #[error(
+        "sequence calculation falls outside the public integer range 0 through 9007199254740991"
+    )]
     SeqOverflow,
 }

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -34,9 +34,7 @@ pub enum WalBuildError {
     },
     #[error("WAL codec error: {0}")]
     Codec(String),
-    #[error(
-        "sequence calculation falls outside the public integer range 0 through 9007199254740991"
-    )]
+    #[error("sequence number cannot exceed 9007199254740991")]
     SeqOverflow,
 }
 
@@ -236,8 +234,6 @@ pub enum WalReplayError {
         object_key: String,
         required_seq: ChangeSeq,
     },
-    #[error(
-        "sequence calculation falls outside the public integer range 0 through 9007199254740991"
-    )]
+    #[error("sequence number cannot exceed 9007199254740991")]
     SeqOverflow,
 }

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -5,7 +5,7 @@ use super::{DecodedWalRecord, ReplayedWalTail, ValidatedWalChain};
 use crate::metadata::{CommitReceiptRecord, MetadataState};
 use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::wal::{WalCommitDelta, WalDelta, WalSegmentEnvelope};
-use loonfs_api::{ChangeSeq, InodeId, NamespaceId, WriterEpoch};
+use loonfs_api::{next_public_ordinal, ChangeSeq, InodeId, NamespaceId, WriterEpoch};
 use loonfs_objectstore::keys::wal_segment;
 
 pub(crate) fn project_validated_wal_tail(
@@ -74,10 +74,7 @@ fn validate_replay_record(
             actual: record.namespace_id.clone(),
         });
     }
-    let expected_seq = current_head
-        .seq
-        .0
-        .checked_add(1)
+    let expected_seq = next_public_ordinal(current_head.seq.0)
         .map(ChangeSeq)
         .ok_or(WalReplayError::SeqOverflow)?;
     if record.seq != expected_seq {
@@ -131,9 +128,7 @@ pub(super) fn validate_wal_segment_for_replay(
         });
     }
 
-    let expected_start = expected_base_head_seq
-        .0
-        .checked_add(1)
+    let expected_start = next_public_ordinal(expected_base_head_seq.0)
         .map(ChangeSeq)
         .ok_or(WalReplayError::SeqOverflow)?;
 

--- a/crates/loonfs-core/src/wal/writer.rs
+++ b/crates/loonfs-core/src/wal/writer.rs
@@ -7,7 +7,7 @@ use loonfs_api::wire::control::WalSegmentPointer;
 use loonfs_api::wire::wal::{
     encode_wal_segment_envelope_zstd, WalCommitPayload, WalSegmentEnvelope, WalSegmentPayload,
 };
-use loonfs_api::{ChangeSeq, NamespaceId, WalSegmentId, WriterEpoch};
+use loonfs_api::{next_public_ordinal, ChangeSeq, NamespaceId, WalSegmentId, WriterEpoch};
 use loonfs_objectstore::keys::wal_segment;
 
 pub(crate) fn prepare_wal_segment(
@@ -30,10 +30,7 @@ pub(crate) fn prepare_wal_segment(
         }
         let payload_record = wal_payload_from_materialized_commit(record);
         if let Some(previous) = payload_records.last() {
-            let expected = previous
-                .seq
-                .0
-                .checked_add(1)
+            let expected = next_public_ordinal(previous.seq.0)
                 .map(ChangeSeq)
                 .ok_or(WalBuildError::SeqOverflow)?;
             if payload_record.seq != expected {

--- a/crates/loonfs-grep/src/codec.rs
+++ b/crates/loonfs-grep/src/codec.rs
@@ -189,7 +189,7 @@ pub fn decode_gram_postings(bytes: &[u8]) -> Result<Vec<GramPosting>, IndexGrams
 fn read_revision_no(bytes: &[u8], cursor: &mut usize) -> Result<RevisionNo, IndexGramsCodecError> {
     let value = read_varint(bytes, cursor)?;
     RevisionNo::parse(value).map_err(|error| {
-        IndexGramsCodecError::Malformed(format!("posting revision `{value}` {error}"))
+        IndexGramsCodecError::Malformed(format!("invalid posting revision `{value}`: {error}"))
     })
 }
 
@@ -415,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn posting_batch_decode_caps_revision_numbers_but_not_inode_ids() {
+    fn posting_batch_decode_rejects_oversized_revisions_but_allows_full_inode_range() {
         let mut full_inode_range = Vec::new();
         write_varint(&mut full_inode_range, 1);
         write_varint(&mut full_inode_range, u64::MAX);

--- a/crates/loonfs-grep/src/codec.rs
+++ b/crates/loonfs-grep/src/codec.rs
@@ -150,7 +150,7 @@ pub fn decode_gram_postings(bytes: &[u8]) -> Result<Vec<GramPosting>, IndexGrams
     let mut postings = Vec::with_capacity(count);
     let mut previous = GramPosting {
         inode_id: InodeId(read_varint(bytes, &mut cursor)?),
-        revision_no: RevisionNo(read_varint(bytes, &mut cursor)?),
+        revision_no: read_revision_no(bytes, &mut cursor)?,
     };
     postings.push(previous);
     for _ in 1..count {
@@ -164,7 +164,7 @@ pub fn decode_gram_postings(bytes: &[u8]) -> Result<Vec<GramPosting>, IndexGrams
             })?;
         let posting = GramPosting {
             inode_id: InodeId(inode_id),
-            revision_no: RevisionNo(read_varint(bytes, &mut cursor)?),
+            revision_no: read_revision_no(bytes, &mut cursor)?,
         };
         if posting <= previous {
             return Err(IndexGramsCodecError::PostingsOutOfOrder {
@@ -184,6 +184,13 @@ pub fn decode_gram_postings(bytes: &[u8]) -> Result<Vec<GramPosting>, IndexGrams
         )));
     }
     Ok(postings)
+}
+
+fn read_revision_no(bytes: &[u8], cursor: &mut usize) -> Result<RevisionNo, IndexGramsCodecError> {
+    let value = read_varint(bytes, cursor)?;
+    RevisionNo::parse(value).map_err(|error| {
+        IndexGramsCodecError::Malformed(format!("posting revision `{value}` {error}"))
+    })
 }
 
 fn write_varint(bytes: &mut Vec<u8>, mut value: u64) {
@@ -405,6 +412,44 @@ mod tests {
             decode_gram_postings(&[]),
             Err(IndexGramsCodecError::Malformed(_))
         ));
+    }
+
+    #[test]
+    fn posting_batch_decode_caps_revision_numbers_but_not_inode_ids() {
+        let mut full_inode_range = Vec::new();
+        write_varint(&mut full_inode_range, 1);
+        write_varint(&mut full_inode_range, u64::MAX);
+        write_varint(&mut full_inode_range, loonfs_api::MAX_PUBLIC_INTEGER);
+        assert_eq!(
+            decode_gram_postings(&full_inode_range).expect("full-range inode id"),
+            vec![posting(u64::MAX, loonfs_api::MAX_PUBLIC_INTEGER)]
+        );
+
+        let mut first_revision_overflow = Vec::new();
+        write_varint(&mut first_revision_overflow, 1);
+        write_varint(&mut first_revision_overflow, 1);
+        write_varint(
+            &mut first_revision_overflow,
+            loonfs_api::MAX_PUBLIC_INTEGER + 1,
+        );
+        let error = decode_gram_postings(&first_revision_overflow)
+            .expect_err("first revision above the public range");
+        assert!(matches!(error, IndexGramsCodecError::Malformed(message)
+            if message.contains("must be an integer from 0 through 9007199254740991")));
+
+        let mut later_revision_overflow = Vec::new();
+        write_varint(&mut later_revision_overflow, 2);
+        write_varint(&mut later_revision_overflow, 1);
+        write_varint(&mut later_revision_overflow, 1);
+        write_varint(&mut later_revision_overflow, 1);
+        write_varint(
+            &mut later_revision_overflow,
+            loonfs_api::MAX_PUBLIC_INTEGER + 1,
+        );
+        let error = decode_gram_postings(&later_revision_overflow)
+            .expect_err("later revision above the public range");
+        assert!(matches!(error, IndexGramsCodecError::Malformed(message)
+            if message.contains("must be an integer from 0 through 9007199254740991")));
     }
 
     #[test]

--- a/crates/loonfs-grep/src/reads.rs
+++ b/crates/loonfs-grep/src/reads.rs
@@ -21,7 +21,7 @@ use loonfs_api::v0::{ChangesResponse, FilesystemChange};
 use loonfs_api::{
     decode_cursor, AbsolutePath, AuthoritativePathEntry, ChangeSeq, CheckpointId, ContentRef,
     DirectoryPageCursor, EffectiveLimit, InodeId, LimitError, NamespaceId, Page, PageRequest,
-    PaginationPolicy, RevisionNo,
+    PaginationPolicy, RevisionNo, MAX_PUBLIC_INTEGER,
 };
 
 /// One namespace's filesystem reads, borrowed from a reader handle.
@@ -60,7 +60,7 @@ impl<'a> NamespaceReads<'a> {
     /// against and no history.
     pub async fn head_seq(&self) -> Result<ChangeSeq> {
         Ok(self
-            .list_changes_after(ChangeSeq(u64::MAX), 1)
+            .list_changes_after(ChangeSeq(MAX_PUBLIC_INTEGER), 1)
             .await?
             .through_seq)
     }

--- a/crates/loonfs-grep/src/reads.rs
+++ b/crates/loonfs-grep/src/reads.rs
@@ -48,16 +48,15 @@ impl<'a> NamespaceReads<'a> {
         }
     }
 
-    /// The namespace every read here answers for.
+    /// Returns the namespace used by this reader.
     pub fn namespace_id(&self) -> &NamespaceId {
         self.namespace_id
     }
 
-    /// The namespace's current head sequence.
+    /// Returns the namespace's current head sequence.
     ///
-    /// The change feed answers this with one head read: asking for changes
-    /// after the last possible sequence reports the head it was evaluated
-    /// against and no history.
+    /// Requesting changes after the largest valid sequence reads the current
+    /// head without returning any history.
     pub async fn head_seq(&self) -> Result<ChangeSeq> {
         Ok(self
             .list_changes_after(ChangeSeq(MAX_PUBLIC_INTEGER), 1)
@@ -68,10 +67,9 @@ impl<'a> NamespaceReads<'a> {
     /// Reads one page of the files a checkpoint pins, in ascending inode-id
     /// order.
     ///
-    /// A checkpoint that no longer pins its basis — released, expired, or
-    /// reaped — answers `checkpoint_unavailable` instead of falling back to
-    /// current state, which is what turns a lost backfill basis into an
-    /// explicit rebootstrap.
+    /// Returns `checkpoint_unavailable` if the checkpoint was released,
+    /// expired, or removed. The caller must then restart the backfill from a
+    /// new checkpoint.
     pub async fn list_checkpoint_files_page(
         &self,
         checkpoint_id: &CheckpointId,

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -34,9 +34,9 @@ use loonfs_api::wire::sst_blocks::{
     index_blocks_for_key_range, DecodedDataBlock, SegmentBlocksBuilder, SegmentIndexEntry,
 };
 use loonfs_api::{
-    decode_namespace_cursor, encode_cursor, sha256_digest, ChangeSeq, CheckpointId, ContentRef,
-    ErrorCode, IndexSegmentId, InodeId, NamespaceCursor, NamespaceCursorError, NamespaceId,
-    PageCursor, RevisionNo,
+    decode_namespace_cursor, encode_cursor, next_public_ordinal, sha256_digest, ChangeSeq,
+    CheckpointId, ContentRef, ErrorCode, IndexSegmentId, InodeId, NamespaceCursor,
+    NamespaceCursorError, NamespaceId, PageCursor, RevisionNo, MAX_PUBLIC_INTEGER,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use loonfs_objectstore::{ImmutableWriteError, ObjectStore, ObjectStoreError};
@@ -585,13 +585,19 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         } = unit;
         let run_seq = progress.run_seq();
         let rows = gram_postings_rows(postings)?;
+        let current_run_ordinal = current.manifest_state().index().next_run_ordinal;
+        let next_run_ordinal = if rows.is_empty() {
+            current_run_ordinal
+        } else {
+            next_grep_run_ordinal(current_run_ordinal)?
+        };
         let timer = StdMonotonicTimer::default();
         let publication_started_ms = timer.monotonic_now_ms();
         let new_segments = write_index_segments(
             &self.store,
             namespace_id,
             run_seq,
-            current.manifest_state().index().next_run_ordinal,
+            current_run_ordinal,
             rows,
             policy.max_rows_per_segment,
             INDEX_GRAMS_DELTA_LEVEL,
@@ -600,8 +606,6 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let segments_written = new_segments.len() as u64;
         let mut segments = current.manifest_state().segments().to_vec();
         segments.extend(new_segments);
-        let next_run_ordinal =
-            current.manifest_state().index().next_run_ordinal + u64::from(segments_written > 0);
         // A finished backfill becomes active at exactly the sequence its
         // checkpoint captured: the walk answered that state and no other, so
         // the watermark it hands the change feed is the target it reached.
@@ -1122,6 +1126,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                     current.manifest_state().index().next_run_ordinal,
                 ),
                 None => {
+                    let current_run_ordinal = current.manifest_state().index().next_run_ordinal;
                     let l0_runs = distinct_run_ordinals_at_level(
                         current.manifest_state().segments(),
                         INDEX_GRAMS_DELTA_LEVEL,
@@ -1165,9 +1170,9 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                             output_segment_ids: Vec::new(),
                             row_key_cursor: String::new(),
                             output_level,
-                            run_ordinal: current.manifest_state().index().next_run_ordinal,
+                            run_ordinal: current_run_ordinal,
                         },
-                        current.manifest_state().index().next_run_ordinal + 1,
+                        next_grep_run_ordinal(current_run_ordinal)?,
                     )
                 }
             };
@@ -1794,6 +1799,15 @@ fn ensure_publication_budget(timer: &impl MonotonicTimer, started_ms: u64) -> Re
 
 fn core_state_error(error: crate::root::GrepManifestStateError) -> GrepError {
     CoreError::Internal(format!("failed to build grep root state: {error}")).into()
+}
+
+fn next_grep_run_ordinal(current: u64) -> Result<u64> {
+    next_public_ordinal(current).ok_or_else(|| {
+        CoreError::Internal(format!(
+            "grep run ordinal cannot advance beyond the public integer range 0 through {MAX_PUBLIC_INTEGER}"
+        ))
+        .into()
+    })
 }
 
 fn core_store_error(object_key: &str, error: &ObjectStoreError) -> GrepError {

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -606,9 +606,8 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         let segments_written = new_segments.len() as u64;
         let mut segments = current.manifest_state().segments().to_vec();
         segments.extend(new_segments);
-        // A finished backfill becomes active at exactly the sequence its
-        // checkpoint captured: the walk answered that state and no other, so
-        // the watermark it hands the change feed is the target it reached.
+        // A completed backfill is current through the sequence captured by
+        // its checkpoint. The change feed resumes after that sequence.
         let (lifecycle, completed_checkpoint_id, built_through_seq) = match progress {
             CollectedProgress::Backfill {
                 checkpoint_id,
@@ -1804,7 +1803,7 @@ fn core_state_error(error: crate::root::GrepManifestStateError) -> GrepError {
 fn next_grep_run_ordinal(current: u64) -> Result<u64> {
     next_public_ordinal(current).ok_or_else(|| {
         CoreError::Internal(format!(
-            "grep run ordinal cannot advance beyond the public integer range 0 through {MAX_PUBLIC_INTEGER}"
+            "grep run ordinal cannot exceed {MAX_PUBLIC_INTEGER}"
         ))
         .into()
     })

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -344,7 +344,7 @@ async fn exhausted_run_ordinals_fail_as_server_errors_without_writing_the_root()
         assert!(matches!(
             error,
             GrepError::Runtime(RuntimeError::Core(CoreError::Internal(message)))
-                if message.contains("grep run ordinal cannot advance beyond the public integer range")
+                if message.contains("grep run ordinal cannot exceed")
         ));
     }
 
@@ -378,7 +378,7 @@ async fn exhausted_run_ordinals_fail_as_server_errors_without_writing_the_root()
             .await
             .expect("list segments after failures"),
         segments_before,
-        "the build guard runs before writing an orphan segment"
+        "the range check must run before writing a segment"
     );
     writer.shutdown().await.expect("shutdown");
 }

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -6,16 +6,17 @@
 use crate::common::{control, grep_with, GrepHost};
 use bytes::Bytes;
 use loonfs::{
-    CreateNamespaceOptions, DeleteNamespaceOptions, ErrorCode, FsAdmin, FsReader, FsWriter,
-    GcConfig, MaintenancePlan, MetadataMaintenanceOptions, NamespaceId, PutFileOptions,
-    SharedObjectStore,
+    CoreError, CreateNamespaceOptions, DeleteNamespaceOptions, ErrorCode, FsAdmin, FsReader,
+    FsWriter, GcConfig, MaintenancePlan, MetadataMaintenanceOptions, NamespaceId, PutFileOptions,
+    RuntimeError, SharedObjectStore,
 };
 use loonfs_api::wire::control::CheckpointRecordLifecycle;
 use loonfs_api::{
     sha256_digest, AbsolutePath, ChangeSeq, GrepRequest, GrepResponse, IndexSegmentId,
+    MAX_PUBLIC_INTEGER,
 };
 use loonfs_grep::keyspace::{
-    manifest_key, manifests_prefix, namespace_prefix, root_key, segment_key,
+    manifest_key, manifests_prefix, namespace_prefix, root_key, segment_key, segments_prefix,
 };
 use loonfs_grep::root::{
     advance_grep_root, encode_grep_root, load_grep_root, GrepIndexState, GrepLifecycle,
@@ -251,6 +252,134 @@ async fn grep_worker_lifecycle_uses_and_releases_checkpointed_backfill() {
         root.manifest_state().lifecycle(),
         GrepLifecycle::Backfilling { .. }
     ));
+    writer.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn exhausted_run_ordinals_fail_as_server_errors_without_writing_the_root() {
+    let temp_dir = tempdir().expect("tempdir");
+    let store: SharedObjectStore =
+        Arc::new(LocalFsStore::new(temp_dir.path()).expect("local store"));
+    let namespace_id = NamespaceId::parse("run-ordinal-limit").expect("namespace id");
+    let writer = FsWriter::builder_with_store(store.clone())
+        .writer_id("run-ordinal-limit-writer")
+        .min_publish_interval_ms(0)
+        .build()
+        .await
+        .expect("writer");
+    writer
+        .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+        .await
+        .expect("create namespace");
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/initial.txt",
+            b"initial ordinal boundary needle\n",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("write initial file");
+
+    let worker = worker(&store).await;
+    worker.enable(&namespace_id).await.expect("enable grep");
+    drive_worker_to_current(&worker, &namespace_id, GramIndexBuildPolicy::default()).await;
+
+    let current = load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load current root")
+        .expect("current root");
+    let current_state = current.manifest_state();
+    let maximum_state = GrepManifestState::new(
+        namespace_id.clone(),
+        current_state.lifecycle().clone(),
+        GrepIndexState::new(current_state.index().reorganize.clone(), MAX_PUBLIC_INTEGER),
+        current_state.segments().to_vec(),
+    )
+    .expect("valid root at the public maximum");
+    let maximum = advance_grep_root(&*store, &current, &maximum_state)
+        .await
+        .expect("install root at the public maximum");
+
+    writer
+        .put_file_bytes(
+            &namespace_id,
+            "/incremental.txt",
+            b"incremental ordinal boundary needle\n",
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .await
+        .expect("write incremental file");
+    let pointer_before = store
+        .get(&root_key(&namespace_id), None)
+        .await
+        .expect("read root pointer before failure")
+        .expect("root pointer exists");
+    let manifests_before = store
+        .list_prefix(&manifests_prefix(&namespace_id))
+        .await
+        .expect("list manifests before failure");
+    let segments_before = store
+        .list_prefix(&segments_prefix(&namespace_id))
+        .await
+        .expect("list segments before failure");
+
+    for error in [
+        worker
+            .build_step(&namespace_id, GramIndexBuildPolicy::default())
+            .await
+            .expect_err("a build cannot allocate a run above the public maximum"),
+        worker
+            .reorganize_step(
+                &namespace_id,
+                GramIndexBuildPolicy {
+                    max_l0_runs: NonZeroUsize::MIN,
+                    ..GramIndexBuildPolicy::default()
+                },
+            )
+            .await
+            .expect_err("a reorganization cannot allocate above the public maximum"),
+    ] {
+        assert_eq!(error.code(), ErrorCode::ServerError);
+        assert!(matches!(
+            error,
+            GrepError::Runtime(RuntimeError::Core(CoreError::Internal(message)))
+                if message.contains("grep run ordinal cannot advance beyond the public integer range")
+        ));
+    }
+
+    let after = load_grep_root(&*store, &namespace_id)
+        .await
+        .expect("load root after failures")
+        .expect("root remains");
+    assert_eq!(after.manifest_id(), maximum.manifest_id());
+    assert_eq!(
+        after.manifest_state().index().next_run_ordinal,
+        MAX_PUBLIC_INTEGER
+    );
+    assert_eq!(
+        store
+            .get(&root_key(&namespace_id), None)
+            .await
+            .expect("read root pointer after failure")
+            .expect("root pointer remains"),
+        pointer_before
+    );
+    assert_eq!(
+        store
+            .list_prefix(&manifests_prefix(&namespace_id))
+            .await
+            .expect("list manifests after failures"),
+        manifests_before
+    );
+    assert_eq!(
+        store
+            .list_prefix(&segments_prefix(&namespace_id))
+            .await
+            .expect("list segments after failures"),
+        segments_before,
+        "the build guard runs before writing an orphan segment"
+    );
     writer.shutdown().await.expect("shutdown");
 }
 

--- a/crates/loonfs-model/src/genesis.rs
+++ b/crates/loonfs-model/src/genesis.rs
@@ -2,13 +2,13 @@
 //! with, mirroring core's bootstrap.
 
 use crate::metadata::{InodeRecord, MetadataState};
-use loonfs_api::{ActorRef, ChangeSeq, InodeId, InodeKind};
+use loonfs_api::{ActorRef, ChangeSeq, InodeKind, ROOT_INODE_ID};
 
 /// Builds the metadata state of a fresh namespace.
 pub fn bootstrap_metadata_state(created_at_ms: u64) -> MetadataState {
     MetadataState {
         inodes: vec![InodeRecord {
-            inode_id: InodeId(1),
+            inode_id: ROOT_INODE_ID,
             inode_kind: InodeKind::Directory,
             created_seq: ChangeSeq(0),
             created_by: ActorRef::loonfs_system(),

--- a/crates/loonfs-server/src/http/handlers_downloads.rs
+++ b/crates/loonfs-server/src/http/handlers_downloads.rs
@@ -7,6 +7,7 @@
 //! advertised together.
 
 use super::error::ApiResponseError;
+use super::handlers_filesystem::parse_revision_no;
 use super::handlers_inodes::InodeRevisionPathParams;
 use super::handlers_uploads::{presign_issuer_error, presign_time};
 use super::{AppJson, AppPath, AppState, NamespaceIdPath};
@@ -19,7 +20,7 @@ use loonfs_api::{
         BeginDownloadByInodeRequest, BeginDownloadByInodeResponse, BeginDownloadRequest,
         BeginDownloadResponse, ObjectTransferAccess,
     },
-    InodeId, RevisionNo, FEATURE_DOWNLOADS_DIRECT_GET,
+    InodeId, FEATURE_DOWNLOADS_DIRECT_GET,
 };
 use loonfs_objectstore::presign::{DirectGetIssuer, PresignedGetRequest};
 use std::time::Duration;
@@ -105,7 +106,7 @@ pub(super) async fn begin_download(
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("inode_id" = InodeId, Path, description = "File inode id"),
-            ("revision_no" = RevisionNo, Path, description = "Revision number")
+            ("revision_no" = loonfs_api::RevisionNo, Path, description = "Revision number")
         ),
         request_body = BeginDownloadByInodeRequest,
         responses(
@@ -130,7 +131,7 @@ pub(super) async fn begin_download_by_inode(
     let namespace_id = namespace_id_path.into_id()?;
     let path = path.into_params()?;
     let inode_id = InodeId(path.inode_id);
-    let revision_no = RevisionNo(path.revision_no);
+    let revision_no = parse_revision_no(&path.revision_no)?;
     let issuer = direct_get_issuer(&state)?;
     let target = state
         .reader

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -28,7 +28,7 @@ use loonfs_api::{
     v0::{ChangesResponse, CommitResponse as ApiCommitResponse},
     CommitRequest as ApiCommitRequest, DirectoryPageCursor, FileRevisionsPageCursor,
     FilesystemOperation, LimitError, ListFileRevisionsResponse, ListTrashResponse, PageCursorError,
-    PageRequest, PaginationPolicy, RevisionNo, MAX_PUBLIC_INTEGER,
+    PageRequest, PaginationPolicy, PublicOrdinalRangeError, RevisionNo,
 };
 use std::convert::Infallible;
 use std::pin::Pin;
@@ -587,7 +587,7 @@ pub(super) async fn list_changes(
 }
 
 fn parse_after_seq(value: &str) -> Result<loonfs_api::ChangeSeq, ApiResponseError> {
-    parse_public_ordinal("after_seq", value).map(loonfs_api::ChangeSeq)
+    parse_public_ordinal("after_seq", value, loonfs_api::ChangeSeq::parse)
 }
 
 pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {
@@ -603,23 +603,30 @@ pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseE
 }
 
 pub(super) fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
-    parse_public_ordinal("revision_no", value).map(RevisionNo)
+    parse_public_ordinal("revision_no", value, RevisionNo::parse)
 }
 
-pub(super) fn parse_public_ordinal(name: &str, value: &str) -> Result<u64, ApiResponseError> {
-    value
+pub(super) fn parse_public_ordinal<T>(
+    name: &str,
+    value: &str,
+    constructor: impl FnOnce(u64) -> Result<T, PublicOrdinalRangeError>,
+) -> Result<T, ApiResponseError> {
+    let parsed = value
         .parse::<u64>()
-        .ok()
-        .filter(|parsed| *parsed <= MAX_PUBLIC_INTEGER)
-        .ok_or_else(|| {
-            ApiResponseError::new(
-                StatusCode::BAD_REQUEST,
-                ErrorCode::InvalidRequest,
-                &format!(
-                    "invalid {name} `{value}`: must be an integer from 0 through {MAX_PUBLIC_INTEGER}"
-                ),
-            )
-        })
+        .map_err(|_| public_ordinal_response_error(name, value, PublicOrdinalRangeError))?;
+    constructor(parsed).map_err(|error| public_ordinal_response_error(name, value, error))
+}
+
+fn public_ordinal_response_error(
+    name: &str,
+    value: &str,
+    error: PublicOrdinalRangeError,
+) -> ApiResponseError {
+    ApiResponseError::new(
+        StatusCode::BAD_REQUEST,
+        ErrorCode::InvalidRequest,
+        &format!("invalid {name} `{value}`: {error}"),
+    )
 }
 
 pub(super) fn resolve_page_limit(
@@ -695,7 +702,7 @@ mod tests {
     fn after_seq_parser_accepts_the_public_maximum_and_rejects_the_next_value() {
         assert!(matches!(
             parse_after_seq("9007199254740991"),
-            Ok(loonfs_api::ChangeSeq(MAX_PUBLIC_INTEGER))
+            Ok(loonfs_api::ChangeSeq(loonfs_api::MAX_PUBLIC_INTEGER))
         ));
         assert!(parse_after_seq("9007199254740992").is_err());
     }

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -28,7 +28,7 @@ use loonfs_api::{
     v0::{ChangesResponse, CommitResponse as ApiCommitResponse},
     CommitRequest as ApiCommitRequest, DirectoryPageCursor, FileRevisionsPageCursor,
     FilesystemOperation, LimitError, ListFileRevisionsResponse, ListTrashResponse, PageCursorError,
-    PageRequest, PaginationPolicy, RevisionNo,
+    PageRequest, PaginationPolicy, RevisionNo, MAX_PUBLIC_INTEGER,
 };
 use std::convert::Infallible;
 use std::pin::Pin;
@@ -587,16 +587,7 @@ pub(super) async fn list_changes(
 }
 
 fn parse_after_seq(value: &str) -> Result<loonfs_api::ChangeSeq, ApiResponseError> {
-    value
-        .parse::<u64>()
-        .map(loonfs_api::ChangeSeq)
-        .map_err(|error| {
-            ApiResponseError::new(
-                StatusCode::BAD_REQUEST,
-                ErrorCode::InvalidRequest,
-                &format!("invalid after_seq `{value}`: {error}"),
-            )
-        })
+    parse_public_ordinal("after_seq", value).map(loonfs_api::ChangeSeq)
 }
 
 pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {
@@ -611,14 +602,24 @@ pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseE
     }
 }
 
-fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
-    value.parse::<u64>().map(RevisionNo).map_err(|err| {
-        ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidRequest,
-            &format!("invalid revision_no `{value}`: {err}"),
-        )
-    })
+pub(super) fn parse_revision_no(value: &str) -> Result<RevisionNo, ApiResponseError> {
+    parse_public_ordinal("revision_no", value).map(RevisionNo)
+}
+
+pub(super) fn parse_public_ordinal(name: &str, value: &str) -> Result<u64, ApiResponseError> {
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|parsed| *parsed <= MAX_PUBLIC_INTEGER)
+        .ok_or_else(|| {
+            ApiResponseError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                &format!(
+                    "invalid {name} `{value}`: must be an integer from 0 through {MAX_PUBLIC_INTEGER}"
+                ),
+            )
+        })
 }
 
 pub(super) fn resolve_page_limit(
@@ -684,4 +685,18 @@ fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
         ErrorCode::InvalidRequest,
         &error.to_string(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn after_seq_parser_accepts_the_public_maximum_and_rejects_the_next_value() {
+        assert!(matches!(
+            parse_after_seq("9007199254740991"),
+            Ok(loonfs_api::ChangeSeq(MAX_PUBLIC_INTEGER))
+        ));
+        assert!(parse_after_seq("9007199254740992").is_err());
+    }
 }

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -3,7 +3,7 @@
 use super::error::ApiResponseError;
 use super::handlers_filesystem::{
     buffered_download_response, decode_file_revisions_page_cursor, parse_include_attributes,
-    resolve_page_limit, PageQuery,
+    parse_revision_no, resolve_page_limit, PageQuery,
 };
 use super::{authorize, AppPath, AppQuery, AppState, NamespaceIdPath};
 use axum::extract::State;
@@ -13,9 +13,7 @@ use axum::Json;
 use loonfs::StatPathOptions;
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
-use loonfs_api::{
-    FileRevisionsPageCursor, InodeId, ListFileRevisionsResponse, PageRequest, RevisionNo,
-};
+use loonfs_api::{FileRevisionsPageCursor, InodeId, ListFileRevisionsResponse, PageRequest};
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct InodePathParams {
@@ -25,7 +23,7 @@ pub(super) struct InodePathParams {
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct InodeRevisionPathParams {
     pub(super) inode_id: u64,
-    pub(super) revision_no: u64,
+    pub(super) revision_no: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -141,7 +139,7 @@ pub(super) async fn list_file_revisions_by_inode(
         params(
             ("namespace_id" = String, Path, description = "Namespace id"),
             ("inode_id" = InodeId, Path, description = "File inode id"),
-            ("revision_no" = RevisionNo, Path, description = "Revision number")
+            ("revision_no" = loonfs_api::RevisionNo, Path, description = "Revision number")
         ),
         responses(
             (status = 200, description = "Revision bytes", body = Vec<u8>, content_type = "application/octet-stream"),
@@ -164,6 +162,7 @@ pub(super) async fn get_file_revision_bytes_by_inode(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     let path = path.into_params()?;
+    let revision_no = parse_revision_no(&path.revision_no)?;
     let permit = state
         .download_permits
         .clone()
@@ -174,11 +173,7 @@ pub(super) async fn get_file_revision_bytes_by_inode(
         })?;
     let bytes = state
         .reader
-        .get_file_revision_bytes_by_inode(
-            &namespace_id,
-            InodeId(path.inode_id),
-            RevisionNo(path.revision_no),
-        )
+        .get_file_revision_bytes_by_inode(&namespace_id, InodeId(path.inode_id), revision_no)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(buffered_download_response(bytes, permit))

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -295,7 +295,7 @@ pub(super) async fn delete_namespace(
 }
 
 fn parse_expected_head_seq(value: &str) -> Result<ChangeSeq, ApiResponseError> {
-    parse_public_ordinal("expected_head_seq", value).map(ChangeSeq)
+    parse_public_ordinal("expected_head_seq", value, ChangeSeq::parse)
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -2,7 +2,7 @@
 //! handlers.
 
 use super::error::ApiResponseError;
-use super::handlers_filesystem::resolve_page_limit;
+use super::handlers_filesystem::{parse_public_ordinal, resolve_page_limit};
 use super::{authorize, AppJson, AppPath, AppQuery, AppState, NamespaceIdPath, OptionalAppJson};
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
@@ -295,13 +295,7 @@ pub(super) async fn delete_namespace(
 }
 
 fn parse_expected_head_seq(value: &str) -> Result<ChangeSeq, ApiResponseError> {
-    value.parse::<u64>().map(ChangeSeq).map_err(|error| {
-        ApiResponseError::new(
-            StatusCode::BAD_REQUEST,
-            ErrorCode::InvalidRequest,
-            &format!("invalid expected_head_seq `{value}`: {error}"),
-        )
-    })
+    parse_public_ordinal("expected_head_seq", value).map(ChangeSeq)
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1754,15 +1754,15 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "{body}"
     );
 
-    // The exact public maximum passes parsing and reaches namespace lookup;
-    // the next integer is rejected by the query surface itself.
+    // The maximum valid value reaches namespace lookup. The next value is
+    // rejected while parsing the query.
     let error = raw_agent()
         .get(&format!(
             "http://{addr}/v0/namespaces/demo/changes?after_seq=9007199254740991"
         ))
         .set("authorization", "Bearer test-token")
         .call()
-        .expect_err("accepted cursor reaches the missing namespace");
+        .expect_err("valid sequence reaches the missing namespace");
     expect_enveloped(error, 404, "namespace_not_found");
 
     let error = raw_agent()
@@ -1771,7 +1771,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         ))
         .set("authorization", "Bearer test-token")
         .call()
-        .expect_err("out-of-range after_seq should answer 400");
+        .expect_err("out-of-range after_seq should return 400");
     let body = expect_enveloped(error, 400, "invalid_request");
     assert_eq!(
         body["message"],

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1754,6 +1754,30 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "{body}"
     );
 
+    // The exact public maximum passes parsing and reaches namespace lookup;
+    // the next integer is rejected by the query surface itself.
+    let error = raw_agent()
+        .get(&format!(
+            "http://{addr}/v0/namespaces/demo/changes?after_seq=9007199254740991"
+        ))
+        .set("authorization", "Bearer test-token")
+        .call()
+        .expect_err("accepted cursor reaches the missing namespace");
+    expect_enveloped(error, 404, "namespace_not_found");
+
+    let error = raw_agent()
+        .get(&format!(
+            "http://{addr}/v0/namespaces/demo/changes?after_seq=9007199254740992"
+        ))
+        .set("authorization", "Bearer test-token")
+        .call()
+        .expect_err("out-of-range after_seq should answer 400");
+    let body = expect_enveloped(error, 400, "invalid_request");
+    assert_eq!(
+        body["message"],
+        "invalid after_seq `9007199254740992`: must be an integer from 0 through 9007199254740991"
+    );
+
     // The same malformed query without credentials: 401 wins.
     let error = raw_agent()
         .get(&changes_url)

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -575,6 +575,19 @@ fn openapi_caps_public_ordinals_but_not_inode_ids() {
             .is_none(),
         "InodeId stays on its existing full-u64 schema in this wave"
     );
+
+    assert_eq!(
+        schemas
+            .get("GrepIndexStatusResponse")
+            .and_then(|schema| schema.get("allOf"))
+            .and_then(Value::as_array)
+            .and_then(|schemas| schemas.iter().find_map(|schema| schema.get("properties")))
+            .and_then(|properties| properties.get("next_run_ordinal"))
+            .and_then(|schema| schema.get("maximum"))
+            .and_then(Value::as_u64),
+        Some(loonfs_api::MAX_PUBLIC_INTEGER),
+        "grep status must publish the next run ordinal maximum"
+    );
 }
 
 #[test]

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -540,6 +540,44 @@ fn openapi_documents_string_id_contracts_without_dead_schemas() {
 }
 
 #[test]
+fn openapi_caps_public_ordinals_but_not_inode_ids() {
+    let raw = std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json");
+    let spec: Value = serde_json::from_str(&raw).expect("parse openapi json");
+    let schemas = spec
+        .get("components")
+        .and_then(|components| components.get("schemas"))
+        .and_then(Value::as_object)
+        .expect("openapi schemas object");
+
+    for name in [
+        "RevisionNo",
+        "ChangeSeq",
+        "AttributeRevisionNo",
+        "ManifestId",
+        "WriterEpoch",
+    ] {
+        let schema = schemas.get(name).unwrap_or_else(|| panic!("{name} schema"));
+        assert_eq!(schema.get("type").and_then(Value::as_str), Some("integer"));
+        assert_eq!(schema.get("format").and_then(Value::as_str), Some("int64"));
+        assert_eq!(schema.get("minimum").and_then(Value::as_u64), Some(0));
+        assert_eq!(
+            schema.get("maximum").and_then(Value::as_u64),
+            Some(loonfs_api::MAX_PUBLIC_INTEGER),
+            "wrong public maximum for {name}"
+        );
+    }
+
+    assert!(
+        schemas
+            .get("InodeId")
+            .expect("InodeId schema")
+            .get("maximum")
+            .is_none(),
+        "InodeId stays on its existing full-u64 schema in this wave"
+    );
+}
+
+#[test]
 fn openapi_reuses_the_one_checksum_and_upload_claim_shapes() {
     let raw = std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json");
     for dead_name in [

--- a/crates/loonfs-server/tests/it/openapi.rs
+++ b/crates/loonfs-server/tests/it/openapi.rs
@@ -540,7 +540,7 @@ fn openapi_documents_string_id_contracts_without_dead_schemas() {
 }
 
 #[test]
-fn openapi_caps_public_ordinals_but_not_inode_ids() {
+fn openapi_limits_public_ordinals_but_not_inode_ids() {
     let raw = std::fs::read_to_string(OPENAPI_JSON_PATH).expect("read static openapi json");
     let spec: Value = serde_json::from_str(&raw).expect("parse openapi json");
     let schemas = spec
@@ -573,7 +573,7 @@ fn openapi_caps_public_ordinals_but_not_inode_ids() {
             .expect("InodeId schema")
             .get("maximum")
             .is_none(),
-        "InodeId stays on its existing full-u64 schema in this wave"
+        "InodeId must allow the full u64 range"
     );
 
     assert_eq!(
@@ -586,7 +586,7 @@ fn openapi_caps_public_ordinals_but_not_inode_ids() {
             .and_then(|schema| schema.get("maximum"))
             .and_then(Value::as_u64),
         Some(loonfs_api::MAX_PUBLIC_INTEGER),
-        "grep status must publish the next run ordinal maximum"
+        "next_run_ordinal must use the public maximum"
     );
 }
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -303,6 +303,13 @@ conditional-request failures.
 One SDK serves both backends; deployment mode never forks the client
 codebase.
 
+Public ordinals — revision numbers, change sequences, attribute revisions,
+manifest ids, and writer epochs — are JSON integers in the inclusive range
+0 through 9007199254740991 (`2^53 - 1`). Implementations MUST reject ordinal
+inputs outside that range and MUST NOT durably advance an ordinal past it.
+`inode_id` is an identity rather than an ordinal and is not covered by this
+integer bound.
+
 - The embedded handles (`loonfs::FsWriter`, `loonfs::FsReader`) and the
   remote client (`loonfs_client::Client`) expose the same operations and the
   same `capabilities()` accessor returning the capability document of

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -303,12 +303,11 @@ conditional-request failures.
 One SDK serves both backends; deployment mode never forks the client
 codebase.
 
-Public ordinals — revision numbers, change sequences, attribute revisions,
-manifest ids, and writer epochs — are JSON integers in the inclusive range
-0 through 9007199254740991 (`2^53 - 1`). Implementations MUST reject ordinal
-inputs outside that range and MUST NOT durably advance an ordinal past it.
-`inode_id` is an identity rather than an ordinal and is not covered by this
-integer bound.
+Revision numbers, change sequences, attribute revisions, manifest ids, writer
+epochs, and grep run ordinals are JSON integers from 0 through 9007199254740991
+(`2^53 - 1`). Implementations MUST reject larger input values and MUST NOT
+store a larger value. `inode_id` is not an ordinal and may use the full `u64`
+range.
 
 - The embedded handles (`loonfs::FsWriter`, `loonfs::FsReader`) and the
   remote client (`loonfs_client::Client`) expose the same operations and the

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -5621,6 +5621,7 @@
                 "type": "integer",
                 "format": "int64",
                 "description": "Next logical run ordinal the index will allocate.",
+                "maximum": 9007199254740991,
                 "minimum": 0
               },
               "reorganize_pending": {

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3419,6 +3419,7 @@
         "type": "integer",
         "format": "int64",
         "description": "Monotonically increasing attribute revision counter within one inode.\n\nEvery inode starts at revision 0 with an empty attribute map, and every\neffective update — one that changes the map — advances the counter by\none. The counter is the optimistic-concurrency token for attribute\nwrites: a writer states the revision it expects, and the write fails\nwhen the inode has moved past it. The counter is not an index into a\nhistory. LoonFS keeps the current map and this number, and promises no\nqueryable record of earlier maps.",
+        "maximum": 9007199254740991,
         "minimum": 0
       },
       "AttributeValue": {
@@ -3926,6 +3927,7 @@
         "type": "integer",
         "format": "int64",
         "description": "Monotonically increasing namespace commit sequence number.\n\nThis is the global visibility order for a namespace.",
+        "maximum": 9007199254740991,
         "minimum": 0
       },
       "ChangesResponse": {
@@ -6011,6 +6013,7 @@
         "type": "integer",
         "format": "int64",
         "description": "Monotonically increasing namespace manifest identity.\n\nThis is the durable file-set version identity for namespace manifests.\nInitial/fork manifests may be seeded from the current head sequence, but\nlater manifest ids can advance for checkpoint metadata, compaction, or\nfork/index metadata without a new namespace commit.",
+        "maximum": 9007199254740991,
         "minimum": 0
       },
       "MetadataMaintenanceRequest": {
@@ -6350,6 +6353,7 @@
         "type": "integer",
         "format": "int64",
         "description": "Monotonically increasing file revision counter within one file inode.",
+        "maximum": 9007199254740991,
         "minimum": 0
       },
       "SignUploadPartsRequest": {
@@ -6828,6 +6832,7 @@
         "type": "integer",
         "format": "int64",
         "description": "Monotonically increasing writer epoch for namespace write fencing.",
+        "maximum": 9007199254740991,
         "minimum": 0
       }
     },

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3418,7 +3418,7 @@
       "AttributeRevisionNo": {
         "type": "integer",
         "format": "int64",
-        "description": "Monotonically increasing attribute revision counter within one inode.\n\nEvery inode starts at revision 0 with an empty attribute map, and every\neffective update — one that changes the map — advances the counter by\none. The counter is the optimistic-concurrency token for attribute\nwrites: a writer states the revision it expects, and the write fails\nwhen the inode has moved past it. The counter is not an index into a\nhistory. LoonFS keeps the current map and this number, and promises no\nqueryable record of earlier maps.",
+        "description": "Revision number for an inode's attributes. It starts at 0 and increases whenever the attribute map changes.",
         "maximum": 9007199254740991,
         "minimum": 0
       },
@@ -3926,7 +3926,7 @@
       "ChangeSeq": {
         "type": "integer",
         "format": "int64",
-        "description": "Monotonically increasing namespace commit sequence number.\n\nThis is the global visibility order for a namespace.",
+        "description": "Sequence number assigned to a namespace commit. It determines the order in which commits become visible.",
         "maximum": 9007199254740991,
         "minimum": 0
       },
@@ -6013,7 +6013,7 @@
       "ManifestId": {
         "type": "integer",
         "format": "int64",
-        "description": "Monotonically increasing namespace manifest identity.\n\nThis is the durable file-set version identity for namespace manifests.\nInitial/fork manifests may be seeded from the current head sequence, but\nlater manifest ids can advance for checkpoint metadata, compaction, or\nfork/index metadata without a new namespace commit.",
+        "description": "Version number for a namespace manifest. It can increase when metadata changes, even if no namespace commit is written.",
         "maximum": 9007199254740991,
         "minimum": 0
       },
@@ -6353,7 +6353,7 @@
       "RevisionNo": {
         "type": "integer",
         "format": "int64",
-        "description": "Monotonically increasing file revision counter within one file inode.",
+        "description": "Revision number for a file's content. It increases whenever the content is replaced or restored.",
         "maximum": 9007199254740991,
         "minimum": 0
       },
@@ -6832,7 +6832,7 @@
       "WriterEpoch": {
         "type": "integer",
         "format": "int64",
-        "description": "Monotonically increasing writer epoch for namespace write fencing.",
+        "description": "Counter used to reject writes from an older writer.",
         "maximum": 9007199254740991,
         "minimum": 0
       }


### PR DESCRIPTION
Revision numbers, change sequences, attribute revisions, manifest IDs, writer epochs, and grep run ordinals are limited to 9,007,199,254,740,991, the largest integer JSON clients can represent exactly. The HTTP API and CLI reject larger input values, and OpenAPI publishes the same maximum.

A shared helper applies the limit when these values advance during commits, WAL replay, manifest publication, writer acquisition, and grep indexing. Reaching the limit fails before another value is stored. WAL replay treats out-of-range state as corruption.

Inode IDs remain full-width u64 values because they are identities rather than counters. The API types, server, CLI, core runtime, documentation, generated OpenAPI schema, and boundary tests are updated for the new range.