### PR TITLE
test(server): retry the macOS teardown EINVAL in raw envelope reads

### DIFF
--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -350,7 +350,7 @@ fn is_snake_case_token(token: &str) -> bool {
             .bytes()
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
-use loonfs_test_support::http::raw_agent;
+use loonfs_test_support::http::{raw_agent, retry_on_macos_teardown_einval};
 use loonfs_test_support::ids::namespace_id;
 use loonfs_test_support::stores::{
     BlockingStore, BufferWatchStore, FailStore, InjectedError, KeyPredicate, OperationClass,
@@ -1728,10 +1728,45 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
     server.abort();
 }
 
+/// Sends the exchange and asserts the error answers inside the JSON
+/// envelope with the expected status and code, returning the body.
+///
+/// The exchange runs behind [`retry_on_macos_teardown_einval`] because
+/// the unauthorized requests here carry bodies the server never reads:
+/// answering 401 before the body is exactly the behavior under test, and
+/// closing the connection afterwards with those bytes unread makes the
+/// close a TCP reset, which macOS can turn into a client-side EINVAL
+/// even though the envelope already arrived. The envelope assertions
+/// themselves never retry: a wrong status, code, or body panics with a
+/// message the retry does not match and fails the test on first sight.
+fn expect_enveloped(
+    send: impl Fn() -> Result<ureq::Response, ureq::Error>,
+    expectation: &str,
+    status: u16,
+    code: &str,
+) -> serde_json::Value {
+    retry_on_macos_teardown_einval(|| {
+        let error = send().expect_err(expectation);
+        let ureq::Error::Status(actual_status, response) = error else {
+            panic!("expected a status error, got {error:?}");
+        };
+        assert_eq!(actual_status, status);
+        assert!(response.header("x-request-id").is_some());
+        let body = response.into_string().expect("read error body");
+        let body: serde_json::Value =
+            serde_json::from_str(&body).unwrap_or_else(|_| panic!("json body, got: {body}"));
+        assert_eq!(body["code"], code);
+        body
+    })
+}
+
 /// Malformed query strings, path parameters, and JSON bodies answer inside
 /// the JSON error envelope as `invalid_request` — never as a framework
 /// plain-text rejection — and authorization is checked first, so the same
 /// malformed request without credentials answers 401.
+// The exchange closures relay ureq's own call() signature, whose error
+// type is large by ureq's design.
+#[allow(clippy::result_large_err)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
     let temp_dir = tempdir().expect("tempdir");
@@ -1746,27 +1781,19 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         axum::serve(listener, router).await.expect("serve app");
     });
 
-    let expect_enveloped = |error: ureq::Error, status: u16, code: &str| {
-        let ureq::Error::Status(actual_status, response) = error else {
-            panic!("expected a status error, got {error:?}");
-        };
-        assert_eq!(actual_status, status);
-        assert!(response.header("x-request-id").is_some());
-        let body = response.into_string().expect("read error body");
-        let body: serde_json::Value =
-            serde_json::from_str(&body).unwrap_or_else(|_| panic!("json body, got: {body}"));
-        assert_eq!(body["code"], code);
-        body
-    };
-
     // A query value that fails its field type: enveloped invalid_request.
     let changes_url = format!("http://{addr}/v0/namespaces/demo/changes?after_seq=abc");
