### PR TITLE
refactor(core): delete duplicated spellings across the read and publish paths

### DIFF
--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -994,7 +994,7 @@ where
     )
 }
 
-/// Builds and encodes a control-object envelope for one serializable state.
+/// Encodes state in a control-object envelope.
 pub fn encode_control_state<T: Serialize>(
     kind: ControlObjectKind,
     state: &T,

--- a/crates/loonfs-api/src/control.rs
+++ b/crates/loonfs-api/src/control.rs
@@ -994,6 +994,15 @@ where
     )
 }
 
+/// Builds and encodes a control-object envelope for one serializable state.
+pub fn encode_control_state<T: Serialize>(
+    kind: ControlObjectKind,
+    state: &T,
+) -> Result<Vec<u8>, EnvelopeCodecError> {
+    let envelope = ControlObjectEnvelope::from_state(kind, state)?;
+    encode_control_object(&envelope)
+}
+
 /// Decodes and verifies a durable JSON control object of `expected_kind`.
 ///
 /// Decoding fails for invalid JSON, an unknown or mismatched kind, an

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -45,7 +45,7 @@ impl EffectiveLimit {
         self.as_usize().saturating_add(1)
     }
 
-    /// Trims one over-fetched row and derives a cursor from the last row kept.
+    /// Truncates an overfilled page and builds a cursor from its last row.
     pub fn finish_page<R, C>(self, rows: &mut Vec<R>, cursor: impl FnOnce(&R) -> C) -> Option<C> {
         if rows.len() <= self.as_usize() {
             return None;

--- a/crates/loonfs-api/src/pagination.rs
+++ b/crates/loonfs-api/src/pagination.rs
@@ -44,6 +44,15 @@ impl EffectiveLimit {
     pub fn limit_plus_one(self) -> usize {
         self.as_usize().saturating_add(1)
     }
+
+    /// Trims one over-fetched row and derives a cursor from the last row kept.
+    pub fn finish_page<R, C>(self, rows: &mut Vec<R>, cursor: impl FnOnce(&R) -> C) -> Option<C> {
+        if rows.len() <= self.as_usize() {
+            return None;
+        }
+        rows.truncate(self.as_usize());
+        rows.last().map(cursor)
+    }
 }
 
 /// Fixed pagination contract for endpoints with potentially unbounded results.

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -328,25 +328,10 @@ impl EmbeddedBackend {
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<GrepIndexStatusResponse, BackendError> {
-        let root = self
-            .grep_worker()
-            .root_state(namespace_id)
+        self.grep_worker()
+            .index_status(namespace_id)
             .await
-            .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))?;
-        let (lifecycle, next_run_ordinal, reorganize_pending) = match &root {
-            Some(root) => (
-                GrepIndexLifecycle::from(root.lifecycle()),
-                root.index().next_run_ordinal,
-                root.index().reorganize.is_some(),
-            ),
-            None => (GrepIndexLifecycle::Disabled, 0, false),
-        };
-        Ok(GrepIndexStatusResponse {
-            namespace_id: namespace_id.clone(),
-            lifecycle,
-            next_run_ordinal,
-            reorganize_pending,
-        })
+            .map_err(|error| map_namespace_scoped_grep_error(namespace_id, error))
     }
 
     pub(super) async fn gc_grep_index(

--- a/crates/loonfs-core/src/checkpoint/compaction_lease.rs
+++ b/crates/loonfs-core/src/checkpoint/compaction_lease.rs
@@ -43,8 +43,8 @@ use crate::limits::{
 use crate::timing::MonotonicTimer;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
-    encode_control_object, ControlObjectKind, MetadataCompactionLeaseEnvelope,
-    MetadataCompactionLeaseState, MetadataCompactionLeaseStatus,
+    encode_control_state, ControlObjectKind, MetadataCompactionLeaseState,
+    MetadataCompactionLeaseStatus,
 };
 use loonfs_api::{MetadataCompactionId, NamespaceId};
 use loonfs_objectstore::keys::metadata_compaction_lease;
@@ -345,14 +345,11 @@ impl<'a> CompactionLease<'a> {
 }
 
 fn encode_lease(state: &MetadataCompactionLeaseState) -> Result<Bytes> {
-    let envelope = MetadataCompactionLeaseEnvelope::from_state(
-        ControlObjectKind::CompactionLease,
-        state.clone(),
-    )
-    .map_err(|error| CoreError::Internal(format!("failed to build a compaction lease: {error}")))?;
-    encode_control_object(&envelope)
+    let object_key = metadata_compaction_lease(&state.namespace_id, &state.job_id);
+    encode_control_state(ControlObjectKind::CompactionLease, state)
         .map(Bytes::from)
-        .map_err(|error| {
-            CoreError::Internal(format!("failed to encode a compaction lease: {error}"))
+        .map_err(|error| CoreError::Codec {
+            object_key,
+            message: error.to_string(),
         })
 }

--- a/crates/loonfs-core/src/checkpoint/create.rs
+++ b/crates/loonfs-core/src/checkpoint/create.rs
@@ -21,7 +21,7 @@ use loonfs_api::wire::control::HeadState;
 use loonfs_api::wire::control::{
     CheckpointOwner, CheckpointRecordLifecycle, CheckpointRecordState,
 };
-use loonfs_api::{Checkpoint, CheckpointId, CreateCheckpointResponse, NamespaceId};
+use loonfs_api::{CheckpointId, CreateCheckpointResponse, NamespaceId};
 use loonfs_objectstore::ObjectStore;
 
 #[cfg(test)]
@@ -105,17 +105,9 @@ pub(crate) async fn create_checkpoint<S: ObjectStore + ?Sized>(
         let within_budget = timer.monotonic_now_ms().saturating_sub(verify_started_ms)
             <= CHECKPOINT_VERIFY_BUDGET_MS;
         if verification == CheckpointBasisVerification::Verified && within_budget {
-            let expires_at_ms = record.owner.expires_at_ms();
             return Ok(CreateCheckpointResponse {
                 namespace_id: namespace_id.clone(),
-                checkpoint: Checkpoint {
-                    checkpoint_id: record.checkpoint_id,
-                    owner: super::checkpoint_owner_summary(record.owner),
-                    created_at_ms: record.created_at_ms,
-                    expires_at_ms,
-                    checkpoint_seq: record.manifest_head_seq,
-                    manifest_id: record.manifest_id,
-                },
+                checkpoint: super::checkpoint_summary(record),
             });
         }
 

--- a/crates/loonfs-core/src/checkpoint/files.rs
+++ b/crates/loonfs-core/src/checkpoint/files.rs
@@ -182,16 +182,11 @@ pub(crate) async fn list_checkpoint_files_page<S: ObjectStore + ?Sized>(
         }
     }
 
-    let has_more = files.len() > request.limit.as_usize();
-    if has_more {
-        files.truncate(request.limit.as_usize());
-    }
-    let next_cursor = has_more.then(|| CheckpointFilesPageCursor {
-        after_inode_id: files
-            .last()
-            .expect("a non-zero page limit with more files must return a file")
-            .inode_id,
-    });
+    let next_cursor = request
+        .limit
+        .finish_page(&mut files, |last| CheckpointFilesPageCursor {
+            after_inode_id: last.inode_id,
+        });
     Ok(CheckpointFilesPage {
         checkpoint_seq,
         files,

--- a/crates/loonfs-core/src/checkpoint/list.rs
+++ b/crates/loonfs-core/src/checkpoint/list.rs
@@ -115,15 +115,7 @@ pub(crate) async fn list_checkpoints_page<S: ObjectStore + ?Sized>(
             continue;
         }
         let record = loaded.state;
-        let expires_at_ms = record.owner.expires_at_ms();
-        checkpoints.push(Checkpoint {
-            checkpoint_id: record.checkpoint_id,
-            owner: super::checkpoint_owner_summary(record.owner),
-            created_at_ms: record.created_at_ms,
-            expires_at_ms,
-            checkpoint_seq: record.manifest_head_seq,
-            manifest_id: record.manifest_id,
-        });
+        checkpoints.push(super::checkpoint_summary(record));
     }
     let has_more = if checkpoints.len() == request.limit.as_usize() {
         match keys.as_mut().peek().await {

--- a/crates/loonfs-core/src/checkpoint/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/mod.rs
@@ -88,10 +88,11 @@ pub(crate) use self::retention::advance_retention_floor;
 pub(crate) use self::scan::{Readahead, VerifiedMetadataTables};
 pub(crate) use self::streaming_compaction::run_metadata_compaction_job;
 
-fn checkpoint_owner_summary(
-    owner: loonfs_api::wire::control::CheckpointOwner,
-) -> loonfs_api::CheckpointOwnerSummary {
-    match owner {
+fn checkpoint_summary(
+    record: loonfs_api::wire::control::CheckpointRecordState,
+) -> loonfs_api::Checkpoint {
+    let expires_at_ms = record.owner.expires_at_ms();
+    let owner = match record.owner {
         loonfs_api::wire::control::CheckpointOwner::User { name, .. } => {
             loonfs_api::CheckpointOwnerSummary::User { name }
         }
@@ -101,5 +102,13 @@ fn checkpoint_owner_summary(
         } => loonfs_api::CheckpointOwnerSummary::Fork {
             target_namespace_id,
         },
+    };
+    loonfs_api::Checkpoint {
+        checkpoint_id: record.checkpoint_id,
+        owner,
+        created_at_ms: record.created_at_ms,
+        expires_at_ms,
+        checkpoint_seq: record.manifest_head_seq,
+        manifest_id: record.manifest_id,
     }
 }

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -7,9 +7,7 @@ use crate::error::{CoreError, Result};
 use crate::limits::CONTENTION_RETRY_LIMIT;
 use crate::namespace::control::{read_metadata_root_object, read_metadata_root_object_if_present};
 use bytes::Bytes;
-use loonfs_api::wire::control::{
-    encode_control_object, ControlObjectKind, MetadataRootEnvelope, MetadataRootState,
-};
+use loonfs_api::wire::control::{encode_control_state, ControlObjectKind, MetadataRootState};
 use loonfs_api::wire::manifest::{encode_namespace_manifest_json, NamespaceManifestEnvelope};
 use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
 use loonfs_objectstore::keys::metadata_manifest_object;
@@ -167,14 +165,13 @@ pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
             manifest_payload_checksum: manifest.payload_checksum.clone(),
             updated_at_ms,
         };
-        let envelope =
-            MetadataRootEnvelope::from_state(ControlObjectKind::MetadataRoot, next.clone())
-                .map_err(|err| {
-                    CoreError::Internal(format!("failed to build metadata root envelope: {err}"))
-                })?;
-        let encoded = encode_control_object(&envelope).map_err(|err| {
-            CoreError::Internal(format!("failed to encode metadata root object: {err}"))
-        })?;
+        let encoded =
+            encode_control_state(ControlObjectKind::MetadataRoot, &next).map_err(|error| {
+                CoreError::Codec {
+                    object_key: loaded.object_key.clone(),
+                    message: error.to_string(),
+                }
+            })?;
         match store
             .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
             .await
@@ -220,13 +217,13 @@ async fn create_first_metadata_root<S: ObjectStore + ?Sized>(
         manifest_payload_checksum: manifest.payload_checksum.clone(),
         updated_at_ms,
     };
-    let envelope = MetadataRootEnvelope::from_state(ControlObjectKind::MetadataRoot, next.clone())
-        .map_err(|err| {
-            CoreError::Internal(format!("failed to build metadata root envelope: {err}"))
+    let encoded =
+        encode_control_state(ControlObjectKind::MetadataRoot, &next).map_err(|error| {
+            CoreError::Codec {
+                object_key: object_key.clone(),
+                message: error.to_string(),
+            }
         })?;
-    let encoded = encode_control_object(&envelope).map_err(|err| {
-        CoreError::Internal(format!("failed to encode metadata root object: {err}"))
-    })?;
     // The metadata root is mutable control state, so its first publication is a conditional create.
     match store.put_if_absent(&object_key, Bytes::from(encoded)).await {
         Ok(_) => Ok(Some(next)),

--- a/crates/loonfs-core/src/checkpoint/record.rs
+++ b/crates/loonfs-core/src/checkpoint/record.rs
@@ -21,8 +21,7 @@ use crate::namespace::basis::resolve_retention_floor_seq;
 use crate::namespace::control::read_head_object;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
-    encode_control_object, CheckpointRecordEnvelope, CheckpointRecordLifecycle,
-    CheckpointRecordState, ControlObjectKind,
+    encode_control_state, CheckpointRecordLifecycle, CheckpointRecordState, ControlObjectKind,
 };
 use loonfs_api::{CheckpointId, NamespaceId};
 use loonfs_objectstore::keys::checkpoint_record;
@@ -32,19 +31,12 @@ use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 pub(crate) fn encode_checkpoint_record(
     record: &CheckpointRecordState,
 ) -> crate::error::Result<Bytes> {
-    let envelope =
-        CheckpointRecordEnvelope::from_state(ControlObjectKind::CheckpointRecord, record.clone())
-            .map_err(|error| {
-            CoreError::Internal(format!(
-                "failed to build checkpoint record envelope: {error}"
-            ))
-        })?;
-    encode_control_object(&envelope)
+    let object_key = checkpoint_record(&record.namespace_id, &record.checkpoint_id);
+    encode_control_state(ControlObjectKind::CheckpointRecord, record)
         .map(Bytes::from)
-        .map_err(|error| {
-            CoreError::Internal(format!(
-                "failed to encode checkpoint record object: {error}"
-            ))
+        .map_err(|error| CoreError::Codec {
+            object_key,
+            message: error.to_string(),
         })
 }
 

--- a/crates/loonfs-core/src/checkpoint/release.rs
+++ b/crates/loonfs-core/src/checkpoint/release.rs
@@ -11,7 +11,7 @@
 use super::record::{read_checkpoint_record, release_checkpoint_record};
 use crate::context::MutationContext;
 use crate::error::{CoreError, Result};
-use loonfs_api::wire::control::{CheckpointOwner, CheckpointRecordLifecycle};
+use loonfs_api::wire::control::CheckpointOwner;
 use loonfs_api::{CheckpointId, NamespaceId, ReleaseCheckpointResponse};
 use loonfs_objectstore::ObjectStore;
 
@@ -38,15 +38,6 @@ pub(crate) async fn release_checkpoint<S: ObjectStore + ?Sized>(
             "checkpoint `{checkpoint_id}` is owned by fork target `{target_namespace_id}`; \
              it is released by deleting that namespace, not by this operation"
         )));
-    }
-    if matches!(
-        loaded.state.state,
-        CheckpointRecordLifecycle::Released { .. }
-    ) {
-        return Ok(ReleaseCheckpointResponse {
-            namespace_id: namespace_id.clone(),
-            checkpoint_id: checkpoint_id.clone(),
-        });
     }
     release_checkpoint_record(store, namespace_id, checkpoint_id, context.now_ms).await?;
     Ok(ReleaseCheckpointResponse {

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -47,6 +47,7 @@ use loonfs_api::wire::manifest::{
     MetadataFileRef, NamespaceManifestEnvelope, NamespaceManifestPayload,
 };
 use loonfs_api::{ChangeSeq, ManifestId, ManifestObjectId, NamespaceId};
+use loonfs_objectstore::keys::metadata_manifest_object;
 use loonfs_objectstore::ObjectStore;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -834,10 +835,12 @@ pub(super) async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
     // hex characters, so the key is this unit's alone and a conflict under it
     // is corruption rather than contention.
     let manifest_id = next_manifest_id_after(previous.payload.manifest_id)?;
+    let manifest_object_id = ManifestObjectId::generate(manifest_id);
+    let object_key = metadata_manifest_object(namespace_id, &manifest_object_id);
     let manifest = NamespaceManifestEnvelope::from_payload(NamespaceManifestPayload {
         namespace_id: namespace_id.clone(),
         manifest_id,
-        manifest_object_id: ManifestObjectId::generate(manifest_id),
+        manifest_object_id,
         head_seq: previous.payload.head_seq,
         head_commit_id: previous.payload.head_commit_id.clone(),
         base_seq,
@@ -846,7 +849,10 @@ pub(super) async fn write_reorganized_manifest<S: ObjectStore + ?Sized>(
         retention_floor_seq,
         metadata_files,
     })
-    .map_err(|err| CoreError::Internal(format!("failed to build reorganized manifest: {err}")))?;
+    .map_err(|error| CoreError::Codec {
+        object_key,
+        message: error.to_string(),
+    })?;
     write_namespace_manifest(store, &manifest)
         .await
         .map_err(manifest_write_failure)?;

--- a/crates/loonfs-core/src/checkpoint/retention.rs
+++ b/crates/loonfs-core/src/checkpoint/retention.rs
@@ -11,9 +11,7 @@ use crate::namespace::control::{
     read_head_object, read_metadata_root_object_if_present, read_wal_floor_object,
 };
 use bytes::Bytes;
-use loonfs_api::wire::control::{
-    encode_control_object, ControlObjectKind, WalFloorEnvelope, WalFloorState,
-};
+use loonfs_api::wire::control::{encode_control_state, ControlObjectKind, WalFloorState};
 use loonfs_api::{AdvanceRetentionResponse, NamespaceId};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError};
 
@@ -92,14 +90,14 @@ pub(crate) async fn advance_retention_floor<S: ObjectStore + ?Sized>(
             verified_at_ms: context.now_ms,
             updated_at_ms: context.now_ms,
         };
-        let envelope =
-            WalFloorEnvelope::from_state(ControlObjectKind::WalFloor, next).map_err(|err| {
-                CoreError::Internal(format!("failed to build wal floor envelope: {err}"))
-            })?;
-        let encoded = encode_control_object(&envelope).map_err(|err| {
-            CoreError::Internal(format!("failed to encode wal floor object: {err}"))
-        })?;
         let object_key = loonfs_objectstore::keys::wal_floor(namespace_id);
+        let encoded =
+            encode_control_state(ControlObjectKind::WalFloor, &next).map_err(|error| {
+                CoreError::Codec {
+                    object_key: object_key.clone(),
+                    message: error.to_string(),
+                }
+            })?;
         let published = match &loaded {
             Some(loaded) => {
                 store

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -127,20 +127,19 @@ pub(crate) struct MetadataLsmPolicy {
 impl Default for MetadataLsmPolicy {
     fn default() -> Self {
         Self {
-            max_l0_runs: NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_L0_RUNS)
-                .expect("default L0 run limit should be nonzero"),
-            max_rows_per_segment: NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT)
-                .expect("default segment row budget should be nonzero"),
-            max_input_runs_per_step: NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_RUNS)
-                .expect("default reorganization run budget should be nonzero"),
-            max_decoded_input_rows_per_step: NonZeroUsize::new(
-                DEFAULT_MAX_REORGANIZATION_INPUT_ROWS,
-            )
-            .expect("default reorganization row budget should be nonzero"),
-            max_decoded_input_bytes_per_step: NonZeroUsize::new(
-                DEFAULT_MAX_REORGANIZATION_INPUT_BYTES,
-            )
-            .expect("default reorganization byte budget should be nonzero"),
+            max_l0_runs: const { NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_L0_RUNS).unwrap() },
+            max_rows_per_segment: const {
+                NonZeroUsize::new(DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT).unwrap()
+            },
+            max_input_runs_per_step: const {
+                NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_RUNS).unwrap()
+            },
+            max_decoded_input_rows_per_step: const {
+                NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_ROWS).unwrap()
+            },
+            max_decoded_input_bytes_per_step: const {
+                NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_BYTES).unwrap()
+            },
         }
     }
 }

--- a/crates/loonfs-core/src/commit/publish.rs
+++ b/crates/loonfs-core/src/commit/publish.rs
@@ -6,7 +6,7 @@ use crate::limits::RECENT_SEGMENTS_LIMIT;
 use crate::wal::PreparedWalSegment;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
-    encode_control_object, ControlObjectKind, HeadState, HeadStateEnvelope, WalSegmentPointer,
+    encode_control_state, ControlObjectKind, HeadState, WalSegmentPointer,
 };
 use loonfs_api::{next_public_ordinal, ChangeSeq};
 use loonfs_objectstore::keys::wal_head;
@@ -97,17 +97,12 @@ pub(crate) fn prepare_commit_head_publish(
     current_head
         .ensure_successor_identity(&resulting_head)
         .map_err(CommitHeadPublishError::HeadIdentityDrift)?;
-    let envelope =
-        HeadStateEnvelope::from_state(ControlObjectKind::WalHead, resulting_head.clone()).map_err(
-            |err| CommitHeadPublishError::Codec {
+    let encoded_bytes =
+        encode_control_state(ControlObjectKind::WalHead, &resulting_head).map_err(|err| {
+            CommitHeadPublishError::Codec {
                 object_key: object_key.clone(),
                 message: err.to_string(),
-            },
-        )?;
-    let encoded_bytes =
-        encode_control_object(&envelope).map_err(|err| CommitHeadPublishError::Codec {
-            object_key: object_key.clone(),
-            message: err.to_string(),
+            }
         })?;
 
     Ok(PreparedCommitHeadPublish {
@@ -167,6 +162,7 @@ fn map_object_store_error(object_key: &str, err: ObjectStoreError) -> CommitHead
 mod tests {
     use super::*;
     use crate::commit::CommitFingerprint;
+    use loonfs_api::wire::control::{encode_control_object, HeadStateEnvelope};
 
     #[test]
     fn head_cas_transport_failure_maps_to_unknown_outcome_not_failure() {

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -187,7 +187,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
             } => {
                 let source_binding =
                     resolve_current_binding_for_mutation(metadata_state, *inode_id).await?;
-                let inode = metadata_state.inode_at_seq(*inode_id).await?.ok_or(
+                let inode = metadata_state.view().inode_at_seq(*inode_id).await?.ok_or(
                     CommitValidationError::RenameInodeMissing {
                         inode_id: *inode_id,
                     },
@@ -421,7 +421,12 @@ async fn validate_undelete_target<S: ObjectStore + ?Sized>(
 ) -> Result<SubtreeTombstoneRecord, CoreError> {
     // A child of a deleted directory is covered by its ancestor's tombstone,
     // not its own — recover the directory, not the child.
-    if metadata_state.inode_at_seq(inode_id).await?.is_none() {
+    if metadata_state
+        .view()
+        .inode_at_seq(inode_id)
+        .await?
+        .is_none()
+    {
         return Err(CommitValidationError::UndeleteInodeMissing { inode_id }.into());
     }
     // Only a deletion from a strictly earlier commit is recoverable.
@@ -434,7 +439,11 @@ async fn validate_undelete_target<S: ObjectStore + ?Sized>(
         }
         .into());
     }
-    let Some(active) = metadata_state.active_subtree_tombstone(inode_id).await? else {
+    let Some(active) = metadata_state
+        .view()
+        .active_subtree_tombstone(inode_id)
+        .await?
+    else {
         return Err(CommitValidationError::UndeleteTargetNotDeleted { inode_id }.into());
     };
     // Recovery is scoped to the deletion the caller observed, never whatever
@@ -456,7 +465,12 @@ async fn validate_attributes_target_visible<S: ObjectStore + ?Sized>(
     metadata_state: &PublishValidationView<'_, S>,
     inode_id: InodeId,
 ) -> Result<(), CoreError> {
-    if metadata_state.visible_inode(inode_id).await?.is_none() {
+    if metadata_state
+        .view()
+        .visible_inode(inode_id)
+        .await?
+        .is_none()
+    {
         return Err(CommitValidationError::UpdateAttributesInodeMissing { inode_id }.into());
     }
 
@@ -474,7 +488,10 @@ async fn validate_inode_attributes_revision_is<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
     expected: AttributeRevisionNo,
 ) -> Result<Attributes, CoreError> {
-    let (actual, attributes) = metadata_state.attributes_at_seq(inode_id).await?;
+    let (actual, attributes) = metadata_state
+        .view()
+        .attributes_at_visible_seq(inode_id)
+        .await?;
     if actual != expected {
         return Err(
             CommitValidationError::UpdateAttributesBaseRevisionMismatch {
@@ -498,6 +515,7 @@ async fn validate_inode_kind<S: ObjectStore + ?Sized>(
     wrong_kind: impl FnOnce(InodeKind) -> CommitValidationError,
 ) -> Result<InodeRecord, CoreError> {
     let inode = metadata_state
+        .view()
         .inode_at_seq(inode_id)
         .await?
         .ok_or_else(missing)?;
@@ -515,7 +533,11 @@ async fn validate_not_covered_by_tombstone<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
     covered: impl FnOnce(&SubtreeTombstoneRecord) -> CommitValidationError,
 ) -> Result<(), CoreError> {
-    if let Some(tombstone) = metadata_state.covering_subtree_tombstone(inode_id).await? {
+    if let Some(tombstone) = metadata_state
+        .view()
+        .covering_subtree_tombstone(inode_id)
+        .await?
+    {
         return Err(covered(&tombstone).into());
     }
 
@@ -576,6 +598,7 @@ async fn validate_name_absent<S: ObjectStore + ?Sized>(
 
     let name_key = NameKey::for_display_name(display_name);
     if let Some(existing) = metadata_state
+        .view()
         .visible_child(parent_inode_id, &name_key)
         .await?
     {
@@ -646,6 +669,7 @@ async fn validate_child_name_absent_precondition<S: ObjectStore + ?Sized>(
     validate_name_precondition_parent(metadata_state, parent_inode_id).await?;
 
     if let Some(existing) = metadata_state
+        .view()
         .visible_child(parent_inode_id, name_key)
         .await?
     {
@@ -671,6 +695,7 @@ async fn validate_binding_is_precondition<S: ObjectStore + ?Sized>(
     validate_name_precondition_parent(metadata_state, parent_inode_id).await?;
 
     let Some(existing) = metadata_state
+        .view()
         .visible_child(parent_inode_id, name_key)
         .await?
     else {
@@ -726,6 +751,7 @@ async fn validate_directory_empty_precondition<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
 ) -> Result<(), CoreError> {
     let inode = metadata_state
+        .view()
         .visible_inode(inode_id)
         .await?
         .ok_or(CommitValidationError::DirectoryEmptyPreconditionInodeMissing { inode_id })?;
@@ -739,7 +765,7 @@ async fn validate_directory_empty_precondition<S: ObjectStore + ?Sized>(
         );
     }
 
-    if metadata_state.has_visible_children(inode_id).await? {
+    if metadata_state.view().has_visible_children(inode_id).await? {
         return Err(CommitValidationError::DirectoryEmptyPreconditionNotEmpty { inode_id }.into());
     }
 
@@ -751,6 +777,7 @@ async fn resolve_current_binding_for_mutation<S: ObjectStore + ?Sized>(
     inode_id: InodeId,
 ) -> Result<ResolvedBinding, CoreError> {
     let binding = metadata_state
+        .view()
         .current_parent_binding_for_child(inode_id)
         .await?
         .ok_or(CommitValidationError::SourceBindingMissing { inode_id })?;
@@ -777,6 +804,7 @@ async fn validate_file_base_revision_is<S: ObjectStore + ?Sized>(
     validate_inode_kind(metadata_state, inode_id, InodeKind::File, missing, not_file).await?;
 
     let actual_revision_no = metadata_state
+        .view()
         .latest_revision_record(inode_id)
         .await?
         .map(|revision| revision.revision_no);
@@ -841,6 +869,7 @@ async fn validate_restore_source_revision<S: ObjectStore + ?Sized>(
     source_revision_no: RevisionNo,
 ) -> Result<RevisionRecord, CoreError> {
     Ok(metadata_state
+        .view()
         .revision_at_head(inode_id, source_revision_no)
         .await?
         .ok_or(
@@ -860,6 +889,7 @@ async fn validate_rename_does_not_cycle<S: ObjectStore + ?Sized>(
         return Ok(());
     }
     if metadata_state
+        .view()
         .would_create_directory_cycle(inode.inode_id, new_parent_inode_id)
         .await?
     {

--- a/crates/loonfs-core/src/commit/validate/view.rs
+++ b/crates/loonfs-core/src/commit/validate/view.rs
@@ -2,14 +2,8 @@
 
 use super::super::metadata_overlay::CommitOverlayRows;
 use super::super::ValidatedOp;
-use crate::error::CoreError;
-use crate::metadata::{
-    DirentryBindRecord, InodeRecord, MetadataState, MetadataView, RevisionRecord,
-    SubtreeTombstoneRecord,
-};
-use loonfs_api::{
-    ActorRef, AttributeRevisionNo, Attributes, ChangeSeq, InodeId, NameKey, RevisionNo,
-};
+use crate::metadata::{MetadataState, MetadataView};
+use loonfs_api::{ActorRef, ChangeSeq};
 use loonfs_objectstore::ObjectStore;
 
 /// The publish view: it holds the loaded [`MetadataView`] plus the
@@ -46,90 +40,6 @@ impl<'a, S: ObjectStore + ?Sized> PublishValidationView<'a, S> {
 }
 
 impl<S: ObjectStore + ?Sized> PublishValidationView<'_, S> {
-    pub(crate) async fn inode_at_seq(
-        &self,
-        inode_id: InodeId,
-    ) -> Result<Option<InodeRecord>, CoreError> {
-        self.view().inode_at_seq(inode_id).await
-    }
-
-    pub(crate) async fn visible_inode(
-        &self,
-        inode_id: InodeId,
-    ) -> Result<Option<InodeRecord>, CoreError> {
-        self.view().visible_inode(inode_id).await
-    }
-
-    pub(crate) async fn visible_child(
-        &self,
-        parent_inode_id: InodeId,
-        name_key: &NameKey,
-    ) -> Result<Option<DirentryBindRecord>, CoreError> {
-        self.view().visible_child(parent_inode_id, name_key).await
-    }
-
-    pub(crate) async fn has_visible_children(
-        &self,
-        parent_inode_id: InodeId,
-    ) -> Result<bool, CoreError> {
-        self.view().has_visible_children(parent_inode_id).await
-    }
-
-    pub(crate) async fn latest_revision_record(
-        &self,
-        inode_id: InodeId,
-    ) -> Result<Option<RevisionRecord>, CoreError> {
-        self.view().latest_revision_record(inode_id).await
-    }
-
-    pub(crate) async fn revision_at_head(
-        &self,
-        inode_id: InodeId,
-        revision_no: RevisionNo,
-    ) -> Result<Option<RevisionRecord>, CoreError> {
-        self.view().revision_at_head(inode_id, revision_no).await
-    }
-
-    pub(crate) async fn current_parent_binding_for_child(
-        &self,
-        child_inode_id: InodeId,
-    ) -> Result<Option<DirentryBindRecord>, CoreError> {
-        self.view()
-            .current_parent_binding_for_child(child_inode_id)
-            .await
-    }
-
-    pub(crate) async fn covering_subtree_tombstone(
-        &self,
-        inode_id: InodeId,
-    ) -> Result<Option<SubtreeTombstoneRecord>, CoreError> {
-        self.view().covering_subtree_tombstone(inode_id).await
-    }
-
-    pub(crate) async fn active_subtree_tombstone(
-        &self,
-        root_inode_id: InodeId,
-    ) -> Result<Option<SubtreeTombstoneRecord>, CoreError> {
-        self.view().active_subtree_tombstone(root_inode_id).await
-    }
-
-    pub(crate) async fn would_create_directory_cycle(
-        &self,
-        inode_id: InodeId,
-        new_parent_inode_id: InodeId,
-    ) -> Result<bool, CoreError> {
-        self.view()
-            .would_create_directory_cycle(inode_id, new_parent_inode_id)
-            .await
-    }
-
-    pub(crate) async fn attributes_at_seq(
-        &self,
-        inode_id: InodeId,
-    ) -> Result<(AttributeRevisionNo, Attributes), CoreError> {
-        self.view().attributes_at_visible_seq(inode_id).await
-    }
-
     pub(crate) fn apply_validated_op_mut(
         &mut self,
         committed_seq: ChangeSeq,

--- a/crates/loonfs-core/src/control_update.rs
+++ b/crates/loonfs-core/src/control_update.rs
@@ -9,8 +9,7 @@ use crate::error::{CoreError, StoreFailureClass};
 use crate::namespace::control::{read_head_object, LoadedHeadObject};
 use bytes::Bytes;
 use loonfs_api::wire::control::{
-    encode_control_object, ControlObjectKind, HeadState, HeadStateEnvelope, UploadSessionEnvelope,
-    UploadSessionState,
+    encode_control_state, ControlObjectKind, HeadState, UploadSessionState,
 };
 use loonfs_api::{NamespaceId, UploadId};
 use loonfs_objectstore::keys::upload_session;
@@ -144,16 +143,11 @@ where
     match update(loaded.state).await? {
         UploadSessionUpdate::Noop(outcome) => Ok(UploadSessionCas::Applied(outcome)),
         UploadSessionUpdate::Replace { next, outcome } => {
-            let envelope =
-                UploadSessionEnvelope::from_state(ControlObjectKind::UploadSession, *next)
-                    .map_err(|err| {
-                        CoreError::Internal(format!(
-                            "failed to build upload session envelope: {err}"
-                        ))
-                    })?;
-            let encoded = encode_control_object(&envelope).map_err(|err| {
-                CoreError::Internal(format!("failed to encode upload session envelope: {err}"))
-            })?;
+            let encoded = encode_control_state(ControlObjectKind::UploadSession, next.as_ref())
+                .map_err(|error| CoreError::Codec {
+                    object_key: loaded.object_key.clone(),
+                    message: error.to_string(),
+                })?;
             match store
                 .compare_and_swap(&loaded.object_key, &loaded.etag, Bytes::from(encoded))
                 .await
@@ -167,16 +161,11 @@ where
 }
 
 fn encode_head(next: HeadState, object_key: &str) -> Result<Vec<u8>, ControlUpdateError> {
-    let envelope =
-        HeadStateEnvelope::from_state(ControlObjectKind::WalHead, next).map_err(|err| {
-            ControlUpdateError::Codec {
-                object_key: object_key.to_owned(),
-                message: err.to_string(),
-            }
-        })?;
-    encode_control_object(&envelope).map_err(|err| ControlUpdateError::Codec {
-        object_key: object_key.to_owned(),
-        message: err.to_string(),
+    encode_control_state(ControlObjectKind::WalHead, &next).map_err(|err| {
+        ControlUpdateError::Codec {
+            object_key: object_key.to_owned(),
+            message: err.to_string(),
+        }
     })
 }
 
@@ -222,7 +211,7 @@ async fn read_upload_session_object<S: ObjectStore + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use loonfs_api::wire::control::{ControlObjectKind, HeadStateEnvelope};
+    use loonfs_api::wire::control::{encode_control_object, ControlObjectKind, HeadStateEnvelope};
     use loonfs_api::NamespaceId;
     use loonfs_objectstore::keys::wal_head;
     use loonfs_objectstore::local_fs_store::LocalFsStore;

--- a/crates/loonfs-core/src/error.rs
+++ b/crates/loonfs-core/src/error.rs
@@ -192,6 +192,8 @@ pub enum CoreError {
         message: String,
         class: StoreFailureClass,
     },
+    #[error("failed to encode `{object_key}`: {message}")]
+    Codec { object_key: String, message: String },
     /// Non-store internal failure (codec, overflow, invariant breach). Same
     /// wire code as [`ErrorCode::ServerError`]; the message is the detail.
     #[error("internal error: {0}")]
@@ -369,7 +371,9 @@ impl CoreError {
             CoreError::DurableContent(error) => classify_durable_content_error(error),
             CoreError::WriterEpoch(error) => classify_writer_epoch_acquire_error(error),
             CoreError::CommitValidation(error) => classify_commit_validation_error(error),
-            CoreError::WalBuild(_) | CoreError::Internal(_) => ErrorCode::ServerError,
+            CoreError::WalBuild(_) | CoreError::Codec { .. } | CoreError::Internal(_) => {
+                ErrorCode::ServerError
+            }
             CoreError::WalWrite { class, .. } | CoreError::Store { class, .. } => {
                 classify_store_failure(*class)
             }

--- a/crates/loonfs-core/src/namespace/bootstrap.rs
+++ b/crates/loonfs-core/src/namespace/bootstrap.rs
@@ -12,8 +12,7 @@ use crate::metadata::{InodeRecord, MetadataState};
 use crate::namespace::control::read_head_object;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
-    encode_control_object, ControlObjectKind, HeadState, HeadStateEnvelope, NamespaceState,
-    WriterBlock,
+    encode_control_state, ControlObjectKind, HeadState, NamespaceState, WriterBlock,
 };
 use loonfs_api::{
     ChangeSeq, ContentStoreId, ErrorCode, InodeKind, NamespaceId, NamespaceStatusResponse,
@@ -156,10 +155,12 @@ pub(super) async fn install_namespace_head<S: ObjectStore + ?Sized>(
     head: &HeadState,
 ) -> Result<NamespaceHeadInstall, CoreError> {
     let object_key = wal_head(namespace_id);
-    let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, head.clone())
-        .map_err(|err| CoreError::Internal(format!("failed to build head envelope: {err}")))?;
-    let bytes = encode_control_object(&envelope)
-        .map_err(|err| CoreError::Internal(format!("failed to encode head object: {err}")))?;
+    let bytes = encode_control_state(ControlObjectKind::WalHead, head).map_err(|error| {
+        CoreError::Codec {
+            object_key: object_key.clone(),
+            message: error.to_string(),
+        }
+    })?;
     // The namespace head is mutable control state, so installation must be a conditional create.
     match store.put_if_absent(&object_key, Bytes::from(bytes)).await {
         Ok(_) => Ok(NamespaceHeadInstall::Landed),

--- a/crates/loonfs-core/src/namespace/delete.rs
+++ b/crates/loonfs-core/src/namespace/delete.rs
@@ -1,17 +1,15 @@
 //! Namespace deletion: a fenced, terminal head-state transition.
 
 use crate::error::CoreError;
+use crate::limits::CONTENTION_RETRY_LIMIT;
 use crate::namespace::control::read_head_object;
 use crate::options::DeleteNamespaceOptions;
 use bytes::Bytes;
 use loonfs_api::wire::control::{
-    encode_control_object, AcquiredWriter, ControlObjectKind, HeadState, HeadStateEnvelope,
-    NamespaceState,
+    encode_control_state, AcquiredWriter, ControlObjectKind, HeadState, NamespaceState,
 };
 use loonfs_api::{DeleteNamespaceResponse, NamespaceId};
 use loonfs_objectstore::{ObjectStore, ObjectStoreError, PutMode};
-
-const MAX_DELETE_CAS_ATTEMPTS: usize = 8;
 
 /// Deletes a namespace by compare-and-swapping its head into the terminal
 /// `deleted` state (format spec, "Tombstones and deletion").
@@ -47,7 +45,7 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
     acquired_writer: AcquiredWriter,
 ) -> Result<DeleteNamespaceResponse, CoreError> {
     let mut attempted_swap = false;
-    for _attempt in 0..MAX_DELETE_CAS_ATTEMPTS {
+    for _attempt in 0..CONTENTION_RETRY_LIMIT {
         let loaded = read_head_object(store, namespace_id)
             .await
             .map_err(|error| CoreError::MetadataProjection(error.into()))?;
@@ -96,10 +94,13 @@ pub(crate) async fn delete_namespace<S: ObjectStore + ?Sized>(
             state: NamespaceState::Deleted,
             ..head.clone()
         };
-        let envelope = HeadStateEnvelope::from_state(ControlObjectKind::WalHead, deleted_head)
-            .map_err(|err| CoreError::Internal(format!("failed to build head envelope: {err}")))?;
-        let encoded = encode_control_object(&envelope)
-            .map_err(|err| CoreError::Internal(format!("failed to encode head object: {err}")))?;
+        let encoded =
+            encode_control_state(ControlObjectKind::WalHead, &deleted_head).map_err(|error| {
+                CoreError::Codec {
+                    object_key: loaded.object_key.clone(),
+                    message: error.to_string(),
+                }
+            })?;
 
         let swap = store
             .put(

--- a/crates/loonfs-core/src/namespace/status.rs
+++ b/crates/loonfs-core/src/namespace/status.rs
@@ -96,7 +96,7 @@ pub async fn load_namespace_head_summary<S: ObjectStore + ?Sized>(
     expected_namespace_id: &NamespaceId,
 ) -> Result<NamespaceStatusResponse> {
     let loaded = load_namespace_head_basis(store, expected_namespace_id).await?;
-    let wal_tail_segments = count_visible_wal_tail_segments(WalChainLoadRequest {
+    let wal_tail_segments = count_visible_wal_tail_segments(&WalChainLoadRequest {
         namespace_id: expected_namespace_id,
         chain_base_seq: loaded.basis_head_seq,
         head_seq: loaded.head.seq,

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -5,13 +5,12 @@ use crate::context::MutationContext;
 use crate::control_object::ControlObjectLoadError;
 use crate::control_update::{update_head, ControlUpdateError, HeadReplacement};
 use crate::error::StoreFailureClass;
+use crate::limits::CONTENTION_RETRY_LIMIT;
 use loonfs_api::wire::control::{AcquiredWriter, HeadState, NamespaceState, WriterBlock};
 use loonfs_api::{next_public_ordinal, NamespaceId, WriterEpoch};
 use loonfs_objectstore::ObjectStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-
-const MAX_WRITER_EPOCH_ACQUIRE_ATTEMPTS: usize = 8;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 pub enum WriterEpochAcquireError {
@@ -59,31 +58,26 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
         return Err(WriterEpochAcquireError::EmptyWriterId);
     }
 
-    update_head(
-        store,
-        namespace_id,
-        MAX_WRITER_EPOCH_ACQUIRE_ATTEMPTS,
-        |loaded_head| {
-            let head = &loaded_head.state;
-            // Check for deletion before incrementing the epoch. A deleted namespace
-            // never grants another writer epoch, including to the writer recorded in
-            // its tombstone.
-            if head.state == NamespaceState::Deleted {
-                return Err(WriterEpochAcquireError::NamespaceDeleted {
-                    namespace_id: head.namespace_id.clone(),
-                });
-            }
+    update_head(store, namespace_id, CONTENTION_RETRY_LIMIT, |loaded_head| {
+        let head = &loaded_head.state;
+        // Check for deletion before incrementing the epoch. A deleted namespace
+        // never grants another writer epoch, including to the writer recorded in
+        // its tombstone.
+        if head.state == NamespaceState::Deleted {
+            return Err(WriterEpochAcquireError::NamespaceDeleted {
+                namespace_id: head.namespace_id.clone(),
+            });
+        }
 
-            let next_epoch = next_writer_epoch(head.writer_epoch)?;
-            Ok(HeadReplacement {
-                next: Box::new(head_with_writer(head, next_epoch, context)),
-                outcome: AcquiredWriter {
-                    writer_id: context.writer_id.clone(),
-                    writer_epoch: next_epoch,
-                },
-            })
-        },
-    )
+        let next_epoch = next_writer_epoch(head.writer_epoch)?;
+        Ok(HeadReplacement {
+            next: Box::new(head_with_writer(head, next_epoch, context)),
+            outcome: AcquiredWriter {
+                writer_id: context.writer_id.clone(),
+                writer_epoch: next_epoch,
+            },
+        })
+    })
     .await
 }
 

--- a/crates/loonfs-core/src/namespace/writer_epoch.rs
+++ b/crates/loonfs-core/src/namespace/writer_epoch.rs
@@ -60,9 +60,8 @@ pub(crate) async fn acquire_writer_epoch<S: ObjectStore + ?Sized>(
 
     update_head(store, namespace_id, CONTENTION_RETRY_LIMIT, |loaded_head| {
         let head = &loaded_head.state;
-        // Check for deletion before incrementing the epoch. A deleted namespace
-        // never grants another writer epoch, including to the writer recorded in
-        // its tombstone.
+        // A deleted namespace cannot grant another writer epoch, even to the
+        // writer recorded in its tombstone.
         if head.state == NamespaceState::Deleted {
             return Err(WriterEpochAcquireError::NamespaceDeleted {
                 namespace_id: head.namespace_id.clone(),

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -489,22 +489,13 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .session()
             .active_deletions_page(start_after, request.limit.limit_plus_one())
             .await?;
-        let has_more = deletions.len() > request.limit.as_usize();
-        if has_more {
-            deletions.truncate(request.limit.as_usize());
-        }
-        let next_cursor = if has_more {
-            let last = deletions
-                .last()
-                .expect("non-zero page limit with more entries must return an item");
-            Some(TrashPageCursor {
+        let next_cursor = request
+            .limit
+            .finish_page(&mut deletions, |last| TrashPageCursor {
                 head_seq: self.head.seq,
                 last_deleted_at_seq: last.deleted_at_seq,
                 last_root_inode_id: last.root_inode_id,
-            })
-        } else {
-            None
-        };
+            });
         // The entry keeps parent, key, and name as separate optional fields,
         // so it projects all three out of the one binding the deletion
         // recorded.
@@ -566,24 +557,16 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .session()
             .revisions_for_inode_page_desc(inode_id, start_after, request.limit.limit_plus_one())
             .await?;
-        let has_more = revision_records.len() > request.limit.as_usize();
-        if has_more {
-            revision_records.truncate(request.limit.as_usize());
-        }
-        let next_cursor = if has_more {
-            let last = revision_records
-                .last()
-                .expect("non-zero page limit with more revisions must return an item");
-            Some(FileRevisionsPageCursor {
-                head_seq: self.head.seq,
-                inode_id,
-                last_revision_no: last.revision_no,
-                last_committed_seq: last.committed_seq,
-                last_revision_delta_index: last.revision_delta_index,
-            })
-        } else {
-            None
-        };
+        let next_cursor =
+            request
+                .limit
+                .finish_page(&mut revision_records, |last| FileRevisionsPageCursor {
+                    head_seq: self.head.seq,
+                    inode_id,
+                    last_revision_no: last.revision_no,
+                    last_committed_seq: last.committed_seq,
+                    last_revision_delta_index: last.revision_delta_index,
+                });
         let revisions = revision_records
             .into_iter()
             .map(|revision| FileRevision {
@@ -718,23 +701,13 @@ impl<'a, S: ObjectStore + ?Sized> LoadedMetadataView<'a, S> {
             .instrument(select_span.clone())
             .await?;
         select_span.record("list_page_children_returned", children.len() as u64);
-        let has_more = children.len() > request.limit.as_usize();
-        if has_more {
-            children.truncate(request.limit.as_usize());
-        }
-
-        let next_cursor = if has_more {
-            let last = children
-                .last()
-                .expect("non-zero page limit with more children must return an item");
-            Some(DirectoryPageCursor {
+        let next_cursor = request
+            .limit
+            .finish_page(&mut children, |last| DirectoryPageCursor {
                 head_seq: self.head.seq,
                 directory_inode_id: resolved.inode_id,
                 last_name_key: last.binding.name_key.clone(),
-            })
-        } else {
-            None
-        };
+            });
 
         let build_span = tracing::debug_span!(
             "loonfs.phase",

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -80,20 +80,17 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     }
     let batch_size = u64::try_from(candidates.len()).unwrap_or(u64::MAX);
     if view.head.namespace_id != *namespace_id {
-        return PublishBatchAgainstViewResult::unchanged(
-            (0..candidates.len())
-                .map(|_| {
-                    Err(CoreError::Internal(
-                        "publish view namespace mismatch".to_owned(),
-                    ))
-                })
-                .collect(),
-        );
+        return PublishBatchAgainstViewResult::unchanged(vec![
+            Err(CoreError::Internal(
+                "publish view namespace mismatch".to_owned()
+            ));
+            candidates.len()
+        ]);
     }
-    let mut outcomes: Vec<Option<Result<ApiCommitResponse>>> =
-        (0..candidates.len()).map(|_| None).collect();
+    let mut outcomes: Vec<Option<Result<ApiCommitResponse>>> = vec![None; candidates.len()];
     let mut session = PublishPlanningSession::new(&view.head);
-    let mut accepted: Vec<(usize, MaterializedCommit)> = Vec::new();
+    let mut accepted_indexes = Vec::new();
+    let mut accepted_commits = Vec::new();
     let mut dedup = BatchDedup::default();
 
     let prepare_span = tracing::debug_span!(
@@ -172,41 +169,38 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                         .entered();
                 session.apply_accepted_commit(&preview, &materialized.commit);
             }
-            accepted.push((index, materialized));
+            accepted_indexes.push(index);
+            accepted_commits.push(materialized);
         }
     }
     .instrument(prepare_span.clone())
     .await;
     prepare_span.record(
         "accepted_count",
-        u64::try_from(accepted.len()).unwrap_or(u64::MAX),
+        u64::try_from(accepted_commits.len()).unwrap_or(u64::MAX),
     );
     drop(prepare_span);
 
-    if accepted.is_empty() {
+    if accepted_commits.is_empty() {
         return PublishBatchAgainstViewResult::unchanged(dedup.finish(outcomes));
     }
-    let records = accepted
-        .iter()
-        .map(|(_, record)| record.clone())
-        .collect::<Vec<_>>();
-    let accepted_count = u64::try_from(records.len()).unwrap_or(u64::MAX);
+    let accepted_count = u64::try_from(accepted_commits.len()).unwrap_or(u64::MAX);
     let put_started_ms = timer.monotonic_now_ms();
     let wal = match write_batch_wal_segment(
         store,
         namespace_id,
         view,
-        &records,
+        &accepted_commits,
         batch_size,
         accepted_count,
     )
     .await
     {
         Ok(wal) => wal,
-        Err(error) => return abort_batch(outcomes, &dedup, &accepted, &error),
+        Err(error) => return abort_batch(outcomes, &dedup, &accepted_indexes, &error),
     };
 
-    let last_plan = &records
+    let last_plan = &accepted_commits
         .last()
         .expect("accepted records should be non-empty")
         .commit;
@@ -215,7 +209,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         Ok(value) => value,
         Err(error) => {
             let error = CoreError::Internal(format!("head publish preparation failed: {error}"));
-            return abort_batch(outcomes, &dedup, &accepted, &error);
+            return abort_batch(outcomes, &dedup, &accepted_indexes, &error);
         }
     };
     let elapsed_ms = timer.monotonic_now_ms().saturating_sub(put_started_ms);
@@ -224,7 +218,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             elapsed_ms,
             budget_ms: WAL_PUBLISH_BUDGET_MS,
         });
-        return abort_batch(outcomes, &dedup, &accepted, &error);
+        return abort_batch(outcomes, &dedup, &accepted_indexes, &error);
     }
     let head_etag = match cas_batch_head(
         store,
@@ -236,21 +230,25 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     .await
     {
         Ok(metadata) => metadata.etag,
-        Err(error) => return abort_batch(outcomes, &dedup, &accepted, &error),
+        Err(error) => return abort_batch(outcomes, &dedup, &accepted_indexes, &error),
     };
 
-    let records = wal.envelope.payload.records.clone();
-    for (accepted_index, (outcome_index, record)) in accepted.into_iter().enumerate() {
+    let wal_records = wal.envelope.payload.records.clone();
+    for (accepted_index, (outcome_index, record)) in accepted_indexes
+        .into_iter()
+        .zip(accepted_commits)
+        .enumerate()
+    {
         outcomes[outcome_index] = Some(Ok(ApiCommitResponse {
             namespace_id: namespace_id.clone(),
             commit_id: record.commit.commit_id,
-            committed_seq: records[accepted_index].seq,
+            committed_seq: wal_records[accepted_index].seq,
         }));
     }
     PublishBatchAgainstViewResult {
         results: dedup.finish(outcomes),
         effect: PublishViewEffect::Advanced {
-            records,
+            records: wal_records,
             head: head_publish.resulting_head,
             head_etag,
         },
@@ -264,10 +262,10 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
 fn abort_batch(
     mut outcomes: Vec<Option<Result<ApiCommitResponse>>>,
     dedup: &BatchDedup,
-    accepted: &[(usize, MaterializedCommit)],
+    accepted_indexes: &[usize],
     error: &CoreError,
 ) -> PublishBatchAgainstViewResult {
-    fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, accepted, error);
+    fail_outcomes_contingent_on_unpublished_batch(&mut outcomes, accepted_indexes, error);
     PublishBatchAgainstViewResult {
         results: dedup.finish(outcomes),
         effect: PublishViewEffect::Invalidated,
@@ -378,14 +376,14 @@ async fn cas_batch_head<S: ObjectStore + ?Sized>(
 /// their primary's final outcome.
 fn fail_outcomes_contingent_on_unpublished_batch(
     outcomes: &mut [Option<Result<ApiCommitResponse>>],
-    accepted: &[(usize, MaterializedCommit)],
+    accepted_indexes: &[usize],
     error: &CoreError,
 ) {
-    let Some(first_accepted_index) = accepted.first().map(|(index, _)| *index) else {
+    let Some(first_accepted_index) = accepted_indexes.first().copied() else {
         return;
     };
-    for (index, _) in accepted {
-        outcomes[*index] = Some(Err(error.clone()));
+    for &index in accepted_indexes {
+        outcomes[index] = Some(Err(error.clone()));
     }
     for outcome in outcomes.iter_mut().skip(first_accepted_index + 1) {
         if matches!(outcome, Some(Err(_))) {

--- a/crates/loonfs-core/src/protocol/candidates.rs
+++ b/crates/loonfs-core/src/protocol/candidates.rs
@@ -173,10 +173,6 @@ pub(super) async fn prepare_candidate_request<S: ObjectStore + ?Sized>(
 fn validate_new_primary(candidate: &CommitCandidate) -> Result<()> {
     // For new primaries, request limits precede rejected content preparation.
     candidate.validate_request_limits()?;
-    reject_failed_content_preparation(candidate)
-}
-
-fn reject_failed_content_preparation(candidate: &CommitCandidate) -> Result<()> {
     match candidate.content_preparation() {
         ContentPreparation::Ready(_) => Ok(()),
         ContentPreparation::Rejected(error) => Err(error.clone().into()),

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -37,8 +37,8 @@ use loonfs_api::v0::{
     UploadPartChecksumClaim, UploadSessionResponse, UploadSessionStatus,
 };
 use loonfs_api::wire::control::{
-    encode_control_object, ControlObjectKind, NamespaceState, ProxiedStaging,
-    UploadSessionEnvelope, UploadSessionLifecycle, UploadSessionState, UploadSessionTransport,
+    encode_control_state, ControlObjectKind, NamespaceState, ProxiedStaging,
+    UploadSessionLifecycle, UploadSessionState, UploadSessionTransport,
 };
 use loonfs_api::{
     Checksum, ChecksumAlgorithm, ContentId, ContentRef, ContentRefKind, ContentStoreId,
@@ -472,14 +472,14 @@ async fn create_upload_session<S: ObjectStore + ?Sized>(
             expires_at_ms: context.now_ms.saturating_add(UPLOAD_SESSION_LEASE_MS),
         },
     };
-    let envelope = UploadSessionEnvelope::from_state(ControlObjectKind::UploadSession, state)
-        .map_err(|err| {
-            CoreError::Internal(format!("failed to build upload session envelope: {err}"))
-        })?;
-    let encoded = encode_control_object(&envelope).map_err(|err| {
-        CoreError::Internal(format!("failed to encode upload session envelope: {err}"))
-    })?;
     let object_key = upload_session(namespace_id, &upload_id);
+    let encoded =
+        encode_control_state(ControlObjectKind::UploadSession, &state).map_err(|error| {
+            CoreError::Codec {
+                object_key: object_key.clone(),
+                message: error.to_string(),
+            }
+        })?;
     // An upload session is mutable control state, so its first lifecycle state is a conditional create.
     store
         .put_if_absent(&object_key, Bytes::from(encoded))
@@ -644,6 +644,28 @@ fn transport_name(transport: &UploadSessionTransport) -> &'static str {
     }
 }
 
+async fn read_open_proxied_session<S: ObjectStore + ?Sized>(
+    store: &S,
+    namespace_id: &NamespaceId,
+    upload_id: &UploadId,
+) -> Result<(ContentStoreId, UploadSessionState)> {
+    let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
+    let session = read_upload_session_state(store, namespace_id, upload_id).await?;
+    if let Some(error) = terminal_session_error(&session.state, upload_id.clone()) {
+        return Err(error);
+    }
+    if !matches!(
+        session.transport,
+        UploadSessionTransport::ServiceProxied { .. }
+    ) {
+        return Err(CoreError::InvalidUploadContent(format!(
+            "{} sessions must be completed after using the presigned URLs",
+            transport_name(&session.transport)
+        )));
+    }
+    Ok((content_store_id, session))
+}
+
 /// Stores bytes in a service-proxied upload session.
 ///
 /// Retries to the same session use the same object identity. Matching bytes
@@ -655,20 +677,8 @@ pub(crate) async fn upload_content<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     bytes: &[u8],
 ) -> Result<UploadContentResponse> {
-    let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
-    let loaded = read_upload_session_state(store, namespace_id, upload_id).await?;
-    if let Some(error) = terminal_session_error(&loaded.state, upload_id.clone()) {
-        return Err(error);
-    }
-    if !matches!(
-        loaded.transport,
-        UploadSessionTransport::ServiceProxied { .. }
-    ) {
-        return Err(CoreError::InvalidUploadContent(format!(
-            "{} sessions must be completed after using the presigned URLs",
-            transport_name(&loaded.transport)
-        )));
-    }
+    let (content_store_id, loaded) =
+        read_open_proxied_session(store, namespace_id, upload_id).await?;
 
     // The claim is what makes the write exclusive, so it is taken before any
     // byte is written and released by the same swap that records the result.
@@ -785,20 +795,8 @@ pub(crate) async fn upload_streamed_content<S: ObjectStore + ?Sized>(
     upload_id: &UploadId,
     body: ByteStream,
 ) -> Result<UploadContentResponse> {
-    let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
-    let loaded = read_upload_session_state(store, namespace_id, upload_id).await?;
-    if let Some(error) = terminal_session_error(&loaded.state, upload_id.clone()) {
-        return Err(error);
-    }
-    if !matches!(
-        loaded.transport,
-        UploadSessionTransport::ServiceProxied { .. }
-    ) {
-        return Err(CoreError::InvalidUploadContent(format!(
-            "{} sessions must be completed after using the presigned URLs",
-            transport_name(&loaded.transport)
-        )));
-    }
+    let (content_store_id, loaded) =
+        read_open_proxied_session(store, namespace_id, upload_id).await?;
 
     // A session that has already staged content must not have its object
     // rewritten while the answer is being worked out. Reading the body
@@ -1148,6 +1146,7 @@ pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
             let upload_id = upload_id.to_owned();
             async move {
                 let mode = upload_mode(&state.transport);
+                let abandoned = AbandonedUpload::of(&state);
                 let aborted = |aborted_at_ms| UploadSessionResponse {
                     namespace_id: namespace_id.clone(),
                     upload_id: upload_id.clone(),
@@ -1155,13 +1154,9 @@ pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
                     status: UploadSessionStatus::Aborted { aborted_at_ms },
                 };
                 match state.state {
-                    UploadSessionLifecycle::Aborted { aborted_at_ms } => {
-                        let abandoned = AbandonedUpload::of(&state);
-                        Ok(UploadSessionUpdate::Noop((
-                            aborted(aborted_at_ms),
-                            abandoned,
-                        )))
-                    }
+                    UploadSessionLifecycle::Aborted { aborted_at_ms } => Ok(
+                        UploadSessionUpdate::Noop((aborted(aborted_at_ms), abandoned)),
+                    ),
                     // Completion is final in the other direction: the
                     // content may already be published, so an abort cannot
                     // quietly succeed over it.
@@ -1169,7 +1164,6 @@ pub(crate) async fn abort_upload<S: ObjectStore + ?Sized>(
                         Err(CoreError::UploadAlreadyCompleted { upload_id })
                     }
                     UploadSessionLifecycle::Open { .. } => {
-                        let abandoned = AbandonedUpload::of(&state);
                         state.state = UploadSessionLifecycle::Aborted {
                             aborted_at_ms: now_ms,
                         };
@@ -1258,11 +1252,7 @@ pub(crate) async fn read_upload_status<S: ObjectStore + ?Sized>(
             completed_at_ms,
             content_ref,
         } => (
-            UploadSessionStatus::Completed {
-                completed_at_ms,
-                content_ref: content_ref.clone(),
-                content_token: None,
-            },
+            completed_status(&content_ref, completed_at_ms),
             receipt_within_window(
                 namespace_id,
                 content_store_id,
@@ -1311,11 +1301,7 @@ fn completed_upload(
             namespace_id: namespace_id.clone(),
             upload_id: upload_id.clone(),
             mode,
-            status: UploadSessionStatus::Completed {
-                completed_at_ms,
-                content_ref: content_ref.clone(),
-                content_token: None,
-            },
+            status: completed_status(content_ref, completed_at_ms),
         },
         prepared: PreparedContent::from_admission(ContentAdmission::for_durable_content_write(
             content_store_id.clone(),
@@ -1328,6 +1314,14 @@ fn completed_upload(
             completed_at_ms,
             now_ms,
         ),
+    }
+}
+
+fn completed_status(content_ref: &ContentRef, completed_at_ms: u64) -> UploadSessionStatus {
+    UploadSessionStatus::Completed {
+        completed_at_ms,
+        content_ref: content_ref.clone(),
+        content_token: None,
     }
 }
 

--- a/crates/loonfs-core/src/wal/frame.rs
+++ b/crates/loonfs-core/src/wal/frame.rs
@@ -23,8 +23,6 @@ pub enum WalBuildError {
         record: NamespaceId,
         segment: NamespaceId,
     },
-    #[error("WAL build base head seq mismatch: request `{request}`, plan `{plan}`")]
-    BaseHeadSeqMismatch { request: ChangeSeq, plan: ChangeSeq },
     #[error("non-contiguous WAL seq: expected `{expected}`, actual `{actual}`")]
     NonContiguousSeq {
         expected: ChangeSeq,

--- a/crates/loonfs-core/src/wal/reader.rs
+++ b/crates/loonfs-core/src/wal/reader.rs
@@ -16,6 +16,38 @@ use std::collections::{HashMap, HashSet};
 /// this is what decides how many round trips it costs.
 pub(super) const RECENT_SEGMENT_PREFETCH_CONCURRENCY: usize = 32;
 
+impl WalChainLoadRequest<'_> {
+    fn tip_and_stop(&self) -> Result<Option<(WalSegmentPointer, ChangeSeq)>, WalChainLoadError> {
+        if self.chain_base_seq > self.head_seq {
+            return Err(WalChainLoadError::InvalidSeqRange {
+                chain_base_seq: self.chain_base_seq,
+                head_seq: self.head_seq,
+            });
+        }
+        if self.chain_base_seq == self.head_seq {
+            return Ok(None);
+        }
+        let tip = self
+            .visible_tip
+            .clone()
+            .ok_or(WalChainLoadError::MissingVisibleTip {
+                namespace_id: self.namespace_id.clone(),
+                seq: self.head_seq,
+            })?;
+        if tip.end_seq != self.head_seq {
+            return Err(WalChainLoadError::TipEndSeqMismatch {
+                expected: self.head_seq,
+                actual: tip.end_seq,
+            });
+        }
+        let stop_after_seq = self.stop_after_seq.unwrap_or(self.chain_base_seq);
+        if tip.end_seq <= stop_after_seq {
+            return Ok(None);
+        }
+        Ok(Some((tip, stop_after_seq)))
+    }
+}
+
 /// The hinted segment keys that cover the replay gap, newest first.
 fn hints_in_gap(
     namespace_id: &NamespaceId,
@@ -158,35 +190,13 @@ async fn walk_chain<S: ObjectStore + ?Sized>(
     request: &WalChainLoadRequest<'_>,
     max_segment_fetches: Option<usize>,
 ) -> Result<WalkedChain, WalChainLoadError> {
-    if request.chain_base_seq > request.head_seq {
-        return Err(WalChainLoadError::InvalidSeqRange {
-            chain_base_seq: request.chain_base_seq,
-            head_seq: request.head_seq,
-        });
-    }
-    if request.chain_base_seq == request.head_seq {
+    let Some((mut pointer, stop_after_seq)) = request.tip_and_stop()? else {
         return Ok(WalkedChain {
             segments: Vec::new(),
             fetches: 0,
             limit_reached: false,
         });
-    }
-
-    let mut pointer = request
-        .visible_tip
-        .clone()
-        .ok_or(WalChainLoadError::MissingVisibleTip {
-            namespace_id: request.namespace_id.clone(),
-            seq: request.head_seq,
-        })?;
-    if pointer.end_seq != request.head_seq {
-        return Err(WalChainLoadError::TipEndSeqMismatch {
-            expected: request.head_seq,
-            actual: pointer.end_seq,
-        });
-    }
-
-    let stop_after_seq = request.stop_after_seq.unwrap_or(request.chain_base_seq);
+    };
     let in_gap = hints_in_gap(
         request.namespace_id,
         &pointer,
@@ -338,34 +348,11 @@ fn validate_pointer_matches_envelope(
     fields(phase = "count_wal_tail_segments", key_class = "wal_segment")
 )]
 pub(crate) fn count_visible_wal_tail_segments(
-    request: WalChainLoadRequest<'_>,
+    request: &WalChainLoadRequest<'_>,
 ) -> Result<u64, WalChainLoadError> {
-    if request.chain_base_seq > request.head_seq {
-        return Err(WalChainLoadError::InvalidSeqRange {
-            chain_base_seq: request.chain_base_seq,
-            head_seq: request.head_seq,
-        });
-    }
-    if request.chain_base_seq == request.head_seq {
+    let Some((tip, stop_after_seq)) = request.tip_and_stop()? else {
         return Ok(0);
-    }
-    let tip = request
-        .visible_tip
-        .clone()
-        .ok_or(WalChainLoadError::MissingVisibleTip {
-            namespace_id: request.namespace_id.clone(),
-            seq: request.head_seq,
-        })?;
-    if tip.end_seq != request.head_seq {
-        return Err(WalChainLoadError::TipEndSeqMismatch {
-            expected: request.head_seq,
-            actual: tip.end_seq,
-        });
-    }
-    let stop_after_seq = request.stop_after_seq.unwrap_or(request.chain_base_seq);
-    if tip.end_seq <= stop_after_seq {
-        return Ok(0);
-    }
+    };
 
     let mut count: u64 = 1;
     // Oldest pointer counted so far: the run has to keep descending from

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -163,8 +163,8 @@ fn replay_next_inode_id_from_commit_deltas(
                 WalDelta::CreateInode { inode_id, .. } => {
                     InodeId(next_inode_id.0.max(inode_id.0.saturating_add(1)))
                 }
-                // Every other delta names an inode that already exists, so none
-                // of them moves the allocation counter.
+                // Other delta types reference existing inodes and do not
+                // allocate IDs.
                 WalDelta::BindDirentry { .. }
                 | WalDelta::UnbindDirentry { .. }
                 | WalDelta::AppendFileRevision { .. }

--- a/crates/loonfs-core/src/wal/replay.rs
+++ b/crates/loonfs-core/src/wal/replay.rs
@@ -152,29 +152,25 @@ pub(super) fn validate_wal_segment_for_replay(
     Ok(())
 }
 
-fn replay_next_inode_id(current_next_inode_id: InodeId, deltas: &[WalDelta]) -> InodeId {
-    deltas
-        .iter()
-        .fold(current_next_inode_id, |next_inode_id, delta| match delta {
-            WalDelta::CreateInode { inode_id, .. } => {
-                InodeId(next_inode_id.0.max(inode_id.0.saturating_add(1)))
-            }
-            // Every other delta names an inode that already exists, so none
-            // of them moves the allocation counter.
-            WalDelta::BindDirentry { .. }
-            | WalDelta::UnbindDirentry { .. }
-            | WalDelta::AppendFileRevision { .. }
-            | WalDelta::TombstoneSubtree { .. }
-            | WalDelta::RevokeSubtreeTombstone { .. }
-            | WalDelta::AppendAttributesRevision { .. } => next_inode_id,
-        })
-}
-
 fn replay_next_inode_id_from_commit_deltas(
     current_next_inode_id: InodeId,
     deltas: &[WalCommitDelta],
 ) -> InodeId {
-    deltas.iter().fold(current_next_inode_id, |next, delta| {
-        replay_next_inode_id(next, std::slice::from_ref(&delta.delta))
-    })
+    deltas
+        .iter()
+        .fold(current_next_inode_id, |next_inode_id, delta| {
+            match &delta.delta {
+                WalDelta::CreateInode { inode_id, .. } => {
+                    InodeId(next_inode_id.0.max(inode_id.0.saturating_add(1)))
+                }
+                // Every other delta names an inode that already exists, so none
+                // of them moves the allocation counter.
+                WalDelta::BindDirentry { .. }
+                | WalDelta::UnbindDirentry { .. }
+                | WalDelta::AppendFileRevision { .. }
+                | WalDelta::TombstoneSubtree { .. }
+                | WalDelta::RevokeSubtreeTombstone { .. }
+                | WalDelta::AppendAttributesRevision { .. } => next_inode_id,
+            }
+        })
 }

--- a/crates/loonfs-core/src/wal/tests.rs
+++ b/crates/loonfs-core/src/wal/tests.rs
@@ -945,7 +945,7 @@ fn tail_count_from_contiguous_hints_covers_the_longest_legal_tail() {
     let chain = prepared_unstored_chain(&namespace_id, boundary);
     let hints = newest_first_pointers(&chain);
 
-    let count = count_visible_wal_tail_segments(tail_count_request(
+    let count = count_visible_wal_tail_segments(&tail_count_request(
         &namespace_id,
         ChangeSeq(0),
         ChangeSeq(boundary),
@@ -956,7 +956,7 @@ fn tail_count_from_contiguous_hints_covers_the_longest_legal_tail() {
 
     // A manifest boundary inside the hinted window is honored: only the
     // segments above it are tail.
-    let count = count_visible_wal_tail_segments(tail_count_request(
+    let count = count_visible_wal_tail_segments(&tail_count_request(
         &namespace_id,
         ChangeSeq(boundary - 1),
         ChangeSeq(boundary),
@@ -966,7 +966,7 @@ fn tail_count_from_contiguous_hints_covers_the_longest_legal_tail() {
     assert_eq!(count, 1);
 
     // An empty tail costs nothing and consults nothing.
-    let count = count_visible_wal_tail_segments(tail_count_request(
+    let count = count_visible_wal_tail_segments(&tail_count_request(
         &namespace_id,
         ChangeSeq(boundary),
         ChangeSeq(boundary),
@@ -987,7 +987,7 @@ fn wal_tail_segment_count_is_identical_across_head_hint_reshape() {
     let former_public_count =
         u64::try_from(former_tip_inclusive_hints.len()).expect("test tail count");
 
-    let reshaped_count = count_visible_wal_tail_segments(tail_count_request(
+    let reshaped_count = count_visible_wal_tail_segments(&tail_count_request(
         &namespace_id,
         ChangeSeq(0),
         ChangeSeq(4),
@@ -1001,7 +1001,7 @@ fn wal_tail_segment_count_is_identical_across_head_hint_reshape() {
 #[test]
 fn tail_count_at_genesis_is_zero_without_tip_or_hints() {
     let namespace_id = NamespaceId::parse("demo").expect("valid namespace id");
-    let count = count_visible_wal_tail_segments(WalChainLoadRequest {
+    let count = count_visible_wal_tail_segments(&WalChainLoadRequest {
         namespace_id: &namespace_id,
         chain_base_seq: ChangeSeq(0),
         head_seq: ChangeSeq(0),
@@ -1025,7 +1025,7 @@ fn tail_count_rejects_a_head_that_does_not_describe_its_tail() {
     let head_seq = ChangeSeq(4);
 
     // A run that stops short of the basis boundary.
-    let error = count_visible_wal_tail_segments(tail_count_request(
+    let error = count_visible_wal_tail_segments(&tail_count_request(
         &namespace_id,
         ChangeSeq(0),
         head_seq,
@@ -1047,7 +1047,7 @@ fn tail_count_rejects_a_head_that_does_not_describe_its_tail() {
         pointers[2].clone(),
         pointers[3].clone(),
     ];
-    let error = count_visible_wal_tail_segments(tail_count_request(
+    let error = count_visible_wal_tail_segments(&tail_count_request(
         &namespace_id,
         ChangeSeq(0),
         head_seq,
@@ -1075,7 +1075,7 @@ async fn tail_count_and_chain_load_agree_where_the_head_describes_the_tail() {
     let pointers = newest_first_pointers(&chain);
 
     let request = tail_count_request(&namespace_id, ChangeSeq(0), ChangeSeq(3), &pointers);
-    let count = count_visible_wal_tail_segments(request.clone()).expect("count tail");
+    let count = count_visible_wal_tail_segments(&request).expect("count tail");
     let loaded = load_validated_wal_chain(&store, request)
         .await
         .expect("load chain");
@@ -1086,7 +1086,7 @@ async fn tail_count_and_chain_load_agree_where_the_head_describes_the_tail() {
         recent_segments: &[],
         ..tail_count_request(&namespace_id, ChangeSeq(0), ChangeSeq(3), &pointers)
     };
-    count_visible_wal_tail_segments(unhinted.clone())
+    count_visible_wal_tail_segments(&unhinted)
         .expect_err("an unhinted head describes no tail to count");
     let loaded = load_validated_wal_chain(&store, unhinted)
         .await

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -97,8 +97,7 @@ impl GrepService {
         namespace_id: &NamespaceId,
     ) -> Result<MaterializedGrepIndexSnapshot> {
         let pointer = load_grep_root_pointer(store, namespace_id)
-            .await
-            .map_err(GrepError::from)?
+            .await?
             .ok_or(GrepError::NotEnabled)?;
         let manifest_id = pointer.pointer().manifest_id();
         let cache_key = GrepBlockCacheKey {
@@ -110,8 +109,7 @@ impl GrepService {
             .block_cache
             .get_or_load(&cache_key, || async {
                 let manifest = load_grep_manifest(store, namespace_id, pointer.pointer())
-                    .await
-                    .map_err(GrepError::from)?
+                    .await?
                     .ok_or_else(|| GrepError::CorruptIndex {
                         message: format!(
                             "grep root `{}` names missing manifest `{}`",

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -460,7 +460,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             .map(|root| root.manifest_state().clone()))
     }
 
-    /// Projects the durable grep root into its public lifecycle summary.
+    /// Returns the public lifecycle summary for the durable grep root.
     pub async fn index_status(
         &self,
         namespace_id: &NamespaceId,
@@ -472,8 +472,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
                 root.index().next_run_ordinal,
                 root.index().reorganize.is_some(),
             ),
-            // No root was ever published, which is the same answer as a root
-            // that was disabled: nothing is being maintained here.
+            // A missing root means indexing has not been enabled.
             None => (GrepIndexLifecycle::Disabled, 0, false),
         };
         Ok(GrepIndexStatusResponse {

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -27,6 +27,7 @@ use loonfs::{
     FsReader, PassBudget, RuntimeError, StoreFailureClass, DEFAULT_GC_MAX_OBJECTS,
     GC_MIN_GRACE_WINDOW_MS, METADATA_PUBLICATION_BUDGET_MS,
 };
+use loonfs_api::v0::{GrepIndexLifecycle, GrepIndexStatusResponse};
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::sst_blocks::{
     index_blocks_for_key_range, DecodedDataBlock, SegmentBlocksBuilder, SegmentIndexEntry,
@@ -95,16 +96,12 @@ pub struct GramIndexBuildPolicy {
 impl Default for GramIndexBuildPolicy {
     fn default() -> Self {
         Self {
-            max_files_per_step: NonZeroUsize::new(256)
-                .expect("default file budget should be nonzero"),
-            max_content_bytes_per_step: NonZeroU64::new(64 * 1024 * 1024)
-                .expect("default content budget should be nonzero"),
-            max_rows_per_segment: NonZeroUsize::new(65_536)
-                .expect("default segment row budget should be nonzero"),
-            max_l0_runs: NonZeroUsize::new(8).expect("default delta run limit should be nonzero"),
-            max_mid_runs: NonZeroUsize::new(8).expect("default mid run limit should be nonzero"),
-            max_decoded_input_rows_per_step: NonZeroUsize::new(131_072)
-                .expect("default reorganize row budget should be nonzero"),
+            max_files_per_step: const { NonZeroUsize::new(256).unwrap() },
+            max_content_bytes_per_step: const { NonZeroU64::new(64 * 1024 * 1024).unwrap() },
+            max_rows_per_segment: const { NonZeroUsize::new(65_536).unwrap() },
+            max_l0_runs: const { NonZeroUsize::new(8).unwrap() },
+            max_mid_runs: const { NonZeroUsize::new(8).unwrap() },
+            max_decoded_input_rows_per_step: const { NonZeroUsize::new(131_072).unwrap() },
         }
     }
 }
@@ -269,10 +266,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     /// Enables grep by pinning a checkpoint and CAS-publishing a fresh
     /// backfilling root. Enabling an active root is idempotent.
     pub async fn enable(&self, namespace_id: &NamespaceId) -> Result<GrepEnableOutcome> {
-        if let Some(current) = load_grep_root(&self.store, namespace_id)
-            .await
-            .map_err(GrepError::from)?
-        {
+        if let Some(current) = load_grep_root(&self.store, namespace_id).await? {
             if !matches!(
                 current.manifest_state().lifecycle(),
                 GrepLifecycle::Disabled
@@ -344,10 +338,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     /// candidates and are never deleted synchronously.
     pub async fn disable(&self, namespace_id: &NamespaceId) -> Result<GrepDisableOutcome> {
         ensure_live_namespace(&self.reads(namespace_id)).await?;
-        let Some(current) = load_grep_root(&self.store, namespace_id)
-            .await
-            .map_err(GrepError::from)?
-        else {
+        let Some(current) = load_grep_root(&self.store, namespace_id).await? else {
             return Ok(GrepDisableOutcome::NotEnabled);
         };
         if matches!(
@@ -366,7 +357,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             GrepIndexState::new(None, current.manifest_state().index().next_run_ordinal),
             Vec::new(),
         )
-        .map_err(core_state_error)?;
+        .map_err(|error| core_state_error(namespace_id, error))?;
         match self.advance_root(&current, &next).await {
             Ok(_) => {
                 if let Some(checkpoint_id) = checkpoint_id {
@@ -386,10 +377,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         policy: GramIndexBuildPolicy,
     ) -> Result<GrepBuildReport> {
-        let Some(current) = load_grep_root(&self.store, namespace_id)
-            .await
-            .map_err(GrepError::from)?
-        else {
+        let Some(current) = load_grep_root(&self.store, namespace_id).await? else {
             return Ok(build_report(namespace_id, GrepBuildOutcome::NotEnabled));
         };
         let reads = self.reads(namespace_id);
@@ -455,8 +443,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     /// and a caller waiting on a captured target both ask.
     pub async fn lifecycle(&self, namespace_id: &NamespaceId) -> Result<GrepLifecycle> {
         Ok(load_grep_root(&self.store, namespace_id)
-            .await
-            .map_err(GrepError::from)?
+            .await?
             .map_or(GrepLifecycle::Disabled, |root| {
                 root.manifest_state().lifecycle().clone()
             }))
@@ -469,9 +456,32 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
     ) -> Result<Option<GrepManifestState>> {
         Ok(load_grep_root(&self.store, namespace_id)
-            .await
-            .map_err(GrepError::from)?
+            .await?
             .map(|root| root.manifest_state().clone()))
+    }
+
+    /// Projects the durable grep root into its public lifecycle summary.
+    pub async fn index_status(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<GrepIndexStatusResponse> {
+        let root = self.root_state(namespace_id).await?;
+        let (lifecycle, next_run_ordinal, reorganize_pending) = match &root {
+            Some(root) => (
+                GrepIndexLifecycle::from(root.lifecycle()),
+                root.index().next_run_ordinal,
+                root.index().reorganize.is_some(),
+            ),
+            // No root was ever published, which is the same answer as a root
+            // that was disabled: nothing is being maintained here.
+            None => (GrepIndexLifecycle::Disabled, 0, false),
+        };
+        Ok(GrepIndexStatusResponse {
+            namespace_id: namespace_id.clone(),
+            lifecycle,
+            next_run_ordinal,
+            reorganize_pending,
+        })
     }
 
     async fn seed_root(
@@ -649,7 +659,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             ),
             segments,
         )
-        .map_err(core_state_error)?;
+        .map_err(|error| core_state_error(namespace_id, error))?;
         ensure_publication_budget(&timer, publication_started_ms)?;
         match self.advance_root(&current, &next).await {
             Ok(_) => {
@@ -699,7 +709,7 @@ fn backfilling_root(
         GrepIndexState::new(None, next_run_ordinal),
         Vec::new(),
     )
-    .map_err(core_state_error)
+    .map_err(|error| core_state_error(namespace_id, error))
 }
 
 /// The two answers that mean "the state this projection was built from is
@@ -1094,10 +1104,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
         namespace_id: &NamespaceId,
         policy: GramIndexBuildPolicy,
     ) -> Result<GrepReorganizeReport> {
-        let Some(current) = load_grep_root(&self.store, namespace_id)
-            .await
-            .map_err(GrepError::from)?
-        else {
+        let Some(current) = load_grep_root(&self.store, namespace_id).await? else {
             return Ok(reorganize_report(
                 namespace_id,
                 GrepReorganizeOutcome::NotEnabled,
@@ -1240,7 +1247,7 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
             GrepIndexState::new(reorganize, next_run_ordinal),
             segments,
         )
-        .map_err(core_state_error)?;
+        .map_err(|error| core_state_error(namespace_id, error))?;
         ensure_publication_budget(&timer, publication_started_ms)?;
         match self.advance_root(&current, &next).await {
             Ok(_) => Ok(reorganize_report(
@@ -1790,8 +1797,15 @@ fn ensure_publication_budget(timer: &impl MonotonicTimer, started_ms: u64) -> Re
     .into())
 }
 
-fn core_state_error(error: crate::root::GrepManifestStateError) -> GrepError {
-    CoreError::Internal(format!("failed to build grep root state: {error}")).into()
+fn core_state_error(
+    namespace_id: &NamespaceId,
+    error: crate::root::GrepManifestStateError,
+) -> GrepError {
+    CoreError::Codec {
+        object_key: root_key(namespace_id),
+        message: error.to_string(),
+    }
+    .into()
 }
 
 fn next_grep_run_ordinal(current: u64) -> Result<u64> {

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -546,7 +546,7 @@ impl ServerConfig {
             });
         }
         require_non_empty("content_token_secret", self.content_token_secret.expose())?;
-        self.store.validate().map_err(ServerConfigError::from)?;
+        self.store.validate()?;
 
         Ok(())
     }

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -26,9 +26,9 @@ use loonfs_api::ApiError;
 use loonfs_api::{
     decode_cursor,
     v0::{ChangesResponse, CommitResponse as ApiCommitResponse},
-    CommitRequest as ApiCommitRequest, DirectoryPageCursor, FileRevisionsPageCursor,
-    FilesystemOperation, LimitError, ListFileRevisionsResponse, ListTrashResponse, PageCursorError,
-    PageRequest, PaginationPolicy, PublicOrdinalRangeError, RevisionNo,
+    CommitRequest as ApiCommitRequest, FilesystemOperation, LimitError, ListFileRevisionsResponse,
+    ListTrashResponse, PageCursorError, PageRequest, PaginationPolicy, PublicOrdinalRangeError,
+    RevisionNo,
 };
 use std::convert::Infallible;
 use std::pin::Pin;
@@ -213,7 +213,7 @@ pub(super) async fn list_path_entries(
             &path,
             PageRequest {
                 limit: resolve_page_limit(query.limit)?,
-                cursor: decode_directory_page_cursor(query.cursor)?,
+                cursor: decode_optional_cursor(query.cursor)?,
             },
             options,
         )
@@ -415,7 +415,7 @@ pub(super) async fn list_file_revisions(
             &path,
             PageRequest {
                 limit: resolve_page_limit(query.limit)?,
-                cursor: decode_file_revisions_page_cursor(query.cursor)?,
+                cursor: decode_optional_cursor(query.cursor)?,
             },
         )
         .await
@@ -648,29 +648,9 @@ fn parse_page_limit(value: &str) -> Result<u32, ApiResponseError> {
     })
 }
 
-fn decode_directory_page_cursor(
-    cursor: Option<String>,
-) -> Result<Option<DirectoryPageCursor>, ApiResponseError> {
-    cursor
-        .as_deref()
-        .map(decode_cursor)
-        .transpose()
-        .map_err(page_cursor_response_error)
-}
-
-fn decode_optional_cursor<C: loonfs_api::PageCursor>(
+pub(super) fn decode_optional_cursor<C: loonfs_api::PageCursor>(
     cursor: Option<String>,
 ) -> Result<Option<C>, ApiResponseError> {
-    cursor
-        .as_deref()
-        .map(decode_cursor)
-        .transpose()
-        .map_err(page_cursor_response_error)
-}
-
-pub(super) fn decode_file_revisions_page_cursor(
-    cursor: Option<String>,
-) -> Result<Option<FileRevisionsPageCursor>, ApiResponseError> {
     cursor
         .as_deref()
         .map(decode_cursor)

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -2,7 +2,7 @@
 
 use super::error::ApiResponseError;
 use super::handlers_filesystem::{
-    buffered_download_response, decode_file_revisions_page_cursor, parse_include_attributes,
+    buffered_download_response, decode_optional_cursor, parse_include_attributes,
     parse_revision_no, resolve_page_limit, PageQuery,
 };
 use super::{authorize, AppPath, AppQuery, AppState, NamespaceIdPath};
@@ -132,7 +132,7 @@ pub(super) async fn list_file_revisions_by_inode(
             inode_id,
             PageRequest::<FileRevisionsPageCursor> {
                 limit: resolve_page_limit(query.limit)?,
-                cursor: decode_file_revisions_page_cursor(query.cursor)?,
+                cursor: decode_optional_cursor(query.cursor)?,
             },
         )
         .await

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -7,8 +7,7 @@ use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::Json;
 use loonfs_api::v0::{
-    GrepGcRequest, GrepGcResponse, GrepIndexLifecycle, GrepIndexStatusResponse, GrepRequest,
-    GrepResponse,
+    GrepGcRequest, GrepGcResponse, GrepIndexStatusResponse, GrepRequest, GrepResponse,
 };
 #[cfg(feature = "openapi")]
 use loonfs_api::ApiError;
@@ -183,29 +182,13 @@ async fn read_grep_index_status(
     state: &AppState,
     namespace_id: &NamespaceId,
 ) -> Result<GrepIndexStatusResponse, ApiResponseError> {
-    let root = state
+    state
         .grep_worker
         .as_ref()
         .expect("grep routes should carry a grep worker")
-        .root_state(namespace_id)
+        .index_status(namespace_id)
         .await
-        .map_err(|error| map_grep_error(namespace_id, error))?;
-    let (lifecycle, next_run_ordinal, reorganize_pending) = match &root {
-        Some(root) => (
-            GrepIndexLifecycle::from(root.lifecycle()),
-            root.index().next_run_ordinal,
-            root.index().reorganize.is_some(),
-        ),
-        // No root was ever published, which is the same answer as a root
-        // that was disabled: nothing is being maintained here.
-        None => (GrepIndexLifecycle::Disabled, 0, false),
-    };
-    Ok(GrepIndexStatusResponse {
-        namespace_id: namespace_id.clone(),
-        lifecycle,
-        next_run_ordinal,
-        reorganize_pending,
-    })
+        .map_err(|error| map_grep_error(namespace_id, error))
 }
 
 #[cfg_attr(

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -479,6 +479,17 @@ fn content_token_error(error: ContentTokenError) -> ApiResponseError {
     )
 }
 
+fn with_content_token(
+    mut response: UploadSessionResponse,
+    verifier: ContentTokenVerifier<'_>,
+    receipt: Option<&CompletedUploadReceipt>,
+) -> Result<UploadSessionResponse, ApiResponseError> {
+    if let UploadSessionStatus::Completed { content_token, .. } = &mut response.status {
+        *content_token = verifier.mint_receipt(receipt)?;
+    }
+    Ok(response)
+}
+
 #[allow(clippy::disallowed_methods)]
 pub(super) fn current_unix_ms() -> Result<u64, ApiResponseError> {
     // Request timestamps enter wall time at this HTTP API boundary so core
@@ -606,12 +617,11 @@ pub(super) async fn complete_upload(
         })
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    let mut response = completed.response;
-    if let UploadSessionStatus::Completed { content_token, .. } = &mut response.status {
-        *content_token = ContentTokenVerifier::new(state.config.content_token_secret())
-            .mint_receipt(completed.receipt.as_ref())?;
-    }
-    Ok(Json(response))
+    Ok(Json(with_content_token(
+        completed.response,
+        ContentTokenVerifier::new(state.config.content_token_secret()),
+        completed.receipt.as_ref(),
+    )?))
 }
 
 fn decode_completion_body(
@@ -799,16 +809,16 @@ pub(super) async fn read_upload_status(
     let namespace_id = namespace_id_path.into_id()?;
     let UploadPathParams { upload_id } = path.into_params()?;
     let upload_id = parse_upload_id(&upload_id)?;
-    let (mut response, receipt) = state
+    let (response, receipt) = state
         .writer
         .read_upload_status(&namespace_id, &upload_id)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
-    if let UploadSessionStatus::Completed { content_token, .. } = &mut response.status {
-        *content_token = ContentTokenVerifier::new(state.config.content_token_secret())
-            .mint_receipt(receipt.as_ref())?;
-    }
-    Ok(Json(response))
+    Ok(Json(with_content_token(
+        response,
+        ContentTokenVerifier::new(state.config.content_token_secret()),
+        receipt.as_ref(),
+    )?))
 }
 
 #[cfg_attr(

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -14,9 +14,9 @@ use crate::{
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
     encode_cursor, CapabilityDocument, EffectiveLimit, FileRevision, FileRevisionsPageCursor, Page,
-    PaginationPolicy, FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_NAMESPACES_CREATE,
-    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART,
-    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_CONTENT_TOKENS,
+    PageCursor, PaginationPolicy, FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET,
+    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
+    FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_CONTENT_TOKENS,
     LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS, LIMIT_COMMIT_MAX_MESSAGE_BYTES,
     LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_GC_MIN_GRACE_WINDOW_MS, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
     PROTOCOL_VERSION,
@@ -303,6 +303,15 @@ pub(super) fn default_page_limit() -> EffectiveLimit {
         .expect("default pagination policy must resolve its default limit")
 }
 
+pub(super) fn encode_next_cursor<C: PageCursor>(
+    cursor: Option<&C>,
+) -> std::result::Result<Option<String>, CoreError> {
+    cursor
+        .map(encode_cursor)
+        .transpose()
+        .map_err(|error| CoreError::InvalidCursor(error.to_string()))
+}
+
 pub(super) fn file_revisions_page_response(
     namespace_id: NamespaceId,
     head_seq: ChangeSeq,
@@ -318,12 +327,7 @@ pub(super) fn file_revisions_page_response(
         .ok_or_else(|| {
             CoreError::InvalidCursor("empty revision page lacks inode identity".into())
         })?;
-    let next_cursor = page
-        .next_cursor
-        .as_ref()
-        .map(encode_cursor)
-        .transpose()
-        .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+    let next_cursor = encode_next_cursor(page.next_cursor.as_ref())?;
     Ok(ListFileRevisionsResponse {
         namespace_id,
         inode_id,

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -9,14 +9,13 @@ use crate::maintenance_runner::CompactionStart;
 use crate::FsAdmin;
 use crate::NamespaceStatusResponse;
 use crate::{
-    AdvanceRetentionResponse, CheckpointId, CoreError, CreateCheckpointOptions,
-    CreateCheckpointResponse, ErrorCode, FlushWalOutcome, FlushWalResponse,
-    ListCheckpointsResponse, MaintenancePlan, MaintenanceStepResponse, MetadataMaintenanceOptions,
-    MetadataMaintenanceResponse, NamespaceId, ReleaseCheckpointResponse, ReorganizeStepOutcome,
-    SharedObjectStore, WalFlushStepOutcome,
+    AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
+    ErrorCode, FlushWalOutcome, FlushWalResponse, ListCheckpointsResponse, MaintenancePlan,
+    MaintenanceStepResponse, MetadataMaintenanceOptions, MetadataMaintenanceResponse, NamespaceId,
+    ReleaseCheckpointResponse, ReorganizeStepOutcome, SharedObjectStore, WalFlushStepOutcome,
 };
 use crate::{ChangeSeq, Result, RuntimeError};
-use loonfs_api::{encode_cursor, PageRequest};
+use loonfs_api::PageRequest;
 use loonfs_core::cache::{load_namespace_fold_basis, load_namespace_head_summary};
 use loonfs_core::CheckpointPageCursor;
 use tokio::time::Instant;
@@ -653,11 +652,7 @@ impl FsAdmin {
         let (mut response, next_cursor) = self
             .list_checkpoints_page_typed(namespace_id, request)
             .await?;
-        response.next_cursor = next_cursor
-            .as_ref()
-            .map(encode_cursor)
-            .transpose()
-            .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+        response.next_cursor = super::core::encode_next_cursor(next_cursor.as_ref())?;
         Ok(response)
     }
 

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -2,7 +2,7 @@
 //! change feed, and the whole-namespace reads a consumer that derives its
 //! own data from the filesystem walks.
 
-use super::core::{default_page_limit, file_revisions_page_response};
+use super::core::{default_page_limit, encode_next_cursor, file_revisions_page_response};
 use crate::downloads::{DirectDownloadByInodeTarget, DirectDownloadTarget};
 use crate::FsReader;
 use crate::Result;
@@ -14,8 +14,7 @@ use crate::{
     RevisionNo, RuntimeError, SharedObjectStore, StatPathOptions,
 };
 use loonfs_api::{
-    encode_cursor, AbsolutePath, DirectoryPageCursor, FileRevisionsPageCursor, PageRequest,
-    PaginationPolicy,
+    AbsolutePath, DirectoryPageCursor, FileRevisionsPageCursor, PageRequest, PaginationPolicy,
 };
 
 impl FsReader {
@@ -144,11 +143,7 @@ impl FsReader {
         let (mut response, next_cursor) = self
             .list_path_entries_page_typed(namespace_id, absolute_path, request, options)
             .await?;
-        response.next_cursor = next_cursor
-            .as_ref()
-            .map(encode_cursor)
-            .transpose()
-            .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+        response.next_cursor = encode_next_cursor(next_cursor.as_ref())?;
         Ok(response)
     }
 
@@ -383,12 +378,7 @@ impl FsReader {
             .inner
             .cache_stats
             .record_latest_metadata_view_read();
-        let next_cursor = page
-            .next_cursor
-            .as_ref()
-            .map(encode_cursor)
-            .transpose()
-            .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+        let next_cursor = encode_next_cursor(page.next_cursor.as_ref())?;
         Ok(loonfs_api::ListTrashResponse {
             namespace_id: namespace_id.clone(),
             head_seq: read_context.head.seq,

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -52,8 +52,9 @@ pub struct MetadataMaintenanceOptions {
 impl Default for MetadataMaintenanceOptions {
     fn default() -> Self {
         Self {
-            max_wal_tail_segments: NonZeroU64::new(WalTailPolicy::DEFAULT.checkpoint_at_segments)
-                .expect("the default flush threshold is non-zero"),
+            max_wal_tail_segments: const {
+                NonZeroU64::new(WalTailPolicy::DEFAULT.checkpoint_at_segments).unwrap()
+            },
         }
     }
 }
@@ -199,8 +200,7 @@ pub struct ReadFileStreamOptions {
 impl Default for ReadFileStreamOptions {
     fn default() -> Self {
         Self {
-            chunk_bytes: NonZeroU64::new(loonfs_core::CONTENT_READ_CHUNK_BYTES)
-                .expect("the default read chunk size is non-zero"),
+            chunk_bytes: const { NonZeroU64::new(loonfs_core::CONTENT_READ_CHUNK_BYTES).unwrap() },
             start_offset: 0,
         }
     }

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1101,18 +1101,17 @@ impl NamespacePublisher {
     // Monotonic time is used only to wait between CAS attempts.
     async fn await_cas_slot(&self, claim: bool) {
         loop {
-            let sleep_until = self.lock_state().next_allowed_cas_at;
-            let arrived = sleep_until.is_none_or(|instant| instant <= Instant::now());
-            if arrived {
-                if claim {
-                    let mut state = self.lock_state();
-                    state.next_allowed_cas_at = Some(Instant::now() + self.min_publish_interval);
-                }
-                return;
+            let Some(sleep_until) = self.lock_state().next_allowed_cas_at else {
+                break;
+            };
+            if sleep_until <= Instant::now() {
+                break;
             }
-            if let Some(sleep_until) = sleep_until {
-                tokio::time::sleep_until(sleep_until).await;
-            }
+            tokio::time::sleep_until(sleep_until).await;
+        }
+        if claim {
+            let mut state = self.lock_state();
+            state.next_allowed_cas_at = Some(Instant::now() + self.min_publish_interval);
         }
     }
 


### PR DESCRIPTION
This removes duplicate helpers and repeated control flow from the read and publish paths. Pagination now has one over-fetch finalizer, WAL loading has one implementation of its tip and stop validation, checkpoint records have one API projection, grep status has one projection, and upload-session guards are shared instead of repeated.

Control-object writers now use one encode_control_state helper. Codec failures also use CoreError::Codec so they retain the relevant object key while keeping the existing server_error wire code. The validation view, commit publisher, and several handlers now call their underlying APIs directly instead of going through pass-through wrappers.

The workspace test suite, clippy, rustfmt, and OpenAPI checks pass.