### PR TITLE
obs: a root span on every handle operation

### DIFF
--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -438,7 +438,10 @@ impl ReadCore {
         level = "debug",
         name = "loonfs.phase",
         skip_all,
-        fields(phase = "update_cache")
+        fields(
+            phase = "update_cache",
+            namespace_id = %namespace_id,
+        )
     )]
     pub(crate) fn invalidate_namespace_read_cache(&self, namespace_id: &NamespaceId) {
         self.inner

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -93,10 +93,23 @@ impl FsAdmin {
 
     /// Summarizes a namespace's current head: manifest, latest checkpoint,
     /// WAL tail, and retention floor.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.namespace_status",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "namespace_status",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn namespace_status(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<NamespaceStatusResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         Ok(load_namespace_head_summary(self.core.store(), namespace_id).await?)
     }
 
@@ -118,6 +131,7 @@ impl FsAdmin {
         skip_all,
         fields(
             operation = "maintenance.step",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
         )
@@ -425,10 +439,23 @@ impl FsAdmin {
     /// reach is compacted on this call rather than after two more delta
     /// merges have published over it — which, under sustained writes, is a
     /// wait with no end.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.compact_metadata",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.compact_metadata",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn compact_metadata(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<MetadataCompactionOutcome> {
+        self.core.record_trace_context(&tracing::Span::current());
         let spec = match self
             .reorganize_once(
                 namespace_id,
@@ -547,11 +574,24 @@ impl FsAdmin {
     /// [`MaintenancePlan::gc`] — and the one thing that asks on its own is a
     /// writer's collection job, which schedules a pass for each upload
     /// deadline that writer created.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.gc_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.gc_namespace",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn gc_namespace(
         &self,
         namespace_id: &NamespaceId,
         config: &crate::GcConfig,
     ) -> Result<crate::GcResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let report = loonfs_core::gc_namespace(
             self.core.store(),
             namespace_id,
@@ -583,6 +623,7 @@ impl FsAdmin {
         skip_all,
         fields(
             operation = "maintenance.checkpoint_create",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
         )
@@ -603,10 +644,23 @@ impl FsAdmin {
     }
 
     /// Lists every active checkpoint by following bounded pages.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.list_checkpoints",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.list_checkpoints",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_checkpoints_all(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<ListCheckpointsResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let limit = super::core::default_page_limit();
         let (mut response, mut next_cursor) = self
             .list_checkpoints_page_typed(
@@ -635,11 +689,24 @@ impl FsAdmin {
 
     /// Lists one page of active checkpoints in ascending id order. The cursor
     /// resumes a live listing and does not create a snapshot.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.list_checkpoints",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.list_checkpoints",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_checkpoints_page(
         &self,
         namespace_id: &NamespaceId,
         request: PageRequest<CheckpointPageCursor>,
     ) -> Result<ListCheckpointsResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (mut response, next_cursor) = self
             .list_checkpoints_page_typed(namespace_id, request)
             .await?;
@@ -669,11 +736,24 @@ impl FsAdmin {
     }
 
     /// Releases a user-owned checkpoint by id. Idempotent.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.release_checkpoint",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.release_checkpoint",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn release_checkpoint(
         &self,
         namespace_id: &NamespaceId,
         checkpoint_id: &CheckpointId,
     ) -> Result<ReleaseCheckpointResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let result = self
             .engine(namespace_id)
             .release_checkpoint(checkpoint_id)
@@ -690,10 +770,23 @@ impl FsAdmin {
     ///
     /// This checks only whether a WAL tail exists. It does not require the
     /// head to contain enough hints to count every segment.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.wal_flush",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.wal_flush",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn flush_wal(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<MetadataMaintenanceResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let basis = load_namespace_flush_basis(self.core.store(), namespace_id).await?;
         self.flush_then_reorganize(namespace_id, basis.has_unflushed_wal_tail, basis.head_seq)
             .await
@@ -709,10 +802,23 @@ impl FsAdmin {
     /// rather than upkeep. Nothing schedules it: no maintenance job exists
     /// for retention, so an unattended deployment keeps its whole history
     /// until a call arrives here.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.maintenance.advance_retention_floor",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "maintenance.advance_retention_floor",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn advance_retention_floor(
         &self,
         namespace_id: &NamespaceId,
     ) -> Result<AdvanceRetentionResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let step = self
             .maintenance_step_namespace(
                 namespace_id,
@@ -735,6 +841,7 @@ impl FsAdmin {
         skip_all,
         fields(
             operation = "maintenance.wal_flush",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
         )

--- a/crates/loonfs/src/fs/namespaces.rs
+++ b/crates/loonfs/src/fs/namespaces.rs
@@ -13,11 +13,24 @@ impl FsWriter {
     ///
     /// With `options.allow_existing`, an already-existing namespace is
     /// treated as success. Returns the namespace's post-operation status.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.create_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "create_namespace",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn create_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: CreateNamespaceOptions,
     ) -> Result<NamespaceStatusResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let result = self
             .engine(namespace_id)
             .bootstrap_namespace(loonfs_core::BootstrapOptions {
@@ -32,11 +45,24 @@ impl FsWriter {
     ///
     /// The fork shares immutable file bytes but gets its own metadata history,
     /// and the response reports the target at the fork point.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.fork_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "fork_namespace",
+            namespace_id = %source,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn fork_namespace(
         &self,
         source: &NamespaceId,
         target: &NamespaceId,
     ) -> Result<NamespaceStatusResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let result = self
             .engine(source)
             .fork_namespace(target)
@@ -60,11 +86,24 @@ impl FsWriter {
     /// Sequenced as a barrier through the publication service: mutations
     /// admitted before the delete publish first, and mutations admitted
     /// after it fail once it succeeds.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.delete_namespace",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "delete_namespace",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn delete_namespace(
         &self,
         namespace_id: &NamespaceId,
         options: DeleteNamespaceOptions,
     ) -> Result<DeleteNamespaceResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.publisher
             .submit_delete(namespace_id.clone(), options)
             .await

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -27,6 +27,7 @@ impl FsReader {
         skip_all,
         fields(
             operation = "stat",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             cache_path = tracing::field::Empty,
@@ -56,6 +57,7 @@ impl FsReader {
         skip_all,
         fields(
             operation = "stat_inode",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             cache_path = tracing::field::Empty,
@@ -83,11 +85,24 @@ impl FsReader {
     /// empty directory still reports which state answered the question).
     /// Entries are returned in canonical name-key order, matching paged
     /// listings.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.list_path_entries",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "list_path_entries",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_path_entries_all(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<ListPathEntriesResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let limit = default_page_limit();
         let (first_page, mut next_cursor) = self
             .list_path_entries_page_typed(
@@ -125,6 +140,18 @@ impl FsReader {
     /// Asking for attributes costs one lookup per entry and adds an unbounded
     /// number of bytes to the page, so a caller that turns the projection on
     /// should also size its page for the maps it expects back.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.list_path_entries",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "list_path_entries",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_path_entries_page(
         &self,
         namespace_id: &NamespaceId,
@@ -132,6 +159,7 @@ impl FsReader {
         request: PageRequest<DirectoryPageCursor>,
         options: ListPathEntriesOptions,
     ) -> Result<ListPathEntriesResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (mut response, next_cursor) = self
             .list_path_entries_page_typed(namespace_id, absolute_path, request, options)
             .await?;
@@ -171,11 +199,24 @@ impl FsReader {
     }
 
     /// Reads a file's current content plus the metadata entry it came from.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.get_file_bytes",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "get_file_bytes",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn get_file_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> Result<AuthoritativeFileBytes> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let read = engine
             .get_file(
@@ -207,12 +248,25 @@ impl FsReader {
     /// resumed stream refuses to fetch anything until it has been handed
     /// the bytes below its start through
     /// [`FileContentStream::fold_resumed_prefix`].
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.get_file_bytes",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "get_file_bytes",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn read_file_stream(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: ReadFileStreamOptions,
     ) -> Result<FileContentStream<SharedObjectStore>> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let stream = engine
             .read_file_stream(
@@ -234,12 +288,25 @@ impl FsReader {
     /// what this process buffers and nothing here buffers anything. A host
     /// signs a short-lived read of the returned key and hands the client
     /// the reference to check the arriving bytes against.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.begin_download",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "begin_download",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn direct_download_target(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         revision_no: Option<RevisionNo>,
     ) -> Result<DirectDownloadTarget> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let target = engine
             .direct_download_target(absolute_path, revision_no, &read_context)
@@ -249,12 +316,25 @@ impl FsReader {
 
     /// Resolves retained inode content for a direct download without
     /// requiring a current path.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.begin_download_by_inode",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "begin_download_by_inode",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn direct_download_target_by_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
         revision_no: RevisionNo,
     ) -> Result<DirectDownloadByInodeTarget> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let target = engine
             .direct_download_target_by_inode(inode_id, revision_no, &read_context)
@@ -277,12 +357,25 @@ impl FsReader {
     ///
     /// This does not increment the latest-metadata-view metric because it
     /// reads a checkpoint snapshot.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.list_checkpoint_files_page",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "list_checkpoint_files_page",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_checkpoint_files_page(
         &self,
         namespace_id: &NamespaceId,
         checkpoint_id: &CheckpointId,
         request: PageRequest<CheckpointFilesPageCursor>,
     ) -> Result<CheckpointFilesPage> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
         Ok(engine
             .list_checkpoint_files_page(checkpoint_id, request, &read_context)
@@ -301,11 +394,24 @@ impl FsReader {
     /// At most [`MAX_RESOLVE_CURRENT_FILES`](crate::MAX_RESOLVE_CURRENT_FILES)
     /// ids per call; a larger batch is refused with `invalid_request`
     /// before anything is read.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.resolve_current_files",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "resolve_current_files",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn resolve_current_files(
         &self,
         namespace_id: &NamespaceId,
         inode_ids: &[InodeId],
     ) -> Result<Vec<CurrentFileState>> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let states = engine
             .resolve_current_files(inode_ids, &read_context)
@@ -322,12 +428,25 @@ impl FsReader {
     ///
     /// This does not increment the latest-metadata-view metric because it
     /// reads immutable content directly.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.read_content_ref",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "read_content_ref",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn read_content_ref(
         &self,
         namespace_id: &NamespaceId,
         content_ref: &ContentRef,
         max_bytes: u64,
     ) -> Result<Vec<u8>> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_read(namespace_id).await?;
         Ok(engine
             .read_content_ref(content_ref, max_bytes, &read_context)
@@ -338,11 +457,24 @@ impl FsReader {
     /// by deleted root inode. Tombstone rows are immortal, so this answers
     /// however far the replay floor has advanced; entries carry the deleted
     /// name when the delete recorded one.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.list_trash",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "list_trash",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_trash_page(
         &self,
         namespace_id: &NamespaceId,
         request: PageRequest<loonfs_api::TrashPageCursor>,
     ) -> Result<loonfs_api::ListTrashResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let page = engine.list_trash_page(request, &read_context).await?;
         let next_cursor = encode_next_cursor(page.next_cursor.as_ref())?;
@@ -355,12 +487,25 @@ impl FsReader {
     }
 
     /// Lists one page of a file path's revision history.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.list_file_revisions",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "list_file_revisions",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_file_revisions_page(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         request: PageRequest<FileRevisionsPageCursor>,
     ) -> Result<ListFileRevisionsResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let absolute_path = AbsolutePath::parse(absolute_path)
             .map_err(|error| CoreError::InvalidPath(error.to_string()))?;
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
@@ -377,12 +522,25 @@ impl FsReader {
     }
 
     /// Lists one page of retained revisions for a file inode.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.list_file_revisions_by_inode",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "list_file_revisions_by_inode",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_file_revisions_by_inode_page(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
         request: PageRequest<FileRevisionsPageCursor>,
     ) -> Result<ListFileRevisionsResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let page = engine
             .list_file_revisions_for_inode_page(inode_id, request, &read_context)
@@ -396,12 +554,25 @@ impl FsReader {
     }
 
     /// Reads the content of one historical file revision by path.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.get_file_bytes",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "get_file_bytes",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn get_file_revision_bytes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         revision_no: RevisionNo,
     ) -> Result<AuthoritativeFileBytes> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let read = engine
             .get_file_revision(
@@ -416,12 +587,25 @@ impl FsReader {
 
     /// Reads and verifies one retained file revision by inode identity.
     /// Current visibility and path are not required.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.get_file_revision_bytes_by_inode",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "get_file_revision_bytes_by_inode",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn get_file_revision_bytes_by_inode(
         &self,
         namespace_id: &NamespaceId,
         inode_id: InodeId,
         revision_no: RevisionNo,
     ) -> Result<Vec<u8>> {
+        self.core.record_trace_context(&tracing::Span::current());
         let (engine, read_context) = self.core.pinned_metadata_read(namespace_id).await?;
         let bytes = engine
             .get_file_revision_for_inode(
@@ -435,12 +619,25 @@ impl FsReader {
     }
 
     /// Reads the ordered change feed after the `after_seq` cursor.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.list_changes",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "list_changes",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn list_changes(
         &self,
         namespace_id: &NamespaceId,
         after_seq: ChangeSeq,
         options: ListChangesOptions,
     ) -> Result<ChangesResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let limit = match options.limit {
             Some(limit) => limit,
             None => PaginationPolicy::default()

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -47,11 +47,24 @@ impl FsWriter {
     }
 
     /// Starts a durable upload session for a namespace.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.begin_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "begin_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn begin_upload(
         &self,
         namespace_id: &NamespaceId,
         request: BeginUploadRequest,
     ) -> Result<BeginUploadResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let response = self.engine(namespace_id).begin_upload(request).await?;
         self.schedule_upload_session_reclamation(namespace_id);
         Ok(response)
@@ -59,11 +72,24 @@ impl FsWriter {
 
     /// Mints the content object a direct upload will write to and returns
     /// the internal target for server-side signing.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.begin_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "begin_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn begin_direct_put_upload_target(
         &self,
         namespace_id: &NamespaceId,
         claim: UploadContentClaim,
     ) -> Result<BeginDirectPutUploadTargetResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let response = self
             .engine(namespace_id)
             .begin_direct_put_upload_target(claim)
@@ -75,11 +101,24 @@ impl FsWriter {
     /// Mints the content object a direct multipart upload assembles into,
     /// opens the provider upload behind it, and returns the internal target
     /// for server-side signing.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.begin_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "begin_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn begin_direct_multipart_upload_target(
         &self,
         namespace_id: &NamespaceId,
         options: DirectMultipartUploadOptions,
     ) -> Result<BeginDirectMultipartUploadTargetResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         let response = self
             .engine(namespace_id)
             .begin_direct_multipart_upload_target(options)
@@ -89,12 +128,25 @@ impl FsWriter {
     }
 
     /// Resolves one wave of multipart parts for server-side signing.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.sign_upload_parts",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "sign_upload_parts",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn direct_multipart_part_targets(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
         requested: &[UploadPartChecksumClaim],
     ) -> Result<MultipartPartTargets> {
+        self.core.record_trace_context(&tracing::Span::current());
         Ok(self
             .engine(namespace_id)
             .direct_multipart_part_targets(upload_id, requested)
@@ -102,12 +154,28 @@ impl FsWriter {
     }
 
     /// Uploads whole-file content into an upload session.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.upload_content",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "upload_content",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            payload_class = tracing::field::Empty,
+        )
+    )]
     pub async fn upload_content(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
         bytes: &[u8],
     ) -> Result<UploadContentResponse> {
+        let span = tracing::Span::current();
+        self.core.record_trace_context(&span);
+        span.record("payload_class", crate::trace::payload_class(bytes.len()));
         Ok(self
             .engine(namespace_id)
             .upload_content(upload_id, bytes)
@@ -122,12 +190,26 @@ impl FsWriter {
     /// produces, completion, publication — is identical to the buffered
     /// path's; callers that already hold their bytes should stay on
     /// [`Self::upload_content`].
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.upload_content",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "upload_content",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+            payload_class = "streamed",
+        )
+    )]
     pub async fn upload_streamed_content(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
         body: ByteStream,
     ) -> Result<UploadContentResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         Ok(self
             .engine(namespace_id)
             .upload_streamed_content(upload_id, body)
@@ -135,11 +217,24 @@ impl FsWriter {
     }
 
     /// Completes a service-proxied or direct-PUT upload session.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.complete_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "complete_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn complete_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
     ) -> Result<UploadSessionResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         Ok(self
             .complete_upload_prepared(namespace_id, upload_id)
             .await?
@@ -147,12 +242,25 @@ impl FsWriter {
     }
 
     /// Completes a direct-multipart upload session.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.complete_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "complete_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn complete_multipart_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
         request: &CompleteMultipartUploadRequest,
     ) -> Result<UploadSessionResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         Ok(self
             .complete_multipart_upload_prepared(namespace_id, upload_id, request)
             .await?
@@ -163,11 +271,24 @@ impl FsWriter {
     ///
     /// Service-proxied completion performs no content-blob I/O. Direct-put
     /// completion performs one content-blob HEAD and no content-blob GET.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.complete_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "complete_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn complete_upload_prepared(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
     ) -> Result<CompletedUpload> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.complete_upload_prepared_inner(
             namespace_id,
             upload_id,
@@ -177,12 +298,25 @@ impl FsWriter {
     }
 
     /// Completes a multipart upload and returns its publication proof.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.complete_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "complete_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn complete_multipart_upload_prepared(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
         request: &CompleteMultipartUploadRequest,
     ) -> Result<CompletedUpload> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.complete_upload_prepared_inner(
             namespace_id,
             upload_id,
@@ -209,6 +343,18 @@ impl FsWriter {
     }
 
     /// Completes an upload after decoding its request for the stored mode.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.complete_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "complete_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn complete_upload_prepared_for_mode<F>(
         &self,
         namespace_id: &NamespaceId,
@@ -220,6 +366,7 @@ impl FsWriter {
             UploadMode,
         ) -> std::result::Result<crate::uploads::ResolvedUploadCompletion, String>,
     {
+        self.core.record_trace_context(&tracing::Span::current());
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
@@ -232,20 +379,46 @@ impl FsWriter {
     }
 
     /// Aborts an upload session and deletes the content object it owned.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.abort_upload",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "abort_upload",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn abort_upload(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
     ) -> Result<UploadSessionResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         Ok(self.engine(namespace_id).abort_upload(upload_id).await?)
     }
 
     /// Reads one upload session, with a fresh receipt when it is completed.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.read_upload_status",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "read_upload_status",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn read_upload_status(
         &self,
         namespace_id: &NamespaceId,
         upload_id: &UploadId,
     ) -> Result<(UploadSessionResponse, Option<CompletedUploadReceipt>)> {
+        self.core.record_trace_context(&tracing::Span::current());
         Ok(self
             .engine(namespace_id)
             .read_upload_status(upload_id)

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -74,6 +74,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "put",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = tracing::field::Empty,
@@ -136,6 +137,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "put",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = "streamed",
@@ -251,6 +253,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "prepare",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = tracing::field::Empty,
@@ -288,6 +291,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "prepare",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = "streamed",
@@ -319,6 +323,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "put",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = tracing::field::Empty,
@@ -374,6 +379,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "put",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = tracing::field::Empty,
@@ -411,6 +417,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "prepare",
+            namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
             payload_class = tracing::field::Empty,
@@ -443,6 +450,18 @@ impl FsWriter {
 
     /// Verifies an authorized content token against the namespace's durable
     /// content-store binding.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.prepare",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "prepare",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn prepare_content_token(
         &self,
         namespace_id: &NamespaceId,
@@ -450,6 +469,7 @@ impl FsWriter {
         token: &crate::content_tokens::ContentToken,
         now_ms: u64,
     ) -> Result<std::result::Result<PreparedContent, loonfs_core::content::ContentTokenError>> {
+        self.core.record_trace_context(&tracing::Span::current());
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
@@ -468,12 +488,25 @@ impl FsWriter {
     }
 
     /// Creates a directory at an absolute path.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn create_directory(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: CreateDirectoryOptions,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.commit(
             namespace_id,
             CommitRequest::single(
@@ -499,12 +532,25 @@ impl FsWriter {
     /// history. Physical reclamation is explicit garbage collection: nothing
     /// sweeps unless an operator asks, through `FsAdmin::gc_namespace` or a
     /// maintenance step that opted in.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn delete_path(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: DeleteOptions,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.commit(
             namespace_id,
             CommitRequest::single(
@@ -526,6 +572,18 @@ impl FsWriter {
     }
 
     /// Moves a path within the same namespace.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn move_path(
         &self,
         namespace_id: &NamespaceId,
@@ -533,6 +591,7 @@ impl FsWriter {
         to_path: &str,
         options: MoveOptions,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.commit(
             namespace_id,
             CommitRequest::single(
@@ -555,6 +614,18 @@ impl FsWriter {
 
     /// Copies a file to a new path in the same namespace. The new file
     /// reuses the source revision's content reference: no bytes are copied.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn copy_path(
         &self,
         namespace_id: &NamespaceId,
@@ -562,6 +633,7 @@ impl FsWriter {
         to_path: &str,
         options: CopyOptions,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.commit(
             namespace_id,
             CommitRequest::single(
@@ -583,6 +655,18 @@ impl FsWriter {
     }
 
     /// Restores a prior file revision by appending a new current revision.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn restore_file_revision(
         &self,
         namespace_id: &NamespaceId,
@@ -590,6 +674,7 @@ impl FsWriter {
         source_revision_no: RevisionNo,
         options: RestoreRevisionOptions,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.commit(
             namespace_id,
             CommitRequest::single(
@@ -615,12 +700,25 @@ impl FsWriter {
     ///
     /// Naming neither a write nor a removal is rejected, as is an update that
     /// would leave the map exactly as it was.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn update_attributes(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
         options: UpdateAttributesOptions,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.commit(
             namespace_id,
             CommitRequest::single(
@@ -644,6 +742,18 @@ impl FsWriter {
     }
 
     /// Restores a deleted file or subtree, optionally at a new path.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn undelete(
         &self,
         namespace_id: &NamespaceId,
@@ -652,6 +762,7 @@ impl FsWriter {
         absolute_path: Option<&str>,
         options: UndeleteOptions,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         // An absent destination restores in place: the entry re-binds under
         // the parent and name its deletion recorded.
         let path = absolute_path
@@ -686,11 +797,24 @@ impl FsWriter {
     /// error of a request that stops names the operation that stopped it.
     /// Operations that introduce new external content require
     /// [`Self::commit_prepared`].
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn commit(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.commit_candidate(namespace_id, CommitCandidate::new(request))
             .await
     }
@@ -699,12 +823,25 @@ impl FsWriter {
     ///
     /// Submission and publication perform no content I/O. One prepared value
     /// covers every operation that uses its content ref.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn commit_prepared(
         &self,
         namespace_id: &NamespaceId,
         request: CommitRequest,
         prepared_content: Vec<PreparedContent>,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.commit_candidate(
             namespace_id,
             CommitCandidate::prepared(request, prepared_content),
@@ -717,11 +854,24 @@ impl FsWriter {
     /// its own durable result, and admitted work is owned by the service's
     /// worker — a cancelled caller abandons only its result delivery, never
     /// the publication.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.apply_commit",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "apply_commit",
+            namespace_id = %namespace_id,
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn commit_candidate(
         &self,
         namespace_id: &NamespaceId,
         candidate: CommitCandidate,
     ) -> Result<CommitResponse> {
+        self.core.record_trace_context(&tracing::Span::current());
         self.publisher
             .submit_candidate(namespace_id.clone(), candidate)
             .await

--- a/crates/loonfs/src/handle/writer.rs
+++ b/crates/loonfs/src/handle/writer.rs
@@ -175,7 +175,21 @@ impl FsWriter {
     /// budget, and this waits for that to finish rather than stopping it.
     /// [`Self::shutdown`] cancels it instead, which is what makes a shutdown
     /// short.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.flush_background",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "flush_background",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn flush_background(&self) -> Result<()> {
+        let span = tracing::Span::current();
+        span.record("mode", self.core.trace_mode());
+        span.record("store_kind", self.core.trace_store_kind());
         self.bits.maintenance.drain().await
     }
 
@@ -198,7 +212,21 @@ impl FsWriter {
     /// are ignored, and reads continue to work. The method is idempotent and
     /// may be called from any clone because all clones share the same shutdown
     /// state. Task panics are returned as runtime errors.
+    #[tracing::instrument(
+        level = "debug",
+        name = "loonfs.shutdown",
+        err(level = "debug"),
+        skip_all,
+        fields(
+            operation = "shutdown",
+            mode = tracing::field::Empty,
+            store_kind = tracing::field::Empty,
+        )
+    )]
     pub async fn shutdown(&self) -> Result<()> {
+        let span = tracing::Span::current();
+        span.record("mode", self.core.trace_mode());
+        span.record("store_kind", self.core.trace_store_kind());
         self.close_admission_for_shutdown();
         self.publisher.drain().await?;
         self.bits.maintenance.drain().await

--- a/crates/loonfs/tests/operation_spans.rs
+++ b/crates/loonfs/tests/operation_spans.rs
@@ -1,0 +1,92 @@
+#![allow(clippy::panic)]
+// Tracing-capture tests panic in helper assertions for precise diagnostics.
+
+//! Smoke-tests the facade operation-span contract in its own process.
+
+use loonfs::{CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter, StoreConfig};
+use loonfs_test_support::block_on::block_on;
+use loonfs_test_support::ids::namespace_id;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+use tracing_subscriber::fmt::format::FmtSpan;
+
+fn store_config(root: &Path) -> StoreConfig {
+    StoreConfig::LocalFs {
+        root: root.to_string_lossy().into_owned(),
+        key_prefix: None,
+    }
+}
+
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn every_handle_emits_an_operation_span_with_its_namespace() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("operation-spans");
+    let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&captured);
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_ansi(false)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_writer(move || CaptureWriter(Arc::clone(&sink)))
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    block_on(async {
+        let writer = FsWriter::builder(store_config(temp_dir.path()))
+            .writer_id("operation-span-writer")
+            .background_work(FsBackgroundWork::ManualOnly)
+            .build()
+            .await
+            .expect("build writer");
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+
+        writer
+            .reader()
+            .stat_path(&namespace_id, "/", Default::default())
+            .await
+            .expect("stat namespace root");
+
+        FsAdmin::builder_with_store(writer.object_store())
+            .actor_id("operation-span-admin")
+            .build()
+            .await
+            .expect("build admin")
+            .namespace_status(&namespace_id)
+            .await
+            .expect("read namespace status");
+    });
+
+    let log = String::from_utf8(captured.lock().expect("capture lock").clone())
+        .expect("captured log is utf8");
+    for span_name in [
+        "loonfs.create_namespace",
+        "loonfs.stat",
+        "loonfs.namespace_status",
+    ] {
+        let span = log
+            .lines()
+            .find(|line| line.contains(span_name) && line.contains("namespace_id=operation-spans"))
+            .unwrap_or_else(|| panic!("`{span_name}` lacks `namespace_id` in:\n{log}"));
+        assert!(
+            span.contains("close"),
+            "`{span_name}` did not close: {span}"
+        );
+    }
+}

--- a/crates/loonfs/tests/operation_spans.rs
+++ b/crates/loonfs/tests/operation_spans.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::panic)]
-// Tracing-capture tests panic in helper assertions for precise diagnostics.
+// Include the captured output when an assertion fails.
 
-//! Smoke-tests the facade operation-span contract in its own process.
+//! Checks operation spans for the writer, reader, and admin handles.
 
 use loonfs::{CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter, StoreConfig};
 use loonfs_test_support::block_on::block_on;


### PR DESCRIPTION
Adds debug tracing spans to public operations on `FsWriter`, `FsReader`, and `FsAdmin`. Namespace-scoped operations record `namespace_id`, `mode`, and `store_kind`. Payload operations also record a size category or whether the payload was streamed. Errors are recorded at debug level.

Span names follow the public API operation names when one exists. Methods that implement variants of the same operation share a span name. Writer lifecycle methods such as `flush_background` and `shutdown` do not record `namespace_id`.

Some convenience methods call another instrumented public method. Those calls currently create nested spans with the same name and `operation` value, including commit wrappers and upload-completion wrappers. The existing internal WAL flush span produces the same result for `flush_wal`.

Adds an integration test that exercises one operation on each handle and checks that the expected span closes with `namespace_id`. This changes tracing only; operation behavior and durable data are unchanged.
