### PR TITLE
refactor(api,core): reads declaration order and completion-outcome naming

### DIFF
--- a/crates/loonfs-api/src/v0/reads.rs
+++ b/crates/loonfs-api/src/v0/reads.rs
@@ -207,6 +207,60 @@ pub struct AuthoritativeFileBytes {
     pub bytes: Vec<u8>,
 }
 
+/// One deletion that can still be restored.
+///
+/// `inode_id` and `deletion_seq` are sufficient to restore it. The original
+/// parent and name are included when they were recorded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct TrashEntry {
+    /// Inode hidden by the deletion.
+    #[serde(with = "crate::public_inode_id")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(schema_with = crate::public_inode_id::schema)
+    )]
+    pub inode_id: InodeId,
+    /// Commit sequence that identifies this deletion.
+    pub deletion_seq: ChangeSeq,
+    /// Time of the deletion, in Unix milliseconds.
+    pub deleted_at_ms: u64,
+    /// Actor responsible for the deletion.
+    pub deleted_by: ActorRef,
+    /// Directory that held the deleted binding, when recorded.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::public_inode_id::option"
+    )]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(schema_with = crate::public_inode_id::optional_schema)
+    )]
+    pub parent_inode_id: Option<InodeId>,
+    /// Canonical key of the deleted binding, when recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name_key: Option<NameKey>,
+    /// User-facing spelling of the deleted binding, when recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<DisplayName>,
+}
+
+/// One trash listing page: the namespace's recoverable deletions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ListTrashResponse {
+    /// Namespace that was read.
+    pub namespace_id: NamespaceId,
+    /// Head sequence this page was evaluated at.
+    pub head_seq: ChangeSeq,
+    /// Recoverable deletions, oldest deletion first.
+    pub entries: Vec<TrashEntry>,
+    /// Present when another page follows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -476,58 +530,4 @@ mod tests {
             "the retired deletion handle must not decode"
         );
     }
-}
-
-/// One deletion that can still be restored.
-///
-/// `inode_id` and `deletion_seq` are sufficient to restore it. The original
-/// parent and name are included when they were recorded.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct TrashEntry {
-    /// Inode hidden by the deletion.
-    #[serde(with = "crate::public_inode_id")]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(schema_with = crate::public_inode_id::schema)
-    )]
-    pub inode_id: InodeId,
-    /// Commit sequence that identifies this deletion.
-    pub deletion_seq: ChangeSeq,
-    /// Time of the deletion, in Unix milliseconds.
-    pub deleted_at_ms: u64,
-    /// Actor responsible for the deletion.
-    pub deleted_by: ActorRef,
-    /// Directory that held the deleted binding, when recorded.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "crate::public_inode_id::option"
-    )]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(schema_with = crate::public_inode_id::optional_schema)
-    )]
-    pub parent_inode_id: Option<InodeId>,
-    /// Canonical key of the deleted binding, when recorded.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name_key: Option<NameKey>,
-    /// User-facing spelling of the deleted binding, when recorded.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<DisplayName>,
-}
-
-/// One trash listing page: the namespace's recoverable deletions.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct ListTrashResponse {
-    /// Namespace that was read.
-    pub namespace_id: NamespaceId,
-    /// Head sequence this page was evaluated at.
-    pub head_seq: ChangeSeq,
-    /// Recoverable deletions, oldest deletion first.
-    pub entries: Vec<TrashEntry>,
-    /// Present when another page follows.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<String>,
 }

--- a/crates/loonfs-core/src/protocol/uploads.rs
+++ b/crates/loonfs-core/src/protocol/uploads.rs
@@ -882,7 +882,7 @@ where
     let mode = upload_mode(&loaded.transport);
     let completion = resolve(mode).map_err(CoreError::InvalidUploadContent)?;
     let plan = completion_plan(&loaded, &completion)?;
-    if let Some(completed) = completed_outcome(
+    if let Some(completed) = already_completed_outcome(
         &loaded.state,
         namespace_id,
         content_store_id,
@@ -953,7 +953,7 @@ async fn freeze_completed_session<S: ObjectStore + ?Sized>(
                 // A racing abort or a peer's completion may have landed
                 // between the read above and this swap. Whatever the durable
                 // record says now is what happened.
-                if let Some(completed) = completed_outcome(
+                if let Some(completed) = already_completed_outcome(
                     &state.state,
                     &namespace_id,
                     &content_store_id,
@@ -1336,7 +1336,7 @@ fn receipt_within_window(
 /// Answers a completion against a session that has already reached a
 /// terminal state: a replay of the same content succeeds idempotently,
 /// anything else is the terminal error for that state.
-fn completed_outcome(
+fn already_completed_outcome(
     state: &UploadSessionLifecycle,
     namespace_id: &NamespaceId,
     content_store_id: &ContentStoreId,


### PR DESCRIPTION
Two leftovers from the recent cleanup pass. v0/reads.rs's test module now sits below TrashEntry and ListTrashResponse instead of above the types its tests use (pure move). completed_outcome is renamed already_completed_outcome so the already-done replay probe stops near-colliding with completion_outcome, the executor (three call sites).