### PR TITLE
refactor(core): fence the content fixtures and flatten read proofs

### DIFF
--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -137,7 +137,7 @@ pub(crate) async fn write_test_file<S: ObjectStore>(
     let stored = store_bytes_as_content(store, namespace_id, b"body\n")
         .await
         .expect("store content");
-    let content_ref = stored.content_ref.clone();
+    let content_ref = stored.content_ref().clone();
     let catalog = load_namespace_catalog_entry(store, namespace_id)
         .await
         .expect("load namespace catalog");

--- a/crates/loonfs-core/src/content.rs
+++ b/crates/loonfs-core/src/content.rs
@@ -5,9 +5,10 @@
 // the caller's byte budget, so no consumer needs the raw store read.
 pub use crate::protocol::CompletedUpload;
 pub use crate::storage::content::{
-    prepare_existing_content_ref, prepare_stored_content, store_bytes_as_content,
-    DurableContentValidationError, StoredContent,
+    prepare_existing_content_ref, DurableContentValidationError, StoredContent,
 };
+#[cfg(any(test, feature = "test-support"))]
+pub use crate::storage::content::{prepare_stored_content, store_bytes_as_content};
 pub use crate::storage::content_admission::{
     mint_content_token, verify_content_token, CompletedUploadReceipt, ContentTokenError,
     PreparedContent,

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -385,13 +385,12 @@ impl<S: ObjectStore> NamespaceEngine<S> {
     ) -> Result<Vec<u8>> {
         let catalog = self.live_catalog(context)?;
         crate::path::read::ensure_within_read_limit(content_ref.size_bytes, Some(max_bytes))?;
-        let read = crate::storage::content::read_durable_content_bytes(
+        Ok(crate::storage::content::read_durable_content_bytes(
             &self.store,
             catalog.content_store_id(),
             content_ref,
         )
-        .await?;
-        Ok(read.bytes)
+        .await?)
     }
 
     /// Returns the namespace catalog derived from the pinned head after checking

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -344,11 +344,8 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
     ) -> Result<AuthoritativeFileBytes> {
         let (entry, content_ref) = self.resolve_file_content(absolute_path).await?;
         ensure_within_read_limit(content_ref.size_bytes, max_content_bytes)?;
-        let read = read_durable_content_bytes(store, &self.content_store_id, &content_ref).await?;
-        Ok(AuthoritativeFileBytes {
-            entry,
-            bytes: read.bytes,
-        })
+        let bytes = read_durable_content_bytes(store, &self.content_store_id, &content_ref).await?;
+        Ok(AuthoritativeFileBytes { entry, bytes })
     }
 
     /// Resolves a path to the file it names and the content reference its
@@ -630,12 +627,10 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             committed_at_ms: revision.committed_at_ms,
         };
         ensure_within_read_limit(revision.content_ref.size_bytes, max_content_bytes)?;
-        let read = read_durable_content_bytes(store, &self.content_store_id, &revision.content_ref)
-            .await?;
-        Ok(AuthoritativeFileBytes {
-            entry,
-            bytes: read.bytes,
-        })
+        let bytes =
+            read_durable_content_bytes(store, &self.content_store_id, &revision.content_ref)
+                .await?;
+        Ok(AuthoritativeFileBytes { entry, bytes })
     }
 
     pub(crate) async fn read_file_revision_bytes_for_inode(
@@ -647,9 +642,10 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
     ) -> Result<Vec<u8>> {
         let revision = self.revision_for_inode(inode_id, revision_no).await?;
         ensure_within_read_limit(revision.content_ref.size_bytes, max_content_bytes)?;
-        let read = read_durable_content_bytes(store, &self.content_store_id, &revision.content_ref)
-            .await?;
-        Ok(read.bytes)
+        Ok(
+            read_durable_content_bytes(store, &self.content_store_id, &revision.content_ref)
+                .await?,
+        )
     }
 
     #[tracing::instrument(

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -682,7 +682,7 @@ mod tests {
             &namespace_id,
             &request(FilesystemOperation::PutFile {
                 path: AbsolutePath::parse("/dead/new.txt").expect("path"),
-                content_ref: staged.content_ref,
+                content_ref: staged.into_content_ref(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
             }),
@@ -711,7 +711,7 @@ mod tests {
                     create_dir("/reports"),
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/reports/a.txt").expect("path"),
-                        content_ref: staged.content_ref.clone(),
+                        content_ref: staged.content_ref().clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },
@@ -779,7 +779,7 @@ mod tests {
                     },
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/docs/tmp.txt").expect("path"),
-                        content_ref: staged.content_ref.clone(),
+                        content_ref: staged.content_ref().clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },

--- a/crates/loonfs-core/src/path/write/session.rs
+++ b/crates/loonfs-core/src/path/write/session.rs
@@ -236,8 +236,8 @@ mod tests {
             vec![put_file_candidate(
                 "seed-docs",
                 "/docs/seed.txt",
-                &staged.content_store_id,
-                staged.content_ref.clone(),
+                staged.content_store_id(),
+                staged.content_ref().clone(),
             )],
             &context,
         )
@@ -256,7 +256,7 @@ mod tests {
             None,
             FilesystemOperation::PutFile {
                 path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                content_ref: staged.content_ref.clone(),
+                content_ref: staged.content_ref().clone(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
             },
@@ -280,7 +280,7 @@ mod tests {
             None,
             FilesystemOperation::PutFile {
                 path: AbsolutePath::parse("/docs/b.txt").expect("path"),
-                content_ref: staged.content_ref.clone(),
+                content_ref: staged.content_ref().clone(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
             },
@@ -325,14 +325,14 @@ mod tests {
                 put_file_candidate(
                     "create-wide-a",
                     "/wide/a.txt",
-                    &staged.content_store_id,
-                    staged.content_ref.clone(),
+                    staged.content_store_id(),
+                    staged.content_ref().clone(),
                 ),
                 put_file_candidate(
                     "create-wide-b",
                     "/wide/b.txt",
-                    &staged.content_store_id,
-                    staged.content_ref.clone(),
+                    staged.content_store_id(),
+                    staged.content_ref().clone(),
                 ),
             ],
             &context,
@@ -429,14 +429,14 @@ mod tests {
                 put_file_candidate(
                     "create-a-first",
                     "/docs/a.txt",
-                    &staged.content_store_id,
-                    staged.content_ref.clone(),
+                    staged.content_store_id(),
+                    staged.content_ref().clone(),
                 ),
                 put_file_candidate(
                     "create-a-second",
                     "/docs/a.txt",
-                    &staged.content_store_id,
-                    staged.content_ref.clone(),
+                    staged.content_store_id(),
+                    staged.content_ref().clone(),
                 ),
             ],
             &context,
@@ -463,8 +463,8 @@ mod tests {
                 put_file_candidate(
                     "create-doomed",
                     "/docs/doomed.txt",
-                    &staged.content_store_id,
-                    staged.content_ref.clone(),
+                    staged.content_store_id(),
+                    staged.content_ref().clone(),
                 ),
                 CommitCandidate::new(CommitRequest::single(
                     CommitId::parse("delete-doomed").expect("valid commit id"),

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -707,7 +707,8 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
         }
     };
 
-    record_staged_content(store, namespace_id, upload_id, stored.content_ref, false).await
+    let content_ref = stored.into_content_ref();
+    record_staged_content(store, namespace_id, upload_id, content_ref, false).await
 }
 
 /// Records a staging result and releases its claim in the same
@@ -1041,7 +1042,7 @@ pub(crate) async fn stage_owned_bytes<S: ObjectStore + ?Sized>(
         store,
         catalog,
         &session.upload_id,
-        stored.content_ref,
+        stored.into_content_ref(),
         context,
     )
     .await

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -2,13 +2,17 @@
 //! validating references, and verified read-back.
 
 use crate::error::CoreError;
-use crate::namespace::catalog::{load_namespace_content_store_id, VerifiedNamespaceCatalogEntry};
+#[cfg(any(test, feature = "test-support"))]
+use crate::namespace::catalog::load_namespace_content_store_id;
+use crate::namespace::catalog::VerifiedNamespaceCatalogEntry;
 use crate::storage::content_admission::{ContentAdmission, PreparedContent};
 use bytes::Bytes;
 use futures::StreamExt;
+#[cfg(any(test, feature = "test-support"))]
+use loonfs_api::NamespaceId;
 use loonfs_api::{
     AuthoritativePathEntry, Checksum, ContentId, ContentRef, ContentRefValidationError,
-    ContentStoreId, NamespaceId, Sha256, StreamingChecksum,
+    ContentStoreId, Sha256, StreamingChecksum,
 };
 use loonfs_objectstore::keys::content_blob;
 use loonfs_objectstore::{ByteRange, ByteStream, ObjectStore, ObjectStoreError, PutMode};
@@ -17,29 +21,38 @@ use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct ValidatedDurableContent {
-    pub content_ref: ContentRef,
-    pub object_key: String,
-    pub file_size_bytes: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct ReadDurableContent {
-    pub validated: ValidatedDurableContent,
-    pub bytes: Vec<u8>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct StoredContent {
-    pub content_store_id: ContentStoreId,
-    pub object_key: String,
-    pub content_ref: ContentRef,
-    pub file_size_bytes: u64,
+    content_store_id: ContentStoreId,
+    #[cfg(any(test, feature = "test-support"))]
+    object_key: String,
+    content_ref: ContentRef,
+    #[cfg(any(test, feature = "test-support"))]
     #[serde(skip)]
     _write_acknowledged: StoredContentWriteAcknowledgement,
 }
 
+impl StoredContent {
+    pub fn content_ref(&self) -> &ContentRef {
+        &self.content_ref
+    }
+
+    pub fn into_content_ref(self) -> ContentRef {
+        self.content_ref
+    }
+
+    #[cfg(test)]
+    pub(crate) fn content_store_id(&self) -> &ContentStoreId {
+        &self.content_store_id
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn object_key(&self) -> &str {
+        &self.object_key
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StoredContentWriteAcknowledgement;
 
@@ -78,7 +91,7 @@ pub(crate) async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
     content_ref: &ContentRef,
-) -> Result<ValidatedDurableContent, DurableContentValidationError> {
+) -> Result<(), DurableContentValidationError> {
     let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
     validate_content_size(store, &object_key, content_ref).await?;
 
@@ -92,6 +105,7 @@ pub(crate) async fn validate_durable_content_reference<S: ObjectStore + ?Sized>(
 /// [`store_bytes_as_content`] or [`store_bytes_as_content_with_store_id`]. The
 /// verified catalog prevents pairing that acknowledgement with an unrelated
 /// namespace binding.
+#[cfg(any(test, feature = "test-support"))]
 pub fn prepare_stored_content(
     catalog: &VerifiedNamespaceCatalogEntry,
     stored_content: StoredContent,
@@ -487,12 +501,11 @@ pub(crate) async fn read_durable_content_bytes<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: &ContentStoreId,
     content_ref: &ContentRef,
-) -> Result<ReadDurableContent, DurableContentValidationError> {
+) -> Result<Vec<u8>, DurableContentValidationError> {
     let object_key = content_object_key_for_ref(content_store_id, content_ref)?;
     let bytes = load_required_object(store, &object_key).await?;
-    let validated = validate_loaded_content_bytes(object_key, content_ref, &bytes)?;
-
-    Ok(ReadDurableContent { validated, bytes })
+    validate_loaded_content_bytes(object_key, content_ref, &bytes)?;
+    Ok(bytes)
 }
 
 pub(crate) fn content_object_key_for_ref(
@@ -513,7 +526,7 @@ fn validate_loaded_content_bytes(
     object_key: String,
     content_ref: &ContentRef,
     bytes: &[u8],
-) -> Result<ValidatedDurableContent, DurableContentValidationError> {
+) -> Result<(), DurableContentValidationError> {
     let actual_size = bytes.len() as u64;
     if actual_size != content_ref.size_bytes {
         return Err(DurableContentValidationError::ContentLengthMismatch {
@@ -533,11 +546,7 @@ fn validate_loaded_content_bytes(
         });
     }
 
-    Ok(ValidatedDurableContent {
-        content_ref: content_ref.clone(),
-        object_key,
-        file_size_bytes: actual_size,
-    })
+    Ok(())
 }
 
 fn describe_checksum(checksum: &Checksum) -> String {
@@ -587,6 +596,7 @@ async fn validate_content_size<S: ObjectStore + ?Sized>(
     skip_all,
     fields(phase = "write_content_blob", key_class = "content_blob")
 )]
+#[cfg(any(test, feature = "test-support"))]
 pub async fn store_bytes_as_content<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
@@ -596,22 +606,12 @@ pub async fn store_bytes_as_content<S: ObjectStore + ?Sized>(
     store_bytes_as_content_with_store_id(store, content_store_id, bytes).await
 }
 
-/// Plants durable content for a caller that already knows the namespace's
-/// content-store binding.
+/// Test fixture for planting durable content without an upload session.
 ///
-/// Every call mints its own content identity, so two writers staging the
-/// same bytes produce two objects rather than racing for one key. Sharing a
-/// key was free deduplication and also a free existence oracle: anyone
-/// allowed to upload could learn whether specific known bytes were already
-/// in a shared content store. Retry idempotency, the thing that dedup was
-/// quietly providing, belongs to the upload session instead.
-///
-/// So does reclamation, which is why this is a fixture rather than a write
-/// path. The object it writes belongs to no session, and a session record is
-/// the only handle anything has on a content object before metadata names
-/// one — so nothing will ever collect it. Production staging opens a session
-/// ([`crate::protocol::stage_owned_bytes`]); immortal bytes are what a test
-/// wants and what a namespace does not.
+/// Every call mints a fresh identity. Production staging uses
+/// [`crate::protocol::stage_owned_bytes`] so the object has a durable owner
+/// before it is written and can later become eligible for reclamation.
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) async fn store_bytes_as_content_with_store_id<S: ObjectStore + ?Sized>(
     store: &S,
     content_store_id: ContentStoreId,
@@ -753,9 +753,10 @@ pub(crate) async fn stage_bytes_under_content_id<S: ObjectStore + ?Sized>(
 
     Ok(StoredContent {
         content_store_id,
+        #[cfg(any(test, feature = "test-support"))]
         object_key,
-        file_size_bytes: content_ref.size_bytes,
         content_ref,
+        #[cfg(any(test, feature = "test-support"))]
         _write_acknowledged: StoredContentWriteAcknowledgement,
     })
 }
@@ -804,11 +805,9 @@ mod tests {
         let content_ref = content_ref(bytes);
         put_content_object(&store, &content_store_id, &content_ref, bytes).await;
 
-        let validated = validate_durable_content_reference(&store, &content_store_id, &content_ref)
+        validate_durable_content_reference(&store, &content_store_id, &content_ref)
             .await
             .expect("validate content ref");
-        assert_eq!(validated.content_ref, content_ref);
-        assert_eq!(validated.file_size_bytes, bytes.len() as u64);
     }
 
     #[tokio::test]
@@ -833,11 +832,10 @@ mod tests {
         let content_ref = content_ref(bytes);
         put_content_object(&store, &content_store_id, &content_ref, bytes).await;
 
-        let read = read_durable_content_bytes(&store, &content_store_id, &content_ref)
+        let bytes = read_durable_content_bytes(&store, &content_store_id, &content_ref)
             .await
             .expect("read empty content ref");
-        assert_eq!(read.bytes, bytes);
-        assert_eq!(read.validated.file_size_bytes, 0);
+        assert!(bytes.is_empty());
     }
 
     #[tokio::test]
@@ -906,7 +904,7 @@ mod tests {
         let read = read_durable_content_bytes(&store, &content_store_id, &content_ref)
             .await
             .expect("a crc32c-only reference verifies by its crc");
-        assert_eq!(read.bytes, bytes);
+        assert_eq!(read, bytes);
 
         // Same length, different bytes: only the checksum can tell.
         let (_temp_dir, store, content_store_id) = test_store();
@@ -942,7 +940,7 @@ mod tests {
         let read = read_durable_content_bytes(&store, &content_store_id, &content_ref)
             .await
             .expect("a crc-only reference verifies by its crc");
-        assert_eq!(read.bytes, bytes);
+        assert_eq!(read, bytes);
 
         // Same length, different bytes: only the checksum can tell.
         let (_temp_dir, store, content_store_id) = test_store();
@@ -1047,18 +1045,20 @@ mod tests {
             .expect("second stage");
 
         assert_ne!(
-            first.content_ref.content_id, second.content_ref.content_id,
+            first.content_ref().content_id,
+            second.content_ref().content_id,
             "each staging write owns its own content object"
         );
-        assert_ne!(first.object_key, second.object_key);
+        assert_ne!(first.object_key(), second.object_key());
         assert_eq!(
-            first.content_ref.checksum, second.content_ref.checksum,
+            first.content_ref().checksum,
+            second.content_ref().checksum,
             "identical bytes still carry identical evidence"
         );
         for stored in [&first, &second] {
             assert_eq!(
                 store
-                    .get(&stored.object_key, None)
+                    .get(stored.object_key(), None)
                     .await
                     .expect("read staged object")
                     .expect("staged object exists"),

--- a/crates/loonfs-core/tests/it/attributes.rs
+++ b/crates/loonfs-core/tests/it/attributes.rs
@@ -588,7 +588,7 @@ async fn a_put_and_an_update_of_the_new_path_commit_together() {
             operations: vec![
                 FilesystemOperation::PutFile {
                     path: path("/docs/a.txt"),
-                    content_ref: content.content_ref.clone(),
+                    content_ref: content.content_ref().clone(),
                     behavior: DestinationBehavior::NoReplace,
                     expected_revision_no: None,
                 },

--- a/crates/loonfs-core/tests/it/batch_publish.rs
+++ b/crates/loonfs-core/tests/it/batch_publish.rs
@@ -392,7 +392,7 @@ async fn batch_delete_then_recreate_of_a_durable_file_layers_over_cached_state()
                     "recreate-cycled",
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/docs/cycled.txt").expect("path"),
-                        content_ref: staged.content_ref,
+                        content_ref: staged.into_content_ref(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },
@@ -562,7 +562,7 @@ async fn ack_lost_head_cas_reports_unknown_outcome_and_replays_idempotently() {
             "ack-lost-put",
             FilesystemOperation::PutFile {
                 path: AbsolutePath::parse("/ack.txt").expect("path"),
-                content_ref: content.content_ref.clone(),
+                content_ref: content.content_ref().clone(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
             },
@@ -606,7 +606,7 @@ async fn retry_succeeds_after_wal_orphaned_by_stale_head_cas() {
         "retry-after-orphan",
         FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/retry.txt").expect("path"),
-            content_ref: content.content_ref,
+            content_ref: content.into_content_ref(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
         },
@@ -744,7 +744,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                     "accept-a",
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                        content_ref: content.content_ref.clone(),
+                        content_ref: content.content_ref().clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },
@@ -760,7 +760,7 @@ async fn failed_wal_write_fails_rejections_decided_against_in_batch_state() {
                     "reject-speculative",
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                        content_ref: content.content_ref.clone(),
+                        content_ref: content.content_ref().clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },
@@ -859,7 +859,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                     "accept-a",
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                        content_ref: content.content_ref.clone(),
+                        content_ref: content.content_ref().clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },
@@ -873,7 +873,7 @@ async fn stale_head_cas_fails_rejections_decided_against_in_batch_state() {
                     "reject-speculative",
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                        content_ref: content.content_ref.clone(),
+                        content_ref: content.content_ref().clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },
@@ -1106,14 +1106,14 @@ async fn oversized_prepared_proof_candidate_replays_receipt_but_new_request_is_r
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
         .await
         .expect("load namespace catalog");
-    let prepared = prepare_existing_content_ref(&store, &catalog, stored.content_ref.clone())
+    let prepared = prepare_existing_content_ref(&store, &catalog, stored.content_ref().clone())
         .await
         .expect("prepare content");
     let put = commit_request(
         "over-proof-replay",
         FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/proof-replay.txt").expect("path"),
-            content_ref: stored.content_ref,
+            content_ref: stored.into_content_ref(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
         },
@@ -1176,14 +1176,14 @@ async fn same_batch_over_limit_proof_duplicate_joins_its_primary() {
     let catalog = loonfs_core::control::load_namespace_catalog_entry(&store, &namespace_id)
         .await
         .expect("load namespace catalog");
-    let prepared = prepare_existing_content_ref(&store, &catalog, stored.content_ref.clone())
+    let prepared = prepare_existing_content_ref(&store, &catalog, stored.content_ref().clone())
         .await
         .expect("prepare content");
     let put = commit_request(
         "over-proof-duplicate",
         FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/batch-proof.txt").expect("path"),
-            content_ref: stored.content_ref,
+            content_ref: stored.into_content_ref(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
         },
@@ -1451,7 +1451,7 @@ async fn path_publishes_use_durable_path_commit_receipt_index() {
         "same-path-request",
         FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/same/path.txt").expect("path"),
-            content_ref: content.content_ref.clone(),
+            content_ref: content.content_ref().clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
         },
@@ -1731,7 +1731,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
                     None,
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
-                        content_ref: content.content_ref.clone(),
+                        content_ref: content.content_ref().clone(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },
@@ -1747,7 +1747,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
     .expect("single response")
     .expect("first commit");
     store
-        .delete(&content.object_key)
+        .delete(content.object_key())
         .await
         .expect("delete committed content blob");
 
@@ -1763,7 +1763,7 @@ async fn idempotent_path_retry_returns_receipt_before_content_validation() {
             None,
             FilesystemOperation::PutFile {
                 path: AbsolutePath::parse("/docs/idempotent.txt").expect("path"),
-                content_ref: content.content_ref,
+                content_ref: content.into_content_ref(),
                 behavior: DestinationBehavior::NoReplace,
                 expected_revision_no: None,
             },

--- a/crates/loonfs-core/tests/it/commit_validation.rs
+++ b/crates/loonfs-core/tests/it/commit_validation.rs
@@ -23,7 +23,6 @@ use loonfs_core::publish::{
     CommitCandidate, CommitRequest, ContentPreparationError, FilesystemOperation,
 };
 use loonfs_core::{Error as CoreError, ErrorCode};
-use loonfs_objectstore::keys::content_blob;
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{
     ByteRange, ObjectBody, ObjectMetadata, ObjectStore, ObjectStoreError, PutMode,
@@ -165,7 +164,7 @@ async fn path_put_file_without_admission_fails_without_reading_content() {
             commit_id("put-cold-content"),
             loonfs_test_support::test_actor(),
             None,
-            put_file("/docs/hello.txt", content.content_ref),
+            put_file("/docs/hello.txt", content.into_content_ref()),
         ))],
         &context,
     )
@@ -204,13 +203,13 @@ async fn path_batch_rejects_repeated_unadmitted_content_without_reading_it() {
                 commit_id("put-shared-a"),
                 loonfs_test_support::test_actor(),
                 None,
-                put_file("/docs/a.txt", content.content_ref.clone()),
+                put_file("/docs/a.txt", content.content_ref().clone()),
             )),
             CommitCandidate::new(CommitRequest::single(
                 commit_id("put-shared-b"),
                 loonfs_test_support::test_actor(),
                 None,
-                put_file("/docs/b.txt", content.content_ref),
+                put_file("/docs/b.txt", content.into_content_ref()),
             )),
         ],
         &context,
@@ -394,7 +393,7 @@ async fn a_directory_delete_observes_an_earlier_batch_candidate() {
                 commit_id("create-child-before-empty-check"),
                 loonfs_test_support::test_actor(),
                 None,
-                put_file("/docs/child.txt", content.content_ref),
+                put_file("/docs/child.txt", content.into_content_ref()),
             ),
             CommitRequest::single(
                 commit_id("delete-dir-with-stale-empty-check"),
@@ -439,7 +438,7 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
         &store,
         &namespace_id("demo"),
         commit_id("restore-create"),
-        put_file("/restore.txt", first.content_ref.clone()),
+        put_file("/restore.txt", first.content_ref().clone()),
         &context,
     )
     .await
@@ -454,7 +453,7 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
         commit_id("restore-replace"),
         FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/restore.txt").expect("path"),
-            content_ref: second.content_ref,
+            content_ref: second.into_content_ref(),
             behavior: DestinationBehavior::Replace,
             expected_revision_no: None,
         },
@@ -464,10 +463,7 @@ async fn restore_revision_does_not_revalidate_retained_content_before_publish() 
     .expect("replace file");
 
     store
-        .delete(&content_blob(
-            &first.content_store_id,
-            &first.content_ref.content_id,
-        ))
+        .delete(first.object_key())
         .await
         .expect("delete first content");
 
@@ -640,8 +636,8 @@ async fn a_batch_creates_a_directory_and_writes_into_it_in_one_commit() {
             message: Some("import reports".to_owned()),
             operations: vec![
                 create_dir("/reports"),
-                put_file("/reports/a.txt", first.content_ref.clone()),
-                put_file("/reports/b.txt", second.content_ref.clone()),
+                put_file("/reports/a.txt", first.content_ref().clone()),
+                put_file("/reports/b.txt", second.content_ref().clone()),
             ],
         },
         &context,
@@ -915,8 +911,8 @@ async fn a_revision_guard_observes_an_earlier_operation_of_the_same_request() {
             actor: loonfs_test_support::test_actor(),
             message: None,
             operations: vec![
-                replace(second.content_ref.clone(), 1),
-                replace(third.content_ref.clone(), 2),
+                replace(second.content_ref().clone(), 1),
+                replace(third.content_ref().clone(), 2),
             ],
         },
         &context,
@@ -934,8 +930,8 @@ async fn a_revision_guard_observes_an_earlier_operation_of_the_same_request() {
             actor: loonfs_test_support::test_actor(),
             message: None,
             operations: vec![
-                replace(second.content_ref, 3),
-                replace(third.content_ref, 3),
+                replace(second.into_content_ref(), 3),
+                replace(third.into_content_ref(), 3),
             ],
         },
         &context,

--- a/crates/loonfs-core/tests/it/common/mod.rs
+++ b/crates/loonfs-core/tests/it/common/mod.rs
@@ -249,7 +249,7 @@ pub(crate) mod commit_split_support {
             test_commit_id(commit_id),
             FilesystemOperation::PutFile {
                 path: AbsolutePath::parse(absolute_path).expect("path"),
-                content_ref: content.content_ref,
+                content_ref: content.into_content_ref(),
                 behavior,
                 expected_revision_no: None,
             },

--- a/crates/loonfs-core/tests/it/fork_lifecycle.rs
+++ b/crates/loonfs-core/tests/it/fork_lifecycle.rs
@@ -902,7 +902,7 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         CommitId::parse("before-delete").expect("valid commit id"),
         FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/keep.txt").expect("path"),
-            content_ref: content.content_ref.clone(),
+            content_ref: content.content_ref().clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
         },
@@ -939,7 +939,7 @@ async fn namespace_delete_is_terminal_for_reads_writes_creation_and_forks() {
         CommitId::parse("after-delete").expect("valid commit id"),
         FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/late.txt").expect("path"),
-            content_ref: content.content_ref.clone(),
+            content_ref: content.content_ref().clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
         },

--- a/crates/loonfs-core/tests/it/layout_acceptance.rs
+++ b/crates/loonfs-core/tests/it/layout_acceptance.rs
@@ -33,7 +33,7 @@ async fn put_file<S: ObjectStore + ?Sized>(
     let catalog = loonfs_core::control::load_namespace_catalog_entry(store, namespace_id)
         .await
         .expect("load namespace catalog");
-    let prepared = prepare_existing_content_ref(store, &catalog, content.content_ref)
+    let prepared = prepare_existing_content_ref(store, &catalog, content.into_content_ref())
         .await
         .expect("prepare existing content");
     let content_ref = prepared.content_ref().clone();

--- a/crates/loonfs-core/tests/it/path_intents.rs
+++ b/crates/loonfs-core/tests/it/path_intents.rs
@@ -1055,7 +1055,7 @@ async fn path_intents_cover_basic_mutations() {
         CommitId::parse("put-path").expect("valid commit id"),
         FilesystemOperation::PutFile {
             path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-            content_ref: content.content_ref.clone(),
+            content_ref: content.content_ref().clone(),
             behavior: DestinationBehavior::NoReplace,
             expected_revision_no: None,
         },
@@ -1142,7 +1142,7 @@ async fn path_intents_in_one_batch_see_tentative_state() {
                     None,
                     FilesystemOperation::PutFile {
                         path: AbsolutePath::parse("/docs/a.txt").expect("path"),
-                        content_ref: content.content_ref,
+                        content_ref: content.into_content_ref(),
                         behavior: DestinationBehavior::NoReplace,
                         expected_revision_no: None,
                     },

--- a/crates/loonfs-core/tests/it/visibility_equivalence.rs
+++ b/crates/loonfs-core/tests/it/visibility_equivalence.rs
@@ -96,7 +96,7 @@ impl VisibilityHarness {
         let stored = store_bytes_as_content(&self.store, self.namespace_id(), bytes)
             .await
             .expect("stage content");
-        let content_ref = stored.content_ref.clone();
+        let content_ref = stored.content_ref().clone();
         let catalog =
             loonfs_core::control::load_namespace_catalog_entry(&self.store, self.namespace_id())
                 .await

--- a/crates/loonfs/tests/it/cold_stat_requests.rs
+++ b/crates/loonfs/tests/it/cold_stat_requests.rs
@@ -106,7 +106,7 @@ async fn cold_stat_pays_no_per_run_filter_fetches() {
             let prepared = loonfs_core::content::prepare_existing_content_ref(
                 &store,
                 &catalog,
-                stored.content_ref,
+                stored.into_content_ref(),
             )
             .await
             .expect("prepare existing content");

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -131,7 +131,7 @@ impl TestHarness {
         loonfs_core::content::store_bytes_as_content(&self.store, &self.namespace_id, bytes)
             .await
             .expect("stage content")
-            .content_ref
+            .into_content_ref()
     }
 }
 
@@ -957,7 +957,7 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
         loonfs_core::content::store_bytes_as_content(&store, &namespace_id, b"duplicate content")
             .await
             .expect("stage content")
-            .content_ref;
+            .into_content_ref();
     let intent = put_request("in-flight-put", "/file.txt", content_ref.clone());
     // Full preparation deliberately costs one content HEAD and one GET; do it
     // before the reset so this phase isolates publication and duplicate join.
@@ -1026,7 +1026,7 @@ async fn stale_head_retry_preserves_content_admission() {
         loonfs_core::content::store_bytes_as_content(&store, &namespace_id, b"retry content")
             .await
             .expect("stage content")
-            .content_ref;
+            .into_content_ref();
     let intent = put_request("retry-put", "/file.txt", content_ref.clone());
     // Full preparation deliberately costs one content HEAD and one GET; do it
     // before the reset so this phase isolates publication retries.
@@ -1062,7 +1062,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
         loonfs_core::content::store_bytes_as_content(&store, &namespace_id, b"mixed content")
             .await
             .expect("stage content")
-            .content_ref;
+            .into_content_ref();
     // Full preparation deliberately costs one content HEAD and one GET; do it
     // before the reset so this phase isolates mixed-batch publication.
     let prepared = prepare_content(&store, &namespace_id, &content_ref).await;

--- a/crates/loonfs/tests/it/request_accounting.rs
+++ b/crates/loonfs/tests/it/request_accounting.rs
@@ -167,7 +167,7 @@ async fn warm_phase_request_accounting() {
             let prepared = loonfs_core::content::prepare_existing_content_ref(
                 &store,
                 &catalog,
-                stored.content_ref,
+                stored.into_content_ref(),
             )
             .await
             .expect("prepare existing content");


### PR DESCRIPTION
Moves raw content-planting helpers behind the test-support feature so production callers can only stage content through owned upload sessions. StoredContent now keeps its stored content metadata private and exposes only the content reference needed by callers.

Verified reads now return bytes directly, and validation-only functions return no value. Size and checksum checks are unchanged. Public and durable formats do not change.