### PR TITLE
docs: make the traces, specs, and hidden seams tell the truth

### DIFF
--- a/crates/loonfs-api/src/public_inode_id.rs
+++ b/crates/loonfs-api/src/public_inode_id.rs
@@ -116,7 +116,10 @@ pub mod option {
 
 /// Builds the OpenAPI schema for a public inode ID.
 #[cfg(feature = "openapi")]
-#[allow(deprecated)]
+#[allow(
+    deprecated,
+    reason = "the published schema uses the requested singular example field"
+)]
 pub fn schema() -> utoipa::openapi::schema::Object {
     utoipa::openapi::schema::Object::builder()
         .schema_type(utoipa::openapi::schema::Type::String)

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -48,15 +48,11 @@ use payload::PartReader;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-/// Payload size from which a put stops holding its bytes whole.
+/// Minimum payload size for streaming uploads.
 ///
-/// It mirrors
-/// `loonfs_objectstore::provider_object_store::PROVIDER_MULTIPART_PART_BYTES`,
-/// and that one number answers two questions the same way: below it a direct
-/// multipart upload would be a one-part upload with extra round trips and
-/// nothing to gain, and a payload that fits in a single part is not worth
-/// streaming either. At or above it — and for any payload whose length is not
-/// known in advance — a put reads its source once, in bounded pieces.
+/// This matches the server's multipart part size. Smaller known-length
+/// payloads are buffered because streaming would add overhead without
+/// reducing peak memory below one part.
 pub const STREAMING_PUT_MIN_BYTES: u64 = 8 * 1024 * 1024;
 
 /// Parts in flight at once. Each holds its bytes, so a one-pass upload's

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -50,12 +50,13 @@ use std::time::Duration;
 
 /// Payload size from which a put stops holding its bytes whole.
 ///
-/// It mirrors the server's multipart part size, and that one number answers
-/// two questions the same way: below it a direct multipart upload would be a
-/// one-part upload with extra round trips and nothing to gain, and a payload
-/// that fits in a single part is not worth streaming either. At or above it
-/// — and for any payload whose length is not known in advance — a put reads
-/// its source once, in bounded pieces.
+/// It mirrors
+/// `loonfs_objectstore::provider_object_store::PROVIDER_MULTIPART_PART_BYTES`,
+/// and that one number answers two questions the same way: below it a direct
+/// multipart upload would be a one-part upload with extra round trips and
+/// nothing to gain, and a payload that fits in a single part is not worth
+/// streaming either. At or above it — and for any payload whose length is not
+/// known in advance — a put reads its source once, in bounded pieces.
 pub const STREAMING_PUT_MIN_BYTES: u64 = 8 * 1024 * 1024;
 
 /// Parts in flight at once. Each holds its bytes, so a one-pass upload's

--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -97,7 +97,7 @@ pub(super) struct MetadataSstRows {
     name = "loonfs.phase",
     err(level = "warn"),
     skip_all,
-    fields(phase = "write_manifest_tables", key_class = "manifest_table")
+    fields(phase = "write_manifest_tables", key_class = "metadata_sst")
 )]
 pub(super) async fn build_manifest_tables_from_rows<S, RowsForFamily>(
     store: &S,

--- a/crates/loonfs-core/src/checkpoint/load.rs
+++ b/crates/loonfs-core/src/checkpoint/load.rs
@@ -204,7 +204,7 @@ pub(crate) async fn load_verified_manifest_tables_with_cache<'a, S: ObjectStore 
             .instrument(tracing::debug_span!(
                 "loonfs.phase",
                 phase = "load_namespace_manifest",
-                key_class = "manifest_table"
+                key_class = "namespace_manifest"
             ))
             .await
             .map_err(|err| ManifestLoadError::ReadManifest {
@@ -310,7 +310,7 @@ pub(crate) async fn load_namespace_manifest_envelope_if_present<S: ObjectStore +
         .instrument(tracing::debug_span!(
             "loonfs.phase",
             phase = "load_namespace_manifest",
-            key_class = "manifest_table"
+            key_class = "namespace_manifest"
         ))
         .await
         .map_err(|err| ManifestLoadError::ReadManifest {

--- a/crates/loonfs-core/src/checkpoint/publish.rs
+++ b/crates/loonfs-core/src/checkpoint/publish.rs
@@ -27,7 +27,7 @@ pub(super) enum ManifestPublicationOutcome {
     name = "loonfs.phase",
     err(level = "warn"),
     skip_all,
-    fields(phase = "write_namespace_manifest", key_class = "manifest_table")
+    fields(phase = "write_namespace_manifest", key_class = "namespace_manifest")
 )]
 pub(crate) async fn write_namespace_manifest<S: ObjectStore + ?Sized>(
     store: &S,
@@ -96,7 +96,7 @@ pub(super) fn manifest_write_failure(error: MetadataProjectionLoadError) -> Core
     name = "loonfs.phase",
     err(level = "warn"),
     skip_all,
-    fields(phase = "publish_metadata_root", key_class = "metadata_root")
+    fields(phase = "publish_metadata_root", key_class = "namespace_manifest")
 )]
 pub(super) async fn publish_metadata_root<S: ObjectStore + ?Sized>(
     store: &S,

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -208,7 +208,7 @@ fn report(
     name = "loonfs.phase",
     err(level = "warn"),
     skip_all,
-    fields(phase = "reorganize_metadata", key_class = "manifest")
+    fields(phase = "reorganize_metadata", key_class = "namespace_manifest")
 )]
 pub(crate) async fn reorganize_metadata_step<S: ObjectStore + ?Sized>(
     store: &S,

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -1002,7 +1002,10 @@ impl ProgressReporter {
 }
 
 impl<'a, S: ObjectStore + ?Sized> GroupMerge<'a, S> {
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "construction keeps one merge's coordinated state explicit"
+    )]
     fn new(
         store: &'a S,
         namespace_id: &'a NamespaceId,

--- a/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inspection_materialization.rs
@@ -117,7 +117,7 @@ pub(super) async fn load_manifest_materialization_for_inspection_if_present<
     name = "loonfs.phase",
     err(level = "warn"),
     skip_all,
-    fields(phase = "load_manifest_tables", key_class = "manifest_table")
+    fields(phase = "load_manifest_tables", key_class = "metadata_sst")
 )]
 #[cfg(test)]
 pub(crate) async fn load_manifest_metadata_state_for_inspection_from_manifest<

--- a/crates/loonfs-core/src/commit/mod.rs
+++ b/crates/loonfs-core/src/commit/mod.rs
@@ -29,5 +29,5 @@ pub(crate) use self::publish::{
 };
 pub use self::publish_error::CommitHeadPublishError;
 pub use self::validate::CommitValidationError;
-pub(crate) use self::validate::{validate_ops, PublishValidationView};
+pub(crate) use self::validate::{validate_ops, CommitNumbering, PublishValidationView};
 pub(crate) use self::wal_payload::wal_payload_from_materialized_commit;

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -15,11 +15,10 @@ use loonfs_api::{
 };
 use loonfs_objectstore::ObjectStore;
 
-/// The commit's running numbering.
+/// Assigns operation and delta indexes across a commit.
 ///
-/// The planner validates one semantic operation's compiled ops at a time and
-/// carries both counters across calls, so positions number exactly as one
-/// pass over the whole list would.
+/// The planner validates each filesystem operation separately. These
+/// counters preserve continuous indexes across those validation calls.
 #[derive(Debug, Default)]
 pub(crate) struct CommitNumbering {
     next_op_index: u32,
@@ -46,9 +45,8 @@ impl CommitNumbering {
     }
 }
 
-/// Validates `ops` in order against `metadata_state`, folding each accepted
-/// operation into it so the next one observes what the previous would
-/// persist.
+/// Validates operations in order and applies each accepted operation to the
+/// view used by the next one.
 pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
     ops: &[PlannedOp],
     metadata_state: &mut PublishValidationView<'_, S>,

--- a/crates/loonfs-core/src/commit/validate/checks.rs
+++ b/crates/loonfs-core/src/commit/validate/checks.rs
@@ -15,19 +15,44 @@ use loonfs_api::{
 };
 use loonfs_objectstore::ObjectStore;
 
+/// The commit's running numbering.
+///
+/// The planner validates one semantic operation's compiled ops at a time and
+/// carries both counters across calls, so positions number exactly as one
+/// pass over the whole list would.
+#[derive(Debug, Default)]
+pub(crate) struct CommitNumbering {
+    next_op_index: u32,
+    next_delta_index: u32,
+}
+
+impl CommitNumbering {
+    fn reserve_op_index(&mut self) -> Result<u32, CommitValidationError> {
+        let op_index = self.next_op_index;
+        self.next_op_index = self
+            .next_op_index
+            .checked_add(1)
+            .ok_or(CommitValidationError::OpIndexOverflow)?;
+        Ok(op_index)
+    }
+
+    fn reserve_delta_index(&mut self) -> Result<u32, CommitValidationError> {
+        let delta_index = self.next_delta_index;
+        self.next_delta_index = self
+            .next_delta_index
+            .checked_add(1)
+            .ok_or(CommitValidationError::DeltaIndexOverflow)?;
+        Ok(delta_index)
+    }
+}
+
 /// Validates `ops` in order against `metadata_state`, folding each accepted
 /// operation into it so the next one observes what the previous would
 /// persist.
-///
-/// `next_op_index` and `next_delta_index` are the commit's running numbering:
-/// the planner validates one semantic operation's compiled ops at a time and
-/// carries both counters across calls, so positions number exactly as one
-/// pass over the whole list would.
 pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
     ops: &[PlannedOp],
     metadata_state: &mut PublishValidationView<'_, S>,
-    next_op_index: &mut u32,
-    next_delta_index: &mut u32,
+    numbering: &mut CommitNumbering,
     committed_seq: ChangeSeq,
     actor: &ActorRef,
     committed_at_ms: u64,
@@ -35,10 +60,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
     let mut validated_ops = Vec::with_capacity(ops.len());
 
     for planned in ops {
-        let op_index = *next_op_index;
-        *next_op_index = op_index
-            .checked_add(1)
-            .ok_or(CommitValidationError::OpIndexOverflow)?;
+        let op_index = numbering.reserve_op_index()?;
         // Race checks belong to the operation that carries them and are
         // evaluated where it runs: an operation's checks describe the state
         // its own planning observed, which includes everything the earlier
@@ -60,8 +82,8 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     display_name: display_name.clone(),
                     name_key,
                     child_inode_id: *child_inode_id,
-                    create_inode_delta_index: reserve_delta_index(next_delta_index)?,
-                    bind_delta_index: reserve_delta_index(next_delta_index)?,
+                    create_inode_delta_index: numbering.reserve_delta_index()?,
+                    bind_delta_index: numbering.reserve_delta_index()?,
                 }
             }
             CommitOp::CreateFile {
@@ -81,9 +103,9 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     name_key,
                     child_inode_id: *child_inode_id,
                     content_ref: content_ref.clone(),
-                    create_inode_delta_index: reserve_delta_index(next_delta_index)?,
-                    bind_delta_index: reserve_delta_index(next_delta_index)?,
-                    revision_delta_index: reserve_delta_index(next_delta_index)?,
+                    create_inode_delta_index: numbering.reserve_delta_index()?,
+                    bind_delta_index: numbering.reserve_delta_index()?,
+                    revision_delta_index: numbering.reserve_delta_index()?,
                 }
             }
             CommitOp::ReplaceFile {
@@ -108,7 +130,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     inode_id: *inode_id,
                     revision_no,
                     content_ref: content_ref.clone(),
-                    revision_delta_index: reserve_delta_index(next_delta_index)?,
+                    revision_delta_index: numbering.reserve_delta_index()?,
                 }
             }
             CommitOp::RestoreRevision {
@@ -145,7 +167,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     source_revision_no: *source_revision_no,
                     revision_no,
                     content_ref: source_revision.content_ref,
-                    revision_delta_index: reserve_delta_index(next_delta_index)?,
+                    revision_delta_index: numbering.reserve_delta_index()?,
                 }
             }
             CommitOp::DeleteFile { inode_id } => {
@@ -176,8 +198,8 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     op_index,
                     inode_id: *inode_id,
                     source_binding,
-                    unbind_delta_index: reserve_delta_index(next_delta_index)?,
-                    tombstone_delta_index: reserve_delta_index(next_delta_index)?,
+                    unbind_delta_index: numbering.reserve_delta_index()?,
+                    tombstone_delta_index: numbering.reserve_delta_index()?,
                 }
             }
             CommitOp::Rename {
@@ -226,8 +248,8 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     new_parent_inode_id: *new_parent_inode_id,
                     new_display_name: new_display_name.clone(),
                     new_name_key,
-                    unbind_delta_index: reserve_delta_index(next_delta_index)?,
-                    bind_delta_index: reserve_delta_index(next_delta_index)?,
+                    unbind_delta_index: numbering.reserve_delta_index()?,
+                    bind_delta_index: numbering.reserve_delta_index()?,
                 }
             }
             CommitOp::DeleteSubtree { root_inode_id } => {
@@ -258,8 +280,8 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     op_index,
                     root_inode_id: *root_inode_id,
                     source_binding,
-                    unbind_delta_index: reserve_delta_index(next_delta_index)?,
-                    tombstone_delta_index: reserve_delta_index(next_delta_index)?,
+                    unbind_delta_index: numbering.reserve_delta_index()?,
+                    tombstone_delta_index: numbering.reserve_delta_index()?,
                 }
             }
             CommitOp::Undelete {
@@ -290,8 +312,8 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     display_name: display_name.clone(),
                     name_key,
                     target: active.generation,
-                    revoke_tombstone_delta_index: reserve_delta_index(next_delta_index)?,
-                    bind_delta_index: reserve_delta_index(next_delta_index)?,
+                    revoke_tombstone_delta_index: numbering.reserve_delta_index()?,
+                    bind_delta_index: numbering.reserve_delta_index()?,
                 }
             }
             CommitOp::UpdateAttributes {
@@ -323,7 +345,7 @@ pub(crate) async fn validate_ops<S: ObjectStore + ?Sized>(
                     inode_id: *inode_id,
                     attributes_revision_no,
                     attributes: attributes.clone(),
-                    attributes_delta_index: reserve_delta_index(next_delta_index)?,
+                    attributes_delta_index: numbering.reserve_delta_index()?,
                 }
             }
         };
