### PR TITLE
feat(api): errors report feature and param from server to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = ["raw_value"] }
+serde_path_to_error = "0.1"
 sha2 = "0.10"
 hmac = "0.12"
 loonfs-model = { path = "crates/loonfs-model" }

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -29,11 +29,9 @@ pub struct ApiError {
     pub feature: Option<String>,
     /// Human-readable error message.
     pub message: String,
-    /// Identifies which input was invalid; code-specific expected and actual values stay in `details`.
-    /// JSON body inputs use JSON Pointer.
-    /// Query parameters use their parameter name.
-    /// Path parameters use their parameter name.
-    /// CLI-local inputs use their flag or argument spelling.
+    /// Identifies the invalid input. Body fields use JSON Pointer paths;
+    /// query and path parameters use their names; CLI errors use the flag or
+    /// argument as written.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub param: Option<String>,
     /// Correlation id the server assigned to the failed request; the same

--- a/crates/loonfs-api/src/v0/operations.rs
+++ b/crates/loonfs-api/src/v0/operations.rs
@@ -29,6 +29,13 @@ pub struct ApiError {
     pub feature: Option<String>,
     /// Human-readable error message.
     pub message: String,
+    /// Identifies which input was invalid; code-specific expected and actual values stay in `details`.
+    /// JSON body inputs use JSON Pointer.
+    /// Query parameters use their parameter name.
+    /// Path parameters use their parameter name.
+    /// CLI-local inputs use their flag or argument spelling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub param: Option<String>,
     /// Correlation id the server assigned to the failed request; the same
     /// value is sent as the `x-request-id` response header.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -37,10 +37,15 @@ pub(crate) struct Cli {
 
 pub(crate) fn validate_cli(cli: &Cli) -> Result<(), clap::Error> {
     if cli.json && matches!(&cli.command, Command::Ls(args) if args.jsonl) {
-        return Err(Cli::command().error(
+        let mut error = Cli::command().error(
             clap::error::ErrorKind::ArgumentConflict,
             "the argument '--jsonl' cannot be used with '--json'",
-        ));
+        );
+        error.insert(
+            clap::error::ContextKind::InvalidArg,
+            clap::error::ContextValue::String("--jsonl".to_owned()),
+        );
+        return Err(error);
     }
     Ok(())
 }

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -751,7 +751,10 @@ impl EmbeddedBackend {
         self.admin
             .create_checkpoint(namespace_id, CreateCheckpointOptions::from_request(request))
             .await
-            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+            .map_err(|error| {
+                map_namespace_scoped_runtime_error(namespace_id, error)
+                    .with_invalid_request_param("/name")
+            })
     }
 
     pub(super) async fn list_checkpoints_page(
@@ -796,8 +799,10 @@ impl EmbeddedBackend {
         namespace_id: &NamespaceId,
         request: MaintenanceStepRequest,
     ) -> Result<MaintenanceStepResponse, BackendError> {
-        let plan = MaintenancePlan::from_request(request)
-            .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))?;
+        let plan = MaintenancePlan::from_request(request).map_err(|error| {
+            map_namespace_scoped_runtime_error(namespace_id, error)
+                .with_invalid_request_param("/metadata/max_wal_tail_segments")
+        })?;
         self.admin
             .maintenance_step_namespace(namespace_id, plan)
             .await
@@ -884,7 +889,10 @@ fn resolve_cli_page_limit(limit: Option<u32>) -> Result<EffectiveLimit, BackendE
     // Embedded and remote modes use the same error code for an invalid limit.
     PaginationPolicy::default()
         .resolve_limit(limit)
-        .map_err(|error| BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()))
+        .map_err(|error| {
+            BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
+                .with_param("limit")
+        })
 }
 
 fn cli_page_request<C: loonfs_api::PageCursor>(
@@ -898,6 +906,7 @@ fn cli_page_request<C: loonfs_api::PageCursor>(
             .transpose()
             .map_err(|error| {
                 BackendError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
+                    .with_param("cursor")
             })?,
     })
 }
@@ -931,8 +940,8 @@ fn store_probe_response(report: StoreProbeReport) -> StoreProbeResponse {
 #[allow(clippy::panic)]
 mod tests {
     use super::{
-        map_runtime_error, resolve_cli_page_limit, GrepError, StepBudget, GREP_GC_JOB,
-        GREP_INDEX_JOB,
+        cli_page_request, map_runtime_error, resolve_cli_page_limit, GrepError, StepBudget,
+        GREP_GC_JOB, GREP_INDEX_JOB,
     };
     use crate::backend_error::map_namespace_scoped_grep_error;
     use crate::config::StoreConfig;
@@ -1271,6 +1280,12 @@ mod tests {
         // CLI-local `invalid_input` rewrite.
         let error = resolve_cli_page_limit(Some(0)).expect_err("zero limit is invalid");
         assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
+        assert_eq!(error.param.as_deref(), Some("limit"));
+
+        let error = cli_page_request::<loonfs_api::DirectoryPageCursor>(None, Some("not-a-cursor"))
+            .expect_err("malformed cursor is invalid");
+        assert_eq!(error.code, ErrorCode::InvalidRequest.as_str());
+        assert_eq!(error.param.as_deref(), Some("cursor"));
     }
 
     #[test]

--- a/crates/loonfs-cli/src/backend_error.rs
+++ b/crates/loonfs-cli/src/backend_error.rs
@@ -1,4 +1,4 @@
-//! [`BackendError`] and the runtime-error shaping the CLI's backends share.
+//! Shared backend errors and runtime error conversion.
 
 use loonfs::RuntimeError;
 use loonfs_api::{ErrorCode, ErrorDetails, NamespaceId};
@@ -6,7 +6,7 @@ use loonfs_client::ClientError;
 use loonfs_grep::GrepError;
 use thiserror::Error;
 
-/// Normalized error returned by either CLI backend.
+/// Error returned by either CLI backend.
 ///
 /// `code` is either a shared [`loonfs_api::ErrorCode`] string or one of the
 /// local codes created below: `invalid_config`, `invalid_input`,
@@ -18,15 +18,13 @@ use thiserror::Error;
 pub(crate) struct BackendError {
     /// Registry or backend-local error code.
     pub code: String,
-    /// Capability feature key accompanying `not_supported` errors.
+    /// Feature key for `not_supported` errors.
     pub feature: Option<String>,
     /// Human-readable description of the failure.
     pub message: String,
-    /// Identifies which input was invalid; code-specific expected and actual values stay in `details`.
-    /// JSON body inputs use JSON Pointer.
-    /// Query parameters use their parameter name.
-    /// Path parameters use their parameter name.
-    /// CLI-local inputs use their flag or argument spelling.
+    /// Identifies the invalid input. Body fields use JSON Pointer paths;
+    /// query and path parameters use their names; CLI errors use the flag or
+    /// argument as written.
     pub param: Option<String>,
     /// Correlation id the server assigned to the failed request. Always
     /// `None` for embedded and local failures, which have no server hop.
@@ -206,7 +204,7 @@ mod tests {
         ));
 
         assert_eq!(error.code, "stale_head");
-        let details = error.details.expect("core details survive the seam");
+        let details = error.details.expect("runtime error includes details");
         assert_eq!(details.expected_head_seq, Some(ChangeSeq(41)));
         assert_eq!(details.actual_head_seq, Some(ChangeSeq(45)));
     }

--- a/crates/loonfs-cli/src/backend_error.rs
+++ b/crates/loonfs-cli/src/backend_error.rs
@@ -18,8 +18,16 @@ use thiserror::Error;
 pub(crate) struct BackendError {
     /// Registry or backend-local error code.
     pub code: String,
+    /// Capability feature key accompanying `not_supported` errors.
+    pub feature: Option<String>,
     /// Human-readable description of the failure.
     pub message: String,
+    /// Identifies which input was invalid; code-specific expected and actual values stay in `details`.
+    /// JSON body inputs use JSON Pointer.
+    /// Query parameters use their parameter name.
+    /// Path parameters use their parameter name.
+    /// CLI-local inputs use their flag or argument spelling.
+    pub param: Option<String>,
     /// Correlation id the server assigned to the failed request. Always
     /// `None` for embedded and local failures, which have no server hop.
     pub request_id: Option<String>,
@@ -32,7 +40,9 @@ impl BackendError {
     pub(crate) fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code: code.into(),
+            feature: None,
             message: message.into(),
+            param: None,
             request_id: None,
             details: None,
         }
@@ -62,6 +72,19 @@ impl BackendError {
     pub(crate) fn runtime_error(message: impl Into<String>) -> Self {
         Self::new("runtime_error", message)
     }
+
+    pub(crate) fn with_param(mut self, param: impl Into<String>) -> Self {
+        self.param = Some(param.into());
+        self
+    }
+
+    pub(crate) fn with_invalid_request_param(self, param: impl Into<String>) -> Self {
+        if self.code == ErrorCode::InvalidRequest.as_str() {
+            self.with_param(param)
+        } else {
+            self
+        }
+    }
 }
 
 impl From<ClientError> for BackendError {
@@ -87,14 +110,18 @@ impl From<ClientError> for BackendError {
             | ClientError::Json(message)
             | ClientError::Protocol(message) => Self::client_error(message),
             ClientError::Api {
+                status: _,
                 code,
+                feature,
                 message,
+                param,
                 request_id,
                 details,
-                ..
             } => Self {
                 code,
+                feature,
                 message,
+                param,
                 request_id,
                 details,
             },
@@ -116,7 +143,9 @@ pub(crate) fn map_runtime_error(error: RuntimeError) -> BackendError {
         // consumers read one contract from both backends.
         error => BackendError {
             code: error.code().as_str().to_owned(),
+            feature: None,
             message: error.to_string(),
+            param: None,
             request_id: None,
             details: error.details().map(Box::new),
         },
@@ -145,7 +174,18 @@ pub(crate) fn map_namespace_scoped_grep_error(
     error: GrepError,
 ) -> BackendError {
     match error {
-        GrepError::Runtime(error) => map_namespace_scoped_runtime_error(namespace_id, error),
+        GrepError::Runtime(error) => {
+            let cursor_is_invalid = matches!(
+                &error,
+                RuntimeError::Core(loonfs::CoreError::InvalidCursor(_))
+            );
+            let response = map_namespace_scoped_runtime_error(namespace_id, error);
+            if cursor_is_invalid {
+                response.with_param("/cursor")
+            } else {
+                response
+            }
+        }
         error => BackendError::new(error.code().as_str(), error.to_string()),
     }
 }
@@ -178,6 +218,7 @@ mod tests {
             code: "namespace_not_found".to_owned(),
             feature: None,
             message: "namespace `demo` does not exist".to_owned(),
+            param: None,
             request_id: None,
             details: None,
         });

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -302,7 +302,8 @@ async fn run_admin_checkpoint_release(
     let checkpoint_id = CheckpointId::parse(&args.checkpoint_id).map_err(|error| {
         context.fail(
             kind,
-            crate::error::CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string()),
+            crate::error::CliError::new(ErrorCode::InvalidRequest.as_str(), error.to_string())
+                .with_param("checkpoint_id"),
         )
     })?;
     let response = context
@@ -397,7 +398,9 @@ async fn run_admin_run(
     let namespaces = args
         .namespaces
         .iter()
-        .map(|namespace| parse_namespace_id(namespace))
+        .map(|namespace| {
+            parse_namespace_id(namespace).map_err(|error| error.with_param("--namespace"))
+        })
         .collect::<Result<BTreeSet<_>, _>>()
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     // Sorted and deduplicated, so the keys are driven in the order the

--- a/crates/loonfs-cli/src/commands/context.rs
+++ b/crates/loonfs-cli/src/commands/context.rs
@@ -48,6 +48,7 @@ pub(crate) fn parse_public_ordinal_arg<T>(
             ErrorCode::InvalidRequest.as_str(),
             format!("invalid {argument} `{value}`: {error}"),
         )
+        .with_param(argument)
     })
 }
 

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -45,8 +45,10 @@ use std::sync::Arc;
 fn parse_commit_id_arg(commit_id: Option<&str>) -> Result<Option<CommitId>, CliError> {
     commit_id
         .map(|value| {
-            CommitId::parse(value)
-                .map_err(|error| CliError::invalid_input(format!("invalid --commit-id: {error}")))
+            CommitId::parse(value).map_err(|error| {
+                CliError::invalid_input(format!("invalid --commit-id: {error}"))
+                    .with_param("--commit-id")
+            })
         })
         .transpose()
 }
@@ -247,18 +249,21 @@ fn parse_attribute_assignment(argument: &str) -> Result<(AttributeKey, Attribute
     let Some((key, value)) = argument.split_once('=') else {
         return Err(CliError::invalid_input(format!(
             "invalid --set `{argument}`: expected key=value"
-        )));
+        ))
+        .with_param("--set"));
     };
     Ok((
         parse_attribute_key_arg("--set", key)?,
-        AttributeValue::parse(value)
-            .map_err(|error| CliError::invalid_input(format!("invalid --set value: {error}")))?,
+        AttributeValue::parse(value).map_err(|error| {
+            CliError::invalid_input(format!("invalid --set value: {error}")).with_param("--set")
+        })?,
     ))
 }
 
 fn parse_attribute_key_arg(flag: &str, key: &str) -> Result<AttributeKey, CliError> {
-    AttributeKey::parse(key)
-        .map_err(|error| CliError::invalid_input(format!("invalid {flag} key: {error}")))
+    AttributeKey::parse(key).map_err(|error| {
+        CliError::invalid_input(format!("invalid {flag} key: {error}")).with_param(flag)
+    })
 }
 
 /// The `--attributes-json` form of the update: one object carrying the same
