### PR TITLE
feat(cli): tab completion for commands, flags, and local paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1421,7 @@ version = "0.2.1"
 dependencies = [
  "bytes",
  "clap",
+ "clap_complete",
  "dialoguer",
  "fs4",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ base64 = "0.22"
 bytes = { version = "1", features = ["serde"] }
 ciborium = "0.2"
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = "4.5"
 crc32c = "0.6"
 crc64fast-nvme = "1.2"
 http = "1"

--- a/crates/loonfs-cli/Cargo.toml
+++ b/crates/loonfs-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 bytes.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 futures.workspace = true
 fs4.workspace = true
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -8,13 +8,15 @@ filesystem operations, and namespace maintenance against LoonFS.
 Generate completion scripts for Bash, Zsh, Fish, PowerShell, or Elvish with:
 
 ```sh
-loonfs completions <shell>
+loonfs completion --shell zsh
 ```
+
+When omitted, `--shell` defaults from `$SHELL`.
 
 For example, enable Zsh completion in the current shell with:
 
 ```sh
-source <(loonfs completions zsh)
+source <(loonfs completion --shell zsh)
 ```
 
 ## Command Reference

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -3,6 +3,20 @@
 `loonfs-cli` provides the `loonfs` command for managing profiles, namespaces, path-based
 filesystem operations, and namespace maintenance against LoonFS.
 
+## Shell completion
+
+Print a completion script for bash, zsh, fish, powershell, or elvish with:
+
+```sh
+loonfs completions <shell>
+```
+
+For example, load zsh completion for the current session with:
+
+```sh
+source <(loonfs completions zsh)
+```
+
 ## Command Reference
 
 ```text

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -5,13 +5,13 @@ filesystem operations, and namespace maintenance against LoonFS.
 
 ## Shell completion
 
-Print a completion script for bash, zsh, fish, powershell, or elvish with:
+Generate completion scripts for Bash, Zsh, Fish, PowerShell, or Elvish with:
 
 ```sh
 loonfs completions <shell>
 ```
 
-For example, load zsh completion for the current session with:
+For example, enable Zsh completion in the current shell with:
 
 ```sh
 source <(loonfs completions zsh)

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -13,7 +13,7 @@ fn parse_public_inode_id(value: &str) -> Result<InodeId, String> {
 /// Defines the `loonfs` command-line interface.
 #[derive(Debug, Parser)]
 #[command(name = "loonfs", version)]
-pub struct Cli {
+pub(crate) struct Cli {
     /// Config file to use, ahead of LOONFS_CONFIG and the default location.
     #[arg(
         long,
@@ -108,16 +108,17 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: ConfigCommand,
     },
-    /// Print shell completions to stdout.
-    Completions(CompletionsArgs),
+    /// Print a shell completion script to stdout.
+    Completion(CompletionArgs),
     /// Print version and build metadata.
     Version,
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct CompletionsArgs {
+pub(crate) struct CompletionArgs {
     /// Shell to generate completions for.
-    pub shell: clap_complete::Shell,
+    #[arg(long, value_enum, value_name = "bash|zsh|fish|powershell|elvish")]
+    pub(crate) shell: Option<clap_complete::Shell>,
 }
 
 #[derive(Debug, Args)]
@@ -1053,6 +1054,7 @@ impl RuntimeBehavior {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CommandKind {
+    Completion,
     Init,
     ProfileCreate,
     ProfileList,
@@ -1102,6 +1104,7 @@ pub(crate) enum CommandKind {
 impl CommandKind {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
+            CommandKind::Completion => "completion",
             CommandKind::Init => "init",
             CommandKind::ProfileCreate => "profile_create",
             CommandKind::ProfileList => "profile_list",
@@ -1150,14 +1153,14 @@ impl CommandKind {
     }
 
     pub(crate) fn supports_json(self) -> bool {
-        !matches!(self, CommandKind::FilesystemCat)
+        !matches!(self, CommandKind::Completion | CommandKind::FilesystemCat)
     }
 }
 
 impl Cli {
-    pub(crate) fn kind(&self) -> Option<CommandKind> {
-        Some(match &self.command {
-            Command::Completions(_) => return None,
+    pub(crate) fn kind(&self) -> CommandKind {
+        match &self.command {
+            Command::Completion(_) => CommandKind::Completion,
             Command::Init(_) => CommandKind::Init,
             Command::Profile { command } => match command {
                 ProfileCommand::Create(_) => CommandKind::ProfileCreate,
@@ -1210,6 +1213,48 @@ impl Cli {
                 ConfigCommand::Show => CommandKind::ConfigShow,
             },
             Command::Version => CommandKind::Version,
-        })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_and_remote_paths_have_completion_hints() {
+        let command = Cli::command();
+
+        assert_hint(&command, "config", ValueHint::FilePath);
+
+        let put = subcommand(&command, "put");
+        assert_hint(put, "local_path", ValueHint::AnyPath);
+        assert_hint(put, "remote_path", ValueHint::Other);
+
+        let get = subcommand(&command, "get");
+        assert_hint(get, "local_destination", ValueHint::AnyPath);
+        assert_hint(get, "remote_path", ValueHint::Other);
+
+        let cat = subcommand(&command, "cat");
+        assert_hint(cat, "path", ValueHint::Other);
+
+        let mv = subcommand(&command, "mv");
+        assert_hint(mv, "source_path", ValueHint::Other);
+        assert_hint(mv, "destination_path", ValueHint::Other);
+    }
+
+    fn subcommand<'a>(command: &'a clap::Command, name: &str) -> &'a clap::Command {
+        command
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == name)
+            .expect("subcommand exists")
+    }
+
+    fn assert_hint(command: &clap::Command, id: &str, expected: ValueHint) {
+        let argument = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == id)
+            .expect("argument exists");
+        assert_eq!(argument.get_value_hint(), expected);
     }
 }

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -1,7 +1,7 @@
 //! The clap argument grammar for every `loonfs` command.
 
 use crate::progress::ProgressMode;
-use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum, ValueHint};
 use loonfs_api::InodeId;
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -10,23 +10,29 @@ fn parse_public_inode_id(value: &str) -> Result<InodeId, String> {
     loonfs_api::public_inode_id::decode(value).map_err(|error| error.to_string())
 }
 
+/// Parsed `loonfs` command line and its Clap command model.
 #[derive(Debug, Parser)]
 #[command(name = "loonfs", version)]
-pub(crate) struct Cli {
+pub struct Cli {
     /// Config file to use, ahead of LOONFS_CONFIG and the default location.
-    #[arg(long, global = true, value_name = "PATH")]
-    pub config: Option<PathBuf>,
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATH",
+        value_hint = ValueHint::FilePath
+    )]
+    pub(crate) config: Option<PathBuf>,
     /// Emit machine-readable JSON instead of human output.
     #[arg(long, global = true)]
-    pub json: bool,
+    pub(crate) json: bool,
     /// Never prompt; fail instead when input would be required.
     #[arg(long, global = true)]
-    pub no_input: bool,
+    pub(crate) no_input: bool,
     /// Say nothing about a transfer while it runs.
     #[arg(long, global = true)]
-    pub no_progress: bool,
+    pub(crate) no_progress: bool,
     #[command(subcommand)]
-    pub command: Command,
+    pub(crate) command: Command,
 }
 
 pub(crate) fn validate_cli(cli: &Cli) -> Result<(), clap::Error> {
@@ -102,12 +108,21 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: ConfigCommand,
     },
+    /// Print a shell completion script to stdout.
+    Completions(CompletionsArgs),
     /// Print version and build metadata.
     Version,
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct CompletionsArgs {
+    /// Shell to generate for.
+    pub shell: clap_complete::Shell,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct InitArgs {
+    #[arg(value_hint = ValueHint::Other)]
     pub name: Option<String>,
     /// Profile mode to configure.
     #[arg(long, value_name = "embedded|remote")]
@@ -116,7 +131,7 @@ pub(crate) struct InitArgs {
     #[arg(long)]
     pub store_kind: Option<String>,
     /// Local filesystem store root.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::DirPath)]
     pub root: Option<String>,
     /// Optional object-key prefix within the provider.
     #[arg(long)]
@@ -139,7 +154,7 @@ pub(crate) struct InitArgs {
     #[arg(long)]
     pub secret_access_key: Option<String>,
     /// Custom provider endpoint URL.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Url)]
     pub endpoint_url: Option<String>,
     /// Optional AWS session token (env AWS_SESSION_TOKEN).
     #[arg(long)]
@@ -160,17 +175,17 @@ pub(crate) struct InitArgs {
     #[arg(long)]
     pub access_key: Option<String>,
     /// Path to a GCP service-account key.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::FilePath)]
     pub service_account_key_path: Option<String>,
     /// Remote LoonFS server URL.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Url)]
     pub server_url: Option<String>,
     /// Remote LoonFS bearer token (env LOONFS_AUTH_TOKEN).
     #[arg(long)]
     pub auth_token: Option<String>,
     /// PEM bundle of extra certificate authorities to trust for an
     /// https server URL, when a private CA issued the certificate.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::FilePath)]
     pub ca_cert_path: Option<String>,
     /// Actor kind to save in the profile. Must be used with --actor-id.
     /// Defaults to service/loonfs-cli when no actor is configured.
@@ -188,17 +203,27 @@ pub(crate) enum ProfileCommand {
     /// List configured profiles.
     List,
     /// Show one profile (secrets redacted).
-    Show { name: Option<String> },
+    Show {
+        #[arg(value_hint = ValueHint::Other)]
+        name: Option<String>,
+    },
     /// Update fields of an existing profile.
     Update(ProfileUpdateArgs),
     /// Delete a profile from the config file.
-    Delete { name: String },
+    Delete {
+        #[arg(value_hint = ValueHint::Other)]
+        name: String,
+    },
     /// Make a profile the default.
-    Use { name: String },
+    Use {
+        #[arg(value_hint = ValueHint::Other)]
+        name: String,
+    },
 }
 
 #[derive(Debug, Args)]
 pub(crate) struct ProfileCreateArgs {
+    #[arg(value_hint = ValueHint::Other)]
     pub name: String,
     /// Profile mode to configure.
     #[arg(long, value_name = "embedded|remote")]
@@ -207,7 +232,7 @@ pub(crate) struct ProfileCreateArgs {
     #[arg(long)]
     pub store_kind: Option<String>,
     /// Local filesystem store root.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::DirPath)]
     pub root: Option<String>,
     /// Optional object-key prefix within the provider.
     #[arg(long)]
@@ -226,7 +251,7 @@ pub(crate) struct ProfileCreateArgs {
     #[arg(long)]
     pub secret_access_key: Option<String>,
     /// Custom provider endpoint URL.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Url)]
     pub endpoint_url: Option<String>,
     /// Optional AWS session token (env AWS_SESSION_TOKEN).
     #[arg(long)]
@@ -247,17 +272,17 @@ pub(crate) struct ProfileCreateArgs {
     #[arg(long)]
     pub access_key: Option<String>,
     /// Path to a GCP service-account key.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::FilePath)]
     pub service_account_key_path: Option<String>,
     /// Remote LoonFS server URL.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Url)]
     pub server_url: Option<String>,
     /// Remote LoonFS bearer token (env LOONFS_AUTH_TOKEN).
     #[arg(long)]
     pub auth_token: Option<String>,
     /// PEM bundle of extra certificate authorities to trust for an
     /// https server URL, when a private CA issued the certificate.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::FilePath)]
     pub ca_cert_path: Option<String>,
     /// Actor kind to save in the profile. Must be used with --actor-id.
     /// Defaults to service/loonfs-cli when no actor is configured.
@@ -270,9 +295,10 @@ pub(crate) struct ProfileCreateArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct ProfileUpdateArgs {
+    #[arg(value_hint = ValueHint::Other)]
     pub name: String,
     /// Local filesystem store root.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::DirPath)]
     pub root: Option<String>,
     /// Optional object-key prefix within the provider.
     #[arg(long)]
@@ -290,7 +316,7 @@ pub(crate) struct ProfileUpdateArgs {
     #[arg(long)]
     pub secret_access_key: Option<String>,
     /// Custom provider endpoint URL.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Url)]
     pub endpoint_url: Option<String>,
     /// Optional AWS session token.
     #[arg(long)]
@@ -308,17 +334,17 @@ pub(crate) struct ProfileUpdateArgs {
     #[arg(long)]
     pub access_key: Option<String>,
     /// Path to a GCP service-account key.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::FilePath)]
     pub service_account_key_path: Option<String>,
     /// Remote LoonFS server URL.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Url)]
     pub server_url: Option<String>,
     /// Remote LoonFS bearer token.
     #[arg(long)]
     pub auth_token: Option<String>,
     /// PEM bundle of extra certificate authorities to trust for an
     /// https server URL, when a private CA issued the certificate.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::FilePath)]
     pub ca_cert_path: Option<String>,
     /// Sets the profile's actor kind. Must be used with --actor-id.
     #[arg(long, value_enum)]
@@ -331,7 +357,7 @@ pub(crate) struct ProfileUpdateArgs {
 #[derive(Debug, Args, Clone)]
 pub(crate) struct ProfileSelectorArgs {
     /// Profile to run against (defaults to the configured default profile).
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub profile: Option<String>,
     /// Disable bounded retry of `server_busy`, `commit_queue_full`,
     /// `shutting_down`, and transport errors.
@@ -345,7 +371,7 @@ pub(crate) struct TargetSelectorArgs {
     pub profile: ProfileSelectorArgs,
     /// Namespace to run against. Precedence is `--namespace`,
     /// `LOONFS_NAMESPACE`, then the profile default.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub namespace: Option<String>,
 }
 
@@ -382,6 +408,7 @@ impl From<ActorKindArg> for loonfs_api::ActorKind {
 pub(crate) struct NamespaceUseArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub namespace: String,
 }
 
@@ -405,6 +432,7 @@ pub(crate) enum NamespaceCommand {
 pub(crate) struct NamespaceCreateArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub namespace_id: String,
 }
 
@@ -412,6 +440,7 @@ pub(crate) struct NamespaceCreateArgs {
 pub(crate) struct NamespaceDeleteArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub namespace_id: String,
     /// Delete only if the namespace head is still at this sequence.
     #[arg(long)]
@@ -425,7 +454,9 @@ pub(crate) struct NamespaceDeleteArgs {
 pub(crate) struct NamespaceForkArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub source: String,
+    #[arg(value_hint = ValueHint::Other)]
     pub new_namespace_id: String,
 }
 
@@ -433,12 +464,13 @@ pub(crate) struct NamespaceForkArgs {
 pub(crate) struct FilesystemLsArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub path: Option<String>,
     /// Stop after this many entries in total.
     #[arg(long, conflicts_with = "all")]
     pub limit: Option<u32>,
     /// Resume cursor from a previous bounded listing.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
     /// Follow every page and print entries as pages arrive.
     #[arg(long)]
@@ -453,7 +485,11 @@ pub(crate) struct FilesystemStatArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     /// Absolute path to describe.
-    #[arg(required_unless_present = "inode", conflicts_with = "inode")]
+    #[arg(
+        required_unless_present = "inode",
+        conflicts_with = "inode",
+        value_hint = ValueHint::Other
+    )]
     pub path: Option<String>,
     /// Visible inode to describe instead of a path.
     #[arg(long, value_name = "INODE_ID", value_parser = parse_public_inode_id)]
@@ -466,6 +502,7 @@ pub(crate) struct FilesystemAnnotateArgs {
     pub target: TargetSelectorArgs,
     #[command(flatten)]
     pub actor: ActorSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub path: String,
     /// Attribute to write, as `key=value`. The key ends at the first `=`, so
     /// the value may contain more of them. Repeat the flag to write more.
@@ -495,7 +532,7 @@ pub(crate) struct FilesystemAnnotateArgs {
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub commit_id: Option<String>,
 }
 
@@ -505,6 +542,7 @@ pub(crate) struct FilesystemRmArgs {
     pub target: TargetSelectorArgs,
     #[command(flatten)]
     pub actor: ActorSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub path: String,
     /// Delete a directory and everything under it, as one commit. The whole
     /// subtree stays recoverable through the printed undelete handle.
@@ -517,7 +555,7 @@ pub(crate) struct FilesystemRmArgs {
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub commit_id: Option<String>,
 }
 
@@ -527,6 +565,7 @@ pub(crate) struct FilesystemMkdirArgs {
     pub target: TargetSelectorArgs,
     #[command(flatten)]
     pub actor: ActorSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub path: String,
     /// Create missing parent directories as well.
     #[arg(short = 'p', long)]
@@ -538,7 +577,7 @@ pub(crate) struct FilesystemMkdirArgs {
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub commit_id: Option<String>,
 }
 
@@ -546,12 +585,13 @@ pub(crate) struct FilesystemMkdirArgs {
 pub(crate) struct FilesystemRevisionsArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub path: String,
     /// Maximum revisions to return in this page.
     #[arg(long)]
     pub limit: Option<u32>,
     /// Resume cursor from a previous revisions page.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
 }
 
@@ -559,6 +599,7 @@ pub(crate) struct FilesystemRevisionsArgs {
 pub(crate) struct FilesystemCatArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub path: String,
     /// Print this revision instead of the current content.
     #[arg(long)]
@@ -570,9 +611,10 @@ pub(crate) struct FilesystemGrepArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     /// Pattern in the Rust regex dialect; `^`/`$` anchor lines.
+    #[arg(value_hint = ValueHint::Other)]
     pub pattern: String,
     /// Restrict matches to files under this absolute path prefix.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub path_prefix: Option<String>,
     /// Match ASCII letters without regard to case.
     #[arg(short = 'i', long)]
@@ -598,6 +640,7 @@ pub(crate) struct FilesystemGrepArgs {
 pub(crate) struct FilesystemGetArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub remote_path: String,
     /// Local destination (defaults to the remote basename; `-` streams to
     /// stdout). A large file is written as it arrives and never held whole,
@@ -608,6 +651,7 @@ pub(crate) struct FilesystemGetArgs {
     /// they arrive, so content that fails verification at the end exits
     /// nonzero after part of it has already been written — the exit status,
     /// not the output, is what says the content was verified.
+    #[arg(value_hint = ValueHint::AnyPath)]
     pub local_destination: Option<String>,
     /// Download the directory tree rooted at `remote_path`, with bounded
     /// concurrency and per-file outcomes. The local destination is created
@@ -632,7 +676,9 @@ pub(crate) struct FilesystemPutArgs {
     /// and a pipe are both read once and never held whole, so what a put
     /// costs in memory does not follow what it uploads. Reading `-` needs
     /// an explicit remote path.
+    #[arg(value_hint = ValueHint::AnyPath)]
     pub local_path: String,
+    #[arg(value_hint = ValueHint::Other)]
     pub remote_path: Option<String>,
     /// Upload the directory tree rooted at `local_path`. Every file lands
     /// as its own commit with bounded concurrency, so progress is per file
@@ -653,7 +699,7 @@ pub(crate) struct FilesystemPutArgs {
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub commit_id: Option<String>,
 }
 
@@ -663,7 +709,9 @@ pub(crate) struct FilesystemTransferArgs {
     pub target: TargetSelectorArgs,
     #[command(flatten)]
     pub actor: ActorSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub source_path: String,
+    #[arg(value_hint = ValueHint::Other)]
     pub destination_path: String,
     /// Copy the directory tree rooted at `source_path` (cp only; mv moves
     /// a directory in one commit without -r).
@@ -679,7 +727,7 @@ pub(crate) struct FilesystemTransferArgs {
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub commit_id: Option<String>,
 }
 
@@ -689,6 +737,7 @@ pub(crate) struct FilesystemRestoreArgs {
     pub target: TargetSelectorArgs,
     #[command(flatten)]
     pub actor: ActorSelectorArgs,
+    #[arg(value_hint = ValueHint::Other)]
     pub path: String,
     #[arg(long)]
     pub revision: u64,
@@ -699,7 +748,7 @@ pub(crate) struct FilesystemRestoreArgs {
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub commit_id: Option<String>,
 }
 
@@ -714,6 +763,7 @@ pub(crate) struct FilesystemUndeleteArgs {
     /// deletion recorded, which lands correctly even when the enclosing
     /// directories were renamed since. A deletion that recorded no binding
     /// needs the explicit path.
+    #[arg(value_hint = ValueHint::Other)]
     pub path: Option<String>,
     /// Inode ID of the deleted item, as reported by `rm` and the change
     /// feed.
@@ -731,7 +781,7 @@ pub(crate) struct FilesystemUndeleteArgs {
     pub message: Option<String>,
     /// Idempotency key for the commit; resubmit with the same id to retry
     /// safely. Generated when absent and returned in the output.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub commit_id: Option<String>,
 }
 
@@ -743,7 +793,7 @@ pub(crate) struct TrashArgs {
     #[arg(long)]
     pub limit: Option<u32>,
     /// Resume cursor from a previous page.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
 }
 
@@ -807,7 +857,11 @@ pub(crate) struct AdminRunArgs {
     /// Namespace this host maintains. Repeat the flag to assign more; at
     /// least one is required, because this command never discovers
     /// namespaces.
-    #[arg(long = "namespace", required = true)]
+    #[arg(
+        long = "namespace",
+        required = true,
+        value_hint = ValueHint::Other
+    )]
     pub namespaces: Vec<String>,
     /// Maintenance job to host. Repeat the flag to select more; all four
     /// when omitted. `core-gc` selects the runtime's collection job, which
@@ -903,7 +957,7 @@ pub(crate) struct AdminCheckpointListArgs {
     #[arg(long)]
     pub limit: Option<u32>,
     /// Resume cursor from a previous page. Supplying this requests one page.
-    #[arg(long)]
+    #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
 }
 
@@ -912,6 +966,7 @@ pub(crate) struct AdminCheckpointReleaseArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     /// Checkpoint id to release.
+    #[arg(value_hint = ValueHint::Other)]
     pub checkpoint_id: String,
 }
 
@@ -946,7 +1001,11 @@ pub(crate) struct AdminGcArgs {
     pub max_objects: Option<u64>,
     /// Resume token from a previous pass's next_cursor; only valid for the
     /// same namespace.
-    #[arg(long, value_name = "TOKEN")]
+    #[arg(
+        long,
+        value_name = "TOKEN",
+        value_hint = ValueHint::Other
+    )]
     pub cursor: Option<String>,
 }
 
@@ -1096,8 +1155,9 @@ impl CommandKind {
 }
 
 impl Cli {
-    pub(crate) fn kind(&self) -> CommandKind {
-        match &self.command {
+    pub(crate) fn kind(&self) -> Option<CommandKind> {
+        Some(match &self.command {
+            Command::Completions(_) => return None,
             Command::Init(_) => CommandKind::Init,
             Command::Profile { command } => match command {
                 ProfileCommand::Create(_) => CommandKind::ProfileCreate,
@@ -1150,6 +1210,6 @@ impl Cli {
                 ConfigCommand::Show => CommandKind::ConfigShow,
             },
             Command::Version => CommandKind::Version,
-        }
+        })
     }
 }

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -10,7 +10,7 @@ fn parse_public_inode_id(value: &str) -> Result<InodeId, String> {
     loonfs_api::public_inode_id::decode(value).map_err(|error| error.to_string())
 }
 
-/// Parsed `loonfs` command line and its Clap command model.
+/// Defines the `loonfs` command-line interface.
 #[derive(Debug, Parser)]
 #[command(name = "loonfs", version)]
 pub struct Cli {
@@ -108,7 +108,7 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: ConfigCommand,
     },
-    /// Print a shell completion script to stdout.
+    /// Print shell completions to stdout.
     Completions(CompletionsArgs),
     /// Print version and build metadata.
     Version,
@@ -116,7 +116,7 @@ pub(crate) enum Command {
 
 #[derive(Debug, Args)]
 pub(crate) struct CompletionsArgs {
-    /// Shell to generate for.
+    /// Shell to generate completions for.
     pub shell: clap_complete::Shell,
 }
 

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -464,7 +464,7 @@ pub(crate) async fn run_filesystem_get(
             kind,
             Some(context.profile_name),
             Some(context.mode),
-            CliError::json_not_supported_for_streaming(),
+            CliError::json_not_supported(),
         ));
     }
 

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -35,7 +35,7 @@ pub(crate) async fn run(
 
     let kind = cli
         .kind()
-        .expect("completions is the only kindless command, and it returned above");
+        .expect("completion generation returns before command dispatch");
     if runtime.json && !kind.supports_json() {
         return Err(CommandFailure {
             kind,
@@ -52,7 +52,6 @@ pub(crate) async fn run(
     let config_path = location.path.as_path();
 
     let result = match cli.command {
-        // Completion generation returned before config resolution above.
         Command::Completions(_) => return Ok(None),
         Command::Version => Ok(CommandOutput {
             kind,

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -17,12 +17,25 @@ pub(crate) use self::output::{
 
 use crate::args::{Cli, Command, RuntimeBehavior};
 use crate::config::resolve_config_location;
+use clap::CommandFactory;
 
 pub(crate) async fn run(
     cli: Cli,
     runtime: RuntimeBehavior,
-) -> Result<CommandOutput, CommandFailure> {
-    let kind = cli.kind();
+) -> Result<Option<CommandOutput>, CommandFailure> {
+    if let Command::Completions(args) = &cli.command {
+        clap_complete::generate(
+            args.shell,
+            &mut Cli::command(),
+            "loonfs",
+            &mut std::io::stdout(),
+        );
+        return Ok(None);
+    }
+
+    let kind = cli
+        .kind()
+        .expect("completions is the only kindless command, and it returned above");
     if runtime.json && !kind.supports_json() {
         return Err(CommandFailure {
             kind,
@@ -38,7 +51,9 @@ pub(crate) async fn run(
         .map_err(|error| context::fail(kind, None, None, error))?;
     let config_path = location.path.as_path();
 
-    match cli.command {
+    let result = match cli.command {
+        // Completion generation returned before config resolution above.
+        Command::Completions(_) => return Ok(None),
         Command::Version => Ok(CommandOutput {
             kind,
             profile: None,
@@ -76,5 +91,6 @@ pub(crate) async fn run(
         Command::Admin { command } => {
             admin::run_admin_command(kind, config_path, command, runtime).await
         }
-    }
+    };
+    result.map(Some)
 }

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -15,34 +15,32 @@ pub(crate) use self::output::{
     CommandData, CommandFailure, CommandOutput, ListingHeadDrift, MaintenanceKeyReport,
 };
 
-use crate::args::{Cli, Command, RuntimeBehavior};
+use crate::args::{Cli, Command, CommandKind, CompletionArgs, RuntimeBehavior};
 use crate::config::resolve_config_location;
+use crate::error::CliError;
 use clap::CommandFactory;
+use clap_complete::Shell;
+use std::path::Path;
+
+const COMPLETION_SHELL_REQUIRED: &str =
+    "pass `--shell` with one of: bash, zsh, fish, powershell, elvish (`$SHELL` is unset or unsupported)";
 
 pub(crate) async fn run(
     cli: Cli,
     runtime: RuntimeBehavior,
-) -> Result<Option<CommandOutput>, CommandFailure> {
-    if let Command::Completions(args) = &cli.command {
-        clap_complete::generate(
-            args.shell,
-            &mut Cli::command(),
-            "loonfs",
-            &mut std::io::stdout(),
-        );
-        return Ok(None);
-    }
-
-    let kind = cli
-        .kind()
-        .expect("completion generation returns before command dispatch");
+) -> Result<CommandOutput, CommandFailure> {
+    let kind = cli.kind();
     if runtime.json && !kind.supports_json() {
         return Err(CommandFailure {
             kind,
             profile: None,
             mode: None,
-            error: Box::new(crate::error::CliError::json_not_supported_for_streaming()),
+            error: Box::new(CliError::json_not_supported()),
         });
+    }
+
+    if let Command::Completion(args) = &cli.command {
+        return run_completion(kind, args);
     }
 
     // One resolution for the whole invocation: every command below reads
@@ -51,8 +49,10 @@ pub(crate) async fn run(
         .map_err(|error| context::fail(kind, None, None, error))?;
     let config_path = location.path.as_path();
 
-    let result = match cli.command {
-        Command::Completions(_) => return Ok(None),
+    match cli.command {
+        // Completion returns before config resolution above. This twin keeps
+        // dispatch exhaustive and deliberately uses the same output path.
+        Command::Completion(args) => run_completion(kind, &args),
         Command::Version => Ok(CommandOutput {
             kind,
             profile: None,
@@ -90,6 +90,42 @@ pub(crate) async fn run(
         Command::Admin { command } => {
             admin::run_admin_command(kind, config_path, command, runtime).await
         }
-    };
-    result.map(Some)
+    }
+}
+
+fn run_completion(
+    kind: CommandKind,
+    args: &CompletionArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let shell = args
+        .shell
+        .or_else(completion_shell_from_environment)
+        .ok_or_else(|| {
+            context::fail(
+                kind,
+                None,
+                None,
+                CliError::invalid_input(COMPLETION_SHELL_REQUIRED),
+            )
+        })?;
+    let mut script = Vec::new();
+    clap_complete::generate(shell, &mut Cli::command(), "loonfs", &mut script);
+    Ok(CommandOutput {
+        kind,
+        profile: None,
+        mode: None,
+        data: CommandData::CompletionScript(script),
+    })
+}
+
+fn completion_shell_from_environment() -> Option<Shell> {
+    let shell = std::env::var_os("SHELL")?;
+    match Path::new(&shell).file_name()?.to_str()? {
+        "bash" => Some(Shell::Bash),
+        "zsh" => Some(Shell::Zsh),
+        "fish" => Some(Shell::Fish),
+        "pwsh" | "powershell" => Some(Shell::PowerShell),
+        "elvish" => Some(Shell::Elvish),
+        _ => None,
+    }
 }

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -276,6 +276,8 @@ pub(crate) enum CommandData {
     Version {
         version: String,
     },
+    /// A generated shell completion script, rendered byte-for-byte.
+    CompletionScript(Vec<u8>),
     StreamBytes(Vec<u8>),
     /// The payload already went to standard output as it arrived, so there is
     /// nothing left to render. `get -` reports this: a download that is

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -149,10 +149,10 @@ impl CliError {
         Self::new("invalid_usage", message)
     }
 
-    pub(crate) fn json_not_supported_for_streaming() -> Self {
+    pub(crate) fn json_not_supported() -> Self {
         Self::new(
             "json_not_supported_for_streaming",
-            "streaming commands do not support `--json`",
+            "`--json` is not supported for this command",
         )
     }
 

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -25,6 +25,8 @@ mod uploads;
 use clap::Parser;
 use std::process::ExitCode;
 
+pub use args::Cli;
+
 /// Exit status for a command line the parser rejected, which is clap's own.
 ///
 /// It stays distinct from the failure status a command that actually ran
@@ -45,7 +47,7 @@ pub async fn main() -> ExitCode {
     // Boxing keeps the public entrypoint's future shallow for downstream binaries.
     let result = Box::pin(commands::run(cli, runtime)).await;
     match result {
-        Ok(output) => match render::render_success(&output, runtime.json) {
+        Ok(Some(output)) => match render::render_success(&output, runtime.json) {
             // A recursive transfer renders its per-item outcomes as success
             // data but still exits nonzero when any item failed.
             Ok(()) if output.data.reports_failures() => ExitCode::FAILURE,
@@ -61,6 +63,7 @@ pub async fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
+        Ok(None) => ExitCode::SUCCESS,
         Err(failure) => {
             let _ = render::render_error(&failure, runtime.json);
             ExitCode::FAILURE

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -25,8 +25,6 @@ mod uploads;
 use clap::Parser;
 use std::process::ExitCode;
 
-pub use args::Cli;
-
 /// Exit status for a command line the parser rejected, which is clap's own.
 ///
 /// It stays distinct from the failure status a command that actually ran
@@ -47,7 +45,7 @@ pub async fn main() -> ExitCode {
     // Boxing keeps the public entrypoint's future shallow for downstream binaries.
     let result = Box::pin(commands::run(cli, runtime)).await;
     match result {
-        Ok(Some(output)) => match render::render_success(&output, runtime.json) {
+        Ok(output) => match render::render_success(&output, runtime.json) {
             // A recursive transfer renders its per-item outcomes as success
             // data but still exits nonzero when any item failed.
             Ok(()) if output.data.reports_failures() => ExitCode::FAILURE,
@@ -63,7 +61,6 @@ pub async fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
-        Ok(None) => ExitCode::SUCCESS,
         Err(failure) => {
             let _ = render::render_error(&failure, runtime.json);
             ExitCode::FAILURE

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -546,7 +546,9 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             )
         }
         CommandData::Version { version } => version.clone(),
-        CommandData::StreamBytes(_) | CommandData::StreamedToStdout => String::new(),
+        CommandData::CompletionScript(_)
+        | CommandData::StreamBytes(_)
+        | CommandData::StreamedToStdout => String::new(),
     }
 }
 

--- a/crates/loonfs-cli/src/render/json.rs
+++ b/crates/loonfs-cli/src/render/json.rs
@@ -21,9 +21,11 @@ where
 
 pub(crate) fn json_success(output: &CommandOutput) -> io::Result<String> {
     match &output.data {
-        CommandData::StreamBytes(_) | CommandData::StreamedToStdout => Err(io::Error::new(
+        CommandData::CompletionScript(_)
+        | CommandData::StreamBytes(_)
+        | CommandData::StreamedToStdout => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "streaming output does not support json rendering",
+            "raw output does not support json rendering",
         )),
         data => serde_json::to_string_pretty(&JsonEnvelope {
             kind: output.kind.as_str(),

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -32,7 +32,7 @@ pub(crate) fn render_success(output: &CommandOutput, json_mode: bool) -> io::Res
     }
 
     match &output.data {
-        CommandData::StreamBytes(bytes) => {
+        CommandData::CompletionScript(bytes) | CommandData::StreamBytes(bytes) => {
             let mut stdout = io::stdout().lock();
             stdout.write_all(bytes)?;
         }

--- a/crates/loonfs-cli/tests/it/completions.rs
+++ b/crates/loonfs-cli/tests/it/completions.rs
@@ -1,0 +1,56 @@
+use clap::{CommandFactory, Parser, ValueHint};
+use clap_complete::Shell;
+use loonfs_cli::Cli;
+
+#[test]
+fn completions_command_parses() {
+    assert!(Cli::try_parse_from(["loonfs", "completions", "zsh"]).is_ok());
+}
+
+#[test]
+fn completions_generate_for_zsh_and_bash() {
+    for shell in [Shell::Zsh, Shell::Bash] {
+        let mut script = Vec::new();
+        clap_complete::generate(shell, &mut Cli::command(), "loonfs", &mut script);
+
+        assert!(!script.is_empty());
+        assert!(String::from_utf8_lossy(&script).contains("loonfs"));
+    }
+}
+
+#[test]
+fn completions_use_local_and_remote_path_hints() {
+    let command = Cli::command();
+
+    assert_hint(&command, "config", ValueHint::FilePath);
+
+    let put = subcommand(&command, "put");
+    assert_hint(put, "local_path", ValueHint::AnyPath);
+    assert_hint(put, "remote_path", ValueHint::Other);
+
+    let get = subcommand(&command, "get");
+    assert_hint(get, "local_destination", ValueHint::AnyPath);
+    assert_hint(get, "remote_path", ValueHint::Other);
+
+    let cat = subcommand(&command, "cat");
+    assert_hint(cat, "path", ValueHint::Other);
+
+    let mv = subcommand(&command, "mv");
+    assert_hint(mv, "source_path", ValueHint::Other);
+    assert_hint(mv, "destination_path", ValueHint::Other);
+}
+
+fn subcommand<'a>(command: &'a clap::Command, name: &str) -> &'a clap::Command {
+    command
+        .get_subcommands()
+        .find(|subcommand| subcommand.get_name() == name)
+        .unwrap_or_else(|| panic!("missing {name} subcommand"))
+}
+
+fn assert_hint(command: &clap::Command, id: &str, expected: ValueHint) {
+    let argument = command
+        .get_arguments()
+        .find(|argument| argument.get_id() == id)
+        .unwrap_or_else(|| panic!("missing {id} argument"));
+    assert_eq!(argument.get_value_hint(), expected);
+}

--- a/crates/loonfs-cli/tests/it/completions.rs
+++ b/crates/loonfs-cli/tests/it/completions.rs
@@ -1,56 +1,84 @@
-use clap::{CommandFactory, Parser, ValueHint};
-use clap_complete::Shell;
-use loonfs_cli::Cli;
+use std::process::{Command, Output, Stdio};
 
 #[test]
-fn completions_command_parses() {
-    assert!(Cli::try_parse_from(["loonfs", "completions", "zsh"]).is_ok());
-}
+fn completion_generates_for_zsh_and_bash() {
+    for shell in ["zsh", "bash"] {
+        let output = loonfs()
+            .args(["completion", "--shell", shell])
+            .output()
+            .expect("run completion generation");
 
-#[test]
-fn completions_generate_for_zsh_and_bash() {
-    for shell in [Shell::Zsh, Shell::Bash] {
-        let mut script = Vec::new();
-        clap_complete::generate(shell, &mut Cli::command(), "loonfs", &mut script);
-
-        assert!(!script.is_empty());
-        assert!(String::from_utf8_lossy(&script).contains("loonfs"));
+        assert!(output.status.success(), "{output:?}");
+        assert!(!output.stdout.is_empty());
+        assert!(stdout(&output).contains("loonfs"));
     }
 }
 
 #[test]
-fn completions_use_local_and_remote_path_hints() {
-    let command = Cli::command();
+fn completion_detects_the_shell_from_the_environment() {
+    let output = loonfs()
+        .arg("completion")
+        .env("SHELL", "/bin/zsh")
+        .output()
+        .expect("run completion generation");
 
-    assert_hint(&command, "config", ValueHint::FilePath);
-
-    let put = subcommand(&command, "put");
-    assert_hint(put, "local_path", ValueHint::AnyPath);
-    assert_hint(put, "remote_path", ValueHint::Other);
-
-    let get = subcommand(&command, "get");
-    assert_hint(get, "local_destination", ValueHint::AnyPath);
-    assert_hint(get, "remote_path", ValueHint::Other);
-
-    let cat = subcommand(&command, "cat");
-    assert_hint(cat, "path", ValueHint::Other);
-
-    let mv = subcommand(&command, "mv");
-    assert_hint(mv, "source_path", ValueHint::Other);
-    assert_hint(mv, "destination_path", ValueHint::Other);
+    assert!(output.status.success(), "{output:?}");
+    assert!(!output.stdout.is_empty());
 }
 
-fn subcommand<'a>(command: &'a clap::Command, name: &str) -> &'a clap::Command {
-    command
-        .get_subcommands()
-        .find(|subcommand| subcommand.get_name() == name)
-        .unwrap_or_else(|| panic!("missing {name} subcommand"))
+#[test]
+fn completion_without_a_shell_fails_cleanly() {
+    let output = loonfs()
+        .arg("completion")
+        .env_remove("SHELL")
+        .output()
+        .expect("run completion generation");
+
+    assert!(!output.status.success(), "{output:?}");
+    let stderr = stderr(&output);
+    assert!(stderr.contains("--shell"), "{stderr}");
+    assert!(!stderr.contains("panicked"), "{stderr}");
 }
 
-fn assert_hint(command: &clap::Command, id: &str, expected: ValueHint) {
-    let argument = command
-        .get_arguments()
-        .find(|argument| argument.get_id() == id)
-        .unwrap_or_else(|| panic!("missing {id} argument"));
-    assert_eq!(argument.get_value_hint(), expected);
+#[test]
+fn completion_does_not_panic_when_stdout_closes() {
+    let mut child = loonfs()
+        .args(["completion", "--shell", "zsh"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn completion generation");
+    drop(child.stdout.take().expect("piped stdout"));
+
+    let output = child
+        .wait_with_output()
+        .expect("wait for completion generation");
+    let stderr = stderr(&output);
+    assert_ne!(output.status.code(), Some(101), "{stderr}");
+    assert!(!stderr.contains("panicked"), "{stderr}");
+}
+
+#[test]
+fn completion_rejects_json_output() {
+    let output = loonfs()
+        .args(["--json", "completion", "--shell", "zsh"])
+        .output()
+        .expect("run completion generation");
+
+    assert!(!output.status.success(), "{output:?}");
+    let stderr = stderr(&output);
+    assert!(stderr.contains("--json"), "{stderr}");
+    assert!(stderr.contains("not supported"), "{stderr}");
+}
+
+fn loonfs() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_loonfs"))
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
 }

--- a/crates/loonfs-cli/tests/it/main.rs
+++ b/crates/loonfs-cli/tests/it/main.rs
@@ -2,6 +2,7 @@
 
 mod admin;
 mod common;
+mod completions;
 mod filesystem;
 mod output;
 mod profile;


### PR DESCRIPTION
Adds `loonfs completions <shell>` for Bash, Zsh, Fish, PowerShell, and Elvish. The script is generated from the existing Clap command definition, so commands and flags do not need a separate completion configuration.

Completion generation runs before profile or config loading and writes the shell script directly to stdout. It does not require credentials, a namespace, or a running server, and it still emits raw shell code when `--json` is present.

Adds value hints for local files, directories, and URLs. LoonFS paths, namespace IDs, profile names, cursors, and similar remote values are marked so the shell does not suggest unrelated local files.

Adds a short README example and tests command parsing, Bash and Zsh generation, and representative local and remote path hints. The branch also exports `Cli`, with private fields, so the integration tests can inspect the Clap command definition.
