### PR TITLE
pagination: standardize CLI flags and add lazy pagers

### DIFF
--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -166,14 +166,18 @@ Namespace management
   loonfs current
     Show the selected profile and namespace
 
+Pagination
+  ls, grep, revisions, trash, changes, and admin checkpoint list return one
+  page by default. --limit sets the maximum number of results, --page-size
+  controls each request, and --cursor resumes a previous result. --all keeps
+  fetching until no pages remain or the limit is reached. --jsonl does the
+  same while writing one result per line. changes uses --after instead of
+  --cursor.
+
 Reading
   loonfs ls [path] [--limit <n>] [--page-size <n>] [--cursor <cursor>]
                    [--all] [--jsonl]
-    List the entries of a directory, `/` when the path is omitted. Without
-    --limit, --all, or --jsonl, one server page is printed. --limit caps the
-    whole command, --page-size sizes each server request, --cursor resumes a
-    prior page, --all follows to exhaustion, and --jsonl follows while
-    streaming one entry per line
+    List the entries of a directory, or `/` when the path is omitted
 
   loonfs stat <path>
     Describe one path: kind, size, revision, content digest, and the
@@ -194,13 +198,10 @@ Reading
                         [--page-size <n>] [--cursor <cursor>] [--all] [--jsonl]
                         [--allow-scan] [--allow-stale]
     Search file content through the gram index with a pattern in the Rust
-    regex dialect, and print every match; -i ignores ASCII case,
-    --path-prefix narrows to a subtree, --limit caps total matches,
-    --page-size sizes each request, --cursor resumes, --all follows every
-    page, and --jsonl follows while streaming one match per line;
-    --allow-scan permits a capped scan for a pattern with no literal bytes,
-    and --allow-stale accepts indexed-only results when the unindexed tail
-    exceeds the scan budget
+    regex dialect. -i ignores ASCII case, --path-prefix limits the search to
+    a subtree, --allow-scan permits a bounded scan for patterns with no
+    literal bytes, and --allow-stale permits results that omit an unindexed
+    tail that is too large to scan
 
 Writing
   Every writing command accepts --actor-kind <user|service|system> together
@@ -250,9 +251,7 @@ Writing
 History and recovery
   loonfs revisions <path> [--limit <n>] [--page-size <n>] [--cursor <cursor>]
                           [--all] [--jsonl]
-    List a file's revision history newest first; one page by default,
-    --limit caps total revisions, --page-size sizes requests, --cursor
-    resumes, --all follows, and --jsonl streams revisions across pages
+    List a file's revision history, newest first
 
   loonfs restore <path> --revision <n>
                  [--actor-kind <kind> --actor-id <id>]
@@ -260,9 +259,8 @@ History and recovery
 
   loonfs trash [--limit <n>] [--page-size <n>] [--cursor <cursor>]
                [--all] [--jsonl]
-    List recoverable deletions: what was deleted, when, and the exact
-    `loonfs undelete` command that recovers each one; one page by default,
-    with the shared total, page-size, resume, follow, and JSONL flags
+    List recoverable deletions, including when each item was deleted and the
+    exact `loonfs undelete` command that restores it
 
   loonfs undelete [<path>] --inode <id> --deletion-seq <seq>
                   [--actor-kind <kind> --actor-id <id>]
@@ -275,10 +273,8 @@ History and recovery
 
   loonfs changes [--after <seq>] [--limit <n>] [--page-size <n>]
                  [--all] [--jsonl]
-    List committed changes after a sequence number, from the start of
-    retained history when --after is omitted; --after is the sequence resume
-    token, one page is the default, and the other pagination flags retain
-    their shared total, page-size, follow, and streaming meanings
+    List committed changes after a sequence number. When --after is omitted,
+    start at the beginning of retained history
 
 Inspection and diagnostics
   loonfs capabilities [--profile <name>]
@@ -332,11 +328,8 @@ Maintenance
 
   loonfs admin checkpoint list [--limit <n>] [--page-size <n>]
                                [--cursor <cursor>] [--all] [--jsonl]
-    List active checkpoints in ID order. By default, the command prints one
-    page. --limit caps the total results, --page-size controls the size of each
-    request, --cursor resumes a previous listing, --all follows every page,
-    and --jsonl streams checkpoints one per line. Expired checkpoints remain
-    visible until garbage collection removes them.
+    List active checkpoints in ID order. Expired checkpoints remain visible
+    until garbage collection removes them.
 
   loonfs admin checkpoint release <checkpoint-id>
     Release a checkpoint pin
@@ -353,9 +346,9 @@ Maintenance
     Disable the gram content index
 
   loonfs admin index gc [--max-objects <n>] [--cursor <token>]
-    Remove unreferenced gram-index objects. By default, the command runs
-    bounded passes until it finishes. --max-objects runs one pass with that
-    read limit, and --cursor resumes a previous pass.
+    Remove unreferenced gram-index objects. Without --max-objects, continue
+    until collection is complete. --max-objects limits one pass to that many
+    reads, and --cursor resumes a previous pass.
 
 Profile create options
   Used by:

--- a/crates/loonfs-cli/README.md
+++ b/crates/loonfs-cli/README.md
@@ -167,11 +167,13 @@ Namespace management
     Show the selected profile and namespace
 
 Reading
-  loonfs ls [path] [--limit <n> | --all] [--cursor <cursor>] [--jsonl]
+  loonfs ls [path] [--limit <n>] [--page-size <n>] [--cursor <cursor>]
+                   [--all] [--jsonl]
     List the entries of a directory, `/` when the path is omitted. Without
-    --limit or --all, one server page is printed. --limit stops
-    after that many entries in total and reports a next_cursor, which
-    --cursor resumes; --all streams pages except in JSON; --jsonl streams entries
+    --limit, --all, or --jsonl, one server page is printed. --limit caps the
+    whole command, --page-size sizes each server request, --cursor resumes a
+    prior page, --all follows to exhaustion, and --jsonl follows while
+    streaming one entry per line
 
   loonfs stat <path>
     Describe one path: kind, size, revision, content digest, and the
@@ -189,12 +191,13 @@ Reading
     an older revision of one file
 
   loonfs grep <pattern> [--path-prefix <path>] [-i] [--limit <n>]
-                        [--max-matches <n>] [--allow-scan] [--allow-stale]
+                        [--page-size <n>] [--cursor <cursor>] [--all] [--jsonl]
+                        [--allow-scan] [--allow-stale]
     Search file content through the gram index with a pattern in the Rust
     regex dialect, and print every match; -i ignores ASCII case,
