### PR TITLE
feat(api): add the public inode id codec

### DIFF
--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -40,6 +40,7 @@ mod name_policy;
 pub mod options;
 mod pagination;
 mod path;
+pub mod public_inode_id;
 mod secret;
 mod sst_blocks;
 pub mod v0;

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -435,72 +435,60 @@ mod tests {
     }
 
     #[test]
-    fn directory_cursor_encoding_is_stable() {
-        // Cursor payloads keep numeric inode IDs. This token detects accidental
-        // changes to version 1 encoding, including the `dir_inode_id` field.
-        const TOKEN: &str = "7b2276223a312c226b696e64223a226469726563746f7279222c22686561645f736571223a3130312c226469725f696e6f64655f6964223a3230322c226c6173745f6e616d655f6b6579223a22717561727465726c792d7265706f72742e6d64227d";
+    fn directory_cursor_round_trips() {
         let cursor = DirectoryPageCursor {
-            head_seq: ChangeSeq(101),
-            directory_inode_id: InodeId(202),
-            last_name_key: NameKey::parse("quarterly-report.md").expect("name key"),
+            head_seq: ChangeSeq(11),
+            directory_inode_id: InodeId(7),
+            last_name_key: NameKey::parse("plan.md").expect("name key"),
         };
 
-        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
-        let decoded: DirectoryPageCursor = decode_cursor(TOKEN).expect("decode pinned cursor");
+        let encoded = encode_cursor(&cursor).expect("encode cursor");
+        let decoded: DirectoryPageCursor = decode_cursor(&encoded).expect("decode cursor");
 
         assert_eq!(decoded, cursor);
     }
 
     #[test]
-    fn file_revisions_cursor_encoding_is_stable() {
-        // Cursor payloads keep numeric inode IDs. This token detects accidental
-        // changes to version 1 encoding.
-        const TOKEN: &str = "7b2276223a312c226b696e64223a2266696c655f7265766973696f6e73222c22686561645f736571223a3330332c22696e6f64655f6964223a3430342c226c6173745f7265766973696f6e5f6e6f223a3530352c226c6173745f636f6d6d69747465645f736571223a3630362c226c6173745f7265766973696f6e5f64656c74615f696e646578223a3730377d";
+    fn file_revisions_cursor_round_trips() {
         let cursor = FileRevisionsPageCursor {
-            head_seq: ChangeSeq(303),
-            inode_id: InodeId(404),
-            last_revision_no: RevisionNo(505),
-            last_committed_seq: ChangeSeq(606),
-            last_revision_delta_index: 707,
+            head_seq: ChangeSeq(11),
+            inode_id: InodeId(7),
+            last_revision_no: RevisionNo(5),
+            last_committed_seq: ChangeSeq(10),
+            last_revision_delta_index: 3,
         };
 
-        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
-        let decoded: FileRevisionsPageCursor = decode_cursor(TOKEN).expect("decode pinned cursor");
+        let encoded = encode_cursor(&cursor).expect("encode cursor");
+        let decoded: FileRevisionsPageCursor = decode_cursor(&encoded).expect("decode cursor");
 
         assert_eq!(decoded, cursor);
     }
 
     #[test]
-    fn trash_cursor_encoding_is_stable() {
-        // Cursor payloads keep numeric inode IDs. This token detects accidental
-        // changes to version 1 encoding.
-        const TOKEN: &str = "7b2276223a312c226b696e64223a227472617368222c22686561645f736571223a3830382c226c6173745f64656c657465645f61745f736571223a3930392c226c6173745f726f6f745f696e6f64655f6964223a313031307d";
+    fn trash_cursor_round_trips() {
         let cursor = TrashPageCursor {
-            head_seq: ChangeSeq(808),
-            last_deleted_at_seq: ChangeSeq(909),
-            last_root_inode_id: InodeId(1010),
+            head_seq: ChangeSeq(11),
+            last_deleted_at_seq: ChangeSeq(10),
+            last_root_inode_id: InodeId(7),
         };
 
-        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
-        let decoded: TrashPageCursor = decode_cursor(TOKEN).expect("decode pinned cursor");
+        let encoded = encode_cursor(&cursor).expect("encode cursor");
+        let decoded: TrashPageCursor = decode_cursor(&encoded).expect("decode cursor");
 
         assert_eq!(decoded, cursor);
     }
 
     #[test]
-    fn grep_cursor_encoding_is_stable() {
-        // Cursor payloads keep numeric inode IDs. This token detects accidental
-        // changes to version 1 encoding.
-        const TOKEN: &str = "7b2276223a312c226b696e64223a2267726570222c22686561645f736571223a313131312c226c6173745f696e6f64655f6964223a313231322c226c6173745f627974655f6f6666736574223a313331332c2266696e6765727072696e74223a313431347d";
+    fn grep_cursor_round_trips() {
         let cursor = GrepPageCursor {
-            head_seq: ChangeSeq(1111),
-            last_inode_id: InodeId(1212),
-            last_byte_offset: 1313,
-            fingerprint: 1414,
+            head_seq: ChangeSeq(11),
+            last_inode_id: InodeId(7),
+            last_byte_offset: 13,
+            fingerprint: 17,
         };
 
-        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
-        let decoded: GrepPageCursor = decode_cursor(TOKEN).expect("decode pinned cursor");
+        let encoded = encode_cursor(&cursor).expect("encode cursor");
+        let decoded: GrepPageCursor = decode_cursor(&encoded).expect("decode cursor");
 
         assert_eq!(decoded, cursor);
     }
@@ -581,20 +569,50 @@ mod tests {
     }
 
     #[test]
-    fn namespace_cursor_encoding_and_validation_are_stable() {
-        // This token covers version, kind, namespace, and key-prefix checks.
-        const TOKEN: &str = "7b2276223a312c226b696e64223a22746573745f6e616d657370616365222c226e616d6573706163655f6964223a2264656d6f222c226c6173745f6b6579223a226e616d657370616365732f64656d6f2f6974656d732f6974656d2d3432227d";
+    fn namespace_cursor_accepts_its_namespace_and_keyspace() {
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
         let cursor = TestNamespaceCursor {
             namespace_id: namespace_id.clone(),
             last_key: "namespaces/demo/items/item-42".to_owned(),
         };
+        let encoded = encode_cursor(&cursor).expect("encode cursor");
 
-        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
         assert_eq!(
-            decode_namespace_cursor::<TestNamespaceCursor>(TOKEN, &namespace_id)
-                .expect("decode pinned namespace cursor"),
+            decode_namespace_cursor::<TestNamespaceCursor>(&encoded, &namespace_id)
+                .expect("decode namespace cursor"),
             cursor
+        );
+    }
+
+    #[test]
+    fn namespace_cursor_rejects_a_different_namespace() {
+        let cursor = TestNamespaceCursor {
+            namespace_id: NamespaceId::parse("demo").expect("namespace id"),
+            last_key: "namespaces/demo/items/item-42".to_owned(),
+        };
+        let encoded = encode_cursor(&cursor).expect("encode cursor");
+
+        assert_eq!(
+            decode_namespace_cursor::<TestNamespaceCursor>(
+                &encoded,
+                &NamespaceId::parse("other").expect("other namespace id")
+            ),
+            Err(NamespaceCursorError::ForeignNamespace)
+        );
+    }
+
+    #[test]
+    fn namespace_cursor_rejects_a_key_outside_its_keyspace() {
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let cursor = TestNamespaceCursor {
+            namespace_id: namespace_id.clone(),
+            last_key: "namespaces/demo/checkpoints/checkpoint-42".to_owned(),
+        };
+        let encoded = encode_cursor(&cursor).expect("encode cursor");
+
+        assert_eq!(
+            decode_namespace_cursor::<TestNamespaceCursor>(&encoded, &namespace_id),
+            Err(NamespaceCursorError::OutsideKeyspace)
         );
     }
 }

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -436,30 +436,75 @@ mod tests {
 
     #[test]
     fn directory_cursor_round_trips() {
+        // Version 1 keeps inode ids numeric inside cursor payloads. A public
+        // `ino_...` spelling change must not move these bytes, change version
+        // 1, or undo the frozen `dir_inode_id` wire rename.
+        const TOKEN: &str = "7b2276223a312c226b696e64223a226469726563746f7279222c22686561645f736571223a3130312c226469725f696e6f64655f6964223a3230322c226c6173745f6e616d655f6b6579223a22717561727465726c792d7265706f72742e6d64227d";
         let cursor = DirectoryPageCursor {
-            head_seq: ChangeSeq(11),
-            directory_inode_id: InodeId(7),
-            last_name_key: NameKey::parse("plan.md").expect("name key"),
+            head_seq: ChangeSeq(101),
+            directory_inode_id: InodeId(202),
+            last_name_key: NameKey::parse("quarterly-report.md").expect("name key"),
         };
 
-        let encoded = encode_cursor(&cursor).expect("encode cursor");
-        let decoded: DirectoryPageCursor = decode_cursor(&encoded).expect("decode cursor");
+        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
+        let decoded: DirectoryPageCursor = decode_cursor(TOKEN).expect("decode pinned cursor");
 
         assert_eq!(decoded, cursor);
     }
 
     #[test]
     fn file_revisions_cursor_round_trips() {
+        // Version 1 keeps inode ids numeric inside cursor payloads. A public
+        // `ino_...` spelling change must not move these bytes or change the
+        // cursor format version.
+        const TOKEN: &str = "7b2276223a312c226b696e64223a2266696c655f7265766973696f6e73222c22686561645f736571223a3330332c22696e6f64655f6964223a3430342c226c6173745f7265766973696f6e5f6e6f223a3530352c226c6173745f636f6d6d69747465645f736571223a3630362c226c6173745f7265766973696f6e5f64656c74615f696e646578223a3730377d";
         let cursor = FileRevisionsPageCursor {
-            head_seq: ChangeSeq(11),
-            inode_id: InodeId(7),
-            last_revision_no: RevisionNo(5),
-            last_committed_seq: ChangeSeq(10),
-            last_revision_delta_index: 3,
+            head_seq: ChangeSeq(303),
+            inode_id: InodeId(404),
+            last_revision_no: RevisionNo(505),
+            last_committed_seq: ChangeSeq(606),
+            last_revision_delta_index: 707,
         };
 
-        let encoded = encode_cursor(&cursor).expect("encode cursor");
-        let decoded: FileRevisionsPageCursor = decode_cursor(&encoded).expect("decode cursor");
+        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
+        let decoded: FileRevisionsPageCursor = decode_cursor(TOKEN).expect("decode pinned cursor");
+
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn trash_cursor_round_trips() {
+        // Version 1 keeps inode ids numeric inside cursor payloads. A public
+        // `ino_...` spelling change must not move these bytes or change the
+        // cursor format version.
+        const TOKEN: &str = "7b2276223a312c226b696e64223a227472617368222c22686561645f736571223a3830382c226c6173745f64656c657465645f61745f736571223a3930392c226c6173745f726f6f745f696e6f64655f6964223a313031307d";
+        let cursor = TrashPageCursor {
+            head_seq: ChangeSeq(808),
+            last_deleted_at_seq: ChangeSeq(909),
+            last_root_inode_id: InodeId(1010),
+        };
+
+        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
+        let decoded: TrashPageCursor = decode_cursor(TOKEN).expect("decode pinned cursor");
+
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn grep_cursor_round_trips() {
+        // Version 1 keeps inode ids numeric inside cursor payloads. A public
+        // `ino_...` spelling change must not move these bytes or change the
+        // cursor format version.
+        const TOKEN: &str = "7b2276223a312c226b696e64223a2267726570222c22686561645f736571223a313131312c226c6173745f696e6f64655f6964223a313231322c226c6173745f627974655f6f6666736574223a313331332c2266696e6765727072696e74223a313431347d";
+        let cursor = GrepPageCursor {
+            head_seq: ChangeSeq(1111),
+            last_inode_id: InodeId(1212),
+            last_byte_offset: 1313,
+            fingerprint: 1414,
+        };
+
+        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
+        let decoded: GrepPageCursor = decode_cursor(TOKEN).expect("decode pinned cursor");
 
         assert_eq!(decoded, cursor);
     }
@@ -512,6 +557,50 @@ mod tests {
                 expected: PAGE_CURSOR_VERSION,
                 actual: PAGE_CURSOR_VERSION + 1,
             })
+        );
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestNamespaceCursor {
+        namespace_id: NamespaceId,
+        last_key: String,
+    }
+
+    impl PageCursor for TestNamespaceCursor {
+        const KIND: &'static str = "test_namespace";
+    }
+
+    impl NamespaceCursor for TestNamespaceCursor {
+        fn namespace_id(&self) -> &NamespaceId {
+            &self.namespace_id
+        }
+
+        fn last_key(&self) -> Option<&str> {
+            Some(&self.last_key)
+        }
+
+        fn key_prefix(&self) -> String {
+            format!("namespaces/{}/items/", self.namespace_id)
+        }
+    }
+
+    #[test]
+    fn pinned_cursor_passes_version_kind_and_namespace_validation() {
+        // This literal pins the complete shared validation path: v1 envelope,
+        // cursor kind, and namespace/keyspace binding must all keep accepting
+        // the same encoded bytes.
+        const TOKEN: &str = "7b2276223a312c226b696e64223a22746573745f6e616d657370616365222c226e616d6573706163655f6964223a2264656d6f222c226c6173745f6b6579223a226e616d657370616365732f64656d6f2f6974656d732f6974656d2d3432227d";
+        let namespace_id = NamespaceId::parse("demo").expect("namespace id");
+        let cursor = TestNamespaceCursor {
+            namespace_id: namespace_id.clone(),
+            last_key: "namespaces/demo/items/item-42".to_owned(),
+        };
+
+        assert_eq!(encode_cursor(&cursor).expect("encode cursor"), TOKEN);
+        assert_eq!(
+            decode_namespace_cursor::<TestNamespaceCursor>(TOKEN, &namespace_id)
+                .expect("decode pinned namespace cursor"),
+            cursor
         );
     }
 }

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -435,10 +435,9 @@ mod tests {
     }
 
     #[test]
-    fn directory_cursor_round_trips() {
-        // Version 1 keeps inode ids numeric inside cursor payloads. A public
-        // `ino_...` spelling change must not move these bytes, change version
-        // 1, or undo the frozen `dir_inode_id` wire rename.
+    fn directory_cursor_encoding_is_stable() {
+        // Cursor payloads keep numeric inode IDs. This token detects accidental
+        // changes to version 1 encoding, including the `dir_inode_id` field.
         const TOKEN: &str = "7b2276223a312c226b696e64223a226469726563746f7279222c22686561645f736571223a3130312c226469725f696e6f64655f6964223a3230322c226c6173745f6e616d655f6b6579223a22717561727465726c792d7265706f72742e6d64227d";
         let cursor = DirectoryPageCursor {
             head_seq: ChangeSeq(101),
@@ -453,10 +452,9 @@ mod tests {
     }
 
     #[test]
-    fn file_revisions_cursor_round_trips() {
-        // Version 1 keeps inode ids numeric inside cursor payloads. A public
-        // `ino_...` spelling change must not move these bytes or change the
-        // cursor format version.
+    fn file_revisions_cursor_encoding_is_stable() {
+        // Cursor payloads keep numeric inode IDs. This token detects accidental
+        // changes to version 1 encoding.
         const TOKEN: &str = "7b2276223a312c226b696e64223a2266696c655f7265766973696f6e73222c22686561645f736571223a3330332c22696e6f64655f6964223a3430342c226c6173745f7265766973696f6e5f6e6f223a3530352c226c6173745f636f6d6d69747465645f736571223a3630362c226c6173745f7265766973696f6e5f64656c74615f696e646578223a3730377d";
         let cursor = FileRevisionsPageCursor {
             head_seq: ChangeSeq(303),
@@ -473,10 +471,9 @@ mod tests {
     }
 
     #[test]
-    fn trash_cursor_round_trips() {
-        // Version 1 keeps inode ids numeric inside cursor payloads. A public
-        // `ino_...` spelling change must not move these bytes or change the
-        // cursor format version.
+    fn trash_cursor_encoding_is_stable() {
+        // Cursor payloads keep numeric inode IDs. This token detects accidental
+        // changes to version 1 encoding.
         const TOKEN: &str = "7b2276223a312c226b696e64223a227472617368222c22686561645f736571223a3830382c226c6173745f64656c657465645f61745f736571223a3930392c226c6173745f726f6f745f696e6f64655f6964223a313031307d";
         let cursor = TrashPageCursor {
             head_seq: ChangeSeq(808),
@@ -491,10 +488,9 @@ mod tests {
     }
 
     #[test]
-    fn grep_cursor_round_trips() {
-        // Version 1 keeps inode ids numeric inside cursor payloads. A public
-        // `ino_...` spelling change must not move these bytes or change the
-        // cursor format version.
+    fn grep_cursor_encoding_is_stable() {
+        // Cursor payloads keep numeric inode IDs. This token detects accidental
+        // changes to version 1 encoding.
         const TOKEN: &str = "7b2276223a312c226b696e64223a2267726570222c22686561645f736571223a313131312c226c6173745f696e6f64655f6964223a313231322c226c6173745f627974655f6f6666736574223a313331332c2266696e6765727072696e74223a313431347d";
         let cursor = GrepPageCursor {
             head_seq: ChangeSeq(1111),
@@ -585,10 +581,8 @@ mod tests {
     }
 
     #[test]
-    fn pinned_cursor_passes_version_kind_and_namespace_validation() {
-        // This literal pins the complete shared validation path: v1 envelope,
-        // cursor kind, and namespace/keyspace binding must all keep accepting
-        // the same encoded bytes.
+    fn namespace_cursor_encoding_and_validation_are_stable() {
+        // This token covers version, kind, namespace, and key-prefix checks.
         const TOKEN: &str = "7b2276223a312c226b696e64223a22746573745f6e616d657370616365222c226e616d6573706163655f6964223a2264656d6f222c226c6173745f6b6579223a226e616d657370616365732f64656d6f2f6974656d732f6974656d2d3432227d";
         let namespace_id = NamespaceId::parse("demo").expect("namespace id");
         let cursor = TestNamespaceCursor {

--- a/crates/loonfs-api/src/public_inode_id.rs
+++ b/crates/loonfs-api/src/public_inode_id.rs
@@ -1,0 +1,259 @@
+//! Public HTTP codec for namespace-scoped inode identities.
+//!
+//! Despite their decimal spelling, public inode ids are opaque to clients:
+//! clients must not allocate them or use lexicographic ordering. An inode id
+//! is scoped to one namespace, so its complete identity is
+//! `(namespace_id, inode_id)`.
+
+use crate::InodeId;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+
+/// Prefix on every public inode id.
+pub const PREFIX: &str = "ino_";
+
+/// OpenAPI pattern for public inode ids.
+pub const PATTERN: &str = r"^ino_[1-9][0-9]*$";
+
+/// Representative public inode id for OpenAPI examples.
+pub const EXAMPLE: &str = "ino_123";
+
+/// OpenAPI description for public inode ids.
+pub const DESCRIPTION: &str = "Namespace-scoped stable inode identity";
+
+const INVALID_REASON: &str = "must match `ino_<decimal>` with no leading zeroes";
+
+/// Describes why text is not a valid public inode id.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid inode id {value:?}: {reason}")]
+pub struct PublicInodeIdError {
+    value: String,
+    reason: String,
+}
+
+impl PublicInodeIdError {
+    /// Returns the rejected input.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Returns the public inode-id grammar the input violated.
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+/// Encodes an inode id in its public HTTP representation.
+pub fn encode(id: InodeId) -> String {
+    format!("{PREFIX}{}", id.0)
+}
+
+/// Decodes and validates a public HTTP inode id.
+pub fn decode(value: &str) -> Result<InodeId, PublicInodeIdError> {
+    let Some(suffix) = value.strip_prefix(PREFIX) else {
+        return Err(invalid(value));
+    };
+    if suffix.is_empty()
+        || suffix.starts_with('0')
+        || !suffix.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(invalid(value));
+    }
+
+    suffix
+        .parse::<u64>()
+        .map(InodeId)
+        .map_err(|_| invalid(value))
+}
+
+fn invalid(value: &str) -> PublicInodeIdError {
+    PublicInodeIdError {
+        value: value.to_owned(),
+        reason: INVALID_REASON.to_owned(),
+    }
+}
+
+/// Serializes an inode id in its public HTTP representation.
+pub fn serialize<S>(id: &InodeId, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    encode(*id).serialize(serializer)
+}
+
+/// Deserializes an inode id from only its public HTTP string representation.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<InodeId, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    decode(&value).map_err(serde::de::Error::custom)
+}
+
+/// Serde adapter for optional public inode-id fields.
+pub mod option {
+    use super::{decode, encode};
+    use crate::InodeId;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Serializes an optional inode id in its public HTTP representation.
+    pub fn serialize<S>(id: &Option<InodeId>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        id.map(encode).serialize(serializer)
+    }
+
+    /// Deserializes an optional inode id from only its public HTTP string representation.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<InodeId>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|value| decode(&value))
+            .transpose()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Builds the authoritative OpenAPI schema for a public inode id.
+///
+/// Cite this from fields as
+/// `#[schema(schema_with = crate::public_inode_id::schema)]`.
+#[cfg(feature = "openapi")]
+#[allow(deprecated)]
+pub fn schema() -> utoipa::openapi::schema::Object {
+    utoipa::openapi::schema::Object::builder()
+        .schema_type(utoipa::openapi::schema::Type::String)
+        .pattern(Some(PATTERN))
+        .example(Some(serde_json::json!(EXAMPLE)))
+        .description(Some(DESCRIPTION))
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_rejected(value: &str) {
+        let error = decode(value).expect_err("invalid public inode id");
+
+        assert_eq!(error.value(), value);
+        assert_eq!(error.reason(), INVALID_REASON);
+        assert_eq!(
+            error.to_string(),
+            format!("invalid inode id {value:?}: {INVALID_REASON}")
+        );
+    }
+
+    #[test]
+    fn decode_accepts_public_inode_id_grammar() {
+        for (value, expected) in [
+            ("ino_1", InodeId(1)),
+            ("ino_42", InodeId(42)),
+            ("ino_18446744073709551615", InodeId(u64::MAX)),
+        ] {
+            assert_eq!(decode(value).expect("valid public inode id"), expected);
+            assert_eq!(encode(expected), value);
+        }
+    }
+
+    macro_rules! rejection_test {
+        ($name:ident, $value:literal) => {
+            #[test]
+            fn $name() {
+                assert_rejected($value);
+            }
+        };
+    }
+
+    rejection_test!(decode_rejects_zero, "ino_0");
+    rejection_test!(decode_rejects_leading_zero, "ino_01");
+    rejection_test!(decode_rejects_sign, "ino_-1");
+    rejection_test!(decode_rejects_uppercase_prefix, "INO_27");
+    rejection_test!(decode_rejects_mixed_case_prefix, "Ino_27");
+    rejection_test!(decode_rejects_missing_prefix, "27");
+    rejection_test!(decode_rejects_empty_suffix, "ino_");
+    rejection_test!(decode_rejects_suffix_trailing_text, "ino_27x");
+    rejection_test!(decode_rejects_leading_whitespace, " ino_27");
+    rejection_test!(decode_rejects_trailing_whitespace, "ino_27 ");
+    rejection_test!(decode_rejects_empty_string, "");
+    rejection_test!(decode_rejects_u64_overflow, "ino_18446744073709551616");
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct RequiredField {
+        #[serde(with = "crate::public_inode_id")]
+        inode_id: InodeId,
+    }
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct OptionalField {
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "crate::public_inode_id::option"
+        )]
+        inode_id: Option<InodeId>,
+    }
+
+    #[test]
+    fn serde_adapter_uses_only_the_string_form() {
+        let value = RequiredField {
+            inode_id: InodeId(42),
+        };
+
+        assert_eq!(
+            serde_json::to_string(&value).expect("serialize public inode id"),
+            r#"{"inode_id":"ino_42"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<RequiredField>(r#"{"inode_id":"ino_42"}"#)
+                .expect("deserialize public inode id"),
+            value
+        );
+        assert!(serde_json::from_str::<RequiredField>(r#"{"inode_id":42}"#).is_err());
+    }
+
+    #[test]
+    fn optional_serde_adapter_composes_with_skip_serializing_if() {
+        let present = OptionalField {
+            inode_id: Some(InodeId(42)),
+        };
+        let absent = OptionalField { inode_id: None };
+
+        assert_eq!(
+            serde_json::to_string(&present).expect("serialize present public inode id"),
+            r#"{"inode_id":"ino_42"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&absent).expect("serialize absent public inode id"),
+            "{}"
+        );
+        assert_eq!(
+            serde_json::from_str::<OptionalField>(r#"{"inode_id":"ino_42"}"#)
+                .expect("deserialize present public inode id"),
+            present
+        );
+        assert_eq!(
+            serde_json::from_str::<OptionalField>(r#"{"inode_id":null}"#)
+                .expect("deserialize null public inode id"),
+            absent
+        );
+        assert_eq!(
+            serde_json::from_str::<OptionalField>("{}").expect("deserialize missing inode id"),
+            absent
+        );
+        assert!(serde_json::from_str::<OptionalField>(r#"{"inode_id":42}"#).is_err());
+    }
+
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn openapi_schema_uses_authoritative_metadata() {
+        let schema = serde_json::to_value(schema()).expect("serialize public inode-id schema");
+
+        assert_eq!(schema["type"], "string");
+        assert_eq!(schema["pattern"], PATTERN);
+        assert_eq!(schema["example"], EXAMPLE);
+        assert_eq!(schema["description"], DESCRIPTION);
+    }
+}

--- a/crates/loonfs-api/src/public_inode_id.rs
+++ b/crates/loonfs-api/src/public_inode_id.rs
@@ -1,29 +1,27 @@
-//! Public HTTP codec for namespace-scoped inode identities.
+//! Converts inode IDs between internal numbers and public API strings.
 //!
-//! Despite their decimal spelling, public inode ids are opaque to clients:
-//! clients must not allocate them or use lexicographic ordering. An inode id
-//! is scoped to one namespace, so its complete identity is
-//! `(namespace_id, inode_id)`.
+//! Public IDs use the form `ino_<number>`. They are scoped to a namespace and
+//! should be treated as identifiers rather than numbers.
 
 use crate::InodeId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
-/// Prefix on every public inode id.
+/// Prefix used by every public inode ID.
 pub const PREFIX: &str = "ino_";
 
-/// OpenAPI pattern for public inode ids.
+/// OpenAPI pattern for public inode IDs.
 pub const PATTERN: &str = r"^ino_[1-9][0-9]*$";
 
-/// Representative public inode id for OpenAPI examples.
+/// Example public inode ID used in OpenAPI.
 pub const EXAMPLE: &str = "ino_123";
 
-/// OpenAPI description for public inode ids.
-pub const DESCRIPTION: &str = "Namespace-scoped stable inode identity";
+/// OpenAPI description for public inode IDs.
+pub const DESCRIPTION: &str = "Stable inode ID within a namespace";
 
-const INVALID_REASON: &str = "must match `ino_<decimal>` with no leading zeroes";
+const INVALID_REASON: &str = "must use `ino_` followed by a nonzero u64 without leading zeroes";
 
-/// Describes why text is not a valid public inode id.
+/// Explains why a string is not a valid public inode ID.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("invalid inode id {value:?}: {reason}")]
 pub struct PublicInodeIdError {
@@ -37,18 +35,18 @@ impl PublicInodeIdError {
         &self.value
     }
 
-    /// Returns the public inode-id grammar the input violated.
+    /// Returns the validation rule that the input failed.
     pub fn reason(&self) -> &str {
         &self.reason
     }
 }
 
-/// Encodes an inode id in its public HTTP representation.
+/// Converts an inode ID to its public API string.
 pub fn encode(id: InodeId) -> String {
     format!("{PREFIX}{}", id.0)
 }
 
-/// Decodes and validates a public HTTP inode id.
+/// Parses and validates a public inode ID.
 pub fn decode(value: &str) -> Result<InodeId, PublicInodeIdError> {
     let Some(suffix) = value.strip_prefix(PREFIX) else {
         return Err(invalid(value));
@@ -73,7 +71,7 @@ fn invalid(value: &str) -> PublicInodeIdError {
     }
 }
 
-/// Serializes an inode id in its public HTTP representation.
+/// Serializes an inode ID as a public API string.
 pub fn serialize<S>(id: &InodeId, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -81,7 +79,7 @@ where
     encode(*id).serialize(serializer)
 }
 
-/// Deserializes an inode id from only its public HTTP string representation.
+/// Deserializes an inode ID from its public API string.
 pub fn deserialize<'de, D>(deserializer: D) -> Result<InodeId, D::Error>
 where
     D: Deserializer<'de>,
@@ -90,13 +88,13 @@ where
     decode(&value).map_err(serde::de::Error::custom)
 }
 
-/// Serde adapter for optional public inode-id fields.
+/// Serde support for optional public inode ID fields.
 pub mod option {
     use super::{decode, encode};
     use crate::InodeId;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    /// Serializes an optional inode id in its public HTTP representation.
+    /// Serializes an optional inode ID as a public API string.
     pub fn serialize<S>(id: &Option<InodeId>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -104,7 +102,7 @@ pub mod option {
         id.map(encode).serialize(serializer)
     }
 
-    /// Deserializes an optional inode id from only its public HTTP string representation.
+    /// Deserializes an optional inode ID from its public API string.
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<InodeId>, D::Error>
     where
         D: Deserializer<'de>,
@@ -116,10 +114,7 @@ pub mod option {
     }
 }
 
-/// Builds the authoritative OpenAPI schema for a public inode id.
-///
-/// Cite this from fields as
-/// `#[schema(schema_with = crate::public_inode_id::schema)]`.
+/// Builds the OpenAPI schema for a public inode ID.
 #[cfg(feature = "openapi")]
 #[allow(deprecated)]
 pub fn schema() -> utoipa::openapi::schema::Object {
@@ -248,7 +243,7 @@ mod tests {
 
     #[cfg(feature = "openapi")]
     #[test]
-    fn openapi_schema_uses_authoritative_metadata() {
+    fn openapi_schema_uses_shared_metadata() {
         let schema = serde_json::to_value(schema()).expect("serialize public inode-id schema");
 
         assert_eq!(schema["type"], "string");


### PR DESCRIPTION
Adds one shared codec for public inode IDs. It encodes `InodeId(42)` as `ino_42` and rejects malformed strings, zero, leading zeroes, incorrect casing, and values outside the `u64` range. Serde adapters support required and optional fields, and OpenAPI metadata describes the same format.

Cursor tests verify round trips, endpoint types, versions, namespaces, and key prefixes without treating exact serialized bytes as a compatibility contract.

This does not change any existing API schema or durable format.