@@ -283,6 +288,7 @@ fn update_attributes_options(
                 CliError::invalid_input(format!(
                     "invalid --attributes-json attribute update: {error}"
                 ))
+                .with_param("--attributes-json")
             })?;
             (update.set, update.remove)
         }
@@ -488,13 +494,15 @@ pub(crate) async fn run_filesystem_get(
                 CliError::invalid_input(format!(
                     "`{}` is not a directory; drop -r to download one file",
                     spec.absolute_path()
-                )),
+                ))
+                .with_param("-r"),
             ));
         }
         if args.revision.is_some() {
             return Err(context.fail(
                 kind,
-                CliError::invalid_input("--revision applies to one file, not a tree"),
+                CliError::invalid_input("--revision applies to one file, not a tree")
+                    .with_param("--revision"),
             ));
         }
         let local_root = match args.local_destination.as_deref() {
@@ -824,7 +832,8 @@ pub(crate) async fn run_filesystem_put(
                 CliError::invalid_input(format!(
                     "`{}` is not a directory; drop -r to upload one file",
                     local_path.display()
-                )),
+                ))
+                .with_param("-r"),
             ));
         }
         if args.commit_id.is_some() {
@@ -832,7 +841,8 @@ pub(crate) async fn run_filesystem_put(
                 kind,
                 CliError::invalid_input(
                     "--commit-id names one commit; a recursive upload makes one commit per file",
-                ),
+                )
+                .with_param("--commit-id"),
             ));
         }
         let remote_root = match args.remote_path {
@@ -1401,7 +1411,8 @@ async fn run_filesystem_transfer(
     if args.recursive && transfer_kind == TransferKind::Move {
         return Err(context.fail(
             kind,
-            CliError::invalid_input("mv moves a directory in one commit; -r is not needed"),
+            CliError::invalid_input("mv moves a directory in one commit; -r is not needed")
+                .with_param("-r"),
         ));
     }
     let allow_root = false;
@@ -1451,7 +1462,8 @@ async fn run_filesystem_transfer(
                     CliError::invalid_input(format!(
                         "`{}` is not a directory; drop -r to copy one file",
                         from.absolute_path()
-                    )),
+                    ))
+                    .with_param("-r"),
                 ));
             }
             if args.commit_id.is_some() {
@@ -1459,7 +1471,8 @@ async fn run_filesystem_transfer(
                     kind,
                     CliError::invalid_input(
                         "--commit-id names one commit; a recursive copy makes one commit per item",
-                    ),
+                    )
+                    .with_param("--commit-id"),
                 ));
             }
             return recursive::run_copy_tree(

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -105,7 +105,7 @@ fn run_completion(
                 kind,
                 None,
                 None,
-                CliError::invalid_input(COMPLETION_SHELL_REQUIRED),
+                CliError::invalid_input(COMPLETION_SHELL_REQUIRED).with_param("--shell"),
             )
         })?;
     let mut script = Vec::new();