@@ -380,14 +402,6 @@ async fn validate_explicit_preconditions<S: ObjectStore + ?Sized>(
     }
 
     Ok(())
-}
-
-fn reserve_delta_index(next_delta_index: &mut u32) -> Result<u32, CommitValidationError> {
-    let delta_index = *next_delta_index;
-    *next_delta_index = next_delta_index
-        .checked_add(1)
-        .ok_or(CommitValidationError::DeltaIndexOverflow)?;
-    Ok(delta_index)
 }
 
 fn next_revision_no(
@@ -577,7 +591,10 @@ async fn validate_replace_target_not_covered<S: ObjectStore + ?Sized>(
 /// Requires `display_name` to be valid and unbound under `parent_inode_id`,
 /// which must be an existing directory; returns the derived name key. The
 /// error vocabulary (create vs rename) is supplied by the call site.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "call-site error constructors keep the validation vocabulary precise"
+)]
 async fn validate_name_absent<S: ObjectStore + ?Sized>(
     metadata_state: &PublishValidationView<'_, S>,
     parent_inode_id: InodeId,

--- a/crates/loonfs-core/src/commit/validate/mod.rs
+++ b/crates/loonfs-core/src/commit/validate/mod.rs
@@ -10,6 +10,6 @@ mod error;
 mod tests;
 mod view;
 
-pub(crate) use checks::validate_ops;
+pub(crate) use checks::{validate_ops, CommitNumbering};
 pub use error::CommitValidationError;
 pub(crate) use view::PublishValidationView;

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::panic)]
 
 use super::super::{CommitOp, CommitPrecondition, PlannedOp, ValidatedCommitPlan};
