### PR TITLE
docs(release): title releases vX.Y.Z without the project prefix

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,7 +44,7 @@ Create the release from the updated `main` branch. This command publishes the
 release and starts the release workflow:
 
 ```sh
-gh release create vX.Y.Z --target main --title "LoonFS vX.Y.Z" --notes-file notes.md
+gh release create vX.Y.Z --target main --title "vX.Y.Z" --notes-file notes.md
 ```
 
 Watch the workflow with `gh run watch`. After it completes, confirm that the


### PR DESCRIPTION
The runbook's release command titled releases "LoonFS vX.Y.Z" (the v0.2.1 title had to be renamed by hand)