--- a/crates/loonfs-cli/src/commands/namespace.rs
+++ b/crates/loonfs-cli/src/commands/namespace.rs
@@ -44,6 +44,7 @@ async fn run_namespace_create(
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
     let namespace_id = parse_namespace_id(&args.namespace_id)
+        .map_err(|error| error.with_param("namespace_id"))
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     let namespace = resolved
         .target
@@ -71,6 +72,7 @@ async fn run_namespace_delete(
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
     let namespace_id = parse_namespace_id(&args.namespace_id)
+        .map_err(|error| error.with_param("namespace_id"))
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     let expected_head_seq = args
         .expected_head_seq
@@ -140,8 +142,10 @@ async fn run_namespace_fork(
         .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
     let source_namespace_id = parse_namespace_id(&args.source)
+        .map_err(|error| error.with_param("source"))
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     let new_namespace_id = parse_namespace_id(&args.new_namespace_id)
+        .map_err(|error| error.with_param("new_namespace_id"))
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
     let namespace = resolved
         .target
@@ -171,6 +175,7 @@ pub(crate) async fn run_namespace_use(
             .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
     let mode = resolved.target.mode_str().to_owned();
     let namespace_id = parse_namespace_id(&args.namespace)
+        .map_err(|error| error.with_param("namespace"))
         .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
 
     resolved

--- a/crates/loonfs-cli/src/commands/profile_config.rs
+++ b/crates/loonfs-cli/src/commands/profile_config.rs
@@ -289,6 +289,7 @@ fn inapplicable_flag(flag: &str, profile_label: &str) -> CliError {
     CliError::invalid_input(format!(
         "`--{flag}` does not apply to {profile_label} profiles"
     ))
+    .with_param(format!("--{flag}"))
 }
 
 // --- create/update helpers ---
@@ -386,7 +387,8 @@ pub(super) fn build_profile_from_create_spec(
         Some(other) => {
             return Err(CliError::invalid_input(format!(
                 "unknown mode: `{other}` (expected embedded or remote)"
-            )))
+            ))
+            .with_param("--mode"))
         }
         None if runtime.interactive => {
             match prompt::prompt_choice("mode", &["embedded", "remote"])?.as_str() {
@@ -422,7 +424,8 @@ fn build_embedded_profile(
         Some(other) => {
             return Err(CliError::invalid_input(format!(
             "unknown store kind: `{other}` (expected local-fs, aws-s3, cloudflare-r2, gcp-gcs, or azure-abs)"
-        )))
+        ))
+            .with_param("--store-kind"))
         }
         None if runtime.interactive => {
             return prompt::prompt_choice(
@@ -569,10 +572,17 @@ fn profile_actor_config(
             actor_kind: Some(ActorKind::from(kind)),
             actor_id: Some(ActorId::parse(id).map_err(|error| {
                 CliError::invalid_input(format!("invalid --actor-id: {error}"))
+                    .with_param("--actor-id")
             })?),
         }),
-        (None, Some(_)) => Err(CliError::invalid_input("--actor-id requires --actor-kind")),
-        (Some(_), None) => Err(CliError::invalid_input("--actor-kind requires --actor-id")),
+        (None, Some(_)) => {
+            Err(CliError::invalid_input("--actor-id requires --actor-kind")
+                .with_param("--actor-id"))
+        }
+        (Some(_), None) => {
+            Err(CliError::invalid_input("--actor-kind requires --actor-id")
+                .with_param("--actor-kind"))
+        }
     }
 }
 

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -28,15 +28,13 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct CliError {
     pub code: String,
-    /// Capability feature key accompanying `not_supported` errors.
+    /// Feature key for `not_supported` errors.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub feature: Option<String>,
     pub message: String,
-    /// Identifies which input was invalid; code-specific expected and actual values stay in `details`.
-    /// JSON body inputs use JSON Pointer.
-    /// Query parameters use their parameter name.
-    /// Path parameters use their parameter name.
-    /// CLI-local inputs use their flag or argument spelling.
+    /// Identifies the invalid input. Body fields use JSON Pointer paths;
+    /// query and path parameters use their names; CLI errors use the flag or
+    /// argument as written.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub param: Option<String>,
     /// Correlation id the server assigned to the failed request; absent for

--- a/crates/loonfs-cli/src/error.rs
+++ b/crates/loonfs-cli/src/error.rs
@@ -28,7 +28,17 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct CliError {
     pub code: String,
+    /// Capability feature key accompanying `not_supported` errors.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feature: Option<String>,
     pub message: String,
+    /// Identifies which input was invalid; code-specific expected and actual values stay in `details`.
+    /// JSON body inputs use JSON Pointer.
+    /// Query parameters use their parameter name.
+    /// Path parameters use their parameter name.
+    /// CLI-local inputs use their flag or argument spelling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub param: Option<String>,
     /// Correlation id the server assigned to the failed request; absent for
     /// embedded and local failures, which have no server hop.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -45,7 +55,9 @@ impl From<crate::backend_error::BackendError> for CliError {
     fn from(error: crate::backend_error::BackendError) -> Self {
         Self {
             code: error.code,
+            feature: error.feature,
             message: error.message,
+            param: error.param,
             request_id: error.request_id,
             details: error.details,
         }
@@ -65,7 +77,9 @@ impl CliError {
     pub(crate) fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code: code.into(),
+            feature: None,
             message: message.into(),
+            param: None,
             request_id: None,
             details: None,
         }
@@ -77,6 +91,11 @@ impl CliError {
 
     pub(crate) fn invalid_input(message: impl Into<String>) -> Self {
         Self::new("invalid_input", message)
+    }
+
+    pub(crate) fn with_param(mut self, param: impl Into<String>) -> Self {
+        self.param = Some(param.into());
+        self
     }
 
     pub(crate) fn profile_not_found(name: &str) -> Self {
@@ -130,6 +149,7 @@ impl CliError {
         Self::non_interactive_input_required(format!(
             "missing required `{field}` while `--no-input` is active"
         ))
+        .with_param(format!("--{field}"))
     }
 
     pub(crate) fn destination_exists(path: &std::path::Path) -> Self {

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -8,6 +8,10 @@
 // the boxed entrypoint, rustc's future-layout query depth needs headroom
 // here. This is the raise rustc itself prescribes.
 #![recursion_limit = "256"]
+#![allow(
+    clippy::result_large_err,
+    reason = "CLI errors preserve backend and request diagnostics as structured fields"
+)]
 mod args;
 mod backend;
 mod backend_error;
@@ -87,9 +91,36 @@ fn render_parse_failure(error: &clap::Error) -> ExitCode {
         error.print().ok();
         return ExitCode::from(USAGE_EXIT_CODE);
     }
-    let failure = error::CliError::invalid_usage(error.render().to_string());
+    let failure = parse_failure_error(error);
     let _ = render::render_parse_error(&failure);
     ExitCode::from(USAGE_EXIT_CODE)
+}
+
+fn parse_failure_error(error: &clap::Error) -> error::CliError {
+    let failure = error::CliError::invalid_usage(error.render().to_string());
+    match parse_error_param(error) {
+        Some(param) => failure.with_param(param),
+        None => failure,
+    }
+}
+
+fn parse_error_param(error: &clap::Error) -> Option<String> {
+    use clap::error::{ContextKind, ContextValue};
+
+    let value = error.get(ContextKind::InvalidArg)?;
+    let rendered = match value {
+        ContextValue::String(value) => value.clone(),
+        ContextValue::Strings(values) => values.first()?.clone(),
+        ContextValue::StyledStr(value) => value.to_string(),
+        ContextValue::StyledStrs(values) => values.first()?.to_string(),
+        _ => return None,
+    };
+    let token = rendered.split_whitespace().next()?;
+    Some(
+        token
+            .trim_matches(|character| matches!(character, '`' | '\'' | '[' | ']'))
+            .to_owned(),
+    )
 }
 
 /// Whether the raw arguments asked for `--json`, scanned the way clap would

--- a/crates/loonfs-cli/src/lib.rs
+++ b/crates/loonfs-cli/src/lib.rs
@@ -10,7 +10,7 @@
 #![recursion_limit = "256"]
 #![allow(
     clippy::result_large_err,
-    reason = "CLI errors preserve backend and request diagnostics as structured fields"
+    reason = "CLI errors expose all structured backend fields"
 )]
 mod args;
 mod backend;

--- a/crates/loonfs-cli/src/render/json.rs
+++ b/crates/loonfs-cli/src/render/json.rs
@@ -47,7 +47,14 @@ const PARSE_ERROR_KIND: &str = "parse_error";
 /// Writes the parse-failure envelope to stderr, in the shape a runtime
 /// failure uses.
 pub(crate) fn render_parse_error(error: &CliError) -> io::Result<()> {
-    let body = serde_json::to_string_pretty(&JsonEnvelope::<serde_json::Value> {
+    let body = json_parse_error(error)?;
+    let mut stderr = io::stderr().lock();
+    stderr.write_all(body.as_bytes())?;
+    stderr.write_all(b"\n")
+}
+
+pub(crate) fn json_parse_error(error: &CliError) -> io::Result<String> {
+    serde_json::to_string_pretty(&JsonEnvelope::<serde_json::Value> {
         kind: PARSE_ERROR_KIND,
         format_version: FORMAT_VERSION,
         profile: None,
@@ -55,10 +62,7 @@ pub(crate) fn render_parse_error(error: &CliError) -> io::Result<()> {
         data: None,
         error: Some(error),
     })
-    .map_err(io::Error::other)?;
-    let mut stderr = io::stderr().lock();
-    stderr.write_all(body.as_bytes())?;
-    stderr.write_all(b"\n")
+    .map_err(io::Error::other)
 }
 
 pub(crate) fn json_error(failure: &CommandFailure) -> io::Result<String> {

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -57,13 +57,24 @@ pub(crate) fn render_error(failure: &CommandFailure, json_mode: bool) -> io::Res
         stderr.write_all(body.as_bytes())?;
         stderr.write_all(b"\n")?;
     } else {
-        stderr.write_all(failure.error.message.as_bytes())?;
-        if let Some(request_id) = &failure.error.request_id {
-            stderr.write_all(format!(" (request id: {request_id})").as_bytes())?;
-        }
+        stderr.write_all(human_error(&failure.error).as_bytes())?;
         stderr.write_all(b"\n")?;
     }
     Ok(())
+}
+
+fn human_error(error: &CliError) -> String {
+    let mut rendered = error.message.clone();
+    if let Some(request_id) = &error.request_id {
+        rendered.push_str(&format!(" (request id: {request_id})"));
+    }
+    if let Some(feature) = &error.feature {
+        rendered.push_str(&format!("\nfeature: {feature}"));
+    }
+    if let Some(param) = &error.param {
+        rendered.push_str(&format!("\nparam: {param}"));
+    }
+    rendered
 }
 
 pub(crate) fn write_stderr_warning(message: impl std::fmt::Display) {
@@ -94,8 +105,8 @@ pub(crate) fn more_entries_hint(cursor: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        human_success, json_error, json_success, listing_drift_warning, AttributeValue,
-        ListingHeadDrift,
+        human_error, human_success, json_error, json_success, listing_drift_warning,
+        AttributeValue, ListingHeadDrift,
     };
     use crate::args::CommandKind;
     use crate::commands::{CommandData, CommandFailure, CommandOutput};
@@ -107,6 +118,38 @@ mod tests {
         AbsolutePath, AttributesProjection, AuthoritativePathEntry, AuthoritativePathEntryKind,
         ChangeSeq, DisplayName, InodeId, NamespaceId,
     };
+    use loonfs_client::ClientError;
+
+    fn rendered_remote_error(server_boundary: &str) -> serde_json::Value {
+        let body: loonfs_api::ApiError =
+            serde_json::from_str(server_boundary).expect("server boundary is valid JSON");
+        let error = CliError::from(crate::backend_error::BackendError::from(
+            ClientError::from_api_error(400, body),
+        ));
+        let failure = CommandFailure {
+            kind: CommandKind::ConfigShow,
+            profile: Some("remote".to_owned()),
+            mode: Some("remote".to_owned()),
+            error: Box::new(error),
+        };
+        serde_json::from_str(&json_error(&failure).expect("JSON error renders"))
+            .expect("rendered error is valid JSON")
+    }
+
+    fn assert_server_fields_survive(server_boundary: &str, rendered: &serde_json::Value) {
+        let boundary: serde_json::Value =
+            serde_json::from_str(server_boundary).expect("server boundary is valid JSON");
+        for (field, value) in boundary
+            .as_object()
+            .expect("server error boundary is an object")
+        {
+            assert_eq!(
+                rendered.pointer(&format!("/error/{field}")),
+                Some(value),
+                "server field `{field}` was lost before CLI JSON"
+            );
+        }
+    }
 
     fn path_entry(path: &str, display_name: Option<&str>) -> AuthoritativePathEntry {
         AuthoritativePathEntry {
@@ -292,6 +335,177 @@ mod tests {
             &json_error(&failure).expect("json error renders")
         )
         .expect("rendered error is valid json"));
+    }
+
+    #[test]
+    fn server_feature_survives_client_and_cli_json() {
+        let boundary = r#"{
+            "code": "not_supported",
+            "feature": "query.grep",
+            "message": "grep is not served",
+            "request_id": "req_feature"
+        }"#;
+        let rendered = rendered_remote_error(boundary);
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{
+                "kind": "config_show",
+                "format_version": 1,
+                "profile": "remote",
+                "mode": "remote",
+                "error": {
+                    "code": "not_supported",
+                    "feature": "query.grep",
+                    "message": "grep is not served",
+                    "request_id": "req_feature"
+                }
+            }"#,
+        )
+        .expect("pinned JSON is valid");
+        assert_eq!(rendered, expected);
+        assert_server_fields_survive(boundary, &rendered);
+    }
+
+    #[test]
+    fn malformed_request_param_survives_client_and_cli_json() {
+        let boundary = r#"{
+            "code": "invalid_request",
+            "message": "path must be absolute",
+            "param": "/operations/0/path",
+            "request_id": "req_param",
+            "details": { "operation_index": 0 }
+        }"#;
+        let rendered = rendered_remote_error(boundary);
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{
+                "kind": "config_show",
+                "format_version": 1,
+                "profile": "remote",
+                "mode": "remote",
+                "error": {
+                    "code": "invalid_request",
+                    "message": "path must be absolute",
+                    "param": "/operations/0/path",
+                    "request_id": "req_param",
+                    "details": { "operation_index": 0 }
+                }
+            }"#,
+        )
+        .expect("pinned JSON is valid");
+        assert_eq!(rendered, expected);
+        assert_server_fields_survive(boundary, &rendered);
+    }
+
+    #[test]
+    fn future_error_code_survives_client_and_cli_json() {
+        let boundary = r#"{
+            "code": "newer_server_code",
+            "message": "a newer server failure",
+            "param": "limit",
+            "request_id": "req_future"
+        }"#;
+        let rendered = rendered_remote_error(boundary);
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{
+                "kind": "config_show",
+                "format_version": 1,
+                "profile": "remote",
+                "mode": "remote",
+                "error": {
+                    "code": "newer_server_code",
+                    "message": "a newer server failure",
+                    "param": "limit",
+                    "request_id": "req_future"
+                }
+            }"#,
+        )
+        .expect("pinned JSON is valid");
+        assert_eq!(rendered, expected);
+        assert_server_fields_survive(boundary, &rendered);
+    }
+
+    #[test]
+    fn remote_request_id_is_absent_from_equivalent_embedded_error() {
+        let remote_boundary = r#"{
+            "code": "invalid_request",
+            "message": "limit must be greater than zero",
+            "param": "limit",
+            "request_id": "req_remote"
+        }"#;
+        let remote = rendered_remote_error(remote_boundary);
+        let embedded_error = CliError::from(
+            crate::backend_error::BackendError::new(
+                loonfs_api::ErrorCode::InvalidRequest.as_str(),
+                "limit must be greater than zero",
+            )
+            .with_param("limit"),
+        );
+        let embedded_failure = CommandFailure {
+            kind: CommandKind::ConfigShow,
+            profile: Some("embedded".to_owned()),
+            mode: Some("embedded".to_owned()),
+            error: Box::new(embedded_error),
+        };
+        let embedded: serde_json::Value = serde_json::from_str(
+            &json_error(&embedded_failure).expect("embedded JSON error renders"),
+        )
+        .expect("embedded error is valid JSON");
+        let expected_embedded: serde_json::Value = serde_json::from_str(
+            r#"{
+                "kind": "config_show",
+                "format_version": 1,
+                "profile": "embedded",
+                "mode": "embedded",
+                "error": {
+                    "code": "invalid_request",
+                    "message": "limit must be greater than zero",
+                    "param": "limit"
+                }
+            }"#,
+        )
+        .expect("pinned JSON is valid");
+
+        assert_eq!(remote["error"]["request_id"], "req_remote");
+        assert_eq!(embedded, expected_embedded);
+        assert!(embedded["error"].get("request_id").is_none());
+        assert_server_fields_survive(remote_boundary, &remote);
+    }
+
+    #[test]
+    fn cli_parse_error_json_names_the_flag_param() {
+        use clap::Parser;
+
+        let clap_error =
+            crate::args::Cli::try_parse_from(["loonfs", "--json", "ls", "--limit", "not-a-number"])
+                .expect_err("invalid --limit must fail parsing");
+        let failure = crate::parse_failure_error(&clap_error);
+        let rendered: serde_json::Value = serde_json::from_str(
+            &super::json::json_parse_error(&failure).expect("parse error JSON renders"),
+        )
+        .expect("parse error is valid JSON");
+
+        assert_eq!(
+            rendered["error"],
+            serde_json::json!({
+                "code": "invalid_usage",
+                "message": failure.message,
+                "param": "--limit"
+            })
+        );
+        assert_eq!(rendered["kind"], "parse_error");
+        assert_eq!(rendered["format_version"], 1);
+    }
+
+    #[test]
+    fn human_errors_render_feature_and_param_diagnostics() {
+        let mut error = CliError::new("not_supported", "grep is not served");
+        error.feature = Some("query.grep".to_owned());
+        error.param = Some("/pattern".to_owned());
+        error.request_id = Some("req_human".to_owned());
+
+        assert_eq!(
+            human_error(&error),
+            "grep is not served (request id: req_human)\nfeature: query.grep\nparam: /pattern"
+        );
     }
 
     #[test]