-use super::checks::validate_ops;
+use super::checks::{validate_ops, CommitNumbering};
 use super::view::PublishValidationView;
 use crate::commit::{
     materialize_commit, CommitFingerprint, CommitPlan, CommitValidationError, InodeAllocator,
@@ -231,13 +231,11 @@ async fn build_commit_plan(
         &accepted_rows,
         committed_seq,
     );
-    let mut next_op_index = 0_u32;
-    let mut next_delta_index = 0_u32;
+    let mut numbering = CommitNumbering::default();
     let result = validate_ops(
         ops,
         &mut metadata_state,
-        &mut next_op_index,
-        &mut next_delta_index,
+        &mut numbering,
         committed_seq,
         &loonfs_test_support::test_actor(),
         committed_at_ms,

--- a/crates/loonfs-core/src/gc/uploads.rs
+++ b/crates/loonfs-core/src/gc/uploads.rs
@@ -61,7 +61,10 @@ pub(super) enum UploadSessionSweep {
 /// session. A CAS conflict keeps the session for a later pass. Provider
 /// cleanup runs only after the durable state transition, so a crash may leave
 /// extra data to clean up but cannot delete data from an open session.
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the sweep decision needs session state, policy, budget, and context together"
+)]
 pub(super) async fn sweep_upload_session<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,

--- a/crates/loonfs-core/src/metadata/rows.rs
+++ b/crates/loonfs-core/src/metadata/rows.rs
@@ -284,7 +284,10 @@ pub struct AttributesRevisionRecord {
 }
 
 impl MetadataState {
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the constructor names every durable metadata row family explicitly"
+    )]
     pub(crate) fn from_rows(
         inodes: Vec<InodeRecord>,
         direntry_binds: Vec<DirentryBindRecord>,

--- a/crates/loonfs-core/src/path/write/planner.rs
+++ b/crates/loonfs-core/src/path/write/planner.rs
@@ -11,7 +11,7 @@ use super::plan_restore::plan_publish_restore_revision;
 use super::plan_transfer::{plan_publish_copy_file_path, plan_publish_move_path};
 use super::publish_path_planning::{CompiledFilesystemOperation, PublishPathPlanningView};
 use crate::commit::{
-    validate_ops, CandidateAllocation, CommitFingerprint, PublishValidationView,
+    validate_ops, CandidateAllocation, CommitFingerprint, CommitNumbering, PublishValidationView,
     ValidatedCommitPlan, ValidatedOp,
 };
 use crate::error::{CoreError, Result};
@@ -75,8 +75,7 @@ pub(crate) async fn prepare_commit_against_publish_view<S: ObjectStore + ?Sized>
         })?;
 
     let mut resolved = PublishValidationView::new(base_view, accepted_rows, committed_seq);
