### PR TITLE
refactor(core): one pinned mode for metadata loading

### DIFF
--- a/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/active_deletions.rs
@@ -10,7 +10,7 @@ use crate::metadata::{
     active_tombstone_from_records, MetadataStateBuilder, SubtreeTombstoneAction,
     SubtreeTombstoneRecord,
 };
-use crate::path::read::{load_metadata_view, AttributeProjection, ReadLoadContext};
+use crate::path::read::{load_current_metadata_view, AttributeProjection};
 use loonfs_api::wire::manifest::{ActiveDeletionRowAction, DeletedDirentry, TombstoneGeneration};
 use loonfs_api::{DisplayName, Page, PageRequest, TrashEntry, TrashPageCursor};
 
@@ -257,7 +257,7 @@ async fn trash_page<S: ObjectStore + ?Sized>(
     limit: u32,
     cursor: Option<TrashPageCursor>,
 ) -> Page<TrashEntry, TrashPageCursor> {
-    let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+    let view = load_current_metadata_view(store, namespace_id)
         .await
         .expect("load read view");
     view.list_trash_page(PageRequest {
@@ -274,7 +274,7 @@ async fn inode_id_of<S: ObjectStore + ?Sized>(
     namespace_id: &NamespaceId,
     absolute_path: &str,
 ) -> InodeId {
-    load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+    load_current_metadata_view(store, namespace_id)
         .await
         .expect("load read view")
         .resolve_path(absolute_path, AttributeProjection::Omit)

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -56,9 +56,7 @@ use crate::namespace::control::{
 };
 use crate::namespace::status::load_namespace_head_summary;
 use crate::namespace::writer_epoch::acquire_writer_epoch;
-use crate::path::read::{
-    load_metadata_view, resolve_current_files, CurrentFileState, ReadLoadContext,
-};
+use crate::path::read::{load_current_metadata_view, resolve_current_files, CurrentFileState};
 use crate::path::write::ops::{
     delete_path, move_path, put_file_bytes, restore_file_revision, write_file_bytes,
 };
@@ -397,7 +395,7 @@ async fn visible_namespace<S: ObjectStore + ?Sized>(
         .iter()
         .map(|inode| inode.inode_id)
         .collect();
-    let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+    let view = load_current_metadata_view(store, namespace_id)
         .await
         .expect("load the read view");
     resolve_current_files(&view, &inode_ids)

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -15,17 +15,10 @@ use loonfs_objectstore::{ObjectMetadata, ObjectStore};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct PreparedControlWrite {
-    pub object_key: String,
-    pub encoded_bytes: Vec<u8>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PreparedCommitHeadPublish {
     pub resulting_head: HeadState,
-    /// The physical write is kept together because its key and bytes are the
-    /// only encoded representation the store operation needs.
-    pub write: PreparedControlWrite,
+    pub object_key: String,
+    pub encoded_bytes: Vec<u8>,
 }
 
 pub(crate) fn prepare_commit_head_publish(
@@ -119,10 +112,8 @@ pub(crate) fn prepare_commit_head_publish(
 
     Ok(PreparedCommitHeadPublish {
         resulting_head,
-        write: PreparedControlWrite {
-            object_key,
-            encoded_bytes,
-        },
+        object_key,
+        encoded_bytes,
     })
 }
 
@@ -154,12 +145,12 @@ pub(crate) async fn publish_commit_head<S: ObjectStore + ?Sized>(
 
     store
         .compare_and_swap(
-            &prepared.write.object_key,
+            &prepared.object_key,
             expected_head_etag,
-            Bytes::copy_from_slice(&prepared.write.encoded_bytes),
+            Bytes::copy_from_slice(&prepared.encoded_bytes),
         )
         .await
-        .map_err(|error| map_object_store_error(&prepared.write.object_key, error))
+        .map_err(|error| map_object_store_error(&prepared.object_key, error))
 }
 
 fn map_object_store_error(object_key: &str, err: ObjectStoreError) -> CommitHeadPublishError {
@@ -316,7 +307,7 @@ mod tests {
             Some(wal.envelope.pointer(wal.object_key.clone()))
         );
         assert_eq!(
-            prepared.write.object_key,
+            prepared.object_key,
             wal_head(&prepared.resulting_head.namespace_id),
         );
         let expected_envelope = HeadStateEnvelope::from_state(
@@ -325,7 +316,7 @@ mod tests {
         )
         .expect("head envelope");
         assert_eq!(
-            prepared.write.encoded_bytes,
+            prepared.encoded_bytes,
             encode_control_object(&expected_envelope).expect("encoded head"),
         );
     }

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -58,10 +58,10 @@ pub struct RuntimeReadContext {
     pub tail_cache: Arc<WalTailProjectionCache>,
 }
 
-fn runtime_read_load_context(context: &RuntimeReadContext) -> ReadLoadContext<'_> {
+fn runtime_read_load_context(context: &RuntimeReadContext) -> ReadLoadContext<'_, '_> {
     ReadLoadContext::pinned_head(
         &context.head,
-        Some(context.head_etag.as_str()),
+        context.head_etag.as_str(),
         &context.basis,
         Some(&context.table_cache),
         Some(&context.tail_cache),

--- a/crates/loonfs-core/src/gc/tests.rs
+++ b/crates/loonfs-core/src/gc/tests.rs
@@ -41,7 +41,7 @@ use crate::commit_engine::delete_namespace;
 use crate::namespace::bootstrap::bootstrap_namespace;
 use crate::namespace::fork::fork_namespace;
 use crate::options::DeleteNamespaceOptions;
-use crate::path::read::{load_metadata_view, AttributeProjection, ReadLoadContext};
+use crate::path::read::{load_current_metadata_view, AttributeProjection};
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
@@ -140,7 +140,7 @@ async fn now_after_newest_object(
 }
 
 async fn stat_root<S: ObjectStore>(store: &S, namespace_id: &NamespaceId) {
-    load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+    load_current_metadata_view(store, namespace_id)
         .await
         .expect("load latest view")
         .resolve_path("/", AttributeProjection::Omit)
@@ -597,7 +597,7 @@ async fn fork_protected_bases_survive_source_deletion_until_the_target_dies() {
         store.head(&basis_key).await.expect("head basis").is_some(),
         "fork basis must survive while the clone lives"
     );
-    let clone_view = load_metadata_view(&store, &clone, ReadLoadContext::latest())
+    let clone_view = load_current_metadata_view(&store, &clone)
         .await
         .expect("load clone view");
     clone_view
@@ -2047,7 +2047,7 @@ async fn a_read_pinned_before_a_fold_still_reads_after_the_sweep() {
     let before_fold = namespace_key_set(&inner, &namespace_id).await;
     let store = aged_before_now(inner, before_fold);
 
-    let pinned = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+    let pinned = load_current_metadata_view(&store, &namespace_id)
         .await
         .expect("pin a read anchor");
 
@@ -2930,7 +2930,7 @@ async fn gc_never_deletes_the_live_replay_chain() {
 
     assert_eq!(report.deleted_wal_segments, 1);
     // Latest reads replay the retained tail over the root basis.
-    let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+    let view = load_current_metadata_view(&store, &namespace_id)
         .await
         .expect("load view");
     view.resolve_path("/docs/two.txt", AttributeProjection::Omit)
@@ -3151,7 +3151,7 @@ async fn gc_reclaims_manifests_superseded_by_wal_flushes() {
     assert!(!after_fold.degraded_retention);
 
     stat_root(&store, &namespace_id).await;
-    let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+    let view = load_current_metadata_view(&store, &namespace_id)
         .await
         .expect("load view");
     for round in 0..3 {
@@ -3893,7 +3893,7 @@ async fn gc_never_releases_a_fork_record_while_its_target_lives() {
     )
     .await
     .is_ok());
-    load_metadata_view(&store, &clone, ReadLoadContext::latest())
+    load_current_metadata_view(&store, &clone)
         .await
         .expect("target readable after every pass")
         .resolve_path("/docs/one.txt", AttributeProjection::Omit)
@@ -4034,7 +4034,7 @@ async fn a_fork_retry_after_abandonment_takes_a_record_of_its_own() {
         CheckpointRecordLifecycle::Active {},
         "the abandoned record is untouched; its lease ends it"
     );
-    load_metadata_view(&store, &clone, ReadLoadContext::latest())
+    load_current_metadata_view(&store, &clone)
         .await
         .expect("target readable after retry")
         .resolve_path("/docs/one.txt", AttributeProjection::Omit)

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -57,52 +57,30 @@ impl From<bool> for AttributeProjection {
 }
 
 #[derive(Clone, Copy)]
-pub(crate) enum ReadViewContext<'a> {
-    /// Fresh head+root read with no caches: the shape embedded unit tests
-    /// exercise; production reads always pin an anchor.
-    #[cfg(test)]
-    Latest,
-    PinnedHead {
-        head: &'a HeadState,
-        head_etag: Option<&'a str>,
-        /// Basis pinned together with the head when the snapshot was
-        /// taken. The live root may have moved past a pinned head; the
-        /// pinned pair stays consistent (any manifest at or below the
-        /// pinned seq serves it, with WAL replay covering the rest).
-        basis: &'a MetadataBasis,
-    },
+pub(crate) struct ReadLoadContext<'anchor, 'cache> {
+    head: &'anchor HeadState,
+    head_etag: &'anchor str,
+    /// Basis pinned together with the head when the snapshot was taken. The
+    /// live root may have moved past a pinned head; the pinned pair stays
+    /// consistent (any manifest at or below the pinned seq serves it, with
+    /// WAL replay covering the rest).
+    basis: &'anchor MetadataBasis,
+    table_cache: Option<&'cache MetadataTableCache>,
+    tail_cache: Option<&'cache WalTailProjectionCache>,
 }
 
-#[derive(Clone, Copy)]
-pub(crate) struct ReadLoadContext<'a> {
-    view: ReadViewContext<'a>,
-    table_cache: Option<&'a MetadataTableCache>,
-    tail_cache: Option<&'a WalTailProjectionCache>,
-}
-
-impl<'a> ReadLoadContext<'a> {
-    #[cfg(test)]
-    pub(crate) fn latest() -> Self {
-        Self {
-            view: ReadViewContext::Latest,
-            table_cache: None,
-            tail_cache: None,
-        }
-    }
-
+impl<'anchor, 'cache> ReadLoadContext<'anchor, 'cache> {
     pub(crate) fn pinned_head(
-        head: &'a HeadState,
-        head_etag: Option<&'a str>,
-        basis: &'a MetadataBasis,
-        table_cache: Option<&'a MetadataTableCache>,
-        tail_cache: Option<&'a WalTailProjectionCache>,
+        head: &'anchor HeadState,
+        head_etag: &'anchor str,
+        basis: &'anchor MetadataBasis,
+        table_cache: Option<&'cache MetadataTableCache>,
+        tail_cache: Option<&'cache WalTailProjectionCache>,
     ) -> Self {
         Self {
-            view: ReadViewContext::PinnedHead {
-                head,
-                head_etag,
-                basis,
-            },
+            head,
+            head_etag,
+            basis,
             table_cache,
             tail_cache,
         }
@@ -131,28 +109,34 @@ struct ReadAnchor {
 pub(crate) async fn load_metadata_view<'a, S: ObjectStore + ?Sized>(
     store: &'a S,
     namespace_id: &NamespaceId,
-    context: ReadLoadContext<'a>,
+    context: ReadLoadContext<'_, 'a>,
 ) -> Result<LoadedMetadataView<'a, S>> {
-    match context.view {
-        #[cfg(test)]
-        ReadViewContext::Latest => {
-            let loaded = read_head_and_metadata_basis(store, namespace_id)
-                .await
-                .map_err(MetadataProjectionLoadError::LoadHead)?;
-            LoadedMetadataView::load_at_head(
-                store,
-                namespace_id,
-                loaded.head.state,
-                &loaded.basis,
-                context,
-            )
-            .await
-        }
-        ReadViewContext::PinnedHead { head, basis, .. } => {
-            LoadedMetadataView::load_at_head(store, namespace_id, head.clone(), basis, context)
-                .await
-        }
-    }
+    LoadedMetadataView::load_at_head(
+        store,
+        namespace_id,
+        context.head.clone(),
+        context.basis,
+        context,
+    )
+    .await
+}
+
+#[cfg(test)]
+pub(crate) async fn load_current_metadata_view<'a, S: ObjectStore + ?Sized>(
+    store: &'a S,
+    namespace_id: &NamespaceId,
+) -> Result<LoadedMetadataView<'a, S>> {
+    let loaded = read_head_and_metadata_basis(store, namespace_id)
+        .await
+        .map_err(MetadataProjectionLoadError::LoadHead)?;
+    let context = ReadLoadContext::pinned_head(
+        &loaded.head.state,
+        &loaded.head.etag,
+        &loaded.basis,
+        None,
+        None,
+    );
+    load_metadata_view(store, namespace_id, context).await
 }
 
 /// Where one file's bytes actually live, for a host that is about to
@@ -216,7 +200,7 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
         namespace_id: &NamespaceId,
         head: HeadState,
         basis: &MetadataBasis,
-        load_context: ReadLoadContext<'a>,
+        load_context: ReadLoadContext<'_, 'a>,
     ) -> Result<Self> {
         if &head.namespace_id != namespace_id {
             return Err(CoreError::NamespaceCorrupt(format!(
@@ -246,21 +230,15 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             manifest_id,
             manifest_head_seq: manifest_head.seq,
         };
-        let cache_key = match load_context.view {
-            #[cfg(test)]
-            ReadViewContext::Latest => None,
-            ReadViewContext::PinnedHead { head_etag, .. } => {
-                head_etag.map(|etag| WalTailProjectionCacheKey {
-                    namespace_id: namespace_id.clone(),
-                    manifest_id,
-                    manifest_head_seq: manifest_head.seq,
-                    head_seq: head.seq,
-                    head_etag: etag.to_owned(),
-                })
-            }
+        let cache_key = WalTailProjectionCacheKey {
+            namespace_id: namespace_id.clone(),
+            manifest_id,
+            manifest_head_seq: manifest_head.seq,
+            head_seq: head.seq,
+            head_etag: load_context.head_etag.to_owned(),
         };
-        if let (Some(cache), Some(key)) = (load_context.tail_cache, cache_key.as_ref()) {
-            if let Some(wal_tail_rows) = cache.get(key) {
+        if let Some(cache) = load_context.tail_cache {
+            if let Some(wal_tail_rows) = cache.get(&cache_key) {
                 return Ok(Self {
                     namespace_id: namespace_id.clone(),
                     content_store_id: catalog_entry.content_store_id().clone(),
@@ -300,8 +278,8 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             })
         }?;
         let wal_tail_rows = Arc::new(replayed.resulting_metadata_state);
-        if let (Some(cache), Some(key)) = (load_context.tail_cache, cache_key) {
-            cache.insert(key, Arc::clone(&wal_tail_rows));
+        if let Some(cache) = load_context.tail_cache {
+            cache.insert(cache_key, Arc::clone(&wal_tail_rows));
         }
         Ok(Self {
             namespace_id: namespace_id.clone(),
@@ -1066,7 +1044,7 @@ mod tests {
     #[tokio::test]
     async fn an_entry_build_projects_grouped_attributes_or_none() {
         let (_temp_dir, store, namespace_id) = namespace_with_annotated_children().await;
-        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+        let view = load_current_metadata_view(&store, &namespace_id)
             .await
             .expect("load view");
 
@@ -1117,7 +1095,7 @@ mod tests {
     #[tokio::test]
     async fn a_listing_reads_attributes_only_when_it_projects_them() {
         let (_temp_dir, store, namespace_id) = namespace_with_annotated_children().await;
-        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+        let view = load_current_metadata_view(&store, &namespace_id)
             .await
             .expect("load view");
         let directory = AbsolutePath::parse("/docs").expect("path");
@@ -1162,7 +1140,7 @@ mod tests {
     #[tokio::test]
     async fn a_projected_listing_reads_its_attributes_in_one_wave() {
         let (_temp_dir, store, namespace_id) = namespace_with_annotated_children().await;
-        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+        let view = load_current_metadata_view(&store, &namespace_id)
             .await
             .expect("load view");
 

--- a/crates/loonfs-core/src/path/read/mod.rs
+++ b/crates/loonfs-core/src/path/read/mod.rs
@@ -7,9 +7,9 @@ mod materialized_view;
 
 pub(crate) use current_files::{ensure_resolve_batch_within_cap, resolve_current_files};
 pub use current_files::{CurrentFileState, MAX_RESOLVE_CURRENT_FILES};
-#[cfg(test)]
-pub(crate) use materialized_view::AttributeProjection;
 pub(crate) use materialized_view::{
     ensure_within_read_limit, load_metadata_view, LoadedMetadataView, ReadLoadContext,
 };
+#[cfg(test)]
+pub(crate) use materialized_view::{load_current_metadata_view, AttributeProjection};
 pub use materialized_view::{DirectDownloadByInodeTarget, DirectDownloadTarget};

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -199,7 +199,7 @@ mod tests {
     use crate::commit_engine::{publish_namespace_commits_batch, CommitCandidate};
     use crate::context::MutationContext;
     use crate::namespace::bootstrap::bootstrap_namespace;
-    use crate::path::read::{load_metadata_view, ReadLoadContext};
+    use crate::path::read::load_current_metadata_view;
     use crate::path::write::ops::{delete_path, put_file_bytes};
     use crate::storage::content::store_bytes_as_content;
     use loonfs_api::{
@@ -322,7 +322,7 @@ mod tests {
         namespace_id: &NamespaceId,
         request: &CommitRequest,
     ) -> Result<TestPlannedCommit> {
-        let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest())
+        let view = load_current_metadata_view(store, namespace_id)
             .await
             .expect("metadata view");
         let empty_overlay = MetadataState::default();
@@ -356,7 +356,7 @@ mod tests {
         commit_id: &str,
         planned: TestPlannedCommit,
     ) -> Result<ValidatedCommitPlan> {
-        let view = load_metadata_view(store, namespace_id, ReadLoadContext::latest()).await?;
+        let view = load_current_metadata_view(store, namespace_id).await?;
         let empty_overlay = MetadataState::default();
         validate_commit_for_publish(
             &CommitIr {
@@ -434,7 +434,7 @@ mod tests {
         .await
         .expect("put file");
 
-        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+        let view = load_current_metadata_view(&store, &namespace_id)
             .await
             .expect("metadata view");
         let resolved = view

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -119,7 +119,7 @@ mod tests {
     use crate::error::{CoreError, ErrorCode};
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::namespace::control::load_namespace_head_control;
-    use crate::path::read::{load_metadata_view, ReadLoadContext};
+    use crate::path::read::load_current_metadata_view;
     use crate::storage::content::store_bytes_as_content;
     use crate::storage::content_admission::{ContentAdmission, PreparedContent};
     use loonfs_api::{CommitId, DeleteDirectoryBehavior, DestinationBehavior, InodeId};
@@ -211,17 +211,13 @@ mod tests {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> InodeId {
-        crate::path::read::load_metadata_view(
-            store,
-            namespace_id,
-            crate::path::read::ReadLoadContext::latest(),
-        )
-        .await
-        .expect("load view")
-        .resolve_path(absolute_path, crate::path::read::AttributeProjection::Omit)
-        .await
-        .expect("visible path")
-        .inode_id
+        crate::path::read::load_current_metadata_view(store, namespace_id)
+            .await
+            .expect("load view")
+            .resolve_path(absolute_path, crate::path::read::AttributeProjection::Omit)
+            .await
+            .expect("visible path")
+            .inode_id
     }
 
     /// Two plans through one session share the durable-layer memo: the
@@ -249,7 +245,7 @@ mod tests {
         .remove(0)
         .expect("seed publish");
 
-        let view = load_metadata_view(&store, &namespace_id, ReadLoadContext::latest())
+        let view = load_current_metadata_view(&store, &namespace_id)
             .await
             .expect("load metadata view");
         let session = PublishPlanningSession::new(view.head());
@@ -490,18 +486,14 @@ mod tests {
             .as_ref()
             .expect("delete sees the create from the same batch");
 
-        crate::path::read::load_metadata_view(
-            &store,
-            &namespace_id,
-            crate::path::read::ReadLoadContext::latest(),
-        )
-        .await
-        .expect("load view")
-        .resolve_path(
-            "/docs/doomed.txt",
-            crate::path::read::AttributeProjection::Omit,
-        )
-        .await
-        .expect_err("deleted file is no longer visible");
+        crate::path::read::load_current_metadata_view(&store, &namespace_id)
+            .await
+            .expect("load view")
+            .resolve_path(
+                "/docs/doomed.txt",
+                crate::path::read::AttributeProjection::Omit,
+            )
+            .await
+            .expect_err("deleted file is no longer visible");
     }
 }


### PR DESCRIPTION
Uses one metadata-loading path for every read. Each load is pinned to a namespace head, its ETag, and the matching metadata basis, and tests now build the same context as production. This keeps a request on one namespace snapshot and gives the caches the same identity inputs in every environment.

Also removes the one-use PreparedControlWrite wrapper and stores the encoded head key and bytes directly in PreparedCommitHeadPublish. Production behavior, the public API, and durable formats are unchanged.