### PR TITLE
cli: add capabilities and doctor commands

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -271,15 +271,15 @@ History and recovery
 
 Inspection and diagnostics
   loonfs capabilities [--profile <name>]
-    Print the selected profile's canonical capability document: protocol
-    version, profiles, enabled and disabled features, and sorted limits
+    Show the protocol version, profiles, features, and limits supported by
+    the selected deployment
 
   loonfs doctor [--profile <name>] [--namespace <name>] [--write-check]
-    Run the stable configuration, provider, connectivity, authentication,
-    health, capability, and optional namespace checks. The default run is
-    read-only; --write-check appends the existing object-store contract
-    probe, which writes and cleans up scratch objects. Every check is printed,
-    and the command exits nonzero when any check failed
+    Check the configuration, provider, connection, authentication, server
+    health, capabilities, and selected namespace. The command is read-only
+    unless --write-check is set. That option also tests the object store by
+    writing and deleting temporary objects. The command prints every result
+    and exits nonzero if a check fails
 
 Maintenance
   loonfs admin maintenance run --namespaces <ns> [--namespaces <ns>]... [--job <job>]... [--drain] [--max-steps <n>] [--deadline-ms <ms>]

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -269,6 +269,18 @@ History and recovery
     List committed changes after a sequence number, from the start of
     retained history when --after is omitted
 
+Inspection and diagnostics
+  loonfs capabilities [--profile <name>]
+    Print the selected profile's canonical capability document: protocol
+    version, profiles, enabled and disabled features, and sorted limits
+
+  loonfs doctor [--profile <name>] [--namespace <name>] [--write-check]
+    Run the stable configuration, provider, connectivity, authentication,
+    health, capability, and optional namespace checks. The default run is
+    read-only; --write-check appends the existing object-store contract
+    probe, which writes and cleans up scratch objects. Every check is printed,
+    and the command exits nonzero when any check failed
+
 Maintenance
   loonfs admin maintenance run --namespaces <ns> [--namespaces <ns>]... [--job <job>]... [--drain] [--max-steps <n>] [--deadline-ms <ms>]
     Run maintenance for explicitly named namespaces in embedded mode. The

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -41,6 +41,8 @@ Inspection:
   revisions   List a file's revision history
   trash       List recoverable deletions
   changes     List committed changes
+  capabilities  Show the selected profile's protocol capabilities
+  doctor      Diagnose the selected profile with read-only checks
   completion  Print a shell completion script
   version     Print version and build metadata
 
