### PR TITLE
refactor: remove duplicated read and publish helpers

### DIFF
--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -643,7 +643,7 @@ string_id! {
 }
 
 string_id! {
-    /// Durable id for one grep root manifest generation.
+    /// Identifies one stored grep manifest.
     GrepManifestId,
     prefix = "gmf"
 }

--- a/crates/loonfs-api/src/ids.rs
+++ b/crates/loonfs-api/src/ids.rs
@@ -643,6 +643,12 @@ string_id! {
 }
 
 string_id! {
+    /// Durable id for one grep root manifest generation.
+    GrepManifestId,
+    prefix = "gmf"
+}
+
+string_id! {
     /// Durable object id for one namespace manifest candidate.
     ManifestObjectId,
     error = GeneratedIdValidationError,

--- a/crates/loonfs-api/src/lib.rs
+++ b/crates/loonfs-api/src/lib.rs
@@ -128,11 +128,11 @@ pub use error::{ErrorCode, ErrorKind};
 pub use ids::{
     generated_id, manifest_object_id_manifest_id, next_public_ordinal, wal_segment_id_start_seq,
     ChangeSeq, CheckpointId, CommitId, CommitIdValidationError, ContentId, ContentStoreId,
-    GeneratedIdValidationError, IndexSegmentId, InodeId, InodeKind, ManifestId, ManifestObjectId,
-    MetadataCompactionId, MetadataTableId, NameKey, NameKeyValidationError, NamespaceId,
-    NamespaceIdValidationError, PublicOrdinalRangeError, RevisionNo, UploadId, WalSegmentId,
-    WriterEpoch, FIRST_ALLOCATABLE_INODE_ID, MAX_ID_BYTES, MAX_NAME_KEY_BYTES, MAX_PUBLIC_INTEGER,
-    ROOT_INODE_ID,
+    GeneratedIdValidationError, GrepManifestId, IndexSegmentId, InodeId, InodeKind, ManifestId,
+    ManifestObjectId, MetadataCompactionId, MetadataTableId, NameKey, NameKeyValidationError,
+    NamespaceId, NamespaceIdValidationError, PublicOrdinalRangeError, RevisionNo, UploadId,
+    WalSegmentId, WriterEpoch, FIRST_ALLOCATABLE_INODE_ID, MAX_ID_BYTES, MAX_NAME_KEY_BYTES,
+    MAX_PUBLIC_INTEGER, ROOT_INODE_ID,
 };
 pub use name_policy::name_key_for_display_name;
 pub use pagination::{

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -49,17 +49,17 @@ use xxhash_rust::xxh64::xxh64;
 /// still moves trivial bytes. Benchmarked over 8 KiB, which priced a full
 /// listing at one GET per tiny block.
 pub const DEFAULT_TARGET_BLOCK_BYTES: usize = 64 * 1024;
-/// Delta-level runs that trigger an LSM reorganization.
+/// Number of level-zero runs that triggers reorganization.
 pub const DEFAULT_MAX_L0_RUNS: usize = 8;
-/// Rows targeted per immutable LSM segment.
+/// Target number of rows in one immutable segment.
 pub const DEFAULT_MAX_ROWS_PER_SEGMENT: usize = 65_536;
-/// Runs merged by one bounded LSM reorganization step.
+/// Maximum number of runs read by one reorganization step.
 pub const DEFAULT_MAX_REORGANIZATION_INPUT_RUNS: usize = 8;
-/// Decoded rows merged by one bounded LSM reorganization step.
+/// Maximum number of decoded rows read by one reorganization step.
 pub const DEFAULT_MAX_REORGANIZATION_INPUT_ROWS: usize = 131_072;
-/// Decoded bytes consumed by one bounded LSM build or reorganization step.
+/// Maximum decoded input size for one build or reorganization step.
 pub const DEFAULT_MAX_REORGANIZATION_INPUT_BYTES: usize = 64 * 1024 * 1024;
-/// Largest stored filter block embedded directly in an LSM segment descriptor.
+/// Maximum stored filter size embedded in a segment descriptor.
 pub const DEFAULT_INLINE_FILTER_MAX_BYTES: u32 = 1024;
 /// Entries between restart points inside a data block.
 pub const RESTART_INTERVAL: usize = 16;

--- a/crates/loonfs-api/src/sst_blocks.rs
+++ b/crates/loonfs-api/src/sst_blocks.rs
@@ -49,6 +49,18 @@ use xxhash_rust::xxh64::xxh64;
 /// still moves trivial bytes. Benchmarked over 8 KiB, which priced a full
 /// listing at one GET per tiny block.
 pub const DEFAULT_TARGET_BLOCK_BYTES: usize = 64 * 1024;
+/// Delta-level runs that trigger an LSM reorganization.
+pub const DEFAULT_MAX_L0_RUNS: usize = 8;
+/// Rows targeted per immutable LSM segment.
+pub const DEFAULT_MAX_ROWS_PER_SEGMENT: usize = 65_536;
+/// Runs merged by one bounded LSM reorganization step.
+pub const DEFAULT_MAX_REORGANIZATION_INPUT_RUNS: usize = 8;
+/// Decoded rows merged by one bounded LSM reorganization step.
+pub const DEFAULT_MAX_REORGANIZATION_INPUT_ROWS: usize = 131_072;
+/// Decoded bytes consumed by one bounded LSM build or reorganization step.
+pub const DEFAULT_MAX_REORGANIZATION_INPUT_BYTES: usize = 64 * 1024 * 1024;
+/// Largest stored filter block embedded directly in an LSM segment descriptor.
+pub const DEFAULT_INLINE_FILTER_MAX_BYTES: u32 = 1024;
 /// Entries between restart points inside a data block.
 pub const RESTART_INTERVAL: usize = 16;
 /// Bloom filter sizing: bits reserved per inserted filter key.

--- a/crates/loonfs-cli/src/backend/mod.rs
+++ b/crates/loonfs-cli/src/backend/mod.rs
@@ -435,7 +435,7 @@ impl ResolvedTarget {
                     stream: Box::new(
                         target
                             .client
-                            .open_direct_download_at(&grant, start_offset)
+                            .open_direct_download(&grant, start_offset)
                             .await?,
                     ),
                     resumed_from: start_offset,

--- a/crates/loonfs-client/src/download_tests.rs
+++ b/crates/loonfs-client/src/download_tests.rs
@@ -215,7 +215,7 @@ async fn a_resumed_crc32c_download_folds_the_prefix_into_the_same_verdict() {
         Outcome::Success(payload[held..].to_vec()),
     ]);
     let mut download = client
-        .open_direct_download_at(
+        .open_direct_download(
             &grant(content_ref.clone(), "http://example.invalid/object"),
             held as u64,
         )
@@ -226,7 +226,7 @@ async fn a_resumed_crc32c_download_folds_the_prefix_into_the_same_verdict() {
 
     // A prefix that is not the object's fails the whole download.
     let mut download = client
-        .open_direct_download_at(
+        .open_direct_download(
             &grant(content_ref, "http://example.invalid/object"),
             held as u64,
         )
@@ -283,7 +283,7 @@ async fn a_resumed_download_asks_for_the_rest_and_verifies_the_whole_file() {
 
     let guard = test_transport::script([Outcome::Success(payload[held..].to_vec())]);
     let mut download = client
-        .open_direct_download_at(
+        .open_direct_download(
             &grant(content_ref, "http://example.invalid/object"),
             held as u64,
         )
@@ -319,7 +319,10 @@ async fn a_resume_is_refused_until_it_accounts_for_what_it_holds() {
 
     let guard = test_transport::script([Outcome::Success(payload.clone())]);
     let mut whole = client
-        .open_direct_download(&grant(content_ref.clone(), "http://example.invalid/object"))
+        .open_direct_download(
+            &grant(content_ref.clone(), "http://example.invalid/object"),
+            0,
+        )
         .await
         .expect("grant");
     while whole.next_chunk().await.expect("chunk").is_some() {}
@@ -332,7 +335,7 @@ async fn a_resume_is_refused_until_it_accounts_for_what_it_holds() {
 
     let _guard = test_transport::script([Outcome::Success(payload[4..].to_vec())]);
     let mut resumed = client
-        .open_direct_download_at(&grant(content_ref, "http://example.invalid/object"), 4)
+        .open_direct_download(&grant(content_ref, "http://example.invalid/object"), 4)
         .await
         .expect("resumed grant");
     let error = resumed

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -826,15 +826,6 @@ impl Client {
         .await
     }
 
-    /// Opens the response body authorized by a download grant as a bounded,
-    /// verified stream.
-    pub async fn open_direct_download(
-        &self,
-        download: &BeginDownloadResponse,
-    ) -> Result<DirectDownloadStream> {
-        self.open_direct_download_at(download, 0).await
-    }
-
     /// Opens a download grant's body from `start_offset`, for a caller that
     /// already holds the bytes below it.
     ///
@@ -844,7 +835,7 @@ impl Client {
     /// stream still reports on the whole object, so a nonzero offset obliges
     /// the caller to hand over what it holds through
     /// [`DirectDownloadStream::fold_resumed_prefix`] before driving it.
-    pub async fn open_direct_download_at(
+    pub async fn open_direct_download(
         &self,
         download: &BeginDownloadResponse,
         start_offset: u64,
@@ -858,16 +849,8 @@ impl Client {
         .await
     }
 
-    /// Opens an inode download as a bounded, verified stream.
-    pub async fn open_direct_download_by_inode(
-        &self,
-        download: &BeginDownloadByInodeResponse,
-    ) -> Result<DirectDownloadStream> {
-        self.open_direct_download_by_inode_at(download, 0).await
-    }
-
     /// Opens an inode download from `start_offset`.
-    pub async fn open_direct_download_by_inode_at(
+    pub async fn open_direct_download_by_inode(
         &self,
         download: &BeginDownloadByInodeResponse,
         start_offset: u64,
@@ -957,7 +940,7 @@ impl Client {
     {
         use tokio::io::AsyncWriteExt as _;
         let path = &download.path;
-        let mut download = self.open_direct_download(download).await?;
+        let mut download = self.open_direct_download(download, 0).await?;
         let mut size_bytes = 0u64;
         while let Some(chunk) = download.next_chunk().await? {
             size_bytes += chunk.len() as u64;

--- a/crates/loonfs-client/src/streaming_tests.rs
+++ b/crates/loonfs-client/src/streaming_tests.rs
@@ -17,6 +17,7 @@ use loonfs_api::{
     direct_put_checksum_feature, CapabilityDocument, ContentId, ContentRef, ContentRefKind,
     FEATURE_UPLOADS_DIRECT_PUT, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
+use loonfs_test_support::ids::content_ref;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -261,10 +262,6 @@ fn signed_parts(first: u32, count: u32) -> Outcome {
             })
             .collect(),
     })
-}
-
-fn content_ref(bytes: &[u8]) -> ContentRef {
-    ContentRef::blob_v1(ContentId::generate(), bytes)
 }
 
 fn completed(content_ref: ContentRef) -> Outcome {

--- a/crates/loonfs-core/src/checkpoint/build.rs
+++ b/crates/loonfs-core/src/checkpoint/build.rs
@@ -13,6 +13,7 @@ use futures::future::try_join_all;
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::manifest::{MetadataFileRef, MetadataRow, MetadataTableFamily};
 use loonfs_api::wire::sst_blocks::SegmentBlocksBuilder;
+pub(super) use loonfs_api::wire::sst_blocks::DEFAULT_INLINE_FILTER_MAX_BYTES as INLINE_SEGMENT_FILTER_MAX_BYTES;
 use loonfs_api::{sha256_digest, ChangeSeq, MetadataCompactionId, MetadataTableId, NamespaceId};
 use loonfs_objectstore::keys::{metadata_compaction_table, metadata_table};
 use loonfs_objectstore::ObjectStore;
@@ -225,14 +226,6 @@ pub(super) struct MetadataSstWriteRequest<'a> {
     segment_index: u32,
     rows: Vec<MetadataRow>,
 }
-
-/// Largest filter block inlined into the segment's manifest descriptor, in
-/// stored bytes (hex doubles it in the manifest JSON). Sized for delta-run
-/// segments — the small, key-range-overlapping tables a point lookup must
-/// otherwise fetch one filter block per run to rule out — while keeping big
-/// base-segment filters (which range pruning already narrows to one
-/// candidate) out of the manifest.
-pub(super) const INLINE_SEGMENT_FILTER_MAX_BYTES: u32 = 1024;
 
 pub(super) async fn write_manifest_segment<S: ObjectStore + ?Sized>(
     store: &S,

--- a/crates/loonfs-core/src/checkpoint/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/cache.rs
@@ -22,7 +22,7 @@ use tokio::sync::OnceCell;
 /// budget is the only limit — one wide directory's segment working set must
 /// fit, or warm listings re-fetch segments superlinearly — and zero
 /// disables the cache.
-pub const DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES: usize = 256 * 1024 * 1024;
+pub(crate) const DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES: usize = 256 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetadataTableCacheConfig {
@@ -181,16 +181,7 @@ struct MetadataTableCacheStatsInner {
 
 impl MetadataTableCache {
     pub fn new(config: MetadataTableCacheConfig) -> Self {
-        Self::with_stored_block_cache(config, None)
-    }
-
-    /// Creates a decoded-block cache with an optional encoded-block cache.
-    /// Passing `None` is equivalent to [`Self::new`].
-    pub fn with_stored_block_cache(
-        config: MetadataTableCacheConfig,
-        stored_block_cache: Option<Arc<dyn StoredMetadataBlockCache>>,
-    ) -> Self {
-        Self::with_stored_block_cache_and_observer(config, stored_block_cache, None)
+        Self::with_stored_block_cache_and_observer(config, None, None)
     }
 
     /// Creates a cache that reports activity to the optional `observer`.

--- a/crates/loonfs-core/src/checkpoint/runs.rs
+++ b/crates/loonfs-core/src/checkpoint/runs.rs
@@ -7,14 +7,11 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 
-pub(super) const DEFAULT_MAX_CHECKPOINT_L0_RUNS: usize = 8;
-/// With block-granular reads the segment is no longer the read unit, so
-/// base segments are sized large to amortize their index and filter
-/// sections across many lookups (design doc, "Sizing").
-pub(super) const DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT: usize = 65_536;
-pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_RUNS: usize = 8;
-pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_ROWS: usize = 131_072;
-pub(super) const DEFAULT_MAX_REORGANIZATION_INPUT_BYTES: usize = 64 * 1024 * 1024;
+pub(super) use loonfs_api::wire::sst_blocks::{
+    DEFAULT_MAX_L0_RUNS as DEFAULT_MAX_CHECKPOINT_L0_RUNS, DEFAULT_MAX_REORGANIZATION_INPUT_BYTES,
+    DEFAULT_MAX_REORGANIZATION_INPUT_ROWS, DEFAULT_MAX_REORGANIZATION_INPUT_RUNS,
+    DEFAULT_MAX_ROWS_PER_SEGMENT as DEFAULT_MAX_CHECKPOINT_ROWS_PER_SEGMENT,
+};
 
 pub(super) const MAX_MAINTENANCE_TABLE_IO: usize = 8;
 pub(super) const CHECKPOINT_L0_RUN_LEVEL: u32 = 0;

--- a/crates/loonfs-core/src/checkpoint/tests/cache.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/cache.rs
@@ -829,9 +829,10 @@ async fn checkpointed_direntry_segment() -> (
 /// built with a local cache hands the read paths. A fresh one stands for a
 /// fresh process: only the local tier carries anything over.
 fn table_cache_over(blocks: &Arc<RecordingStoredMetadataBlockCache>) -> MetadataTableCache {
-    MetadataTableCache::with_stored_block_cache(
+    MetadataTableCache::with_stored_block_cache_and_observer(
         MetadataTableCacheConfig::default(),
         Some(Arc::clone(blocks) as Arc<dyn StoredMetadataBlockCache>),
+        None,
     )
 }
 

--- a/crates/loonfs-core/src/checkpoint/tests/inventory.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/inventory.rs
@@ -9,15 +9,9 @@ use super::*;
 use crate::checkpoint::list::list_checkpoints_page;
 use loonfs_api::wire::control::CheckpointOwner;
 use loonfs_api::{
-    CheckpointOwnerSummary, EffectiveLimit, ErrorCode, ListCheckpointsResponse, NamespaceCursor,
-    PageRequest, PaginationPolicy,
+    CheckpointOwnerSummary, ErrorCode, ListCheckpointsResponse, NamespaceCursor, PageRequest,
 };
-
-fn page_limit(limit: u32) -> EffectiveLimit {
-    PaginationPolicy::default()
-        .resolve_limit(Some(limit))
-        .expect("test page limit")
-}
+use loonfs_test_support::ids::page_limit;
 
 async fn list_all_checkpoints<S: ObjectStore + ?Sized>(
     store: &S,

--- a/crates/loonfs-core/src/commit/validate/tests.rs
+++ b/crates/loonfs-core/src/commit/validate/tests.rs
@@ -19,8 +19,8 @@ use loonfs_api::wire::control::{HeadState, WriterBlock};
 use loonfs_api::wire::wal::WalDelta;
 use loonfs_api::{
     next_public_ordinal, AttributeKey, AttributeRevisionNo, AttributeValue, Attributes, ChangeSeq,
-    CommitId, ContentId, ContentRef, DisplayName, InodeId, InodeKind, NameKey, NamespaceId,
-    RevisionNo, WriterEpoch, MAX_PUBLIC_INTEGER,
+    CommitId, ContentRef, DisplayName, InodeId, InodeKind, NameKey, NamespaceId, RevisionNo,
+    WriterEpoch, MAX_PUBLIC_INTEGER,
 };
 
 fn test_display_name(value: impl AsRef<str>) -> DisplayName {
@@ -28,7 +28,7 @@ fn test_display_name(value: impl AsRef<str>) -> DisplayName {
 }
 
 fn content_ref(seed: &str) -> ContentRef {
-    ContentRef::blob_v1(ContentId::generate(), seed.as_bytes())
+    loonfs_test_support::ids::content_ref(seed.as_bytes())
 }
 
 fn test_attributes(entries: &[(&str, &str)]) -> Attributes {

--- a/crates/loonfs-core/src/lib.rs
+++ b/crates/loonfs-core/src/lib.rs
@@ -108,7 +108,6 @@ pub mod time;
 pub mod cache {
     pub use crate::recency::Recency;
 
-    pub use crate::checkpoint::cache::DEFAULT_METADATA_TABLE_CACHE_DECODED_BYTES;
     pub use crate::checkpoint::{
         ManifestLoadError, ManifestLoadFailureClass, MetadataTableCache, MetadataTableCacheConfig,
         MetadataTableCacheObserver, MetadataTableCacheStats, StoredMetadataBlockCache,

--- a/crates/loonfs-core/src/path/read/materialized_view.rs
+++ b/crates/loonfs-core/src/path/read/materialized_view.rs
@@ -923,8 +923,9 @@ mod tests {
     use crate::context::MutationContext;
     use crate::namespace::bootstrap::bootstrap_namespace;
     use crate::path::write::{CommitRequest, FilesystemOperation};
-    use loonfs_api::{AttributeKey, AttributeRevisionNo, AttributeValue, CommitId};
+    use loonfs_api::{AttributeRevisionNo, AttributeValue, CommitId};
     use loonfs_objectstore::local_fs_store::LocalFsStore;
+    use loonfs_test_support::ids::attribute_key;
     use std::collections::BTreeMap;
     use tempfile::TempDir;
 
@@ -933,10 +934,6 @@ mod tests {
             writer_id: "reader-tests".to_owned(),
             now_ms: 1,
         }
-    }
-
-    fn attribute_key(key: &str) -> AttributeKey {
-        AttributeKey::parse(key).expect("attribute key")
     }
 
     /// Bootstraps a namespace holding `/docs` with one annotated child

--- a/crates/loonfs-core/src/protocol/publish_view.rs
+++ b/crates/loonfs-core/src/protocol/publish_view.rs
@@ -337,10 +337,7 @@ mod tests {
     use crate::namespace::basis::BasisManifest;
     use crate::namespace::bootstrap::bootstrap_metadata_state;
     use loonfs_api::ManifestObjectId;
-
-    fn namespace_id(value: &str) -> NamespaceId {
-        NamespaceId::parse(value).expect("valid namespace id")
-    }
+    use loonfs_test_support::ids::namespace_id;
 
     fn manifest_basis(
         owner: &str,

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -317,8 +317,10 @@ fn multipart_session_upload(session: &UploadSessionState) -> Result<(&str, Check
     }
 }
 
-/// Builds a claimed content reference: multipart fixes the checksum algorithm,
-/// while direct PUT accepts the algorithm supplied by the client.
+/// Builds a content reference from a client's upload claim.
+///
+/// Multipart uploads require the provider's checksum algorithm. Direct PUT
+/// uploads accept the algorithm in the claim.
 fn claimed_content_ref(
     content_id: ContentId,
     claim: &UploadContentClaim,

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -161,7 +161,7 @@ pub(crate) async fn begin_direct_put_upload_target<S: ObjectStore + ?Sized>(
     ensure_upload_namespace_available(store, namespace_id).await?;
     let content_store_id = load_namespace_content_store_id(store, namespace_id).await?;
     let content_id = ContentId::generate();
-    let content_ref = direct_put_content_ref(content_id.clone(), &claim)?;
+    let content_ref = claimed_content_ref(content_id.clone(), &claim, None)?;
     let object_key = content_blob(&content_store_id, &content_id);
     let upload_id = create_upload_session(
         store,
@@ -317,20 +317,21 @@ fn multipart_session_upload(session: &UploadSessionState) -> Result<(&str, Check
     }
 }
 
-/// Builds the content reference for a completed multipart upload.
-///
-/// Completion verifies the provider-reported CRC-64/NVME checksum, which the
-/// resulting content reference records as its one full-object checksum.
-fn direct_multipart_content_ref(
+/// Builds a claimed content reference: multipart fixes the checksum algorithm,
+/// while direct PUT accepts the algorithm supplied by the client.
+fn claimed_content_ref(
     content_id: ContentId,
     claim: &UploadContentClaim,
-    checksum_algorithm: ChecksumAlgorithm,
+    required_algorithm: Option<ChecksumAlgorithm>,
 ) -> Result<ContentRef> {
     let content_ref = ContentRef {
         kind: ContentRefKind::BlobV1,
         content_id,
         size_bytes: claim.size_bytes,
-        checksum: validate_upload_checksum(&claim.checksum, checksum_algorithm)?.clone(),
+        checksum: match required_algorithm {
+            Some(algorithm) => validate_upload_checksum(&claim.checksum, algorithm)?.clone(),
+            None => claim.checksum.clone(),
+        },
     };
     content_ref
         .validate()
@@ -387,23 +388,6 @@ fn multipart_parts(
             })
         })
         .collect()
-}
-
-/// Builds the content reference for a direct PUT claim.
-///
-/// The provider enforces the supplied checksum, and completion verifies the
-/// stored object against it.
-fn direct_put_content_ref(content_id: ContentId, claim: &UploadContentClaim) -> Result<ContentRef> {
-    let content_ref = ContentRef {
-        kind: ContentRefKind::BlobV1,
-        content_id,
-        size_bytes: claim.size_bytes,
-        checksum: claim.checksum.clone(),
-    };
-    content_ref
-        .validate()
-        .map_err(|err| CoreError::InvalidUploadContent(err.to_string()))?;
-    Ok(content_ref)
 }
 
 /// What a session is opened with: everything decided before any byte moves.
@@ -1463,10 +1447,10 @@ fn completion_plan<'a>(
             },
             ResolvedUploadCompletion::Multipart(CompleteMultipartUploadRequest { content, parts }),
         ) => Ok(CompletionPlan::DirectMultipart {
-            requested: direct_multipart_content_ref(
+            requested: claimed_content_ref(
                 session.content_id.clone(),
                 content,
-                *checksum_algorithm,
+                Some(*checksum_algorithm),
             )?,
             provider_upload_id,
             checksum_algorithm: *checksum_algorithm,
@@ -1688,9 +1672,12 @@ mod tests {
             size_bytes: 7,
             checksum: Checksum::crc32c(b"payload"),
         };
-        let content_ref =
-            direct_multipart_content_ref(session.content_id.clone(), &content, required_algorithm)
-                .expect("the stored algorithm accepts the content claim");
+        let content_ref = claimed_content_ref(
+            session.content_id.clone(),
+            &content,
+            Some(required_algorithm),
+        )
+        .expect("the stored algorithm accepts the content claim");
         assert_eq!(content_ref.checksum.algorithm, ChecksumAlgorithm::Crc32c);
 
         let part = CompletedUploadPart {
@@ -1723,12 +1710,10 @@ mod tests {
             size_bytes: 7,
             checksum: Checksum::sha256(b"payload"),
         };
-        assert!(direct_multipart_content_ref(
-            session.content_id,
-            &wrong_content,
-            required_algorithm
-        )
-        .is_err());
+        assert!(
+            claimed_content_ref(session.content_id, &wrong_content, Some(required_algorithm))
+                .is_err()
+        );
     }
 
     /// An aborted session is logically absent: it will never select content,

--- a/crates/loonfs-core/src/storage/content.rs
+++ b/crates/loonfs-core/src/storage/content.rs
@@ -791,12 +791,9 @@ mod tests {
     use loonfs_objectstore::keys::content_blob;
     use loonfs_objectstore::local_fs_store::LocalFsStore;
     use loonfs_objectstore::ObjectStore;
+    use loonfs_test_support::ids::content_ref;
     use loonfs_test_support::stores::{CountingStore, KeyPredicate, OperationClass};
     use tempfile::tempdir;
-
-    fn content_ref(bytes: &[u8]) -> ContentRef {
-        ContentRef::blob_v1(ContentId::generate(), bytes)
-    }
 
     #[tokio::test]
     async fn validate_content_ref_success() {

--- a/crates/loonfs-core/tests/it/common/mod.rs
+++ b/crates/loonfs-core/tests/it/common/mod.rs
@@ -56,7 +56,6 @@ pub(crate) mod commit_split_support {
     use async_trait::async_trait;
     use bytes::Bytes;
     use futures::stream::BoxStream;
-    use loonfs_api::ContentId;
     use loonfs_api::{
         AbsolutePath, ChangeSeq, CommitId, ContentRef, DestinationBehavior, NamespaceId,
     };
@@ -479,7 +478,7 @@ pub(crate) mod commit_split_support {
     }
 
     pub(crate) fn content_ref(seed: &str) -> ContentRef {
-        ContentRef::blob_v1(ContentId::generate(), seed.as_bytes())
+        loonfs_test_support::ids::content_ref(seed.as_bytes())
     }
 
     pub(crate) fn content_blob_counting_store(

--- a/crates/loonfs-core/tests/it/differential.rs
+++ b/crates/loonfs-core/tests/it/differential.rs
@@ -75,7 +75,7 @@ struct NormalizedBinding {
 }
 
 fn content_ref(seed: &str) -> ContentRef {
-    ContentRef::blob_v1(ContentId::generate(), seed.as_bytes())
+    loonfs_test_support::ids::content_ref(seed.as_bytes())
 }
 
 fn create_directory(

--- a/crates/loonfs-grep/src/root/error.rs
+++ b/crates/loonfs-grep/src/root/error.rs
@@ -6,13 +6,6 @@ use loonfs_api::{IndexSegmentId, NamespaceId};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error("invalid grep manifest id {value:?}: {reason}")]
-pub struct GrepManifestIdError {
-    pub(crate) value: String,
-    pub(crate) reason: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum GrepManifestStateError {
     #[error("unsupported grep index format version `{found}`: this build supports `{supported}`")]

--- a/crates/loonfs-grep/src/root/mod.rs
+++ b/crates/loonfs-grep/src/root/mod.rs
@@ -22,9 +22,7 @@ pub use codec::{
     GrepManifestEnvelope, GrepRootEnvelope, GREP_MANIFEST_FORMAT_VERSION, GREP_MANIFEST_KIND,
     GREP_ROOT_FORMAT_VERSION, GREP_ROOT_KIND,
 };
-pub use error::{
-    GrepEnvelopeCodecError, GrepManifestIdError, GrepManifestStateError, GrepRootError,
-};
+pub use error::{GrepEnvelopeCodecError, GrepManifestStateError, GrepRootError};
 pub(crate) use state::ChangeFeedResume;
 pub use state::{
     GrepIndexState, GrepLifecycle, GrepManifestId, GrepManifestState, GrepReorganizeState,

--- a/crates/loonfs-grep/src/root/state.rs
+++ b/crates/loonfs-grep/src/root/state.rs
@@ -1,16 +1,11 @@
 //! Constructor-validated grep manifest payload and its root pointer.
 
-use super::error::{GrepManifestIdError, GrepManifestStateError};
-use loonfs_api::generated_id;
+use super::error::GrepManifestStateError;
 use loonfs_api::wire::sst_blocks::BlockHandle;
+pub use loonfs_api::GrepManifestId;
 use loonfs_api::{ChangeSeq, CheckpointId, IndexSegmentId, InodeId, NamespaceId};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt;
-use std::str::FromStr;
-
-const GREP_MANIFEST_ID_PREFIX: &str = "gmf";
-const GREP_MANIFEST_ID_BODY_LEN: usize = 32;
 
 /// Version of the grep index state nested inside a v1 manifest.
 ///
@@ -18,119 +13,6 @@ const GREP_MANIFEST_ID_BODY_LEN: usize = 32;
 /// compatibility starts with the released format, not intermediate
 /// pre-release encodings.
 pub const GREP_INDEX_FORMAT_VERSION: u32 = 1;
-
-/// Durable object id for one immutable grep manifest candidate.
-///
-/// The id is drawn fresh for every candidate and names *which object*, never
-/// what it contains. A content-derived id would make an identical rebuild
-/// reuse the object an earlier publication left behind, and that reuse is
-/// what lets collection race a publication for a manifest the winner is
-/// about to point at. Integrity evidence rides
-/// [`GrepRootPointer::manifest_payload_checksum`] beside the id.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct GrepManifestId(String);
-
-impl GrepManifestId {
-    /// Generates an id no earlier candidate can carry.
-    pub fn generate() -> Self {
-        Self(generated_id(GREP_MANIFEST_ID_PREFIX))
-    }
-
-    /// Parses the `gmf_` marker plus a 32-character lowercase hex body.
-    pub fn parse(value: impl AsRef<str>) -> Result<Self, GrepManifestIdError> {
-        let value = value.as_ref();
-        let expected_prefix = format!("{GREP_MANIFEST_ID_PREFIX}_");
-        let Some(body) = value.strip_prefix(&expected_prefix) else {
-            return Err(GrepManifestIdError {
-                value: value.to_owned(),
-                reason: format!("must start with `{expected_prefix}`"),
-            });
-        };
-        if body.len() != GREP_MANIFEST_ID_BODY_LEN {
-            return Err(GrepManifestIdError {
-                value: value.to_owned(),
-                reason: format!(
-                    "body must be {GREP_MANIFEST_ID_BODY_LEN} lowercase hex characters"
-                ),
-            });
-        }
-        if !body
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-        {
-            return Err(GrepManifestIdError {
-                value: value.to_owned(),
-                reason: "body must contain only lowercase hex characters".to_owned(),
-            });
-        }
-        Ok(Self(value.to_owned()))
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AsRef<str> for GrepManifestId {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl std::borrow::Borrow<str> for GrepManifestId {
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl fmt::Display for GrepManifestId {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.as_str())
-    }
-}
-
-impl FromStr for GrepManifestId {
-    type Err = GrepManifestIdError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Self::parse(value)
-    }
-}
-
-impl TryFrom<&str> for GrepManifestId {
-    type Error = GrepManifestIdError;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::parse(value)
-    }
-}
-
-impl TryFrom<String> for GrepManifestId {
-    type Error = GrepManifestIdError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::parse(value)
-    }
-}
-
-impl Serialize for GrepManifestId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for GrepManifestId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        Self::parse(value).map_err(serde::de::Error::custom)
-    }
-}
 
 /// Small mutable control payload installed at `extensions/grep/root.json`.
 ///

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -31,6 +31,9 @@ use loonfs_api::v0::{GrepIndexLifecycle, GrepIndexStatusResponse};
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::sst_blocks::{
     index_blocks_for_key_range, DecodedDataBlock, SegmentBlocksBuilder, SegmentIndexEntry,
+    DEFAULT_INLINE_FILTER_MAX_BYTES, DEFAULT_MAX_L0_RUNS, DEFAULT_MAX_REORGANIZATION_INPUT_BYTES,
+    DEFAULT_MAX_REORGANIZATION_INPUT_ROWS, DEFAULT_MAX_REORGANIZATION_INPUT_RUNS,
+    DEFAULT_MAX_ROWS_PER_SEGMENT,
 };
 use loonfs_api::{
     decode_namespace_cursor, encode_cursor, next_public_ordinal, sha256_digest, ChangeSeq,
@@ -70,7 +73,6 @@ const _: () = assert!(
 
 const GREP_BACKFILL_CHECKPOINT_NAME: &str = "loonfs-grep-backfill";
 const GRAM_POSTING_BATCH_TARGET: usize = 256;
-const INLINE_INDEX_FILTER_MAX_BYTES: u32 = 1024;
 const MAX_GREP_WORKER_IO: usize = 8;
 const INDEX_GRAMS_DELTA_LEVEL: u32 = 0;
 const INDEX_GRAMS_MID_LEVEL: u32 = 1;
@@ -97,11 +99,15 @@ impl Default for GramIndexBuildPolicy {
     fn default() -> Self {
         Self {
             max_files_per_step: const { NonZeroUsize::new(256).unwrap() },
-            max_content_bytes_per_step: const { NonZeroU64::new(64 * 1024 * 1024).unwrap() },
-            max_rows_per_segment: const { NonZeroUsize::new(65_536).unwrap() },
-            max_l0_runs: const { NonZeroUsize::new(8).unwrap() },
-            max_mid_runs: const { NonZeroUsize::new(8).unwrap() },
-            max_decoded_input_rows_per_step: const { NonZeroUsize::new(131_072).unwrap() },
+            max_content_bytes_per_step: const {
+                NonZeroU64::new(DEFAULT_MAX_REORGANIZATION_INPUT_BYTES as u64).unwrap()
+            },
+            max_rows_per_segment: const { NonZeroUsize::new(DEFAULT_MAX_ROWS_PER_SEGMENT).unwrap() },
+            max_l0_runs: const { NonZeroUsize::new(DEFAULT_MAX_L0_RUNS).unwrap() },
+            max_mid_runs: const { NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_RUNS).unwrap() },
+            max_decoded_input_rows_per_step: const {
+                NonZeroUsize::new(DEFAULT_MAX_REORGANIZATION_INPUT_ROWS).unwrap()
+            },
         }
     }
 }
@@ -1077,7 +1083,7 @@ async fn write_index_segment<S: ObjectStore + ?Sized>(
         .put_immutable_verified(&object_key, bytes::Bytes::from(built.bytes.clone()))
         .await
         .map_err(grep_immutable_write_error)?;
-    let filter_inline = (built.filter.stored_len <= INLINE_INDEX_FILTER_MAX_BYTES).then(|| {
+    let filter_inline = (built.filter.stored_len <= DEFAULT_INLINE_FILTER_MAX_BYTES).then(|| {
         let start = built.filter.offset as usize;
         hex_encode_bytes(&built.bytes[start..start + built.filter.stored_len as usize])
     });

--- a/crates/loonfs-grep/src/worker.rs
+++ b/crates/loonfs-grep/src/worker.rs
@@ -31,9 +31,8 @@ use loonfs_api::v0::{GrepIndexLifecycle, GrepIndexStatusResponse};
 use loonfs_api::wire::hex::hex_encode_bytes;
 use loonfs_api::wire::sst_blocks::{
     index_blocks_for_key_range, DecodedDataBlock, SegmentBlocksBuilder, SegmentIndexEntry,
-    DEFAULT_INLINE_FILTER_MAX_BYTES, DEFAULT_MAX_L0_RUNS, DEFAULT_MAX_REORGANIZATION_INPUT_BYTES,
-    DEFAULT_MAX_REORGANIZATION_INPUT_ROWS, DEFAULT_MAX_REORGANIZATION_INPUT_RUNS,
-    DEFAULT_MAX_ROWS_PER_SEGMENT,
+    DEFAULT_INLINE_FILTER_MAX_BYTES, DEFAULT_MAX_L0_RUNS, DEFAULT_MAX_REORGANIZATION_INPUT_ROWS,
+    DEFAULT_MAX_REORGANIZATION_INPUT_RUNS, DEFAULT_MAX_ROWS_PER_SEGMENT,
 };
 use loonfs_api::{
     decode_namespace_cursor, encode_cursor, next_public_ordinal, sha256_digest, ChangeSeq,
@@ -72,6 +71,11 @@ const _: () = assert!(
 );
 
 const GREP_BACKFILL_CHECKPOINT_NAME: &str = "loonfs-grep-backfill";
+/// Content bytes one backfill step ingests before it checkpoints its cursor.
+/// This budgets ingestion, not LSM merging — it happens to share a value
+/// with the metadata reorganization input limit, and must stay independent
+/// so a compaction policy change cannot silently change backfill behavior.
+const GREP_BACKFILL_MAX_CONTENT_BYTES_PER_STEP: u64 = 64 * 1024 * 1024;
 const GRAM_POSTING_BATCH_TARGET: usize = 256;
 const MAX_GREP_WORKER_IO: usize = 8;
 const INDEX_GRAMS_DELTA_LEVEL: u32 = 0;
@@ -100,7 +104,7 @@ impl Default for GramIndexBuildPolicy {
         Self {
             max_files_per_step: const { NonZeroUsize::new(256).unwrap() },
             max_content_bytes_per_step: const {
-                NonZeroU64::new(DEFAULT_MAX_REORGANIZATION_INPUT_BYTES as u64).unwrap()
+                NonZeroU64::new(GREP_BACKFILL_MAX_CONTENT_BYTES_PER_STEP).unwrap()
             },
             max_rows_per_segment: const { NonZeroUsize::new(DEFAULT_MAX_ROWS_PER_SEGMENT).unwrap() },
             max_l0_runs: const { NonZeroUsize::new(DEFAULT_MAX_L0_RUNS).unwrap() },

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -32,6 +32,7 @@ use loonfs_objectstore::keys::{
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_objectstore::{ObjectStore, PutMode};
+use loonfs_test_support::ids::nonzero_usize;
 use loonfs_test_support::stores::{
     BlockingStore, FailStore, InjectedError, KeyPredicate, MetadataMapStore, OperationClass,
     OperationContext, OperationKind, RecordedOperation, RecordingStore,
@@ -53,10 +54,6 @@ fn request(pattern: &str) -> GrepRequest {
         allow_stale: false,
         allow_scan: false,
     }
-}
-
-fn nonzero_usize(value: usize) -> NonZeroUsize {
-    NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
 async fn worker(store: &SharedObjectStore) -> GrepWorker<SharedObjectStore> {

--- a/crates/loonfs-objectstore/src/abs.rs
+++ b/crates/loonfs-objectstore/src/abs.rs
@@ -151,11 +151,9 @@ impl ObjectStore for AzureAbsStore {
 #[cfg(test)]
 mod tests {
     use super::{AzureAbsStore, AzureAbsStoreConfig};
+    use crate::test_support::AZURITE_ACCOUNT_KEY;
     use crate::ObjectStore;
     use crate::ObjectStoreError;
-
-    const AZURITE_ACCOUNT_KEY: &str =
-        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
     #[test]
     fn access_key_is_required() {

--- a/crates/loonfs-objectstore/src/configured.rs
+++ b/crates/loonfs-objectstore/src/configured.rs
@@ -264,7 +264,7 @@ mod tests {
         GCP_GCS_MAX_DIRECT_PUT_BYTES,
     };
     use crate::s3_compatible::{AwsS3StoreConfig, CloudflareR2StoreConfig};
-    use crate::test_support::gcs_fixture_service_account_key_file;
+    use crate::test_support::{gcs_fixture_service_account_key_file, AZURITE_ACCOUNT_KEY};
     use crate::ObjectStore;
     use crate::ObjectStoreError;
     use bytes::Bytes;
@@ -274,9 +274,6 @@ mod tests {
     use loonfs_api::ContentRef;
     use std::sync::Arc;
     use std::time::{Duration, UNIX_EPOCH};
-
-    const AZURITE_ACCOUNT_KEY: &str =
-        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
     #[tokio::test]
     async fn configured_local_fs_scopes_optional_key_prefix() {

--- a/crates/loonfs-objectstore/src/gcs.rs
+++ b/crates/loonfs-objectstore/src/gcs.rs
@@ -2,7 +2,9 @@
 
 use super::{ByteRange, ByteStream, ObjectBody, ObjectMetadata, ObjectStore, PutMode};
 use crate::object_store::Result;
-use crate::presign::{stored_crc32c, GcsPresignerConfig, GcsV4Presigner, PresignedUrl};
+use crate::presign::{
+    stored_crc32c, GcsPresignerConfig, GcsV4Presigner, PresignedUrl, CHECKSUM_HEAD_TTL,
+};
 use crate::store_io_runtime::StoreIoRuntime;
 use crate::{
     ObjectStoreError, ProviderObjectStore, ProviderObjectStoreConfig, StoredObjectChecksum,
@@ -14,12 +16,7 @@ use loonfs_api::Checksum;
 use object_store::client::{HttpClient, HttpConnector, HttpRequestBody};
 use object_store::gcp::GoogleCloudStorageBuilder;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
-
-/// Lifetime of the internally signed request used for checksum readback. It
-/// is issued immediately and never handed out, so it only needs to outlive
-/// one round trip and its clock skew.
-const CHECKSUM_HEAD_TTL: Duration = Duration::from_secs(60);
+use std::time::SystemTime;
 
 /// Supplies explicit credentials and key scoping for the native Google Cloud Storage adapter.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/loonfs-objectstore/src/presign/gcs.rs
+++ b/crates/loonfs-objectstore/src/presign/gcs.rs
@@ -9,6 +9,7 @@
 
 use super::{
     DirectGetIssuer, DirectPutIssuer, PresignedGetRequest, PresignedPutRequest, PresignedUrl,
+    MAX_PRESIGN_EXPIRY,
 };
 use crate::keyspace::{normalize_key_prefix, scope_object_key};
 use crate::object_store::Result;
@@ -53,9 +54,6 @@ const GCS_SIGNING_ALGORITHM: &str = "GOOG4-RSA-SHA256";
 /// location rather than requiring the bucket's region, which is what Google's
 /// own client libraries write, so a deployment never has to configure one.
 const GCS_CREDENTIAL_SCOPE_SUFFIX: &str = "auto/storage/goog4_request";
-
-/// Google's documented ceiling for a signed URL's lifetime: seven days.
-const MAX_PRESIGN_EXPIRY: u64 = 7 * 24 * 60 * 60;
 
 /// Google Cloud Storage's documented maximum for a single-request upload:
 /// 5 TiB.

--- a/crates/loonfs-objectstore/src/presign/mod.rs
+++ b/crates/loonfs-objectstore/src/presign/mod.rs
@@ -6,6 +6,12 @@ mod issuer;
 mod s3_compatible;
 mod v4;
 
+/// Maximum lifetime accepted by both supported signed-URL schemes.
+const MAX_PRESIGN_EXPIRY: u64 = 7 * 24 * 60 * 60;
+
+/// Lifetime of an internally signed checksum-readback request.
+pub(crate) const CHECKSUM_HEAD_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
 pub use gcs::{GcsPresignerConfig, GcsV4Presigner, GCP_GCS_MAX_DIRECT_PUT_BYTES};
 pub use issuer::{
     DirectGetIssuer, DirectMultipartIssuer, DirectPutIssuer, DirectTransferIssuers,

--- a/crates/loonfs-objectstore/src/presign/mod.rs
+++ b/crates/loonfs-objectstore/src/presign/mod.rs
@@ -6,10 +6,10 @@ mod issuer;
 mod s3_compatible;
 mod v4;
 
-/// Maximum lifetime accepted by both supported signed-URL schemes.
+/// Maximum lifetime supported by both signed-URL implementations.
 const MAX_PRESIGN_EXPIRY: u64 = 7 * 24 * 60 * 60;
 
-/// Lifetime of an internally signed checksum-readback request.
+/// Lifetime of a signed checksum-readback request.
 pub(crate) const CHECKSUM_HEAD_TTL: std::time::Duration = std::time::Duration::from_secs(60);
 
 pub use gcs::{GcsPresignerConfig, GcsV4Presigner, GCP_GCS_MAX_DIRECT_PUT_BYTES};

--- a/crates/loonfs-objectstore/src/presign/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/presign/s3_compatible.rs
@@ -2,7 +2,7 @@
 
 use super::{
     DirectGetIssuer, DirectMultipartIssuer, DirectPutIssuer, PresignedGetRequest,
-    PresignedPartRequest, PresignedPutRequest, PresignedUrl,
+    PresignedPartRequest, PresignedPutRequest, PresignedUrl, MAX_PRESIGN_EXPIRY,
 };
 use crate::crypto::hmac_sha256;
 use crate::keyspace::{normalize_key_prefix, parse_endpoint_url, scope_object_key};
@@ -34,8 +34,6 @@ const S3_FULL_OBJECT_CHECKSUM_TYPE: &str = "FULL_OBJECT";
 const S3_CRC64NVME_ALGORITHM: &str = "CRC64NVME";
 /// Asks S3-family `HeadObject` to report the object's stored checksum.
 pub(crate) const S3_CHECKSUM_MODE_HEADER: &str = "x-amz-checksum-mode";
-const MAX_PRESIGN_EXPIRY: u64 = 7 * 24 * 60 * 60;
-
 /// AWS S3's documented maximum for a single `PutObject`: 5 GiB. A larger
 /// object has to be uploaded in parts.
 ///

--- a/crates/loonfs-objectstore/src/s3_compatible.rs
+++ b/crates/loonfs-objectstore/src/s3_compatible.rs
@@ -8,7 +8,7 @@ use crate::keyspace::parse_endpoint_url;
 use crate::object_store::Result;
 use crate::presign::PresignedUrl;
 use crate::presign::{
-    S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES,
+    S3CompatiblePresigner, S3PresignerConfig, AWS_S3_MAX_DIRECT_PUT_BYTES, CHECKSUM_HEAD_TTL,
     CLOUDFLARE_R2_MAX_DIRECT_PUT_BYTES,
 };
 use crate::store_io_runtime::StoreIoRuntime;
@@ -28,11 +28,6 @@ use object_store::client::{HttpClient, HttpConnector, HttpRequestBody};
 use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-
-/// Lifetime of the internally signed `HeadObject` used for checksum
-/// readback. The request is issued immediately and never handed out, so it
-/// only needs to outlive one round trip and its clock skew.
-const CHECKSUM_HEAD_TTL: Duration = Duration::from_secs(60);
 
 /// Lifetime of the internally signed multipart control requests. Like the
 /// checksum head, each is issued immediately and never handed out.

--- a/crates/loonfs-objectstore/src/test_support.rs
+++ b/crates/loonfs-objectstore/src/test_support.rs
@@ -3,6 +3,10 @@
 use crate::timing::MonotonicTimer;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+/// Azurite's published development-account key.
+pub(crate) const AZURITE_ACCOUNT_KEY: &str =
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
 /// Deterministic timer that advances a fixed step per reading.
 #[derive(Debug)]
 pub(crate) struct SteppingTimer {

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -520,18 +520,13 @@ pub(super) async fn apply_commit(
             };
             state
                 .writer
-                .publisher()
-                .submit_candidate(namespace_id.clone(), candidate)
+                .commit_candidate(&namespace_id, candidate)
                 .await
         }
         .instrument(span)
         .await
     } else {
-        state
-            .writer
-            .publisher()
-            .submit_commit(namespace_id.clone(), request)
-            .await
+        state.writer.commit(&namespace_id, request).await
     };
     let response = response_result.map_err(|error| {
         ApiResponseError::runtime_for_namespace(&namespace_id, error)

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -287,8 +287,7 @@ pub(super) async fn delete_namespace(
     };
     let response = state
         .writer
-        .publisher()
-        .submit_delete(namespace_id.clone(), options)
+        .delete_namespace(&namespace_id, options)
         .await
         .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
     Ok(Json(response))

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -50,10 +50,7 @@ pub(super) async fn grep(
     if let Some(maintenance) = &state.grep_maintenance {
         maintenance.nudge_if_behind(&namespace_id).await;
     }
-    let service = state
-        .grep_service
-        .as_ref()
-        .expect("grep routes should carry a grep service");
+    let service = state.grep_service();
     // Grep's own segments come off the instrumented store every LoonFS
     // request in this process is measured on; its filesystem reads go
     // through the same reader handle the core planes serve from.
@@ -122,9 +119,7 @@ pub(super) async fn enable_grep_index(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     let outcome = state
-        .grep_worker
-        .as_ref()
-        .expect("grep routes should carry a grep worker")
+        .grep_worker()
         .enable(&namespace_id)
         .await
         .map_err(|error| map_grep_error(&namespace_id, error))?;
@@ -183,9 +178,7 @@ async fn read_grep_index_status(
     namespace_id: &NamespaceId,
 ) -> Result<GrepIndexStatusResponse, ApiResponseError> {
     state
-        .grep_worker
-        .as_ref()
-        .expect("grep routes should carry a grep worker")
+        .grep_worker()
         .index_status(namespace_id)
         .await
         .map_err(|error| map_grep_error(namespace_id, error))
@@ -225,9 +218,7 @@ pub(super) async fn disable_grep_index(
     // to maintain, and the runner forgets the namespace. Nothing here waits
     // on a background task to notice.
     let outcome = state
-        .grep_worker
-        .as_ref()
-        .expect("grep routes should carry a grep worker")
+        .grep_worker()
         .disable(&namespace_id)
         .await
         .map_err(|error| map_grep_error(&namespace_id, error))?;
@@ -277,9 +268,7 @@ pub(super) async fn gc_grep_index(
     let namespace_id = namespace_id_path.into_id()?;
     let request = request.unwrap_or_default();
     let report = state
-        .grep_worker
-        .as_ref()
-        .expect("grep routes should carry a grep worker")
+        .grep_worker()
         .garbage_collect_namespace(
             &namespace_id,
             current_unix_ms()?,

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -172,6 +172,20 @@ pub(super) struct AppState {
     pub(super) local_cache: Option<Arc<FoyerStoredMetadataBlockCache>>,
 }
 
+impl AppState {
+    pub(super) fn grep_worker(&self) -> &GrepWorker<SharedObjectStore> {
+        self.grep_worker
+            .as_ref()
+            .expect("grep routes should carry a grep worker")
+    }
+
+    pub(super) fn grep_service(&self) -> &GrepService {
+        self.grep_service
+            .as_deref()
+            .expect("grep routes should carry a grep service")
+    }
+}
+
 /// Request-side access to grep maintenance.
 ///
 /// Requests may probe whether indexing is due and submit a non-blocking nudge.

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -3483,7 +3483,7 @@ mod direct_download {
         assert_eq!(inode_grant.inode_id, entry.inode_id);
         assert_eq!(inode_grant.content_ref, grant.content_ref);
         let mut stream = client
-            .open_direct_download_by_inode(&inode_grant)
+            .open_direct_download_by_inode(&inode_grant, 0)
             .await
             .expect("open inode grant");
         let mut inode_received = Vec::new();

--- a/crates/loonfs-test-support/src/ids.rs
+++ b/crates/loonfs-test-support/src/ids.rs
@@ -4,7 +4,7 @@ use loonfs_api::{
     ActorId, ActorRef, AttributeKey, AttributeValue, ContentId, ContentRef, EffectiveLimit,
     NamespaceId,
 };
-use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
+use std::num::{NonZeroU32, NonZeroUsize};
 
 /// Parses a namespace id that is expected to be valid test data.
 pub fn namespace_id(value: &str) -> NamespaceId {
@@ -46,13 +46,8 @@ pub fn nonzero_usize(value: usize) -> NonZeroUsize {
     NonZeroUsize::new(value).expect("test value should be nonzero")
 }
 
-/// Constructs a nonzero `u64` that is expected to be valid test data.
-pub fn nonzero_u64(value: u64) -> NonZeroU64 {
-    NonZeroU64::new(value).expect("test value should be nonzero")
-}
-
 /// Constructs a nonzero `u32` that is expected to be valid test data.
-pub fn nonzero_u32(value: u32) -> NonZeroU32 {
+fn nonzero_u32(value: u32) -> NonZeroU32 {
     NonZeroU32::new(value).expect("test value should be nonzero")
 }
 

--- a/crates/loonfs-test-support/src/stores/blocking_store.rs
+++ b/crates/loonfs-test-support/src/stores/blocking_store.rs
@@ -1,5 +1,5 @@
 //! An async gate for selected object-store operations.
-//! `wait_until_completed` is the completing half of its deliberately two-sided gate.
+//! Tests can wait for both the blocked operation and its eventual completion.
 
 use super::{KeyPredicate, OperationClass, OperationContext, OperationKind};
 use async_trait::async_trait;

--- a/crates/loonfs-test-support/src/stores/blocking_store.rs
+++ b/crates/loonfs-test-support/src/stores/blocking_store.rs
@@ -1,4 +1,5 @@
 //! An async gate for selected object-store operations.
+//! `wait_until_completed` is the completing half of its deliberately two-sided gate.
 
 use super::{KeyPredicate, OperationClass, OperationContext, OperationKind};
 use async_trait::async_trait;

--- a/crates/loonfs-test-support/src/stores/counting_store.rs
+++ b/crates/loonfs-test-support/src/stores/counting_store.rs
@@ -96,11 +96,6 @@ impl<S> CountingStore<S> {
         }
     }
 
-    /// Counts operations on content blobs.
-    pub fn content_blobs(inner: S) -> Self {
-        Self::new(inner, KeyPredicate::content_blob())
-    }
-
     /// Counts operations on metadata tables.
     pub fn metadata_tables(inner: S) -> Self {
         Self::new(inner, KeyPredicate::metadata_table())

--- a/crates/loonfs-test-support/src/stores/multipart_store.rs
+++ b/crates/loonfs-test-support/src/stores/multipart_store.rs
@@ -98,23 +98,6 @@ impl<S> MultipartStore<S> {
         format!("\"{}\"", Checksum::crc64nvme(bytes).value)
     }
 
-    /// The part list a well-behaved client would carry to completion.
-    pub fn completed_parts(&self, provider_upload_id: &str) -> Vec<MultipartPart> {
-        let open = self.lock();
-        let upload = open
-            .get(provider_upload_id)
-            .expect("parts listed for an open multipart upload");
-        upload
-            .parts
-            .iter()
-            .map(|(part_number, bytes)| MultipartPart {
-                part_number: *part_number,
-                etag: format!("\"{}\"", Checksum::crc64nvme(bytes).value),
-                checksum: Checksum::crc64nvme(bytes),
-            })
-            .collect()
-    }
-
     fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<String, OpenUpload>> {
         self.open.lock().unwrap_or_else(|err| err.into_inner())
     }

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -357,6 +357,20 @@ impl ReadCore {
         Ok((self.reader_engine(namespace_id), read_context))
     }
 
+    /// Opens a pinned read of the latest metadata view and records it in the
+    /// runtime cache counters.
+    pub(crate) async fn pinned_metadata_read(
+        &self,
+        namespace_id: &NamespaceId,
+    ) -> Result<(
+        loonfs_core::NamespaceReaderEngine<crate::SharedObjectStore>,
+        RuntimeReadContext,
+    )> {
+        let pinned = self.pinned_read(namespace_id).await?;
+        self.inner.cache_stats.record_latest_metadata_view_read();
+        Ok(pinned)
+    }
+
     /// Returns the namespace's immutable identity, read off the cached head
     /// anchor.
     pub(crate) async fn load_namespace_catalog_cached(

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -357,8 +357,7 @@ impl ReadCore {
         Ok((self.reader_engine(namespace_id), read_context))
     }
 
-    /// Opens a pinned read of the latest metadata view and records it in the
-    /// runtime cache counters.
+    /// Pins the latest metadata view and records the read in cache metrics.
     pub(crate) async fn pinned_metadata_read(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -271,11 +271,12 @@ impl FsReader {
     /// [`CheckpointFilesPage::checkpoint_seq`] is what
     /// [`Self::list_changes`] reports. Directories are not returned.
     ///
-    /// A checkpoint that was released, expired, or reaped answers
-    /// `checkpoint_unavailable`; the enumeration never silently falls back
-    /// to current state. A consumer that loses its checkpoint takes a new
-    /// one and starts over.
-    /// This reads a checkpoint snapshot, not the latest metadata view, so it does not count as one.
+    /// A released, expired, or reaped checkpoint returns
+    /// `checkpoint_unavailable`. The caller must create a new checkpoint and
+    /// restart instead of silently reading current state.
+    ///
+    /// This does not increment the latest-metadata-view metric because it
+    /// reads a checkpoint snapshot.
     pub async fn list_checkpoint_files_page(
         &self,
         namespace_id: &NamespaceId,
@@ -314,13 +315,13 @@ impl FsReader {
 
     /// Reads one immutable content object by reference.
     ///
-    /// `max_bytes` is this caller's own budget, checked against the
-    /// reference's declared size before any fetch, and deliberately
-    /// independent of the deployment's configured download limit — a
-    /// consumer that streams work through a fixed buffer says so here. The
-    /// fetched bytes are verified against the reference's size and digest,
-    /// and a mismatch fails the read.
-    /// This reads immutable content, not the latest metadata view, so it does not count as one.
+    /// `max_bytes` is checked against the declared size before fetching. It is
+    /// independent of the deployment's download limit so callers can apply a
+    /// smaller memory budget. The read fails if the returned size or digest
+    /// does not match the reference.
+    ///
+    /// This does not increment the latest-metadata-view metric because it
+    /// reads immutable content directly.
     pub async fn read_content_ref(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -40,15 +40,11 @@ impl FsReader {
     ) -> Result<AuthoritativePathEntry> {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let entry = engine
             .resolve_path(absolute_path, options, &read_context)
             .await?;
         tracing::Span::current().record("cache_path", crate::trace::CACHE_MATERIALIZED_TABLES);
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(entry)
     }
 
@@ -73,13 +69,9 @@ impl FsReader {
     ) -> Result<AuthoritativePathEntry> {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let entry = engine.stat_inode(inode_id, options, &read_context).await?;
         tracing::Span::current().record("cache_path", crate::trace::CACHE_MATERIALIZED_TABLES);
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(entry)
     }
 
@@ -156,15 +148,11 @@ impl FsReader {
     ) -> Result<(ListPathEntriesResponse, Option<DirectoryPageCursor>)> {
         let listed_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let request_head_seq = request.cursor.as_ref().map(|cursor| cursor.head_seq);
         let page = engine
             .list_path_page(listed_path.as_str(), request, options, &read_context)
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         let head_seq = page
             .items
             .first()
@@ -188,7 +176,7 @@ impl FsReader {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativeFileBytes> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let read = engine
             .read_file(
                 absolute_path,
@@ -196,10 +184,6 @@ impl FsReader {
                 self.core.inner.config.max_read_content_bytes,
             )
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(read)
     }
 
@@ -229,7 +213,7 @@ impl FsReader {
         absolute_path: &str,
         options: ReadFileStreamOptions,
     ) -> Result<FileContentStream<SharedObjectStore>> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let stream = engine
             .read_file_stream(
                 absolute_path,
@@ -238,10 +222,6 @@ impl FsReader {
                 options.start_offset,
             )
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(stream)
     }
 
@@ -260,14 +240,10 @@ impl FsReader {
         absolute_path: &str,
         revision_no: Option<RevisionNo>,
     ) -> Result<DirectDownloadTarget> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let target = engine
             .direct_download_target(absolute_path, revision_no, &read_context)
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(target)
     }
 
@@ -279,14 +255,10 @@ impl FsReader {
         inode_id: InodeId,
         revision_no: RevisionNo,
     ) -> Result<DirectDownloadByInodeTarget> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let target = engine
             .direct_download_target_by_inode(inode_id, revision_no, &read_context)
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(target)
     }
 
@@ -303,6 +275,7 @@ impl FsReader {
     /// `checkpoint_unavailable`; the enumeration never silently falls back
     /// to current state. A consumer that loses its checkpoint takes a new
     /// one and starts over.
+    /// This reads a checkpoint snapshot, not the latest metadata view, so it does not count as one.
     pub async fn list_checkpoint_files_page(
         &self,
         namespace_id: &NamespaceId,
@@ -332,14 +305,10 @@ impl FsReader {
         namespace_id: &NamespaceId,
         inode_ids: &[InodeId],
     ) -> Result<Vec<CurrentFileState>> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let states = engine
             .resolve_current_files(inode_ids, &read_context)
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(states)
     }
 
@@ -351,6 +320,7 @@ impl FsReader {
     /// consumer that streams work through a fixed buffer says so here. The
     /// fetched bytes are verified against the reference's size and digest,
     /// and a mismatch fails the read.
+    /// This reads immutable content, not the latest metadata view, so it does not count as one.
     pub async fn read_content_ref(
         &self,
         namespace_id: &NamespaceId,
@@ -372,12 +342,8 @@ impl FsReader {
         namespace_id: &NamespaceId,
         request: PageRequest<loonfs_api::TrashPageCursor>,
     ) -> Result<loonfs_api::ListTrashResponse> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let page = engine.list_trash_page(request, &read_context).await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         let next_cursor = encode_next_cursor(page.next_cursor.as_ref())?;
         Ok(loonfs_api::ListTrashResponse {
             namespace_id: namespace_id.clone(),
@@ -396,15 +362,11 @@ impl FsReader {
     ) -> Result<ListFileRevisionsResponse> {
         let absolute_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let fallback_inode_id = request.cursor.as_ref().map(|cursor| cursor.inode_id);
         let page = engine
             .list_file_revisions_page(absolute_path.as_str(), request, &read_context)
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
             read_context.head.seq,
@@ -420,14 +382,10 @@ impl FsReader {
         inode_id: InodeId,
         request: PageRequest<FileRevisionsPageCursor>,
     ) -> Result<ListFileRevisionsResponse> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let page = engine
             .list_file_revisions_for_inode_page(inode_id, request, &read_context)
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(file_revisions_page_response(
             namespace_id.clone(),
             read_context.head.seq,
@@ -443,7 +401,7 @@ impl FsReader {
         absolute_path: &str,
         revision_no: RevisionNo,
     ) -> Result<AuthoritativeFileBytes> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let read = engine
             .read_file_revision(
                 absolute_path,
@@ -452,10 +410,6 @@ impl FsReader {
                 self.core.inner.config.max_read_content_bytes,
             )
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(read)
     }
 
@@ -467,7 +421,7 @@ impl FsReader {
         inode_id: InodeId,
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>> {
-        let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
+        let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let bytes = engine
             .read_file_revision_for_inode(
                 inode_id,
@@ -476,10 +430,6 @@ impl FsReader {
                 self.core.inner.config.max_read_content_bytes,
             )
             .await?;
-        self.core
-            .inner
-            .cache_stats
-            .record_latest_metadata_view_read();
         Ok(bytes)
     }
 

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -691,7 +691,7 @@ impl FsWriter {
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
-        self.publish_candidate(namespace_id, CommitCandidate::new(request))
+        self.commit_candidate(namespace_id, CommitCandidate::new(request))
             .await
     }
 
@@ -705,7 +705,7 @@ impl FsWriter {
         request: CommitRequest,
         prepared_content: Vec<PreparedContent>,
     ) -> Result<CommitResponse> {
-        self.publish_candidate(
+        self.commit_candidate(
             namespace_id,
             CommitCandidate::prepared(request, prepared_content),
         )
@@ -717,7 +717,7 @@ impl FsWriter {
     /// its own durable result, and admitted work is owned by the service's
     /// worker — a cancelled caller abandons only its result delivery, never
     /// the publication.
-    async fn publish_candidate(
+    pub async fn commit_candidate(
         &self,
         namespace_id: &NamespaceId,
         candidate: CommitCandidate,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -197,11 +197,11 @@ pub use maintenance_runner::{
     MaintenanceStepConclusion, MaintenanceStepResult,
 };
 pub use options::{
-    gc_config_from_request, CommitOptions, CopyOptions, CreateCheckpointOptions,
-    CreateDirectoryOptions, CreateNamespaceOptions, DeleteOptions, ListChangesOptions,
-    ListPathEntriesOptions, MaintenancePlan, MetadataMaintenanceOptions, MoveOptions,
-    PutFileOptions, ReadFileStreamOptions, RestoreRevisionOptions, StatPathOptions,
-    UndeleteOptions, UpdateAttributesOptions,
+    CommitOptions, CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions,
+    CreateNamespaceOptions, DeleteOptions, ListChangesOptions, ListPathEntriesOptions,
+    MaintenancePlan, MetadataMaintenanceOptions, MoveOptions, PutFileOptions,
+    ReadFileStreamOptions, RestoreRevisionOptions, StatPathOptions, UndeleteOptions,
+    UpdateAttributesOptions,
 };
 pub use trace::{payload_class, TraceMode, TraceStoreKind};
 

--- a/crates/loonfs/src/options.rs
+++ b/crates/loonfs/src/options.rs
@@ -128,7 +128,7 @@ fn metadata_options_from_request(
 ///
 /// [`GcRequest`] carries optional overrides; [`GcConfig`] carries the values
 /// the pass actually runs with, so the two are deliberately distinct shapes.
-pub fn gc_config_from_request(request: GcRequest) -> GcConfig {
+pub(crate) fn gc_config_from_request(request: GcRequest) -> GcConfig {
     let defaults = GcConfig::default();
     GcConfig {
         grace_window_ms: request.grace_window_ms.unwrap_or(defaults.grace_window_ms),

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -23,7 +23,7 @@
 
 use crate::fs::{ReadCore, WriterBits};
 use crate::metrics::PublishOutcome;
-use crate::publish::{CommitCandidate, CommitRequest, PreparedContent};
+use crate::publish::CommitCandidate;
 use crate::{
     CoreError, DeleteNamespaceOptions, DeleteNamespaceResponse, RuntimeCacheConfig, RuntimeError,
 };
@@ -318,28 +318,6 @@ impl PublisherRegistry {
             trace_mode,
             trace_store_kind,
         }
-    }
-
-    /// Submits one mutation request through the namespace's publisher.
-    pub async fn submit_commit(
-        &self,
-        namespace_id: NamespaceId,
-        request: CommitRequest,
-    ) -> CommitResult {
-        self.submit_candidate(namespace_id, CommitCandidate::new(request))
-            .await
-    }
-
-    /// Submits one mutation request together with opaque proofs for its
-    /// already-prepared content.
-    pub async fn submit_commit_with_prepared_content(
-        &self,
-        namespace_id: NamespaceId,
-        request: CommitRequest,
-        content: Vec<PreparedContent>,
-    ) -> CommitResult {
-        self.submit_candidate(namespace_id, CommitCandidate::prepared(request, content))
-            .await
     }
 
     /// Submits a namespace deletion, sequenced as a barrier: mutations

--- a/crates/loonfs/src/publisher/tests.rs
+++ b/crates/loonfs/src/publisher/tests.rs
@@ -9,7 +9,7 @@ use crate::content_tokens::ContentTokenError;
 use crate::fs::WriterIdentity;
 use crate::maintenance_runner::MaintenanceRunner;
 use crate::metrics::{DefaultMetricsRecorder, MetricValue, RuntimeInstruments};
-use crate::publish::{ContentPreparationError, FilesystemOperation};
+use crate::publish::{CommitRequest, ContentPreparationError, FilesystemOperation};
 use crate::{
     BeginUploadRequest, CreateNamespaceOptions, ErrorCode, RuntimeCacheConfig,
     SharedObjectStore as SharedStore, TraceMode, TraceStoreKind,
@@ -307,9 +307,9 @@ async fn publish_once_into_each(writer: &crate::FsWriter, namespaces: &[Namespac
             .await
             .expect("bootstrap");
         registry
-            .submit_commit(
+            .submit_candidate(
                 namespace_id.clone(),
-                create_directory_request("seed", "docs"),
+                CommitCandidate::new(create_directory_request("seed", "docs")),
             )
             .await
             .expect("commit");
@@ -883,9 +883,9 @@ async fn hot_submissions_wait_out_the_pacing_interval() {
     let registry = writer.publisher();
 
     registry
-        .submit_commit(
+        .submit_candidate(
             namespace_id.clone(),
-            create_directory_request("warmup", "warmup"),
+            CommitCandidate::new(create_directory_request("warmup", "warmup")),
         )
         .await
         .expect("warmup commit");
@@ -895,7 +895,10 @@ async fn hot_submissions_wait_out_the_pacing_interval() {
         let namespace_id = namespace_id.clone();
         async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("hot", "hot"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("hot", "hot")),
+                )
                 .await
         }
     });
@@ -1402,7 +1405,10 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("warmup", "warmup"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("warmup", "warmup")),
+                )
                 .await
         })
     };
@@ -1417,12 +1423,20 @@ async fn publisher_batches_concurrent_distinct_commits_into_one_wal_segment() {
     let response_a = {
         let registry = registry.clone();
         let namespace_id = namespace_id.clone();
-        tokio::spawn(async move { registry.submit_commit(namespace_id, request_a).await })
+        tokio::spawn(async move {
+            registry
+                .submit_candidate(namespace_id, CommitCandidate::new(request_a))
+                .await
+        })
     };
     let response_b = {
         let registry = registry.clone();
         let namespace_id = namespace_id.clone();
-        tokio::spawn(async move { registry.submit_commit(namespace_id, request_b).await })
+        tokio::spawn(async move {
+            registry
+                .submit_candidate(namespace_id, CommitCandidate::new(request_b))
+                .await
+        })
     };
     let publisher = registry.publisher_for(&namespace_id).expect("publisher");
     wait_for_queued_candidates(&publisher, 2).await;
@@ -1531,7 +1545,10 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("warmup", "warmup"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("warmup", "warmup")),
+                )
                 .await
         })
     };
@@ -1552,14 +1569,21 @@ async fn publisher_batches_plain_and_prepared_mutations_together() {
     let plain_response = {
         let registry = registry.clone();
         let namespace_id = namespace_id.clone();
-        tokio::spawn(async move { registry.submit_commit(namespace_id, plain).await })
+        tokio::spawn(async move {
+            registry
+                .submit_candidate(namespace_id, CommitCandidate::new(plain))
+                .await
+        })
     };
     let prepared_response = {
         let registry = registry.clone();
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit_with_prepared_content(namespace_id, prepared, vec![prepared_content])
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::prepared(prepared, vec![prepared_content]),
+                )
                 .await
         })
     };
@@ -1632,7 +1656,10 @@ async fn registry_close_admission_refuses_new_work_while_admitted_work_drains() 
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("active", "active"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("active", "active")),
+                )
                 .await
         })
     };
@@ -1641,9 +1668,9 @@ async fn registry_close_admission_refuses_new_work_while_admitted_work_drains() 
     // Admission then closes, and new work is refused.
     registry.close_admission();
     let refused = registry
-        .submit_commit(
+        .submit_candidate(
             namespace_id.clone(),
-            create_directory_request("refused", "refused"),
+            CommitCandidate::new(create_directory_request("refused", "refused")),
         )
         .await
         .expect_err("submission after close_admission");
@@ -1700,7 +1727,10 @@ async fn worker_survives_panic_and_processes_later_queue_items() {
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("doomed", "doomed"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("doomed", "doomed")),
+                )
                 .await
         })
     };
@@ -1713,7 +1743,10 @@ async fn worker_survives_panic_and_processes_later_queue_items() {
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("queued", "queued"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("queued", "queued")),
+                )
                 .await
         })
     };
@@ -1764,9 +1797,9 @@ async fn successful_delete_evicts_the_namespace_publisher() {
     let registry = writer.publisher();
 
     registry
-        .submit_commit(
+        .submit_candidate(
             namespace_id.clone(),
-            create_directory_request("before", "before"),
+            CommitCandidate::new(create_directory_request("before", "before")),
         )
         .await
         .expect("commit before delete");
@@ -1784,9 +1817,9 @@ async fn successful_delete_evicts_the_namespace_publisher() {
     // A later submission builds a fresh publisher and still fails, now
     // on the durable tombstone instead of the fast in-memory flag.
     let late = registry
-        .submit_commit(
+        .submit_candidate(
             namespace_id.clone(),
-            create_directory_request("late", "late"),
+            CommitCandidate::new(create_directory_request("late", "late")),
         )
         .await
         .expect_err("submission after delete");
@@ -1805,9 +1838,9 @@ async fn close_admission_refuses_without_creating_publishers() {
 
     registry.close_admission();
     let refused = registry
-        .submit_commit(
+        .submit_candidate(
             namespace_id.clone(),
-            create_directory_request("nope", "nope"),
+            CommitCandidate::new(create_directory_request("nope", "nope")),
         )
         .await
         .expect_err("closed registry refuses commits");
@@ -1846,7 +1879,10 @@ async fn a_delete_admitted_before_close_admission_lands_terminal() {
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("active", "active"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("active", "active")),
+                )
                 .await
         })
     };
@@ -1914,7 +1950,10 @@ async fn delete_queued_mid_publish_waits_behind_admitted_work() {
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("before", "before"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("before", "before")),
+                )
                 .await
         })
     };
@@ -1934,7 +1973,10 @@ async fn delete_queued_mid_publish_waits_behind_admitted_work() {
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(namespace_id, create_directory_request("second", "second"))
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::new(create_directory_request("second", "second")),
+                )
                 .await
         })
     };
@@ -2235,7 +2277,10 @@ async fn a_skipped_eviction_leaves_the_namespace_accounted() {
         .await
         .expect("bootstrap");
     registry
-        .submit_commit(other.clone(), create_directory_request("seed", "docs"))
+        .submit_candidate(
+            other.clone(),
+            CommitCandidate::new(create_directory_request("seed", "docs")),
+        )
         .await
         .expect("commit while the other engine is held");
 
@@ -2253,7 +2298,10 @@ async fn a_skipped_eviction_leaves_the_namespace_accounted() {
 
     drop(held_engine);
     registry
-        .submit_commit(other.clone(), create_directory_request("second", "more"))
+        .submit_candidate(
+            other.clone(),
+            CommitCandidate::new(create_directory_request("second", "more")),
+        )
         .await
         .expect("commit once the engine is free");
 

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::panic)]
 // Fixture assertions panic for precise diagnostics, as the test modules do.
 
-use loonfs::publish::CommitRequest;
+use loonfs::publish::{CommitCandidate, CommitRequest};
 use loonfs::UploadContentClaim;
 use loonfs::{
     AdvanceRetentionResponse, AuthoritativeFileBytes, AuthoritativePathEntry, BeginUploadRequest,
@@ -511,9 +511,9 @@ impl RuntimeTestExt for TestRuntime {
         block_on(async move {
             // Admitted in one pass, before the publisher's worker can take
             // any of them, so the requests coalesce into one publication.
-            let submissions = requests
-                .into_iter()
-                .map(|request| publisher.submit_commit(namespace_id.clone(), request));
+            let submissions = requests.into_iter().map(|request| {
+                publisher.submit_candidate(namespace_id.clone(), CommitCandidate::new(request))
+            });
             futures::future::join_all(submissions).await
         })
     }

--- a/crates/loonfs/tests/it/content_request_accounting.rs
+++ b/crates/loonfs/tests/it/content_request_accounting.rs
@@ -614,9 +614,13 @@ async fn plain_path_put_fails_unprepared_without_content_io() {
     let error = harness
         .writer
         .publisher()
-        .submit_commit(
+        .submit_candidate(
             harness.namespace_id.clone(),
-            put_request("plain-unprepared-put", "/file.txt", content_ref.clone()),
+            CommitCandidate::new(put_request(
+                "plain-unprepared-put",
+                "/file.txt",
+                content_ref.clone(),
+            )),
         )
         .await
         .expect_err("plain path put must require prepared content");
@@ -677,9 +681,9 @@ async fn replacing_put_fails_unprepared_without_content_io() {
     let error = harness
         .writer
         .publisher()
-        .submit_commit(
+        .submit_candidate(
             harness.namespace_id.clone(),
-            CommitRequest::single(
+            CommitCandidate::new(CommitRequest::single(
                 CommitId::parse("unprepared-replace").expect("valid commit id"),
                 loonfs_test_support::test_actor(),
                 None,
@@ -689,7 +693,7 @@ async fn replacing_put_fails_unprepared_without_content_io() {
                     behavior: DestinationBehavior::Replace,
                     expected_revision_no: None,
                 },
-            ),
+            )),
         )
         .await
         .expect_err("unprepared replacement must fail");
@@ -844,10 +848,9 @@ async fn commit_id_replay_performs_no_content_operations() {
     let original = harness
         .writer
         .publisher()
-        .submit_commit_with_prepared_content(
+        .submit_candidate(
             harness.namespace_id.clone(),
-            intent.clone(),
-            vec![prepared],
+            CommitCandidate::prepared(intent.clone(), vec![prepared]),
         )
         .await
         .expect("publish original put");
@@ -856,7 +859,7 @@ async fn commit_id_replay_performs_no_content_operations() {
     let replay = harness
         .writer
         .publisher()
-        .submit_commit(harness.namespace_id.clone(), intent)
+        .submit_candidate(harness.namespace_id.clone(), CommitCandidate::new(intent))
         .await
         .expect("replay put");
 
@@ -873,10 +876,9 @@ async fn rejected_preparation_replays_durable_receipt_without_content_operations
     let original = harness
         .writer
         .publisher()
-        .submit_commit_with_prepared_content(
+        .submit_candidate(
             harness.namespace_id.clone(),
-            intent.clone(),
-            vec![prepared],
+            CommitCandidate::prepared(intent.clone(), vec![prepared]),
         )
         .await
         .expect("publish original put");
@@ -975,7 +977,10 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
         let prepared = prepared.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit_with_prepared_content(namespace_id, intent, vec![prepared])
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::prepared(intent, vec![prepared]),
+                )
                 .await
         })
     };
@@ -984,10 +989,9 @@ async fn in_flight_duplicate_performs_no_additional_content_operations() {
     assert_content_counts(primary_counts, 0, 0, 0, 0);
 
     let registry = writer.publisher();
-    let mut duplicate = Box::pin(registry.submit_commit_with_prepared_content(
+    let mut duplicate = Box::pin(registry.submit_candidate(
         namespace_id.clone(),
-        intent,
-        vec![prepared],
+        CommitCandidate::prepared(intent, vec![prepared]),
     ));
     assert!(
         futures::poll!(duplicate.as_mut()).is_pending(),
@@ -1039,7 +1043,10 @@ async fn stale_head_retry_preserves_content_admission() {
 
     writer
         .publisher()
-        .submit_commit_with_prepared_content(namespace_id, intent, vec![prepared])
+        .submit_candidate(
+            namespace_id,
+            CommitCandidate::prepared(intent, vec![prepared]),
+        )
         .await
         .expect("publish after stale-head retry");
 
@@ -1077,9 +1084,9 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
         let namespace_id = namespace_id.clone();
         tokio::spawn(async move {
             registry
-                .submit_commit(
+                .submit_candidate(
                     namespace_id,
-                    CommitRequest::single(
+                    CommitCandidate::new(CommitRequest::single(
                         CommitId::parse("mixed-blocker").expect("valid commit id"),
                         loonfs_test_support::test_actor(),
                         None,
@@ -1087,7 +1094,7 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
                             path: parse_mutation_path("/hold").expect("valid mutation path"),
                             parents: false,
                         },
-                    ),
+                    )),
                 )
                 .await
         })
@@ -1095,18 +1102,24 @@ async fn mixed_batch_publishes_admitted_put_and_rejects_unprepared_put_without_c
     blocking.wait_until_blocked().await;
 
     let registry = writer.publisher();
-    let mut admitted = Box::pin(registry.submit_commit_with_prepared_content(
+    let mut admitted = Box::pin(registry.submit_candidate(
         namespace_id.clone(),
-        put_request("mixed-admitted", "/admitted.txt", content_ref.clone()),
-        vec![prepared],
+        CommitCandidate::prepared(
+            put_request("mixed-admitted", "/admitted.txt", content_ref.clone()),
+            vec![prepared],
+        ),
     ));
     assert!(
         futures::poll!(admitted.as_mut()).is_pending(),
         "admitted put must queue behind the blocked publication"
     );
-    let mut unprepared = Box::pin(registry.submit_commit(
+    let mut unprepared = Box::pin(registry.submit_candidate(
         namespace_id.clone(),
-        put_request("mixed-unprepared", "/unprepared.txt", content_ref.clone()),
+        CommitCandidate::new(put_request(
+            "mixed-unprepared",
+            "/unprepared.txt",
+            content_ref.clone(),
+        )),
     ));
     assert!(
         futures::poll!(unprepared.as_mut()).is_pending(),

--- a/crates/loonfs/tests/it/direct_put.rs
+++ b/crates/loonfs/tests/it/direct_put.rs
@@ -5,7 +5,7 @@
 
 use crate::common::*;
 use bytes::Bytes;
-use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
+use loonfs::publish::{parse_mutation_path, CommitCandidate, CommitRequest, FilesystemOperation};
 use loonfs::{
     BeginUploadRequest, ChangeSeq, CommitId, CreateDirectoryOptions, CreateNamespaceOptions,
     DestinationBehavior, ErrorCode, NamespaceId, PutFileOptions, RuntimeCacheConfig,
@@ -574,10 +574,22 @@ fn concurrent_puts_coalesce_into_one_wal_segment() {
         let publisher = fs.writer.publisher();
 
         let puts = tokio::join!(
-            publisher.submit_commit_with_prepared_content(namespace_id.clone(), put_a.0, put_a.1,),
-            publisher.submit_commit_with_prepared_content(namespace_id.clone(), put_b.0, put_b.1,),
-            publisher.submit_commit_with_prepared_content(namespace_id.clone(), put_c.0, put_c.1,),
-            publisher.submit_commit_with_prepared_content(namespace_id.clone(), put_d.0, put_d.1,),
+            publisher.submit_candidate(
+                namespace_id.clone(),
+                CommitCandidate::prepared(put_a.0, put_a.1),
+            ),
+            publisher.submit_candidate(
+                namespace_id.clone(),
+                CommitCandidate::prepared(put_b.0, put_b.1),
+            ),
+            publisher.submit_candidate(
+                namespace_id.clone(),
+                CommitCandidate::prepared(put_c.0, put_c.1),
+            ),
+            publisher.submit_candidate(
+                namespace_id.clone(),
+                CommitCandidate::prepared(put_d.0, put_d.1),
+            ),
         );
         puts.0.expect("put a");
         puts.1.expect("put b");

--- a/crates/loonfs/tests/it/publication.rs
+++ b/crates/loonfs/tests/it/publication.rs
@@ -4,7 +4,7 @@
 //! publication itself.
 
 use futures::future::BoxFuture;
-use loonfs::publish::{parse_mutation_path, CommitRequest, FilesystemOperation};
+use loonfs::publish::{parse_mutation_path, CommitCandidate, CommitRequest, FilesystemOperation};
 use loonfs::{
     BeginUploadRequest, CommitId, CommitResponse, CreateNamespaceOptions, DestinationBehavior,
     FsWriter, NamespaceId, PutFileOptions, SharedObjectStore,
@@ -116,7 +116,10 @@ async fn park_two_puts(temp_dir: &Path) -> ParkedPuts {
         );
         Box::pin(async move {
             registry
-                .submit_commit_with_prepared_content(namespace_id, request, vec![prepared])
+                .submit_candidate(
+                    namespace_id,
+                    CommitCandidate::prepared(request, vec![prepared]),
+                )
                 .await
         })
     };


### PR DESCRIPTION
This removes repeated helpers and routes mutations through the public runtime APIs. Filesystem handlers now submit commits through FsWriter, grep routes share accessors for their required worker and service, and direct downloads use one method per target with an explicit starting offset.

GrepManifestId now uses the shared identifier implementation. Pagination, checkpoint projections, upload content-reference construction, cache accounting, test fixtures, and several repeated constants also have single implementations. Unused wrappers and test helpers are removed.

The workspace test suite, clippy, rustfmt, and OpenAPI checks pass.