--- a/crates/loonfs-cli/src/resolve.rs
+++ b/crates/loonfs-cli/src/resolve.rs
@@ -115,15 +115,20 @@ fn actor_from_pair(
     id_name: &str,
     id: Option<&str>,
 ) -> Result<ActorRef, CliError> {
-    let together = || {
-        CliError::invalid_input(format!(
-            "{kind_name} and {id_name} must be supplied together"
-        ))
-    };
-    let kind = kind.ok_or_else(&together)?;
-    let id = id.ok_or_else(together)?;
+    let kind = kind.ok_or_else(|| {
+        named_cli_input_error(
+            kind_name,
+            format!("{kind_name} and {id_name} must be supplied together"),
+        )
+    })?;
+    let id = id.ok_or_else(|| {
+        named_cli_input_error(
+            id_name,
+            format!("{kind_name} and {id_name} must be supplied together"),
+        )
+    })?;
     let id = ActorId::parse(id)
-        .map_err(|error| CliError::invalid_input(format!("invalid {id_name}: {error}")))?;
+        .map_err(|error| named_cli_input_error(id_name, format!("invalid {id_name}: {error}")))?;
     Ok(ActorRef { kind, id })
 }
 
@@ -132,9 +137,19 @@ fn parse_actor_kind(name: &str, value: &str) -> Result<ActorKind, CliError> {
         "user" => Ok(ActorKind::User),
         "service" => Ok(ActorKind::Service),
         "system" => Ok(ActorKind::System),
-        _ => Err(CliError::invalid_input(format!(
-            "invalid {name}: expected user, service, or system"
-        ))),
+        _ => Err(named_cli_input_error(
+            name,
+            format!("invalid {name}: expected user, service, or system"),
+        )),
+    }
+}
+
+fn named_cli_input_error(name: &str, message: String) -> CliError {
+    let error = CliError::invalid_input(message);
+    if name.starts_with('-') {
+        error.with_param(name)
+    } else {
+        error
     }
 }
 