-    --path-prefix narrows to a subtree, --limit sizes a page (bounded by the
-    deployment's query.grep.max_limit) while --max-matches caps the total
-    and reports that it stopped early,
+    --path-prefix narrows to a subtree, --limit caps total matches,
+    --page-size sizes each request, --cursor resumes, --all follows every
+    page, and --jsonl follows while streaming one match per line;
     --allow-scan permits a capped scan for a pattern with no literal bytes,
     and --allow-stale accepts indexed-only results when the unindexed tail
     exceeds the scan budget
@@ -245,16 +248,21 @@ Writing
     --force replaces an existing destination
 
 History and recovery
-  loonfs revisions <path> [--limit <n>] [--cursor <cursor>]
-    List a file's revision history newest first, one page at a time
+  loonfs revisions <path> [--limit <n>] [--page-size <n>] [--cursor <cursor>]
+                          [--all] [--jsonl]
+    List a file's revision history newest first; one page by default,
+    --limit caps total revisions, --page-size sizes requests, --cursor
+    resumes, --all follows, and --jsonl streams revisions across pages
 
   loonfs restore <path> --revision <n>
                  [--actor-kind <kind> --actor-id <id>]
     Write a prior revision's content as the file's next revision
 
-  loonfs trash [--limit <n>] [--cursor <cursor>]
+  loonfs trash [--limit <n>] [--page-size <n>] [--cursor <cursor>]
+               [--all] [--jsonl]
     List recoverable deletions: what was deleted, when, and the exact
-    `loonfs undelete` command that recovers each one
+    `loonfs undelete` command that recovers each one; one page by default,
+    with the shared total, page-size, resume, follow, and JSONL flags
 
   loonfs undelete [<path>] --inode <id> --deletion-seq <seq>
                   [--actor-kind <kind> --actor-id <id>]
@@ -265,9 +273,12 @@ History and recovery
     works if an enclosing directory was renamed. Pass <path> to restore it
     somewhere else, or when the deletion did not record a binding
 
-  loonfs changes [--after <seq>] [--limit <n>]
+  loonfs changes [--after <seq>] [--limit <n>] [--page-size <n>]
+                 [--all] [--jsonl]
     List committed changes after a sequence number, from the start of
-    retained history when --after is omitted
+    retained history when --after is omitted; --after is the sequence resume
+    token, one page is the default, and the other pagination flags retain
+    their shared total, page-size, follow, and streaming meanings
 
 Inspection and diagnostics
   loonfs capabilities [--profile <name>]
@@ -319,11 +330,13 @@ Maintenance
     Pin the namespace's current state. --ttl-ms sets an expiry; without it,
     the checkpoint remains until release.
 
-  loonfs admin checkpoint list [--limit <n>] [--cursor <cursor>]
-    List active checkpoints in ID order. By default the command follows all
-    pages. --limit or --cursor requests one page and prints next_cursor when
-    more results are available. Expired checkpoints remain visible until
-    garbage collection removes them.
+  loonfs admin checkpoint list [--limit <n>] [--page-size <n>]
+                               [--cursor <cursor>] [--all] [--jsonl]
+    List active checkpoints in ID order. By default, the command prints one
+    page. --limit caps the total results, --page-size controls the size of each
+    request, --cursor resumes a previous listing, --all follows every page,
+    and --jsonl streams checkpoints one per line. Expired checkpoints remain
+    visible until garbage collection removes them.
 
   loonfs admin checkpoint release <checkpoint-id>
     Release a checkpoint pin
@@ -339,9 +352,10 @@ Maintenance
   loonfs admin index disable
     Disable the gram content index
 
-  loonfs admin index gc [--max-objects <n>]
-    Remove unreferenced gram-index objects. By default the command follows
-    all bounded passes. --max-objects runs one pass with that read limit.
+  loonfs admin index gc [--max-objects <n>] [--cursor <token>]
+    Remove unreferenced gram-index objects. By default, the command runs
+    bounded passes until it finishes. --max-objects runs one pass with that
+    read limit, and --cursor resumes a previous pass.
 
 Profile create options
   Used by:

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -100,7 +100,7 @@ pub(crate) fn validate_cli(cli: &Cli) -> Result<(), clap::Error> {
     if cli.json && pagination.all && pagination.limit.is_none() {
         let mut error = Cli::command().error(
             clap::error::ErrorKind::ArgumentConflict,
-            "'--all --json' would buffer an unbounded array; use '--jsonl' or add '--limit'",
+            "'--all --json' requires '--limit'; use '--jsonl' to stream without a limit",
         );
         error.insert(
             clap::error::ContextKind::InvalidArg,
@@ -613,16 +613,16 @@ pub(crate) struct NamespaceForkArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct PaginationArgs {
-    /// Stop after this many items across all fetched pages.
+    /// Return at most this many items.
     #[arg(long)]
     pub limit: Option<u32>,
-    /// Request this many items per server page.
+    /// Request this many items per page.
     #[arg(long)]
     pub page_size: Option<u32>,
-    /// Follow pages to exhaustion.
+    /// Continue until the limit is reached or no pages remain.
     #[arg(long)]
     pub all: bool,
-    /// Stream one JSON item per line and follow pages to exhaustion.
+    /// Write one JSON item per line until the limit is reached or no pages remain.
     #[arg(long)]
     pub jsonl: bool,
 }
@@ -635,7 +635,7 @@ pub(crate) struct FilesystemLsArgs {
     pub path: Option<String>,
     #[command(flatten)]
     pub pagination: PaginationArgs,
-    /// Resume cursor from a previous listing.
+    /// Resume from a cursor returned by a previous listing.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
 }
@@ -780,7 +780,7 @@ pub(crate) struct FilesystemGrepArgs {
     pub ignore_case: bool,
     #[command(flatten)]
     pub pagination: PaginationArgs,
-    /// Resume cursor from a previous search page.
+    /// Resume from a cursor returned by a previous search.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
     /// Permit a capped exhaustive scan for patterns with no literal bytes.
@@ -1116,8 +1116,7 @@ pub(crate) struct AdminIndexGcArgs {
     /// Omit to loop bounded passes through completion.
     #[arg(long)]
     pub max_objects: Option<u64>,
-    /// Resume token from a previous pass's next_cursor; only valid for the
-    /// same namespace.
+    /// Resume from `next_cursor` returned by a previous pass.
     #[arg(long, value_name = "TOKEN", value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
 }
@@ -1147,7 +1146,7 @@ pub(crate) struct AdminCheckpointListArgs {
     pub target: TargetSelectorArgs,
     #[command(flatten)]
     pub pagination: PaginationArgs,
-    /// Resume cursor from a previous page.
+    /// Resume from a cursor returned by a previous listing.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
 }
@@ -1535,12 +1534,14 @@ mod tests {
         for arguments in cases {
             let cli = Cli::try_parse_from(*arguments).expect("arguments parse");
             let error = validate_cli(&cli).expect_err("unbounded JSON must fail");
-            assert!(error.to_string().contains("use '--jsonl' or add '--limit'"));
+            assert!(error
+                .to_string()
+                .contains("use '--jsonl' to stream without a limit"));
         }
     }
 
     #[test]
-    fn grep_drops_max_matches_and_changes_does_not_gain_an_opaque_cursor() {
+    fn max_matches_is_removed_and_changes_uses_after_to_resume() {
         assert!(Cli::try_parse_from(["loonfs", "grep", "x", "--max-matches", "1"]).is_err());
         assert!(Cli::try_parse_from(["loonfs", "changes", "--cursor", "opaque"]).is_err());
     }

--- a/crates/loonfs-cli/src/args.rs
+++ b/crates/loonfs-cli/src/args.rs
@@ -83,7 +83,10 @@ pub(crate) struct Cli {
 }
 
 pub(crate) fn validate_cli(cli: &Cli) -> Result<(), clap::Error> {
-    if cli.json && matches!(&cli.command, Command::Ls(args) if args.jsonl) {
+    let Some(pagination) = cli.command.pagination() else {
+        return Ok(());
+    };
+    if cli.json && pagination.jsonl {
         let mut error = Cli::command().error(
             clap::error::ErrorKind::ArgumentConflict,
             "the argument '--jsonl' cannot be used with '--json'",
@@ -91,6 +94,17 @@ pub(crate) fn validate_cli(cli: &Cli) -> Result<(), clap::Error> {
         error.insert(
             clap::error::ContextKind::InvalidArg,
             clap::error::ContextValue::String("--jsonl".to_owned()),
+        );
+        return Err(error);
+    }
+    if cli.json && pagination.all && pagination.limit.is_none() {
+        let mut error = Cli::command().error(
+            clap::error::ErrorKind::ArgumentConflict,
+            "'--all --json' would buffer an unbounded array; use '--jsonl' or add '--limit'",
+        );
+        error.insert(
+            clap::error::ContextKind::InvalidArg,
+            clap::error::ContextValue::String("--all".to_owned()),
         );
         return Err(error);
     }
@@ -168,6 +182,25 @@ pub(crate) enum Command {
     Completion(CompletionArgs),
     /// Print version and build metadata.
     Version,
+}
+
+impl Command {
+    fn pagination(&self) -> Option<&PaginationArgs> {
+        match self {
+            Self::Ls(args) => Some(&args.pagination),
+            Self::Grep(args) => Some(&args.pagination),
+            Self::Revisions(args) => Some(&args.pagination),
+            Self::Trash(args) => Some(&args.pagination),
+            Self::Changes(args) => Some(&args.pagination),
+            Self::Admin {
+                command:
+                    AdminCommand::Checkpoint {
+                        command: AdminCheckpointCommand::List(args),
+                    },
+            } => Some(&args.pagination),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Args)]
@@ -579,23 +612,32 @@ pub(crate) struct NamespaceForkArgs {
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct PaginationArgs {
+    /// Stop after this many items across all fetched pages.
+    #[arg(long)]
+    pub limit: Option<u32>,
+    /// Request this many items per server page.
+    #[arg(long)]
+    pub page_size: Option<u32>,
+    /// Follow pages to exhaustion.
+    #[arg(long)]
+    pub all: bool,
+    /// Stream one JSON item per line and follow pages to exhaustion.
+    #[arg(long)]
+    pub jsonl: bool,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct FilesystemLsArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
     #[arg(value_hint = ValueHint::Other)]
     pub path: Option<String>,
-    /// Stop after this many entries in total.
-    #[arg(long, conflicts_with = "all")]
-    pub limit: Option<u32>,
-    /// Resume cursor from a previous bounded listing.
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
+    /// Resume cursor from a previous listing.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
-    /// Follow every page and print entries as pages arrive.
-    #[arg(long)]
-    pub all: bool,
-    /// Print one JSON entry per line as pages arrive.
-    #[arg(long)]
-    pub jsonl: bool,
 }
 
 #[derive(Debug, Args)]
@@ -705,9 +747,8 @@ pub(crate) struct FilesystemRevisionsArgs {
     pub target: TargetSelectorArgs,
     #[arg(value_hint = ValueHint::Other)]
     pub path: String,
-    /// Maximum revisions to return in this page.
-    #[arg(long)]
-    pub limit: Option<u32>,
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
     /// Resume cursor from a previous revisions page.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
@@ -737,14 +778,11 @@ pub(crate) struct FilesystemGrepArgs {
     /// Match ASCII letters without regard to case.
     #[arg(short = 'i', long)]
     pub ignore_case: bool,
-    /// Matches fetched per page, bounded by the deployment's
-    /// `query.grep.max_limit`. To bound the total, use --max-matches.
-    #[arg(long)]
-    pub limit: Option<u32>,
-    /// Stop after this many matches in total. Without it the command
-    /// follows cursors to completion and prints every match.
-    #[arg(long)]
-    pub max_matches: Option<u32>,
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
+    /// Resume cursor from a previous search page.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub cursor: Option<String>,
     /// Permit a capped exhaustive scan for patterns with no literal bytes.
     #[arg(long)]
     pub allow_scan: bool,
@@ -907,9 +945,8 @@ pub(crate) struct FilesystemUndeleteArgs {
 pub(crate) struct TrashArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
-    /// Maximum number of entries to return.
-    #[arg(long)]
-    pub limit: Option<u32>,
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
     /// Resume cursor from a previous page.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
@@ -923,9 +960,8 @@ pub(crate) struct ChangesArgs {
     /// start of retained history).
     #[arg(long)]
     pub after: Option<u64>,
-    /// Maximum number of changes to return.
-    #[arg(long)]
-    pub limit: Option<u32>,
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1080,6 +1116,10 @@ pub(crate) struct AdminIndexGcArgs {
     /// Omit to loop bounded passes through completion.
     #[arg(long)]
     pub max_objects: Option<u64>,
+    /// Resume token from a previous pass's next_cursor; only valid for the
+    /// same namespace.
+    #[arg(long, value_name = "TOKEN", value_hint = ValueHint::Other)]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -1105,10 +1145,9 @@ pub(crate) struct AdminCheckpointArgs {
 pub(crate) struct AdminCheckpointListArgs {
     #[command(flatten)]
     pub target: TargetSelectorArgs,
-    /// Maximum checkpoints to return. Supplying this requests one page.
-    #[arg(long)]
-    pub limit: Option<u32>,
-    /// Resume cursor from a previous page. Supplying this requests one page.
+    #[command(flatten)]
+    pub pagination: PaginationArgs,
+    /// Resume cursor from a previous page.
     #[arg(long, value_hint = ValueHint::Other)]
     pub cursor: Option<String>,
 }
@@ -1392,6 +1431,152 @@ impl Cli {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_paginated_listing_accepts_the_shared_flags() {
+        let cases: &[&[&str]] = &[
+            &[
+                "loonfs",
+                "ls",
+                "--limit",
+                "5",
+                "--page-size",
+                "2",
+                "--all",
+                "--jsonl",
+                "--cursor",
+                "c",
+            ],
+            &[
+                "loonfs",
+                "revisions",
+                "/f",
+                "--limit",
+                "5",
+                "--page-size",
+                "2",
+                "--all",
+                "--jsonl",
+                "--cursor",
+                "c",
+            ],
+            &[
+                "loonfs",
+                "trash",
+                "--limit",
+                "5",
+                "--page-size",
+                "2",
+                "--all",
+                "--jsonl",
+                "--cursor",
+                "c",
+            ],
+            &[
+                "loonfs",
+                "changes",
+                "--limit",
+                "5",
+                "--page-size",
+                "2",
+                "--all",
+                "--jsonl",
+                "--after",
+                "1",
+            ],
+            &[
+                "loonfs",
+                "grep",
+                "x",
+                "--limit",
+                "5",
+                "--page-size",
+                "2",
+                "--all",
+                "--jsonl",
+                "--cursor",
+                "c",
+            ],
+            &[
+                "loonfs",
+                "admin",
+                "checkpoint",
+                "list",
+                "--limit",
+                "5",
+                "--page-size",
+                "2",
+                "--all",
+                "--jsonl",
+                "--cursor",
+                "c",
+            ],
+        ];
+        for arguments in cases {
+            let cli = Cli::try_parse_from(*arguments).expect("pagination arguments parse");
+            let pagination = cli.command.pagination().expect("paginated command");
+            assert_eq!(pagination.limit, Some(5));
+            assert_eq!(pagination.page_size, Some(2));
+            assert!(pagination.all);
+            assert!(pagination.jsonl);
+        }
+    }
+
+    #[test]
+    fn unbounded_all_json_is_rejected_for_every_paginated_listing() {
+        let cases: &[&[&str]] = &[
+            &["loonfs", "--json", "ls", "--all"],
+            &["loonfs", "--json", "revisions", "/f", "--all"],
+            &["loonfs", "--json", "trash", "--all"],
+            &["loonfs", "--json", "changes", "--all"],
+            &["loonfs", "--json", "grep", "x", "--all"],
+            &["loonfs", "--json", "admin", "checkpoint", "list", "--all"],
+        ];
+        for arguments in cases {
+            let cli = Cli::try_parse_from(*arguments).expect("arguments parse");
+            let error = validate_cli(&cli).expect_err("unbounded JSON must fail");
+            assert!(error.to_string().contains("use '--jsonl' or add '--limit'"));
+        }
+    }
+
+    #[test]
+    fn grep_drops_max_matches_and_changes_does_not_gain_an_opaque_cursor() {
+        assert!(Cli::try_parse_from(["loonfs", "grep", "x", "--max-matches", "1"]).is_err());
+        assert!(Cli::try_parse_from(["loonfs", "changes", "--cursor", "opaque"]).is_err());
+    }
+
+    #[test]
+    fn index_gc_accepts_the_same_cursor_flag_as_core_gc() {
+        let cli = Cli::try_parse_from([
+            "loonfs",
+            "admin",
+            "index",
+            "gc",
+            "--max-objects",
+            "7",
+            "--cursor",
+            "resume",
+        ])
+        .expect("index gc arguments");
+        assert!(matches!(
+            &cli.command,
+            Command::Admin {
+                command: AdminCommand::Index {
+                    command: AdminIndexCommand::Gc(_),
+                },
+            }
+        ));
+        if let Command::Admin {
+            command:
+                AdminCommand::Index {
+                    command: AdminIndexCommand::Gc(args),
+                },
+        } = &cli.command
+        {
+            assert_eq!(args.max_objects, Some(7));
+            assert_eq!(args.cursor.as_deref(), Some("resume"));
+        }
+    }
 
     #[test]
     fn command_kind_envelope_values_are_pinned() {

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -2,7 +2,7 @@
 
 use super::progress::rest_between_status_checks;
 use super::{FileDownload, GrepWaitProgress, MaintenanceDrainProgress, StepBudget};
-use crate::backend_error::BackendError;
+use crate::backend_error::{map_namespace_scoped_runtime_error, BackendError};
 use crate::payload::LocalPayload;
 use crate::progress::ProgressReporter;
 use crate::resolve::ResolvedTarget;
@@ -47,6 +47,30 @@ fn maintenance_host_needs_an_embedded_profile() -> BackendError {
          own maintenance; use `loonfs admin maintenance step` for one pass or `loonfs admin \
          index status` to inspect the index",
     )
+}
+
+/// One lazy directory pager across either CLI backend.
+pub(crate) enum PathEntriesPager {
+    Embedded {
+        pager: loonfs::PathEntriesPager,
+        namespace_id: NamespaceId,
+    },
+    Remote(loonfs_client::PathEntriesPager),
+}
+
+impl PathEntriesPager {
+    /// Returns the next original page envelope.
+    pub(crate) async fn next(&mut self) -> Option<Result<ListPathEntriesResponse, BackendError>> {
+        match self {
+            Self::Embedded {
+                pager,
+                namespace_id,
+            } => pager.next().await.map(|result| {
+                result.map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
+            }),
+            Self::Remote(pager) => pager.next().await.map(|result| result.map_err(Into::into)),
+        }
+    }
 }
 
 /// Implements CLI operations for embedded and remote targets.
@@ -148,17 +172,28 @@ impl ResolvedTarget {
         }
     }
 
-    /// Lists the entries of a directory.
-    pub(crate) async fn list_path_entries_all(
+    /// Creates a lazy directory pager.
+    pub(crate) fn list_path_entries_pager(
         &self,
         spec: &NamespacePath,
-    ) -> Result<ListPathEntriesResponse, BackendError> {
+        page_size: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<PathEntriesPager, BackendError> {
         match self {
-            Self::Embedded(target) => target.backend.list_path_entries_all(spec).await,
-            Self::Remote(target) => Ok(target
-                .client
-                .list_path_entries_all(spec, &ListPathEntriesOptions::default())
-                .await?),
+            Self::Embedded(target) => Ok(PathEntriesPager::Embedded {
+                pager: target
+                    .backend
+                    .list_path_entries_pager(spec, page_size, cursor)?,
+                namespace_id: spec.namespace().clone(),
+            }),
+            Self::Remote(target) => Ok(PathEntriesPager::Remote(
+                target.client.list_path_entries_pager(
+                    spec,
+                    page_size,
+                    cursor.map(ToOwned::to_owned),
+                    &ListPathEntriesOptions::default(),
+                ),
+            )),
         }
     }
 

--- a/crates/loonfs-cli/src/backend/dispatch.rs
+++ b/crates/loonfs-cli/src/backend/dispatch.rs
@@ -49,7 +49,7 @@ fn maintenance_host_needs_an_embedded_profile() -> BackendError {
     )
 }
 
-/// One lazy directory pager across either CLI backend.
+/// Directory pager for embedded and remote profiles.
 pub(crate) enum PathEntriesPager {
     Embedded {
         pager: loonfs::PathEntriesPager,
@@ -59,7 +59,7 @@ pub(crate) enum PathEntriesPager {
 }
 
 impl PathEntriesPager {
-    /// Returns the next original page envelope.
+    /// Returns the next page with its metadata.
     pub(crate) async fn next(&mut self) -> Option<Result<ListPathEntriesResponse, BackendError>> {
         match self {
             Self::Embedded {
@@ -172,7 +172,7 @@ impl ResolvedTarget {
         }
     }
 
-    /// Creates a lazy directory pager.
+    /// Creates a directory pager that fetches pages as needed.
     pub(crate) fn list_path_entries_pager(
         &self,
         spec: &NamespacePath,

--- a/crates/loonfs-cli/src/backend/embedded.rs
+++ b/crates/loonfs-cli/src/backend/embedded.rs
@@ -186,14 +186,19 @@ impl EmbeddedBackend {
             .map_err(|error| map_namespace_scoped_runtime_error(namespace_id, error))
     }
 
-    pub(super) async fn list_path_entries_all(
+    pub(super) fn list_path_entries_pager(
         &self,
         spec: &NamespacePath,
-    ) -> Result<ListPathEntriesResponse, BackendError> {
-        self.reader
-            .list_path_entries_all(spec.namespace(), spec.absolute_path().as_str())
-            .await
-            .map_err(|error| map_namespace_scoped_runtime_error(spec.namespace(), error))
+        page_size: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<loonfs::PathEntriesPager, BackendError> {
+        let request = cli_page_request(page_size, cursor)?;
+        Ok(self.reader.list_path_entries_pager(
+            spec.namespace(),
+            spec.absolute_path().as_str(),
+            request,
+            ListPathEntriesOptions::default(),
+        ))
     }
 
     pub(super) async fn list_path_entries_page(

--- a/crates/loonfs-cli/src/commands/admin.rs
+++ b/crates/loonfs-cli/src/commands/admin.rs
@@ -3,6 +3,7 @@
 
 use super::context::{fail, fail_for, parse_public_ordinal_arg, resolve_command_context};
 use super::output::{CommandData, CommandFailure, CommandOutput, MaintenanceKeyReport};
+use super::pagination::{write_jsonl_page, PagePlan};
 use crate::args::{
     AdminCheckpointArgs, AdminCheckpointCommand, AdminCheckpointListArgs,
     AdminCheckpointReleaseArgs, AdminCommand, AdminGcArgs, AdminIndexCommand, AdminIndexEnableArgs,
@@ -22,6 +23,7 @@ use loonfs_api::{
 };
 use loonfs_grep::{GREP_GC_JOB, GREP_INDEX_JOB};
 use std::collections::BTreeSet;
+use std::io::{self, BufWriter};
 use std::path::Path;
 
 // --- maintenance/admin plane ---
@@ -284,23 +286,42 @@ async fn run_admin_checkpoint_list(
     args: AdminCheckpointListArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, config_path, &args.target).await?;
-    let single_page = args.limit.is_some() || args.cursor.is_some();
-    let mut response = context
-        .target
-        .list_checkpoints_page(&context.namespace, args.limit, args.cursor.as_deref())
-        .await
-        .map_err(|error| context.fail(kind, error))?;
-    if !single_page {
-        while let Some(cursor) = response.next_cursor.take() {
-            let page = context
-                .target
-                .list_checkpoints_page(&context.namespace, None, Some(&cursor))
-                .await
+    let mut plan = PagePlan::new(&args.pagination);
+    let mut cursor = args.cursor.clone();
+    let mut response: Option<loonfs_api::ListCheckpointsResponse> = None;
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
+    loop {
+        let page = context
+            .target
+            .list_checkpoints_page(&context.namespace, plan.request_size(), cursor.as_deref())
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        plan.record(page.checkpoints.len());
+        cursor = page.next_cursor.clone();
+        if args.pagination.jsonl {
+            write_jsonl_page(&mut stdout, &page.checkpoints)
+                .map_err(crate::error::CliError::io)
                 .map_err(|error| context.fail(kind, error))?;
+        } else if let Some(response) = response.as_mut() {
             response.checkpoints.extend(page.checkpoints);
             response.next_cursor = page.next_cursor;
+        } else {
+            response = Some(page);
+        }
+        if !plan.should_continue(cursor.is_some()) {
+            break;
         }
     }
+    if args.pagination.jsonl {
+        return Ok(CommandOutput {
+            kind,
+            profile: Some(context.profile_name),
+            mode: Some(context.mode),
+            data: CommandData::StreamedToStdout,
+        });
+    }
+    let response = response.expect("checkpoint loop should fetch at least one page");
 
     Ok(CommandOutput {
         kind,
@@ -547,11 +568,44 @@ pub(crate) async fn run_admin_changes(
     let context = resolve_command_context(kind, config_path, &args.target).await?;
     let after_seq = parse_public_ordinal_arg("--after", args.after.unwrap_or(0), ChangeSeq::parse)
         .map_err(|error| context.fail(kind, error))?;
-    let response = context
-        .target
-        .list_changes(&context.namespace, after_seq, args.limit)
-        .await
-        .map_err(|error| context.fail(kind, error))?;
+    let mut plan = PagePlan::new(&args.pagination);
+    let mut cursor = after_seq;
+    let mut response: Option<loonfs_api::v0::ChangesResponse> = None;
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
+    loop {
+        let page = context
+            .target
+            .list_changes(&context.namespace, cursor, plan.request_size())
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        plan.record(page.changes.len());
+        let next_after_seq = page.next_after_seq;
+        if args.pagination.jsonl {
+            write_jsonl_page(&mut stdout, &page.changes)
+                .map_err(crate::error::CliError::io)
+                .map_err(|error| context.fail(kind, error))?;
+        } else if let Some(response) = response.as_mut() {
+            response.through_seq = page.through_seq;
+            response.next_after_seq = page.next_after_seq;
+            response.changes.extend(page.changes);
+        } else {
+            response = Some(page);
+        }
+        if !plan.should_continue(next_after_seq.is_some()) {
+            break;
+        }
+        cursor = next_after_seq.expect("continuation was checked above");
+    }
+    if args.pagination.jsonl {
+        return Ok(CommandOutput {
+            kind,
+            profile: Some(context.profile_name),
+            mode: Some(context.mode),
+            data: CommandData::StreamedToStdout,
+        });
+    }
+    let response = response.expect("changes loop should fetch at least one page");
 
     Ok(CommandOutput {
         kind,
@@ -672,7 +726,7 @@ async fn run_admin_index_gc(
     // is what keeps a remote pass and an embedded one the same size.
     let mut request = GrepGcRequest {
         max_objects: args.max_objects,
-        cursor: None,
+        cursor: args.cursor,
     };
     let mut progress = PassProgress::new(runtime);
     let mut response: Option<loonfs_api::v0::GrepGcResponse> = None;
@@ -692,7 +746,7 @@ async fn run_admin_index_gc(
             Some(total) => accumulate_grep_gc_response(total, pass),
             None => response = Some(pass),
         }
-        if single_pass || next_cursor.is_none() {
+        if single_pass || next_cursor.is_none() || next_cursor == request.cursor {
             break;
         }
         request.cursor = next_cursor;

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -147,8 +147,8 @@ pub(crate) async fn run_filesystem_ls(
             },
         )
         .await?;
-        // The drift note is operational and goes to standard error in every
-        // streaming mode.
+        // Write head-drift warnings to stderr so streamed stdout contains
+        // only entries.
         if let Some(drift) = followed.head_drift {
             crate::render::write_listing_drift_warning(&drift);
         }

--- a/crates/loonfs-cli/src/commands/fs.rs
+++ b/crates/loonfs-cli/src/commands/fs.rs
@@ -10,13 +10,14 @@ use super::output::{
     CommandData, CommandFailure, CommandOutput, ListingHeadDrift, ListingHeadObservation,
     TrashListing,
 };
+use super::pagination::{write_jsonl_page, PagePlan};
 use super::partial::{self, PartialDownload, PartialMeta};
 use super::recursive;
 use crate::args::{
     CommandKind, FilesystemAnnotateArgs, FilesystemCatArgs, FilesystemGetArgs, FilesystemGrepArgs,
     FilesystemLsArgs, FilesystemMkdirArgs, FilesystemPutArgs, FilesystemRestoreArgs,
     FilesystemRevisionsArgs, FilesystemRmArgs, FilesystemStatArgs, FilesystemTransferArgs,
-    FilesystemUndeleteArgs, RuntimeBehavior, TrashArgs,
+    FilesystemUndeleteArgs, PaginationArgs, RuntimeBehavior, TrashArgs,
 };
 use crate::backend::FileDownload;
 use crate::config::ConfigLocation;
@@ -77,23 +78,17 @@ async fn follow_path_entry_pages(
     context: &CommandContext,
     kind: CommandKind,
     spec: &NamespacePath,
-    limit: Option<u32>,
+    pagination: &PaginationArgs,
     cursor: Option<&str>,
-    follow: bool,
     mut visit: impl FnMut(Vec<loonfs_api::AuthoritativePathEntry>) -> Result<(), CliError>,
 ) -> Result<FollowedPathEntryPages, CommandFailure> {
-    let mut visited = 0_u32;
+    let mut plan = PagePlan::new(pagination);
     let mut cursor = cursor.map(ToOwned::to_owned);
     let mut heads = ListingHeadObservation::default();
     loop {
-        let page_limit = limit.map(|limit| {
-            limit
-                .saturating_sub(visited)
-                .min(loonfs_api::DEFAULT_PAGE_LIMIT)
-        });
         let page = context
             .target
-            .list_path_entries_page(spec, page_limit, cursor.as_deref())
+            .list_path_entries_page(spec, plan.request_size(), cursor.as_deref())
             .await
             .map_err(|error| context.fail(kind, error))?;
         let ListPathEntriesResponse {
@@ -104,12 +99,11 @@ async fn follow_path_entry_pages(
             next_cursor,
         } = page;
         heads.observe(head_seq);
-        visited = visited.saturating_add(entries.len() as u32);
+        plan.record(entries.len());
         visit(entries).map_err(|error| context.fail(kind, error))?;
         cursor = next_cursor;
 
-        let filled = limit.is_some_and(|limit| visited >= limit);
-        if filled || !follow || cursor.is_none() {
+        if !plan.should_continue(cursor.is_some()) {
             return Ok(FollowedPathEntryPages {
                 namespace_id,
                 path: absolute_path,
@@ -137,8 +131,7 @@ pub(crate) async fn run_filesystem_ls(
         allow_root,
     )
     .map_err(|error| context.fail(kind, error))?;
-    let follow = args.all || args.limit.is_some();
-    let streams_pages = args.jsonl || (args.all && !runtime.json);
+    let streams_pages = args.pagination.jsonl || (args.pagination.all && !runtime.json);
     if streams_pages {
         let stdout = io::stdout();
         let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
@@ -146,23 +139,16 @@ pub(crate) async fn run_filesystem_ls(
             &context,
             kind,
             &spec,
-            args.limit,
+            &args.pagination,
             args.cursor.as_deref(),
-            follow,
             |entries| {
-                write_path_entries_page(&mut stdout, &entries, args.jsonl).map_err(CliError::io)
+                write_path_entries_page(&mut stdout, &entries, args.pagination.jsonl)
+                    .map_err(CliError::io)
             },
         )
         .await?;
-        if let Some(cursor) = followed.next_cursor {
-            // Standard output stays machine-pure in `--jsonl`, so the
-            // continuation signal goes to standard error, where this CLI
-            // already reports progress. Without it a one-page stream would
-            // truncate silently.
-            crate::render::write_stderr_progress(crate::render::more_entries_hint(&cursor));
-        }
-        // Like the continuation signal above, the drift note is operational
-        // and goes to standard error in every streaming mode.
+        // The drift note is operational and goes to standard error in every
+        // streaming mode.
         if let Some(drift) = followed.head_drift {
             crate::render::write_listing_drift_warning(&drift);
         }
@@ -179,9 +165,8 @@ pub(crate) async fn run_filesystem_ls(
         &context,
         kind,
         &spec,
-        args.limit,
+        &args.pagination,
         args.cursor.as_deref(),
-        follow,
         |page| {
             entries.extend(page);
             Ok(())
@@ -368,20 +353,18 @@ pub(crate) async fn run_filesystem_grep(
         pattern: args.pattern.clone(),
         case_insensitive: args.ignore_case,
         path_prefix,
-        cursor: None,
-        limit: args.limit,
+        cursor: args.cursor.clone(),
+        limit: None,
         allow_stale: args.allow_stale,
         allow_scan: args.allow_scan,
     };
     let mut matches = Vec::new();
     let mut tail_scanned = true;
-    let mut truncated = false;
-    // `--limit` sizes a page and is bounded by the deployment's
-    // `query.grep.max_limit`; `--max-matches` bounds the whole command. They
-    // are separate because a total cap larger than that per-page maximum
-    // would be rejected if it were sent as one.
-    let max_matches = args.max_matches.map(|max| max as usize);
-    let (namespace_id, head_seq, built_through_seq) = loop {
+    let mut plan = PagePlan::new(&args.pagination);
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
+    let (namespace_id, head_seq, built_through_seq, next_cursor) = loop {
+        request.limit = plan.request_size();
         let response = context
             .target
             .grep(&context.namespace, &request)
@@ -392,23 +375,29 @@ pub(crate) async fn run_filesystem_grep(
             response.head_seq,
             response.built_through_seq,
         );
-        matches.extend(response.matches);
+        plan.record(response.matches.len());
+        if args.pagination.jsonl {
+            write_jsonl_page(&mut stdout, &response.matches)
+                .map_err(CliError::io)
+                .map_err(|error| context.fail(kind, error))?;
+        } else {
+            matches.extend(response.matches);
+        }
         tail_scanned &= response.tail_scanned;
-        if let Some(max_matches) = max_matches {
-            if matches.len() >= max_matches {
-                // A page can overshoot the cap; the extra matches are real
-                // but were not asked for.
-                truncated = matches.len() > max_matches || response.next_cursor.is_some();
-                matches.truncate(max_matches);
-                break snapshot;
-            }
+        let next_cursor = response.next_cursor;
+        if !plan.should_continue(next_cursor.is_some()) {
+            break (snapshot.0, snapshot.1, snapshot.2, next_cursor);
         }
-        match response.next_cursor {
-            Some(cursor) => request.cursor = Some(cursor),
-            // The final page's snapshot describes the completed query.
-            None => break snapshot,
-        }
+        request.cursor.clone_from(&next_cursor);
     };
+    if args.pagination.jsonl {
+        return Ok(CommandOutput {
+            kind,
+            profile: Some(context.profile_name),
+            mode: Some(context.mode),
+            data: CommandData::StreamedToStdout,
+        });
+    }
     Ok(CommandOutput {
         kind,
         profile: Some(context.profile_name),
@@ -420,7 +409,8 @@ pub(crate) async fn run_filesystem_grep(
             built_through_seq,
             matches,
             tail_scanned,
-            truncated,
+            truncated: next_cursor.is_some(),
+            next_cursor,
         },
     })
 }
@@ -753,11 +743,43 @@ pub(crate) async fn run_filesystem_trash(
     args: TrashArgs,
 ) -> Result<CommandOutput, CommandFailure> {
     let context = resolve_command_context(kind, &location.path, &args.target).await?;
-    let response = context
-        .target
-        .list_trash(&context.namespace, args.limit, args.cursor.as_deref())
-        .await
-        .map_err(|error| context.fail(kind, error))?;
+    let mut plan = PagePlan::new(&args.pagination);
+    let mut cursor = args.cursor.clone();
+    let mut response: Option<loonfs_api::ListTrashResponse> = None;
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
+    loop {
+        let page = context
+            .target
+            .list_trash(&context.namespace, plan.request_size(), cursor.as_deref())
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        plan.record(page.entries.len());
+        cursor = page.next_cursor.clone();
+        if args.pagination.jsonl {
+            write_jsonl_page(&mut stdout, &page.entries)
+                .map_err(CliError::io)
+                .map_err(|error| context.fail(kind, error))?;
+        } else if let Some(response) = response.as_mut() {
+            response.head_seq = page.head_seq;
+            response.entries.extend(page.entries);
+            response.next_cursor = page.next_cursor;
+        } else {
+            response = Some(page);
+        }
+        if !plan.should_continue(cursor.is_some()) {
+            break;
+        }
+    }
+    if args.pagination.jsonl {
+        return Ok(CommandOutput {
+            kind,
+            profile: Some(context.profile_name),
+            mode: Some(context.mode),
+            data: CommandData::StreamedToStdout,
+        });
+    }
+    let response = response.expect("trash loop should fetch at least one page");
     let hint = UndeleteHint::new(&context, location, args.target.profile.profile.is_some());
     // An entry that recorded its binding restores in place with no
     // destination in the command; only a legacy entry that recorded none
@@ -793,11 +815,38 @@ pub(crate) async fn run_filesystem_revisions(
     let allow_root = false;
     let spec = namespace_path(&context.namespace, &args.path, allow_root)
         .map_err(|error| context.fail(kind, error))?;
-    let response = context
-        .target
-        .list_file_revisions_page(&spec, args.limit, args.cursor.as_deref())
-        .await
-        .map_err(|error| context.fail(kind, error))?;
+    let mut plan = PagePlan::new(&args.pagination);
+    let mut cursor = args.cursor.clone();
+    let mut revisions = Vec::new();
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::with_capacity(64 * 1024, stdout.lock());
+    loop {
+        let page = context
+            .target
+            .list_file_revisions_page(&spec, plan.request_size(), cursor.as_deref())
+            .await
+            .map_err(|error| context.fail(kind, error))?;
+        plan.record(page.revisions.len());
+        cursor = page.next_cursor;
+        if args.pagination.jsonl {
+            write_jsonl_page(&mut stdout, &page.revisions)
+                .map_err(CliError::io)
+                .map_err(|error| context.fail(kind, error))?;
+        } else {
+            revisions.extend(page.revisions);
+        }
+        if !plan.should_continue(cursor.is_some()) {
+            break;
+        }
+    }
+    if args.pagination.jsonl {
+        return Ok(CommandOutput {
+            kind,
+            profile: Some(context.profile_name),
+            mode: Some(context.mode),
+            data: CommandData::StreamedToStdout,
+        });
+    }
 
     Ok(CommandOutput {
         kind,
@@ -805,8 +854,8 @@ pub(crate) async fn run_filesystem_revisions(
         mode: Some(context.mode),
         data: CommandData::FileRevisions {
             target: render_target(&context.namespace, spec.absolute_path()),
-            revisions: response.revisions,
-            next_cursor: response.next_cursor,
+            revisions,
+            next_cursor: cursor,
         },
     })
 }

--- a/crates/loonfs-cli/src/commands/mod.rs
+++ b/crates/loonfs-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod fs;
 mod inspection;
 mod namespace;
 mod output;
+mod pagination;
 mod partial;
 mod profile;
 mod profile_config;

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -235,9 +235,9 @@ pub(crate) enum CommandData {
         built_through_seq: ChangeSeq,
         matches: Vec<GrepMatch>,
         tail_scanned: bool,
-        /// True when a bounded invocation stopped with matches left to find.
+        /// Whether more matches were available when the command stopped.
         truncated: bool,
-        /// Where a bounded search stopped, and how to resume it.
+        /// Cursor for the next search page.
         #[serde(skip_serializing_if = "Option::is_none")]
         next_cursor: Option<String>,
     },

--- a/crates/loonfs-cli/src/commands/output.rs
+++ b/crates/loonfs-cli/src/commands/output.rs
@@ -235,9 +235,11 @@ pub(crate) enum CommandData {
         built_through_seq: ChangeSeq,
         matches: Vec<GrepMatch>,
         tail_scanned: bool,
-        /// True when `--max-matches` stopped the search with matches left
-        /// to find.
+        /// True when a bounded invocation stopped with matches left to find.
         truncated: bool,
+        /// Where a bounded search stopped, and how to resume it.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        next_cursor: Option<String>,
     },
     FileRevisions {
         target: String,

--- a/crates/loonfs-cli/src/commands/pagination.rs
+++ b/crates/loonfs-cli/src/commands/pagination.rs
@@ -1,9 +1,9 @@
-//! Shared command-level pagination decisions.
+//! Pagination shared by CLI listing commands.
 
 use crate::args::PaginationArgs;
 use std::io::{self, Write};
 
-/// Tracks a command-wide item cap independently from transport page size.
+/// Tracks the total result limit and the size of each request.
 pub(super) struct PagePlan {
     limit: Option<u32>,
     page_size: Option<u32>,
@@ -11,8 +11,7 @@ pub(super) struct PagePlan {
     emitted: u32,
 }
 
-/// Writes serializable page items one per line and flushes before another
-/// page is fetched.
+/// Writes one JSON item per line and flushes the page before the next request.
 pub(super) fn write_jsonl_page<T: serde::Serialize>(
     stdout: &mut impl Write,
     items: &[T],
@@ -34,8 +33,9 @@ impl PagePlan {
         }
     }
 
-    /// Page size for the next request. A command-wide limit is split into
-    /// ordinary server pages and never sent as one oversized page request.
+    /// Returns the number of items to request on the next page.
+    ///
+    /// A total limit larger than one page is split across several requests.
     pub(super) fn request_size(&self) -> Option<u32> {
         self.limit.map_or(self.page_size, |limit| {
             let remaining = limit.saturating_sub(self.emitted);

--- a/crates/loonfs-cli/src/commands/pagination.rs
+++ b/crates/loonfs-cli/src/commands/pagination.rs
@@ -1,0 +1,111 @@
+//! Shared command-level pagination decisions.
+
+use crate::args::PaginationArgs;
+use std::io::{self, Write};
+
+/// Tracks a command-wide item cap independently from transport page size.
+pub(super) struct PagePlan {
+    limit: Option<u32>,
+    page_size: Option<u32>,
+    follow_to_end: bool,
+    emitted: u32,
+}
+
+/// Writes serializable page items one per line and flushes before another
+/// page is fetched.
+pub(super) fn write_jsonl_page<T: serde::Serialize>(
+    stdout: &mut impl Write,
+    items: &[T],
+) -> io::Result<()> {
+    for item in items {
+        serde_json::to_writer(&mut *stdout, item).map_err(io::Error::other)?;
+        stdout.write_all(b"\n")?;
+    }
+    stdout.flush()
+}
+
+impl PagePlan {
+    pub(super) fn new(args: &PaginationArgs) -> Self {
+        Self {
+            limit: args.limit,
+            page_size: args.page_size,
+            follow_to_end: args.all || args.jsonl,
+            emitted: 0,
+        }
+    }
+
+    /// Page size for the next request. A command-wide limit is split into
+    /// ordinary server pages and never sent as one oversized page request.
+    pub(super) fn request_size(&self) -> Option<u32> {
+        self.limit.map_or(self.page_size, |limit| {
+            let remaining = limit.saturating_sub(self.emitted);
+            Some(
+                self.page_size
+                    .unwrap_or(loonfs_api::DEFAULT_PAGE_LIMIT)
+                    .min(remaining),
+            )
+        })
+    }
+
+    pub(super) fn record(&mut self, items: usize) {
+        self.emitted = self
+            .emitted
+            .saturating_add(u32::try_from(items).unwrap_or(u32::MAX));
+    }
+
+    pub(super) fn should_continue(&self, has_next: bool) -> bool {
+        has_next
+            && self
+                .limit
+                .map_or(self.follow_to_end, |limit| self.emitted < limit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(limit: Option<u32>, page_size: Option<u32>, all: bool) -> PaginationArgs {
+        PaginationArgs {
+            limit,
+            page_size,
+            all,
+            jsonl: false,
+        }
+    }
+
+    #[test]
+    fn a_total_smaller_than_a_page_is_the_first_request_size() {
+        let plan = PagePlan::new(&args(Some(3), Some(10), false));
+        assert_eq!(plan.request_size(), Some(3));
+    }
+
+    #[test]
+    fn a_total_larger_than_a_page_follows_until_the_remaining_final_page() {
+        let mut plan = PagePlan::new(&args(Some(7), Some(3), false));
+        assert_eq!(plan.request_size(), Some(3));
+        plan.record(3);
+        assert!(plan.should_continue(true));
+        assert_eq!(plan.request_size(), Some(3));
+        plan.record(3);
+        assert_eq!(plan.request_size(), Some(1));
+        plan.record(1);
+        assert!(!plan.should_continue(true));
+    }
+
+    #[test]
+    fn one_page_is_the_default_but_all_follows() {
+        let mut one_page = PagePlan::new(&args(None, Some(2), false));
+        one_page.record(2);
+        assert!(!one_page.should_continue(true));
+
+        let mut all = PagePlan::new(&args(None, Some(2), true));
+        all.record(2);
+        assert!(all.should_continue(true));
+        assert!(!all.should_continue(false));
+
+        let mut bounded_all = PagePlan::new(&args(Some(2), Some(2), true));
+        bounded_all.record(2);
+        assert!(!bounded_all.should_continue(true));
+    }
+}

--- a/crates/loonfs-cli/src/commands/recursive.rs
+++ b/crates/loonfs-cli/src/commands/recursive.rs
@@ -626,42 +626,40 @@ async fn walk_remote_tree(
         };
         let spec = NamespacePath::parse(context.namespace.as_str(), listed)
             .map_err(|error| context.fail(kind, CliError::invalid_input(error.to_string())))?;
-        let response = context
+        let mut pager = context
             .target
-            .list_path_entries_all(&spec)
-            .await
+            .list_path_entries_pager(&spec, None, None)
             .map_err(|error| context.fail(kind, error))?;
-        let response_head_seq = response.head_seq;
-        for entry in response.entries {
-            // Aggregated entries retain the head of the page that supplied
-            // them, in page order; the envelope carries the final page head.
-            heads.observe(entry.head_seq);
-            let Some(name) = entry.display_name.as_ref() else {
-                continue;
-            };
-            let mut child_components = components.clone();
-            child_components.push(name.as_str().to_owned());
-            match entry.kind {
-                AuthoritativePathEntryKind::Directory {} => {
-                    tree.directories.push(child_components.clone());
-                    queue.push_back((
-                        format!("{remote_dir}/{name}", name = name.as_str()),
-                        child_components,
-                    ));
+        while let Some(response) = pager.next().await {
+            let response = response.map_err(|error| context.fail(kind, error))?;
+            heads.observe(response.head_seq);
+            for entry in response.entries {
+                let Some(name) = entry.display_name.as_ref() else {
+                    continue;
+                };
+                let mut child_components = components.clone();
+                child_components.push(name.as_str().to_owned());
+                match entry.kind {
+                    AuthoritativePathEntryKind::Directory {} => {
+                        tree.directories.push(child_components.clone());
+                        queue.push_back((
+                            format!("{remote_dir}/{name}", name = name.as_str()),
+                            child_components,
+                        ));
+                    }
+                    AuthoritativePathEntryKind::File {
+                        size_bytes,
+                        content_ref,
+                        ..
+                    } => tree.files.push(FileJob {
+                        local: PathBuf::from(child_components.join("/")),
+                        remote: format!("{remote_dir}/{name}", name = name.as_str()),
+                        size_bytes: Some(size_bytes),
+                        content_ref: Some(content_ref),
+                    }),
                 }
-                AuthoritativePathEntryKind::File {
-                    size_bytes,
-                    content_ref,
-                    ..
-                } => tree.files.push(FileJob {
-                    local: PathBuf::from(child_components.join("/")),
-                    remote: format!("{remote_dir}/{name}", name = name.as_str()),
-                    size_bytes: Some(size_bytes),
-                    content_ref: Some(content_ref),
-                }),
             }
         }
-        heads.observe(response_head_seq);
     }
     tree.head_drift = heads.drift();
     Ok(tree)

--- a/crates/loonfs-cli/src/render/human.rs
+++ b/crates/loonfs-cli/src/render/human.rs
@@ -321,6 +321,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
             matches,
             tail_scanned,
             truncated,
+            next_cursor,
             ..
         } => {
             let mut lines: Vec<String> = matches
@@ -329,7 +330,7 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                 .collect();
             if *truncated {
                 lines.push(format!(
-                    "{} matches for `{pattern}` (stopped at --max-matches; there are more)",
+                    "{} matches for `{pattern}` (stopped at --limit; there are more)",
                     matches.len()
                 ));
             } else {
@@ -340,6 +341,9 @@ pub(crate) fn human_success(output: &CommandOutput) -> String {
                     "warning: recent commits were not scanned (allow_stale); results may be stale"
                         .to_owned(),
                 );
+            }
+            if let Some(cursor) = next_cursor {
+                lines.push(format!("next_cursor: {cursor}"));
             }
             lines.join("\n")
         }

--- a/crates/loonfs-cli/tests/it/admin.rs
+++ b/crates/loonfs-cli/tests/it/admin.rs
@@ -84,11 +84,8 @@ fn embedded_grep_works_after_index_enable() {
     );
 }
 
-/// `--max-matches` caps the whole search, which `--limit` cannot: `--limit`
-/// sizes one page and the deployment rejects a page larger than its own
-/// maximum.
 #[test]
-fn grep_max_matches_caps_the_search_while_limit_sizes_a_page() {
+fn grep_limit_caps_the_whole_search_while_page_size_sizes_requests() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
     assert_success(&harness.run(&["namespace", "create", "code"]));
@@ -105,7 +102,7 @@ fn grep_max_matches_caps_the_search_while_limit_sizes_a_page() {
     assert_eq!(all_data["matches"].as_array().expect("json array").len(), 4);
     assert_eq!(all_data["truncated"], false);
 
-    let capped = harness.run(&["--json", "grep", "TODO", "--max-matches", "2"]);
+    let capped = harness.run(&["--json", "grep", "TODO", "--limit", "2"]);
     assert_success(&capped);
     let capped_data = json_data(&capped);
     assert_eq!(
@@ -115,7 +112,7 @@ fn grep_max_matches_caps_the_search_while_limit_sizes_a_page() {
     assert_eq!(capped_data["truncated"], true);
 
     // A cap the search never reaches is not a truncation.
-    let roomy = harness.run(&["--json", "grep", "TODO", "--max-matches", "99"]);
+    let roomy = harness.run(&["--json", "grep", "TODO", "--limit", "99"]);
     assert_success(&roomy);
     assert_eq!(
         json_data(&roomy)["matches"]
@@ -126,43 +123,92 @@ fn grep_max_matches_caps_the_search_while_limit_sizes_a_page() {
     );
     assert_eq!(json_data(&roomy)["truncated"], false);
 
-    // A small page still returns every match, because it bounds a page and
-    // the command follows the cursor.
-    let paged = harness.run(&["--json", "grep", "TODO", "--limit", "1"]);
+    // A total larger than the page size follows enough pages to satisfy it.
+    let paged = harness.run(&["--json", "grep", "TODO", "--limit", "3", "--page-size", "1"]);
     assert_success(&paged);
     assert_eq!(
         json_data(&paged)["matches"]
             .as_array()
             .expect("json array")
             .len(),
-        4
+        3
     );
-    assert_eq!(json_data(&paged)["truncated"], false);
+    assert_eq!(json_data(&paged)["truncated"], true);
 
-    // The two compose: pages of one, stopped after three.
-    let both = harness.run(&[
+    // A bounded total beyond the deployment page cap is legal and chunked.
+    let over_page_cap = harness.run(&[
         "--json",
         "grep",
         "TODO",
         "--limit",
+        "1001",
+        "--page-size",
         "1",
-        "--max-matches",
-        "3",
     ]);
-    assert_success(&both);
+    assert_success(&over_page_cap);
     assert_eq!(
-        json_data(&both)["matches"]
+        json_data(&over_page_cap)["matches"]
             .as_array()
             .expect("json array")
             .len(),
-        3
+        4
     );
-    assert_eq!(json_data(&both)["truncated"], true);
+    assert_eq!(json_data(&over_page_cap)["truncated"], false);
+
+    let removed = harness.run(&["grep", "TODO", "--max-matches", "2"]);
+    assert_failure(&removed);
+    assert!(stderr_string(&removed).contains("unexpected argument '--max-matches'"));
 
     // The human rendering says it stopped early.
-    let human = harness.run(&["grep", "TODO", "--max-matches", "2"]);
+    let human = harness.run(&["grep", "TODO", "--limit", "2"]);
     assert_success(&human);
-    assert!(stdout_string(&human).contains("--max-matches"));
+    assert!(stdout_string(&human).contains("--limit"));
+}
+
+#[test]
+fn changes_checkpoints_and_grep_jsonl_follow_across_pages() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let empty_changes = harness.run(&["changes", "--page-size", "1", "--jsonl"]);
+    assert_success(&empty_changes);
+    assert!(stdout_string(&empty_changes).is_empty());
+
+    let first = harness.temp_dir.path().join("first.txt");
+    let second = harness.temp_dir.path().join("second.txt");
+    fs::write(&first, b"TODO one\nTODO two\n").expect("first payload");
+    fs::write(&second, b"second\n").expect("second payload");
+    assert_success(&harness.run(&["put", first.to_str().expect("utf-8 path"), "/first.txt"]));
+    assert_success(&harness.run(&["put", second.to_str().expect("utf-8 path"), "/second.txt"]));
+
+    let changes = harness.run(&["changes", "--page-size", "1", "--jsonl"]);
+    assert_success(&changes);
+    assert_eq!(stdout_string(&changes).lines().count(), 2);
+
+    for name in ["first", "second"] {
+        assert_success(&harness.run(&["admin", "checkpoint", "create", "--name", name]));
+    }
+    let one_checkpoint =
+        harness.run(&["--json", "admin", "checkpoint", "list", "--page-size", "1"]);
+    assert_success(&one_checkpoint);
+    assert_eq!(
+        json_data(&one_checkpoint)["checkpoints"]
+            .as_array()
+            .expect("checkpoint array")
+            .len(),
+        1
+    );
+    assert!(json_data(&one_checkpoint)["next_cursor"].is_string());
+    let checkpoints = harness.run(&["admin", "checkpoint", "list", "--page-size", "1", "--jsonl"]);
+    assert_success(&checkpoints);
+    assert_eq!(stdout_string(&checkpoints).lines().count(), 2);
+
+    assert_success(&harness.run(&["admin", "index", "enable"]));
+    let grep = harness.run(&["grep", "TODO", "--page-size", "1", "--jsonl"]);
+    assert_success(&grep);
+    assert_eq!(stdout_string(&grep).lines().count(), 2);
 }
 
 #[test]
@@ -394,6 +440,27 @@ fn index_gc_loops_its_cursor_and_accumulates() {
         json_data(&single)["next_cursor"].is_string(),
         "{}",
         json_data(&single)
+    );
+    let cursor = json_data(&single)["next_cursor"]
+        .as_str()
+        .expect("bounded index collection returns a cursor")
+        .to_owned();
+    let resumed = harness.run(&[
+        "--json",
+        "admin",
+        "index",
+        "gc",
+        "--max-objects",
+        "1",
+        "--cursor",
+        &cursor,
+    ]);
+    assert_success(&resumed);
+    assert_ne!(
+        json_data(&resumed)
+            .get("next_cursor")
+            .and_then(Value::as_str),
+        Some(cursor.as_str())
     );
 }
 

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -3,6 +3,75 @@
 use super::common::*;
 
 #[test]
+fn revisions_and_trash_share_total_page_and_jsonl_behavior() {
+    let harness = Harness::new();
+    harness.add_embedded_profile("default");
+    assert_success(&harness.run(&["namespace", "create", "demo"]));
+    assert_success(&harness.run(&["use", "demo"]));
+
+    let payload = harness.temp_dir.path().join("payload.txt");
+    fs::write(&payload, b"one\n").expect("payload");
+    assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), "/report.txt"]));
+    fs::write(&payload, b"two\n").expect("replacement payload");
+    assert_success(&harness.run(&[
+        "put",
+        payload.to_str().expect("utf-8 path"),
+        "/report.txt",
+        "--force",
+    ]));
+
+    let first_revision = harness.run(&["--json", "revisions", "/report.txt", "--page-size", "1"]);
+    assert_success(&first_revision);
+    assert_eq!(
+        json_data(&first_revision)["revisions"]
+            .as_array()
+            .expect("revision array")
+            .len(),
+        1
+    );
+    let revision_cursor = json_data(&first_revision)["next_cursor"]
+        .as_str()
+        .expect("revision cursor")
+        .to_owned();
+    let resumed_revision = harness.run(&[
+        "--json",
+        "revisions",
+        "/report.txt",
+        "--cursor",
+        &revision_cursor,
+    ]);
+    assert_success(&resumed_revision);
+    assert_eq!(
+        json_data(&resumed_revision)["revisions"]
+            .as_array()
+            .expect("revision array")
+            .len(),
+        1
+    );
+    let revisions = harness.run(&["revisions", "/report.txt", "--page-size", "1", "--jsonl"]);
+    assert_success(&revisions);
+    assert_eq!(stdout_string(&revisions).lines().count(), 2);
+
+    for index in 0..2 {
+        let path = format!("/trash-{index}.txt");
+        assert_success(&harness.run(&["put", payload.to_str().expect("utf-8 path"), &path]));
+        assert_success(&harness.run(&["rm", &path]));
+    }
+    let bounded_trash = harness.run(&["--json", "trash", "--limit", "2", "--page-size", "1"]);
+    assert_success(&bounded_trash);
+    assert_eq!(
+        json_data(&bounded_trash)["entries"]
+            .as_array()
+            .expect("trash array")
+            .len(),
+        2
+    );
+    let trash = harness.run(&["trash", "--page-size", "1", "--jsonl"]);
+    assert_success(&trash);
+    assert_eq!(stdout_string(&trash).lines().count(), 2);
+}
+
+#[test]
 fn embedded_profile_filesystem_flow_works_end_to_end() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");

--- a/crates/loonfs-cli/tests/it/filesystem.rs
+++ b/crates/loonfs-cli/tests/it/filesystem.rs
@@ -3,7 +3,7 @@
 use super::common::*;
 
 #[test]
-fn revisions_and_trash_share_total_page_and_jsonl_behavior() {
+fn revisions_and_trash_use_the_shared_pagination_flags() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
     assert_success(&harness.run(&["namespace", "create", "demo"]));

--- a/crates/loonfs-cli/tests/it/output.rs
+++ b/crates/loonfs-cli/tests/it/output.rs
@@ -545,11 +545,11 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
         .as_str()
         .expect("default JSON page carries a cursor");
 
-    let one_page_jsonl = harness.run(&["ls", "/listing", "--jsonl"]);
-    assert_success(&one_page_jsonl);
+    let followed_jsonl = harness.run(&["ls", "/listing", "--jsonl"]);
+    assert_success(&followed_jsonl);
     assert_eq!(
-        stdout_string(&one_page_jsonl).lines().count(),
-        loonfs_api::DEFAULT_PAGE_LIMIT as usize
+        stdout_string(&followed_jsonl).lines().count(),
+        loonfs_api::DEFAULT_PAGE_LIMIT as usize + 1
     );
 
     let all = harness.run(&["ls", "/listing", "--all"]);
@@ -560,7 +560,7 @@ fn ls_default_all_jsonl_and_cursor_obey_page_boundaries() {
     );
     assert!(!stdout_string(&all).contains("more entries exist"));
 
-    let all_json = harness.run(&["--json", "ls", "/listing", "--all"]);
+    let all_json = harness.run(&["--json", "ls", "/listing", "--all", "--limit", "1001"]);
     assert_success(&all_json);
     let all_json_data = json_data(&all_json);
     assert_eq!(all_json_data["namespace_id"], "demo");
@@ -633,7 +633,7 @@ fn ls_surfaces_head_drift_from_paged_responses() {
         }),
     ]);
     harness.write_remote_listing_config(&server_url);
-    let json = harness.run(&["--json", "ls", "/docs", "--all"]);
+    let json = harness.run(&["--json", "ls", "/docs", "--all", "--limit", "2"]);
     assert_success(&json);
     assert!(json.stderr.is_empty());
     let data = json_data(&json);
@@ -681,10 +681,10 @@ fn ls_surfaces_head_drift_from_paged_responses() {
     server.join().expect("listing server");
 }
 
-/// `ls --limit` bounds the total, and incompatible output bounds fail in
-/// clap before the command runs.
+/// `ls --limit` bounds the total, including when `--all` is also present,
+/// while unbounded buffered JSON fails before the command runs.
 #[test]
-fn ls_limit_bounds_the_whole_listing_and_rejects_all() {
+fn ls_limit_bounds_the_whole_listing_and_rejects_unbounded_json() {
     let harness = Harness::new();
     harness.add_embedded_profile("default");
     assert_success(&harness.run(&["namespace", "create", "demo"]));
@@ -700,12 +700,11 @@ fn ls_limit_bounds_the_whole_listing_and_rejects_all() {
         ]));
     }
 
-    // Explicitly unbounded JSON still prints everything in one document.
+    // Explicitly unbounded JSON must use JSONL or add a bound.
     let all = harness.run(&["--json", "ls", "--all"]);
-    assert_success(&all);
-    let all_data = json_data(&all);
-    assert_eq!(all_data["entries"].as_array().expect("json array").len(), 5);
-    assert!(all_data.get("next_cursor").is_none());
+    assert_failure(&all);
+    assert_eq!(all.status.code(), Some(2));
+    assert!(stderr_string(&all).contains("use '--jsonl' or add '--limit'"));
 
     // A bound stops at exactly that many entries and returns a cursor.
     let first = harness.run(&["--json", "ls", "--limit", "2"]);
@@ -751,8 +750,8 @@ fn ls_limit_bounds_the_whole_listing_and_rejects_all() {
     assert!(stdout_string(&human).contains("continue with --cursor"));
 
     let conflicting_bound = harness.run(&["ls", "--all", "--limit", "2"]);
-    assert_failure(&conflicting_bound);
-    assert_eq!(conflicting_bound.status.code(), Some(2));
+    assert_success(&conflicting_bound);
+    assert_eq!(stdout_string(&conflicting_bound).lines().count(), 2);
 
     let conflicting_json = harness.run(&["--json", "ls", "--jsonl"]);
     assert_failure(&conflicting_json);

--- a/crates/loonfs-cli/tests/it/output.rs
+++ b/crates/loonfs-cli/tests/it/output.rs
@@ -681,8 +681,7 @@ fn ls_surfaces_head_drift_from_paged_responses() {
     server.join().expect("listing server");
 }
 
-/// `ls --limit` bounds the total, including when `--all` is also present,
-/// while unbounded buffered JSON fails before the command runs.
+/// `--limit` still applies with `--all`, and buffered JSON requires a limit.
 #[test]
 fn ls_limit_bounds_the_whole_listing_and_rejects_unbounded_json() {
     let harness = Harness::new();
@@ -704,7 +703,7 @@ fn ls_limit_bounds_the_whole_listing_and_rejects_unbounded_json() {
     let all = harness.run(&["--json", "ls", "--all"]);
     assert_failure(&all);
     assert_eq!(all.status.code(), Some(2));
-    assert!(stderr_string(&all).contains("use '--jsonl' or add '--limit'"));
+    assert!(stderr_string(&all).contains("use '--jsonl' to stream without a limit"));
 
     // A bound stops at exactly that many entries and returns a cursor.
     let first = harness.run(&["--json", "ls", "--limit", "2"]);

--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::transport::append_optional_pagination_query;
 
-/// Lazy active-checkpoint page reader.
+/// Fetches active-checkpoint pages as needed.
 #[must_use]
 pub struct CheckpointsPager {
     client: Client,
@@ -33,7 +33,9 @@ impl CheckpointsPager {
         }))
     }
 
-    /// Collects at most `max_items` checkpoints without losing a partially read page.
+    /// Returns at most `max_items` checkpoints.
+    ///
+    /// Unused checkpoints from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<Checkpoint>> {
         let mut checkpoints = Vec::new();
         while checkpoints.len() < max_items {
@@ -86,7 +88,7 @@ impl Client {
         self.request_json(self.post(&url), Some(request)).await
     }
 
-    /// Creates a lazy checkpoint pager beginning at `cursor` (admin plane).
+    /// Creates a checkpoint pager beginning at `cursor` (admin plane).
     pub fn list_checkpoints_pager(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-client/src/admin.rs
+++ b/crates/loonfs-client/src/admin.rs
@@ -3,6 +3,58 @@
 use super::*;
 use crate::transport::append_optional_pagination_query;
 
+/// Lazy active-checkpoint page reader.
+#[must_use]
+pub struct CheckpointsPager {
+    client: Client,
+    namespace_id: NamespaceId,
+    page_size: Option<u32>,
+    cursor: Option<String>,
+    pending: Option<ListCheckpointsResponse>,
+    exhausted: bool,
+}
+
+impl CheckpointsPager {
+    /// Returns the next checkpoint page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ListCheckpointsResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .client
+            .list_checkpoints_page(&self.namespace_id, self.page_size, self.cursor.as_deref())
+            .await;
+        Some(page.inspect(|page| {
+            self.cursor = page.next_cursor.clone();
+            self.exhausted = self.cursor.is_none();
+        }))
+    }
+
+    /// Collects at most `max_items` checkpoints without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<Checkpoint>> {
+        let mut checkpoints = Vec::new();
+        while checkpoints.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - checkpoints.len()).min(page.checkpoints.len());
+            if take < page.checkpoints.len() {
+                let remaining = page.checkpoints.split_off(take);
+                checkpoints.extend(page.checkpoints);
+                page.checkpoints = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            checkpoints.extend(page.checkpoints);
+        }
+        Ok(checkpoints)
+    }
+}
+
 impl Client {
     /// Returns namespace state and storage details used by maintenance.
     pub async fn namespace_diagnostics(
@@ -34,32 +86,21 @@ impl Client {
         self.request_json(self.post(&url), Some(request)).await
     }
 
-    /// Lists every active checkpoint record by following bounded pages
-    /// (admin plane).
-    ///
-    /// A checkpoint name is a label rather than a key, so this is how a pin
-    /// is found again once its creation response is gone. An expired record
-    /// that no collection pass has released yet is still listed, with its
-    /// expiry in the entry.
-    pub async fn list_checkpoints_all(
+    /// Creates a lazy checkpoint pager beginning at `cursor` (admin plane).
+    pub fn list_checkpoints_pager(
         &self,
         namespace_id: &NamespaceId,
-    ) -> Result<ListCheckpointsResponse> {
-        let first_page = self.list_checkpoints_page(namespace_id, None, None).await?;
-        let mut response = ListCheckpointsResponse {
-            namespace_id: first_page.namespace_id,
-            checkpoints: first_page.checkpoints,
-            next_cursor: None,
-        };
-        let mut next_cursor = first_page.next_cursor;
-        while let Some(cursor) = next_cursor {
-            let page = self
-                .list_checkpoints_page(namespace_id, None, Some(&cursor))
-                .await?;
-            response.checkpoints.extend(page.checkpoints);
-            next_cursor = page.next_cursor;
+        page_size: Option<u32>,
+        cursor: Option<String>,
+    ) -> CheckpointsPager {
+        CheckpointsPager {
+            client: self.clone(),
+            namespace_id: namespace_id.clone(),
+            page_size,
+            cursor,
+            pending: None,
+            exhausted: false,
         }
-        Ok(response)
     }
 
     /// Lists one bounded page of active checkpoint records (admin plane).

--- a/crates/loonfs-client/src/lib.rs
+++ b/crates/loonfs-client/src/lib.rs
@@ -35,22 +35,22 @@ use loonfs_api::{
     v0::{
         BeginDownloadByInodeRequest, BeginDownloadByInodeResponse, BeginDownloadRequest,
         BeginDownloadResponse, BeginUploadRequest, BeginUploadResponse, ChangesResponse,
-        CommitResponse as ApiCommitResponse, CompleteKnownContentUploadRequest,
+        CommitResponse as ApiCommitResponse, CommittedChange, CompleteKnownContentUploadRequest,
         CompleteMultipartUploadRequest, CompletedUploadPart, ContentToken,
         DirectMultipartUploadOptions, GrepGcRequest, GrepGcResponse, GrepIndexStatusResponse,
         ObjectTransferAccess, SignUploadPartsRequest, SignUploadPartsResponse, SignedUploadPart,
         StoreProbeRequest, StoreProbeResponse, UploadContentClaim, UploadContentResponse,
         UploadPartChecksumClaim, UploadSessionResponse, UploadSessionStatus,
     },
-    AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, CheckpointId, Checksum,
-    ChecksumAlgorithm, CommitId, CommitRequest, ContentEvidence, ContentRef,
+    AbsolutePath, AuthoritativePathEntry, CapabilityDocument, ChangeSeq, Checkpoint, CheckpointId,
+    Checksum, ChecksumAlgorithm, CommitId, CommitRequest, ContentEvidence, ContentRef,
     CreateCheckpointRequest, CreateCheckpointResponse, CreateNamespaceRequest,
-    DeleteNamespaceResponse, ErrorCode, FilesystemOperation, ForkNamespaceRequest, GrepRequest,
-    GrepResponse, InodeId, ListCheckpointsResponse, ListFileRevisionsResponse,
+    DeleteNamespaceResponse, ErrorCode, FileRevision, FilesystemOperation, ForkNamespaceRequest,
+    GrepRequest, GrepResponse, InodeId, ListCheckpointsResponse, ListFileRevisionsResponse,
     ListPathEntriesResponse, ListTrashResponse, MaintenanceStepRequest, MaintenanceStepResponse,
     Namespace, NamespaceDiagnostics, NamespaceId, PutRetryAttempt, PutRetryErrorClassification,
     PutRetryReceipt, ReleaseCheckpointResponse, RevisionNo, SecretString, StreamingChecksum,
-    UploadId, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_UPLOADS_DIRECT_MULTIPART,
+    TrashEntry, UploadId, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_UPLOADS_DIRECT_MULTIPART,
     LIMIT_DOWNLOAD_MAX_CONTENT_BYTES, LIMIT_UPLOAD_DIRECT_PUT_MAX_CONTENT_BYTES,
     LIMIT_UPLOAD_MAX_CONTENT_BYTES,
 };
@@ -58,9 +58,11 @@ use payload::PartReader;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
+pub use admin::CheckpointsPager;
 pub use config::ClientConfig;
 pub use error::ClientError;
 pub use payload::{PayloadSource, PayloadStream};
+pub use reads::{ChangesPager, FileRevisionsPager, PathEntriesPager, TrashPager};
 use transport::{StdMonotonicTimer, TransportRetryPolicy, WireRequest, IO_INACTIVITY_TIMEOUT};
 pub use ClientError as Error;
 

--- a/crates/loonfs-client/src/reads.rs
+++ b/crates/loonfs-client/src/reads.rs
@@ -3,6 +3,251 @@
 use super::*;
 use crate::transport::{append_optional_pagination_query, append_query_param};
 
+/// Lazy directory-page reader.
+///
+/// Each call to [`Self::next`] returns one original response envelope, so a
+/// caller can observe head changes between pages. [`Self::collect_up_to`]
+/// collects only entries and keeps any unconsumed part of the final page for
+/// the next call to [`Self::next`].
+#[must_use]
+pub struct PathEntriesPager {
+    client: Client,
+    spec: NamespacePath,
+    page_size: Option<u32>,
+    cursor: Option<String>,
+    options: ListPathEntriesOptions,
+    pending: Option<ListPathEntriesResponse>,
+    exhausted: bool,
+}
+
+impl PathEntriesPager {
+    /// Returns the next directory page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ListPathEntriesResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .client
+            .list_path_entries_page(
+                &self.spec,
+                self.page_size,
+                self.cursor.as_deref(),
+                &self.options,
+            )
+            .await;
+        Some(page.inspect(|page| {
+            self.cursor = page.next_cursor.clone();
+            self.exhausted = self.cursor.is_none();
+        }))
+    }
+
+    /// Collects at most `max_items` entries without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<AuthoritativePathEntry>> {
+        let mut entries = Vec::new();
+        while entries.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - entries.len()).min(page.entries.len());
+            if take < page.entries.len() {
+                let remaining = page.entries.split_off(take);
+                entries.extend(page.entries);
+                page.entries = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            entries.extend(page.entries);
+        }
+        Ok(entries)
+    }
+}
+
+enum FileRevisionsTarget {
+    Path(NamespacePath),
+    Inode {
+        namespace_id: NamespaceId,
+        inode_id: InodeId,
+    },
+}
+
+/// Lazy file-revision page reader for either a path or an inode.
+#[must_use]
+pub struct FileRevisionsPager {
+    client: Client,
+    target: FileRevisionsTarget,
+    page_size: Option<u32>,
+    cursor: Option<String>,
+    pending: Option<ListFileRevisionsResponse>,
+    exhausted: bool,
+}
+
+impl FileRevisionsPager {
+    /// Returns the next revision page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ListFileRevisionsResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = match &self.target {
+            FileRevisionsTarget::Path(spec) => {
+                self.client
+                    .list_file_revisions_page(spec, self.page_size, self.cursor.as_deref())
+                    .await
+            }
+            FileRevisionsTarget::Inode {
+                namespace_id,
+                inode_id,
+            } => {
+                self.client
+                    .list_file_revisions_by_inode_page(
+                        namespace_id,
+                        *inode_id,
+                        self.page_size,
+                        self.cursor.as_deref(),
+                    )
+                    .await
+            }
+        };
+        Some(page.inspect(|page| {
+            self.cursor = page.next_cursor.clone();
+            self.exhausted = self.cursor.is_none();
+        }))
+    }
+
+    /// Collects at most `max_items` revisions without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<FileRevision>> {
+        let mut revisions = Vec::new();
+        while revisions.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - revisions.len()).min(page.revisions.len());
+            if take < page.revisions.len() {
+                let remaining = page.revisions.split_off(take);
+                revisions.extend(page.revisions);
+                page.revisions = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            revisions.extend(page.revisions);
+        }
+        Ok(revisions)
+    }
+}
+
+/// Lazy recoverable-deletion page reader.
+#[must_use]
+pub struct TrashPager {
+    client: Client,
+    namespace_id: NamespaceId,
+    page_size: Option<u32>,
+    cursor: Option<String>,
+    pending: Option<ListTrashResponse>,
+    exhausted: bool,
+}
+
+impl TrashPager {
+    /// Returns the next trash page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ListTrashResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .client
+            .list_trash_page(&self.namespace_id, self.page_size, self.cursor.as_deref())
+            .await;
+        Some(page.inspect(|page| {
+            self.cursor = page.next_cursor.clone();
+            self.exhausted = self.cursor.is_none();
+        }))
+    }
+
+    /// Collects at most `max_items` deletions without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<TrashEntry>> {
+        let mut entries = Vec::new();
+        while entries.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - entries.len()).min(page.entries.len());
+            if take < page.entries.len() {
+                let remaining = page.entries.split_off(take);
+                entries.extend(page.entries);
+                page.entries = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            entries.extend(page.entries);
+        }
+        Ok(entries)
+    }
+}
+
+/// Lazy change-feed page reader using sequence positions rather than opaque cursors.
+#[must_use]
+pub struct ChangesPager {
+    client: Client,
+    namespace_id: NamespaceId,
+    after_seq: ChangeSeq,
+    page_size: Option<u32>,
+    pending: Option<ChangesResponse>,
+    exhausted: bool,
+}
+
+impl ChangesPager {
+    /// Returns the next change page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ChangesResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .client
+            .list_changes(&self.namespace_id, self.after_seq, self.page_size)
+            .await;
+        Some(page.inspect(|page| {
+            self.exhausted = page.next_after_seq.is_none();
+            if let Some(next_after_seq) = page.next_after_seq {
+                self.after_seq = next_after_seq;
+            }
+        }))
+    }
+
+    /// Collects at most `max_items` changes without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<CommittedChange>> {
+        let mut changes = Vec::new();
+        while changes.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - changes.len()).min(page.changes.len());
+            if take < page.changes.len() {
+                let remaining = page.changes.split_off(take);
+                changes.extend(page.changes);
+                page.changes = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            changes.extend(page.changes);
+        }
+        Ok(changes)
+    }
+}
+
 impl Client {
     /// Creates an empty namespace with the given ID and returns its genesis state.
     pub async fn create_namespace(&self, namespace_id: &NamespaceId) -> Result<Namespace> {
@@ -66,41 +311,23 @@ impl Client {
         .await
     }
 
-    /// Lists a directory by aggregating every page into one response.
-    ///
-    /// Listing cursors tolerate commits landing mid-listing — each page
-    /// resumes in name-key order against the head the server has loaded —
-    /// so aggregation never restarts. The envelope's `head_seq` reports the
-    /// newest head that served a page. Use
-    /// [`Self::list_path_entries_page`] for page-level control. `options`
-    /// selects the entry projection.
-    pub async fn list_path_entries_all(
+    /// Creates a lazy directory pager beginning at `cursor`.
+    pub fn list_path_entries_pager(
         &self,
         spec: &NamespacePath,
+        page_size: Option<u32>,
+        cursor: Option<String>,
         options: &ListPathEntriesOptions,
-    ) -> Result<ListPathEntriesResponse> {
-        let first_page = self
-            .list_path_entries_page(spec, None, None, options)
-            .await?;
-        let mut envelope = ListPathEntriesResponse {
-            namespace_id: first_page.namespace_id,
-            path: first_page.path,
-            head_seq: first_page.head_seq,
-            entries: first_page.entries,
-            next_cursor: None,
-        };
-        let mut next_cursor = first_page.next_cursor;
-        while let Some(cursor) = next_cursor {
-            let page = self
-                .list_path_entries_page(spec, None, Some(&cursor), options)
-                .await?;
-            envelope.head_seq = envelope.head_seq.max(page.head_seq);
-            envelope.entries.extend(page.entries);
-            next_cursor = page.next_cursor;
+    ) -> PathEntriesPager {
+        PathEntriesPager {
+            client: self.clone(),
+            spec: spec.clone(),
+            page_size,
+            cursor,
+            options: options.clone(),
+            pending: None,
+            exhausted: false,
         }
-        // Pages arrive in canonical name-key order; concatenation preserves
-        // it, so aggregation must not re-sort.
-        Ok(envelope)
     }
 
     /// Lists one directory page using the requested projection.
@@ -233,6 +460,23 @@ impl Client {
             .await
     }
 
+    /// Creates a lazy path-based revision pager beginning at `cursor`.
+    pub fn list_file_revisions_pager(
+        &self,
+        spec: &NamespacePath,
+        page_size: Option<u32>,
+        cursor: Option<String>,
+    ) -> FileRevisionsPager {
+        FileRevisionsPager {
+            client: self.clone(),
+            target: FileRevisionsTarget::Path(spec.clone()),
+            page_size,
+            cursor,
+            pending: None,
+            exhausted: false,
+        }
+    }
+
     /// Returns one page of retained revisions for a file inode.
     pub async fn list_file_revisions_by_inode_page(
         &self,
@@ -250,6 +494,27 @@ impl Client {
         append_optional_pagination_query(&mut url, &mut has_query, limit, cursor);
         self.request_json::<(), ListFileRevisionsResponse>(self.get(&url), None)
             .await
+    }
+
+    /// Creates a lazy inode-based revision pager beginning at `cursor`.
+    pub fn list_file_revisions_by_inode_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        page_size: Option<u32>,
+        cursor: Option<String>,
+    ) -> FileRevisionsPager {
+        FileRevisionsPager {
+            client: self.clone(),
+            target: FileRevisionsTarget::Inode {
+                namespace_id: namespace_id.clone(),
+                inode_id,
+            },
+            page_size,
+            cursor,
+            pending: None,
+            exhausted: false,
+        }
     }
 
     /// Returns one page of recoverable deletions in a namespace.
@@ -270,6 +535,23 @@ impl Client {
             .await
     }
 
+    /// Creates a lazy trash pager beginning at `cursor`.
+    pub fn list_trash_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        page_size: Option<u32>,
+        cursor: Option<String>,
+    ) -> TrashPager {
+        TrashPager {
+            client: self.clone(),
+            namespace_id: namespace_id.clone(),
+            page_size,
+            cursor,
+            pending: None,
+            exhausted: false,
+        }
+    }
+
     /// Returns committed changes after the given sequence number.
     pub async fn list_changes(
         &self,
@@ -286,5 +568,22 @@ impl Client {
         }
         self.request_json::<(), ChangesResponse>(self.get(&url), None)
             .await
+    }
+
+    /// Creates a lazy change-feed pager beginning after `after_seq`.
+    pub fn list_changes_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+        page_size: Option<u32>,
+    ) -> ChangesPager {
+        ChangesPager {
+            client: self.clone(),
+            namespace_id: namespace_id.clone(),
+            after_seq,
+            page_size,
+            pending: None,
+            exhausted: false,
+        }
     }
 }

--- a/crates/loonfs-client/src/reads.rs
+++ b/crates/loonfs-client/src/reads.rs
@@ -3,12 +3,11 @@
 use super::*;
 use crate::transport::{append_optional_pagination_query, append_query_param};
 
-/// Lazy directory-page reader.
+/// Fetches directory pages as needed.
 ///
-/// Each call to [`Self::next`] returns one original response envelope, so a
-/// caller can observe head changes between pages. [`Self::collect_up_to`]
-/// collects only entries and keeps any unconsumed part of the final page for
-/// the next call to [`Self::next`].
+/// [`Self::next`] returns one page with its metadata. [`Self::collect_up_to`]
+/// returns at most the requested number of entries and saves unused entries
+/// for later calls.
 #[must_use]
 pub struct PathEntriesPager {
     client: Client,
@@ -44,7 +43,9 @@ impl PathEntriesPager {
         }))
     }
 
-    /// Collects at most `max_items` entries without losing a partially read page.
+    /// Returns at most `max_items` entries.
+    ///
+    /// Unused entries from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<AuthoritativePathEntry>> {
         let mut entries = Vec::new();
         while entries.len() < max_items {
@@ -74,7 +75,7 @@ enum FileRevisionsTarget {
     },
 }
 
-/// Lazy file-revision page reader for either a path or an inode.
+/// Fetches file-revision pages as needed for a path or inode.
 #[must_use]
 pub struct FileRevisionsPager {
     client: Client,
@@ -120,7 +121,9 @@ impl FileRevisionsPager {
         }))
     }
 
-    /// Collects at most `max_items` revisions without losing a partially read page.
+    /// Returns at most `max_items` revisions.
+    ///
+    /// Unused revisions from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<FileRevision>> {
         let mut revisions = Vec::new();
         while revisions.len() < max_items {
@@ -142,7 +145,7 @@ impl FileRevisionsPager {
     }
 }
 
-/// Lazy recoverable-deletion page reader.
+/// Fetches recoverable-deletion pages as needed.
 #[must_use]
 pub struct TrashPager {
     client: Client,
@@ -172,7 +175,9 @@ impl TrashPager {
         }))
     }
 
-    /// Collects at most `max_items` deletions without losing a partially read page.
+    /// Returns at most `max_items` deletions.
+    ///
+    /// Unused deletions from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<TrashEntry>> {
         let mut entries = Vec::new();
         while entries.len() < max_items {
@@ -194,7 +199,7 @@ impl TrashPager {
     }
 }
 
-/// Lazy change-feed page reader using sequence positions rather than opaque cursors.
+/// Fetches change-feed pages as needed, using sequence numbers to resume.
 #[must_use]
 pub struct ChangesPager {
     client: Client,
@@ -226,7 +231,9 @@ impl ChangesPager {
         }))
     }
 
-    /// Collects at most `max_items` changes without losing a partially read page.
+    /// Returns at most `max_items` changes.
+    ///
+    /// Unused changes from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<CommittedChange>> {
         let mut changes = Vec::new();
         while changes.len() < max_items {
@@ -311,7 +318,7 @@ impl Client {
         .await
     }
 
-    /// Creates a lazy directory pager beginning at `cursor`.
+    /// Creates a directory pager beginning at `cursor`.
     pub fn list_path_entries_pager(
         &self,
         spec: &NamespacePath,
@@ -460,7 +467,7 @@ impl Client {
             .await
     }
 
-    /// Creates a lazy path-based revision pager beginning at `cursor`.
+    /// Creates a path-based revision pager beginning at `cursor`.
     pub fn list_file_revisions_pager(
         &self,
         spec: &NamespacePath,
@@ -496,7 +503,7 @@ impl Client {
             .await
     }
 
-    /// Creates a lazy inode-based revision pager beginning at `cursor`.
+    /// Creates an inode-based revision pager beginning at `cursor`.
     pub fn list_file_revisions_by_inode_pager(
         &self,
         namespace_id: &NamespaceId,
@@ -535,7 +542,7 @@ impl Client {
             .await
     }
 
-    /// Creates a lazy trash pager beginning at `cursor`.
+    /// Creates a trash pager beginning at `cursor`.
     pub fn list_trash_pager(
         &self,
         namespace_id: &NamespaceId,
@@ -570,7 +577,7 @@ impl Client {
             .await
     }
 
-    /// Creates a lazy change-feed pager beginning after `after_seq`.
+    /// Creates a change-feed pager beginning after `after_seq`.
     pub fn list_changes_pager(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs-grep/tests/it/grep_worker.rs
+++ b/crates/loonfs-grep/tests/it/grep_worker.rs
@@ -12,8 +12,8 @@ use loonfs::{
 };
 use loonfs_api::wire::control::{CheckpointOwner, CheckpointRecordLifecycle};
 use loonfs_api::{
-    sha256_digest, AbsolutePath, ChangeSeq, GrepRequest, GrepResponse, IndexSegmentId,
-    MAX_PUBLIC_INTEGER,
+    sha256_digest, AbsolutePath, ChangeSeq, GrepRequest, GrepResponse, IndexSegmentId, PageRequest,
+    PaginationPolicy, MAX_PUBLIC_INTEGER,
 };
 use loonfs_grep::keyspace::{
     grep_prefix, manifest_key, manifests_prefix, root_key, segment_key, segments_prefix,
@@ -424,10 +424,17 @@ async fn enable_releases_its_checkpoint_when_root_reload_fails_before_publicatio
     assert!(matches!(error, GrepError::StoreUnavailable { .. }));
     assert_eq!(failing_store.attempts(), 1);
 
-    let checkpoints = host
-        .admin
-        .list_checkpoints_all(&namespace_id)
+    let request = PageRequest {
+        limit: PaginationPolicy::default()
+            .resolve_limit(None)
+            .expect("default page limit"),
+        cursor: None,
+    };
+    let mut pager = host.admin.list_checkpoints_pager(&namespace_id, request);
+    let checkpoints = pager
+        .next()
         .await
+        .expect("a fresh pager has one page")
         .expect("list checkpoints after failed enable");
     assert!(
         checkpoints.checkpoints.is_empty(),

--- a/crates/loonfs-server/src/http/tests.rs
+++ b/crates/loonfs-server/src/http/tests.rs
@@ -1517,11 +1517,12 @@ async fn http_missing_namespace_reads_return_namespace_not_found() {
     let harness = start_server(store, temp_dir.path(), "server-writer").await;
 
     let target = NamespacePath::parse("missing", "/").expect("target");
-    assert_api_error(
+    let mut pager =
         harness
             .client
-            .list_path_entries_all(&target, &Default::default())
-            .await,
+            .list_path_entries_pager(&target, None, None, &Default::default());
+    assert_api_error(
+        pager.next().await.expect("a fresh pager has one page"),
         404,
         "namespace_not_found",
         Some("namespace `missing` does not exist"),
@@ -1776,8 +1777,9 @@ async fn http_answers_401_in_envelope_for_missing_and_wrong_tokens() {
         );
         // The checkpoint inventory names this deployment's garbage-collection
         // roots, so it answers behind the same token as everything else.
+        let mut pager = client.list_checkpoints_pager(&namespace_id("demo"), None, None);
         assert_api_error(
-            client.list_checkpoints_all(&namespace_id("demo")).await,
+            pager.next().await.expect("a fresh pager has one page"),
             401,
             "unauthorized",
             Some("missing or invalid bearer token"),

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -22,7 +22,7 @@ pub(crate) async fn collect_path_entries(
     options: &ListPathEntriesOptions,
 ) -> loonfs_client::Result<ListPathEntriesResponse> {
     let mut pager = client.list_path_entries_pager(spec, None, None, options);
-    let mut response = pager.next().await.expect("a fresh pager has one page")?;
+    let mut response = pager.next().await.expect("first page")?;
     while let Some(page) = pager.next().await {
         let page = page?;
         response.head_seq = page.head_seq;
@@ -37,7 +37,7 @@ pub(crate) async fn collect_checkpoints(
     namespace_id: &NamespaceId,
 ) -> loonfs_client::Result<ListCheckpointsResponse> {
     let mut pager = client.list_checkpoints_pager(namespace_id, None, None);
-    let mut response = pager.next().await.expect("a fresh pager has one page")?;
+    let mut response = pager.next().await.expect("first page")?;
     while let Some(page) = pager.next().await {
         let page = page?;
         response.checkpoints.extend(page.checkpoints);

--- a/crates/loonfs-server/tests/it/common/mod.rs
+++ b/crates/loonfs-server/tests/it/common/mod.rs
@@ -3,7 +3,8 @@
 #![allow(dead_code)]
 #![allow(clippy::panic)]
 
-use loonfs_client::{Client, ClientConfig};
+use loonfs_api::{ListCheckpointsResponse, ListPathEntriesResponse, NamespaceId};
+use loonfs_client::{Client, ClientConfig, ListPathEntriesOptions, NamespacePath};
 use loonfs_server::{
     app, serve_with_shutdown, GrepConfig, MaintenanceMode, RuntimeCacheConfigOverrides, ServeError,
     ServerConfig, StoreConfig, TlsServerConfig,
@@ -14,6 +15,36 @@ use std::io::Read as _;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
+
+pub(crate) async fn collect_path_entries(
+    client: &Client,
+    spec: &NamespacePath,
+    options: &ListPathEntriesOptions,
+) -> loonfs_client::Result<ListPathEntriesResponse> {
+    let mut pager = client.list_path_entries_pager(spec, None, None, options);
+    let mut response = pager.next().await.expect("a fresh pager has one page")?;
+    while let Some(page) = pager.next().await {
+        let page = page?;
+        response.head_seq = page.head_seq;
+        response.entries.extend(page.entries);
+        response.next_cursor = page.next_cursor;
+    }
+    Ok(response)
+}
+
+pub(crate) async fn collect_checkpoints(
+    client: &Client,
+    namespace_id: &NamespaceId,
+) -> loonfs_client::Result<ListCheckpointsResponse> {
+    let mut pager = client.list_checkpoints_pager(namespace_id, None, None);
+    let mut response = pager.next().await.expect("a fresh pager has one page")?;
+    while let Some(page) = pager.next().await {
+        let page = page?;
+        response.checkpoints.extend(page.checkpoints);
+        response.next_cursor = page.next_cursor;
+    }
+    Ok(response)
+}
 
 /// The exposition lines of one scrape, keyed by everything left of the
 /// value. Comment lines are dropped; a value that does not parse as a number

--- a/crates/loonfs-server/tests/it/http_admin.rs
+++ b/crates/loonfs-server/tests/it/http_admin.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::panic)]
 
 use crate::common::http_split_support::*;
-use crate::common::start_server;
+use crate::common::{collect_checkpoints, start_server};
 use bytes::Bytes;
 use loonfs_api::{
     ApiError, ChangeSeq, CheckpointId, CheckpointOwnerSummary, CreateCheckpointResponse,
@@ -199,8 +199,7 @@ async fn http_admin_checkpoint_and_retention_are_idempotent_and_soft() {
     );
     assert_eq!(first.checkpoint.checkpoint_seq, ChangeSeq(1));
     assert_eq!(first.checkpoint.manifest_id, ManifestId(1));
-    let listed = client
-        .list_checkpoints_all(&namespace)
+    let listed = collect_checkpoints(&client, &namespace)
         .await
         .expect("list first checkpoint");
     assert_eq!(listed.checkpoints, vec![first.checkpoint.clone()]);

--- a/crates/loonfs-server/tests/it/http_attributes.rs
+++ b/crates/loonfs-server/tests/it/http_attributes.rs
@@ -5,7 +5,7 @@
 // A transport failure is not an outcome under test; it panics with what it saw.
 
 use crate::common::http_split_support::*;
-use crate::common::start_server;
+use crate::common::{collect_path_entries, start_server};
 use loonfs_api::AttributeRevisionNo;
 use loonfs_client::{
     ListPathEntriesOptions, NamespacePath, PutFileOptions, StatPathOptions, UpdateAttributesOptions,
@@ -252,9 +252,7 @@ async fn the_client_round_trips_the_read_options() {
         .expect("stat without attributes");
     assert!(without.attributes.is_none());
 
-    let listing = harness
-        .client
-        .list_path_entries_all(&path("/docs"), &Default::default())
+    let listing = collect_path_entries(&harness.client, &path("/docs"), &Default::default())
         .await
         .expect("list");
     assert!(listing
@@ -262,16 +260,15 @@ async fn the_client_round_trips_the_read_options() {
         .iter()
         .all(|entry| entry.attributes.is_none()));
 
-    let projected = harness
-        .client
-        .list_path_entries_all(
-            &path("/docs"),
-            &ListPathEntriesOptions {
-                include_attributes: true,
-            },
-        )
-        .await
-        .expect("list with attributes");
+    let projected = collect_path_entries(
+        &harness.client,
+        &path("/docs"),
+        &ListPathEntriesOptions {
+            include_attributes: true,
+        },
+    )
+    .await
+    .expect("list with attributes");
     assert!(projected
         .entries
         .iter()

--- a/crates/loonfs-server/tests/it/http_pagination.rs
+++ b/crates/loonfs-server/tests/it/http_pagination.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::panic)]
 
 use crate::common::http_split_support::*;
-use crate::common::start_server;
+use crate::common::{collect_checkpoints, collect_path_entries, start_server};
 use loonfs_api::{
     v0::FilesystemChange, ApiError, ChangeSeq, CommitId, CreateCheckpointRequest,
     DestinationBehavior, ListCheckpointsResponse, ListPathEntriesResponse, RevisionNo,
@@ -100,9 +100,7 @@ async fn http_paginates_checkpoint_inventory_and_rejects_invalid_requests() {
     }
     assert_eq!(actual_ids, expected_ids);
 
-    let all = harness
-        .client
-        .list_checkpoints_all(&demo)
+    let all = collect_checkpoints(&harness.client, &demo)
         .await
         .expect("aggregate checkpoint pages");
     assert_eq!(
@@ -258,9 +256,7 @@ async fn http_paginates_directory_listing_and_rejects_cursor_path_mismatch() {
     assert_eq!(entry_names(&second_page), vec!["c.txt"]);
     assert_eq!(second_page.next_cursor, None);
 
-    let full_listing = harness
-        .client
-        .list_path_entries_all(&docs, &Default::default())
+    let full_listing = collect_path_entries(&harness.client, &docs, &Default::default())
         .await
         .expect("full directory list");
     assert_eq!(entry_names(&full_listing), vec!["a.txt", "b.txt", "c.txt"]);
@@ -340,9 +336,7 @@ async fn http_client_listing_preserves_canonical_name_key_order() {
             .expect("write file");
     }
 
-    let listing = harness
-        .client
-        .list_path_entries_all(&docs, &Default::default())
+    let listing = collect_path_entries(&harness.client, &docs, &Default::default())
         .await
         .expect("directory list");
     assert_eq!(entry_names(&listing), vec!["a.txt", "B.txt", "c.txt"]);

--- a/crates/loonfs-server/tests/it/local_cache.rs
+++ b/crates/loonfs-server/tests/it/local_cache.rs
@@ -1,7 +1,7 @@
 //! What the node-local block cache carries from one server to the next.
 
 use crate::common::http_split_support::*;
-use crate::common::{scrape, series, start_graceful_server};
+use crate::common::{collect_path_entries, scrape, series, start_graceful_server};
 use loonfs_api::CreateCheckpointRequest;
 use loonfs_client::NamespacePath;
 use loonfs_server::{LocalCacheConfig, MaintenanceMode, ServerConfig};
@@ -98,9 +98,7 @@ async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
         .await
         .expect("put file after the checkpoint");
 
-    let warmed = first
-        .client
-        .list_path_entries_all(&listing, &Default::default())
+    let warmed = collect_path_entries(&first.client, &listing, &Default::default())
         .await
         .expect("warm the cache");
     assert_eq!(warmed.entries.len(), 5);
@@ -123,9 +121,7 @@ async fn a_restarted_server_uses_the_local_cache_for_index_but_not_scan_data() {
         "local-cache-second",
     ))
     .await;
-    let served = second
-        .client
-        .list_path_entries_all(&listing, &Default::default())
+    let served = collect_path_entries(&second.client, &listing, &Default::default())
         .await
         .expect("list from the restarted server");
     assert_eq!(served.entries, warmed.entries);

--- a/crates/loonfs/src/fs/core.rs
+++ b/crates/loonfs/src/fs/core.rs
@@ -13,10 +13,10 @@ use crate::{
 };
 use crate::{Result, RuntimeError, SharedObjectStore};
 use loonfs_api::{
-    encode_cursor, CapabilityDocument, EffectiveLimit, FileRevision, FileRevisionsPageCursor, Page,
-    PageCursor, PaginationPolicy, FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET,
-    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
-    FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_CONTENT_TOKENS,
+    encode_cursor, CapabilityDocument, FileRevision, FileRevisionsPageCursor, Page, PageCursor,
+    PaginationPolicy, FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_NAMESPACES_CREATE,
+    FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART,
+    FEATURE_UPLOADS_DIRECT_PUT, LIMIT_COMMIT_MAX_CONTENT_TOKENS,
     LIMIT_COMMIT_MAX_EXTERNAL_CONTENT_REFS, LIMIT_COMMIT_MAX_MESSAGE_BYTES,
     LIMIT_COMMIT_MAX_OPERATIONS, LIMIT_GC_MIN_GRACE_WINDOW_MS, PROFILE_ADMIN_V0, PROFILE_CORE_V0,
     PROTOCOL_VERSION,
@@ -295,12 +295,6 @@ pub(crate) fn should_invalidate_after_result<T>(result: &Result<T>) -> bool {
         Err(RuntimeError::Core(error)) if error.code() == ErrorCode::StaleHead => true,
         _ => false,
     }
-}
-
-pub(super) fn default_page_limit() -> EffectiveLimit {
-    PaginationPolicy::default()
-        .resolve_limit(None)
-        .expect("default pagination policy must resolve its default limit")
 }
 
 pub(super) fn encode_next_cursor<C: PageCursor>(

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -56,7 +56,7 @@ enum ReorganizationStep {
     CompactionPlanned(loonfs_core::MetadataCompactionSpec),
 }
 
-/// Lazy active-checkpoint page reader.
+/// Fetches active-checkpoint pages as needed.
 #[must_use]
 pub struct CheckpointsPager {
     admin: FsAdmin,
@@ -87,7 +87,9 @@ impl CheckpointsPager {
         }))
     }
 
-    /// Collects at most `max_items` checkpoints without losing a partially read page.
+    /// Returns at most `max_items` checkpoints.
+    ///
+    /// Unused checkpoints from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<Checkpoint>> {
         let mut checkpoints = Vec::new();
         while checkpoints.len() < max_items {
@@ -690,7 +692,7 @@ impl FsAdmin {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    /// Creates a lazy checkpoint pager beginning at `request.cursor`.
+    /// Creates a checkpoint pager beginning at `request.cursor`.
     pub fn list_checkpoints_pager(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/fs/maintenance.rs
+++ b/crates/loonfs/src/fs/maintenance.rs
@@ -9,10 +9,11 @@ use crate::maintenance_runner::CompactionStart;
 use crate::FsAdmin;
 use crate::NamespaceDiagnostics;
 use crate::{
-    AdvanceRetentionResponse, CheckpointId, CreateCheckpointOptions, CreateCheckpointResponse,
-    ErrorCode, FlushWalOutcome, FlushWalResponse, ListCheckpointsResponse, MaintenancePlan,
-    MaintenanceStepResponse, MetadataMaintenanceOptions, MetadataMaintenanceResponse, NamespaceId,
-    ReleaseCheckpointResponse, ReorganizeStepOutcome, SharedObjectStore, WalFlushStepOutcome,
+    AdvanceRetentionResponse, Checkpoint, CheckpointId, CreateCheckpointOptions,
+    CreateCheckpointResponse, ErrorCode, FlushWalOutcome, FlushWalResponse,
+    ListCheckpointsResponse, MaintenancePlan, MaintenanceStepResponse, MetadataMaintenanceOptions,
+    MetadataMaintenanceResponse, NamespaceId, ReleaseCheckpointResponse, ReorganizeStepOutcome,
+    SharedObjectStore, WalFlushStepOutcome,
 };
 use crate::{ChangeSeq, Result, RuntimeError};
 use loonfs_api::PageRequest;
@@ -53,6 +54,59 @@ enum ReorganizationStep {
     /// A family group has outgrown a bounded step. The caller starts the job
     /// as background work, or runs it in its own task.
     CompactionPlanned(loonfs_core::MetadataCompactionSpec),
+}
+
+/// Lazy active-checkpoint page reader.
+#[must_use]
+pub struct CheckpointsPager {
+    admin: FsAdmin,
+    namespace_id: NamespaceId,
+    request: PageRequest<CheckpointPageCursor>,
+    pending: Option<ListCheckpointsResponse>,
+    exhausted: bool,
+}
+
+impl CheckpointsPager {
+    /// Returns the next checkpoint page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ListCheckpointsResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .admin
+            .list_checkpoints_page_typed(&self.namespace_id, self.request.clone())
+            .await;
+        Some(page.and_then(|(mut page, next_cursor)| {
+            page.next_cursor = super::core::encode_next_cursor(next_cursor.as_ref())?;
+            self.exhausted = next_cursor.is_none();
+            self.request.cursor = next_cursor;
+            Ok(page)
+        }))
+    }
+
+    /// Collects at most `max_items` checkpoints without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<Checkpoint>> {
+        let mut checkpoints = Vec::new();
+        while checkpoints.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - checkpoints.len()).min(page.checkpoints.len());
+            if take < page.checkpoints.len() {
+                let remaining = page.checkpoints.split_off(take);
+                checkpoints.extend(page.checkpoints);
+                page.checkpoints = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            checkpoints.extend(page.checkpoints);
+        }
+        Ok(checkpoints)
+    }
 }
 
 impl FsAdmin {
@@ -636,49 +690,19 @@ impl FsAdmin {
         self.finish_namespace_mutation(namespace_id, result)
     }
 
-    /// Lists every active checkpoint by following bounded pages.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.maintenance.list_checkpoints",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "maintenance.list_checkpoints",
-            method = "list_checkpoints_all",
-            namespace_id = %namespace_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn list_checkpoints_all(
+    /// Creates a lazy checkpoint pager beginning at `request.cursor`.
+    pub fn list_checkpoints_pager(
         &self,
         namespace_id: &NamespaceId,
-    ) -> Result<ListCheckpointsResponse> {
-        self.core.record_trace_context(&tracing::Span::current());
-        let limit = super::core::default_page_limit();
-        let (mut response, mut next_cursor) = self
-            .list_checkpoints_page_typed(
-                namespace_id,
-                PageRequest {
-                    limit,
-                    cursor: None,
-                },
-            )
-            .await?;
-        while let Some(cursor) = next_cursor {
-            let (page, page_next_cursor) = self
-                .list_checkpoints_page_typed(
-                    namespace_id,
-                    PageRequest {
-                        limit,
-                        cursor: Some(cursor),
-                    },
-                )
-                .await?;
-            response.checkpoints.extend(page.checkpoints);
-            next_cursor = page_next_cursor;
+        request: PageRequest<CheckpointPageCursor>,
+    ) -> CheckpointsPager {
+        CheckpointsPager {
+            admin: self.clone(),
+            namespace_id: namespace_id.clone(),
+            request,
+            pending: None,
+            exhausted: false,
         }
-        Ok(response)
     }
 
     /// Lists one page of active checkpoints in ascending id order. The cursor

--- a/crates/loonfs/src/fs/mod.rs
+++ b/crates/loonfs/src/fs/mod.rs
@@ -9,7 +9,8 @@ mod reads;
 mod uploads;
 mod writes;
 
-pub use maintenance::MetadataCompactionOutcome;
+pub use maintenance::{CheckpointsPager, MetadataCompactionOutcome};
+pub use reads::{ChangesPager, FileRevisionsPager, PathEntriesPager, TrashPager};
 
 pub(crate) use core::{should_invalidate_after_result, ReadCore, WriterBits, WriterIdentity};
 pub(crate) use namespaces::delete_namespace_with_engine;

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -1,19 +1,276 @@
 //! Read-only namespace and filesystem operations for [`FsReader`].
 
-use super::core::{default_page_limit, encode_next_cursor, file_revisions_page_response};
+use super::core::{encode_next_cursor, file_revisions_page_response};
 use crate::downloads::{DirectDownloadByInodeTarget, DirectDownloadTarget};
 use crate::FsReader;
 use crate::Result;
 use crate::{
     AuthoritativeFileBytes, AuthoritativePathEntry, ChangeSeq, ChangesResponse,
-    CheckpointFilesPage, CheckpointFilesPageCursor, CheckpointId, ContentRef, CoreError,
-    CurrentFileState, FileContentStream, InodeId, ListChangesOptions, ListFileRevisionsResponse,
-    ListPathEntriesOptions, ListPathEntriesResponse, Namespace, NamespaceId, ReadFileStreamOptions,
-    RevisionNo, RuntimeError, SharedObjectStore, StatPathOptions,
+    CheckpointFilesPage, CheckpointFilesPageCursor, CheckpointId, CommittedChange, ContentRef,
+    CoreError, CurrentFileState, FileContentStream, FileRevision, InodeId, ListChangesOptions,
+    ListFileRevisionsResponse, ListPathEntriesOptions, ListPathEntriesResponse, Namespace,
+    NamespaceId, ReadFileStreamOptions, RevisionNo, RuntimeError, SharedObjectStore,
+    StatPathOptions, TrashEntry,
 };
 use loonfs_api::{
-    AbsolutePath, DirectoryPageCursor, FileRevisionsPageCursor, PageRequest, PaginationPolicy,
+    AbsolutePath, DirectoryPageCursor, FileRevisionsPageCursor, PageCursor, PageRequest,
+    PaginationPolicy, TrashPageCursor,
 };
+
+/// Lazy directory-page reader.
+///
+/// Each call to [`Self::next`] returns one original response envelope, so a
+/// caller can observe head changes between pages. [`Self::collect_up_to`]
+/// collects only entries and keeps any unconsumed part of the final page for
+/// the next call to [`Self::next`].
+#[must_use]
+pub struct PathEntriesPager {
+    reader: FsReader,
+    namespace_id: NamespaceId,
+    absolute_path: String,
+    request: PageRequest<DirectoryPageCursor>,
+    options: ListPathEntriesOptions,
+    pending: Option<ListPathEntriesResponse>,
+    exhausted: bool,
+}
+
+impl PathEntriesPager {
+    /// Returns the next directory page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ListPathEntriesResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .reader
+            .list_path_entries_page(
+                &self.namespace_id,
+                &self.absolute_path,
+                self.request.clone(),
+                self.options.clone(),
+            )
+            .await;
+        Some(page.and_then(|page| {
+            advance_typed_cursor(&mut self.request, page.next_cursor.as_deref())?;
+            self.exhausted = self.request.cursor.is_none();
+            Ok(page)
+        }))
+    }
+
+    /// Collects at most `max_items` entries without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<AuthoritativePathEntry>> {
+        let mut entries = Vec::new();
+        while entries.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - entries.len()).min(page.entries.len());
+            if take < page.entries.len() {
+                let remaining = page.entries.split_off(take);
+                entries.extend(page.entries);
+                page.entries = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            entries.extend(page.entries);
+        }
+        Ok(entries)
+    }
+}
+
+enum FileRevisionsTarget {
+    Path(String),
+    Inode(InodeId),
+}
+
+/// Lazy file-revision page reader for either a path or an inode.
+#[must_use]
+pub struct FileRevisionsPager {
+    reader: FsReader,
+    namespace_id: NamespaceId,
+    target: FileRevisionsTarget,
+    request: PageRequest<FileRevisionsPageCursor>,
+    pending: Option<ListFileRevisionsResponse>,
+    exhausted: bool,
+}
+
+impl FileRevisionsPager {
+    /// Returns the next revision page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ListFileRevisionsResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = match &self.target {
+            FileRevisionsTarget::Path(absolute_path) => {
+                self.reader
+                    .list_file_revisions_page(
+                        &self.namespace_id,
+                        absolute_path,
+                        self.request.clone(),
+                    )
+                    .await
+            }
+            FileRevisionsTarget::Inode(inode_id) => {
+                self.reader
+                    .list_file_revisions_by_inode_page(
+                        &self.namespace_id,
+                        *inode_id,
+                        self.request.clone(),
+                    )
+                    .await
+            }
+        };
+        Some(page.and_then(|page| {
+            advance_typed_cursor(&mut self.request, page.next_cursor.as_deref())?;
+            self.exhausted = self.request.cursor.is_none();
+            Ok(page)
+        }))
+    }
+
+    /// Collects at most `max_items` revisions without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<FileRevision>> {
+        let mut revisions = Vec::new();
+        while revisions.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - revisions.len()).min(page.revisions.len());
+            if take < page.revisions.len() {
+                let remaining = page.revisions.split_off(take);
+                revisions.extend(page.revisions);
+                page.revisions = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            revisions.extend(page.revisions);
+        }
+        Ok(revisions)
+    }
+}
+
+/// Lazy recoverable-deletion page reader.
+#[must_use]
+pub struct TrashPager {
+    reader: FsReader,
+    namespace_id: NamespaceId,
+    request: PageRequest<TrashPageCursor>,
+    pending: Option<loonfs_api::ListTrashResponse>,
+    exhausted: bool,
+}
+
+impl TrashPager {
+    /// Returns the next trash page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<loonfs_api::ListTrashResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .reader
+            .list_trash_page(&self.namespace_id, self.request.clone())
+            .await;
+        Some(page.and_then(|page| {
+            advance_typed_cursor(&mut self.request, page.next_cursor.as_deref())?;
+            self.exhausted = self.request.cursor.is_none();
+            Ok(page)
+        }))
+    }
+
+    /// Collects at most `max_items` deletions without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<TrashEntry>> {
+        let mut entries = Vec::new();
+        while entries.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - entries.len()).min(page.entries.len());
+            if take < page.entries.len() {
+                let remaining = page.entries.split_off(take);
+                entries.extend(page.entries);
+                page.entries = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            entries.extend(page.entries);
+        }
+        Ok(entries)
+    }
+}
+
+/// Lazy change-feed page reader using sequence positions rather than opaque cursors.
+#[must_use]
+pub struct ChangesPager {
+    reader: FsReader,
+    namespace_id: NamespaceId,
+    after_seq: ChangeSeq,
+    options: ListChangesOptions,
+    pending: Option<ChangesResponse>,
+    exhausted: bool,
+}
+
+impl ChangesPager {
+    /// Returns the next change page, or `None` after exhaustion.
+    pub async fn next(&mut self) -> Option<Result<ChangesResponse>> {
+        if let Some(page) = self.pending.take() {
+            return Some(Ok(page));
+        }
+        if self.exhausted {
+            return None;
+        }
+        let page = self
+            .reader
+            .list_changes(&self.namespace_id, self.after_seq, self.options.clone())
+            .await;
+        Some(page.inspect(|page| {
+            self.exhausted = page.next_after_seq.is_none();
+            if let Some(next_after_seq) = page.next_after_seq {
+                self.after_seq = next_after_seq;
+            }
+        }))
+    }
+
+    /// Collects at most `max_items` changes without losing a partially read page.
+    pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<CommittedChange>> {
+        let mut changes = Vec::new();
+        while changes.len() < max_items {
+            let Some(page) = self.next().await else {
+                break;
+            };
+            let mut page = page?;
+            let take = (max_items - changes.len()).min(page.changes.len());
+            if take < page.changes.len() {
+                let remaining = page.changes.split_off(take);
+                changes.extend(page.changes);
+                page.changes = remaining;
+                self.pending = Some(page);
+                break;
+            }
+            changes.extend(page.changes);
+        }
+        Ok(changes)
+    }
+}
+
+fn advance_typed_cursor<C: PageCursor>(
+    request: &mut PageRequest<C>,
+    next_cursor: Option<&str>,
+) -> Result<()> {
+    request.cursor = next_cursor
+        .map(loonfs_api::decode_cursor)
+        .transpose()
+        .map_err(|error| CoreError::InvalidCursor(error.to_string()))?;
+    Ok(())
+}
 
 impl FsReader {
     /// Returns a namespace's current state.
@@ -93,63 +350,23 @@ impl FsReader {
         Ok(entry)
     }
 
-    /// Lists a directory by aggregating every page into one response.
-    ///
-    /// Listing cursors tolerate commits landing mid-listing — each page
-    /// resumes in name-key order against the current head — so the
-    /// envelope's `head_seq` reports the newest head that served a page (an
-    /// empty directory still reports which state answered the question).
-    /// Entries are returned in canonical name-key order, matching paged
-    /// listings.
-    #[tracing::instrument(
-        level = "debug",
-        name = "loonfs.list_path_entries",
-        err(level = "debug"),
-        skip_all,
-        fields(
-            operation = "list_path_entries",
-            method = "list_path_entries_all",
-            namespace_id = %namespace_id,
-            mode = tracing::field::Empty,
-            store_kind = tracing::field::Empty,
-        )
-    )]
-    pub async fn list_path_entries_all(
+    /// Creates a lazy directory pager beginning at `request.cursor`.
+    pub fn list_path_entries_pager(
         &self,
         namespace_id: &NamespaceId,
         absolute_path: &str,
-    ) -> Result<ListPathEntriesResponse> {
-        self.core.record_trace_context(&tracing::Span::current());
-        let limit = default_page_limit();
-        let (first_page, mut next_cursor) = self
-            .list_path_entries_page_typed(
-                namespace_id,
-                absolute_path,
-                PageRequest {
-                    limit,
-                    cursor: None,
-                },
-                ListPathEntriesOptions::default(),
-            )
-            .await?;
-        let mut envelope = first_page;
-        while let Some(cursor) = next_cursor {
-            let (page, page_next_cursor) = self
-                .list_path_entries_page_typed(
-                    namespace_id,
-                    absolute_path,
-                    PageRequest {
-                        limit,
-                        cursor: Some(cursor),
-                    },
-                    ListPathEntriesOptions::default(),
-                )
-                .await?;
-            envelope.head_seq = envelope.head_seq.max(page.head_seq);
-            envelope.entries.extend(page.entries);
-            next_cursor = page_next_cursor;
+        request: PageRequest<DirectoryPageCursor>,
+        options: ListPathEntriesOptions,
+    ) -> PathEntriesPager {
+        PathEntriesPager {
+            reader: self.clone(),
+            namespace_id: namespace_id.clone(),
+            absolute_path: absolute_path.to_owned(),
+            request,
+            options,
+            pending: None,
+            exhausted: false,
         }
-        Ok(envelope)
     }
 
     /// Lists one page of a directory, projecting what `options` asks for.
@@ -506,6 +723,21 @@ impl FsReader {
         })
     }
 
+    /// Creates a lazy trash pager beginning at `request.cursor`.
+    pub fn list_trash_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        request: PageRequest<TrashPageCursor>,
+    ) -> TrashPager {
+        TrashPager {
+            reader: self.clone(),
+            namespace_id: namespace_id.clone(),
+            request,
+            pending: None,
+            exhausted: false,
+        }
+    }
+
     /// Lists one page of a file path's revision history.
     #[tracing::instrument(
         level = "debug",
@@ -541,6 +773,23 @@ impl FsReader {
         )?)
     }
 
+    /// Creates a lazy path-based revision pager beginning at `request.cursor`.
+    pub fn list_file_revisions_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        absolute_path: &str,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> FileRevisionsPager {
+        FileRevisionsPager {
+            reader: self.clone(),
+            namespace_id: namespace_id.clone(),
+            target: FileRevisionsTarget::Path(absolute_path.to_owned()),
+            request,
+            pending: None,
+            exhausted: false,
+        }
+    }
+
     /// Lists one page of retained revisions for a file inode.
     #[tracing::instrument(
         level = "debug",
@@ -571,6 +820,23 @@ impl FsReader {
             page,
             Some(inode_id),
         )?)
+    }
+
+    /// Creates a lazy inode-based revision pager beginning at `request.cursor`.
+    pub fn list_file_revisions_by_inode_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        inode_id: InodeId,
+        request: PageRequest<FileRevisionsPageCursor>,
+    ) -> FileRevisionsPager {
+        FileRevisionsPager {
+            reader: self.clone(),
+            namespace_id: namespace_id.clone(),
+            target: FileRevisionsTarget::Inode(inode_id),
+            request,
+            pending: None,
+            exhausted: false,
+        }
     }
 
     /// Reads the content of one historical file revision by path.
@@ -670,5 +936,22 @@ impl FsReader {
             .reader_engine(namespace_id)
             .list_changes_after(after_seq, limit)
             .await?)
+    }
+
+    /// Creates a lazy change-feed pager beginning after `after_seq`.
+    pub fn list_changes_pager(
+        &self,
+        namespace_id: &NamespaceId,
+        after_seq: ChangeSeq,
+        options: ListChangesOptions,
+    ) -> ChangesPager {
+        ChangesPager {
+            reader: self.clone(),
+            namespace_id: namespace_id.clone(),
+            after_seq,
+            options,
+            pending: None,
+            exhausted: false,
+        }
     }
 }

--- a/crates/loonfs/src/fs/reads.rs
+++ b/crates/loonfs/src/fs/reads.rs
@@ -17,12 +17,11 @@ use loonfs_api::{
     PaginationPolicy, TrashPageCursor,
 };
 
-/// Lazy directory-page reader.
+/// Fetches directory pages as needed.
 ///
-/// Each call to [`Self::next`] returns one original response envelope, so a
-/// caller can observe head changes between pages. [`Self::collect_up_to`]
-/// collects only entries and keeps any unconsumed part of the final page for
-/// the next call to [`Self::next`].
+/// [`Self::next`] returns one page with its metadata. [`Self::collect_up_to`]
+/// returns at most the requested number of entries and saves unused entries
+/// for later calls.
 #[must_use]
 pub struct PathEntriesPager {
     reader: FsReader,
@@ -59,7 +58,9 @@ impl PathEntriesPager {
         }))
     }
 
-    /// Collects at most `max_items` entries without losing a partially read page.
+    /// Returns at most `max_items` entries.
+    ///
+    /// Unused entries from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<AuthoritativePathEntry>> {
         let mut entries = Vec::new();
         while entries.len() < max_items {
@@ -86,7 +87,7 @@ enum FileRevisionsTarget {
     Inode(InodeId),
 }
 
-/// Lazy file-revision page reader for either a path or an inode.
+/// Fetches file-revision pages as needed for a path or inode.
 #[must_use]
 pub struct FileRevisionsPager {
     reader: FsReader,
@@ -133,7 +134,9 @@ impl FileRevisionsPager {
         }))
     }
 
-    /// Collects at most `max_items` revisions without losing a partially read page.
+    /// Returns at most `max_items` revisions.
+    ///
+    /// Unused revisions from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<FileRevision>> {
         let mut revisions = Vec::new();
         while revisions.len() < max_items {
@@ -155,7 +158,7 @@ impl FileRevisionsPager {
     }
 }
 
-/// Lazy recoverable-deletion page reader.
+/// Fetches recoverable-deletion pages as needed.
 #[must_use]
 pub struct TrashPager {
     reader: FsReader,
@@ -185,7 +188,9 @@ impl TrashPager {
         }))
     }
 
-    /// Collects at most `max_items` deletions without losing a partially read page.
+    /// Returns at most `max_items` deletions.
+    ///
+    /// Unused deletions from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<TrashEntry>> {
         let mut entries = Vec::new();
         while entries.len() < max_items {
@@ -207,7 +212,7 @@ impl TrashPager {
     }
 }
 
-/// Lazy change-feed page reader using sequence positions rather than opaque cursors.
+/// Fetches change-feed pages as needed, using sequence numbers to resume.
 #[must_use]
 pub struct ChangesPager {
     reader: FsReader,
@@ -239,7 +244,9 @@ impl ChangesPager {
         }))
     }
 
-    /// Collects at most `max_items` changes without losing a partially read page.
+    /// Returns at most `max_items` changes.
+    ///
+    /// Unused changes from the last page remain available to later calls.
     pub async fn collect_up_to(&mut self, max_items: usize) -> Result<Vec<CommittedChange>> {
         let mut changes = Vec::new();
         while changes.len() < max_items {
@@ -350,7 +357,7 @@ impl FsReader {
         Ok(entry)
     }
 
-    /// Creates a lazy directory pager beginning at `request.cursor`.
+    /// Creates a directory pager beginning at `request.cursor`.
     pub fn list_path_entries_pager(
         &self,
         namespace_id: &NamespaceId,
@@ -723,7 +730,7 @@ impl FsReader {
         })
     }
 
-    /// Creates a lazy trash pager beginning at `request.cursor`.
+    /// Creates a trash pager beginning at `request.cursor`.
     pub fn list_trash_pager(
         &self,
         namespace_id: &NamespaceId,
@@ -773,7 +780,7 @@ impl FsReader {
         )?)
     }
 
-    /// Creates a lazy path-based revision pager beginning at `request.cursor`.
+    /// Creates a path-based revision pager beginning at `request.cursor`.
     pub fn list_file_revisions_pager(
         &self,
         namespace_id: &NamespaceId,
@@ -822,7 +829,7 @@ impl FsReader {
         )?)
     }
 
-    /// Creates a lazy inode-based revision pager beginning at `request.cursor`.
+    /// Creates an inode-based revision pager beginning at `request.cursor`.
     pub fn list_file_revisions_by_inode_pager(
         &self,
         namespace_id: &NamespaceId,
@@ -938,7 +945,7 @@ impl FsReader {
             .await?)
     }
 
-    /// Creates a lazy change-feed pager beginning after `after_seq`.
+    /// Creates a change-feed pager beginning after `after_seq`.
     pub fn list_changes_pager(
         &self,
         namespace_id: &NamespaceId,

--- a/crates/loonfs/src/lib.rs
+++ b/crates/loonfs/src/lib.rs
@@ -99,10 +99,10 @@ pub use loonfs_api::{
     MetadataMaintenanceRequest, MetadataMaintenanceResponse, NameKey, Namespace,
     NamespaceDiagnostics, NamespaceId, Page, PageRequest, PaginationPolicy,
     ReleaseCheckpointResponse, ReorganizeStepOutcome, RetainedCandidates, RetainedReason,
-    RevisionNo, UploadId, WalFlushStepOutcome, FEATURE_ATTRIBUTES, FEATURE_DOWNLOADS_DIRECT_GET,
-    FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE, FEATURE_NAMESPACES_FORK,
-    FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT, PROFILE_ADMIN_V0,
-    PROFILE_CORE_V0, PROTOCOL_VERSION,
+    RevisionNo, TrashEntry, UploadId, WalFlushStepOutcome, FEATURE_ATTRIBUTES,
+    FEATURE_DOWNLOADS_DIRECT_GET, FEATURE_NAMESPACES_CREATE, FEATURE_NAMESPACES_DELETE,
+    FEATURE_NAMESPACES_FORK, FEATURE_UPLOADS_DIRECT_MULTIPART, FEATURE_UPLOADS_DIRECT_PUT,
+    PROFILE_ADMIN_V0, PROFILE_CORE_V0, PROTOCOL_VERSION,
 };
 pub use loonfs_core::cache::{
     MetadataTableCacheConfig, Recency, StoredMetadataBlockCache,
@@ -190,7 +190,10 @@ pub use loonfs_objectstore::{
 
 pub use cache::RuntimeCacheStats;
 pub use config::{RuntimeCacheConfig, DEFAULT_MAX_CONCURRENT_MAINTENANCE};
-pub use fs::MetadataCompactionOutcome;
+pub use fs::{
+    ChangesPager, CheckpointsPager, FileRevisionsPager, MetadataCompactionOutcome,
+    PathEntriesPager, TrashPager,
+};
 pub use handle::{FsAdmin, FsAdminBuilder, FsReader, FsReaderBuilder, FsWriter, FsWriterBuilder};
 pub use maintenance_runner::{
     FsBackgroundWork, MaintenanceHandle, MaintenanceJob, MaintenanceJobId, MaintenanceProbe,

--- a/crates/loonfs/tests/it/bulk_file_reads.rs
+++ b/crates/loonfs/tests/it/bulk_file_reads.rs
@@ -45,8 +45,7 @@ async fn listed_files(
     let mut found = BTreeMap::new();
     let mut directories = vec!["/".to_owned()];
     while let Some(directory) = directories.pop() {
-        let entries = reader
-            .list_path_entries_all(namespace_id, &directory)
+        let entries = collect_path_entries(reader, namespace_id, &directory)
             .await
             .expect("list directory")
             .entries;

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -40,7 +40,7 @@ pub(crate) async fn collect_path_entries(
     };
     let mut pager =
         reader.list_path_entries_pager(namespace_id, absolute_path, request, Default::default());
-    let mut response = pager.next().await.expect("a fresh pager has one page")?;
+    let mut response = pager.next().await.expect("first page")?;
     while let Some(page) = pager.next().await {
         let page = page?;
         response.head_seq = page.head_seq;
@@ -61,7 +61,7 @@ pub(crate) async fn collect_checkpoints(
         cursor: None,
     };
     let mut pager = admin.list_checkpoints_pager(namespace_id, request);
-    let mut response = pager.next().await.expect("a fresh pager has one page")?;
+    let mut response = pager.next().await.expect("first page")?;
     while let Some(page) = pager.next().await {
         let page = page?;
         response.checkpoints.extend(page.checkpoints);

--- a/crates/loonfs/tests/it/common/mod.rs
+++ b/crates/loonfs/tests/it/common/mod.rs
@@ -12,8 +12,8 @@ use loonfs::{
     CopyOptions, CreateCheckpointOptions, CreateDirectoryOptions, CreateNamespaceOptions,
     DeleteOptions, DirectoryPageCursor, ErrorCode, FsAdmin, FsReader, FsWriter, FsWriterBuilder,
     ListChangesOptions, MaintenancePlan, MaintenanceStepResponse, MetadataMaintenanceResponse,
-    MoveOptions, NamespaceDiagnostics, NamespaceId, PageRequest, PutFileOptions, RuntimeError,
-    SharedObjectStore, UploadContentResponse, UploadId, UploadSessionResponse,
+    MoveOptions, NamespaceDiagnostics, NamespaceId, PageRequest, PaginationPolicy, PutFileOptions,
+    RuntimeError, SharedObjectStore, UploadContentResponse, UploadId, UploadSessionResponse,
 };
 use loonfs_objectstore::local_fs_store::LocalFsStore;
 use loonfs_test_support::block_on::block_on;
@@ -25,6 +25,49 @@ use std::sync::Arc;
 
 pub(crate) fn store(root: &Path) -> SharedObjectStore {
     Arc::new(LocalFsStore::new(root).expect("create local-fs store"))
+}
+
+pub(crate) async fn collect_path_entries(
+    reader: &FsReader,
+    namespace_id: &NamespaceId,
+    absolute_path: &str,
+) -> loonfs::Result<loonfs::ListPathEntriesResponse> {
+    let request = PageRequest {
+        limit: PaginationPolicy::default()
+            .resolve_limit(None)
+            .expect("default page limit"),
+        cursor: None,
+    };
+    let mut pager =
+        reader.list_path_entries_pager(namespace_id, absolute_path, request, Default::default());
+    let mut response = pager.next().await.expect("a fresh pager has one page")?;
+    while let Some(page) = pager.next().await {
+        let page = page?;
+        response.head_seq = page.head_seq;
+        response.entries.extend(page.entries);
+        response.next_cursor = page.next_cursor;
+    }
+    Ok(response)
+}
+
+pub(crate) async fn collect_checkpoints(
+    admin: &FsAdmin,
+    namespace_id: &NamespaceId,
+) -> loonfs::Result<loonfs::ListCheckpointsResponse> {
+    let request = PageRequest {
+        limit: PaginationPolicy::default()
+            .resolve_limit(None)
+            .expect("default page limit"),
+        cursor: None,
+    };
+    let mut pager = admin.list_checkpoints_pager(namespace_id, request);
+    let mut response = pager.next().await.expect("a fresh pager has one page")?;
+    while let Some(page) = pager.next().await {
+        let page = page?;
+        response.checkpoints.extend(page.checkpoints);
+        response.next_cursor = page.next_cursor;
+    }
+    Ok(response)
 }
 
 /// The upkeep report a step that selected metadata is obliged to carry.
@@ -147,11 +190,11 @@ impl TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<Vec<AuthoritativePathEntry>> {
-        Ok(self
-            .reader
-            .list_path_entries_all(namespace_id, absolute_path)
-            .await?
-            .entries)
+        Ok(
+            collect_path_entries(&self.reader, namespace_id, absolute_path)
+                .await?
+                .entries,
+        )
     }
 
     pub(crate) async fn list_path_entries(
@@ -159,9 +202,7 @@ impl TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<loonfs::ListPathEntriesResponse> {
-        self.reader
-            .list_path_entries_all(namespace_id, absolute_path)
-            .await
+        collect_path_entries(&self.reader, namespace_id, absolute_path).await
     }
 
     pub(crate) async fn list_path_entries_page(
@@ -389,10 +430,11 @@ impl RuntimeTestExt for TestRuntime {
         namespace_id: &NamespaceId,
         absolute_path: &str,
     ) -> loonfs::Result<Vec<AuthoritativePathEntry>> {
-        block_on(
-            self.reader
-                .list_path_entries_all(namespace_id, absolute_path),
-        )
+        block_on(collect_path_entries(
+            &self.reader,
+            namespace_id,
+            absolute_path,
+        ))
         .map(|response| response.entries)
     }
 

--- a/crates/loonfs/tests/it/handles.rs
+++ b/crates/loonfs/tests/it/handles.rs
@@ -6,6 +6,7 @@
 //! handle from one runtime fixture, matching the runtime-ownership contract
 //! the handles document.
 
+use crate::common::collect_path_entries;
 use loonfs::{
     CommitId, CreateCheckpointOptions, CreateNamespaceOptions, ErrorCode, FsAdmin,
     FsBackgroundWork, FsReader, FsWriter, MaintenanceJobId, MaintenancePlan, ManifestId,
@@ -438,8 +439,7 @@ fn writer_reader_and_admin_share_a_namespace_through_store_config() {
             .await
             .expect("read through standalone reader");
         assert_eq!(read.bytes, b"hello");
-        let entries = standalone
-            .list_path_entries_all(&namespace_id, "/docs")
+        let entries = collect_path_entries(&standalone, &namespace_id, "/docs")
             .await
             .expect("list through standalone reader")
             .entries;
@@ -502,8 +502,7 @@ fn standalone_reader_builds_without_writer_identity() {
             .await
             .expect("stat through standalone reader");
         assert_eq!(stat.size_bytes(), Some(5));
-        let entries = reader
-            .list_path_entries_all(&namespace_id, "/docs")
+        let entries = collect_path_entries(&reader, &namespace_id, "/docs")
             .await
             .expect("list through standalone reader")
             .entries;

--- a/crates/loonfs/tests/it/maintenance.rs
+++ b/crates/loonfs/tests/it/maintenance.rs
@@ -755,8 +755,8 @@ fn tombstoned_namespace_keeps_checkpoint_inventory_and_user_release_available() 
         .create_checkpoint_blocking(&source)
         .expect("create user checkpoint");
 
-    let before_delete =
-        block_on(fs.admin.list_checkpoints_all(&source)).expect("list checkpoints before deletion");
+    let before_delete = block_on(collect_checkpoints(&fs.admin, &source))
+        .expect("list checkpoints before deletion");
     let fork_checkpoint = before_delete
         .checkpoints
         .iter()
@@ -787,7 +787,7 @@ fn tombstoned_namespace_keeps_checkpoint_inventory_and_user_release_available() 
             .build(),
     )
     .expect("build post-delete admin");
-    let listed = block_on(admin.list_checkpoints_all(&source))
+    let listed = block_on(collect_checkpoints(&admin, &source))
         .expect("list checkpoints on deleted namespace");
     assert_eq!(listed.checkpoints.len(), 2);
     assert!(listed

--- a/crates/loonfs/tests/it/pagination.rs
+++ b/crates/loonfs/tests/it/pagination.rs
@@ -26,6 +26,90 @@ fn display_names(entries: &[AuthoritativePathEntry]) -> Vec<&str> {
 }
 
 #[test]
+fn path_entries_pager_exhausts_and_collect_up_to_keeps_the_rest_of_a_page() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "path-pager-collect-test");
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            path,
+            path.as_bytes(),
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .expect("put file");
+    }
+
+    let mut pager = fs.reader.list_path_entries_pager(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit: page_limit(2),
+            cursor: None,
+        },
+        Default::default(),
+    );
+    let collected = block_on(pager.collect_up_to(1)).expect("collect one entry");
+    assert_eq!(display_names(&collected), vec!["a.txt"]);
+
+    let rest_of_first = block_on(pager.next())
+        .expect("buffered page remainder")
+        .expect("page succeeds");
+    assert_eq!(display_names(&rest_of_first.entries), vec!["b.txt"]);
+    let final_page = block_on(pager.next())
+        .expect("final page")
+        .expect("page succeeds");
+    assert_eq!(display_names(&final_page.entries), vec!["c.txt"]);
+    assert!(block_on(pager.next()).is_none());
+}
+
+#[test]
+fn path_entries_pager_keeps_each_pages_head_visible_across_drift() {
+    let temp_dir = tempdir().expect("tempdir");
+    let fs = runtime(temp_dir.path(), "path-pager-drift-test");
+    let namespace_id = namespace_id("demo");
+    fs.create_namespace_blocking(&namespace_id, CreateNamespaceOptions::default())
+        .expect("create namespace");
+    for path in ["/docs/a.txt", "/docs/b.txt", "/docs/c.txt"] {
+        fs.put_file_bytes_blocking(
+            &namespace_id,
+            path,
+            path.as_bytes(),
+            PutFileOptions::new(loonfs_test_support::test_actor()),
+        )
+        .expect("put file");
+    }
+
+    let mut pager = fs.reader.list_path_entries_pager(
+        &namespace_id,
+        "/docs",
+        PageRequest {
+            limit: page_limit(2),
+            cursor: None,
+        },
+        Default::default(),
+    );
+    let first = block_on(pager.next())
+        .expect("first page")
+        .expect("page succeeds");
+    fs.put_file_bytes_blocking(
+        &namespace_id,
+        "/docs/z.txt",
+        b"newer",
+        PutFileOptions::new(loonfs_test_support::test_actor()),
+    )
+    .expect("put later file");
+    let second = block_on(pager.next())
+        .expect("second page")
+        .expect("page succeeds");
+
+    assert_ne!(first.head_seq, second.head_seq);
+    assert_eq!(display_names(&second.entries), vec!["c.txt", "z.txt"]);
+}
+
+#[test]
 fn directory_pages_use_canonical_name_key_order() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "directory-page-order-test");

--- a/crates/loonfs/tests/it/pagination.rs
+++ b/crates/loonfs/tests/it/pagination.rs
@@ -26,7 +26,7 @@ fn display_names(entries: &[AuthoritativePathEntry]) -> Vec<&str> {
 }
 
 #[test]
-fn path_entries_pager_exhausts_and_collect_up_to_keeps_the_rest_of_a_page() {
+fn collect_up_to_keeps_unused_entries_for_the_next_call() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "path-pager-collect-test");
     let namespace_id = namespace_id("demo");
@@ -66,7 +66,7 @@ fn path_entries_pager_exhausts_and_collect_up_to_keeps_the_rest_of_a_page() {
 }
 
 #[test]
-fn path_entries_pager_keeps_each_pages_head_visible_across_drift() {
+fn path_entries_pager_preserves_each_page_head() {
     let temp_dir = tempdir().expect("tempdir");
     let fs = runtime(temp_dir.path(), "path-pager-drift-test");
     let namespace_id = namespace_id("demo");


### PR DESCRIPTION
This standardizes pagination for `loonfs ls`, `revisions`, `trash`, `changes`, `grep`, and `admin checkpoint list`. Each command returns one page by default. `--limit` caps the total number of results, `--page-size` controls each request, `--all` follows additional pages, and `--jsonl` streams one item per line. Commands with opaque cursors use `--cursor`; `changes` uses `--after`.

Unbounded `--all --json` is rejected because it would buffer every result. `grep --max-matches` is removed because `--limit` now sets the total match count. `admin index gc` also accepts a cursor so a bounded pass can be resumed.

The eager SDK helpers are replaced with pagers for directory entries, file revisions, trash, changes, and checkpoints. Each pager returns one page at a time with its metadata and provides `collect_up_to` for explicitly bounded collection. The HTTP API and response formats do not change.

Validated with Rustfmt, Clippy across the affected crates, 91 CLI unit tests, 9 core pagination tests, and focused CLI integration tests.