@@ -148,6 +150,10 @@ pub(crate) enum Command {
     Trash(TrashArgs),
     /// List committed changes after a sequence number.
     Changes(ChangesArgs),
+    /// Show the selected profile's protocol capabilities.
+    Capabilities(CapabilitiesArgs),
+    /// Diagnose configuration and the selected profile without writing.
+    Doctor(DoctorArgs),
     /// Maintenance operations: checkpoints, steps, retention, GC, indexes.
     Admin {
         #[command(subcommand)]
@@ -494,6 +500,24 @@ pub(crate) struct NamespaceUseArgs {
 pub(crate) struct CurrentArgs {
     #[command(flatten)]
     pub profile: ProfileSelectorArgs,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct CapabilitiesArgs {
+    #[command(flatten)]
+    pub profile: ProfileSelectorArgs,
+    #[command(flatten)]
+    pub request: RequestBehaviorArgs,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct DoctorArgs {
+    #[command(flatten)]
+    pub target: TargetSelectorArgs,
+    /// Run the existing write-producing object-store contract probe as a
+    /// tenth check.
+    #[arg(long)]
+    pub write_check: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1214,6 +1238,8 @@ pub(crate) enum CommandKind {
     FilesystemMv,
     FilesystemCp,
     Changes,
+    Capabilities,
+    Doctor,
     AdminCheckpointCreate,
     AdminCheckpointList,
     AdminCheckpointRelease,
@@ -1265,6 +1291,8 @@ impl CommandKind {
             CommandKind::FilesystemMv => "filesystem_mv",
             CommandKind::FilesystemCp => "filesystem_cp",
             CommandKind::Changes => "changes",
+            CommandKind::Capabilities => "capabilities",
+            CommandKind::Doctor => "doctor",
             CommandKind::AdminCheckpointCreate => "admin_checkpoint_create",
             CommandKind::AdminCheckpointList => "admin_checkpoint_list",
             CommandKind::AdminCheckpointRelease => "admin_checkpoint_release",
@@ -1326,6 +1354,8 @@ impl Cli {
             Command::Mv(_) => CommandKind::FilesystemMv,
             Command::Cp(_) => CommandKind::FilesystemCp,
             Command::Changes(_) => CommandKind::Changes,
+            Command::Capabilities(_) => CommandKind::Capabilities,
+            Command::Doctor(_) => CommandKind::Doctor,
             Command::Admin { command } => match command {
                 AdminCommand::Checkpoint { command } => match command {
                     AdminCheckpointCommand::Create(_) => CommandKind::AdminCheckpointCreate,
@@ -1397,6 +1427,8 @@ mod tests {
             (CommandKind::FilesystemMv, "filesystem_mv"),
             (CommandKind::FilesystemCp, "filesystem_cp"),
             (CommandKind::Changes, "changes"),
+            (CommandKind::Capabilities, "capabilities"),
+            (CommandKind::Doctor, "doctor"),
             (
                 CommandKind::AdminCheckpointCreate,
                 "admin_checkpoint_create",
@@ -1525,6 +1557,13 @@ mod tests {
         assert_hint(gcs, "service_account_key_path", ValueHint::FilePath);
         let namespace_show = subcommand(subcommand(&command, "namespace"), "show");
         assert_hint(namespace_show, "namespace_id", ValueHint::Other);
+
+        let capabilities = subcommand(&command, "capabilities");
+        assert_hint(capabilities, "profile", ValueHint::Other);
+
+        let doctor = subcommand(&command, "doctor");
+        assert_hint(doctor, "profile", ValueHint::Other);
+        assert_hint(doctor, "namespace", ValueHint::Other);
     }
 
     fn subcommand<'a>(command: &'a clap::Command, name: &str) -> &'a clap::Command {

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -41,8 +41,8 @@ Inspection:
   revisions   List a file's revision history
   trash       List recoverable deletions
   changes     List committed changes
-  capabilities  Show the selected profile's protocol capabilities
-  doctor      Diagnose the selected profile with read-only checks
+  capabilities  Show the selected deployment's protocol capabilities
+  doctor      Check the selected deployment without writing to it
   completion  Print a shell completion script
   version     Print version and build metadata
 
@@ -150,9 +150,9 @@ pub(crate) enum Command {
     Trash(TrashArgs),
     /// List committed changes after a sequence number.
     Changes(ChangesArgs),
-    /// Show the selected profile's protocol capabilities.
+    /// Show the selected deployment's protocol capabilities.
     Capabilities(CapabilitiesArgs),
-    /// Diagnose configuration and the selected profile without writing.
+    /// Check the selected deployment without writing to it.
     Doctor(DoctorArgs),
     /// Maintenance operations: checkpoints, steps, retention, GC, indexes.
     Admin {
@@ -514,8 +514,7 @@ pub(crate) struct CapabilitiesArgs {
 pub(crate) struct DoctorArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
-    /// Run the existing write-producing object-store contract probe as a
-    /// tenth check.
+    /// Also test the object store by writing and deleting temporary objects.
     #[arg(long)]
     pub write_check: bool,
 }

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -55,7 +55,7 @@ fn maintenance_host_needs_an_embedded_profile() -> BackendError {
 /// target requires handling both transports. Both paths normalize failures to
 /// the same error-code registry, which keeps command output consistent.
 impl ResolvedTarget {
-    /// Returns the selected deployment's canonical capability document.
+    /// Returns the capabilities reported by the selected deployment.
     pub(crate) async fn capabilities(&self) -> Result<CapabilityDocument, BackendError> {
         match self {
             Self::Embedded(target) => Ok(target.backend.reader.capabilities()),
@@ -63,11 +63,10 @@ impl ResolvedTarget {
         }
     }
 
-    /// Establishes the remote transport through the public health endpoint.
+    /// Checks whether the client can reach the remote health endpoint.
     ///
-    /// Any served API response proves DNS, TCP, and TLS (when applicable)
-    /// completed. The health check itself runs separately and judges the
-    /// response status.
+    /// Any API response means the connection succeeded. A separate check
+    /// determines whether the health endpoint returned a successful status.
     pub(crate) async fn remote_connectivity(&self) -> Result<(), BackendError> {
         match self {
             Self::Embedded(_) => Ok(()),
@@ -78,7 +77,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Checks the remote server's public liveness endpoint.
+    /// Checks the remote server's public health endpoint.
     pub(crate) async fn remote_health(&self) -> Result<(), BackendError> {
         match self {
             Self::Embedded(_) => Ok(()),

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -13,16 +13,17 @@ use loonfs_api::{
         ChangesResponse, GrepGcRequest, GrepGcResponse, GrepIndexStatusResponse, StoreProbeRequest,
         StoreProbeResponse, UploadSessionResponse,
     },
-    AbsolutePath, AuthoritativePathEntry, ChangeSeq, CheckpointId, CommitResponse, ContentRef,
-    CreateCheckpointRequest, CreateCheckpointResponse, DeleteNamespaceResponse, GrepRequest,
-    GrepResponse, InodeId, ListCheckpointsResponse, ListFileRevisionsResponse,
-    ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest, MaintenanceStepResponse,
-    Namespace, NamespaceId, ReleaseCheckpointResponse, RevisionNo, UploadId,
+    AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId,
+    CommitResponse, ContentRef, CreateCheckpointRequest, CreateCheckpointResponse,
+    DeleteNamespaceResponse, GrepRequest, GrepResponse, InodeId, ListCheckpointsResponse,
+    ListFileRevisionsResponse, ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest,
+    MaintenanceStepResponse, Namespace, NamespaceId, ReleaseCheckpointResponse, RevisionNo,
+    UploadId,
 };
 use loonfs_client::{
-    CopyOptions, CreateDirectoryOptions, DeleteOptions, ListPathEntriesOptions, MoveOptions,
-    NamespacePath, PutFileOptions, RestoreRevisionOptions, StatPathOptions, UndeleteOptions,
-    UpdateAttributesOptions,
+    ClientError, CopyOptions, CreateDirectoryOptions, DeleteOptions, ListPathEntriesOptions,
+    MoveOptions, NamespacePath, PutFileOptions, RestoreRevisionOptions, StatPathOptions,
+    UndeleteOptions, UpdateAttributesOptions,
 };
 use loonfs_objectstore::timing::{MonotonicTimer, StdMonotonicTimer};
 use std::sync::Arc;
@@ -54,6 +55,37 @@ fn maintenance_host_needs_an_embedded_profile() -> BackendError {
 /// target requires handling both transports. Both paths normalize failures to
 /// the same error-code registry, which keeps command output consistent.
 impl ResolvedTarget {
+    /// Returns the selected deployment's canonical capability document.
+    pub(crate) async fn capabilities(&self) -> Result<CapabilityDocument, BackendError> {
+        match self {
+            Self::Embedded(target) => Ok(target.backend.reader.capabilities()),
+            Self::Remote(target) => Ok(target.client.capabilities().await?),
+        }
+    }
+
+    /// Establishes the remote transport through the public health endpoint.
+    ///
+    /// Any served API response proves DNS, TCP, and TLS (when applicable)
+    /// completed. The health check itself runs separately and judges the
+    /// response status.
+    pub(crate) async fn remote_connectivity(&self) -> Result<(), BackendError> {
+        match self {
+            Self::Embedded(_) => Ok(()),
+            Self::Remote(target) => match target.client.health().await {
+                Ok(()) | Err(ClientError::Api { .. }) => Ok(()),
+                Err(error) => Err(error.into()),
+            },
+        }
+    }
+
+    /// Checks the remote server's public liveness endpoint.
+    pub(crate) async fn remote_health(&self) -> Result<(), BackendError> {
+        match self {
+            Self::Embedded(_) => Ok(()),
+            Self::Remote(target) => Ok(target.client.health().await?),
+        }
+    }
+
     /// Creates a new empty namespace.
     pub(crate) async fn create_namespace(
         &self,

--- a/crates/loonfs-cli/src/commands/inspection.rs
+++ b/crates/loonfs-cli/src/commands/inspection.rs
@@ -1,0 +1,563 @@
+//! Profile-scoped capability discovery and read-only diagnostics.
+
+use super::context::{fail, fail_for};
+use super::output::{CommandData, CommandFailure, CommandOutput, DoctorCheck, DoctorStatus};
+use crate::args::{CapabilitiesArgs, CommandKind, DoctorArgs};
+use crate::backend_error::BackendError;
+use crate::config::{
+    load_config, non_empty_env, resolve_config_location, ConfigSource, ProfileConfig, StoreConfig,
+    PROFILE_ENV,
+};
+use crate::error::CliError;
+use crate::profiles::resolve_profile;
+use crate::resolve::{resolve_namespace, resolve_target_profile, ResolvedTarget};
+use loonfs_api::v0::{StoreProbeCheckOutcome, StoreProbeResponse};
+use loonfs_api::{CapabilityDocument, PROTOCOL_VERSION};
+use std::path::Path;
+
+pub(crate) const DOCTOR_CHECK_NAMES: [&str; 9] = [
+    "config",
+    "config_decode",
+    "profile",
+    "provider_config",
+    "connectivity",
+    "auth",
+    "health",
+    "capabilities",
+    "namespace",
+];
+pub(crate) const WRITE_CHECK_NAME: &str = "store_probe";
+
+pub(crate) async fn run_capabilities(
+    kind: CommandKind,
+    config_path: &Path,
+    args: CapabilitiesArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let explicit_profile = args.profile.profile.as_deref();
+    let resolved = resolve_target_profile(config_path, explicit_profile, args.request.no_retry)
+        .await
+        .map_err(|error| fail(kind, explicit_profile.map(ToOwned::to_owned), None, error))?;
+    let mode = resolved.target.mode_str().to_owned();
+    let document = resolved
+        .target
+        .capabilities()
+        .await
+        .map_err(|error| fail_for(kind, &resolved.profile_name, &mode, error))?;
+
+    Ok(CommandOutput {
+        kind,
+        profile: Some(resolved.profile_name),
+        mode: Some(mode),
+        data: CommandData::Capabilities(document),
+    })
+}
+
+/// Runs every diagnostic it can reach and returns the checks as data even
+/// when one failed. [`CommandData::reports_failures`] turns that data into a
+/// nonzero process status after the renderer has printed all of it.
+pub(crate) async fn run_doctor(
+    kind: CommandKind,
+    config_flag: Option<&Path>,
+    args: &DoctorArgs,
+) -> Result<CommandOutput, CommandFailure> {
+    let mut checks = Vec::with_capacity(if args.write_check { 10 } else { 9 });
+
+    let location = match resolve_config_location(config_flag) {
+        Ok(location) => {
+            checks.push(ok(
+                DOCTOR_CHECK_NAMES[0],
+                config_resolution_message(&location),
+            ));
+            location
+        }
+        Err(error) => {
+            checks.push(failed(DOCTOR_CHECK_NAMES[0], error));
+            skip_remaining(
+                &mut checks,
+                1,
+                args.write_check,
+                "config path resolution failed",
+            );
+            return Ok(doctor_output(kind, None, None, checks));
+        }
+    };
+
+    let config = match load_config(&location.path) {
+        Ok(config) => {
+            checks.push(ok(
+                DOCTOR_CHECK_NAMES[1],
+                format!("strictly decoded and validated {}", location.path.display()),
+            ));
+            config
+        }
+        Err(error) => {
+            checks.push(failed(DOCTOR_CHECK_NAMES[1], error));
+            skip_remaining(&mut checks, 2, args.write_check, "config did not decode");
+            return Ok(doctor_output(kind, None, None, checks));
+        }
+    };
+
+    let explicit_profile = args.target.profile.profile.as_deref();
+    let (profile_name, profile) = match resolve_profile(&config, explicit_profile) {
+        Ok((name, profile)) => {
+            checks.push(ok(
+                DOCTOR_CHECK_NAMES[2],
+                format!(
+                    "profile `{name}` selected via {}",
+                    profile_selection_source(explicit_profile)
+                ),
+            ));
+            (name.to_owned(), profile.clone())
+        }
+        Err(error) => {
+            checks.push(failed(DOCTOR_CHECK_NAMES[2], error));
+            skip_remaining(&mut checks, 3, args.write_check, "profile selection failed");
+            return Ok(doctor_output(
+                kind,
+                explicit_profile.map(ToOwned::to_owned),
+                None,
+                checks,
+            ));
+        }
+    };
+    let mode = profile.mode_str().to_owned();
+
+    let mut target = match provider_check(&profile, args.target.request.no_retry).await {
+        Ok((message, target)) => {
+            checks.push(ok(DOCTOR_CHECK_NAMES[3], message));
+            target
+        }
+        Err(error) => {
+            checks.push(failed(DOCTOR_CHECK_NAMES[3], error));
+            skip_remaining(
+                &mut checks,
+                4,
+                args.write_check,
+                "provider configuration is unusable",
+            );
+            return Ok(doctor_output(kind, Some(profile_name), Some(mode), checks));
+        }
+    };
+
+    let remote = matches!(&profile, ProfileConfig::Remote { .. });
+    if remote {
+        let result = target
+            .as_ref()
+            .expect("remote provider validation constructs a target")
+            .remote_connectivity()
+            .await;
+        checks.push(check_from_backend_result(
+            DOCTOR_CHECK_NAMES[4],
+            "DNS, TCP, and TLS connectivity succeeded",
+            result,
+        ));
+    } else {
+        checks.push(skipped(
+            DOCTOR_CHECK_NAMES[4],
+            "embedded profiles do not use a network connection",
+        ));
+    }
+
+    let mut remote_capabilities = None;
+    if remote {
+        let result = target
+            .as_ref()
+            .expect("remote provider validation constructs a target")
+            .capabilities()
+            .await;
+        checks.push(match &result {
+            Ok(_) => ok(
+                DOCTOR_CHECK_NAMES[5],
+                "authenticated capabilities request succeeded",
+            ),
+            Err(error) => failed(DOCTOR_CHECK_NAMES[5], CliError::from(error.clone())),
+        });
+        remote_capabilities = Some(result);
+    } else {
+        checks.push(skipped(
+            DOCTOR_CHECK_NAMES[5],
+            "embedded profiles do not authenticate to a server",
+        ));
+    }
+
+    if remote {
+        let result = target
+            .as_ref()
+            .expect("remote provider validation constructs a target")
+            .remote_health()
+            .await;
+        checks.push(check_from_backend_result(
+            DOCTOR_CHECK_NAMES[6],
+            "server health endpoint answered successfully",
+            result,
+        ));
+    } else if local_root_is_missing(&profile) && !args.write_check {
+        checks.push(skipped(
+            DOCTOR_CHECK_NAMES[6],
+            "opening this local store would create its missing root; read-only doctor left it untouched",
+        ));
+    } else {
+        match ResolvedTarget::resolve(&profile, args.target.request.no_retry).await {
+            Ok(resolved) => {
+                target = Some(resolved);
+                checks.push(ok(
+                    DOCTOR_CHECK_NAMES[6],
+                    "embedded object store opened without an object write",
+                ));
+            }
+            Err(error) => checks.push(failed(DOCTOR_CHECK_NAMES[6], error)),
+        }
+    }
+
+    let capability_result = if remote {
+        remote_capabilities.expect("remote auth check records its capability result")
+    } else if let Some(target) = &target {
+        target.capabilities().await
+    } else {
+        checks.push(skipped(
+            DOCTOR_CHECK_NAMES[7],
+            "embedded store was not opened read-only",
+        ));
+        namespace_check(
+            &mut checks,
+            &config,
+            explicit_profile,
+            args,
+            target.as_ref(),
+        )
+        .await;
+        append_write_check(&mut checks, args.write_check, target.as_ref()).await;
+        return Ok(doctor_output(kind, Some(profile_name), Some(mode), checks));
+    };
+    checks.push(capability_document_check(capability_result));
+
+    namespace_check(
+        &mut checks,
+        &config,
+        explicit_profile,
+        args,
+        target.as_ref(),
+    )
+    .await;
+    append_write_check(&mut checks, args.write_check, target.as_ref()).await;
+
+    Ok(doctor_output(kind, Some(profile_name), Some(mode), checks))
+}
+
+async fn provider_check(
+    profile: &ProfileConfig,
+    no_retry: bool,
+) -> Result<(String, Option<ResolvedTarget>), CliError> {
+    match profile {
+        ProfileConfig::Embedded { store, .. } => {
+            store.validate().map_err(|error| {
+                CliError::invalid_config(format!("invalid embedded store config: {error}"))
+            })?;
+            Ok((
+                format!("{} store configuration is valid", store.kind().as_str()),
+                None,
+            ))
+        }
+        ProfileConfig::Remote { server_url, .. } => {
+            let target = ResolvedTarget::resolve(profile, no_retry).await?;
+            Ok((
+                format!("server URL and TLS configuration parsed for {server_url}"),
+                Some(target),
+            ))
+        }
+    }
+}
+
+async fn namespace_check(
+    checks: &mut Vec<DoctorCheck>,
+    config: &crate::config::CliConfig,
+    explicit_profile: Option<&str>,
+    args: &DoctorArgs,
+    target: Option<&ResolvedTarget>,
+) {
+    let namespace =
+        match resolve_namespace(config, explicit_profile, args.target.namespace.as_deref()) {
+            Ok(resolved) => resolved.namespace,
+            Err(error) if error.is_no_default_namespace() => {
+                checks.push(skipped(DOCTOR_CHECK_NAMES[8], "no namespace is selected"));
+                return;
+            }
+            Err(error) => {
+                checks.push(failed(DOCTOR_CHECK_NAMES[8], error));
+                return;
+            }
+        };
+    let Some(target) = target else {
+        checks.push(skipped(
+            DOCTOR_CHECK_NAMES[8],
+            "the selected provider is unavailable",
+        ));
+        return;
+    };
+    let result = target.namespace_status(&namespace).await;
+    checks.push(check_from_backend_result(
+        DOCTOR_CHECK_NAMES[8],
+        format!("namespace `{namespace}` is reachable"),
+        result.map(|_| ()),
+    ));
+}
+
+async fn append_write_check(
+    checks: &mut Vec<DoctorCheck>,
+    requested: bool,
+    target: Option<&ResolvedTarget>,
+) {
+    if !requested {
+        return;
+    }
+    let Some(target) = target else {
+        checks.push(skipped(
+            WRITE_CHECK_NAME,
+            "the selected provider is unavailable",
+        ));
+        return;
+    };
+    match target.probe_store().await {
+        Ok(response) => checks.push(store_probe_check(response)),
+        Err(error) => checks.push(failed(WRITE_CHECK_NAME, CliError::from(error))),
+    }
+}
+
+fn capability_document_check(result: Result<CapabilityDocument, BackendError>) -> DoctorCheck {
+    let document = match result {
+        Ok(document) => document,
+        Err(error) => return failed(DOCTOR_CHECK_NAMES[7], CliError::from(error)),
+    };
+    if let Err(error) = document.validate() {
+        return failed_message(
+            DOCTOR_CHECK_NAMES[7],
+            format!("capability document is not well-formed: {error}"),
+        );
+    }
+    if document.protocol_version != PROTOCOL_VERSION {
+        return failed_message(
+            DOCTOR_CHECK_NAMES[7],
+            format!(
+                "server protocol `{}` is not supported by this CLI (speaks `{PROTOCOL_VERSION}`)",
+                document.protocol_version
+            ),
+        );
+    }
+    ok(
+        DOCTOR_CHECK_NAMES[7],
+        format!("well-formed capability document speaks `{PROTOCOL_VERSION}`"),
+    )
+}
+
+fn store_probe_check(response: StoreProbeResponse) -> DoctorCheck {
+    let failed_count = response
+        .checks
+        .iter()
+        .filter(|check| check.outcome == StoreProbeCheckOutcome::Failed)
+        .count();
+    let unsupported_count = response
+        .checks
+        .iter()
+        .filter(|check| check.outcome == StoreProbeCheckOutcome::Unsupported)
+        .count();
+    let status = if failed_count > 0 {
+        DoctorStatus::Failed
+    } else if unsupported_count > 0 {
+        DoctorStatus::Warning
+    } else {
+        DoctorStatus::Ok
+    };
+    let message = if failed_count > 0 {
+        format!(
+            "store probe {}: {failed_count} of {} checks failed",
+            response.run_id,
+            response.checks.len()
+        )
+    } else if unsupported_count > 0 {
+        format!(
+            "store probe {}: {unsupported_count} of {} checks unsupported",
+            response.run_id,
+            response.checks.len()
+        )
+    } else {
+        format!(
+            "store probe {}: {} checks passed",
+            response.run_id,
+            response.checks.len()
+        )
+    };
+    DoctorCheck {
+        name: WRITE_CHECK_NAME.to_owned(),
+        status,
+        message,
+        request_id: None,
+        store_probe: Some(response),
+    }
+}
+
+fn local_root_is_missing(profile: &ProfileConfig) -> bool {
+    matches!(
+        profile,
+        ProfileConfig::Embedded {
+            store: StoreConfig::LocalFs { root, .. },
+            ..
+        } if !Path::new(root).exists()
+    )
+}
+
+fn config_resolution_message(location: &crate::config::ConfigLocation) -> String {
+    match location.source {
+        ConfigSource::Flag => format!("resolved {} from --config", location.path.display()),
+        ConfigSource::Env => format!("resolved {} from LOONFS_CONFIG", location.path.display()),
+        ConfigSource::Xdg | ConfigSource::Legacy => {
+            format!("defaulted to {}", location.path.display())
+        }
+    }
+}
+
+fn profile_selection_source(explicit_profile: Option<&str>) -> &'static str {
+    if explicit_profile.is_some() {
+        "--profile"
+    } else if non_empty_env(PROFILE_ENV).is_some() {
+        "LOONFS_PROFILE"
+    } else {
+        "the configured default"
+    }
+}
+
+fn check_from_backend_result<T>(
+    name: &str,
+    success_message: impl Into<String>,
+    result: Result<T, BackendError>,
+) -> DoctorCheck {
+    match result {
+        Ok(_) => ok(name, success_message),
+        Err(error) => failed(name, CliError::from(error)),
+    }
+}
+
+fn ok(name: &str, message: impl Into<String>) -> DoctorCheck {
+    DoctorCheck {
+        name: name.to_owned(),
+        status: DoctorStatus::Ok,
+        message: message.into(),
+        request_id: None,
+        store_probe: None,
+    }
+}
+
+fn skipped(name: &str, message: impl Into<String>) -> DoctorCheck {
+    DoctorCheck {
+        name: name.to_owned(),
+        status: DoctorStatus::Skipped,
+        message: message.into(),
+        request_id: None,
+        store_probe: None,
+    }
+}
+
+fn failed(name: &str, error: CliError) -> DoctorCheck {
+    DoctorCheck {
+        name: name.to_owned(),
+        status: DoctorStatus::Failed,
+        message: error.message,
+        request_id: error.request_id,
+        store_probe: None,
+    }
+}
+
+fn failed_message(name: &str, message: impl Into<String>) -> DoctorCheck {
+    DoctorCheck {
+        name: name.to_owned(),
+        status: DoctorStatus::Failed,
+        message: message.into(),
+        request_id: None,
+        store_probe: None,
+    }
+}
+
+fn skip_remaining(checks: &mut Vec<DoctorCheck>, first: usize, write_check: bool, reason: &str) {
+    checks.extend(
+        DOCTOR_CHECK_NAMES[first..]
+            .iter()
+            .map(|name| skipped(name, reason)),
+    );
+    if write_check {
+        checks.push(skipped(WRITE_CHECK_NAME, reason));
+    }
+}
+
+fn doctor_output(
+    kind: CommandKind,
+    profile: Option<String>,
+    mode: Option<String>,
+    checks: Vec<DoctorCheck>,
+) -> CommandOutput {
+    CommandOutput {
+        kind,
+        profile,
+        mode,
+        data: CommandData::Doctor { checks },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use loonfs_api::v0::StoreProbeCheckResult;
+    use std::collections::BTreeMap;
+
+    fn capability_document(protocol_version: &str) -> CapabilityDocument {
+        CapabilityDocument {
+            protocol_version: protocol_version.to_owned(),
+            profiles: vec!["core/v0".to_owned()],
+            features: BTreeMap::new(),
+            limits: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn doctor_check_names_are_pinned_in_execution_order() {
+        assert_eq!(
+            DOCTOR_CHECK_NAMES,
+            [
+                "config",
+                "config_decode",
+                "profile",
+                "provider_config",
+                "connectivity",
+                "auth",
+                "health",
+                "capabilities",
+                "namespace",
+            ]
+        );
+        assert_eq!(WRITE_CHECK_NAME, "store_probe");
+    }
+
+    #[test]
+    fn capabilities_check_pins_the_protocol_version() {
+        assert_eq!(
+            capability_document_check(Ok(capability_document(PROTOCOL_VERSION))).status,
+            DoctorStatus::Ok
+        );
+        let failed = capability_document_check(Ok(capability_document("v-next")));
+        assert_eq!(failed.status, DoctorStatus::Failed);
+        assert!(failed.message.contains("not supported"));
+    }
+
+    #[test]
+    fn store_probe_failure_remains_nested_data_and_fails_doctor() {
+        let response = StoreProbeResponse {
+            run_id: "probe_test".to_owned(),
+            checks: vec![StoreProbeCheckResult {
+                name: "compare_and_swap".to_owned(),
+                outcome: StoreProbeCheckOutcome::Failed,
+                message: Some("replacement was not atomic".to_owned()),
+            }],
+        };
+        let check = store_probe_check(response.clone());
+        assert_eq!(check.status, DoctorStatus::Failed);
+        assert_eq!(check.store_probe, Some(response));
+    }
+}

--- a/crates/loonfs-cli/src/commands/inspection.rs
+++ b/crates/loonfs-cli/src/commands/inspection.rs
@@ -1,4 +1,4 @@
-//! Profile-scoped capability discovery and read-only diagnostics.
+//! Commands for viewing deployment capabilities and checking configuration.
 
 use super::context::{fail, fail_for};
 use super::output::{CommandData, CommandFailure, CommandOutput, DoctorCheck, DoctorStatus};
@@ -52,9 +52,8 @@ pub(crate) async fn run_capabilities(
     })
 }
 
-/// Runs every diagnostic it can reach and returns the checks as data even
-/// when one failed. [`CommandData::reports_failures`] turns that data into a
-/// nonzero process status after the renderer has printed all of it.
+/// Runs every available check and returns all results, including failures.
+/// Failed checks produce a nonzero exit status after all results are printed.
 pub(crate) async fn run_doctor(
     kind: CommandKind,
     config_flag: Option<&Path>,
@@ -86,7 +85,7 @@ pub(crate) async fn run_doctor(
         Ok(config) => {
             checks.push(ok(
                 DOCTOR_CHECK_NAMES[1],
-                format!("strictly decoded and validated {}", location.path.display()),
+                format!("decoded and validated {}", location.path.display()),
             ));
             config
         }
@@ -148,7 +147,7 @@ pub(crate) async fn run_doctor(
             .await;
         checks.push(check_from_backend_result(
             DOCTOR_CHECK_NAMES[4],
-            "DNS, TCP, and TLS connectivity succeeded",
+            "connected to the server",
             result,
         ));
     } else {
@@ -168,7 +167,7 @@ pub(crate) async fn run_doctor(
         checks.push(match &result {
             Ok(_) => ok(
                 DOCTOR_CHECK_NAMES[5],
-                "authenticated capabilities request succeeded",
+                "server accepted the capabilities request",
             ),
             Err(error) => failed(DOCTOR_CHECK_NAMES[5], CliError::from(error.clone())),
         });
@@ -194,7 +193,7 @@ pub(crate) async fn run_doctor(
     } else if local_root_is_missing(&profile) && !args.write_check {
         checks.push(skipped(
             DOCTOR_CHECK_NAMES[6],
-            "opening this local store would create its missing root; read-only doctor left it untouched",
+            "local store root is missing; doctor did not create it",
         ));
     } else {
         match ResolvedTarget::resolve(&profile, args.target.request.no_retry).await {
@@ -202,7 +201,7 @@ pub(crate) async fn run_doctor(
                 target = Some(resolved);
                 checks.push(ok(
                     DOCTOR_CHECK_NAMES[6],
-                    "embedded object store opened without an object write",
+                    "opened the embedded object store without writing to it",
                 ));
             }
             Err(error) => checks.push(failed(DOCTOR_CHECK_NAMES[6], error)),
@@ -216,7 +215,7 @@ pub(crate) async fn run_doctor(
     } else {
         checks.push(skipped(
             DOCTOR_CHECK_NAMES[7],
-            "embedded store was not opened read-only",
+            "embedded store was not opened",
         ));
         namespace_check(
             &mut checks,
@@ -338,14 +337,14 @@ fn capability_document_check(result: Result<CapabilityDocument, BackendError>) -
         return failed_message(
             DOCTOR_CHECK_NAMES[7],
             format!(
-                "server protocol `{}` is not supported by this CLI (speaks `{PROTOCOL_VERSION}`)",
+                "server uses protocol `{}`, but this CLI expects `{PROTOCOL_VERSION}`",
                 document.protocol_version
             ),
         );
     }
     ok(
         DOCTOR_CHECK_NAMES[7],
-        format!("well-formed capability document speaks `{PROTOCOL_VERSION}`"),
+        format!("capability document is valid and uses protocol `{PROTOCOL_VERSION}`"),
     )
 }
 
@@ -375,7 +374,7 @@ fn store_probe_check(response: StoreProbeResponse) -> DoctorCheck {
         )
     } else if unsupported_count > 0 {
         format!(
-            "store probe {}: {unsupported_count} of {} checks unsupported",
+            "store probe {}: {unsupported_count} of {} checks are unsupported",
             response.run_id,
             response.checks.len()
         )
@@ -517,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn doctor_check_names_are_pinned_in_execution_order() {
+    fn doctor_check_names_have_a_stable_order() {
         assert_eq!(
             DOCTOR_CHECK_NAMES,
             [
@@ -536,18 +535,18 @@ mod tests {
     }
 
     #[test]
-    fn capabilities_check_pins_the_protocol_version() {
+    fn capabilities_check_rejects_a_different_protocol_version() {
         assert_eq!(
             capability_document_check(Ok(capability_document(PROTOCOL_VERSION))).status,
             DoctorStatus::Ok
         );
         let failed = capability_document_check(Ok(capability_document("v-next")));
         assert_eq!(failed.status, DoctorStatus::Failed);
-        assert!(failed.message.contains("not supported"));
+        assert!(failed.message.contains("but this CLI expects"));
     }
 
     #[test]
-    fn store_probe_failure_remains_nested_data_and_fails_doctor() {
+    fn store_probe_failure_is_included_and_fails_doctor() {
         let response = StoreProbeResponse {
             run_id: "probe_test".to_owned(),
             checks: vec![StoreProbeCheckResult {

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ mod admin;
 mod config;
 mod context;
 mod fs;
+mod inspection;
 mod namespace;
 mod output;
 mod partial;
@@ -12,7 +13,8 @@ mod profile_config;
 mod recursive;
 
 pub(crate) use self::output::{
-    CommandData, CommandFailure, CommandOutput, ListingHeadDrift, MaintenanceKeyReport,
+    CommandData, CommandFailure, CommandOutput, DoctorCheck, DoctorStatus, ListingHeadDrift,
+    MaintenanceKeyReport,
 };
 
 use crate::args::{Cli, Command, CommandKind, CompletionArgs, RuntimeBehavior};
@@ -41,6 +43,12 @@ pub(crate) async fn run(
 
     if let Command::Completion(args) = &cli.command {
         return run_completion(kind, args);
+    }
+
+    // Doctor owns config resolution as its first check, so it must run
+    // before the shared resolution boundary used by normal commands.
+    if let Command::Doctor(args) = &cli.command {
+        return inspection::run_doctor(kind, cli.config.as_deref(), args).await;
     }
 
     // One resolution for the whole invocation: every command below reads
@@ -87,6 +95,9 @@ pub(crate) async fn run(
         Command::Cp(args) => fs::run_filesystem_cp(kind, config_path, args, runtime).await,
         Command::Trash(args) => fs::run_filesystem_trash(kind, &location, args).await,
         Command::Changes(args) => admin::run_admin_changes(kind, config_path, args).await,
+        Command::Capabilities(args) => inspection::run_capabilities(kind, config_path, args).await,
+        // Returned before shared config resolution above.
+        Command::Doctor(args) => inspection::run_doctor(kind, cli.config.as_deref(), &args).await,
         Command::Admin { command } => {
             admin::run_admin_command(kind, config_path, command, runtime).await
         }

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -45,8 +45,8 @@ pub(crate) async fn run(
         return run_completion(kind, args);
     }
 
-    // Doctor owns config resolution as its first check, so it must run
-    // before the shared resolution boundary used by normal commands.
+    // `doctor` reports config resolution as its first result, so run it before
+    // the config used by other commands is resolved.
     if let Command::Doctor(args) = &cli.command {
         return inspection::run_doctor(kind, cli.config.as_deref(), args).await;
     }
@@ -96,7 +96,7 @@ pub(crate) async fn run(
         Command::Trash(args) => fs::run_filesystem_trash(kind, &location, args).await,
         Command::Changes(args) => admin::run_admin_changes(kind, config_path, args).await,
         Command::Capabilities(args) => inspection::run_capabilities(kind, config_path, args).await,
-        // Returned before shared config resolution above.
+        // This arm is unreachable because `doctor` returns above.
         Command::Doctor(args) => inspection::run_doctor(kind, cli.config.as_deref(), &args).await,
         Command::Admin { command } => {
             admin::run_admin_command(kind, config_path, command, runtime).await

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -88,7 +88,7 @@ pub(crate) struct MaintenanceKeyReport {
     pub settled: bool,
 }
 
-/// Stable result vocabulary for one `doctor` check.
+/// Possible results for one `doctor` check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum DoctorStatus {
@@ -109,16 +109,16 @@ impl DoctorStatus {
     }
 }
 
-/// One named `doctor` check, in the order the command performed it.
+/// The result of one named `doctor` check.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct DoctorCheck {
     pub name: String,
     pub status: DoctorStatus,
     pub message: String,
-    /// Correlation id from a failed remote request, when one was returned.
+    /// Request ID returned with a remote failure.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
-    /// The existing store-probe response, present only for `--write-check`.
+    /// Object-store probe results, present only when `--write-check` is set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub store_probe: Option<StoreProbeResponse>,
 }
@@ -398,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    fn inspection_data_kinds_are_additive_and_pinned() {
+    fn inspection_data_uses_the_expected_kind_names() {
         let capabilities = CommandData::Capabilities(CapabilityDocument {
             protocol_version: loonfs_api::PROTOCOL_VERSION.to_owned(),
             profiles: Vec::new(),

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -9,9 +9,10 @@ use loonfs_api::v0::{
     StoreProbeResponse,
 };
 use loonfs_api::{
-    AbsolutePath, AuthoritativePathEntry, ChangeSeq, CommitId, CreateCheckpointResponse,
-    DeleteNamespaceResponse, FileRevision, GcResponse, GrepMatch, InodeId, ListCheckpointsResponse,
-    MaintenanceStepResponse, Namespace, NamespaceId, ReleaseCheckpointResponse,
+    AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CommitId,
+    CreateCheckpointResponse, DeleteNamespaceResponse, FileRevision, GcResponse, GrepMatch,
+    InodeId, ListCheckpointsResponse, MaintenanceStepResponse, Namespace, NamespaceId,
+    ReleaseCheckpointResponse,
 };
 use serde::Serialize;
 
@@ -87,6 +88,41 @@ pub(crate) struct MaintenanceKeyReport {
     pub settled: bool,
 }
 
+/// Stable result vocabulary for one `doctor` check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DoctorStatus {
+    Ok,
+    Warning,
+    Failed,
+    Skipped,
+}
+
+impl DoctorStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Warning => "warning",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+/// One named `doctor` check, in the order the command performed it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DoctorCheck {
+    pub name: String,
+    pub status: DoctorStatus,
+    pub message: String,
+    /// Correlation id from a failed remote request, when one was returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    /// The existing store-probe response, present only for `--write-check`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store_probe: Option<StoreProbeResponse>,
+}
+
 pub(crate) struct CommandOutput {
     pub kind: CommandKind,
     pub profile: Option<String>,
@@ -106,6 +142,10 @@ pub(crate) struct CommandFailure {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub(crate) enum CommandData {
+    Capabilities(CapabilityDocument),
+    Doctor {
+        checks: Vec<DoctorCheck>,
+    },
     Profile(ProfileConfig),
     ProfileSummary(ProfileSummary),
     ProfileList {
@@ -293,6 +333,9 @@ impl CommandData {
     pub(crate) fn reports_failures(&self) -> bool {
         match self {
             CommandData::TreeTransfer { failures, .. } => !failures.is_empty(),
+            CommandData::Doctor { checks } => checks
+                .iter()
+                .any(|check| check.status == DoctorStatus::Failed),
             // A wait that ran out of budget renders where the index got to
             // — real data, not an error — and still exits nonzero, because
             // the caller asked for a target that was not reached.
@@ -320,6 +363,7 @@ impl CommandData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     fn path_entries(head_drift: Option<ListingHeadDrift>) -> CommandData {
         CommandData::PathEntries {
@@ -350,6 +394,26 @@ mod tests {
                 "first_head_seq": 5,
                 "last_head_seq": 8,
             })
+        );
+    }
+
+    #[test]
+    fn inspection_data_kinds_are_additive_and_pinned() {
+        let capabilities = CommandData::Capabilities(CapabilityDocument {
+            protocol_version: loonfs_api::PROTOCOL_VERSION.to_owned(),
+            profiles: Vec::new(),
+            features: BTreeMap::new(),
+            limits: BTreeMap::new(),
+        });
+        let doctor = CommandData::Doctor { checks: Vec::new() };
+
+        assert_eq!(
+            serde_json::to_value(capabilities).expect("serialize capabilities")["kind"],
+            "capabilities"
+        );
+        assert_eq!(
+            serde_json::to_value(doctor).expect("serialize doctor")["kind"],
+            "doctor"
         );
     }
 }

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -5,6 +5,8 @@ use super::*;
 
 pub(crate) fn human_success(output: &CommandOutput) -> String {
     match &output.data {
+        CommandData::Capabilities(document) => human_capabilities(document),
+        CommandData::Doctor { checks } => human_doctor(checks),
         CommandData::Profile(profile) => {
             let rendered = toml::to_string_pretty(profile)
                 .unwrap_or_else(|_| format!("mode = \"{}\"", profile.mode_str()));
@@ -280,29 +282,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             });
             lines.join("\n")
         }
-        CommandData::StoreProbed(response) => {
-            let failed = response
-                .checks
-                .iter()
-                .filter(|check| check.outcome == StoreProbeCheckOutcome::Failed)
-                .count();
-            let mut lines: Vec<String> =
-                response.checks.iter().map(store_probe_check_line).collect();
-            lines.push(if failed == 0 {
-                format!(
-                    "store probe {}: {} checks passed",
-                    response.run_id,
-                    response.checks.len()
-                )
-            } else {
-                format!(
-                    "store probe {}: {failed} of {} checks failed",
-                    response.run_id,
-                    response.checks.len()
-                )
-            });
-            lines.join("\n")
-        }
+        CommandData::StoreProbed(response) => store_probe_report_lines(response).join("\n"),
         CommandData::GrepIndexDisabled(response) => {
             format!("grep index disabled on {}", response.namespace_id)
         }
@@ -550,6 +530,84 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
         | CommandData::StreamBytes(_)
         | CommandData::StreamedToStdout => String::new(),
     }
+}
+
+fn human_capabilities(document: &loonfs_api::CapabilityDocument) -> String {
+    let mut profiles = document.profiles.clone();
+    profiles.sort();
+
+    let enabled = document
+        .features
+        .iter()
+        .filter(|(_, enabled)| **enabled)
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    let disabled = document
+        .features
+        .iter()
+        .filter(|(_, enabled)| !**enabled)
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    let limits = document
+        .limits
+        .iter()
+        .map(|(name, value)| format!("{name}\t{value}"))
+        .collect::<Vec<_>>();
+
+    [
+        capability_group(
+            "protocol version",
+            std::slice::from_ref(&document.protocol_version),
+        ),
+        capability_group("profiles", &profiles),
+        capability_group("enabled features", &enabled),
+        capability_group("disabled features", &disabled),
+        capability_group("limits", &limits),
+    ]
+    .join("\n\n")
+}
+
+fn capability_group(heading: &str, rows: &[String]) -> String {
+    let mut lines = vec![heading.to_owned()];
+    if rows.is_empty() {
+        lines.push("(none)".to_owned());
+    } else {
+        lines.extend_from_slice(rows);
+    }
+    lines.join("\n")
+}
+
+fn human_doctor(checks: &[DoctorCheck]) -> String {
+    let mut lines = Vec::new();
+    for check in checks {
+        if check.status == DoctorStatus::Failed {
+            lines.push(format!("{}: failed", check.name));
+            let mut detail = format!("  detail: {}", single_line(&check.message));
+            if let Some(request_id) = &check.request_id {
+                detail.push_str(&format!(" (request id: {request_id})"));
+            }
+            lines.push(detail);
+        } else {
+            lines.push(format!(
+                "{}: {}: {}",
+                check.name,
+                check.status.as_str(),
+                single_line(&check.message)
+            ));
+        }
+        if let Some(response) = &check.store_probe {
+            lines.extend(
+                store_probe_report_lines(response)
+                    .into_iter()
+                    .map(|line| format!("  {line}")),
+            );
+        }
+    }
+    lines.join("\n")
+}
+
+fn single_line(message: &str) -> String {
+    message.lines().collect::<Vec<_>>().join(" | ")
 }
 
 pub(crate) fn human_path_entry(entry: &loonfs_api::AuthoritativePathEntry) -> String {

--- a/crates/loonfs-cli/src/render/mod.rs
+++ b/crates/loonfs-cli/src/render/mod.rs
@@ -6,7 +6,8 @@ mod summaries;
 
 use crate::args::CommandKind;
 use crate::commands::{
-    CommandData, CommandFailure, CommandOutput, ListingHeadDrift, MaintenanceKeyReport,
+    CommandData, CommandFailure, CommandOutput, DoctorCheck, DoctorStatus, ListingHeadDrift,
+    MaintenanceKeyReport,
 };
 use crate::config::ConfigSource;
 use crate::error::CliError;
@@ -109,7 +110,7 @@ mod tests {
         AttributeValue, ListingHeadDrift,
     };
     use crate::args::CommandKind;
-    use crate::commands::{CommandData, CommandFailure, CommandOutput};
+    use crate::commands::{CommandData, CommandFailure, CommandOutput, DoctorCheck, DoctorStatus};
     use crate::config::{ProfileConfig, StoreConfig};
     use crate::error::CliError;
     use crate::profiles::ProfileSummary;
@@ -505,6 +506,29 @@ mod tests {
         assert_eq!(
             human_error(&error),
             "grep is not served (request id: req_human)\nfeature: query.grep\nparam: /pattern"
+        );
+    }
+
+    #[test]
+    fn human_doctor_failure_has_one_detail_line_with_the_request_id() {
+        let output = CommandOutput {
+            kind: CommandKind::Doctor,
+            profile: Some("remote".to_owned()),
+            mode: Some("remote".to_owned()),
+            data: CommandData::Doctor {
+                checks: vec![DoctorCheck {
+                    name: "auth".to_owned(),
+                    status: DoctorStatus::Failed,
+                    message: "token rejected\ncheck the profile".to_owned(),
+                    request_id: Some("req_doctor".to_owned()),
+                    store_probe: None,
+                }],
+            },
+        };
+
+        assert_eq!(
+            human_success(&output),
+            "auth: failed\n  detail: token rejected | check the profile (request id: req_doctor)"
         );
     }
 

--- a/crates/loonfs-cli/src/render/summaries.rs
+++ b/crates/loonfs-cli/src/render/summaries.rs
@@ -18,6 +18,33 @@ pub(super) fn store_probe_check_line(check: &StoreProbeCheckResult) -> String {
     }
 }
 
+/// The complete existing store-probe rendering, shared by `admin store
+/// probe` and doctor's explicit write check.
+pub(super) fn store_probe_report_lines(
+    response: &loonfs_api::v0::StoreProbeResponse,
+) -> Vec<String> {
+    let failed = response
+        .checks
+        .iter()
+        .filter(|check| check.outcome == StoreProbeCheckOutcome::Failed)
+        .count();
+    let mut lines: Vec<String> = response.checks.iter().map(store_probe_check_line).collect();
+    lines.push(if failed == 0 {
+        format!(
+            "store probe {}: {} checks passed",
+            response.run_id,
+            response.checks.len()
+        )
+    } else {
+        format!(
+            "store probe {}: {failed} of {} checks failed",
+            response.run_id,
+            response.checks.len()
+        )
+    });
+    lines
+}
+
 /// Formats the result of one WAL flush step.
 pub(super) fn wal_flush_summary(outcome: &WalFlushStepOutcome, tail_segments: u64) -> String {
     match outcome {

--- a/crates/loonfs-cli/src/render/summaries.rs
+++ b/crates/loonfs-cli/src/render/summaries.rs
@@ -18,8 +18,8 @@ pub(super) fn store_probe_check_line(check: &StoreProbeCheckResult) -> String {
     }
 }
 
-/// The complete existing store-probe rendering, shared by `admin store
-/// probe` and doctor's explicit write check.
+/// Formats the object-store probe for both `admin store probe` and
+/// `doctor --write-check`.
 pub(super) fn store_probe_report_lines(
     response: &loonfs_api::v0::StoreProbeResponse,
 ) -> Vec<String> {

--- a/crates/loonfs-cli/tests/it/completions.rs
+++ b/crates/loonfs-cli/tests/it/completions.rs
@@ -15,6 +15,26 @@ fn completion_generates_for_zsh_and_bash() {
 }
 
 #[test]
+fn completion_covers_capabilities_and_doctor_selectors() {
+    let output = loonfs()
+        .args(["completion", "--shell", "zsh"])
+        .output()
+        .expect("run completion generation");
+
+    assert!(output.status.success(), "{output:?}");
+    let script = stdout(&output);
+    for surface in [
+        "(capabilities)",
+        "(doctor)",
+        "--profile=",
+        "--namespace=",
+        "--write-check",
+    ] {
+        assert!(script.contains(surface), "missing {surface} in completion");
+    }
+}
+
+#[test]
 fn completion_detects_the_shell_from_the_environment() {
     let output = loonfs()
         .arg("completion")

--- a/crates/loonfs-cli/tests/it/inspection.rs
+++ b/crates/loonfs-cli/tests/it/inspection.rs
@@ -1,0 +1,183 @@
+//! Capability discovery and the stable doctor check contract.
+
+use super::common::*;
+use loonfs_api::{CapabilityDocument, PROTOCOL_VERSION};
+use std::collections::BTreeMap;
+
+const CHECK_NAMES: [&str; 9] = [
+    "config",
+    "config_decode",
+    "profile",
+    "provider_config",
+    "connectivity",
+    "auth",
+    "health",
+    "capabilities",
+    "namespace",
+];
+
+#[test]
+fn embedded_capabilities_are_the_canonical_document() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+
+    let output = harness.run(&["--json", "capabilities"]);
+    assert_success(&output);
+    let data = json_data(&output);
+    assert_eq!(data["kind"], "capabilities");
+    assert_eq!(data["protocol_version"], PROTOCOL_VERSION);
+    assert!(data["profiles"]
+        .as_array()
+        .is_some_and(|rows| !rows.is_empty()));
+    assert!(data["features"].is_object());
+    assert!(data["limits"].is_object());
+
+    let human = harness.run(&["capabilities"]);
+    assert_success(&human);
+    let rendered = stdout_string(&human);
+    for heading in [
+        "protocol version",
+        "profiles",
+        "enabled features",
+        "disabled features",
+        "limits",
+    ] {
+        assert!(rendered.lines().any(|line| line == heading), "{rendered}");
+    }
+}
+
+#[test]
+fn doctor_is_read_only_when_a_local_store_root_is_missing() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    let root = harness.store_root("default");
+    assert!(!root.exists());
+
+    let output = harness.run(&["--json", "doctor"]);
+    assert_success(&output);
+    assert!(
+        !root.exists(),
+        "read-only doctor must not create the store root"
+    );
+
+    let checks = json_data(&output)["checks"]
+        .as_array()
+        .expect("doctor checks")
+        .clone();
+    assert_eq!(check_names(&checks), CHECK_NAMES);
+    assert_eq!(check_status(&checks, "health"), "skipped");
+    assert_eq!(check_status(&checks, "capabilities"), "skipped");
+    assert_eq!(check_status(&checks, "namespace"), "skipped");
+}
+
+#[test]
+fn doctor_opens_an_existing_embedded_store_without_writing_it() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    let root = harness.store_root("default");
+    fs::create_dir_all(&root).expect("create empty store root");
+
+    let output = harness.run(&["--json", "doctor"]);
+    assert_success(&output);
+    let checks = json_data(&output)["checks"]
+        .as_array()
+        .expect("doctor checks")
+        .clone();
+    assert_eq!(check_status(&checks, "health"), "ok");
+    assert_eq!(check_status(&checks, "capabilities"), "ok");
+    assert_eq!(check_status(&checks, "namespace"), "skipped");
+    assert_eq!(
+        fs::read_dir(&root).expect("read empty store root").count(),
+        0,
+        "read-only doctor must not create store objects"
+    );
+}
+
+#[test]
+fn doctor_renders_every_check_before_exiting_for_a_bad_config() {
+    let harness = Harness::new();
+
+    let output = harness.run(&["--json", "doctor"]);
+    assert_failure(&output);
+    assert!(output.stderr.is_empty(), "doctor results belong on stdout");
+    let checks = json_data(&output)["checks"]
+        .as_array()
+        .expect("doctor checks")
+        .clone();
+    assert_eq!(check_names(&checks), CHECK_NAMES);
+    assert_eq!(check_status(&checks, "config"), "ok");
+    assert_eq!(check_status(&checks, "config_decode"), "failed");
+    assert_eq!(check_status(&checks, "profile"), "skipped");
+}
+
+#[test]
+fn doctor_write_check_appends_the_existing_fourteen_check_probe() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+
+    let output = harness.run(&["--json", "doctor", "--write-check"]);
+    assert_success(&output);
+    let checks = json_data(&output)["checks"]
+        .as_array()
+        .expect("doctor checks")
+        .clone();
+    assert_eq!(checks.len(), 10);
+    assert_eq!(checks[9]["name"], "store_probe");
+    assert_eq!(
+        checks[9]["store_probe"]["checks"]
+            .as_array()
+            .expect("store probe checks")
+            .len(),
+        14
+    );
+}
+
+#[test]
+fn remote_doctor_checks_transport_auth_health_and_capabilities() {
+    let harness = Harness::new();
+    let document = CapabilityDocument {
+        protocol_version: PROTOCOL_VERSION.to_owned(),
+        profiles: vec!["core/v0".to_owned()],
+        features: BTreeMap::new(),
+        limits: BTreeMap::new(),
+    };
+    let (server_url, server) = json_response_server(vec![
+        serde_json::json!({}),
+        serde_json::to_value(document).expect("capabilities JSON"),
+        serde_json::json!({}),
+        serde_json::json!({
+            "namespace_id": "demo",
+            "head_seq": 0,
+            "wal_tail_segments": 0,
+            "retention_floor_seq": 0
+        }),
+    ]);
+    harness.write_remote_listing_config(&server_url);
+
+    let output = harness.run(&["--json", "doctor"]);
+    server.join().expect("JSON server");
+    assert_success(&output);
+    let checks = json_data(&output)["checks"]
+        .as_array()
+        .expect("doctor checks")
+        .clone();
+    for name in ["connectivity", "auth", "health", "capabilities"] {
+        assert_eq!(check_status(&checks, name), "ok", "{name}: {checks:?}");
+    }
+    assert_eq!(check_status(&checks, "namespace"), "ok");
+}
+
+fn check_names(checks: &[Value]) -> Vec<&str> {
+    checks
+        .iter()
+        .map(|check| check["name"].as_str().expect("check name"))
+        .collect()
+}
+
+fn check_status<'a>(checks: &'a [Value], name: &str) -> &'a str {
+    checks
+        .iter()
+        .find(|check| check["name"] == name)
+        .and_then(|check| check["status"].as_str())
+        .expect("named check status")
+}

--- a/crates/loonfs-cli/tests/it/inspection.rs
+++ b/crates/loonfs-cli/tests/it/inspection.rs
@@ -1,4 +1,4 @@
-//! Capability discovery and the stable doctor check contract.
+//! Integration tests for `capabilities` and `doctor`.
 
 use super::common::*;
 use loonfs_api::{CapabilityDocument, PROTOCOL_VERSION};
@@ -55,10 +55,7 @@ fn doctor_is_read_only_when_a_local_store_root_is_missing() {
 
     let output = harness.run(&["--json", "doctor"]);
     assert_success(&output);
-    assert!(
-        !root.exists(),
-        "read-only doctor must not create the store root"
-    );
+    assert!(!root.exists(), "doctor must not create the store root");
 
     let checks = json_data(&output)["checks"]
         .as_array()
@@ -89,7 +86,7 @@ fn doctor_opens_an_existing_embedded_store_without_writing_it() {
     assert_eq!(
         fs::read_dir(&root).expect("read empty store root").count(),
         0,
-        "read-only doctor must not create store objects"
+        "doctor must not create store objects"
     );
 }
 
@@ -99,7 +96,10 @@ fn doctor_renders_every_check_before_exiting_for_a_bad_config() {
 
     let output = harness.run(&["--json", "doctor"]);
     assert_failure(&output);
-    assert!(output.stderr.is_empty(), "doctor results belong on stdout");
+    assert!(
+        output.stderr.is_empty(),
+        "doctor should write results to stdout"
+    );
     let checks = json_data(&output)["checks"]
         .as_array()
         .expect("doctor checks")

--- a/crates/loonfs-cli/tests/it/main.rs
+++ b/crates/loonfs-cli/tests/it/main.rs
@@ -4,6 +4,7 @@ mod admin;
 mod common;
 mod completions;
 mod filesystem;
+mod inspection;
 mod output;
 mod profile;
 mod recursive;


### PR DESCRIPTION
This adds `loonfs capabilities`, which shows the protocol version, profiles, features, and limits supported by the selected deployment. Embedded profiles read the local capability document, while remote profiles fetch it from the server.

It also adds `loonfs doctor`. The command checks configuration, profile selection, provider setup, connectivity, authentication, health, capabilities, and the selected namespace. It prints every result, preserves remote request IDs, and exits nonzero if a check fails.

Doctor is read-only by default. `--write-check` also runs the object-store probe, which writes and removes temporary objects. `loonfs admin store probe` remains available for running that storage check directly.

Validated with `cargo fmt --all -- --check`, `cargo clippy -p loonfs-cli --all-targets -- -D warnings`, and the full `loonfs-cli` unit and integration suites.