### PR TITLE
fix(obs): one operation span per public call

### DIFF
--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -651,6 +651,7 @@ impl FsAdmin {
         skip_all,
         fields(
             operation = "maintenance.list_checkpoints",
+            method = "list_checkpoints_all",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -696,6 +697,7 @@ impl FsAdmin {
         skip_all,
         fields(
             operation = "maintenance.list_checkpoints",
+            method = "list_checkpoints_page",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -836,19 +838,15 @@ impl FsAdmin {
     /// Shared implementation for metadata maintenance and [`Self::flush_wal`].
     #[tracing::instrument(
         level = "debug",
-        name = "loonfs.maintenance.wal_flush",
+        name = "loonfs.phase",
         err(level = "debug"),
         skip_all,
         fields(
-            operation = "maintenance.wal_flush",
+            phase = "wal_flush",
             namespace_id = %namespace_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
         )
     )]
     async fn run_wal_flush(&self, namespace_id: &NamespaceId) -> Result<FlushWalResponse> {
-        let span = tracing::Span::current();
-        self.core.record_trace_context(&span);
         let result = self
             .engine(namespace_id)
             .flush_wal()

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -92,6 +92,7 @@ impl FsReader {
         skip_all,
         fields(
             operation = "list_path_entries",
+            method = "list_path_entries_all",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -147,6 +148,7 @@ impl FsReader {
         skip_all,
         fields(
             operation = "list_path_entries",
+            method = "list_path_entries_page",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -206,6 +208,7 @@ impl FsReader {
         skip_all,
         fields(
             operation = "get_file_bytes",
+            method = "get_file_bytes",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -255,6 +258,7 @@ impl FsReader {
         skip_all,
         fields(
             operation = "get_file_bytes",
+            method = "read_file_stream",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -561,6 +565,7 @@ impl FsReader {
         skip_all,
         fields(
             operation = "get_file_bytes",
+            method = "get_file_revision_bytes",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,

--- a/crates/loonfs/src/fs/uploads.rs
+++ b/crates/loonfs/src/fs/uploads.rs
@@ -54,6 +54,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "begin_upload",
+            method = "begin_upload",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -79,6 +80,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "begin_upload",
+            method = "begin_direct_put_upload_target",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -108,6 +110,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "begin_upload",
+            method = "begin_direct_multipart_upload_target",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -161,6 +164,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "upload_content",
+            method = "upload_content",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -197,6 +201,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "upload_content",
+            method = "upload_streamed_content",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -224,6 +229,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "complete_upload",
+            method = "complete_upload",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -236,7 +242,11 @@ impl FsWriter {
     ) -> Result<UploadSessionResponse> {
         self.core.record_trace_context(&tracing::Span::current());
         Ok(self
-            .complete_upload_prepared(namespace_id, upload_id)
+            .complete_upload_prepared_inner(
+                namespace_id,
+                upload_id,
+                loonfs_core::ResolvedUploadCompletion::KnownContent,
+            )
             .await?
             .response)
     }
@@ -249,6 +259,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "complete_upload",
+            method = "complete_multipart_upload",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -262,7 +273,11 @@ impl FsWriter {
     ) -> Result<UploadSessionResponse> {
         self.core.record_trace_context(&tracing::Span::current());
         Ok(self
-            .complete_multipart_upload_prepared(namespace_id, upload_id, request)
+            .complete_upload_prepared_inner(
+                namespace_id,
+                upload_id,
+                loonfs_core::ResolvedUploadCompletion::Multipart(request.clone()),
+            )
             .await?
             .response)
     }
@@ -278,6 +293,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "complete_upload",
+            method = "complete_upload_prepared",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -305,6 +321,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "complete_upload",
+            method = "complete_multipart_upload_prepared",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -350,6 +367,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "complete_upload",
+            method = "complete_upload_prepared_for_mode",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -74,6 +74,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "put",
+            method = "put_file_bytes",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -102,9 +103,9 @@ impl FsWriter {
         self.core.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
         let attempt = options.clone();
-        let prepared_content = self.prepare_file_bytes(namespace_id, bytes).await?;
+        let prepared_content = self.prepare_file_bytes_inner(namespace_id, bytes).await?;
         let published = self
-            .put_file_prepared(namespace_id, absolute_path, prepared_content, options)
+            .put_file_prepared_inner(namespace_id, absolute_path, prepared_content, options)
             .await;
         self.settle_put(
             namespace_id,
@@ -137,6 +138,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "put",
+            method = "put_file_stream",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -152,13 +154,13 @@ impl FsWriter {
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
         let attempt = options.clone();
-        let prepared_content = self.prepare_file_stream(namespace_id, body).await?;
+        let prepared_content = self.prepare_file_stream_inner(namespace_id, body).await?;
         // The prepared reference describes the bytes that just went past,
         // and with the payload gone it is the only description of them that
         // still exists.
         let staged = prepared_content.content_ref().clone();
         let published = self
-            .put_file_prepared(namespace_id, absolute_path, prepared_content, options)
+            .put_file_prepared_inner(namespace_id, absolute_path, prepared_content, options)
             .await;
         self.settle_put(
             namespace_id,
@@ -253,6 +255,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "prepare",
+            method = "prepare_file_bytes",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -267,6 +270,14 @@ impl FsWriter {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
         span.record("payload_class", crate::trace::payload_class(bytes.len()));
+        self.prepare_file_bytes_inner(namespace_id, bytes).await
+    }
+
+    async fn prepare_file_bytes_inner(
+        &self,
+        namespace_id: &NamespaceId,
+        bytes: &[u8],
+    ) -> Result<PreparedContent> {
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
@@ -291,6 +302,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "prepare",
+            method = "prepare_file_stream",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -303,6 +315,14 @@ impl FsWriter {
         body: ByteStream,
     ) -> Result<PreparedContent> {
         self.core.record_trace_context(&tracing::Span::current());
+        self.prepare_file_stream_inner(namespace_id, body).await
+    }
+
+    async fn prepare_file_stream_inner(
+        &self,
+        namespace_id: &NamespaceId,
+        body: ByteStream,
+    ) -> Result<PreparedContent> {
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
@@ -323,6 +343,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "put",
+            method = "put_file_prepared",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -344,25 +365,38 @@ impl FsWriter {
                 usize::try_from(prepared_content.content_ref().size_bytes).unwrap_or(usize::MAX),
             ),
         );
+        self.put_file_prepared_inner(namespace_id, absolute_path, prepared_content, options)
+            .await
+    }
+
+    async fn put_file_prepared_inner(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        prepared_content: PreparedContent,
+        options: PutFileOptions,
+    ) -> Result<CommitResponse> {
         let content_ref = prepared_content.content_ref().clone();
-        self.commit_prepared(
+        self.commit_candidate_inner(
             namespace_id,
-            CommitRequest::single(
-                options
-                    .commit
-                    .commit_id
-                    .clone()
-                    .unwrap_or_else(CommitId::generate),
-                options.commit.actor.clone(),
-                options.commit.message.clone(),
-                FilesystemOperation::PutFile {
-                    path: loonfs_core::path::parse_mutation_path(absolute_path)?,
-                    content_ref,
-                    behavior: options.behavior,
-                    expected_revision_no: options.expected_revision_no,
-                },
+            CommitCandidate::prepared(
+                CommitRequest::single(
+                    options
+                        .commit
+                        .commit_id
+                        .clone()
+                        .unwrap_or_else(CommitId::generate),
+                    options.commit.actor.clone(),
+                    options.commit.message.clone(),
+                    FilesystemOperation::PutFile {
+                        path: loonfs_core::path::parse_mutation_path(absolute_path)?,
+                        content_ref,
+                        behavior: options.behavior,
+                        expected_revision_no: options.expected_revision_no,
+                    },
+                ),
+                vec![prepared_content],
             ),
-            vec![prepared_content],
         )
         .await
     }
@@ -379,6 +413,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "put",
+            method = "put_file_content_ref",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -400,8 +435,10 @@ impl FsWriter {
                 usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX),
             ),
         );
-        let prepared_content = self.prepare_content_ref(namespace_id, content_ref).await?;
-        self.put_file_prepared(namespace_id, absolute_path, prepared_content, options)
+        let prepared_content = self
+            .prepare_content_ref_inner(namespace_id, content_ref)
+            .await?;
+        self.put_file_prepared_inner(namespace_id, absolute_path, prepared_content, options)
             .await
     }
 
@@ -417,6 +454,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "prepare",
+            method = "prepare_content_ref",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -436,6 +474,15 @@ impl FsWriter {
                 usize::try_from(content_ref.size_bytes).unwrap_or(usize::MAX),
             ),
         );
+        self.prepare_content_ref_inner(namespace_id, content_ref)
+            .await
+    }
+
+    async fn prepare_content_ref_inner(
+        &self,
+        namespace_id: &NamespaceId,
+        content_ref: ContentRef,
+    ) -> Result<PreparedContent> {
         let catalog = self
             .load_namespace_catalog_for_content_preparation(namespace_id)
             .await?;
@@ -457,6 +504,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "prepare",
+            method = "prepare_content_token",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -495,6 +543,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "create_directory",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -507,9 +556,9 @@ impl FsWriter {
         options: CreateDirectoryOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit(
+        self.commit_candidate_inner(
             namespace_id,
-            CommitRequest::single(
+            CommitCandidate::new(CommitRequest::single(
                 options
                     .commit
                     .commit_id
@@ -521,7 +570,7 @@ impl FsWriter {
                     path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     parents: options.parents,
                 },
-            ),
+            )),
         )
         .await
     }
@@ -539,6 +588,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "delete_path",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -551,9 +601,9 @@ impl FsWriter {
         options: DeleteOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit(
+        self.commit_candidate_inner(
             namespace_id,
-            CommitRequest::single(
+            CommitCandidate::new(CommitRequest::single(
                 options
                     .commit
                     .commit_id
@@ -566,7 +616,7 @@ impl FsWriter {
                     behavior: options.behavior,
                     expected_inode_id: options.expected_inode_id,
                 },
-            ),
+            )),
         )
         .await
     }
@@ -579,6 +629,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "move_path",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -592,9 +643,9 @@ impl FsWriter {
         options: MoveOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit(
+        self.commit_candidate_inner(
             namespace_id,
-            CommitRequest::single(
+            CommitCandidate::new(CommitRequest::single(
                 options
                     .commit
                     .commit_id
@@ -607,7 +658,7 @@ impl FsWriter {
                     to_path: loonfs_core::path::parse_mutation_path(to_path)?,
                     behavior: options.behavior,
                 },
-            ),
+            )),
         )
         .await
     }
@@ -621,6 +672,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "copy_path",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -634,9 +686,9 @@ impl FsWriter {
         options: CopyOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit(
+        self.commit_candidate_inner(
             namespace_id,
-            CommitRequest::single(
+            CommitCandidate::new(CommitRequest::single(
                 options
                     .commit
                     .commit_id
@@ -649,7 +701,7 @@ impl FsWriter {
                     to_path: loonfs_core::path::parse_mutation_path(to_path)?,
                     behavior: options.behavior,
                 },
-            ),
+            )),
         )
         .await
     }
@@ -662,6 +714,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "restore_file_revision",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -675,9 +728,9 @@ impl FsWriter {
         options: RestoreRevisionOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit(
+        self.commit_candidate_inner(
             namespace_id,
-            CommitRequest::single(
+            CommitCandidate::new(CommitRequest::single(
                 options
                     .commit
                     .commit_id
@@ -689,7 +742,7 @@ impl FsWriter {
                     path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     source_revision_no,
                 },
-            ),
+            )),
         )
         .await
     }
@@ -707,6 +760,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "update_attributes",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -719,9 +773,9 @@ impl FsWriter {
         options: UpdateAttributesOptions,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit(
+        self.commit_candidate_inner(
             namespace_id,
-            CommitRequest::single(
+            CommitCandidate::new(CommitRequest::single(
                 options
                     .commit
                     .commit_id
@@ -736,7 +790,7 @@ impl FsWriter {
                     expected_inode_id: options.expected_inode_id,
                     expected_attributes_revision_no: options.expected_attributes_revision_no,
                 },
-            ),
+            )),
         )
         .await
     }
@@ -749,6 +803,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "undelete",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -768,9 +823,9 @@ impl FsWriter {
         let path = absolute_path
             .map(loonfs_core::path::parse_mutation_path)
             .transpose()?;
-        self.commit(
+        self.commit_candidate_inner(
             namespace_id,
-            CommitRequest::single(
+            CommitCandidate::new(CommitRequest::single(
                 options
                     .commit
                     .commit_id
@@ -783,7 +838,7 @@ impl FsWriter {
                     deletion_seq,
                     path,
                 },
-            ),
+            )),
         )
         .await
     }
@@ -804,6 +859,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "commit",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -815,7 +871,7 @@ impl FsWriter {
         request: CommitRequest,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit_candidate(namespace_id, CommitCandidate::new(request))
+        self.commit_candidate_inner(namespace_id, CommitCandidate::new(request))
             .await
     }
 
@@ -830,6 +886,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "commit_prepared",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -842,7 +899,7 @@ impl FsWriter {
         prepared_content: Vec<PreparedContent>,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
-        self.commit_candidate(
+        self.commit_candidate_inner(
             namespace_id,
             CommitCandidate::prepared(request, prepared_content),
         )
@@ -861,6 +918,7 @@ impl FsWriter {
         skip_all,
         fields(
             operation = "apply_commit",
+            method = "commit_candidate",
             namespace_id = %namespace_id,
             mode = tracing::field::Empty,
             store_kind = tracing::field::Empty,
@@ -872,6 +930,14 @@ impl FsWriter {
         candidate: CommitCandidate,
     ) -> Result<CommitResponse> {
         self.core.record_trace_context(&tracing::Span::current());
+        self.commit_candidate_inner(namespace_id, candidate).await
+    }
+
+    async fn commit_candidate_inner(
+        &self,
+        namespace_id: &NamespaceId,
+        candidate: CommitCandidate,
+    ) -> Result<CommitResponse> {
         self.publisher
             .submit_candidate(namespace_id.clone(), candidate)
             .await

--- a/crates/loonfs/tests/operation_spans.rs
+++ b/crates/loonfs/tests/operation_spans.rs
@@ -3,7 +3,10 @@
 
 //! Checks operation spans for the writer, reader, and admin handles.
 
-use loonfs::{CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter, StoreConfig};
+use loonfs::{
+    CreateDirectoryOptions, CreateNamespaceOptions, FsAdmin, FsBackgroundWork, FsWriter,
+    PutFileOptions, StoreConfig,
+};
 use loonfs_test_support::block_on::block_on;
 use loonfs_test_support::ids::namespace_id;
 use std::path::Path;
@@ -29,6 +32,17 @@ impl std::io::Write for CaptureWriter {
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
+}
+
+fn take_captured_log(captured: &Arc<Mutex<Vec<u8>>>) -> String {
+    let bytes = std::mem::take(&mut *captured.lock().expect("capture lock"));
+    String::from_utf8(bytes).expect("captured log is utf8")
+}
+
+fn closed_span_count(log: &str, span_name: &str) -> usize {
+    log.lines()
+        .filter(|line| line.contains(span_name) && line.contains("close"))
+        .count()
 }
 
 #[test]
@@ -89,4 +103,83 @@ fn every_handle_emits_an_operation_span_with_its_namespace() {
             "`{span_name}` did not close: {span}"
         );
     }
+}
+
+#[test]
+fn delegated_writer_calls_close_one_operation_span() {
+    let temp_dir = tempdir().expect("tempdir");
+    let namespace_id = namespace_id("operation-span-counts");
+    let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&captured);
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_ansi(false)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_writer(move || CaptureWriter(Arc::clone(&sink)))
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let (create_log, put_log) = block_on(async {
+        let writer = FsWriter::builder(store_config(temp_dir.path()))
+            .writer_id("operation-span-count-writer")
+            .background_work(FsBackgroundWork::ManualOnly)
+            .build()
+            .await
+            .expect("build writer");
+        writer
+            .create_namespace(&namespace_id, CreateNamespaceOptions::default())
+            .await
+            .expect("create namespace");
+        let _setup_log = take_captured_log(&captured);
+        writer
+            .create_directory(
+                &namespace_id,
+                "/docs",
+                CreateDirectoryOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("create directory");
+        let create_log = take_captured_log(&captured);
+        writer
+            .put_file_bytes(
+                &namespace_id,
+                "/docs/file.txt",
+                b"body",
+                PutFileOptions::new(loonfs_test_support::test_actor()),
+            )
+            .await
+            .expect("put file");
+        let put_log = take_captured_log(&captured);
+        (create_log, put_log)
+    });
+
+    let apply_commit = create_log
+        .lines()
+        .filter(|line| line.contains("loonfs.apply_commit") && line.contains("close"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        apply_commit.len(),
+        1,
+        "create_directory closed the wrong number of apply_commit spans:\n{create_log}"
+    );
+    assert!(
+        apply_commit[0].contains("method=\"create_directory\""),
+        "create_directory apply_commit span lacks its method field:\n{}",
+        apply_commit[0]
+    );
+    assert_eq!(
+        closed_span_count(&put_log, "loonfs.put"),
+        1,
+        "put_file_bytes closed the wrong number of put spans:\n{put_log}"
+    );
+    assert_eq!(
+        closed_span_count(&put_log, "loonfs.prepare"),
+        0,
+        "put_file_bytes closed a prepare span:\n{put_log}"
+    );
+    assert_eq!(
+        closed_span_count(&put_log, "loonfs.apply_commit"),
+        0,
+        "put_file_bytes closed an apply_commit span:\n{put_log}"
+    );
 }

--- a/crates/loonfs/tests/tracing_capture.rs
+++ b/crates/loonfs/tests/tracing_capture.rs
@@ -142,7 +142,7 @@ fn background_step_conclusions_emit_debug_events() {
     for field in ["dispatched=", "ready_queued=", "oldest_queued_ms="] {
         assert!(dispatch.contains(field), "missing `{field}` in: {dispatch}");
     }
-    // The spans this work runs under say maintenance, which is what it is.
+    // Record both the maintenance operation and its WAL flush phase.
     for span_evidence in [
         "loonfs.maintenance.step",
         "loonfs.phase{phase=\"wal_flush\"",

--- a/crates/loonfs/tests/tracing_capture.rs
+++ b/crates/loonfs/tests/tracing_capture.rs
@@ -143,8 +143,14 @@ fn background_step_conclusions_emit_debug_events() {
         assert!(dispatch.contains(field), "missing `{field}` in: {dispatch}");
     }
     // The spans this work runs under say maintenance, which is what it is.
-    for span in ["loonfs.maintenance.step", "loonfs.maintenance.wal_flush"] {
-        assert!(log.contains(span), "missing span `{span}` in:\n{log}");
+    for span_evidence in [
+        "loonfs.maintenance.step",
+        "loonfs.phase{phase=\"wal_flush\"",
+    ] {
+        assert!(
+            log.contains(span_evidence),
+            "missing span evidence `{span_evidence}` in:\n{log}"
+        );
     }
     assert!(
         !log.contains("compaction"),


### PR DESCRIPTION
Removes duplicate operation spans from writer methods that call other public writer methods. Path mutations, file puts, preparation helpers, commit helpers, and upload completion now share private uninstrumented implementations. Calling any of those public methods directly still creates its own operation span.

Adds a static `method` field when several public methods share an operation name. This keeps stable operation names such as `loonfs.put` and `loonfs.apply_commit` while identifying the public method that was called.

Changes the internal WAL flush span to `loonfs.phase` with `phase="wal_flush"`. Explicit WAL flushes keep their public operation span, while background maintenance records the flush as a phase of `loonfs.maintenance.step`.

Tests verify that `create_directory` emits one `loonfs.apply_commit` span with its method and that `put_file_bytes` emits one `loonfs.put` span without nested prepare or commit operation spans. The maintenance tracing test now checks for the WAL flush phase. Runtime behavior, public APIs, and durable data are unchanged.
