### PR TITLE
refactor: sweep naming drift and few-line readability papercuts

### DIFF
--- a/crates/loonfs-api/src/actor.rs
+++ b/crates/loonfs-api/src/actor.rs
@@ -210,7 +210,10 @@ fn validate_actor_id(value: &str) -> Result<(), ActorIdValidationError> {
         return Err(actor_id_error(value, "must not be empty"));
     }
     if value.len() > MAX_ACTOR_ID_BYTES {
-        return Err(actor_id_error(value, "must be 256 bytes or fewer"));
+        return Err(actor_id_error(
+            value,
+            &format!("must be {MAX_ACTOR_ID_BYTES} bytes or fewer"),
+        ));
     }
     if value.trim() != value {
         return Err(actor_id_error(

--- a/crates/loonfs-api/src/commit_identity.rs
+++ b/crates/loonfs-api/src/commit_identity.rs
@@ -19,7 +19,6 @@ use crate::{
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::fmt::Write as _;
 use std::future::Future;
 use thiserror::Error;
 
@@ -54,13 +53,10 @@ where
 
 fn fingerprint_bytes(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
-    let mut value = String::with_capacity(FINGERPRINT_SCHEME.len() + 1 + digest.len() * 2);
-    value.push_str(FINGERPRINT_SCHEME);
-    value.push(':');
-    for byte in digest {
-        write!(&mut value, "{byte:02x}").expect("writing to a String should not fail");
-    }
-    value
+    format!(
+        "{FINGERPRINT_SCHEME}:{}",
+        crate::hex::hex_encode_bytes(&digest)
+    )
 }
 
 /// Canonical preimage for one operation inside a mutation fingerprint.
@@ -234,7 +230,7 @@ fn operation_fingerprint_input(operation: &FilesystemOperation) -> OperationFing
         } => OperationFingerprintInput::Undelete {
             inode_id: *inode_id,
             deleted_at_seq: *deletion_seq,
-            absolute_path: path.as_ref().map(|path| path.as_str()),
+            absolute_path: path.as_ref().map(AbsolutePath::as_str),
         },
         FilesystemOperation::UpdateAttributes {
             path,
@@ -436,8 +432,8 @@ where
 /// file.
 fn sole_committed_content_ref(change: &crate::v0::CommittedChange) -> Option<&ContentRef> {
     let mut content = change.events.iter().filter_map(|event| match event {
-        crate::v0::FilesystemChange::FileCreated { content_ref, .. } => Some(content_ref),
-        crate::v0::FilesystemChange::ContentChanged { content_ref, .. } => Some(content_ref),
+        crate::v0::FilesystemChange::FileCreated { content_ref, .. }
+        | crate::v0::FilesystemChange::ContentChanged { content_ref, .. } => Some(content_ref),
         _ => None,
     });
     let only = content.next()?;

--- a/crates/loonfs-api/src/digest.rs
+++ b/crates/loonfs-api/src/digest.rs
@@ -1,7 +1,6 @@
 //! The `sha256:<64hex>` digest form durable formats use.
 
 use sha2::{Digest, Sha256};
-use std::fmt::Write as _;
 
 /// Computes the durable `sha256:` digest spelling used by envelope payloads
 /// and local compare tokens.
@@ -10,12 +9,5 @@ pub fn sha256_digest(bytes: &[u8]) -> String {
 }
 
 pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    let mut encoded = String::with_capacity(digest.len() * 2);
-
-    for byte in digest {
-        write!(&mut encoded, "{byte:02x}").expect("writing to a String should not fail");
-    }
-
-    encoded
+    crate::hex::hex_encode_bytes(&Sha256::digest(bytes))
 }

--- a/crates/loonfs-api/src/manifest.rs
+++ b/crates/loonfs-api/src/manifest.rs
@@ -424,22 +424,23 @@ impl MetadataRow {
                 bind_seq,
                 bind_delta_index,
                 ..
-            } => match family {
-                MetadataTableFamily::DirentryChildBinds => {
-                    let name_key = hex_encode_row_key_component(name_key.as_str());
-                    format!(
-                        "direntry-child-{:020}-{:020}-{:010}-{:020}-{name_key}",
-                        child_inode_id.0, bind_seq.0, bind_delta_index, parent_inode_id.0
-                    )
+            } => {
+                let name_key = hex_encode_row_key_component(name_key.as_str());
+                match family {
+                    MetadataTableFamily::DirentryChildBinds => {
+                        format!(
+                            "direntry-child-{:020}-{:020}-{:010}-{:020}-{name_key}",
+                            child_inode_id.0, bind_seq.0, bind_delta_index, parent_inode_id.0
+                        )
+                    }
+                    _ => {
+                        format!(
+                            "direntry-{:020}-{name_key}-{:020}-{:010}",
+                            parent_inode_id.0, bind_seq.0, bind_delta_index
+                        )
+                    }
                 }
-                _ => {
-                    let name_key = hex_encode_row_key_component(name_key.as_str());
-                    format!(
-                        "direntry-{:020}-{name_key}-{:020}-{:010}",
-                        parent_inode_id.0, bind_seq.0, bind_delta_index
-                    )
-                }
-            },
+            }
             Self::DirentryUnbind {
                 parent_inode_id,
                 name_key,

--- a/crates/loonfs-api/src/v0/search.rs
+++ b/crates/loonfs-api/src/v0/search.rs
@@ -56,8 +56,7 @@ impl GrepRequest {
         seed = xxh64(
             self.path_prefix
                 .as_ref()
-                .map(AbsolutePath::as_str)
-                .unwrap_or("")
+                .map_or("", AbsolutePath::as_str)
                 .as_bytes(),
             seed,
         );

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -587,22 +587,22 @@ impl ResolvedTarget {
     /// When `path` is absent, the original parent and name are used.
     pub(crate) async fn undelete(
         &self,
-        namespace: &NamespaceId,
-        path: Option<&AbsolutePath>,
+        namespace_id: &NamespaceId,
         inode_id: InodeId,
         deletion_seq: ChangeSeq,
+        path: Option<&AbsolutePath>,
         options: &UndeleteOptions,
     ) -> Result<CommitResponse, BackendError> {
         match self {
             Self::Embedded(target) => {
                 target
                     .backend
-                    .undelete(namespace, path, inode_id, deletion_seq, options)
+                    .undelete(namespace_id, inode_id, deletion_seq, path, options)
                     .await
             }
             Self::Remote(target) => Ok(target
                 .client
-                .undelete(namespace, inode_id, deletion_seq, path, options)
+                .undelete(namespace_id, inode_id, deletion_seq, path, options)
                 .await?),
         }
     }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -881,8 +881,7 @@ fn current_unix_ms() -> Result<u64, BackendError> {
 }
 
 fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendError> {
-    // The server maps this same policy error to `invalid_request`; embedded
-    // mode must report the identical registry code for the identical failure.
+    // Embedded and remote modes use the same error code for an invalid limit.
     PaginationPolicy::default()
         .resolve_limit(limit)
         .map_err(|error| BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
@@ -903,8 +902,7 @@ fn cli_page_request<C: loonfs_api::PageCursor>(
     })
 }
 
-/// Renders a probe report as the wire shape both backends answer with, so
-/// an embedded run and a remote one print the same thing.
+/// Converts a store probe report to the response returned by both backends.
 fn store_probe_response(report: StoreProbeReport) -> StoreProbeResponse {
     StoreProbeResponse {
         run_id: report.run_id,

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -203,15 +203,7 @@ impl EmbeddedBackend {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListPathEntriesResponse, BackendError> {
-        let request = loonfs_api::PageRequest {
-            limit: resolve_cli_page_limit(limit)?,
-            cursor: cursor
-                .map(loonfs_api::decode_cursor)
-                .transpose()
-                .map_err(|error| {
-                    BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
-                })?,
-        };
+        let request = cli_page_request(limit, cursor)?;
         self.reader
             .list_path_entries_page(
                 spec.namespace(),
@@ -565,15 +557,7 @@ impl EmbeddedBackend {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListTrashResponse, BackendError> {
-        let request = loonfs_api::PageRequest {
-            limit: resolve_cli_page_limit(limit)?,
-            cursor: cursor
-                .map(loonfs_api::decode_cursor)
-                .transpose()
-                .map_err(|error| {
-                    BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
-                })?,
-        };
+        let request = cli_page_request(limit, cursor)?;
         self.reader
             .list_trash_page(namespace_id, request)
             .await
@@ -586,15 +570,7 @@ impl EmbeddedBackend {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListFileRevisionsResponse, BackendError> {
-        let request = loonfs_api::PageRequest {
-            limit: resolve_cli_page_limit(limit)?,
-            cursor: cursor
-                .map(loonfs_api::decode_cursor)
-                .transpose()
-                .map_err(|error| {
-                    BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
-                })?,
-        };
+        let request = cli_page_request(limit, cursor)?;
         self.reader
             .list_file_revisions_page(spec.namespace(), spec.absolute_path().as_str(), request)
             .await
@@ -744,15 +720,15 @@ impl EmbeddedBackend {
 
     pub(super) async fn undelete(
         &self,
-        namespace: &NamespaceId,
-        path: Option<&AbsolutePath>,
+        namespace_id: &NamespaceId,
         inode_id: InodeId,
         deletion_seq: ChangeSeq,
+        path: Option<&AbsolutePath>,
         options: &UndeleteOptions,
     ) -> Result<CommitResponse, BackendError> {
-        self.publish_with_maintenance_recovery(namespace, || {
+        self.publish_with_maintenance_recovery(namespace_id, || {
             self.writer.undelete(
-                namespace,
+                namespace_id,
                 inode_id,
                 deletion_seq,
                 path.map(|path| path.as_str()),
@@ -910,6 +886,21 @@ fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendE
     PaginationPolicy::default()
         .resolve_limit(limit)
         .map_err(|error| BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
+}
+
+fn cli_page_request<C: loonfs_api::PageCursor>(
+    limit: Option<u32>,
+    cursor: Option<&str>,
+) -> Result<loonfs_api::PageRequest<C>, BackendError> {
+    Ok(loonfs_api::PageRequest {
+        limit: resolve_cli_page_limit(limit)?,
+        cursor: cursor
+            .map(loonfs_api::decode_cursor)
+            .transpose()
+            .map_err(|error| {
+                BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
+            })?,
+    })
 }
 
 /// Renders a probe report as the wire shape both backends answer with, so

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -980,19 +980,13 @@ async fn commit_put(
     })
 }
 
-/// Uploads one payload and commits it at `spec`: the one way this CLI
-/// moves a file, whether the command named it or a recursive walk found it.
+/// Uploads one file and commits it at `spec`.
 ///
-/// The payload decides how it travels, and nothing else does. One small
-/// enough to hold goes as bytes; one that is large — or that cannot say how
-/// large it is — is read once, in pieces, whichever transport the profile
-/// selects, so what the upload costs in memory follows the transport's
-/// window and not the file's length. Where a payload travels in parts, an
-/// interrupted transfer of it is picked up rather than started over.
+/// Small payloads are buffered. Large payloads and streams are uploaded in
+/// chunks with bounded memory. Multipart uploads from files can resume after
+/// an interruption.
 ///
-/// `progress` counts what the payload gives up. A tree hands the same
-/// reporter to every file it is uploading, which is why the counting lives
-/// here rather than in the callers.
+/// Recursive uploads share `progress` across their files.
 pub(super) async fn put_payload(
     context: &CommandContext,
     spec: &NamespacePath,
@@ -1000,9 +994,8 @@ pub(super) async fn put_payload(
     options: &PutFileOptions,
     progress: &Arc<ProgressReporter>,
 ) -> Result<CommitResponse, CliError> {
-    // Only a payload large enough to travel in parts has anything an
-    // interruption could leave half-done, and only a source that can be
-    // opened twice can pick it up: a pipe is gone once it is read.
+    // Resume only multipart uploads backed by a file that can be reopened.
+    // Streams cannot be read again after an interruption.
     let journal = payload
         .resumable_source()
         .and_then(|local_path| resume_journal(context, spec, local_path));

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -1003,10 +1003,9 @@ pub(super) async fn put_payload(
     // Only a payload large enough to travel in parts has anything an
     // interruption could leave half-done, and only a source that can be
     // opened twice can pick it up: a pipe is gone once it is read.
-    let journal = match payload.resumable_source() {
-        Some(local_path) => resume_journal(context, spec, local_path),
-        None => None,
-    };
+    let journal = payload
+        .resumable_source()
+        .and_then(|local_path| resume_journal(context, spec, local_path));
     if let Some(journal) = journal.as_ref() {
         if let Some(committed) =
             commit_a_finished_upload(context, spec, options, journal, progress).await?
@@ -1252,9 +1251,9 @@ pub(crate) async fn run_filesystem_undelete(
         .target
         .undelete(
             &context.namespace,
-            spec.as_ref().map(|spec| spec.absolute_path()),
             args.inode,
             deletion_seq,
+            spec.as_ref().map(|spec| spec.absolute_path()),
             &loonfs_client::UndeleteOptions {
                 commit: commit_options(&context.actor, commit_id, args.message.clone()),
             },
@@ -1441,6 +1440,11 @@ async fn run_filesystem_transfer(
 
     let commit_id = parse_commit_id_arg(args.commit_id.as_deref())
         .map_err(|error| context.fail(kind, error))?;
+    let behavior = if args.force {
+        DestinationBehavior::Replace
+    } else {
+        DestinationBehavior::NoReplace
+    };
     let result = if transfer_kind == TransferKind::Copy {
         let entry = context
             .target
@@ -1485,11 +1489,6 @@ async fn run_filesystem_transfer(
                 )),
             ));
         }
-        let behavior = if args.force {
-            DestinationBehavior::Replace
-        } else {
-            DestinationBehavior::NoReplace
-        };
         context
             .target
             .copy_path(
@@ -1502,11 +1501,6 @@ async fn run_filesystem_transfer(
             )
             .await
     } else {
-        let behavior = if args.force {
-            DestinationBehavior::Replace
-        } else {
-            DestinationBehavior::NoReplace
-        };
         context
             .target
             .move_path(

--- a/crates/loonfs-cli/src/commands/partial.rs
+++ b/crates/loonfs-cli/src/commands/partial.rs
@@ -109,7 +109,7 @@ pub(super) struct PartialDownload {
 }
 
 impl PartialDownload {
-    /// Opens the partial file for a download that starts at `resume_from`,
+    /// Opens the partial file for a download that starts at `resumed_from`,
     /// and lays the note down beside it.
     ///
     /// The note is written before the first byte: bytes on disk with
@@ -120,7 +120,7 @@ impl PartialDownload {
     pub(super) fn open(
         destination: &Path,
         meta: Option<&PartialMeta>,
-        resume_from: u64,
+        resumed_from: u64,
     ) -> std::io::Result<Self> {
         let (Some(path), Some(meta_path)) = (
             sibling(destination, PARTIAL_SUFFIX),
@@ -146,8 +146,8 @@ impl PartialDownload {
             .open(&path)?;
         // One call covers both cases: it drops a longer partial's tail, and
         // it empties one this download is not resuming at all.
-        file.set_len(resume_from)?;
-        file.seek(std::io::SeekFrom::Start(resume_from))?;
+        file.set_len(resumed_from)?;
+        file.seek(std::io::SeekFrom::Start(resumed_from))?;
         Ok(Self {
             file: tempfile::NamedTempFile::from_parts(
                 file,
@@ -155,7 +155,7 @@ impl PartialDownload {
             ),
             _meta: meta,
             path,
-            resumed_from: resume_from,
+            resumed_from,
         })
     }
 

--- a/crates/loonfs-cli/src/commands/partial.rs
+++ b/crates/loonfs-cli/src/commands/partial.rs
@@ -90,37 +90,33 @@ pub(super) fn resumable_bytes(destination: &Path, meta: &PartialMeta) -> u64 {
     let Ok(metadata) = std::fs::metadata(&partial_path) else {
         return 0;
     };
-    // A partial longer than the content is not a prefix of it, whatever the
-    // note says.
+    // A partial file cannot be reused if it is longer than the content.
     if metadata.len() > meta.size_bytes {
         return 0;
     }
     metadata.len()
 }
 
-/// A download's bytes on their way to a destination.
+/// Stores a partial download and its metadata until completion.
 pub(super) struct PartialDownload {
     file: tempfile::NamedTempFile,
-    /// The note, held as a temporary path so it is removed on exactly the
-    /// occasions the bytes are.
+    /// Metadata stored as a temporary path so it is removed with the partial
+    /// file.
     _meta: tempfile::TempPath,
     path: PathBuf,
     resumed_from: u64,
 }
 
 impl PartialDownload {
-    /// Opens the partial file for a download that starts at `resumed_from`,
-    /// and lays the note down beside it.
+    /// Opens the partial file at `resume_from` and writes its metadata file.
     ///
-    /// The note is written before the first byte: bytes on disk with
-    /// nothing saying what they are cannot be resumed from, and a rerun
-    /// that guessed would be worse than one that started over. Content this
-    /// build cannot identify gets no note at all, which is the same answer
-    /// spelled by its absence.
+    /// Metadata is written before content so a later run can verify that the
+    /// existing bytes belong to the same download. Content without a stable
+    /// identity is not resumed.
     pub(super) fn open(
         destination: &Path,
         meta: Option<&PartialMeta>,
-        resumed_from: u64,
+        resume_from: u64,
     ) -> std::io::Result<Self> {
         let (Some(path), Some(meta_path)) = (
             sibling(destination, PARTIAL_SUFFIX),
@@ -144,10 +140,9 @@ impl PartialDownload {
             .create(true)
             .truncate(false)
             .open(&path)?;
-        // One call covers both cases: it drops a longer partial's tail, and
-        // it empties one this download is not resuming at all.
-        file.set_len(resumed_from)?;
-        file.seek(std::io::SeekFrom::Start(resumed_from))?;
+        // Remove stale trailing bytes, or clear the file when starting over.
+        file.set_len(resume_from)?;
+        file.seek(std::io::SeekFrom::Start(resume_from))?;
         Ok(Self {
             file: tempfile::NamedTempFile::from_parts(
                 file,
@@ -155,18 +150,14 @@ impl PartialDownload {
             ),
             _meta: meta,
             path,
-            resumed_from,
+            resumed_from: resume_from,
         })
     }
 
-    /// Hands the download the bytes already on disk, so its verification
-    /// still covers the whole file and not merely the part this run
-    /// fetched.
+    /// Adds the existing bytes to the verifier so it checks the complete file.
     ///
-    /// `local_error` shapes a failure to read those bytes back. A download
-    /// that refuses them — a partial longer than the content it claims to
-    /// resume — reports its own reason instead, because that is the answer
-    /// worth printing.
+    /// `local_error` maps failures while reading the partial file. Validation
+    /// errors from the download are returned unchanged.
     pub(super) fn fold_into(
         &self,
         download: &mut FileDownload,

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -644,9 +644,10 @@ async fn walk_remote_tree(
             match entry.kind {
                 AuthoritativePathEntryKind::Directory {} => {
                     tree.directories.push(child_components.clone());
-                    queue.push_back((format!("{remote_dir}/{name}", name = name.as_str()), {
-                        child_components
-                    }));
+                    queue.push_back((
+                        format!("{remote_dir}/{name}", name = name.as_str()),
+                        child_components,
+                    ));
                 }
                 AuthoritativePathEntryKind::File {
                     size_bytes,

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -188,7 +188,7 @@ impl ProfileConfig {
                 default_namespace,
                 ..
             } => {
-                validate_common(name, actor, default_namespace.as_ref())?;
+                validate_actor_and_default_namespace(name, actor, default_namespace.as_deref())?;
                 store
                     .validate()
                     .map_err(|error| profile_store_error(name, &error))
@@ -200,7 +200,7 @@ impl ProfileConfig {
                 auth_token,
                 ca_cert_path,
             } => {
-                validate_common(name, actor, default_namespace.as_ref())?;
+                validate_actor_and_default_namespace(name, actor, default_namespace.as_deref())?;
                 validate_http_url(&profile_field(name, "server_url"), server_url)?;
                 if let Some(token) = auth_token {
                     require_non_empty(&profile_field(name, "auth_token"), token.expose())?;
@@ -243,10 +243,10 @@ impl ProfileConfig {
     }
 }
 
-fn validate_common(
+fn validate_actor_and_default_namespace(
     name: &str,
     actor: &ProfileActorConfig,
-    default_namespace: Option<&String>,
+    default_namespace: Option<&str>,
 ) -> Result<(), CliError> {
     actor.validate(name)?;
     if let Some(namespace) = default_namespace {
@@ -255,16 +255,11 @@ fn validate_common(
     Ok(())
 }
 
-/// Prefixes a shared store-validation error (`store.<field>`-rooted) with the
-/// profile name, preserving the CLI's `missing `<profile>.store.<field>``
-/// message shape.
+/// Adds the profile name to a store validation error.
 fn profile_store_error(profile_name: &str, error: &StoreConfigError) -> CliError {
     match error {
-        // A missing credential reports as a missing field here, without the
-        // shared error's environment hint: this loader does not consult the
-        // environment. A profile stores the credentials it was created
-        // with, and `profile create`/`update` is where the environment is
-        // read.
+        // Profiles store credentials directly. Only profile creation and
+        // updates read credentials from the environment.
         StoreConfigError::MissingField { field }
         | StoreConfigError::MissingCredential { field, .. } => {
             CliError::invalid_config(format!("missing `{profile_name}.{field}`"))

--- a/crates/loonfs-cli/src/config.rs
+++ b/crates/loonfs-cli/src/config.rs
@@ -188,13 +188,7 @@ impl ProfileConfig {
                 default_namespace,
                 ..
             } => {
-                actor.validate(name)?;
-                if let Some(namespace) = default_namespace {
-                    validate_default_namespace(
-                        &profile_field(name, "default_namespace"),
-                        namespace,
-                    )?;
-                }
+                validate_common(name, actor, default_namespace.as_ref())?;
                 store
                     .validate()
                     .map_err(|error| profile_store_error(name, &error))
@@ -206,13 +200,7 @@ impl ProfileConfig {
                 auth_token,
                 ca_cert_path,
             } => {
-                actor.validate(name)?;
-                if let Some(namespace) = default_namespace {
-                    validate_default_namespace(
-                        &profile_field(name, "default_namespace"),
-                        namespace,
-                    )?;
-                }
+                validate_common(name, actor, default_namespace.as_ref())?;
                 validate_http_url(&profile_field(name, "server_url"), server_url)?;
                 if let Some(token) = auth_token {
                     require_non_empty(&profile_field(name, "auth_token"), token.expose())?;
@@ -253,6 +241,18 @@ impl ProfileConfig {
             },
         }
     }
+}
+
+fn validate_common(
+    name: &str,
+    actor: &ProfileActorConfig,
+    default_namespace: Option<&String>,
+) -> Result<(), CliError> {
+    actor.validate(name)?;
+    if let Some(namespace) = default_namespace {
+        validate_default_namespace(&profile_field(name, "default_namespace"), namespace)?;
+    }
+    Ok(())
 }
 
 /// Prefixes a shared store-validation error (`store.<field>`-rooted) with the

--- a/crates/loonfs-cli/src/profiles.rs
+++ b/crates/loonfs-cli/src/profiles.rs
@@ -31,17 +31,7 @@ pub(crate) fn show_profile(
     config: &CliConfig,
     explicit_name: Option<&str>,
 ) -> Result<(String, ProfileConfig), CliError> {
-    let name = match explicit_name {
-        Some(name) => name,
-        None => config
-            .default_profile
-            .as_deref()
-            .ok_or_else(CliError::no_default_profile)?,
-    };
-    let profile = config
-        .profiles
-        .get(name)
-        .ok_or_else(|| CliError::profile_not_found(name))?;
+    let (name, profile) = resolve_profile(config, explicit_name)?;
     Ok((name.to_owned(), profile.redacted()))
 }
 

--- a/crates/loonfs-cli/src/progress.rs
+++ b/crates/loonfs-cli/src/progress.rs
@@ -102,10 +102,10 @@ impl ProgressState {
         if self.reported_bytes == Some(self.bytes_done) {
             return false;
         }
-        let Some(reported_ms) = self.reported_bytes.map(|_| self.reported_ms) else {
+        if self.reported_bytes.is_none() {
             return true;
-        };
-        now_ms.saturating_sub(reported_ms) >= MIN_REPORT_INTERVAL_MS
+        }
+        now_ms.saturating_sub(self.reported_ms) >= MIN_REPORT_INTERVAL_MS
             || self.percent() != self.reported_percent
     }
 
@@ -375,7 +375,8 @@ impl ProgressReporter {
 
     /// Redraws the one line in place, covering whatever the last one left.
     fn draw(&self, state: &mut ProgressState, line: &str) {
-        let padding = state.drawn_width.saturating_sub(line.chars().count());
+        let width = line.chars().count();
+        let padding = state.drawn_width.saturating_sub(width);
         let _ = write!(
             std::io::stderr().lock(),
             "\r{line}{:padding$}",
@@ -383,7 +384,7 @@ impl ProgressReporter {
             padding = padding
         );
         let _ = std::io::stderr().lock().flush();
-        state.drawn_width = line.chars().count();
+        state.drawn_width = width;
     }
 
     fn erase(&self, state: &mut ProgressState) {

--- a/crates/loonfs-cli/src/prompt.rs
+++ b/crates/loonfs-cli/src/prompt.rs
@@ -106,8 +106,8 @@ pub(crate) fn prompt_fuzzy_choice(
     options: &[&str],
     default: usize,
 ) -> Result<String, CliError> {
-    let mut items: Vec<String> = options.iter().map(|s| s.to_string()).collect();
-    items.push("(other)".to_string());
+    let mut items: Vec<String> = options.iter().map(|option| (*option).to_owned()).collect();
+    items.push("(other)".to_owned());
     let selection = FuzzySelect::new()
         .with_prompt(label)
         .items(&items)

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -588,9 +588,10 @@ fn escape_control_characters(value: &str) -> String {
     }
     let mut escaped = String::with_capacity(value.len());
     for character in value.chars() {
-        match character.is_control() {
-            true => escaped.extend(character.escape_default()),
-            false => escaped.push(character),
+        if character.is_control() {
+            escaped.extend(character.escape_default());
+        } else {
+            escaped.push(character);
         }
     }
     escaped

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -115,16 +115,13 @@ fn actor_from_pair(
     id_name: &str,
     id: Option<&str>,
 ) -> Result<ActorRef, CliError> {
-    let kind = kind.ok_or_else(|| {
+    let together = || {
         CliError::invalid_input(format!(
             "{kind_name} and {id_name} must be supplied together"
         ))
-    })?;
-    let id = id.ok_or_else(|| {
-        CliError::invalid_input(format!(
-            "{kind_name} and {id_name} must be supplied together"
-        ))
-    })?;
+    };
+    let kind = kind.ok_or_else(&together)?;
+    let id = id.ok_or_else(together)?;
     let id = ActorId::parse(id)
         .map_err(|error| CliError::invalid_input(format!("invalid {id_name}: {error}")))?;
     Ok(ActorRef { kind, id })

--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -56,11 +56,10 @@ impl Client {
         limit: Option<u32>,
         cursor: Option<&str>,
     ) -> Result<ListCheckpointsResponse> {
-        let url = format!(
+        let mut url = format!(
             "{}/v0/admin/namespaces/{namespace_id}/checkpoints",
             self.base_url
         );
-        let mut url = url;
         let mut has_query = false;
         append_optional_pagination_query(&mut url, &mut has_query, limit, cursor);
         self.request_json::<(), ListCheckpointsResponse>(self.get(&url), None)

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -3,6 +3,10 @@
 use super::*;
 use crate::uploads::staging::{StagedContent, UploadContinuity};
 
+fn commit_id_or_generated(commit: &CommitOptions) -> CommitId {
+    commit.commit_id.clone().unwrap_or_else(CommitId::generate)
+}
+
 fn classify_put_retry_error(error: &ClientError) -> PutRetryErrorClassification {
     match error.code() {
         Some(ErrorCode::CommitIdReuseConflict) => {
@@ -178,11 +182,7 @@ impl Client {
         options: &PutFileOptions,
         uploaded: ContentEvidence<'_>,
     ) -> Result<ApiCommitResponse> {
-        let commit_id = options
-            .commit
-            .commit_id
-            .clone()
-            .unwrap_or_else(CommitId::generate);
+        let commit_id = commit_id_or_generated(&options.commit);
         let response = self
             .commit(
                 spec.namespace(),
@@ -247,26 +247,19 @@ impl Client {
         spec: &NamespacePath,
         options: &CreateDirectoryOptions,
     ) -> Result<ApiCommitResponse> {
-        let commit_id = options
-            .commit
-            .commit_id
-            .clone()
-            .unwrap_or_else(CommitId::generate);
-        let response = self
-            .commit(
-                spec.namespace(),
-                &CommitRequest::single(
-                    commit_id,
-                    options.commit.actor.clone(),
-                    options.commit.message.clone(),
-                    FilesystemOperation::CreateDirectory {
-                        path: spec.absolute_path().clone(),
-                        parents: options.parents,
-                    },
-                ),
-            )
-            .await?;
-        Ok(response)
+        self.commit(
+            spec.namespace(),
+            &CommitRequest::single(
+                commit_id_or_generated(&options.commit),
+                options.commit.actor.clone(),
+                options.commit.message.clone(),
+                FilesystemOperation::CreateDirectory {
+                    path: spec.absolute_path().clone(),
+                    parents: options.parents,
+                },
+            ),
+        )
+        .await
     }
 
     /// Deletes the requested path.
@@ -275,27 +268,20 @@ impl Client {
         spec: &NamespacePath,
         options: &DeleteOptions,
     ) -> Result<ApiCommitResponse> {
-        let commit_id = options
-            .commit
-            .commit_id
-            .clone()
-            .unwrap_or_else(CommitId::generate);
-        let response = self
-            .commit(
-                spec.namespace(),
-                &CommitRequest::single(
-                    commit_id,
-                    options.commit.actor.clone(),
-                    options.commit.message.clone(),
-                    FilesystemOperation::DeletePath {
-                        path: spec.absolute_path().clone(),
-                        behavior: options.behavior,
-                        expected_inode_id: options.expected_inode_id,
-                    },
-                ),
-            )
-            .await?;
-        Ok(response)
+        self.commit(
+            spec.namespace(),
+            &CommitRequest::single(
+                commit_id_or_generated(&options.commit),
+                options.commit.actor.clone(),
+                options.commit.message.clone(),
+                FilesystemOperation::DeletePath {
+                    path: spec.absolute_path().clone(),
+                    behavior: options.behavior,
+                    expected_inode_id: options.expected_inode_id,
+                },
+            ),
+        )
+        .await
     }
 
     /// Writes and removes attributes on the inode a path resolves to. The
@@ -305,29 +291,22 @@ impl Client {
         spec: &NamespacePath,
         options: &UpdateAttributesOptions,
     ) -> Result<ApiCommitResponse> {
-        let commit_id = options
-            .commit
-            .commit_id
-            .clone()
-            .unwrap_or_else(CommitId::generate);
-        let response = self
-            .commit(
-                spec.namespace(),
-                &CommitRequest::single(
-                    commit_id,
-                    options.commit.actor.clone(),
-                    options.commit.message.clone(),
-                    FilesystemOperation::UpdateAttributes {
-                        path: spec.absolute_path().clone(),
-                        set: options.set.clone(),
-                        remove: options.remove.clone(),
-                        expected_inode_id: options.expected_inode_id,
-                        expected_attributes_revision_no: options.expected_attributes_revision_no,
-                    },
-                ),
-            )
-            .await?;
-        Ok(response)
+        self.commit(
+            spec.namespace(),
+            &CommitRequest::single(
+                commit_id_or_generated(&options.commit),
+                options.commit.actor.clone(),
+                options.commit.message.clone(),
+                FilesystemOperation::UpdateAttributes {
+                    path: spec.absolute_path().clone(),
+                    set: options.set.clone(),
+                    remove: options.remove.clone(),
+                    expected_inode_id: options.expected_inode_id,
+                    expected_attributes_revision_no: options.expected_attributes_revision_no,
+                },
+            ),
+        )
+        .await
     }
 
     /// Moves a path within one namespace.
@@ -344,27 +323,20 @@ impl Client {
                 to.namespace()
             )));
         }
-        let commit_id = options
-            .commit
-            .commit_id
-            .clone()
-            .unwrap_or_else(CommitId::generate);
-        let response = self
-            .commit(
-                from.namespace(),
-                &CommitRequest::single(
-                    commit_id,
-                    options.commit.actor.clone(),
-                    options.commit.message.clone(),
-                    FilesystemOperation::MovePath {
-                        from_path: from.absolute_path().clone(),
-                        to_path: to.absolute_path().clone(),
-                        behavior: options.behavior,
-                    },
-                ),
-            )
-            .await?;
-        Ok(response)
+        self.commit(
+            from.namespace(),
+            &CommitRequest::single(
+                commit_id_or_generated(&options.commit),
+                options.commit.actor.clone(),
+                options.commit.message.clone(),
+                FilesystemOperation::MovePath {
+                    from_path: from.absolute_path().clone(),
+                    to_path: to.absolute_path().clone(),
+                    behavior: options.behavior,
+                },
+            ),
+        )
+        .await
     }
 
     /// Copies a path within one namespace.
@@ -381,33 +353,26 @@ impl Client {
                 to.namespace()
             )));
         }
-        let commit_id = options
-            .commit
-            .commit_id
-            .clone()
-            .unwrap_or_else(CommitId::generate);
-        let response = self
-            .commit(
-                from.namespace(),
-                &CommitRequest::single(
-                    commit_id,
-                    options.commit.actor.clone(),
-                    options.commit.message.clone(),
-                    FilesystemOperation::CopyPath {
-                        from_path: from.absolute_path().clone(),
-                        to_path: to.absolute_path().clone(),
-                        behavior: options.behavior,
-                    },
-                ),
-            )
-            .await?;
-        Ok(response)
+        self.commit(
+            from.namespace(),
+            &CommitRequest::single(
+                commit_id_or_generated(&options.commit),
+                options.commit.actor.clone(),
+                options.commit.message.clone(),
+                FilesystemOperation::CopyPath {
+                    from_path: from.absolute_path().clone(),
+                    to_path: to.absolute_path().clone(),
+                    behavior: options.behavior,
+                },
+            ),
+        )
+        .await
     }
 
     /// Restores a deleted file or subtree, optionally at a new path.
     pub async fn undelete(
         &self,
-        namespace: &NamespaceId,
+        namespace_id: &NamespaceId,
         inode_id: InodeId,
         deletion_seq: ChangeSeq,
         path: Option<&AbsolutePath>,
@@ -415,27 +380,20 @@ impl Client {
     ) -> Result<ApiCommitResponse> {
         // An absent destination restores in place: the entry re-binds under
         // the parent and name its deletion recorded.
-        let commit_id = options
-            .commit
-            .commit_id
-            .clone()
-            .unwrap_or_else(CommitId::generate);
-        let response = self
-            .commit(
-                namespace,
-                &CommitRequest::single(
-                    commit_id,
-                    options.commit.actor.clone(),
-                    options.commit.message.clone(),
-                    FilesystemOperation::Undelete {
-                        inode_id,
-                        deletion_seq,
-                        path: path.cloned(),
-                    },
-                ),
-            )
-            .await?;
-        Ok(response)
+        self.commit(
+            namespace_id,
+            &CommitRequest::single(
+                commit_id_or_generated(&options.commit),
+                options.commit.actor.clone(),
+                options.commit.message.clone(),
+                FilesystemOperation::Undelete {
+                    inode_id,
+                    deletion_seq,
+                    path: path.cloned(),
+                },
+            ),
+        )
+        .await
     }
 
     /// Makes an earlier file revision the current revision.
@@ -445,26 +403,19 @@ impl Client {
         source_revision_no: RevisionNo,
         options: &RestoreRevisionOptions,
     ) -> Result<ApiCommitResponse> {
-        let commit_id = options
-            .commit
-            .commit_id
-            .clone()
-            .unwrap_or_else(CommitId::generate);
-        let response = self
-            .commit(
-                spec.namespace(),
-                &CommitRequest::single(
-                    commit_id,
-                    options.commit.actor.clone(),
-                    options.commit.message.clone(),
-                    FilesystemOperation::RestoreRevision {
-                        path: spec.absolute_path().clone(),
-                        source_revision_no,
-                    },
-                ),
-            )
-            .await?;
-        Ok(response)
+        self.commit(
+            spec.namespace(),
+            &CommitRequest::single(
+                commit_id_or_generated(&options.commit),
+                options.commit.actor.clone(),
+                options.commit.message.clone(),
+                FilesystemOperation::RestoreRevision {
+                    path: spec.absolute_path().clone(),
+                    source_revision_no,
+                },
+            ),
+        )
+        .await
     }
 }
 

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -422,7 +422,7 @@ impl Client {
             let mut body = body;
             let mut chunks = Vec::new();
             while let Some(chunk) = futures::StreamExt::next(&mut body).await {
-                chunks.push(chunk.map(|bytes| bytes.len()).unwrap_or(0));
+                chunks.push(chunk.map_or(0, |bytes| bytes.len()));
             }
             test_transport::record_streamed_body(chunks);
             return outcome;

--- a/crates/loonfs-client/src/uploads/staging.rs
+++ b/crates/loonfs-client/src/uploads/staging.rs
@@ -244,7 +244,7 @@ impl Client {
                 .await
             }
             UploadTransport::DirectPut(algorithm) => {
-                self.stage_via_direct_put(namespace_id, bytes, algorithm)
+                self.stage_bytes_via_direct_put(namespace_id, bytes, algorithm)
                     .await
             }
             UploadTransport::Proxied => self.stage_bytes_via_server(namespace_id, bytes).await,
@@ -429,7 +429,7 @@ impl Client {
     /// Uploads in-memory bytes directly to object storage.
     ///
     /// The provider enforces the checksum included in the signed request.
-    async fn stage_via_direct_put(
+    async fn stage_bytes_via_direct_put(
         &self,
         namespace_id: &NamespaceId,
         bytes: &[u8],
@@ -538,7 +538,7 @@ impl Client {
                 )
             }
         };
-        let uploaded = self
+        let uploaded = match self
             .upload_every_part(
                 namespace_id,
                 &upload_id,
@@ -547,8 +547,8 @@ impl Client {
                 checksum_algorithm,
                 continuity,
             )
-            .await;
-        let uploaded = match uploaded {
+            .await
+        {
             Ok(uploaded) => uploaded,
             Err(error) => {
                 // Abort best-effort and preserve the original upload error.

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -351,15 +351,15 @@ pub(super) async fn reorganize_metadata_step_with_timer<S: ObjectStore + ?Sized>
         .min()
         .unwrap_or(previous.payload.base_seq);
 
-    let manifest =
-        write_reorganized_manifest(store, namespace_id, previous, metadata_files, base_seq, {
-            let mut payload_floor = previous.payload.retention_floor_seq;
-            if floor_seq > payload_floor {
-                payload_floor = floor_seq;
-            }
-            payload_floor
-        })
-        .await?;
+    let manifest = write_reorganized_manifest(
+        store,
+        namespace_id,
+        previous,
+        metadata_files,
+        base_seq,
+        previous.payload.retention_floor_seq.max(floor_seq),
+    )
+    .await?;
 
     ensure_metadata_publication_budget(timer, publication_started_ms, namespace_id)?;
     match publish_metadata_root(
@@ -503,6 +503,19 @@ pub(super) struct OverBudgetRun {
     pub(super) decoded_bytes: Option<u64>,
 }
 
+fn over_budget_run(
+    run: &MetadataRunManifest,
+    rows: u64,
+    decoded_bytes: Option<u64>,
+) -> OverBudgetRun {
+    OverBudgetRun {
+        run_seq: run.run_seq,
+        level: run.level,
+        rows,
+        decoded_bytes,
+    }
+}
+
 /// Selects bounded merge input or plans a full compaction for one family
 /// group.
 ///
@@ -589,12 +602,7 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
                 // accumulator is still empty there, so this is the group's
                 // oldest run failing the budget on its own.
                 if index == 0 {
-                    group_bottom_over_budget = Some(OverBudgetRun {
-                        run_seq: run.run_seq,
-                        level: run.level,
-                        rows: run_rows,
-                        decoded_bytes: None,
-                    });
+                    group_bottom_over_budget = Some(over_budget_run(run, run_rows, None));
                 }
                 break;
             }
@@ -608,12 +616,8 @@ pub(super) async fn select_reorganization_input<S: ObjectStore + ?Sized>(
             };
             if decoded_bytes.saturating_add(run_bytes) > byte_budget {
                 if index == 0 {
-                    group_bottom_over_budget = Some(OverBudgetRun {
-                        run_seq: run.run_seq,
-                        level: run.level,
-                        rows: run_rows,
-                        decoded_bytes: Some(run_bytes),
-                    });
+                    group_bottom_over_budget =
+                        Some(over_budget_run(run, run_rows, Some(run_bytes)));
                 }
                 break;
             }

--- a/crates/loonfs-core/src/checkpoint/reorganize.rs
+++ b/crates/loonfs-core/src/checkpoint/reorganize.rs
@@ -498,8 +498,7 @@ pub(super) struct OverBudgetRun {
     pub(super) run_seq: ChangeSeq,
     pub(super) level: u32,
     pub(super) rows: u64,
-    /// The run's decoded byte total, or `None` when the row budget ruled
-    /// the run out before its byte total was read.
+    /// Decoded bytes, or `None` if the row limit rejected the run first.
     pub(super) decoded_bytes: Option<u64>,
 }
 

--- a/crates/loonfs-core/src/checkpoint/row.rs
+++ b/crates/loonfs-core/src/checkpoint/row.rs
@@ -185,8 +185,8 @@ pub(super) fn manifest_row_commit_seq(row: &MetadataRow) -> ChangeSeq {
             ActiveDeletionRowAction::Listed { .. } => *deleted_at_seq,
             ActiveDeletionRowAction::Removed { revoked_at_seq } => *revoked_at_seq,
         },
-        MetadataRow::CommitReceipt { committed_seq, .. } => *committed_seq,
-        MetadataRow::AttributesRevision { committed_seq, .. } => *committed_seq,
+        MetadataRow::CommitReceipt { committed_seq, .. }
+        | MetadataRow::AttributesRevision { committed_seq, .. } => *committed_seq,
     }
 }
 

--- a/crates/loonfs-core/src/checkpoint/scan.rs
+++ b/crates/loonfs-core/src/checkpoint/scan.rs
@@ -418,10 +418,7 @@ pub(super) fn descriptor_may_intersect_range(
     if descriptor.max_key.as_str() < lower_bound {
         return false;
     }
-    if upper_bound
-        .map(|upper_bound| descriptor.min_key.as_str() >= upper_bound)
-        .unwrap_or(false)
-    {
+    if upper_bound.is_some_and(|upper_bound| descriptor.min_key.as_str() >= upper_bound) {
         return false;
     }
     true

--- a/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/streaming_compaction.rs
@@ -449,8 +449,8 @@ pub(crate) async fn run_metadata_compaction_job<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     context: &MutationContext,
-    policy: MetadataLsmPolicy,
     spec: &MetadataCompactionSpec,
+    policy: MetadataLsmPolicy,
     cancellation: &MetadataCompactionCancellation,
 ) -> Result<MetadataCompactionJobOutcome> {
     let timer = StdMonotonicTimer::default();

--- a/crates/loonfs-core/src/checkpoint/tests/mod.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/mod.rs
@@ -360,8 +360,8 @@ async fn run_planned_compaction<S: ObjectStore + ?Sized>(
         store,
         namespace_id,
         context,
-        policy,
         spec,
+        policy,
         &MetadataCompactionCancellation::default(),
     )
     .await

--- a/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
+++ b/crates/loonfs-core/src/checkpoint/tests/streaming_compaction.rs
@@ -2273,8 +2273,8 @@ async fn a_job_claims_its_prefix_while_it_runs_and_leaves_the_claim_standing_whe
         &store,
         &namespace_id,
         &context,
-        policy,
         &spec,
+        policy,
         &MetadataCompactionCancellation::default(),
     )
     .await
@@ -2340,8 +2340,8 @@ async fn a_cancelled_job_leaves_its_claim_standing() {
         &dying_store,
         &namespace_id,
         &context,
-        policy,
         &spec,
+        policy,
         &cancellation,
     )
     .await
@@ -3143,8 +3143,8 @@ async fn a_job_that_dies_mid_run_leaves_orphans_and_the_next_step_plans_it_again
             &dying_store,
             &namespace_id,
             &context,
-            policy,
             &spec,
+            policy,
             &cancellation,
         )
         .await

--- a/crates/loonfs-core/src/engine.rs
+++ b/crates/loonfs-core/src/engine.rs
@@ -941,8 +941,8 @@ impl<S: ObjectStore> NamespaceEngine<S, Writable> {
             &self.store,
             &self.namespace_id,
             &self.mutation_context()?,
-            self.metadata_lsm_policy(),
             spec,
+            self.metadata_lsm_policy(),
             cancellation,
         )
         .await

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -58,10 +58,9 @@ impl PassBudget {
     /// largest count there is, so a caller that sizes work by what remains
     /// puts no cap on it.
     pub(super) fn remaining(&self) -> u64 {
-        match self.max_objects {
-            Some(max_objects) => max_objects.saturating_sub(self.spent),
-            None => u64::MAX,
-        }
+        self.max_objects.map_or(u64::MAX, |max_objects| {
+            max_objects.saturating_sub(self.spent)
+        })
     }
 
     /// Charges one unit for work already done.

--- a/crates/loonfs-core/src/gc/budget.rs
+++ b/crates/loonfs-core/src/gc/budget.rs
@@ -54,9 +54,7 @@ impl PassBudget {
         self.remaining() == 0
     }
 
-    /// How many units are left to spend. An unmetered pass reports the
-    /// largest count there is, so a caller that sizes work by what remains
-    /// puts no cap on it.
+    /// Returns the remaining allowance. An unlimited pass returns `u64::MAX`.
     pub(super) fn remaining(&self) -> u64 {
         self.max_objects.map_or(u64::MAX, |max_objects| {
             max_objects.saturating_sub(self.spent)

--- a/crates/loonfs-core/src/gc/live_set.rs
+++ b/crates/loonfs-core/src/gc/live_set.rs
@@ -236,7 +236,7 @@ pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
     store: &S,
     namespace_id: &NamespaceId,
     grace_window_ms: u64,
-    anchor: Option<ReferenceAnchor>,
+    reused_anchor: Option<ReferenceAnchor>,
     budget: &mut PassBudget,
     context: &MutationContext,
 ) -> Result<LiveSetCollection> {
@@ -251,7 +251,7 @@ pub(super) async fn recollect_live_set<S: ObjectStore + ?Sized>(
         namespace_id,
         &loaded,
         grace_window_ms,
-        anchor,
+        reused_anchor,
         budget,
         context,
     )

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -398,10 +398,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
         .await?
         {
             CheckpointSweep::Delete => {
-                self.store
-                    .delete(key)
-                    .await
-                    .map_err(|error| CoreError::store(key, &error))?;
+                self.delete_key(key).await?;
                 self.report.deleted_checkpoint_records += 1;
             }
             CheckpointSweep::Released => self.report.released_expired_checkpoints += 1,
@@ -428,10 +425,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
         .await?
         {
             UploadSessionSweep::Delete { reclaimed_content } => {
-                self.store
-                    .delete(key)
-                    .await
-                    .map_err(|error| CoreError::store(key, &error))?;
+                self.delete_key(key).await?;
                 self.report.deleted_upload_sessions += 1;
                 if reclaimed_content {
                     self.report.deleted_content_objects += 1;
@@ -478,11 +472,15 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             }
             GraceAge::Aged => {}
         }
+        self.delete_key(key).await?;
+        Ok(true)
+    }
+
+    async fn delete_key(&self, key: &str) -> Result<()> {
         self.store
             .delete(key)
             .await
-            .map_err(|error| CoreError::store(key, &error))?;
-        Ok(true)
+            .map_err(|error| CoreError::store(key, &error))
     }
 
     /// Folds one retained candidate's future deadline into the report.
@@ -490,10 +488,11 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
         let Some(at_ms) = at_ms.filter(|at_ms| *at_ms > self.mutation.now_ms) else {
             return;
         };
-        self.report.next_reclamation_at_ms = Some(match self.report.next_reclamation_at_ms {
-            Some(soonest_ms) => soonest_ms.min(at_ms),
-            None => at_ms,
-        });
+        self.report.next_reclamation_at_ms = Some(
+            self.report
+                .next_reclamation_at_ms
+                .map_or(at_ms, |soonest_ms| soonest_ms.min(at_ms)),
+        );
     }
 
     /// Produces the response after lease settlement. Budget-stop cursor and

--- a/crates/loonfs-core/src/gc/run.rs
+++ b/crates/loonfs-core/src/gc/run.rs
@@ -483,7 +483,7 @@ impl<S: ObjectStore + ?Sized> GcPass<'_, S> {
             .map_err(|error| CoreError::store(key, &error))
     }
 
-    /// Folds one retained candidate's future deadline into the report.
+    /// Records the earliest future reclamation deadline.
     fn note_reclamation_deadline(&mut self, at_ms: Option<u64>) {
         let Some(at_ms) = at_ms.filter(|at_ms| *at_ms > self.mutation.now_ms) else {
             return;

--- a/crates/loonfs-core/src/metadata/indexes.rs
+++ b/crates/loonfs-core/src/metadata/indexes.rs
@@ -229,16 +229,14 @@ impl MetadataIndexes {
         if self
             .active_child_by_parent_name
             .get(&parent_name_key)
-            .map(|active| unbind_matches_binding(record, active))
-            .unwrap_or(false)
+            .is_some_and(|active| unbind_matches_binding(record, active))
         {
             self.active_child_by_parent_name.remove(&parent_name_key);
         }
         if self
             .active_parent_by_child
             .get(&record.child_inode_id)
-            .map(|active| unbind_matches_binding(record, active))
-            .unwrap_or(false)
+            .is_some_and(|active| unbind_matches_binding(record, active))
         {
             self.active_parent_by_child.remove(&record.child_inode_id);
         }
@@ -321,8 +319,7 @@ fn replace_if_newer_bind<K>(
 {
     let should_replace = map
         .get(&key)
-        .map(|existing| bind_order_key(&record) > bind_order_key(existing))
-        .unwrap_or(true);
+        .is_none_or(|existing| bind_order_key(&record) > bind_order_key(existing));
     if should_replace {
         map.insert(key, record);
     }
@@ -335,8 +332,7 @@ fn replace_if_newer_receipt(
 ) {
     let should_replace = map
         .get(&key)
-        .map(|existing| record.committed_seq > existing.committed_seq)
-        .unwrap_or(true);
+        .is_none_or(|existing| record.committed_seq > existing.committed_seq);
     if should_replace {
         map.insert(key, record);
     }
@@ -349,8 +345,7 @@ fn replace_if_newer_tombstone(
 ) {
     let should_replace = map
         .get(&key)
-        .map(|existing| tombstone_order_key(&record) > tombstone_order_key(existing))
-        .unwrap_or(true);
+        .is_none_or(|existing| tombstone_order_key(&record) > tombstone_order_key(existing));
     if should_replace {
         map.insert(key, record);
     }
@@ -362,8 +357,7 @@ fn remove_active_parent_if_same(
 ) {
     if active_parent_by_child
         .get(&record.child_inode_id)
-        .map(|active| active.same_binding(record))
-        .unwrap_or(false)
+        .is_some_and(|active| active.same_binding(record))
     {
         active_parent_by_child.remove(&record.child_inode_id);
     }
@@ -376,8 +370,7 @@ fn remove_active_child_if_same(
     let key = (record.parent_inode_id, record.name_key.clone());
     if active_child_by_parent_name
         .get(&key)
-        .map(|active| active.same_binding(record))
-        .unwrap_or(false)
+        .is_some_and(|active| active.same_binding(record))
     {
         active_child_by_parent_name.remove(&key);
     }

--- a/crates/loonfs-core/src/metadata/view.rs
+++ b/crates/loonfs-core/src/metadata/view.rs
@@ -749,8 +749,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                 revision.inode_id == inode_id
                     && revision.committed_seq <= self.visible_seq()
                     && start_after
-                        .map(|position| revision_is_after_position_desc(revision, position))
-                        .unwrap_or(true)
+                        .is_none_or(|position| revision_is_after_position_desc(revision, position))
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -848,8 +847,9 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
                 (None, None) => break,
             };
             let (row_key, record) = if take_tail {
+                let row = tail[tail_index].clone();
                 tail_index += 1;
-                tail[tail_index - 1].clone()
+                row
             } else {
                 durable
                     .buffered

--- a/crates/loonfs-core/src/metadata/view_session.rs
+++ b/crates/loonfs-core/src/metadata/view_session.rs
@@ -43,8 +43,7 @@ impl<'a, 'store, S: ObjectStore + ?Sized> MetadataView<'a, 'store, S> {
             .filter(|direntry| {
                 direntry.parent_inode_id == parent_inode_id
                     && start_after_name_key
-                        .map(|last_name_key| direntry.name_key.as_str() > last_name_key)
-                        .unwrap_or(true)
+                        .is_none_or(|last_name_key| direntry.name_key.as_str() > last_name_key)
             })
             .map(|record| DirentryBindPageCandidate {
                 row_key: direntry_bind_row_key(record),

--- a/crates/loonfs-core/src/protocol/batch.rs
+++ b/crates/loonfs-core/src/protocol/batch.rs
@@ -201,8 +201,7 @@ pub(crate) async fn publish_namespace_commits_batch_against_publish_view<
         .last()
         .expect("accepted records should be non-empty")
         .commit;
-    let head_publish = prepare_commit_head_publish(&view.head, last_plan, &wal);
-    let head_publish = match head_publish {
+    let head_publish = match prepare_commit_head_publish(&view.head, last_plan, &wal) {
         Ok(value) => value,
         Err(error) => {
             let error = CoreError::Internal(format!("head publish preparation failed: {error}"));

--- a/crates/loonfs-core/src/protocol/changes.rs
+++ b/crates/loonfs-core/src/protocol/changes.rs
@@ -71,9 +71,9 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
     'segments: for segment in wal_chain.segments() {
         for record in segment.records() {
             if record.seq > after_seq {
-                let seq = record.seq;
+                let committed_seq = record.seq;
                 changes.push(CommittedChange {
-                    committed_seq: seq,
+                    committed_seq,
                     commit_id: record.commit_id.clone(),
                     actor: record.actor.clone(),
                     committed_at_ms: record.committed_at_ms,
@@ -81,9 +81,9 @@ pub(crate) async fn list_changes_after<S: ObjectStore + ?Sized>(
                     events: events_from_wal_deltas(&record.deltas)?,
                 });
                 if changes.len() == limit.as_usize() {
-                    through_seq = seq;
-                    if seq < head.seq {
-                        next_after_seq = Some(seq);
+                    through_seq = committed_seq;
+                    if committed_seq < head.seq {
+                        next_after_seq = Some(committed_seq);
                     }
                     break 'segments;
                 }

--- a/crates/loonfs-core/src/test_support/ops.rs
+++ b/crates/loonfs-core/src/test_support/ops.rs
@@ -149,11 +149,10 @@ async fn delete_path_with_behavior<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     commit_id: Option<&CommitId>,
 ) -> Result<CommitResponse> {
-    let commit_id = normalized_commit_id(commit_id);
     submit_operation(
         store,
         namespace_id,
-        commit_id,
+        normalized_commit_id(commit_id),
         FilesystemOperation::DeletePath {
             path: parse_mutation_path(absolute_path)?,
             behavior,
@@ -173,11 +172,10 @@ pub(crate) async fn move_path<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     commit_id: Option<&CommitId>,
 ) -> Result<CommitResponse> {
-    let commit_id = normalized_commit_id(commit_id);
     submit_operation(
         store,
         namespace_id,
-        commit_id,
+        normalized_commit_id(commit_id),
         FilesystemOperation::MovePath {
             from_path: parse_mutation_path(from_path)?,
             to_path: parse_mutation_path(to_path)?,
@@ -197,11 +195,10 @@ pub(crate) async fn restore_file_revision<S: ObjectStore + ?Sized>(
     context: &MutationContext,
     commit_id: Option<&CommitId>,
 ) -> Result<CommitResponse> {
-    let commit_id = normalized_commit_id(commit_id);
     submit_operation(
         store,
         namespace_id,
-        commit_id,
+        normalized_commit_id(commit_id),
         FilesystemOperation::RestoreRevision {
             path: parse_mutation_path(absolute_path)?,
             source_revision_no,

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -139,17 +139,15 @@ fn not_enabled_step() -> MaintenanceStepReport {
 
 /// Runs one bounded grep garbage-collection pass.
 ///
-/// The runner stores the enumeration cursor as the job continuation. Every
-/// resumed pass rebuilds liveness from durable state, so losing the cursor
-/// only restarts enumeration and cannot authorize deletion.
+/// The continuation stores the enumeration cursor. Each pass reloads live
+/// references from durable state, so a missing cursor can only repeat work.
 #[derive(Debug, Clone)]
 pub struct GrepGcJob<S> {
     worker: GrepWorker<S>,
 }
 
 impl<S: ObjectStore + Clone> GrepGcJob<S> {
-    /// Creates the executor a host registers, over the worker that owns
-    /// grep's durable keyspace.
+    /// Creates a grep garbage-collection maintenance job.
     pub fn new(worker: GrepWorker<S>) -> Self {
         Self { worker }
     }
@@ -167,8 +165,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepGcJo
         continuation: Option<&str>,
     ) -> Result<MaintenanceStepReport> {
         let request = GrepGcOptions {
-            // The pass resolves the absent candidate budget to the per-step
-            // default, which is what bounds it.
+            // Use the default per-step object limit.
             max_objects: None,
             cursor: continuation.map(str::to_owned),
         };

--- a/crates/loonfs-grep/src/maintenance.rs
+++ b/crates/loonfs-grep/src/maintenance.rs
@@ -71,11 +71,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
     ) -> Result<MaintenanceStepReport> {
         let build = match self.worker.build_step(namespace_id, self.policy).await {
             Ok(report) => report.outcome,
-            Err(error) if has_nothing_to_index(&error) => {
-                return Ok(MaintenanceStepReport::concluded(
-                    MaintenanceStepConclusion::NotEnabled,
-                ))
-            }
+            Err(error) if has_nothing_to_index(&error) => return Ok(not_enabled_step()),
             Err(error) => return Err(step_failure(namespace_id, "grep_build", error)),
         };
         let GrepBuildOutcome::UpToDate { .. } = build else {
@@ -83,11 +79,7 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
         };
         let reorganize = match self.worker.reorganize_step(namespace_id, self.policy).await {
             Ok(report) => report.outcome,
-            Err(error) if has_nothing_to_index(&error) => {
-                return Ok(MaintenanceStepReport::concluded(
-                    MaintenanceStepConclusion::NotEnabled,
-                ))
-            }
+            Err(error) if has_nothing_to_index(&error) => return Ok(not_enabled_step()),
             Err(error) => return Err(step_failure(namespace_id, "grep_reorganize", error)),
         };
         Ok(MaintenanceStepReport::concluded(reorganize_conclusion(
@@ -139,6 +131,10 @@ impl<S: ObjectStore + Clone + Send + Sync + 'static> MaintenanceJob for GrepMain
             }
         }
     }
+}
+
+fn not_enabled_step() -> MaintenanceStepReport {
+    MaintenanceStepReport::concluded(MaintenanceStepConclusion::NotEnabled)
 }
 
 /// Runs one bounded grep garbage-collection pass.

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -733,7 +733,7 @@ impl GrepService {
                 // The walk enumerates current state, so a plan-less scan has
                 // no unindexed tail of its own: everything committed through
                 // this head is already a candidate.
-                candidates.unfiltered = scan_candidate_inodes(reads, &scope).await?;
+                candidates.unfiltered = scan_candidate_inodes(reads, scope.as_ref()).await?;
                 None
             }
         };
@@ -978,7 +978,7 @@ impl GrepService {
 /// also what stops a walk if bindings ever formed a cycle.
 async fn scan_candidate_inodes(
     reads: &NamespaceReads<'_>,
-    scope: &Option<AuthoritativePathEntry>,
+    scope: Option<&AuthoritativePathEntry>,
 ) -> Result<BTreeSet<InodeId>> {
     let mut inodes = BTreeSet::new();
     let root = match scope {

--- a/crates/loonfs-grep/src/service.rs
+++ b/crates/loonfs-grep/src/service.rs
@@ -730,9 +730,8 @@ impl GrepService {
                     )
                     .into());
                 }
-                // The walk enumerates current state, so a plan-less scan has
-                // no unindexed tail of its own: everything committed through
-                // this head is already a candidate.
+                // A full scan includes all files at the current head, so it
+                // does not need a separate scan of recent unindexed changes.
                 candidates.unfiltered = scan_candidate_inodes(reads, scope.as_ref()).await?;
                 None
             }
@@ -966,16 +965,11 @@ impl GrepService {
     }
 }
 
-/// Every visible file inside the query's scope, for plan-less scans.
+/// Collects visible files in the query scope for a full scan.
 ///
-/// A plan-less pattern has no gram filter, so the candidates are the files
-/// themselves: a bounded directory walk from the scope root — the namespace
-/// root when the request names no prefix — at the pinned head. The walk
-/// reads current state, so it covers revisions the index has not reached
-/// yet and needs no separate tail. Refuses past the scan budget, which
-/// bounds directories as well as files: a namespace deep enough to exhaust
-/// it is past what a plan-less query serves either way, and the count is
-/// also what stops a walk if bindings ever formed a cycle.
+/// The bounded walk starts at the requested path, or at the namespace root
+/// when no path is given. The directory limit bounds the work and prevents a
+/// binding cycle from running forever.
 async fn scan_candidate_inodes(
     reads: &NamespaceReads<'_>,
     scope: Option<&AuthoritativePathEntry>,
@@ -983,7 +977,7 @@ async fn scan_candidate_inodes(
     let mut inodes = BTreeSet::new();
     let root = match scope {
         Some(entry) if entry.inode_kind() == InodeKind::File => {
-            // A file-shaped scope names exactly one candidate.
+            // A file scope contains only that file.
             inodes.insert(entry.inode_id);
             return Ok(inodes);
         }

--- a/crates/loonfs-model/src/genesis.rs
+++ b/crates/loonfs-model/src/genesis.rs
@@ -14,10 +14,6 @@ pub fn bootstrap_metadata_state(created_at_ms: u64) -> MetadataState {
             created_by: ActorRef::loonfs_system(),
             created_at_ms,
         }],
-        direntry_binds: Vec::new(),
-        direntry_unbinds: Vec::new(),
-        revisions: Vec::new(),
-        subtree_tombstones: Vec::new(),
-        attribute_revisions: Vec::new(),
+        ..MetadataState::default()
     }
 }

--- a/crates/loonfs-objectstore/src/keyspace.rs
+++ b/crates/loonfs-objectstore/src/keyspace.rs
@@ -76,9 +76,7 @@ pub(crate) fn scope_list_prefix(key_prefix: Option<&str>, prefix: &str) -> Resul
 pub(crate) fn unscope_listed_key(key_prefix: Option<&str>, scoped_key: &str) -> Option<String> {
     let key_prefix = key_prefix.filter(|value| !value.is_empty())?;
     let prefix = format!("{key_prefix}/");
-    scoped_key
-        .strip_prefix(&prefix)
-        .map(|unscoped| unscoped.to_owned())
+    scoped_key.strip_prefix(&prefix).map(str::to_owned)
 }
 
 /// A parsed `http(s)://authority[/base-path]` endpoint, shared by the

--- a/crates/loonfs-objectstore/src/layout.rs
+++ b/crates/loonfs-objectstore/src/layout.rs
@@ -366,38 +366,33 @@ mod tests {
             "namespaces/ns-1/"
         );
         assert_eq!(
-            layout.wal_head(&namespace_id()).as_str(),
+            layout.wal_head(&namespace_id()),
             "namespaces/ns-1/wal/head.json"
         );
         assert_eq!(
-            layout.wal_floor(&namespace_id()).as_str(),
+            layout.wal_floor(&namespace_id()),
             "namespaces/ns-1/wal/floor.json"
         );
         assert_eq!(
-            layout
-                .wal_segment(
-                    &namespace_id(),
-                    &wal_segment_id("00000000000000000001-0123456789abcdef")
-                )
-                .as_str(),
+            layout.wal_segment(
+                &namespace_id(),
+                &wal_segment_id("00000000000000000001-0123456789abcdef")
+            ),
             "namespaces/ns-1/wal/segments/00000000000000000001-0123456789abcdef.wal.zst"
         );
         assert_eq!(
-            layout.metadata_root(&namespace_id()).as_str(),
+            layout.metadata_root(&namespace_id()),
             "namespaces/ns-1/metadata/root.json"
         );
         let manifest_object_id = ManifestObjectId::parse("00000000000000000400-0123456789abcdef")
             .expect("valid manifest object id");
         assert_eq!(
             layout
-                .metadata_manifest_object(&namespace_id(), &manifest_object_id)
-                .as_str(),
+                .metadata_manifest_object(&namespace_id(), &manifest_object_id),
             "namespaces/ns-1/metadata/manifests/00000000000000000400-0123456789abcdef.manifest.json"
         );
         assert_eq!(
-            layout
-                .metadata_table(&namespace_id(), &metadata_table_id())
-                .as_str(),
+            layout.metadata_table(&namespace_id(), &metadata_table_id()),
             "namespaces/ns-1/metadata/tables/tbl_00000000000000000000000000000001.sst.zst"
         );
         assert_eq!(
@@ -406,32 +401,24 @@ mod tests {
                     &namespace_id(),
                     &metadata_compaction_id(1),
                     &metadata_table_id()
-                )
-                .as_str(),
+                ),
             "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/tables/tbl_00000000000000000000000000000001.sst.zst"
         );
         assert_eq!(
-            layout
-                .metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1))
-                .as_str(),
+            layout.metadata_compaction_lease(&namespace_id(), &metadata_compaction_id(1)),
             "namespaces/ns-1/metadata/compactions/cmp_00000000000000000000000000000001/lease.json"
         );
         assert_eq!(
-            layout
-                .checkpoint_record(&namespace_id(), &checkpoint_id())
-                .as_str(),
+            layout.checkpoint_record(&namespace_id(), &checkpoint_id()),
             "namespaces/ns-1/checkpoints/chk_00000000000000000000000000000001.json"
         );
         assert_eq!(
-            layout
-                .upload_session(&namespace_id(), &upload_id())
-                .as_str(),
+            layout.upload_session(&namespace_id(), &upload_id()),
             "namespaces/ns-1/uploads/upl_00000000000000000000000000000001.json"
         );
         assert_eq!(
             layout
-                .content_blob(&content_store_id(), &content_id())
-                .as_str(),
+                .content_blob(&content_store_id(), &content_id()),
             "content-stores/cs_00000000000000000000000000000001/objects/ab/cd/con_abcdef0123456789abcdef0123456789"
         );
     }

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -222,7 +222,7 @@ impl VecObjectStoreMetricsRecorder {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    /// Returns a snapshot copy of every sample recorded so far.
+    /// Returns a copy of all recorded samples.
     pub fn samples(&self) -> Vec<ObjectStoreMetricSample> {
         self.lock().clone()
     }

--- a/crates/loonfs-objectstore/src/metrics.rs
+++ b/crates/loonfs-objectstore/src/metrics.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 /// One object-store call sample delivered to an object-store metrics recorder.
@@ -216,21 +216,21 @@ pub struct VecObjectStoreMetricsRecorder {
 }
 
 impl VecObjectStoreMetricsRecorder {
-    /// Returns a snapshot copy of every sample recorded so far.
-    pub fn samples(&self) -> Vec<ObjectStoreMetricSample> {
+    fn lock(&self) -> MutexGuard<'_, Vec<ObjectStoreMetricSample>> {
         self.samples
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clone()
+    }
+
+    /// Returns a snapshot copy of every sample recorded so far.
+    pub fn samples(&self) -> Vec<ObjectStoreMetricSample> {
+        self.lock().clone()
     }
 }
 
 impl ObjectStoreMetricsRecorder for VecObjectStoreMetricsRecorder {
     fn record(&self, sample: ObjectStoreMetricSample) {
-        self.samples
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .push(sample);
+        self.lock().push(sample);
     }
 }
 
@@ -243,6 +243,12 @@ pub struct JsonlObjectStoreMetricsRecorder {
 }
 
 impl JsonlObjectStoreMetricsRecorder {
+    fn lock(&self) -> MutexGuard<'_, BufWriter<File>> {
+        self.writer
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     /// Creates or truncates a JSONL output file, creating missing parent directories.
     ///
     /// The operation fails when directories or the output file cannot be created.
@@ -262,19 +268,13 @@ impl JsonlObjectStoreMetricsRecorder {
     ///
     /// The operation fails when the filesystem cannot accept pending bytes.
     pub fn flush(&self) -> io::Result<()> {
-        self.writer
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .flush()
+        self.lock().flush()
     }
 }
 
 impl ObjectStoreMetricsRecorder for JsonlObjectStoreMetricsRecorder {
     fn record(&self, sample: ObjectStoreMetricSample) {
-        let mut writer = self
-            .writer
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut writer = self.lock();
         let _ = serde_json::to_writer(&mut *writer, &sample);
         let _ = writer.write_all(b"\n");
     }
@@ -725,14 +725,15 @@ fn classify_key(key: &str) -> KeyClass {
         DurableObjectFamily::ContentBlob => KeyClass::Content,
         DurableObjectFamily::WalHead => KeyClass::NamespaceHead,
         DurableObjectFamily::WalSegment => KeyClass::WalSegment,
-        DurableObjectFamily::MetadataManifest => KeyClass::NamespaceManifest,
+        DurableObjectFamily::MetadataManifest | DurableObjectFamily::MetadataRoot => {
+            KeyClass::NamespaceManifest
+        }
         DurableObjectFamily::MetadataTable | DurableObjectFamily::MetadataCompactionStaging => {
             KeyClass::MetadataSst
         }
         DurableObjectFamily::CheckpointRecord
         | DurableObjectFamily::WalFloor
         | DurableObjectFamily::MetadataCompactionLease => KeyClass::GcControl,
-        DurableObjectFamily::MetadataRoot => KeyClass::NamespaceManifest,
         DurableObjectFamily::UploadSession => KeyClass::Metadata,
     }
 }

--- a/crates/loonfs-objectstore/src/presign/v4.rs
+++ b/crates/loonfs-objectstore/src/presign/v4.rs
@@ -11,7 +11,7 @@
 use crate::object_store::Result;
 use crate::ObjectStoreError;
 use std::collections::BTreeMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
 /// The two date spellings a V4 signature carries: the credential scope's day
 /// and the request's full timestamp, which must agree.
@@ -24,12 +24,7 @@ pub(crate) struct SigningDates {
 pub(crate) fn signing_dates(object_key: &str, time: SystemTime) -> Result<SigningDates> {
     let seconds = time
         .duration_since(UNIX_EPOCH)
-        .map_err(|err| {
-            ObjectStoreError::transport(
-                object_key,
-                format!("system time is before unix epoch: {err}"),
-            )
-        })?
+        .map_err(|err| before_unix_epoch(object_key, err))?
         .as_secs() as i64;
     let days = seconds.div_euclid(86_400);
     let seconds_of_day = seconds.rem_euclid(86_400);
@@ -48,13 +43,17 @@ pub(crate) fn signing_dates(object_key: &str, time: SystemTime) -> Result<Signin
 /// Unix milliseconds for a signing instant, used to report when an issued
 /// capability stops working.
 pub(crate) fn unix_ms(object_key: &str, time: SystemTime) -> Result<u64> {
-    let duration = time.duration_since(UNIX_EPOCH).map_err(|err| {
-        ObjectStoreError::transport(
-            object_key,
-            format!("system time is before unix epoch: {err}"),
-        )
-    })?;
+    let duration = time
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| before_unix_epoch(object_key, err))?;
     Ok(duration.as_millis() as u64)
+}
+
+fn before_unix_epoch(object_key: &str, err: SystemTimeError) -> ObjectStoreError {
+    ObjectStoreError::transport(
+        object_key,
+        format!("system time is before unix epoch: {err}"),
+    )
 }
 
 pub(crate) fn canonical_query_string(query: &BTreeMap<String, String>) -> String {

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -283,10 +283,7 @@ pub(super) async fn gc_grep_index(
 fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> ApiResponseError {
     let code = error.code();
     match error {
-        // One name for the capability, whichever half is missing: a
-        // deployment that does not serve grep and a namespace whose index is
-        // not built both leave `query.grep` unavailable, which is the key
-        // capability discovery advertises it under.
+        // Both cases mean the advertised query.grep capability is unavailable.
         error @ (GrepError::NotEnabled | GrepError::Backfilling) => {
             ApiResponseError::not_supported(FEATURE_QUERY_GREP, &error.to_string())
         }

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -126,12 +126,7 @@ pub(super) async fn enable_grep_index(
     match outcome {
         GrepEnableOutcome::Enabled { .. } | GrepEnableOutcome::AlreadyEnabled { .. } => {}
         GrepEnableOutcome::Superseded => {
-            return Err(map_grep_error(
-                &namespace_id,
-                GrepError::PublicationConflict {
-                    object_key: loonfs_grep::keyspace::root_key(&namespace_id),
-                },
-            ));
+            return Err(grep_root_conflict(&namespace_id));
         }
     }
     // Read after the transition so every index endpoint reports bookkeeping
@@ -225,12 +220,7 @@ pub(super) async fn disable_grep_index(
     match outcome {
         GrepDisableOutcome::Disabled | GrepDisableOutcome::NotEnabled => {}
         GrepDisableOutcome::Superseded => {
-            return Err(map_grep_error(
-                &namespace_id,
-                GrepError::PublicationConflict {
-                    object_key: loonfs_grep::keyspace::root_key(&namespace_id),
-                },
-            ));
+            return Err(grep_root_conflict(&namespace_id));
         }
     }
     // The disabled root retains genuine index bookkeeping, so read it after
@@ -303,4 +293,13 @@ fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> A
         GrepError::Runtime(error) => ApiResponseError::runtime_for_namespace(namespace_id, error),
         error => ApiResponseError::new(status_for_core_error_code(code), code, &error.to_string()),
     }
+}
+
+fn grep_root_conflict(namespace_id: &NamespaceId) -> ApiResponseError {
+    map_grep_error(
+        namespace_id,
+        GrepError::PublicationConflict {
+            object_key: loonfs_grep::keyspace::root_key(namespace_id),
+        },
+    )
 }

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -412,12 +412,10 @@ pub(super) async fn content_preparation_for_puts(
 ) -> Result<PutContentPreparation, ApiResponseError> {
     let mut prepared_content = Vec::new();
     let mut rejections = Vec::new();
-    let matching_tokens = tokens
+    for token in tokens
         .iter()
         .filter(|token| content_refs.contains(&&token.content_ref))
-        .cloned()
-        .collect::<Vec<_>>();
-    for token in &matching_tokens {
+    {
         match verifier
             .prepare(writer, namespace_id, token, now_ms)
             .await?

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -313,41 +313,24 @@ pub(super) async fn app_with_store_and_direct_transfers(
         .serves_grep()
         .then(|| Arc::new(GrepService::with_block_cache(Arc::clone(&grep_block_cache))));
     let grep_maintenance = if maintains_grep_index {
+        let grep_worker = grep_worker
+            .as_ref()
+            .expect("an index-maintaining deployment composes a grep worker");
         let policy = config
             .grep
             .worker_config()
             .build_policy()
-            .map_err(|error| ServerConfigError::InvalidField {
-                field: "grep",
-                reason: error.to_string(),
-            })?;
-        let job = Arc::new(GrepMaintenanceJob::new(
-            grep_worker
-                .as_ref()
-                .expect("an index-maintaining deployment composes a grep worker")
-                .clone(),
-            policy,
-        ));
+            .map_err(grep_config_error)?;
+        let job = Arc::new(GrepMaintenanceJob::new(grep_worker.clone(), policy));
         writer
             .register_maintenance_job(job.clone())
-            .map_err(|error| ServerConfigError::InvalidField {
-                field: "grep",
-                reason: error.to_string(),
-            })?;
+            .map_err(grep_config_error)?;
         // Reclaiming what the index leaves behind is upkeep for the same
         // namespaces, gated by the same switch: a deployment that builds
         // grep objects is the one that should collect them.
         writer
-            .register_maintenance_job(Arc::new(GrepGcJob::new(
-                grep_worker
-                    .as_ref()
-                    .expect("an index-maintaining deployment composes a grep worker")
-                    .clone(),
-            )))
-            .map_err(|error| ServerConfigError::InvalidField {
-                field: "grep",
-                reason: error.to_string(),
-            })?;
+            .register_maintenance_job(Arc::new(GrepGcJob::new(grep_worker.clone())))
+            .map_err(grep_config_error)?;
         Some(GrepMaintenance {
             handle: writer.maintenance(),
             job,
@@ -376,6 +359,13 @@ pub(super) async fn app_with_store_and_direct_transfers(
         local_cache,
     };
     Ok((router(state.clone()), state))
+}
+
+fn grep_config_error(error: impl std::fmt::Display) -> ServerConfigError {
+    ServerConfigError::InvalidField {
+        field: "grep",
+        reason: error.to_string(),
+    }
 }
 
 /// Opens the node-local block cache the config asks for, or answers `None`

--- a/crates/loonfs-server/src/http/serve.rs
+++ b/crates/loonfs-server/src/http/serve.rs
@@ -315,7 +315,7 @@ pub(super) async fn app_with_store_and_direct_transfers(
     let grep_maintenance = if maintains_grep_index {
         let grep_worker = grep_worker
             .as_ref()
-            .expect("an index-maintaining deployment composes a grep worker");
+            .expect("grep maintenance requires a grep worker");
         let policy = config
             .grep
             .worker_config()
@@ -325,9 +325,8 @@ pub(super) async fn app_with_store_and_direct_transfers(
         writer
             .register_maintenance_job(job.clone())
             .map_err(grep_config_error)?;
-        // Reclaiming what the index leaves behind is upkeep for the same
-        // namespaces, gated by the same switch: a deployment that builds
-        // grep objects is the one that should collect them.
+        // Register garbage collection with index maintenance so deployments
+        // that create grep objects also reclaim them.
         writer
             .register_maintenance_job(Arc::new(GrepGcJob::new(grep_worker.clone())))
             .map_err(grep_config_error)?;

--- a/crates/loonfs-server/src/local_cache.rs
+++ b/crates/loonfs-server/src/local_cache.rs
@@ -141,12 +141,7 @@ impl FoyerStoredMetadataBlockCache {
         recorder: &dyn MetricsRecorder,
     ) -> Result<Self, ServerConfigError> {
         let root = PathBuf::from(config.path.trim());
-        std::fs::create_dir_all(&root).map_err(|error| {
-            invalid_local_cache(format!(
-                "failed to create `{}`: {error}",
-                display_path(&root)
-            ))
-        })?;
+        create_directory(&root)?;
         let directory_lock = lock_directory(&root)?;
 
         let directory = root.join(CACHE_DIRECTORY);
@@ -400,12 +395,7 @@ fn prepare_directory(directory: &Path, capacity: usize) -> Result<(), ServerConf
         })?;
     }
 
-    std::fs::create_dir_all(directory).map_err(|error| {
-        invalid_local_cache(format!(
-            "failed to create `{}`: {error}",
-            display_path(directory)
-        ))
-    })?;
+    create_directory(directory)?;
     // A marker that already says exactly this is left alone. Every other
     // case — a discarded directory, and a kept one this start grows — needs
     // the new geometry on disk before any block file is.
@@ -519,6 +509,15 @@ fn invalid_local_cache(reason: String) -> ServerConfigError {
         field: "local_cache.path",
         reason,
     }
+}
+
+fn create_directory(path: &Path) -> Result<(), ServerConfigError> {
+    std::fs::create_dir_all(path).map_err(|error| {
+        invalid_local_cache(format!(
+            "failed to create `{}`: {error}",
+            display_path(path)
+        ))
+    })
 }
 
 /// A path as a string, for an error message. A path that is not UTF-8 still

--- a/crates/loonfs-server/src/local_cache.rs
+++ b/crates/loonfs-server/src/local_cache.rs
@@ -342,22 +342,15 @@ struct DiskGeometry {
     blocks: usize,
 }
 
-/// Makes the versioned directory one that can hold the configured geometry,
-/// discarding it when it cannot.
+/// Prepares the versioned cache directory for the configured capacity.
 ///
-/// A directory built for the same block size and no more blocks than this
-/// start claims is kept: foyer reopens the files that are there and creates
-/// the rest, so growing the tier keeps everything it had cached. A shrunk
-/// block count, a different block size, and a directory that says nothing
-/// about itself are all discarded, because each of them would leave files
-/// behind that nothing would ever open again. The tier holds nothing
-/// durable, so discarding costs one cold start.
+/// A directory with the same block size is reused when its capacity is no
+/// larger than the requested capacity. Other layouts are discarded because
+/// Foyer would leave unused block files behind. The cache contains no durable
+/// data, so rebuilding it is safe.
 ///
-/// The marker is written before the device is built, which is what makes it
-/// an upper bound: a build that dies partway can leave fewer block files
-/// than the marker names, never more. The directory lock is already held,
-/// and the lock file sits beside the versioned directory rather than inside
-/// it, so nothing here races and nothing here removes the lock.
+/// The geometry marker is written before Foyer opens the device. The caller
+/// already holds the directory lock.
 fn prepare_directory(directory: &Path, capacity: usize) -> Result<(), ServerConfigError> {
     let wanted = DiskGeometry {
         block_bytes: DISK_BLOCK_BYTES,
@@ -370,21 +363,20 @@ fn prepare_directory(directory: &Path, capacity: usize) -> Result<(), ServerConf
 
     if !keep && directory.exists() {
         let reason = match found {
-            None => "it records no geometry of its own".to_owned(),
+            None => "the geometry marker is missing or invalid".to_owned(),
             Some(found) if found.block_bytes != wanted.block_bytes => format!(
-                "it was built for blocks of {} bytes and this start uses {}",
+                "the stored block size is {} bytes but the configured size is {}",
                 found.block_bytes, wanted.block_bytes
             ),
             Some(found) => format!(
-                "it was built for {} blocks and this start claims only {}",
+                "the stored block count is {} but the configured capacity allows {}",
                 found.blocks, wanted.blocks
             ),
         };
         tracing::info!(
             cache = CACHE_NAME,
-            "discarding the local cache directory `{}` and starting it empty because {reason}; \
-             it holds nothing durable, and keeping it would leave block files behind that \
-             nothing reads and nothing reclaims",
+            "discarding the local cache directory `{}` because {reason}; keeping it would leave \
+             unused block files",
             display_path(directory)
         );
         std::fs::remove_dir_all(directory).map_err(|error| {
@@ -396,9 +388,7 @@ fn prepare_directory(directory: &Path, capacity: usize) -> Result<(), ServerConf
     }
 
     create_directory(directory)?;
-    // A marker that already says exactly this is left alone. Every other
-    // case — a discarded directory, and a kept one this start grows — needs
-    // the new geometry on disk before any block file is.
+    // Update the marker after replacing the directory or increasing capacity.
     if found != Some(wanted) {
         write_geometry(directory, wanted)?;
     }

--- a/crates/loonfs-test-support/src/stores/counting_store.rs
+++ b/crates/loonfs-test-support/src/stores/counting_store.rs
@@ -149,6 +149,24 @@ impl<S> CountingStore<S> {
         self.keys.matches(key)
     }
 
+    fn record_put_mode(&self, mode: &PutMode) {
+        match mode {
+            PutMode::Overwrite => {
+                self.counters.overwrite_puts.fetch_add(1, Ordering::SeqCst);
+            }
+            PutMode::CreateIfAbsent => {
+                self.counters
+                    .create_if_absent_puts
+                    .fetch_add(1, Ordering::SeqCst);
+            }
+            PutMode::CompareAndSwap { .. } => {
+                self.counters
+                    .compare_and_swaps
+                    .fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    }
+
     fn record_read_bytes(&self, bytes: usize) {
         self.counters
             .read_bytes
@@ -221,21 +239,7 @@ impl<S: ObjectStore> ObjectStore for CountingStore<S> {
                 u64::try_from(bytes.len()).unwrap_or(u64::MAX),
                 Ordering::SeqCst,
             );
-            match mode {
-                PutMode::Overwrite => {
-                    self.counters.overwrite_puts.fetch_add(1, Ordering::SeqCst);
-                }
-                PutMode::CreateIfAbsent => {
-                    self.counters
-                        .create_if_absent_puts
-                        .fetch_add(1, Ordering::SeqCst);
-                }
-                PutMode::CompareAndSwap { .. } => {
-                    self.counters
-                        .compare_and_swaps
-                        .fetch_add(1, Ordering::SeqCst);
-                }
-            }
+            self.record_put_mode(&mode);
         }
         self.inner.put(key, bytes, mode).await
     }
@@ -254,21 +258,7 @@ impl<S: ObjectStore> ObjectStore for CountingStore<S> {
                     .written_bytes
                     .fetch_add(*bytes, Ordering::SeqCst);
             }
-            match mode {
-                PutMode::Overwrite => {
-                    self.counters.overwrite_puts.fetch_add(1, Ordering::SeqCst);
-                }
-                PutMode::CreateIfAbsent => {
-                    self.counters
-                        .create_if_absent_puts
-                        .fetch_add(1, Ordering::SeqCst);
-                }
-                PutMode::CompareAndSwap { .. } => {
-                    self.counters
-                        .compare_and_swaps
-                        .fetch_add(1, Ordering::SeqCst);
-                }
-            }
+            self.record_put_mode(&mode);
         }
         result
     }

--- a/crates/loonfs/src/cache.rs
+++ b/crates/loonfs/src/cache.rs
@@ -147,7 +147,10 @@ impl RuntimeCacheStatsInner {
 }
 
 impl RuntimeControlCache {
-    fn wal_head(&mut self, namespace_id: &NamespaceId) -> Option<CachedNamespaceAnchor> {
+    fn cached_namespace_head(
+        &mut self,
+        namespace_id: &NamespaceId,
+    ) -> Option<CachedNamespaceAnchor> {
         let head = self.namespaces.get(namespace_id)?.head.clone()?;
         self.touch_namespace(namespace_id);
         Some(head)
@@ -237,7 +240,10 @@ impl ReadCore {
                 .map(cached_anchor);
         }
 
-        let cached = self.inner.control_cache().wal_head(namespace_id);
+        let cached = self
+            .inner
+            .control_cache()
+            .cached_namespace_head(namespace_id);
         if let Some(head) = cached {
             match self
                 .cached_control_identity_matches(&wal_head(namespace_id), &head.head.identity)

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -139,7 +139,7 @@ impl FsAdmin {
     pub async fn maintenance_step_namespace(
         &self,
         namespace_id: &NamespaceId,
-        plan: MaintenancePlan,
+        mut plan: MaintenancePlan,
     ) -> Result<MaintenanceStepResponse> {
         let span = tracing::Span::current();
         self.core.record_trace_context(&span);
@@ -148,7 +148,6 @@ impl FsAdmin {
                 "a maintenance step must select at least one action".to_owned(),
             ));
         }
-        let mut plan = plan;
         if let Some(gc) = &mut plan.gc {
             // Every pass a step runs is bounded, however the plan reached
             // here; only a direct `gc_namespace` call sweeps unbounded.
@@ -337,8 +336,8 @@ impl FsAdmin {
                 // cannot see how long that has been true, so the count that
                 // decides when to stop merging deltas and start the job lives
                 // here.
-                if let Some(background) = &self.compactions {
-                    background.record_merge(namespace_id, group, bottom_anchored_merge_blocked);
+                if let Some(compactions) = &self.compactions {
+                    compactions.record_merge(namespace_id, group, bottom_anchored_merge_blocked);
                 }
                 tracing::info!(
                     families = ?group.families(),
@@ -537,8 +536,8 @@ impl FsAdmin {
                 // The group's base is no longer frozen, so the delta merges it
                 // published over that base are spent. It starts counting again
                 // from nothing.
-                if let Some(background) = &self.compactions {
-                    background.clear_published_delta_merges(namespace_id, spec.group());
+                if let Some(compactions) = &self.compactions {
+                    compactions.clear_published_delta_merges(namespace_id, spec.group());
                 }
                 tracing::info!(
                     namespace_id = %namespace_id,

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -149,8 +149,8 @@ impl FsAdmin {
             ));
         }
         if let Some(gc) = &mut plan.gc {
-            // Every pass a step runs is bounded, however the plan reached
-            // here; only a direct `gc_namespace` call sweeps unbounded.
+            // Maintenance steps always bound GC work. Direct `gc_namespace`
+            // calls remain unbounded unless the caller sets a limit.
             gc.max_objects
                 .get_or_insert(loonfs_core::limits::DEFAULT_GC_MAX_OBJECTS);
         }
@@ -331,11 +331,8 @@ impl FsAdmin {
                 ..
             } => {
                 self.invalidate_namespace(namespace_id);
-                // A merge that had to start above the group's base leaves the
-                // base frozen and the group's retention stopped. One step
-                // cannot see how long that has been true, so the count that
-                // decides when to stop merging deltas and start the job lives
-                // here.
+                // Track delta-only merges across steps so the runner knows
+                // when to schedule a full compaction.
                 if let Some(compactions) = &self.compactions {
                     compactions.record_merge(namespace_id, group, bottom_anchored_merge_blocked);
                 }
@@ -530,12 +527,10 @@ impl FsAdmin {
                 output_segments,
                 ..
             }) => {
-                // The manifest moved, so every cached view of this namespace
-                // is one manifest behind.
+                // Compaction changed the manifest, so cached views are stale.
                 self.invalidate_namespace(namespace_id);
-                // The group's base is no longer frozen, so the delta merges it
-                // published over that base are spent. It starts counting again
-                // from nothing.
+                // A full compaction includes the base run, so reset the count
+                // of delta-only merges.
                 if let Some(compactions) = &self.compactions {
                     compactions.clear_published_delta_merges(namespace_id, spec.group());
                 }

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -973,9 +973,8 @@ pub(crate) async fn publish_batch_with_engine(
         .into_iter()
         .map(|result| result.map_err(RuntimeError::Core))
         .collect::<Vec<_>>();
-    // One reading of what landed serves both the host's observer and the
-    // jobs that asked to hear about publications.
-    if let Some(committed_seq) = landed_committed_seq(&results) {
+    // Notify observers only when at least one commit succeeded.
+    if let Some(committed_seq) = highest_committed_seq(&results) {
         notify_publish_observer(writer, namespace_id, committed_seq);
         writer
             .maintenance
@@ -985,9 +984,8 @@ pub(crate) async fn publish_batch_with_engine(
     results
 }
 
-/// The furthest sequence this batch actually committed, or `None` when
-/// nothing in it landed.
-fn landed_committed_seq(results: &[Result<CommitResponse>]) -> Option<ChangeSeq> {
+/// Returns the highest sequence committed by the batch.
+fn highest_committed_seq(results: &[Result<CommitResponse>]) -> Option<ChangeSeq> {
     results
         .iter()
         .filter_map(|result| result.as_ref().ok())

--- a/crates/loonfs/src/fs/writes.rs
+++ b/crates/loonfs/src/fs/writes.rs
@@ -5,7 +5,7 @@ use crate::publish::{CommitCandidate, CommitRequest, FilesystemOperation, Prepar
 use crate::ByteStream;
 use crate::FsWriter;
 use crate::{
-    ChangeSeq, CommitId, CommitResponse, ContentRef, CopyOptions, CoreError,
+    ChangeSeq, CommitId, CommitOptions, CommitResponse, ContentRef, CopyOptions, CoreError,
     CreateDirectoryOptions, DeleteOptions, InodeId, MaintenanceJobId, MetadataMaintenanceOptions,
     MoveOptions, NamespaceId, PutFileOptions, RestoreRevisionOptions, RevisionNo, UndeleteOptions,
     UpdateAttributesOptions,
@@ -18,6 +18,15 @@ use loonfs_api::{
 use loonfs_core::NamespaceWriterEngine;
 use std::num::NonZeroU32;
 use std::sync::Arc;
+
+fn single_operation(commit: &CommitOptions, operation: FilesystemOperation) -> CommitRequest {
+    CommitRequest::single(
+        commit.commit_id.clone().unwrap_or_else(CommitId::generate),
+        commit.actor.clone(),
+        commit.message.clone(),
+        operation,
+    )
+}
 
 fn classify_put_retry_error(error: &RuntimeError) -> PutRetryErrorClassification {
     match error.code() {
@@ -380,14 +389,8 @@ impl FsWriter {
         self.commit_candidate_inner(
             namespace_id,
             CommitCandidate::prepared(
-                CommitRequest::single(
-                    options
-                        .commit
-                        .commit_id
-                        .clone()
-                        .unwrap_or_else(CommitId::generate),
-                    options.commit.actor.clone(),
-                    options.commit.message.clone(),
+                single_operation(
+                    &options.commit,
                     FilesystemOperation::PutFile {
                         path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                         content_ref,
@@ -558,14 +561,8 @@ impl FsWriter {
         self.core.record_trace_context(&tracing::Span::current());
         self.commit_candidate_inner(
             namespace_id,
-            CommitCandidate::new(CommitRequest::single(
-                options
-                    .commit
-                    .commit_id
-                    .clone()
-                    .unwrap_or_else(CommitId::generate),
-                options.commit.actor.clone(),
-                options.commit.message.clone(),
+            CommitCandidate::new(single_operation(
+                &options.commit,
                 FilesystemOperation::CreateDirectory {
                     path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     parents: options.parents,
@@ -603,14 +600,8 @@ impl FsWriter {
         self.core.record_trace_context(&tracing::Span::current());
         self.commit_candidate_inner(
             namespace_id,
-            CommitCandidate::new(CommitRequest::single(
-                options
-                    .commit
-                    .commit_id
-                    .clone()
-                    .unwrap_or_else(CommitId::generate),
-                options.commit.actor.clone(),
-                options.commit.message.clone(),
+            CommitCandidate::new(single_operation(
+                &options.commit,
                 FilesystemOperation::DeletePath {
                     path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     behavior: options.behavior,
@@ -645,14 +636,8 @@ impl FsWriter {
         self.core.record_trace_context(&tracing::Span::current());
         self.commit_candidate_inner(
             namespace_id,
-            CommitCandidate::new(CommitRequest::single(
-                options
-                    .commit
-                    .commit_id
-                    .clone()
-                    .unwrap_or_else(CommitId::generate),
-                options.commit.actor.clone(),
-                options.commit.message.clone(),
+            CommitCandidate::new(single_operation(
+                &options.commit,
                 FilesystemOperation::MovePath {
                     from_path: loonfs_core::path::parse_mutation_path(from_path)?,
                     to_path: loonfs_core::path::parse_mutation_path(to_path)?,
@@ -688,14 +673,8 @@ impl FsWriter {
         self.core.record_trace_context(&tracing::Span::current());
         self.commit_candidate_inner(
             namespace_id,
-            CommitCandidate::new(CommitRequest::single(
-                options
-                    .commit
-                    .commit_id
-                    .clone()
-                    .unwrap_or_else(CommitId::generate),
-                options.commit.actor.clone(),
-                options.commit.message.clone(),
+            CommitCandidate::new(single_operation(
+                &options.commit,
                 FilesystemOperation::CopyPath {
                     from_path: loonfs_core::path::parse_mutation_path(from_path)?,
                     to_path: loonfs_core::path::parse_mutation_path(to_path)?,
@@ -730,14 +709,8 @@ impl FsWriter {
         self.core.record_trace_context(&tracing::Span::current());
         self.commit_candidate_inner(
             namespace_id,
-            CommitCandidate::new(CommitRequest::single(
-                options
-                    .commit
-                    .commit_id
-                    .clone()
-                    .unwrap_or_else(CommitId::generate),
-                options.commit.actor.clone(),
-                options.commit.message.clone(),
+            CommitCandidate::new(single_operation(
+                &options.commit,
                 FilesystemOperation::RestoreRevision {
                     path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     source_revision_no,
@@ -775,14 +748,8 @@ impl FsWriter {
         self.core.record_trace_context(&tracing::Span::current());
         self.commit_candidate_inner(
             namespace_id,
-            CommitCandidate::new(CommitRequest::single(
-                options
-                    .commit
-                    .commit_id
-                    .clone()
-                    .unwrap_or_else(CommitId::generate),
-                options.commit.actor.clone(),
-                options.commit.message.clone(),
+            CommitCandidate::new(single_operation(
+                &options.commit,
                 FilesystemOperation::UpdateAttributes {
                     path: loonfs_core::path::parse_mutation_path(absolute_path)?,
                     set: options.set,
@@ -825,14 +792,8 @@ impl FsWriter {
             .transpose()?;
         self.commit_candidate_inner(
             namespace_id,
-            CommitCandidate::new(CommitRequest::single(
-                options
-                    .commit
-                    .commit_id
-                    .clone()
-                    .unwrap_or_else(CommitId::generate),
-                options.commit.actor.clone(),
-                options.commit.message.clone(),
+            CommitCandidate::new(single_operation(
+                &options.commit,
                 FilesystemOperation::Undelete {
                     inode_id,
                     deletion_seq,
@@ -1014,7 +975,7 @@ pub(crate) async fn publish_batch_with_engine(
         .collect::<Vec<_>>();
     // One reading of what landed serves both the host's observer and the
     // jobs that asked to hear about publications.
-    if let Some(committed_seq) = landed_commit_seq(&results) {
+    if let Some(committed_seq) = landed_committed_seq(&results) {
         notify_publish_observer(writer, namespace_id, committed_seq);
         writer
             .maintenance
@@ -1026,7 +987,7 @@ pub(crate) async fn publish_batch_with_engine(
 
 /// The furthest sequence this batch actually committed, or `None` when
 /// nothing in it landed.
-fn landed_commit_seq(results: &[Result<CommitResponse>]) -> Option<ChangeSeq> {
+fn landed_committed_seq(results: &[Result<CommitResponse>]) -> Option<ChangeSeq> {
     results
         .iter()
         .filter_map(|result| result.as_ref().ok())

--- a/crates/loonfs/src/maintenance_runner.rs
+++ b/crates/loonfs/src/maintenance_runner.rs
@@ -676,10 +676,9 @@ impl RunnerInner {
     }
 
     fn runtime(&self) -> Option<tokio::runtime::Handle> {
-        match &self.runtime {
-            Some(handle) => Some(handle.clone()),
-            None => tokio::runtime::Handle::try_current().ok(),
-        }
+        self.runtime
+            .clone()
+            .or_else(|| tokio::runtime::Handle::try_current().ok())
     }
 
     /// Spawns maintenance on the owning runtime and tracks it for shutdown.

--- a/crates/loonfs/src/maintenance_runner/admission.rs
+++ b/crates/loonfs/src/maintenance_runner/admission.rs
@@ -610,17 +610,11 @@ impl Admission {
     /// pick up from the same place.
     fn record_failure(&mut self, key: &MaintenanceKey, now_ms: u64) {
         let ticket = self.take_ticket();
-        let Some(failures) = self
-            .keys
-            .get(key)
-            .map(|state| state.consecutive_failures.saturating_add(1))
-        else {
-            return;
-        };
-        let delay_ms = backoff_delay_ms(failures, self.clock.as_ref());
         let Some(state) = self.keys.get_mut(key) else {
             return;
         };
+        let failures = state.consecutive_failures.saturating_add(1);
+        let delay_ms = backoff_delay_ms(failures, self.clock.as_ref());
         state.consecutive_failures = failures;
         state.settle(Some(ReadyRun::gated(
             ticket,

--- a/crates/loonfs/src/maintenance_runner/admission.rs
+++ b/crates/loonfs/src/maintenance_runner/admission.rs
@@ -605,9 +605,7 @@ impl Admission {
         }
     }
 
-    /// Backs a failed key off and leaves its continuation alone: a failure
-    /// says nothing about where the last step stopped, and the retry should
-    /// pick up from the same place.
+    /// Applies retry backoff without changing the job's continuation.
     fn record_failure(&mut self, key: &MaintenanceKey, now_ms: u64) {
         let ticket = self.take_ticket();
         let Some(state) = self.keys.get_mut(key) else {

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -368,11 +368,7 @@ impl CompactionClaim {
     }
 }
 
-/// Holds a namespace's compaction slot and gives it back exactly once.
-///
-/// Dropping is the only way the slot is released — on a normal finish, on a
-/// panic, and on a task discarded with its runtime — so no namespace is ever
-/// left claiming a job that is not running.
+/// Releases a namespace's compaction slot when the job ends or is dropped.
 struct CompactionSlot {
     namespaces: Arc<Mutex<BTreeMap<NamespaceId, NamespaceCompactions>>>,
     permits: Arc<Semaphore>,
@@ -387,9 +383,7 @@ impl CompactionSlot {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    /// Reports how many jobs are running and how many are waiting for a
-    /// permit, from the two facts that decide it: the slots claimed, and the
-    /// permits taken.
+    /// Updates the running and waiting compaction metrics.
     fn report_counts(&self) {
         let Some(runner) = self.runner.upgrade() else {
             return;

--- a/crates/loonfs/src/maintenance_runner/compaction.rs
+++ b/crates/loonfs/src/maintenance_runner/compaction.rs
@@ -381,6 +381,12 @@ struct CompactionSlot {
 }
 
 impl CompactionSlot {
+    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<NamespaceId, NamespaceCompactions>> {
+        self.namespaces
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     /// Reports how many jobs are running and how many are waiting for a
     /// permit, from the two facts that decide it: the slots claimed, and the
     /// permits taken.
@@ -389,9 +395,7 @@ impl CompactionSlot {
             return;
         };
         let claimed = self
-            .namespaces
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .values()
             .filter(|entry| entry.active.is_some())
             .count();
@@ -405,10 +409,7 @@ impl CompactionSlot {
 impl Drop for CompactionSlot {
     fn drop(&mut self) {
         {
-            let mut namespaces = self
-                .namespaces
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut namespaces = self.lock();
             let Some(entry) = namespaces.get_mut(&self.namespace_id) else {
                 return;
             };

--- a/crates/loonfs/src/maintenance_runner/jobs.rs
+++ b/crates/loonfs/src/maintenance_runner/jobs.rs
@@ -338,8 +338,7 @@ fn gc_conclusion(gc: &GcResponse, submitted_cursor: Option<&str>) -> Maintenance
         }
         Some(_) => MaintenanceStepConclusion::Progressed,
         None if reclaimed_anything(gc) => MaintenanceStepConclusion::Progressed,
-        None if gc.budget_exhausted => MaintenanceStepConclusion::Blocked,
-        None if gc.degraded_retention => MaintenanceStepConclusion::Blocked,
+        None if gc.budget_exhausted || gc.degraded_retention => MaintenanceStepConclusion::Blocked,
         None => MaintenanceStepConclusion::Idle,
     }
 }

--- a/crates/loonfs/src/publisher.rs
+++ b/crates/loonfs/src/publisher.rs
@@ -1128,13 +1128,13 @@ impl NamespacePublisher {
             }
         }
 
-        for (result, wait_ms) in wait_traces {
-            self.read_core.instruments().publisher_publish(result);
+        for (outcome, wait_ms) in wait_traces {
+            self.read_core.instruments().publisher_publish(outcome);
             tracing::info!(
                 phase = "wait_for_result",
                 mode = self.trace_mode,
                 store_kind = self.trace_store_kind,
-                result = result.as_str(),
+                result = outcome.as_str(),
                 wait_ms
             );
         }

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -530,14 +530,7 @@ impl RuntimeTestExt for TestRuntime {
     }
 
     fn create_checkpoint_blocking(&self, namespace_id: &NamespaceId) -> loonfs::Result<Checkpoint> {
-        block_on(self.admin.create_checkpoint(
-            namespace_id,
-            CreateCheckpointOptions {
-                name: "test-pin".to_owned(),
-                ttl_ms: None,
-            },
-        ))
-        .map(|response| response.checkpoint)
+        block_on(self.create_checkpoint(namespace_id))
     }
 
     fn advance_retention_floor_blocking(


### PR DESCRIPTION
Applies small, behavior-preserving cleanups across the API, CLI, client, runtime, storage, and server crates. The changes align internal names and argument ordering, remove redundant temporary values and clones, simplify conditionals and matches, and move repeated local code into private helpers.

Examples include consistent undelete parameters across the CLI backends, shared page-request and single-operation builders, simpler object-store metrics locking, direct token iteration during upload preparation, and smaller maintenance and garbage-collection branches. The API digest code also reuses the existing lowercase hex encoder.

No public APIs or serialized formats are intended to change. The full workspace test suite, rustfmt, and clippy pass.
