### PR TITLE
docs(release): note that first-time packages start private

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,3 +84,9 @@ Update the API reference website through its private release process.
   `X.Y.Z`.
 - `docker pull ghcr.io/loonfs/loonfs-server:vX.Y.Z` downloads the digest
   recorded in `ARTIFACTS.txt`.
+
+A package published for the first time starts private, and the organization
+blocks public packages by default. Before anonymous pulls can work, enable
+public packages once in the organization's package settings, then make the new
+package public in its own package settings. This applies to the server image
+and the chart package separately.


### PR DESCRIPTION
Follow-up to #645, split out after it merged mid-push. Records last night's finding in the runbook's verify section: a first-time ghcr package starts private, the org blocks public packages by default, and the image and chart packages each need the flip before anonymous pulls work.