--- a/crates/loonfs-client/src/error.rs
+++ b/crates/loonfs-client/src/error.rs
@@ -53,11 +53,9 @@ pub enum ClientError {
         feature: Option<String>,
         /// Error message returned by the server.
         message: String,
-        /// Identifies which input was invalid; code-specific expected and actual values stay in `details`.
-        /// JSON body inputs use JSON Pointer.
-        /// Query parameters use their parameter name.
-        /// Path parameters use their parameter name.
-        /// CLI-local inputs use their flag or argument spelling.
+        /// Identifies the invalid input. Body fields use JSON Pointer paths;
+        /// query and path parameters use their names; CLI errors use the flag
+        /// or argument as written.
         param: Option<String>,
         /// Correlation ID assigned to the failed request.
         request_id: Option<String>,
@@ -91,7 +89,7 @@ pub enum ClientError {
 }
 
 impl ClientError {
-    /// Builds the client representation of a decoded API error body.
+    /// Converts a decoded API error into a client error.
     pub fn from_api_error(status: u16, body: ApiError) -> Self {
         Self::Api {
             status,

--- a/crates/loonfs-client/src/error.rs
+++ b/crates/loonfs-client/src/error.rs
@@ -1,6 +1,6 @@
 //! Defines [`ClientError`], returned by asynchronous client operations.
 
-use loonfs_api::{ErrorCode, ErrorDetails};
+use loonfs_api::{ApiError, ErrorCode, ErrorDetails};
 use thiserror::Error;
 
 /// Error returned by the asynchronous HTTP client.
@@ -53,6 +53,12 @@ pub enum ClientError {
         feature: Option<String>,
         /// Error message returned by the server.
         message: String,
+        /// Identifies which input was invalid; code-specific expected and actual values stay in `details`.
+        /// JSON body inputs use JSON Pointer.
+        /// Query parameters use their parameter name.
+        /// Path parameters use their parameter name.
+        /// CLI-local inputs use their flag or argument spelling.
+        param: Option<String>,
         /// Correlation ID assigned to the failed request.
         request_id: Option<String>,
         /// Additional structured error details, when provided by the server.
@@ -85,6 +91,19 @@ pub enum ClientError {
 }
 
 impl ClientError {
+    /// Builds the client representation of a decoded API error body.
+    pub fn from_api_error(status: u16, body: ApiError) -> Self {
+        Self::Api {
+            status,
+            code: body.code,
+            feature: body.feature,
+            message: body.message,
+            param: body.param,
+            request_id: body.request_id,
+            details: body.details,
+        }
+    }
+
     /// Returns the typed code for [`ClientError::Api`].
     ///
     /// Returns `None` for other error variants and for API codes this client

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -15,7 +15,7 @@
 #![warn(missing_docs)]
 #![allow(
     clippy::result_large_err,
-    reason = "ClientError::Api preserves the server's additive error fields as public values"
+    reason = "ClientError::Api exposes all structured server error fields"
 )]
 
 mod admin;

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -13,6 +13,10 @@
 //! live in `loonfs-api`) so their arguments cannot drift apart.
 
 #![warn(missing_docs)]
+#![allow(
+    clippy::result_large_err,
+    reason = "ClientError::Api preserves the server's additive error fields as public values"
+)]
 
 mod admin;
 mod config;

--- a/crates/loonfs-client/src/mutations.rs
+++ b/crates/loonfs-client/src/mutations.rs
@@ -544,6 +544,7 @@ mod tests {
             code: code.to_owned(),
             feature: None,
             message: String::new(),
+            param: None,
             request_id: None,
             details: None,
         };
@@ -881,6 +882,7 @@ mod tests {
             code: code.to_owned(),
             feature: None,
             message: "test".to_owned(),
+            param: None,
             request_id: None,
             details: None,
         }

--- a/crates/loonfs-client/src/transport.rs
+++ b/crates/loonfs-client/src/transport.rs
@@ -507,14 +507,7 @@ pub(crate) struct FailedAttempt {
 
 pub(crate) fn map_status_error(status: u16, body: &[u8]) -> ClientError {
     match serde_json::from_slice::<ApiError>(body) {
-        Ok(body) => ClientError::Api {
-            status,
-            code: body.code,
-            feature: body.feature,
-            message: body.message,
-            request_id: body.request_id,
-            details: body.details,
-        },
+        Ok(body) => ClientError::from_api_error(status, body),
         // A status with a non-envelope body is most commonly an intermediary
         // answering for the server (a load balancer's HTML 502): keep the
         // status — it is the only signal the response carried.

--- a/crates/loonfs-server/Cargo.toml
+++ b/crates/loonfs-server/Cargo.toml
@@ -37,6 +37,7 @@ rustls.workspace = true
 rustls-pemfile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_path_to_error.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -11,7 +11,7 @@ use loonfs_api::{
 
 pub(super) struct ApiResponseError {
     status: StatusCode,
-    body: ApiError,
+    body: Box<ApiError>,
     /// Emitted as a `Retry-After` header, for retryable capacity errors.
     retry_after_seconds: Option<u32>,
 }
@@ -20,13 +20,14 @@ impl ApiResponseError {
     pub(super) fn new(status: StatusCode, code: ErrorCode, message: &str) -> Self {
         let response = Self {
             status,
-            body: ApiError {
+            body: Box::new(ApiError {
                 code: code.as_str().to_owned(),
                 feature: None,
                 message: message.to_owned(),
+                param: None,
                 request_id: None,
                 details: None,
-            },
+            }),
             retry_after_seconds: None,
         };
         if code.retryable_without_operator_action() {
@@ -39,13 +40,14 @@ impl ApiResponseError {
     pub(super) fn not_supported(feature: &str, message: &str) -> Self {
         Self {
             status: StatusCode::NOT_IMPLEMENTED,
-            body: ApiError {
+            body: Box::new(ApiError {
                 code: ErrorCode::NotSupported.as_str().to_owned(),
                 feature: Some(feature.to_owned()),
                 message: message.to_owned(),
+                param: None,
                 request_id: None,
                 details: None,
-            },
+            }),
             retry_after_seconds: None,
         }
     }
@@ -56,6 +58,26 @@ impl ApiResponseError {
     pub(super) fn with_retry_after(mut self, seconds: u32) -> Self {
         self.retry_after_seconds = Some(seconds);
         self
+    }
+
+    /// Attributes the failure to one request input.
+    pub(super) fn with_param(mut self, param: impl Into<String>) -> Self {
+        self.body.param = Some(param.into());
+        self
+    }
+
+    /// Attributes an invalid-request failure without relabeling other codes.
+    pub(super) fn with_invalid_request_param(self, param: impl Into<String>) -> Self {
+        if self.body.code == ErrorCode::InvalidRequest.as_str() {
+            self.with_param(param)
+        } else {
+            self
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn param(&self) -> Option<&str> {
+        self.body.param.as_deref()
     }
 
     /// Stamps the mutation's idempotency key into the error details, so a
@@ -77,6 +99,7 @@ impl ApiResponseError {
             ErrorCode::InvalidRequest,
             &error.to_string(),
         )
+        .with_param("namespace_id")
     }
 
     pub(super) fn runtime(error: RuntimeError) -> Self {

--- a/crates/loonfs-server/src/http/error.rs
+++ b/crates/loonfs-server/src/http/error.rs
@@ -60,13 +60,13 @@ impl ApiResponseError {
         self
     }
 
-    /// Attributes the failure to one request input.
+    /// Identifies the request input that caused the error.
     pub(super) fn with_param(mut self, param: impl Into<String>) -> Self {
         self.body.param = Some(param.into());
         self
     }
 
-    /// Attributes an invalid-request failure without relabeling other codes.
+    /// Sets `param` only for an `invalid_request` error.
     pub(super) fn with_invalid_request_param(self, param: impl Into<String>) -> Self {
         if self.body.code == ErrorCode::InvalidRequest.as_str() {
             self.with_param(param)

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -203,7 +203,7 @@ where
     T: serde::de::DeserializeOwned,
 {
     let mut deserializer = serde_json::Deserializer::from_slice(body);
-    serde_path_to_error::deserialize(&mut deserializer).map_err(|error| {
+    let decoded = serde_path_to_error::deserialize(&mut deserializer).map_err(|error| {
         let param = json_pointer(error.path())
             .and_then(|pointer| refine_internally_tagged_path(body, pointer));
         let response = ApiResponseError::new(
@@ -215,7 +215,17 @@ where
             Some(param) => response.with_param(param),
             None => response,
         }
-    })
+    })?;
+    // One value is the whole body: `end` rejects trailing data, which no
+    // single field can be blamed for, so this arm carries no param.
+    deserializer.end().map_err(|error| {
+        ApiResponseError::new(
+            StatusCode::BAD_REQUEST,
+            ErrorCode::InvalidRequest,
+            &format!("invalid JSON request body: {error}"),
+        )
+    })?;
+    Ok(decoded)
 }
 
 fn refine_internally_tagged_path(body: &[u8], pointer: String) -> Option<String> {
@@ -638,6 +648,18 @@ mod tests {
         )
         .expect_err("path has the wrong type");
         assert_eq!(error.param(), Some("/operations/0/path"));
+    }
+
+    #[test]
+    fn json_decode_rejects_trailing_data_after_the_value() {
+        let error = decode_json::<Request>(br#"{"operations": []}{"operations": []}"#)
+            .expect_err("trailing data is not part of the request");
+        assert_eq!(error.param(), None);
+
+        assert!(
+            decode_json::<Request>(br#"{"operations": []}  "#).is_ok(),
+            "trailing whitespace is not data"
+        );
     }
 
     #[test]

--- a/crates/loonfs-server/src/http/extractors.rs
+++ b/crates/loonfs-server/src/http/extractors.rs
@@ -11,7 +11,7 @@ use axum::Json;
 use bytes::Bytes;
 use futures::StreamExt;
 use loonfs::{ByteStream, ErrorCode, MAX_MULTIPART_PARTS, MAX_SIGNED_PARTS_PER_REQUEST};
-use loonfs_api::NamespaceId;
+use loonfs_api::{AbsolutePath, NamespaceId};
 use std::convert::Infallible;
 use std::sync::{Arc, Mutex};
 use tokio::sync::OwnedSemaphorePermit;
@@ -182,17 +182,88 @@ where
     T: serde::de::DeserializeOwned,
     S: Send + Sync,
 {
-    match Json::<T>::from_request(req, state).await {
-        Ok(Json(value)) => Ok(value),
+    let body = match Json::<Box<serde_json::value::RawValue>>::from_request(req, state).await {
+        Ok(Json(body)) => body,
         Err(rejection) if rejection.status() == StatusCode::PAYLOAD_TOO_LARGE => {
-            Err(body_too_large)
+            return Err(body_too_large);
         }
-        Err(rejection) => Err(ApiResponseError::new(
+        Err(rejection) => {
+            return Err(ApiResponseError::new(
+                StatusCode::BAD_REQUEST,
+                ErrorCode::InvalidRequest,
+                &rejection.body_text(),
+            ));
+        }
+    };
+    decode_json(body.get().as_bytes())
+}
+
+fn decode_json<T>(body: &[u8]) -> Result<T, ApiResponseError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let mut deserializer = serde_json::Deserializer::from_slice(body);
+    serde_path_to_error::deserialize(&mut deserializer).map_err(|error| {
+        let param = json_pointer(error.path())
+            .and_then(|pointer| refine_internally_tagged_path(body, pointer));
+        let response = ApiResponseError::new(
             StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
-            &rejection.body_text(),
-        )),
+            &format!("invalid JSON request body: {}", error.inner()),
+        );
+        match param {
+            Some(param) => response.with_param(param),
+            None => response,
+        }
+    })
+}
+
+fn refine_internally_tagged_path(body: &[u8], pointer: String) -> Option<String> {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return Some(pointer);
+    };
+    let Some(object) = value
+        .pointer(&pointer)
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Some(pointer);
+    };
+    if !object.contains_key("kind") {
+        return Some(pointer);
     }
+    let invalid_path_fields = object
+        .iter()
+        .filter(|(name, value)| {
+            matches!(name.as_str(), "path" | "from_path" | "to_path")
+                && serde_json::from_value::<AbsolutePath>((*value).clone()).is_err()
+        })
+        .map(|(name, _)| name.as_str())
+        .collect::<Vec<_>>();
+    if let [field] = invalid_path_fields.as_slice() {
+        return Some(format!("{pointer}/{}", escape_json_pointer_segment(field)));
+    }
+    None
+}
+
+fn escape_json_pointer_segment(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
+}
+
+fn json_pointer(path: &serde_path_to_error::Path) -> Option<String> {
+    let mut pointer = String::new();
+    for segment in path {
+        pointer.push('/');
+        match segment {
+            serde_path_to_error::Segment::Seq { index } => pointer.push_str(&index.to_string()),
+            serde_path_to_error::Segment::Map { key } => {
+                pointer.push_str(&escape_json_pointer_segment(key));
+            }
+            serde_path_to_error::Segment::Enum { .. } | serde_path_to_error::Segment::Unknown => {
+                return None
+            }
+        }
+    }
+    (!pointer.is_empty()).then_some(pointer)
 }
 
 impl<T> FromRequest<AppState> for AppJson<T>
@@ -537,13 +608,82 @@ where
         if body.is_empty() {
             return Ok(OptionalAppJson(None));
         }
-        let value = serde_json::from_slice(&body).map_err(|error| {
-            ApiResponseError::new(
-                StatusCode::BAD_REQUEST,
-                ErrorCode::InvalidRequest,
-                &format!("request body is not valid JSON for this operation: {error}"),
-            )
-        })?;
+        let value = decode_json(&body)?;
         Ok(OptionalAppJson(Some(value)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(dead_code)]
+    #[derive(Debug, serde::Deserialize)]
+    struct Request {
+        operations: Vec<Operation>,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, serde::Deserialize)]
+    struct Operation {
+        path: u64,
+    }
+
+    #[test]
+    fn typed_json_decode_reports_json_pointer() {
+        let error = decode_json::<Request>(
+            br#"{
+            "operations": [{ "path": "relative" }]
+        }"#,
+        )
+        .expect_err("path has the wrong type");
+        assert_eq!(error.param(), Some("/operations/0/path"));
+    }
+
+    #[test]
+    fn api_commit_decode_reports_operation_field_pointer() {
+        let error = decode_json::<loonfs_api::CommitRequest>(
+            br#"{
+                "commit_id": "invalid-path",
+                "actor": { "kind": "service", "id": "test-service" },
+                "operations": [{ "kind": "create_directory", "path": "relative" }]
+            }"#,
+        )
+        .expect_err("relative operation path is invalid");
+        assert_eq!(error.param(), Some("/operations/0/path"));
+    }
+
+    #[test]
+    fn ambiguous_operation_fields_do_not_report_a_param() {
+        let error = decode_json::<loonfs_api::CommitRequest>(
+            br#"{
+                "commit_id": "invalid-paths",
+                "actor": { "kind": "service", "id": "test-service" },
+                "operations": [{
+                    "kind": "move_path",
+                    "from_path": "relative",
+                    "to_path": "also-relative"
+                }]
+            }"#,
+        )
+        .expect_err("two relative operation paths are ambiguous");
+        assert_eq!(error.param(), None);
+    }
+
+    #[test]
+    fn json_pointer_escapes_object_keys() {
+        #[allow(dead_code)]
+        #[derive(Debug, serde::Deserialize)]
+        struct MapRequest {
+            values: std::collections::BTreeMap<String, u64>,
+        }
+
+        let error = decode_json::<MapRequest>(
+            br#"{
+            "values": { "a/b~c": false }
+        }"#,
+        )
+        .expect_err("value has the wrong type");
+        assert_eq!(error.param(), Some("/values/a~1b~0c"));
     }
 }

--- a/crates/loonfs-server/src/http/handlers_filesystem.rs
+++ b/crates/loonfs-server/src/http/handlers_filesystem.rs
@@ -38,13 +38,13 @@ use tracing::Instrument;
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct PathQuery {
-    path: String,
+    path: Option<String>,
     include_attributes: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct PathPageQuery {
-    path: String,
+    path: Option<String>,
     limit: Option<String>,
     cursor: Option<String>,
 }
@@ -54,7 +54,7 @@ pub(super) struct PathPageQuery {
 /// `serde_urlencoded`, which does not support `#[serde(flatten)]`.
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct ListPathPageQuery {
-    path: String,
+    path: Option<String>,
     limit: Option<String>,
     cursor: Option<String>,
     include_attributes: Option<String>,
@@ -68,7 +68,7 @@ pub(super) struct PageQuery {
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct ContentQuery {
-    path: String,
+    path: Option<String>,
     revision_no: Option<String>,
 }
 
@@ -105,7 +105,7 @@ impl Stream for DownloadBodyStream {
 
 #[derive(Debug, serde::Deserialize)]
 pub(super) struct ChangesQuery {
-    after_seq: String,
+    after_seq: Option<String>,
     limit: Option<String>,
 }
 
@@ -199,7 +199,7 @@ pub(super) async fn list_path_entries(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
-    let path = query.path;
+    let path = required_query_param(query.path, "path")?;
     // An absent parameter leaves the option type's own default in place, so
     // the HTTP surface and the in-process one cannot answer differently.
     let mut options = ListPathEntriesOptions::default();
@@ -218,7 +218,10 @@ pub(super) async fn list_path_entries(
             options,
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("path")
+        })?;
     Ok(Json(listing))
 }
 
@@ -254,7 +257,7 @@ pub(super) async fn stat_path(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
-    let path = query.path;
+    let path = required_query_param(query.path, "path")?;
     let mut options = StatPathOptions::default();
     if let Some(value) = query.include_attributes.as_deref() {
         options.include_attributes = parse_include_attributes(value)?;
@@ -263,7 +266,10 @@ pub(super) async fn stat_path(
         .reader
         .stat_path(&namespace_id, &path, options)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("path")
+        })?;
     Ok(Json(entry))
 }
 
@@ -310,7 +316,7 @@ pub(super) async fn get_file_bytes(
             state.metrics.download_rejected_as_busy();
             super::server_busy_error("proxied content reads")
         })?;
-    let path = query.path;
+    let path = required_query_param(query.path, "path")?;
     let revision_no = query
         .revision_no
         .as_deref()
@@ -325,7 +331,10 @@ pub(super) async fn get_file_bytes(
         }
         None => state.reader.get_file_bytes(&namespace_id, &path).await,
     }
-    .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    .map_err(|error| {
+        ApiResponseError::runtime_for_namespace(&namespace_id, error)
+            .with_invalid_request_param("path")
+    })?;
     Ok(buffered_download_response(file.bytes, permit))
 }
 
@@ -407,7 +416,7 @@ pub(super) async fn list_file_revisions(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
-    let path = query.path;
+    let path = required_query_param(query.path, "path")?;
     let response = state
         .reader
         .list_file_revisions_page(
@@ -419,7 +428,10 @@ pub(super) async fn list_file_revisions(
             },
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("path")
+        })?;
     Ok(Json(response))
 }
 
@@ -567,7 +579,7 @@ pub(super) async fn list_changes(
     authorize(state.config.auth_policy(), &headers)?;
     let namespace_id = namespace_id_path.into_id()?;
     let query = query.into_params()?;
-    let after_seq = parse_after_seq(&query.after_seq)?;
+    let after_seq = parse_after_seq(&required_query_param(query.after_seq, "after_seq")?)?;
     let limit = resolve_page_limit(query.limit)?;
     let response = state
         .reader
@@ -585,6 +597,17 @@ fn parse_after_seq(value: &str) -> Result<loonfs_api::ChangeSeq, ApiResponseErro
     parse_public_ordinal("after_seq", value, loonfs_api::ChangeSeq::parse)
 }
 
+fn required_query_param(value: Option<String>, name: &str) -> Result<String, ApiResponseError> {
+    value.ok_or_else(|| {
+        ApiResponseError::new(
+            StatusCode::BAD_REQUEST,
+            ErrorCode::InvalidRequest,
+            &format!("missing required query parameter `{name}`"),
+        )
+        .with_param(name)
+    })
+}
+
 pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseError> {
     match value {
         "true" => Ok(true),
@@ -593,7 +616,8 @@ pub(super) fn parse_include_attributes(value: &str) -> Result<bool, ApiResponseE
             StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &format!("invalid include_attributes `{other}`: expected `true` or `false`"),
-        )),
+        )
+        .with_param("include_attributes")),
     }
 }
 
@@ -622,6 +646,7 @@ fn public_ordinal_response_error(
         ErrorCode::InvalidRequest,
         &format!("invalid {name} `{value}`: {error}"),
     )
+    .with_param(name)
 }
 
 pub(super) fn resolve_page_limit(
@@ -640,6 +665,7 @@ fn parse_page_limit(value: &str) -> Result<u32, ApiResponseError> {
             ErrorCode::InvalidRequest,
             &format!("invalid limit `{value}`: {error}"),
         )
+        .with_param("limit")
     })
 }
 
@@ -659,6 +685,7 @@ fn limit_response_error(error: LimitError) -> ApiResponseError {
         ErrorCode::InvalidRequest,
         &error.to_string(),
     )
+    .with_param("limit")
 }
 
 fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
@@ -667,6 +694,7 @@ fn page_cursor_response_error(error: PageCursorError) -> ApiResponseError {
         ErrorCode::InvalidRequest,
         &error.to_string(),
     )
+    .with_param("cursor")
 }
 
 #[cfg(test)]

--- a/crates/loonfs-server/src/http/handlers_inodes.rs
+++ b/crates/loonfs-server/src/http/handlers_inodes.rs
@@ -35,6 +35,7 @@ pub(super) fn parse_inode_id(value: &str) -> Result<InodeId, ApiResponseError> {
             ErrorCode::InvalidRequest,
             &format!("path.inode_id {}", error.reason()),
         )
+        .with_param("inode_id")
     })
 }
 