-    let error = raw_agent()
-        .get(&changes_url)
-        .set("authorization", "Bearer test-token")
-        .call()
-        .expect_err("malformed after_seq should answer 400");
-    let body = expect_enveloped(error, 400, "invalid_request");
+    let body = expect_enveloped(
+        || {
+            raw_agent()
+                .get(&changes_url)
+                .set("authorization", "Bearer test-token")
+                .call()
+        },
+        "malformed after_seq should answer 400",
+        400,
+        "invalid_request",
+    );
     assert!(
         body["message"]
             .as_str()
@@ -1776,45 +1803,61 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
 
     // The maximum valid value reaches namespace lookup. The next value is
     // rejected while parsing the query.
-    let error = raw_agent()
-        .get(&format!(
-            "http://{addr}/v0/namespaces/demo/changes?after_seq=9007199254740991"
-        ))
-        .set("authorization", "Bearer test-token")
-        .call()
-        .expect_err("valid sequence reaches the missing namespace");
-    expect_enveloped(error, 404, "namespace_not_found");
+    expect_enveloped(
+        || {
+            raw_agent()
+                .get(&format!(
+                    "http://{addr}/v0/namespaces/demo/changes?after_seq=9007199254740991"
+                ))
+                .set("authorization", "Bearer test-token")
+                .call()
+        },
+        "valid sequence reaches the missing namespace",
+        404,
+        "namespace_not_found",
+    );
 
-    let error = raw_agent()
-        .get(&format!(
-            "http://{addr}/v0/namespaces/demo/changes?after_seq=9007199254740992"
-        ))
-        .set("authorization", "Bearer test-token")
-        .call()
-        .expect_err("out-of-range after_seq should return 400");
-    let body = expect_enveloped(error, 400, "invalid_request");
+    let body = expect_enveloped(
+        || {
+            raw_agent()
+                .get(&format!(
+                    "http://{addr}/v0/namespaces/demo/changes?after_seq=9007199254740992"
+                ))
+                .set("authorization", "Bearer test-token")
+                .call()
+        },
+        "out-of-range after_seq should return 400",
+        400,
+        "invalid_request",
+    );
     assert_eq!(
         body["message"],
         "invalid after_seq `9007199254740992`: must be an integer from 0 through 9007199254740991"
     );
 
     // The same malformed query without credentials: 401 wins.
-    let error = raw_agent()
-        .get(&changes_url)
-        .call()
-        .expect_err("unauthorized should answer 401");
-    expect_enveloped(error, 401, "unauthorized");
+    expect_enveloped(
+        || raw_agent().get(&changes_url).call(),
+        "unauthorized should answer 401",
+        401,
+        "unauthorized",
+    );
 
     // Optional numeric query fields use the same hand-parse policy and name
     // themselves in the rejection rather than leaking framework wording.
-    let error = raw_agent()
-        .delete(&format!(
-            "http://{addr}/v0/namespaces/demo?expected_head_seq=abc"
-        ))
-        .set("authorization", "Bearer test-token")
-        .call()
-        .expect_err("malformed expected_head_seq should answer 400");
-    let body = expect_enveloped(error, 400, "invalid_request");
+    let body = expect_enveloped(
+        || {
+            raw_agent()
+                .delete(&format!(
+                    "http://{addr}/v0/namespaces/demo?expected_head_seq=abc"
+                ))
+                .set("authorization", "Bearer test-token")
+                .call()
+        },
+        "malformed expected_head_seq should answer 400",
+        400,
+        "invalid_request",
+    );
     assert!(
         body["message"]
             .as_str()
@@ -1823,29 +1866,44 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
     );
 
     // A missing required query parameter: enveloped invalid_request.
-    let error = raw_agent()
-        .get(&format!("http://{addr}/v0/namespaces/demo/filesystem/stat"))
-        .set("authorization", "Bearer test-token")
-        .call()
-        .expect_err("missing path parameter should answer 400");
-    expect_enveloped(error, 400, "invalid_request");
+    expect_enveloped(
+        || {
+            raw_agent()
+                .get(&format!("http://{addr}/v0/namespaces/demo/filesystem/stat"))
+                .set("authorization", "Bearer test-token")
+                .call()
+        },
+        "missing path parameter should answer 400",
+        400,
+        "invalid_request",
+    );
 
     // A malformed JSON body: enveloped invalid_request with credentials,
     // 401 without — the body is not read before authorization.
     let create_url = format!("http://{addr}/v0/namespaces");
-    let error = raw_agent()
-        .post(&create_url)
-        .set("authorization", "Bearer test-token")
-        .set("content-type", "application/json")
-        .send_string("{not json")
-        .expect_err("malformed body should answer 400");
-    expect_enveloped(error, 400, "invalid_request");
-    let error = raw_agent()
-        .post(&create_url)
-        .set("content-type", "application/json")
-        .send_string("{not json")
-        .expect_err("unauthorized malformed body should answer 401");
-    expect_enveloped(error, 401, "unauthorized");
+    expect_enveloped(
+        || {
+            raw_agent()
+                .post(&create_url)
+                .set("authorization", "Bearer test-token")
+                .set("content-type", "application/json")
+                .send_string("{not json")
+        },
+        "malformed body should answer 400",
+        400,
+        "invalid_request",
+    );
+    expect_enveloped(
+        || {
+            raw_agent()
+                .post(&create_url)
+                .set("content-type", "application/json")
+                .send_string("{not json")
+        },
+        "unauthorized malformed body should answer 401",
+        401,
+        "unauthorized",
+    );
 
     // Commit operation paths now validate while the authorized JSON body
     // is decoded. The served code stays the same invalid_request
@@ -1856,19 +1914,29 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "actor":{"kind":"service","id":"test-service"},
         "operations":[{"kind":"create_directory","path":"relative"}]
     }"#;