-    let mut next_op_index = 0_u32;
-    let mut next_delta_index = 0_u32;
+    let mut numbering = CommitNumbering::default();
     let mut validated_ops: Vec<ValidatedOp> = Vec::new();
     let operation_count = request.operations.len();
     for (index, operation) in request.operations.iter().enumerate() {
@@ -93,8 +92,7 @@ pub(crate) async fn prepare_commit_against_publish_view<S: ObjectStore + ?Sized>
         let validated_unit = validate_ops(
             &unit_ops,
             &mut resolved,
-            &mut next_op_index,
-            &mut next_delta_index,
+            &mut numbering,
             committed_seq,
             &request.actor,
             committed_at_ms,

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -94,8 +94,8 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
     let mut dedup = BatchDedup::default();
 
     let prepare_span = tracing::debug_span!(
-        "publisher.batch_prepare",
-        phase = "batch_prepare",
+        "loonfs.phase",
+        phase = "prepare_batch",
         batch_size,
         accepted_count = tracing::field::Empty
     );
@@ -147,7 +147,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
             };
             let plan = {
                 let _span =
-                    tracing::debug_span!("loonfs.phase", phase = "CommitPlan::finish").entered();
+                    tracing::debug_span!("loonfs.phase", phase = "finish_commit_plan").entered();
                 validated.finish(resulting_next_inode_id)
             };
             let materialized = {
@@ -156,11 +156,8 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
                 materialize_commit(plan, context.now_ms)
             };
             let preview = {
-                let _span = tracing::debug_span!(
-                    "loonfs.phase",
-                    phase = "wal_payload_from_materialized_commit"
-                )
-                .entered();
+                let _span =
+                    tracing::debug_span!("loonfs.phase", phase = "build_wal_payload").entered();
                 wal_payload_from_materialized_commit(&materialized)
             };
             {
@@ -282,7 +279,7 @@ async fn write_batch_wal_segment<S: ObjectStore + ?Sized>(
     accepted_count: u64,
 ) -> Result<PreparedWalSegment> {
     let span = tracing::debug_span!(
-        "publisher.batch_write_wal",
+        "loonfs.phase",
         phase = "batch_write_wal",
         batch_size,
         accepted_count,
@@ -346,11 +343,11 @@ async fn cas_batch_head<S: ObjectStore + ?Sized>(
     accepted_count: u64,
 ) -> Result<ObjectMetadata> {
     let span = tracing::debug_span!(
-        "publisher.batch_cas_head",
+        "loonfs.phase",
         phase = "batch_cas_head",
         batch_size,
         accepted_count,
-        key_class = "wal_head",
+        key_class = "namespace_head",
         result = tracing::field::Empty
     );
     let result = publish_commit_head(store, head_etag, head_publish)

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -21,7 +21,7 @@ use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
-/// Witnesses that LoonFS completed the durable content write described by its reference.
+/// Confirms that LoonFS durably stored the content described by this reference.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct StoredContent {
     content_store_id: ContentStoreId,

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -21,6 +21,7 @@ use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
+/// Witnesses that LoonFS completed the durable content write described by its reference.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct StoredContent {
     content_store_id: ContentStoreId,
@@ -594,7 +595,7 @@ async fn validate_content_size<S: ObjectStore + ?Sized>(
     name = "loonfs.phase",
     err(level = "warn"),
     skip_all,
-    fields(phase = "write_content_blob", key_class = "content_blob")
+    fields(phase = "write_content_blob", key_class = "content")
 )]
 #[cfg(any(test, feature = "test-support"))]
 pub async fn store_bytes_as_content<S: ObjectStore + ?Sized>(

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -1363,7 +1363,10 @@ impl<S: ObjectStore + Clone> GrepWorker<S> {
     /// Answers whether the key was deleted. Selection may be stale — the
     /// listing is a snapshot — but every decision here re-reads what
     /// authorizes it, which is what makes resuming from a cursor safe.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "one collection decision needs liveness, budget, and report state together"
+    )]
     async fn collect_one_key(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-objectstore/src/crypto.rs
+++ b/crates/loonfs-objectstore/src/crypto.rs
@@ -4,7 +4,7 @@
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
-/// Computes the shared signing primitive that loonfs-core uses to mint content tokens.
+/// Computes the HMAC-SHA256 signature used by content tokens.
 pub fn hmac_sha256(key: &[u8], value: &[u8]) -> Vec<u8> {
     let mut mac =
         <Hmac<Sha256>>::new_from_slice(key).expect("HMAC-SHA256 accepts keys of any length");

--- a/crates/loonfs-objectstore/src/crypto.rs
+++ b/crates/loonfs-objectstore/src/crypto.rs
@@ -4,8 +4,7 @@
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
-/// Computes an HMAC-SHA256 authentication code.
-#[doc(hidden)]
+/// Computes the shared signing primitive that loonfs-core uses to mint content tokens.
 pub fn hmac_sha256(key: &[u8], value: &[u8]) -> Vec<u8> {
     let mut mac =
         <Hmac<Sha256>>::new_from_slice(key).expect("HMAC-SHA256 accepts keys of any length");

--- a/crates/loonfs-objectstore/src/lib.rs
+++ b/crates/loonfs-objectstore/src/lib.rs
@@ -14,7 +14,6 @@
 pub mod abs;
 mod attempts;
 mod configured;
-#[doc(hidden)]
 pub mod crypto;
 pub mod gcs;
 mod immutable_write;

--- a/crates/loonfs-server/src/config.rs
+++ b/crates/loonfs-server/src/config.rs
@@ -385,6 +385,7 @@ impl ServerConfig {
         }
     }
 
+    /// Resolves runtime cache settings by applying server overrides to the defaults.
     pub fn runtime_cache_config(&self) -> RuntimeCacheConfig {
         let mut config = RuntimeCacheConfig::default();
         if let Some(value) = self.runtime_cache.max_cached_namespaces {
@@ -405,6 +406,7 @@ impl ServerConfig {
         config
     }
 
+    /// Builds the object store selected by this server configuration.
     pub fn object_store(&self) -> Result<ConfiguredObjectStore, ServerConfigError> {
         self.store
             .configured_object_store()
@@ -570,6 +572,7 @@ impl From<StoreConfigError> for ServerConfigError {
     }
 }
 
+/// Loads, environment-fills, and validates a server configuration from TOML.
 pub fn load_server_config(path: impl AsRef<Path>) -> Result<ServerConfig, ServerConfigError> {
     let bytes = fs::read(path.as_ref()).map_err(|err| ServerConfigError::Io(err.to_string()))?;
     let source =

--- a/crates/loonfs-server/src/http/openapi.rs
+++ b/crates/loonfs-server/src/http/openapi.rs
@@ -24,10 +24,12 @@ use loonfs_api::{
     ReorganizeStepOutcome, RetainedCandidates, RevisionNo, TrashEntry, WalFlushStepOutcome,
 };
 
+/// Builds the static OpenAPI document for the v0 HTTP API.
 pub fn openapi_document() -> utoipa::openapi::OpenApi {
     <LoonfsOpenApi as utoipa::OpenApi>::openapi()
 }
 
+/// Serializes the static OpenAPI document as pretty-printed JSON.
 pub fn openapi_json_pretty() -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&openapi_document())
 }

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -241,7 +241,7 @@ pub async fn app(
     Ok((router, state.writer, state.local_cache))
 }
 
-#[doc(hidden)]
+/// Test-only: builds the router around an already-constructed object store.
 pub async fn app_with_store(
     config: ServerConfig,
     store: SharedObjectStore,

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -241,7 +241,7 @@ pub async fn app(
     Ok((router, state.writer, state.local_cache))
 }
 
-/// Test-only: builds the router around an already-constructed object store.
+/// Builds the router around an existing object store for tests.
 pub async fn app_with_store(
     config: ServerConfig,
     store: SharedObjectStore,

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -52,7 +52,6 @@ const API_SPEC_NON_ERROR_CODE_TOKENS: &[&str] = &[
     "attributes_updated_at_ms",
     "attributes_updated_by",
     "bearer_auth",
-    "begin_put",
     "budget_exhausted",
     "built_through_seq",
     "checkpoint_id",
@@ -305,13 +304,30 @@ fn error_detail_fields_match_the_api_spec_table() {
 }
 
 fn assert_api_spec_error_codes_are_registered(spec: &str) {
+    let openapi: serde_json::Value = serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../docs/specs/openapi.json"
+    )))
+    .expect("decode docs/specs/openapi.json");
+    let operation_ids: std::collections::BTreeSet<_> = openapi["paths"]
+        .as_object()
+        .expect("OpenAPI paths object")
+        .values()
+        .flat_map(|path| {
+            path.as_object()
+                .expect("OpenAPI path item")
+                .values()
+                .filter_map(|operation| operation.get("operationId")?.as_str())
+        })
+        .collect();
+
     for token in spec
         .split('`')
         .skip(1)
         .step_by(2)
         .filter(|token| is_snake_case_token(token))
     {
-        if API_SPEC_NON_ERROR_CODE_TOKENS.contains(&token) {
+        if API_SPEC_NON_ERROR_CODE_TOKENS.contains(&token) || operation_ids.contains(token) {
             continue;
         }
         // Valid inode IDs are examples, not error codes.

--- a/crates/loonfs-sim/src/lib.rs
+++ b/crates/loonfs-sim/src/lib.rs
@@ -4,9 +4,8 @@
 //! injection, and trace/replay support for reproducing failed simulation
 //! seeds.
 //!
-//! Its public surface is also the hook contract for out-of-repository
-//! simulation drivers, so some public items intentionally have no in-repo
-//! callers.
+//! External simulation drivers also use this public API, so some items have
+//! no callers in this repository.
 
 pub mod clock;
 pub mod failure;

--- a/crates/loonfs-sim/src/lib.rs
+++ b/crates/loonfs-sim/src/lib.rs
@@ -3,6 +3,10 @@
 //! The crate provides seeded randomness, a virtual clock, object-store fault
 //! injection, and trace/replay support for reproducing failed simulation
 //! seeds.
+//!
+//! Its public surface is also the hook contract for out-of-repository
+//! simulation drivers, so some public items intentionally have no in-repo
+//! callers.
 
 pub mod clock;
 pub mod failure;

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -803,8 +803,7 @@ impl NamespacePublisher {
                         batch_size = usize_to_u64(batch.candidates.len()),
                         queue_depth_start = usize_to_u64(queue_depth_start),
                         queue_depth_end = usize_to_u64(batch.candidates.len()),
-                        collect_ms = elapsed_ms_since(collect_started),
-                        "publisher.batch_collect"
+                        collect_ms = elapsed_ms_since(collect_started)
                     );
                     self.publish_batch(batch.candidates).await;
                 }
@@ -888,8 +887,7 @@ impl NamespacePublisher {
                 mode = self.trace_mode,
                 store_kind = self.trace_store_kind,
                 result = "ok",
-                wait_ms = elapsed_ms_from(candidate.enqueued_at, selected_at),
-                "publisher.wait_for_batch"
+                wait_ms = elapsed_ms_from(candidate.enqueued_at, selected_at)
             );
         }
 
@@ -1137,8 +1135,7 @@ impl NamespacePublisher {
                 mode = self.trace_mode,
                 store_kind = self.trace_store_kind,
                 result = result.as_str(),
-                wait_ms,
-                "publisher.wait_for_result"
+                wait_ms
             );
         }
 
@@ -1156,8 +1153,7 @@ impl NamespacePublisher {
             mode = self.trace_mode,
             store_kind = self.trace_store_kind,
             queue_depth = usize_to_u64(queue_depth),
-            reason,
-            "publisher.enqueue"
+            reason
         );
     }
 }

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2522,12 +2522,15 @@ not require durable control-plane state. Long-running operations may span
 multiple requests, may require a stable snapshot or destination binding, and
 may need resumability across client or server restarts.
 
+In v0, upload sessions are the only registered control object in this model.
+Read sessions are forward-looking and are not in v0.
+
 ### 9.1 Definitions
 
 | Term | Meaning |
 | --- | --- |
 | **Single-request operation** | An operation that is fully described by a single request and does not require a server-side control object after the request completes. |
-| **Control object** | A server-side control-plane object used when the client continues driving an operation across multiple requests. For large or resumable `put <file>`, an implementation may use a single `UploadHandle`. |
+| **Control object** | A server-side control-plane object used when the client continues driving an operation across multiple requests. For large or resumable `put <file>`, an implementation may use a single upload session. |
 | **Implementation-specific coordinator** | A helper resource or service that correlates multiple logical commits for one higher-level workflow. Coordinators are outside the core interoperable model and do not define namespace history. |
 | **Authoritative operation state** | The state that determines the correctness, visibility, and resumability of an operation. |
 | **Transfer progress** | Non-authoritative progress information such as completed bytes, completed files, local temporary outputs, or user-interface counters. |
@@ -2552,7 +2555,7 @@ may need resumability across client or server restarts.
      safety, or promised resumability guarantees.
 
    For large or resumable `put <file>`, an implementation that uses a
-   server-side control object typically uses a single `UploadHandle`.
+   server-side control object typically uses a single upload session.
 
 3. The core specification does **NOT** require a server-side job object for
    recursive `put` or recursive `cp`. Those workflows may be realized as one
@@ -2579,7 +2582,7 @@ may need resumability across client or server restarts.
 | `get <file>` | Single-request read | none | No | path resolution, access check, selected file revision, content serving or delegated download | local download progress, temporary file, client retries |
 | `get -r <dir>` | Multi-request snapshot read | optional read session pinning a consistent snapshot | Only if a consistent snapshot is promised across requests | snapshot selection, per-request reads as for `get` | traversal progress, local outputs, client retries |
 | `put <file>` (small, one-shot convenience) | Single request | none | No | destination resolution, validation, metadata commit | request payload, client retries |
-| `put <file>` (large or resumable) | Begin, upload, commit | `UploadHandle`, if used | Only if server-side resumability or stable binding is promised | stable destination binding, expected slot or revision, upload handle validity, final publish | file reading, hashing, content upload progress, retry tokens |
+| `put <file>` (large or resumable) | Begin, upload, commit | upload session, if used | Only if server-side resumability or stable binding is promised | stable destination binding, expected slot or revision, upload session validity, final publish | file reading, hashing, content upload progress, retry tokens |
 | `put -r <dir>` | Client- or coordinator-driven uploads plus one or more logical commits | none required by the core model | No | each commit's validation and publication | orchestration across files, progress, retries |
 | `cp <file>` (same server) | Single-request server-side copy | none | No | source resolution, destination resolution, metadata publication, content reference reuse | request retry |
 | `cp -r <dir>` (same server) | Client- or coordinator-driven sequence of logical commits | none required by the core model | No | each commit's validation and publication | orchestration across entries, retries |
@@ -2595,7 +2598,7 @@ filesystem commands.
 | --- | --- | --- |
 | `get <file>` | resolve the requested path or handle; authorize the read; select the file revision to read; serve bytes or delegated download targets | receive bytes; write local output; maintain local retry and resume state |
 | `put <file>` (one-shot) | resolve the destination; validate preconditions; publish the metadata change | supply bytes or content reference; retry the request if needed |
-| `put <file>` (resumable) | if an `UploadHandle` is used, create or validate it; bind the destination; validate durable content and commit the final publish | read the local file; hash it; upload content; track upload progress; submit the final commit request |
+| `put <file>` (resumable) | if an upload session is used, create or validate it; bind the destination; validate durable content and commit the final publish | read the local file; hash it; upload content; track upload progress; submit the final commit request |
 | `cp <file>` (same server) | resolve source and destination; authorize both sides; create the copied resource; publish the metadata change | submit the request; retry if appropriate |
 
 ### 9.5 When raw paths cease to identify the operation
@@ -2607,7 +2610,7 @@ a raw path string.
 | Operation | Raw path is used for | Stable in-flight identity after start |
 | --- | --- | --- |
 | `get <file>` | the request itself | none required |
-| `put <file>` (resumable) | `begin_put` only | server-issued `UploadHandle`, if used |
+| `put <file>` (resumable) | `begin_upload` only | server-issued upload session, if used |
 
 ### 9.6 Control-plane durability guidance
 
@@ -2615,7 +2618,7 @@ a raw path string.
    would change correctness, visibility, retention safety, or promised
    resumability.
 
-2. At minimum, an `UploadHandle` is normally durable when an implementation
+2. At minimum, an upload session is normally durable when an implementation
    uses one for stable destination binding across time or restart-safe
    resumability.
 
@@ -2634,7 +2637,7 @@ stronger mode is explicitly requested:
 - `get <file>` is a single-request operation;
 - `cp <file>` on the same service is a single-request operation;
 - if large or resumable `put <file>` uses a control object, it uses a single
-  `UploadHandle`.
+  upload session.
 
 These defaults preserve a simple model for single-request commands while
 allowing multi-request correctness and resumability where they actually

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -2522,15 +2522,15 @@ not require durable control-plane state. Long-running operations may span
 multiple requests, may require a stable snapshot or destination binding, and
 may need resumability across client or server restarts.
 
-In v0, upload sessions are the only registered control object in this model.
-Read sessions are forward-looking and are not in v0.
+For the operations in this section, v0 defines upload sessions but not read
+sessions.
 
 ### 9.1 Definitions
 
 | Term | Meaning |
 | --- | --- |
 | **Single-request operation** | An operation that is fully described by a single request and does not require a server-side control object after the request completes. |
-| **Control object** | A server-side control-plane object used when the client continues driving an operation across multiple requests. For large or resumable `put <file>`, an implementation may use a single upload session. |
+| **Control object** | Server-side state for an operation that spans multiple requests. A large or resumable `put <file>` may use one upload session. |
 | **Implementation-specific coordinator** | A helper resource or service that correlates multiple logical commits for one higher-level workflow. Coordinators are outside the core interoperable model and do not define namespace history. |
 | **Authoritative operation state** | The state that determines the correctness, visibility, and resumability of an operation. |
 | **Transfer progress** | Non-authoritative progress information such as completed bytes, completed files, local temporary outputs, or user-interface counters. |
@@ -2554,8 +2554,8 @@ Read sessions are forward-looking and are not in v0.
    - loss of server restart state would change correctness, retention
      safety, or promised resumability guarantees.
 
-   For large or resumable `put <file>`, an implementation that uses a
-   server-side control object typically uses a single upload session.
+   A large or resumable `put <file>` that needs server-side state typically
+   uses one upload session.
 
 3. The core specification does **NOT** require a server-side job object for
    recursive `put` or recursive `cp`. Those workflows may be realized as one
@@ -2580,7 +2580,7 @@ Read sessions are forward-looking and are not in v0.
 | Operation | Typical execution shape | Typical server-side control-plane object | Long-lived server state required? | Server is authoritative for | Client is authoritative for |
 | --- | --- | --- | --- | --- | --- |
 | `get <file>` | Single-request read | none | No | path resolution, access check, selected file revision, content serving or delegated download | local download progress, temporary file, client retries |
-| `get -r <dir>` | Multi-request snapshot read | optional read session pinning a consistent snapshot | Only if a consistent snapshot is promised across requests | snapshot selection, per-request reads as for `get` | traversal progress, local outputs, client retries |
+| `get -r <dir>` | Client-driven multi-request read | none in v0 | No | each request's path resolution, access check, and selected file revision | traversal progress, local outputs, client retries |
 | `put <file>` (small, one-shot convenience) | Single request | none | No | destination resolution, validation, metadata commit | request payload, client retries |
 | `put <file>` (large or resumable) | Begin, upload, commit | upload session, if used | Only if server-side resumability or stable binding is promised | stable destination binding, expected slot or revision, upload session validity, final publish | file reading, hashing, content upload progress, retry tokens |
 | `put -r <dir>` | Client- or coordinator-driven uploads plus one or more logical commits | none required by the core model | No | each commit's validation and publication | orchestration across files, progress, retries |
@@ -2618,9 +2618,8 @@ a raw path string.
    would change correctness, visibility, retention safety, or promised
    resumability.
 
-2. At minimum, an upload session is normally durable when an implementation
-   uses one for stable destination binding across time or restart-safe
-   resumability.
+2. An upload session must be durable when it provides a stable destination
+   across requests or must survive a server restart.
 
 3. Implementation-specific coordinators **MAY** also be stored durably, but
    they are not required by this specification.

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -46,7 +46,7 @@ Most core operations fall into one of two classes.
 | Class | Typical examples | Server-side state |
 | --- | --- | --- |
 | **One-shot** | `ls`, `stat`, `get <file>`, `put <small file>`, `cp <file>` on one service | Usually none after the request completes. |
-| **Client-driven long-running** | recursive `get`, resumable `put`, recursive `put`, recursive `cp` realized as several commits | A handle or intent may be used to pin a snapshot or destination across multiple requests. Other orchestration may remain client-side. |
+| **Client-driven long-running** | recursive `get`, resumable `put`, recursive `put`, recursive `cp` realized as several commits | Resumable puts may use an upload session. Other orchestration remains client-side. |
 
 Implementations may additionally expose coordinator-specific helpers for recursive workflows or admin work, but those helpers are outside the interoperable core model.
 

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -18,7 +18,7 @@ Namespaces and content stores are separate durable domains. A namespace owns fil
 | --- | --- | --- | --- |
 | **Data plane** | Stores and serves file bytes. | Whole-file content objects and download streams. | No, by itself. |
 | **Metadata plane** | Defines the filesystem's durable truth. | WAL segments, namespace head, manifests, checkpoints, inode and direntry state. | Yes. |
-| **Control plane** | Coordinates multi-request work and authorization. | Upload handles, put intents, ACLs, shares, leases. | No. |
+| **Control plane** | Coordinates multi-request work and authorization. | Upload sessions. | No. |
 
 Two rules follow from this split:
 

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1735,8 +1735,8 @@ Examples include:
 - recursive reads that need a pinned snapshot; and
 - resumable uploads that need a stable destination binding.
 
-In those cases, the server may create control-plane objects such as read
-sessions, upload sessions, or put intents.
+In v0, the server creates upload sessions for resumable uploads. Read sessions
+and put intents are possible future control-plane objects, but are not in v0.
 
 A durable upload session has three states and one transition:
 
@@ -2456,7 +2456,7 @@ publishing CAS) — under these rules:
    a cursor, an output descriptor, an offset, or resumable progress. The job
    creates it `active` with create-if-absent before its first output object,
    and refreshes it by compare-and-swap on the etag it last observed, every
-   `METADATA_COMPACTION_HEARTBEAT_INTERVAL` while it runs and at the top of
+   `METADATA_COMPACTION_HEARTBEAT_INTERVAL_MS` while it runs and at the top of
    every finalization attempt.
 
    The lease is a fence, not a timestamp. An expired lease alone proves
@@ -2485,20 +2485,21 @@ publishing CAS) — under these rules:
    A pass decides one of the prefix's objects as follows. An object the
    manifest references is live, like every other referenced object. Otherwise,
    if the owning job's lease decodes, is `active`, and its `heartbeat_at_ms`
-   is within `METADATA_COMPACTION_LEASE_EXPIRY`, the object is retained
+   is within `METADATA_COMPACTION_LEASE_EXPIRY_MS`, the object is retained
    whatever its age; so is one whose expired lease the pass tried and failed
    to claim. Otherwise the prefix is orphaned and the object ages as an
-   ordinary unreferenced orphan under `METADATA_COMPACTION_STAGING_GRACE`,
+   ordinary unreferenced orphan under `METADATA_COMPACTION_STAGING_GRACE_MS`,
    which is derived rather than tuned:
 
    ```
-   METADATA_COMPACTION_STAGING_GRACE
-       >= METADATA_COMPACTION_LEASE_EXPIRY   (a job's claim outliving its last heartbeat)
+   METADATA_COMPACTION_STAGING_GRACE_MS
+       >= METADATA_COMPACTION_LEASE_EXPIRY_MS   (a job's claim outliving its last heartbeat)
           + T                                (rule 1: the publication that may still name it)
    ```
 
-   `METADATA_COMPACTION_LEASE_EXPIRY` is a small multiple of the heartbeat
-   interval, and it must itself be at least `T`: a job's last heartbeat before
+   `METADATA_COMPACTION_LEASE_EXPIRY_MS` is
+   `METADATA_COMPACTION_LEASE_MISSED_HEARTBEATS` times the heartbeat interval,
+   and it must itself be at least `T`: a job's last heartbeat before
    its output becomes referenced is at the top of a finalization attempt, and
    that attempt's compare-and-swap lands within one publication bound of it.
    That inequality is also what completes the fence — a job that heartbeated

--- a/docs/specs/format.md
+++ b/docs/specs/format.md
@@ -1735,8 +1735,8 @@ Examples include:
 - recursive reads that need a pinned snapshot; and
 - resumable uploads that need a stable destination binding.
 
-In v0, the server creates upload sessions for resumable uploads. Read sessions
-and put intents are possible future control-plane objects, but are not in v0.
+v0 uses upload sessions for resumable uploads. It does not define read
+sessions or put intents.
 
 A durable upload session has three states and one transition:
 


### PR DESCRIPTION
This aligns tracing fields with the vocabularies already used by object-store metrics and the rest of the runtime. Metadata manifests, metadata SSTs, namespace heads, WAL segments, and content now use consistent key classes, and publisher spans use the loonfs.phase namespace with plain phase names.

The API and format specifications now describe the v0 surface that actually exists: begin_upload, upload sessions, and the current compaction constant names. The API-spec check reads operation IDs from the generated OpenAPI document so valid operation names do not need a manual allowlist.

The change also restores CommitNumbering as the checked owner of operation and delta indexes, documents public functions that were previously hidden or undocumented, and explains the external simulation API. The workspace clippy check and OpenAPI snapshot tests pass.