--- a/crates/loonfs-server/src/http/handlers_namespace.rs
+++ b/crates/loonfs-server/src/http/handlers_namespace.rs
@@ -367,7 +367,10 @@ pub(super) async fn create_checkpoint(
             loonfs::CreateCheckpointOptions::from_request(request),
         )
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("/name")
+        })?;
     Ok(Json(response))
 }
 
@@ -413,6 +416,7 @@ pub(super) async fn list_checkpoints(
                 ErrorCode::InvalidRequest,
                 &error.to_string(),
             )
+            .with_param("cursor")
         })?;
     let response = state
         .admin
@@ -479,6 +483,7 @@ fn parse_checkpoint_id(value: &str) -> Result<CheckpointId, ApiResponseError> {
             ErrorCode::InvalidRequest,
             &format!("invalid checkpoint_id `{value}`: {error}"),
         )
+        .with_param("checkpoint_id")
     })
 }
 
@@ -507,8 +512,11 @@ pub(super) async fn maintenance_step(
     OptionalAppJson(request): OptionalAppJson<MaintenanceStepRequest>,
 ) -> Result<Json<MaintenanceStepResponse>, ApiResponseError> {
     let namespace_id = namespace_id_path.into_id()?;
-    let plan = loonfs::MaintenancePlan::from_request(request.unwrap_or_default())
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+    let plan =
+        loonfs::MaintenancePlan::from_request(request.unwrap_or_default()).map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("/metadata/max_wal_tail_segments")
+        })?;
     let result = state
         .admin
         .maintenance_step_namespace(&namespace_id, plan)