-    let error = raw_agent()
-        .post(&commits_url)
-        .set("authorization", "Bearer test-token")
-        .set("content-type", "application/json")
-        .send_string(invalid_operation)
-        .expect_err("invalid operation path should answer 400");
-    expect_enveloped(error, 400, "invalid_request");
-    let error = raw_agent()
-        .post(&commits_url)
-        .set("content-type", "application/json")
-        .send_string(invalid_operation)
-        .expect_err("authorization should precede operation path decoding");
-    expect_enveloped(error, 401, "unauthorized");
+    expect_enveloped(
+        || {
+            raw_agent()
+                .post(&commits_url)
+                .set("authorization", "Bearer test-token")
+                .set("content-type", "application/json")
+                .send_string(invalid_operation)
+        },
+        "invalid operation path should answer 400",
+        400,
+        "invalid_request",
+    );
+    expect_enveloped(
+        || {
+            raw_agent()
+                .post(&commits_url)
+                .set("content-type", "application/json")
+                .send_string(invalid_operation)
+        },
+        "authorization should precede operation path decoding",
+        401,
+        "unauthorized",
+    );
 
     for (body, description) in [
         (
@@ -1880,38 +1948,58 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
             "malformed actor",
         ),
     ] {
-        let error = raw_agent()
-            .post(&commits_url)
-            .set("authorization", "Bearer test-token")
-            .set("content-type", "application/json")
-            .send_string(body)
-            .expect_err(description);
-        expect_enveloped(error, 400, "invalid_request");
-        let error = raw_agent()
-            .post(&commits_url)
-            .set("content-type", "application/json")
-            .send_string(body)
-            .expect_err(description);
-        expect_enveloped(error, 401, "unauthorized");
+        expect_enveloped(
+            || {
+                raw_agent()
+                    .post(&commits_url)
+                    .set("authorization", "Bearer test-token")
+                    .set("content-type", "application/json")
+                    .send_string(body)
+            },
+            description,
+            400,
+            "invalid_request",
+        );
+        expect_enveloped(
+            || {
+                raw_agent()
+                    .post(&commits_url)
+                    .set("content-type", "application/json")
+                    .send_string(body)
+            },
+            description,
+            401,
+            "unauthorized",
+        );
     }
 
     // Grep scope paths make the same boundary move and retain the same
     // invalid_request code.
     let grep_url = format!("http://{addr}/v0/namespaces/demo/query/grep");
     let invalid_grep = r#"{"pattern":"needle","path_prefix":"relative"}"#;