--- a/crates/loonfs-server/src/http/handlers_query.rs
+++ b/crates/loonfs-server/src/http/handlers_query.rs
@@ -287,7 +287,18 @@ fn map_grep_error(namespace_id: &loonfs_api::NamespaceId, error: GrepError) -> A
         error @ (GrepError::NotEnabled | GrepError::Backfilling) => {
             ApiResponseError::not_supported(FEATURE_QUERY_GREP, &error.to_string())
         }
-        GrepError::Runtime(error) => ApiResponseError::runtime_for_namespace(namespace_id, error),
+        GrepError::Runtime(error) => {
+            let cursor_is_invalid = matches!(
+                &error,
+                loonfs::RuntimeError::Core(loonfs::CoreError::InvalidCursor(_))
+            );
+            let response = ApiResponseError::runtime_for_namespace(namespace_id, error);
+            if cursor_is_invalid {
+                response.with_param("/cursor")
+            } else {
+                response
+            }
+        }
         error => ApiResponseError::new(status_for_core_error_code(code), code, &error.to_string()),
     }
 }

--- a/crates/loonfs-server/src/http/handlers_uploads.rs
+++ b/crates/loonfs-server/src/http/handlers_uploads.rs
@@ -175,7 +175,8 @@ async fn begin_direct_put_upload(
             StatusCode::BAD_REQUEST,
             ErrorCode::InvalidRequest,
             &message,
-        ));
+        )
+        .with_param("/content/checksum/algorithm"));
     }
     let max_content_bytes = issuer.max_content_bytes();
     if claim.size_bytes > max_content_bytes {
@@ -190,7 +191,8 @@ async fn begin_direct_put_upload(
                  `{FEATURE_UPLOADS_DIRECT_MULTIPART}` is advertised",
                 claim.size_bytes,
             ),
-        ));
+        )
+        .with_param("/content/size_bytes"));
     }
 
     let prepared = state
@@ -264,7 +266,10 @@ async fn begin_direct_multipart_upload(
         .writer
         .begin_direct_multipart_upload_target(&namespace_id, options)
         .await
-        .map_err(|error| ApiResponseError::runtime_for_namespace(&namespace_id, error))?;
+        .map_err(|error| {
+            ApiResponseError::runtime_for_namespace(&namespace_id, error)
+                .with_invalid_request_param("/multipart/part_size_bytes")
+        })?;
 
     Ok(Json(BeginUploadResponse::DirectMultipart {
         namespace_id: prepared.namespace_id,
@@ -377,6 +382,7 @@ pub(super) fn presign_issuer_error(error: ObjectStoreError) -> ApiResponseError 
     match error {
         ObjectStoreError::InvalidContentRef(message) => {
             ApiResponseError::new(StatusCode::BAD_REQUEST, ErrorCode::InvalidRequest, &message)
+                .with_param("/content")
         }
         error => ApiResponseError::new(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -867,6 +873,7 @@ fn parse_upload_id(value: &str) -> Result<UploadId, ApiResponseError> {
             ErrorCode::InvalidRequest,
             &error.to_string(),
         )
+        .with_param("upload_id")
     })
 }
 

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1790,6 +1790,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
             .is_some_and(|message| message.starts_with("invalid after_seq `abc`:")),
         "{body}"
     );
+    assert_eq!(body["param"], "after_seq");
 
     // The largest allowed value reaches namespace lookup. One higher is
     // rejected while parsing the query.
@@ -1824,6 +1825,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         body["message"],
         "invalid after_seq `9007199254740992`: must be an integer from 0 through 9007199254740991"
     );
+    assert_eq!(body["param"], "after_seq");
 
     // Without credentials, authentication fails before the query is parsed.
     expect_enveloped(
@@ -1853,9 +1855,10 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
             .is_some_and(|message| message.starts_with("invalid expected_head_seq `abc`:")),
         "{body}"
     );
+    assert_eq!(body["param"], "expected_head_seq");
 
     // A missing required query parameter returns invalid_request.
-    expect_enveloped(
+    let body = expect_enveloped(
         || {
             raw_agent()
                 .get(&format!("http://{addr}/v0/namespaces/demo/filesystem/stat"))
@@ -1866,11 +1869,12 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         400,
         "invalid_request",
     );
+    assert_eq!(body["param"], "path");
 
     // A malformed JSON body returns invalid_request after authentication.
     // Without credentials, the server returns 401 before reading the body.
     let create_url = format!("http://{addr}/v0/namespaces");
-    expect_enveloped(
+    let body = expect_enveloped(
         || {
             raw_agent()
                 .post(&create_url)
@@ -1882,6 +1886,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         400,
         "invalid_request",
     );
+    assert!(body.get("param").is_none());
     expect_enveloped(
         || {
             raw_agent()
@@ -1901,7 +1906,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         "actor":{"kind":"service","id":"test-service"},
         "operations":[{"kind":"create_directory","path":"relative"}]
     }"#;
-    expect_enveloped(
+    let body = expect_enveloped(
         || {
             raw_agent()
                 .post(&commits_url)
@@ -1913,6 +1918,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         400,
         "invalid_request",
     );
+    assert_eq!(body["param"], "/operations/0/path");
     expect_enveloped(
         || {
             raw_agent()
@@ -1963,7 +1969,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
     // Invalid grep path prefixes return invalid_request after authentication.
     let grep_url = format!("http://{addr}/v0/namespaces/demo/query/grep");
     let invalid_grep = r#"{"pattern":"needle","path_prefix":"relative"}"#;
-    expect_enveloped(
+    let body = expect_enveloped(
         || {
             raw_agent()
                 .post(&grep_url)
@@ -1975,6 +1981,7 @@ async fn http_malformed_request_pieces_answer_in_envelope_behind_auth() {
         400,
         "invalid_request",
     );
+    assert_eq!(body["param"], "/path_prefix");
     expect_enveloped(
         || {
             raw_agent()

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -16,10 +16,9 @@ use loonfs_test_support::http::raw_agent;
 use loonfs_test_support::ids::namespace_id;
 use tempfile::tempdir;
 
-fn post_checkpoint(
-    server_url: &str,
-    namespace: &str,
-) -> Result<CreateCheckpointResponse, ApiError> {
+type ApiResult<T> = Result<T, Box<ApiError>>;
+
+fn post_checkpoint(server_url: &str, namespace: &str) -> ApiResult<CreateCheckpointResponse> {
     post_admin_json_body(
         &format!("{server_url}/v0/admin/namespaces/{namespace}/checkpoints"),
         "test-token",
@@ -31,7 +30,7 @@ fn post_checkpoint_release(
     server_url: &str,
     namespace: &str,
     checkpoint_id: &str,
-) -> Result<loonfs_api::ReleaseCheckpointResponse, ApiError> {
+) -> ApiResult<loonfs_api::ReleaseCheckpointResponse> {
     post_admin_json(
         &format!(
             "{server_url}/v0/admin/namespaces/{namespace}/checkpoints/{checkpoint_id}/release"
@@ -40,7 +39,7 @@ fn post_checkpoint_release(
     )
 }
 
-fn post_gc(server_url: &str, namespace: &str) -> Result<loonfs_api::GcResponse, ApiError> {
+fn post_gc(server_url: &str, namespace: &str) -> ApiResult<loonfs_api::GcResponse> {
     post_gc_with(server_url, namespace, serde_json::json!({}))
 }
 
@@ -64,8 +63,8 @@ fn post_gc_with(
     server_url: &str,
     namespace: &str,
     gc: serde_json::Value,
-) -> Result<loonfs_api::GcResponse, ApiError> {
-    let step: Result<loonfs_api::MaintenanceStepResponse, ApiError> = post_admin_json_body(
+) -> ApiResult<loonfs_api::GcResponse> {
+    let step: ApiResult<loonfs_api::MaintenanceStepResponse> = post_admin_json_body(
         &format!("{server_url}/v0/admin/namespaces/{namespace}/maintenance/step"),
         "test-token",
         serde_json::json!({ "gc": gc }),
@@ -80,7 +79,7 @@ fn post_gc_with(
 fn post_maintenance_step(
     server_url: &str,
     namespace: &str,
-) -> Result<loonfs_api::MaintenanceStepResponse, ApiError> {
+) -> ApiResult<loonfs_api::MaintenanceStepResponse> {
     post_admin_json_body(
         &format!("{server_url}/v0/admin/namespaces/{namespace}/maintenance/step"),
         "test-token",
@@ -92,7 +91,7 @@ fn post_maintenance_step(
 fn post_empty_maintenance_step(
     server_url: &str,
     namespace: &str,
-) -> Result<loonfs_api::MaintenanceStepResponse, ApiError> {
+) -> ApiResult<loonfs_api::MaintenanceStepResponse> {
     post_admin_json_body(
         &format!("{server_url}/v0/admin/namespaces/{namespace}/maintenance/step"),
         "test-token",
@@ -104,7 +103,7 @@ fn post_empty_maintenance_step(
 fn post_retention_advance(
     server_url: &str,
     namespace: &str,
-) -> Result<loonfs_api::MaintenanceStepResponse, ApiError> {
+) -> ApiResult<loonfs_api::MaintenanceStepResponse> {
     post_admin_json_body(
         &format!("{server_url}/v0/admin/namespaces/{namespace}/maintenance/step"),
         "test-token",
@@ -112,10 +111,7 @@ fn post_retention_advance(
     )
 }
 
-fn post_admin_json<T: serde::de::DeserializeOwned>(
-    url: &str,
-    auth_token: &str,
-) -> Result<T, ApiError> {
+fn post_admin_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> ApiResult<T> {
     let request = raw_agent()
         .post(url)
         .set("authorization", &format!("Bearer {auth_token}"));
@@ -126,7 +122,7 @@ fn post_admin_json_body<T: serde::de::DeserializeOwned>(
     url: &str,
     auth_token: &str,
     body: serde_json::Value,
-) -> Result<T, ApiError> {
+) -> ApiResult<T> {
     let request = raw_agent()
         .post(url)
         .set("authorization", &format!("Bearer {auth_token}"));
@@ -135,32 +131,38 @@ fn post_admin_json_body<T: serde::de::DeserializeOwned>(
 
 fn decode_admin_response<T: serde::de::DeserializeOwned>(
     result: Result<ureq::Response, ureq::Error>,
-) -> Result<T, ApiError> {
+) -> ApiResult<T> {
     match result {
-        Ok(response) => serde_json::from_reader(response.into_reader()).map_err(|err| ApiError {
-            code: "invalid_json".to_owned(),
-            feature: None,
-            message: err.to_string(),
-            request_id: None,
-            details: None,
+        Ok(response) => serde_json::from_reader(response.into_reader()).map_err(|err| {
+            Box::new(ApiError {
+                code: "invalid_json".to_owned(),
+                feature: None,
+                message: err.to_string(),
+                param: None,
+                request_id: None,
+                details: None,
+            })
         }),
-        Err(ureq::Error::Status(_, response)) => Err(serde_json::from_reader::<_, ApiError>(
-            response.into_reader(),
-        )
-        .unwrap_or_else(|err| ApiError {
-            code: "invalid_json".to_owned(),
-            feature: None,
-            message: err.to_string(),
-            request_id: None,
-            details: None,
-        })),
-        Err(ureq::Error::Transport(error)) => Err(ApiError {
+        Err(ureq::Error::Status(_, response)) => Err(Box::new(
+            serde_json::from_reader::<_, ApiError>(response.into_reader()).unwrap_or_else(|err| {
+                ApiError {
+                    code: "invalid_json".to_owned(),
+                    feature: None,
+                    message: err.to_string(),
+                    param: None,
+                    request_id: None,
+                    details: None,
+                }
+            }),
+        )),
+        Err(ureq::Error::Transport(error)) => Err(Box::new(ApiError {
             code: "transport".to_owned(),
             feature: None,
             message: error.to_string(),
+            param: None,
             request_id: None,
             details: None,
-        }),
+        })),
     }
 }
 
@@ -594,7 +596,7 @@ async fn http_admin_store_probe_requires_a_token_and_accepts_a_bodyless_request(
     .await;
     let url = format!("{}/v0/admin/store/probe", harness.server_url);
 
-    let unauthorized: Result<loonfs_api::v0::StoreProbeResponse, ApiError> =
+    let unauthorized: ApiResult<loonfs_api::v0::StoreProbeResponse> =
         post_admin_json_body(&url, "wrong-token", serde_json::json!({}));
     assert_eq!(
         unauthorized.expect_err("a wrong token is refused").code,

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -159,35 +159,44 @@ async fn http_paginates_checkpoint_inventory_and_rejects_invalid_requests() {
     harness.server.abort();
 }
 
-fn get_json<T: serde::de::DeserializeOwned>(url: &str, auth_token: &str) -> Result<T, ApiError> {
+fn get_json<T: serde::de::DeserializeOwned>(
+    url: &str,
+    auth_token: &str,
+) -> Result<T, Box<ApiError>> {
     let request = raw_agent()
         .get(url)
         .set("authorization", &format!("Bearer {auth_token}"));
     match request.call() {
-        Ok(response) => serde_json::from_reader(response.into_reader()).map_err(|err| ApiError {
-            code: "invalid_json".to_owned(),
-            feature: None,
-            message: err.to_string(),
-            request_id: None,
-            details: None,
+        Ok(response) => serde_json::from_reader(response.into_reader()).map_err(|err| {
+            Box::new(ApiError {
+                code: "invalid_json".to_owned(),
+                feature: None,
+                message: err.to_string(),
+                param: None,
+                request_id: None,
+                details: None,
+            })
         }),
-        Err(ureq::Error::Status(_, response)) => Err(serde_json::from_reader::<_, ApiError>(
-            response.into_reader(),
-        )
-        .unwrap_or_else(|err| ApiError {
-            code: "invalid_json".to_owned(),
-            feature: None,
-            message: err.to_string(),
-            request_id: None,
-            details: None,
-        })),
-        Err(ureq::Error::Transport(error)) => Err(ApiError {
+        Err(ureq::Error::Status(_, response)) => Err(Box::new(
+            serde_json::from_reader::<_, ApiError>(response.into_reader()).unwrap_or_else(|err| {
+                ApiError {
+                    code: "invalid_json".to_owned(),
+                    feature: None,
+                    message: err.to_string(),
+                    param: None,
+                    request_id: None,
+                    details: None,
+                }
+            }),
+        )),
+        Err(ureq::Error::Transport(error)) => Err(Box::new(ApiError {
             code: "transport".to_owned(),
             feature: None,
             message: error.to_string(),
+            param: None,
             request_id: None,
             details: None,
-        }),
+        })),
     }
 }
 
@@ -281,7 +290,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
     assert_eq!(raw_first_page.entries.len(), 1);
     assert!(raw_first_page.next_cursor.is_some());
 
-    let nonnumeric_limit: Result<ListPathEntriesResponse, ApiError> = get_json(
+    let nonnumeric_limit: Result<ListPathEntriesResponse, Box<ApiError>> = get_json(
         &format!(
             "{}/v0/namespaces/demo/filesystem/list?path=/docs&limit=not-a-number",
             harness.server_url

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -200,7 +200,10 @@ Every error response is a JSON body:
 }
 ```
 
-| `param` input source | Value |
+`param` is present when the error identifies one invalid input. Its format
+depends on where the input came from:
+
+| Input source | `param` value |
 | --- | --- |
 | JSON request body | JSON Pointer |
 | Query parameter | Parameter name |

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -200,6 +200,13 @@ Every error response is a JSON body:
 }
 ```
 
+| `param` input source | Value |
+| --- | --- |
+| JSON request body | JSON Pointer |
+| Query parameter | Parameter name |
+| Path parameter | Parameter name |
+| CLI-local input | Flag or argument spelling |
+
 `code` is the stable machine contract; `message` is human-readable and may
 change between releases; `feature` is present only on `not_supported` errors
 and names the capability-document key the client should reconcile against.

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3409,6 +3409,13 @@
             "type": "string",
             "description": "Human-readable error message."
           },
+          "param": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Identifies which input was invalid; code-specific expected and actual values stay in `details`.\nJSON body inputs use JSON Pointer.\nQuery parameters use their parameter name.\nPath parameters use their parameter name.\nCLI-local inputs use their flag or argument spelling."
+          },
           "request_id": {
             "type": [
               "string",
@@ -6928,6 +6935,13 @@
                 "message": {
                   "type": "string",
                   "description": "Human-readable error message."
+                },
+                "param": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Identifies which input was invalid; code-specific expected and actual values stay in `details`.\nJSON body inputs use JSON Pointer.\nQuery parameters use their parameter name.\nPath parameters use their parameter name.\nCLI-local inputs use their flag or argument spelling."
                 },
                 "request_id": {
                   "type": [

--- a/docs/specs/openapi.json
+++ b/docs/specs/openapi.json
@@ -3414,7 +3414,7 @@
               "string",
               "null"
             ],
-            "description": "Identifies which input was invalid; code-specific expected and actual values stay in `details`.\nJSON body inputs use JSON Pointer.\nQuery parameters use their parameter name.\nPath parameters use their parameter name.\nCLI-local inputs use their flag or argument spelling."
+            "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
           },
           "request_id": {
             "type": [
@@ -6941,7 +6941,7 @@
                     "string",
                     "null"
                   ],
-                  "description": "Identifies which input was invalid; code-specific expected and actual values stay in `details`.\nJSON body inputs use JSON Pointer.\nQuery parameters use their parameter name.\nPath parameters use their parameter name.\nCLI-local inputs use their flag or argument spelling."
+                  "description": "Identifies the invalid input. Body fields use JSON Pointer paths;\nquery and path parameters use their names; CLI errors use the flag or\nargument as written."
                 },
                 "request_id": {
                   "type": [


### PR DESCRIPTION
Preserves structured error details from the server through the client and CLI. The existing `feature` field is no longer dropped, and a new optional `param` field identifies the input responsible for an error.

Body fields use JSON Pointer paths. Query and path parameters use their names. Errors created by the CLI use the flag or argument as written. The server derives body paths from typed deserialization errors and leaves `param` unset when it cannot identify one input reliably. Human and JSON CLI output include both fields when present.