-    let error = raw_agent()
-        .post(&grep_url)
-        .set("authorization", "Bearer test-token")
-        .set("content-type", "application/json")
-        .send_string(invalid_grep)
-        .expect_err("invalid grep path should answer 400");
-    expect_enveloped(error, 400, "invalid_request");
-    let error = raw_agent()
-        .post(&grep_url)
-        .set("content-type", "application/json")
-        .send_string(invalid_grep)
-        .expect_err("authorization should precede grep path decoding");
-    expect_enveloped(error, 401, "unauthorized");
+    expect_enveloped(
+        || {
+            raw_agent()
+                .post(&grep_url)
+                .set("authorization", "Bearer test-token")
+                .set("content-type", "application/json")
+                .send_string(invalid_grep)
+        },
+        "invalid grep path should answer 400",
+        400,
+        "invalid_request",
+    );
+    expect_enveloped(
+        || {
+            raw_agent()
+                .post(&grep_url)
+                .set("content-type", "application/json")
+                .send_string(invalid_grep)
+        },
+        "authorization should precede grep path decoding",
+        401,
+        "unauthorized",
+    );
 
     server.abort();
 }

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1728,17 +1728,10 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
     server.abort();
 }
 
-/// Sends the exchange and asserts the error answers inside the JSON
-/// envelope with the expected status and code, returning the body.
+/// Sends a request and checks its JSON error response.
 ///
-/// The exchange runs behind [`retry_on_macos_teardown_einval`] because
-/// the unauthorized requests here carry bodies the server never reads:
-/// answering 401 before the body is exactly the behavior under test, and
-/// closing the connection afterwards with those bytes unread makes the
-/// close a TCP reset, which macOS can turn into a client-side EINVAL
-/// even though the envelope already arrived. The envelope assertions
-/// themselves never retry: a wrong status, code, or body panics with a
-/// message the retry does not match and fails the test on first sight.
+/// On macOS, ureq can hit EINVAL when the server rejects a request before
+/// reading its body. The retry helper handles only that socket error.
 fn expect_enveloped(
     send: impl Fn() -> Result<ureq::Response, ureq::Error>,
     expectation: &str,
@@ -1760,12 +1753,9 @@ fn expect_enveloped(
     })
 }
 
-/// Malformed query strings, path parameters, and JSON bodies answer inside
-/// the JSON error envelope as `invalid_request` — never as a framework
-/// plain-text rejection — and authorization is checked first, so the same
-/// malformed request without credentials answers 401.
-// The exchange closures relay ureq's own call() signature, whose error
-// type is large by ureq's design.
+/// Checks that malformed requests return JSON API errors and that
+/// authentication runs before request parsing.
+// The request closures return ureq's large error type.
 #[allow(clippy::result_large_err)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
@@ -1781,7 +1771,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         axum::serve(listener, router).await.expect("serve app");
     });
 
-    // A query value that fails its field type: enveloped invalid_request.
+    // An invalid numeric query value returns invalid_request.
     let changes_url = format!("http://{addr}/v0/namespaces/demo/changes?after_seq=abc");
     let body = expect_enveloped(
         || {
@@ -1801,7 +1791,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "{body}"
     );
 
-    // The maximum valid value reaches namespace lookup. The next value is
+    // The largest allowed value reaches namespace lookup. One higher is
     // rejected while parsing the query.
     expect_enveloped(
         || {
@@ -1835,7 +1825,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "invalid after_seq `9007199254740992`: must be an integer from 0 through 9007199254740991"
     );
 
-    // The same malformed query without credentials: 401 wins.
+    // Without credentials, authentication fails before the query is parsed.
     expect_enveloped(
         || raw_agent().get(&changes_url).call(),
         "unauthorized should answer 401",
@@ -1843,8 +1833,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "unauthorized",
     );
 
-    // Optional numeric query fields use the same hand-parse policy and name
-    // themselves in the rejection rather than leaking framework wording.
+    // Optional numeric fields return a message that identifies the field.
     let body = expect_enveloped(
         || {
             raw_agent()
@@ -1865,7 +1854,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "{body}"
     );
 
-    // A missing required query parameter: enveloped invalid_request.
+    // A missing required query parameter returns invalid_request.
     expect_enveloped(
         || {
             raw_agent()
@@ -1878,8 +1867,8 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "invalid_request",
     );
 
-    // A malformed JSON body: enveloped invalid_request with credentials,
-    // 401 without — the body is not read before authorization.
+    // A malformed JSON body returns invalid_request after authentication.
+    // Without credentials, the server returns 401 before reading the body.
     let create_url = format!("http://{addr}/v0/namespaces");
     expect_enveloped(
         || {
@@ -1905,9 +1894,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "unauthorized",
     );
 
-    // Commit operation paths now validate while the authorized JSON body
-    // is decoded. The served code stays the same invalid_request
-    // classification the former handler-boundary validation used.
+    // Invalid operation paths return invalid_request after authentication.
     let commits_url = format!("http://{addr}/v0/namespaces/demo/commits");
     let invalid_operation = r#"{
         "commit_id":"invalid-path",
@@ -1973,8 +1960,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         );
     }
 
-    // Grep scope paths make the same boundary move and retain the same
-    // invalid_request code.
+    // Invalid grep path prefixes return invalid_request after authentication.
     let grep_url = format!("http://{addr}/v0/namespaces/demo/query/grep");
     let invalid_grep = r#"{"pattern":"needle","path_prefix":"relative"}"#;
     expect_enveloped(

--- a/crates/loonfs-test-support/src/http.rs
+++ b/crates/loonfs-test-support/src/http.rs
@@ -1,11 +1,9 @@
-//! HTTP-client setup shared by raw server tests.
+//! HTTP helpers shared by server tests.
 
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 
-/// Raw-request agent with socket inactivity timeouts. A starved or wedged
-/// server must produce a readable transport error, not an indefinite hang
-/// or a panic inside the HTTP client's response path — the failure mode a
-/// loaded CI runner once hit through the default timeout-less agent.
+/// Creates an HTTP client with read and write timeouts so a stalled server
+/// fails the test instead of waiting indefinitely.
 pub fn raw_agent() -> ureq::Agent {
     ureq::AgentBuilder::new()
         .timeout_read(std::time::Duration::from_secs(30))
@@ -13,28 +11,11 @@ pub fn raw_agent() -> ureq::Agent {
         .build()
 }
 
-/// Runs one raw HTTP exchange, retrying it when macOS tears the socket
-/// down under the client between the response head and the body read.
+/// Retries an HTTP exchange when ureq hits a known macOS socket error.
 ///
-/// When the server answers without consuming the request body and then
-/// closes the connection, the unread bytes make the close a TCP reset.
-/// Once the reset lands, the client socket is shut down in both
-/// directions, and macOS rejects every later setsockopt on it with
-/// EINVAL, where Linux accepts them. ureq resets its socket read timeout
-/// after parsing the response head and again when it pools the
-/// connection, so losing that race turns an already-delivered response
-/// into either a body read that fails with "Invalid argument (os error
-/// 22)" or a panic inside ureq's own pool-return expect. The server
-/// answered correctly in both shapes; only the client-side timeout
-/// bookkeeping raced the teardown. Under load the window stretches from
-/// microseconds to milliseconds and the race becomes reachable.
-///
-/// The retry stays honest about real failures. Only a panic carrying the
-/// EINVAL signature is retried, so a wrong or missing envelope fails on
-/// the first attempt, and the last attempt runs outside the catch so a
-/// persistent failure surfaces with its real message.
-// The breadcrumb prints straight to the test log so a tolerated race
-// stays visible instead of vanishing into a silent retry.
+/// This can happen when the server rejects a request before reading its body.
+/// Only the matching EINVAL panic is retried. Other panics are rethrown, and
+/// the final attempt runs normally so a persistent failure keeps its message.
 #[allow(clippy::print_stderr)]
 pub fn retry_on_macos_teardown_einval<T>(exchange: impl Fn() -> T) -> T {
     if !cfg!(target_os = "macos") {
@@ -55,10 +36,7 @@ pub fn retry_on_macos_teardown_einval<T>(exchange: impl Fn() -> T) -> T {
     exchange()
 }
 
-/// Matches both shapes the teardown race takes inside ureq: the reader
-/// that reports `Custom { kind: InvalidInput, error: "Invalid argument
-/// (os error 22)" }` and the internal expect that panics with
-/// `Os { code: 22, kind: InvalidInput, ... }`.
+/// Returns true for the ureq panic caused by the macOS socket error.
 fn panic_is_teardown_einval(payload: &(dyn std::any::Any + Send)) -> bool {
     let message = if let Some(owned) = payload.downcast_ref::<String>() {
         owned.as_str()

--- a/crates/loonfs-test-support/src/http.rs
+++ b/crates/loonfs-test-support/src/http.rs
@@ -1,5 +1,7 @@
 //! HTTP-client setup shared by raw server tests.
 
+use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+
 /// Raw-request agent with socket inactivity timeouts. A starved or wedged
 /// server must produce a readable transport error, not an indefinite hang
 /// or a panic inside the HTTP client's response path — the failure mode a
@@ -9,4 +11,61 @@ pub fn raw_agent() -> ureq::Agent {
         .timeout_read(std::time::Duration::from_secs(30))
         .timeout_write(std::time::Duration::from_secs(30))
         .build()
+}
+
+/// Runs one raw HTTP exchange, retrying it when macOS tears the socket
+/// down under the client between the response head and the body read.
+///
+/// When the server answers without consuming the request body and then
+/// closes the connection, the unread bytes make the close a TCP reset.
+/// Once the reset lands, the client socket is shut down in both
+/// directions, and macOS rejects every later setsockopt on it with
+/// EINVAL, where Linux accepts them. ureq resets its socket read timeout
+/// after parsing the response head and again when it pools the
+/// connection, so losing that race turns an already-delivered response
+/// into either a body read that fails with "Invalid argument (os error
+/// 22)" or a panic inside ureq's own pool-return expect. The server
+/// answered correctly in both shapes; only the client-side timeout
+/// bookkeeping raced the teardown. Under load the window stretches from
+/// microseconds to milliseconds and the race becomes reachable.
+///
+/// The retry stays honest about real failures. Only a panic carrying the
+/// EINVAL signature is retried, so a wrong or missing envelope fails on
+/// the first attempt, and the last attempt runs outside the catch so a
+/// persistent failure surfaces with its real message.
+// The breadcrumb prints straight to the test log so a tolerated race
+// stays visible instead of vanishing into a silent retry.
+#[allow(clippy::print_stderr)]
+pub fn retry_on_macos_teardown_einval<T>(exchange: impl Fn() -> T) -> T {
+    if !cfg!(target_os = "macos") {
+        return exchange();
+    }
+    const ATTEMPTS: usize = 3;
+    for _ in 1..ATTEMPTS {
+        match catch_unwind(AssertUnwindSafe(&exchange)) {
+            Ok(value) => return value,
+            Err(payload) => {
+                if !panic_is_teardown_einval(payload.as_ref()) {
+                    resume_unwind(payload);
+                }
+                eprintln!("retrying: macOS reset the connection before the client's timeout reset");
+            }
+        }
+    }
+    exchange()
+}
+
+/// Matches both shapes the teardown race takes inside ureq: the reader
+/// that reports `Custom { kind: InvalidInput, error: "Invalid argument
+/// (os error 22)" }` and the internal expect that panics with
+/// `Os { code: 22, kind: InvalidInput, ... }`.
+fn panic_is_teardown_einval(payload: &(dyn std::any::Any + Send)) -> bool {
+    let message = if let Some(owned) = payload.downcast_ref::<String>() {
+        owned.as_str()
+    } else if let Some(literal) = payload.downcast_ref::<&'static str>() {
+        literal
+    } else {
+        return false;
+    };
+    message.contains("kind: InvalidInput") && message.contains("Invalid argument")
 }


### PR DESCRIPTION
Fixes an intermittent macOS failure in the malformed-request HTTP test. When the server returns 401 without reading the request body, ureq can hit EINVAL while finishing the response. The test retries only that macOS-specific panic, up to two times. Every other failure still fails immediately.

The envelope assertion now accepts a request closure so the request can be repeated. Each successful exchange still checks the status, request ID, JSON error code, and relevant error message.
